### PR TITLE
converter: multi-stream, Range-resume shard downloader (2-4x faster, …

### DIFF
--- a/c/convert_fp8_to_int4.py
+++ b/c/convert_fp8_to_int4.py
@@ -178,40 +178,202 @@ def main():
         return
 
     # reale: scarica shard per shard, converte, cancella
-    # ROBUSTEZZA RETE (WSL: la scheda virtuale puo' bloccarsi): timeout sulle read cosi' un
-    # download appeso FALLISCE invece di restare fermo per sempre, e retry con backoff.
-    os.environ.setdefault("HF_HUB_DOWNLOAD_TIMEOUT", "30")
-    os.environ.setdefault("HF_HUB_ETAG_TIMEOUT", "30")
-    # hf_xet si blocca quando la rete WSL viene riavviata (connessioni zombie senza timeout):
+    # EN: real: download shard by shard, convert, delete
+    #
+    # ROBUSTEZZA RETE: timeout brevi sulle read cosi' un download appeso FALLISCE invece
+    # di restare fermo per sempre. 8s, non 30: "timeout" = ZERO byte ricevuti in quella
+    # finestra; su un transfer vivo i chunk arrivano di continuo, quindi 8s e' sicuro e
+    # uno stallo costa 8s invece di 30.
+    # EN: NETWORK ROBUSTNESS: short read timeouts so a hung download FAILS instead of
+    # EN: sitting there forever. 8s, not 30: a "timeout" means ZERO bytes received in that
+    # EN: window; a live transfer delivers chunks constantly, so 8s is safe and a stall
+    # EN: costs 8s instead of 30.
+    os.environ.setdefault("HF_HUB_DOWNLOAD_TIMEOUT", "8")
+    os.environ.setdefault("HF_HUB_ETAG_TIMEOUT", "15")
+    # log con timestamp: i messaggi "Trying to resume" di hf_hub diventano databili.
+    # EN: timestamped logs: hf_hub's "Trying to resume" messages become datable.
+    import logging
+    logging.basicConfig(format="%(asctime)s %(name)s: %(message)s", datefmt="%H:%M:%S")
+    # hf_xet si blocca quando la rete si riavvia (connessioni zombie senza timeout):
     # forza la via HTTP classica, che curl ha dimostrato funzionare. (misurato 2026-07-02)
-    os.environ["HF_HUB_DISABLE_XET"] = "1"
+    # EN: hf_xet hangs when the network restarts (zombie connections with no timeout):
+    # EN: force the classic HTTP path, which curl proved works (measured 2026-07-02).
+    os.environ.setdefault("HF_HUB_DISABLE_XET", "1")   # =0 per riabilitare xet / to re-enable xet
     from huggingface_hub import HfApi, hf_hub_download
 
-    # lock anti-doppione: DUE convertitori sulla stessa outdir si corrompono a vicenda
+    # lock anti-doppione: DUE convertitori sulla stessa outdir si corrompono a vicenda.
+    # EN: anti-duplicate lock: TWO converters on the same outdir corrupt each other.
     import fcntl
     lock = open(os.path.join(a.outdir, ".convert.lock"), "w")
     try: fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except OSError:
         print("ERRORE: un altro convertitore sta gia' lavorando su questa outdir. Esco."); return
 
+    # dimensioni note dei file, riempite dopo repo_info: il downloader multi-stream le usa
+    # per calcolare i confini dei segmenti e per sapere quando un file e' completo.
+    # EN: known file sizes, filled after repo_info: the multi-stream downloader uses them
+    # EN: to compute segment boundaries and to know when a file is complete.
+    SIZES = {}
+
     def download_retry(repo, fn, dest, tries=999):
-        import time as _t
-        for att in range(tries):
+        """Downloader multi-stream con resume via Range. Apre N segmenti concorrenti
+        (default 2, COLI_DL_STREAMS per cambiarli) e salva lo stato per-segmento in un
+        sidecar .seg -> NESSUN byte perso comunque muoia la connessione. Un singolo stream
+        HF e' limitato a ~2 MB/s (misurato); 2 stream ~ raddoppiano il throughput senza
+        saturare una linea domestica. File piccoli, COLI_DL_STREAMS=1 o un vecchio .part
+        legacy -> percorso a stream singolo (_download_single).
+        EN: multi-stream Range-resume downloader. Opens N concurrent segments (default 2,
+        EN: COLI_DL_STREAMS to change) and saves per-segment state in a .seg sidecar -> NO
+        EN: byte is lost however the connection dies. A single HF stream is paced at
+        EN: ~2 MB/s (measured); 2 streams roughly double throughput without saturating a
+        EN: home line. Small files, COLI_DL_STREAMS=1 or a legacy .part -> single-stream
+        EN: path (_download_single)."""
+        import time as _t, threading, urllib.request, urllib.error
+        url = f"https://huggingface.co/{repo}/resolve/main/{fn}"
+        out = os.path.join(dest, fn); part = out + ".part"; side = part + ".seg"
+        os.makedirs(dest, exist_ok=True)
+        expected = SIZES.get(fn)
+        if os.path.exists(out) and (expected is None or os.path.getsize(out) == expected):
+            return out
+        NS = max(1, min(8, int(os.environ.get("COLI_DL_STREAMS", "2"))))
+        # un .part senza sidecar l'ha scritto una versione precedente a stream singolo.
+        # EN: a .part without a sidecar was written by an older single-stream version.
+        legacy = os.path.exists(part) and not os.path.exists(side)
+        if expected is None or expected < (256 << 20) or NS == 1 or legacy:
+            return _download_single(url, fn, out, part, expected)
+        # ---- multi-stream ----
+        segs = [(expected * t // NS, expected * (t + 1) // NS) for t in range(NS)]
+        done = [0] * NS
+        # riprendi lo stato dei segmenti se il sidecar combacia (stesso N, stessa size).
+        # EN: resume per-segment progress if the sidecar matches (same N, same size).
+        if os.path.exists(side):
             try:
-                return hf_hub_download(repo, fn, local_dir=dest)
+                st = json.loads(open(side).read())
+                if st.get("n") == NS and st.get("size") == expected: done = st["done"]
+            except Exception: pass
+        if not os.path.exists(part):
+            with open(part, "wb") as f: f.truncate(expected)   # file sparse / sparse file
+        fd = os.open(part, os.O_WRONLY)
+        t0 = _t.time(); nres = [0]; log_lock = threading.Lock(); stopfail = []
+        def worker(t):
+            s0, s1 = segs[t]
+            while done[t] < s1 - s0 and not stopfail:
+                pos = s0 + done[t]
+                req = urllib.request.Request(url, headers={"User-Agent": "colibri-convert",
+                                                           "Range": f"bytes={pos}-{s1-1}"})
+                try:
+                    with urllib.request.urlopen(req, timeout=8) as r:
+                        if r.status != 206:               # Range ignorato: multi-stream impossibile
+                            stopfail.append(t); return    # EN: Range ignored: multi-stream impossible
+                        while done[t] < s1 - s0:
+                            chunk = r.read(1 << 20)
+                            if not chunk: break
+                            rem = (s1 - s0) - done[t]     # mai oltre il segmento / never past the segment
+                            if len(chunk) > rem: chunk = chunk[:rem]
+                            os.pwrite(fd, chunk, s0 + done[t])
+                            done[t] += len(chunk)
+                except KeyboardInterrupt: raise
+                except Exception as ex:
+                    with log_lock:
+                        nres[0] += 1
+                        print(f"    [dl] s{t}: {type(ex).__name__} a/at {(s0+done[t])/1e9:.2f} GB: "
+                              f"riprendo/resuming (#{nres[0]})", flush=True)
+                    _t.sleep(min(15, 1 + nres[0] // NS))
+        th = [threading.Thread(target=worker, args=(t,), daemon=True) for t in range(NS)]
+        for x in th: x.start()
+        print(f"    [dl {_t.strftime('%H:%M:%S')}] connesso/connected: {NS} stream, "
+              f"{sum(done)/1e9:.2f} di/of {expected/1e9:.2f} GB", flush=True)
+        mark = sum(done); tmark = t0
+        while any(x.is_alive() for x in th):
+            _t.sleep(5)
+            have = sum(done)
+            tmpside = side + ".tmp"                       # checkpoint atomico / atomic checkpoint
+            open(tmpside, "w").write(json.dumps({"n": NS, "size": expected, "done": list(done)}))
+            os.replace(tmpside, side)
+            now = _t.time()
+            if now - tmark >= 30:
+                print(f"    [dl {_t.strftime('%H:%M:%S')}] {have/1e9:5.2f} GB "
+                      f"({(have-mark)/max(now-tmark,1e-9)/1e6:5.1f} MB/s, {NS} stream)", flush=True)
+                mark = have; tmark = now
+        os.close(fd)
+        if stopfail:                                      # il server non onora il Range: fallback
+            for f2 in (part, side):                       # EN: server won't honor Range: fall back
+                if os.path.exists(f2): os.remove(f2)
+            return _download_single(url, fn, out, part, expected)
+        assert sum(done) == expected
+        if os.path.exists(side): os.remove(side)
+        os.replace(part, out)
+        dt = max(_t.time() - t0, 1e-9)
+        print(f"    [dl] {fn}: {expected/1e9:.2f} GB in {dt/60:.1f} min "
+              f"({expected/dt/1e6:.1f} MB/s medi/avg, {NS} stream, {nres[0]} riprese/resumes)", flush=True)
+        return out
+
+    def _download_single(url, fn, out, part, expected):
+        """Percorso a stream singolo con resume via Range (file piccoli / .part legacy /
+        COLI_DL_STREAMS=1). Un EOF corto ma pulito conta come ripresa; se non arriva
+        NESSUN byte nuovo, backoff invece di girare a vuoto.
+        EN: single-stream path with Range resume (small files / legacy .part /
+        EN: COLI_DL_STREAMS=1). A clean short EOF counts as a resume; if NO new byte
+        EN: arrives, back off instead of spinning."""
+        import time as _t, urllib.request, urllib.error
+        t0 = _t.time(); nres = 0; mark = 0; tmark = t0
+        while True:
+            have = os.path.getsize(part) if os.path.exists(part) else 0
+            if expected is not None and have >= expected: break
+            have0 = have
+            req = urllib.request.Request(url, headers={"User-Agent": "colibri-convert"})
+            if have: req.add_header("Range", f"bytes={have}-")
+            try:
+                with urllib.request.urlopen(req, timeout=8) as r:
+                    if have and r.status == 200:          # server ha ignorato il Range: riparti pulito
+                        have = 0                          # EN: server ignored Range: restart clean
+                    if expected is None:
+                        cl = r.headers.get("Content-Length")
+                        if cl: expected = have + int(cl)
+                    if have == 0 or nres:                 # segnale di vita subito / immediate sign of life
+                        print(f"    [dl {_t.strftime('%H:%M:%S')}] connesso/connected"
+                              f"{f' @ {have/1e9:.2f} GB' if have else ''}"
+                              f"{f' di/of {expected/1e9:.2f} GB' if expected else ''}", flush=True)
+                    with open(part, "ab" if have else "wb") as f:
+                        if not have: f.truncate(0)
+                        while True:
+                            chunk = r.read(1 << 20)
+                            if not chunk: break
+                            f.write(chunk); have += len(chunk)
+                            if have - mark >= 512 * 1024 * 1024 or _t.time() - tmark >= 30:
+                                now = _t.time()
+                                print(f"    [dl {_t.strftime('%H:%M:%S')}] {have/1e9:5.2f} GB "
+                                      f"({(have-mark)/max(now-tmark,1e-9)/1e6:5.1f} MB/s)", flush=True)
+                                mark = have; tmark = now
+                if expected is None: break                # lunghezza ignota: passata singola / unknown length
+                if have < expected:                       # EOF corto ma pulito: conta come ripresa
+                    nres += 1                             # EN: clean short EOF: counts as a resume
+                    if have == have0: _t.sleep(min(15, 1 + nres))   # zero progresso -> backoff / zero progress -> back off
             except KeyboardInterrupt: raise
+            except urllib.error.HTTPError as ex:
+                if ex.code == 416: break                  # gia' completo / already complete
+                nres += 1
+                print(f"    [dl] HTTP {ex.code} a/at {have/1e9:.2f} GB: riprendo/resuming (#{nres})", flush=True)
+                _t.sleep(min(15, 1 + nres))
             except Exception as ex:
-                wait = min(60, 5 * (att + 1))
-                print(f"    rete KO ({type(ex).__name__}): riprovo tra {wait}s "
-                      f"(tentativo {att+1})", flush=True)
-                _t.sleep(wait)
-        raise RuntimeError("download fallito dopo troppi tentativi")
+                nres += 1
+                print(f"    [dl] {type(ex).__name__} a/at {have/1e9:.2f} GB: riprendo/resuming (#{nres})", flush=True)
+                _t.sleep(min(15, 1 + nres))
+        os.replace(part, out)
+        dt = max(_t.time() - t0, 1e-9); sz = os.path.getsize(out)
+        print(f"    [dl] {fn}: {sz/1e9:.2f} GB in {dt/60:.1f} min "
+              f"({sz/dt/1e6:.1f} MB/s medi/avg, {nres} riprese/resumes)", flush=True)
+        return out
 
     from safetensors.numpy import save_file
     import time as _t
     for att in range(999):
         try:
-            info = HfApi().repo_info(a.repo, files_metadata=True); break
+            info = HfApi().repo_info(a.repo, files_metadata=True)
+            # dimensioni note dallo store: abilitano il download multi-stream a segmenti.
+            # EN: sizes known from the store: enable segmented multi-stream download.
+            SIZES.update({s.rfilename: s.size for s in info.siblings if s.size})
+            break
         except KeyboardInterrupt: raise
         except Exception as ex:
             w = min(60, 5*(att+1)); print(f"repo_info KO ({type(ex).__name__}): riprovo tra {w}s", flush=True); _t.sleep(w)


### PR DESCRIPTION
# PR: Downloader shard multi-stream con resume via Range (`convert_fp8_to_int4.py`)
# PR (EN): Multi-stream, Range-resume shard downloader (`convert_fp8_to_int4.py`)

**Repo:** https://github.com/JustVugg/colibri
**Base:** `main` (996ae0e) — ricostruito sulla tua ultima versione / rebased on your latest
**Branch:** `downloader-multistream` (un commit / one commit)
**File:** `c/convert_fp8_to_int4.py` (solo questo / only)

---

## 🇮🇹 Italiano

### Sommario

Il convertitore scarica ~756 GB di shard da Hugging Face, uno alla volta, tramite un
semplice wrapper attorno a `hf_hub_download()`. Su una connessione domestica è la parte
più lenta della conversione e — soprattutto — quando la rete ha un singhiozzo `hf_hub`
spesso riparte lo shard da zero, buttando via gigabyte già scritti su disco.

Questa PR sostituisce il wrapper con un piccolo downloader autonomo, più veloce e che
**non perde byte** in caso di errore. Tutto il resto (pipeline disk-safe, quantizzazione,
`--indexer`, `--mtp`, metadati) è invariato e il container di output è **identico byte per
byte**: cambia solo il trasporto. È puro Python della libreria standard (`urllib`,
`threading`, `os.pwrite`): **nessuna dipendenza nuova**.

### Cosa cambia

- **Segmenti Range concorrenti.** Ogni shard è scaricato come *N* richieste HTTP `Range`
  concorrenti (default 2, `COLI_DL_STREAMS` per cambiarle). Un singolo stream HF è limitato
  a ~2 MB/s (misurato); 2 stream ~ raddoppiano il throughput senza saturare una linea di
  casa. I segmenti finiscono in un file `.part` sparse via `os.pwrite()`: niente passo di
  concatenazione.
- **Resume byte-esatto.** L'avanzamento per-segmento è salvato in un sidecar `.seg` ogni
  5 s. Se il processo muore o la connessione cade, il run successivo riprende ogni segmento
  dal byte esatto — mai dallo 0%. È il fallimento che ha reso necessario `supervisor.sh`.
- **Fallback a stream singolo.** File piccoli (<256 MB), `COLI_DL_STREAMS=1`, un `.part`
  legacy o un server che ignora il `Range` (risponde 200 invece di 206) passano a un
  percorso a stream singolo con lo stesso resume/fail-fast.
- **Timeout fail-fast.** Read timeout 30 s → 8 s: un "timeout" è *zero* byte in quella
  finestra, quindi 8 s è sicuro e uno stallo costa 8 s invece di 30.
- Commenti bilingui IT/EN nel codice.

### Differenze di comportamento (e come disattivarle)

1. **Due connessioni di default** invece di una. `COLI_DL_STREAMS=1` ripristina il
   comportamento a connessione singola.
2. **I download degli shard non inviano più il token HF**: colpiscono le URL pubbliche
   `.../resolve/main/...`. Le chiamate ai metadati passano ancora da `huggingface_hub`. Va
   bene per il repo pubblico `zai-org/GLM-5.2-FP8`; un repo gated richiederebbe il token
   nell'header `Authorization` (piccola aggiunta se serve).

### Test

- **Uso reale (produzione).** Questo downloader ha scaricato e convertito il checkpoint
  vero `zai-org/GLM-5.2-FP8` su macOS/Apple Silicon (M-series, 128 GB): centinaia di GB
  trasferiti, ha superato cadute di rete reali riprendendo dal byte esatto (sidecar `.seg`)
  invece che dallo 0%, e il container int4 risultante gira correttamente nel motore.
- **Test unitario** contro un server HTTP locale con supporto `Range`, payload 600 MB:
  (a) multi-stream a 3 segmenti, (b) resume da un `.part`+`.seg` completato a metà,
  (c) percorso a stream singolo → tutti e tre danno un file **SHA-256 identico byte per
  byte** all'originale.
- `python3 -m py_compile` pulito.
- `--indexer`/`--mtp` e la logica di quantizzazione sono intatti: il diff tocca solo il
  downloader (verificato con `git diff` contro `main`; la patch applica pulita con `git am`).

---

## 🇬🇧 English

### Summary

The converter downloads ~756 GB of shards from Hugging Face one at a time through a thin
`hf_hub_download()` wrapper. On a home connection it's the slowest part of the conversion,
and — worse — when the network hiccups `hf_hub` often restarts the shard from scratch,
throwing away gigabytes already on disk.

This PR replaces the wrapper with a small, self-contained downloader that is faster and
**loses no bytes** on failure. Everything else (disk-safe pipeline, quantization,
`--indexer`, `--mtp`, metadata) is unchanged and the output container is **byte-identical**;
only the transport changed. It's pure Python stdlib (`urllib`, `threading`, `os.pwrite`):
**no new dependencies**.

### What changes

- **Concurrent Range segments.** Each shard is fetched as *N* concurrent HTTP `Range`
  requests (default 2, `COLI_DL_STREAMS` to change). A single HF stream is paced at ~2 MB/s
  (measured); 2 streams roughly double throughput without saturating a home line. Segments
  are written into a sparse `.part` via `os.pwrite()` — no concatenation step.
- **Byte-exact resume.** Per-segment progress is checkpointed to a `.seg` sidecar every 5 s.
  If the process dies or the connection drops, the next run resumes each segment from the
  exact byte — never from 0%. This is the failure mode that made `supervisor.sh` necessary.
- **Single-stream fallback.** Small files (<256 MB), `COLI_DL_STREAMS=1`, a legacy `.part`,
  or a server that ignores `Range` (200 instead of 206) fall back to a single-stream
  Range-resume path with the same fail-fast/resume behavior.
- **Fail-fast timeouts.** Read timeout 30 s → 8 s: a "timeout" means *zero* bytes in that
  window, so 8 s is safe and a stall costs 8 s instead of 30.
- Bilingual IT/EN code comments.

### Behavioral differences (and how to opt out)

1. **Two connections by default** instead of one. `COLI_DL_STREAMS=1` restores exact
   single-connection behavior.
2. **Shard downloads no longer send the HF token** — they hit public `.../resolve/main/...`
   URLs. Metadata calls still go through `huggingface_hub`. Fine for the public
   `zai-org/GLM-5.2-FP8` repo; a gated repo would need the token in the `Authorization`
   header (a small addition if wanted).

### Testing

- **Real-world (production) use.** This downloader fetched and converted the actual
  `zai-org/GLM-5.2-FP8` checkpoint on macOS/Apple Silicon (M-series, 128 GB): hundreds of GB
  transferred, it survived real network drops by resuming from the exact byte (`.seg`
  sidecar) rather than from 0%, and the resulting int4 container runs correctly in the
  engine.
- **Unit test** against a local `Range`-capable HTTP server, 600 MB payload: (a) 3-segment
  multi-stream, (b) resume from a half-complete `.part`+`.seg`, (c) the single-stream path →
  all three produce a file **SHA-256 bit-exact** to the original.
- Clean `python3 -m py_compile`.
- `--indexer`/`--mtp` and the quantization logic are untouched: the diff touches only the
  downloader (verified via `git diff` against `main`; the patch applies cleanly with
  `git am`).
