### PR TITLE
PIN: mlock pinned experts into physical RAM (macOS: stop the compress…

### DIFF
--- a/c/glm.c
+++ b/c/glm.c
@@ -23,6 +23,9 @@
 #include <math.h>
 #include <time.h>
 #include <sys/resource.h>
+#if defined(__APPLE__) || defined(__linux__)
+#include <sys/mman.h>                             /* mlock: inchioda le pagine in RAM / wire pages into RAM */
+#endif
 #include "st.h"
 #include "tok.h"
 #ifdef __AVX2__
@@ -1589,6 +1592,51 @@ static void usage_save(Model *m){ if(g_usage_path[0]) stats_dump_q(m,g_usage_pat
 /* HOT-STORE ("il redis del colibri'"): carica in RAM, UNA VOLTA e per sempre, i top expert
  * per frequenza d'uso misurata (file STATS di un run precedente), entro un budget in GB.
  * Ogni hit evita una lettura dal disco lento. */
+/* MLOCK: inchioda in RAM fisica gli expert pinnati cosi' il compressore di memoria di
+ * macOS non li comprime/evacua (visto: RSS reale < residente previsto -> "hit" lenti).
+ * -1 = auto (ON su macOS dove serve e RLIMIT_MEMLOCK e' permissivo; OFF altrove, dove
+ * il limite e' spesso minuscolo e va alzato a mano), 0 = off, 1 = force.
+ * EN: MLOCK: wire pinned experts into physical RAM so macOS's memory compressor can't
+ * compress/evict them (we saw actual RSS < intended resident -> slow "hits"). -1 = auto
+ * (ON on macOS where it matters and RLIMIT_MEMLOCK is permissive; OFF elsewhere, where the
+ * limit is often tiny and must be raised by hand), 0 = off, 1 = force. */
+static int g_mlock=-1;
+static int mem_should_wire(void){
+    if(g_mlock>=0) return g_mlock;
+#if defined(__APPLE__)
+    return 1;                                     /* macOS: default ON */
+#else
+    return 0;                                     /* Linux/altri: opt-in via MLOCK=1 / opt-in */
+#endif
+}
+/* Inchioda [addr,addr+len) in RAM fisica. No-op fuori da POSIX (Windows ecc.).
+ * EN: wire [addr,addr+len) into physical RAM. No-op off POSIX (Windows, etc.). */
+static int mem_wire(void *addr, size_t len){
+#if defined(__APPLE__) || defined(__linux__)
+    return mlock(addr, len);
+#else
+    (void)addr; (void)len; return 0;
+#endif
+}
+/* Inchioda tutti gli slab degli expert pinnati (pesi + scale). Non fatale se fallisce.
+ * EN: wire all pinned-expert slabs (weights + scales). Non-fatal on failure. */
+static void pin_wire(Model *m){
+    if(!mem_should_wire()) return;
+    Cfg *c=&m->c; double t0=now_s(); int64_t wired=0; long failed=0;
+    for(int i=0;i<c->n_layers;i++) for(int z=0;z<m->npin[i];z++){
+        ESlot *s=&m->pin[i][z];
+        if(s->slab){  if(mem_wire(s->slab, s->slab_cap)==0) wired+=s->slab_cap; else failed++; }
+        if(s->fslab){ size_t fl=(size_t)s->fslab_cap*sizeof(float);
+                      if(mem_wire(s->fslab, fl)==0) wired+=fl; else failed++; }
+    }
+    if(failed)
+        fprintf(stderr,"[PIN] mlock: %.1f GB inchiodati/wired, %ld alloc fallite/failed "
+            "(alza il limite / raise it: ulimit -l unlimited) in %.0fs\n", wired/1e9, failed, now_s()-t0);
+    else
+        fprintf(stderr,"[PIN] mlock: %.1f GB inchiodati in RAM fisica / wired in physical RAM "
+            "(niente compressione/no compression) in %.0fs\n", wired/1e9, now_s()-t0);
+}
+
 static void pin_load(Model *m, const char *statspath, double gb){
     FILE *f=fopen(statspath,"r"); if(!f){ perror(statspath); return; }
     typedef struct { int l,e; uint32_t c; } Rec;
@@ -1623,6 +1671,7 @@ static void pin_load(Model *m, const char *statspath, double gb){
     m->resident_bytes += (int64_t)npin*eb;
     fprintf(stderr,"[PIN] hot-store: %d expert in RAM (%.1f GB) in %.0fs da %s\n",
         npin, npin*eb/1e9, now_s()-t0, statspath);
+    pin_wire(m);                                   /* inchioda in RAM (no compressione) / wire in RAM (no compression) */
     free(r); free(cnt_l);
 }
 
@@ -1704,6 +1753,7 @@ int main(int argc, char **argv){
     g_prefetch = getenv("PREFETCH")?atoi(getenv("PREFETCH")):0;
     g_topk = getenv("TOPK")?atoi(getenv("TOPK")):0;
     g_topp = getenv("TOPP")?atof(getenv("TOPP")):0;
+    g_mlock  = getenv("MLOCK")?atoi(getenv("MLOCK")):-1;   /* -1 auto (ON macOS), 0 off, 1 force / auto (ON macOS), 0 off, 1 force */
     g_spec = getenv("SPEC")?atoi(getenv("SPEC")):1;
     g_draft = getenv("DRAFT")?atoi(getenv("DRAFT")):-1;   /* -1 = auto: 3 se MTP, 0 senza */
     g_direct = getenv("DIRECT")?atoi(getenv("DIRECT")):0;


### PR DESCRIPTION
# PR: mlock degli expert pinnati in RAM fisica (`glm.c`)
# PR (EN): mlock pinned experts into physical RAM (`glm.c`)

**Repo:** https://github.com/JustVugg/colibri
**Base:** `main` (996ae0e) — ricostruito sulla tua ultima versione / rebased on your latest
**Branch:** `pin-mlock-wire` (un commit / one commit)
**File:** `c/glm.c` (solo questo / only) — +50 righe / +50 lines

---

## 🇮🇹 Italiano

### Sommario

`PIN`/`PIN_GB` carica gli expert più caldi in RAM come "hot-store" che non viene mai
evacuato dalla logica del motore. Ma la memoria non è `mlock`-ata: sotto pressione il
**compressore di memoria di macOS** (e lo swap su Linux) può comprimere/paginare fuori
proprio quelle pagine. Misurato su un Mac (M-series, 128 GB): con `PIN_GB 80` il residente
previsto era 87.6 GB ma l'`ru_maxrss` reale non ha mai superato ~57 GB — cioè ~29 GB del
pin erano compressi. Ogni "hit" su quelle pagine diventa un decompress, e la hit-rate alta
finisce per essere *più lenta* del percorso a freddo.

Questa PR inchioda gli slab degli expert pinnati (pesi + scale) in RAM fisica con `mlock`,
così restano davvero residenti. Tutto è protetto da direttive del preprocessore: **no-op
fuori da POSIX** (Windows ecc.).

### Cosa cambia

- Nuovo helper `mem_wire()` → `mlock` su `__APPLE__`/`__linux__`, no-op altrove.
- `pin_wire()` inchioda tutti gli slab pinnati subito dopo `pin_load`, con una riga di
  conferma su stderr (`[PIN] mlock: X GB inchiodati...`). Non fatale se fallisce.
- Variabile d'ambiente `MLOCK`: `-1` = auto (**ON su macOS**, dove il compressore morde e
  `RLIMIT_MEMLOCK` è permissivo; **OFF altrove**, dove il limite è spesso minuscolo e va
  alzato a mano), `0` = off, `1` = force.

Il default conservativo (OFF su Linux) è voluto: su Linux `ulimit -l` di default è piccolo
e un `mlock` di decine di GB fallirebbe; chi vuole lo attiva con `MLOCK=1` (dopo aver alzato
il limite). Su macOS è ON perché è lì che serve.

### Perché

Su un SSD lento (il tuo caso di riferimento) `PIN` è una grande vittoria: evita letture da
disco per gli expert caldi. Ma se il pin viene compresso sotto pressione, il beneficio
sparisce silenziosamente. `mlock` rende `PIN` **affidabile**: quello che dici di pinnare
resta davvero in RAM.

### Test

- **Misurato su macOS (Apple Silicon, 128 GB), stesso prompt, `PIN_GB 80`:**
  - PRIMA (senza mlock): residente previsto 87.6 GB, ma l'`ru_maxrss` reale ha toccato al
    massimo **56.95 GB** → ~29 GB del pin erano compressi; hit-rate 38% eppure tok/s
    *peggiore* del percorso senza pin.
  - DOPO (con mlock): compare la riga `[PIN] mlock: 77.5 GB inchiodati in RAM fisica`, e
    l'`RSS` finale **tiene a 84.68 GB** per tutto il run — il pin non viene più compresso.
- `cc -O3 -c c/glm.c` pulito su Apple Silicon; anche il ramo no-op (non-POSIX) compila
  pulito (verificato che `mem_wire` senza `mlock` è C ben formato).
- `MLOCK=0` ripristina byte per byte il comportamento attuale (percorso invariato).

---

## 🇬🇧 English

### Summary

`PIN`/`PIN_GB` loads the hottest experts into RAM as a "hot-store" the engine never evicts.
But that memory isn't `mlock`-ed, so under pressure **macOS's memory compressor** (and swap
on Linux) can compress/page out exactly those pages. Measured on a Mac (M-series, 128 GB):
with `PIN_GB 80` the intended resident was 87.6 GB but actual `ru_maxrss` peaked at only
~57 GB — i.e. ~29 GB of the pin was compressed. Every "hit" on those pages becomes a
decompress, and the high hit-rate ends up *slower* than the cold path.

This PR wires the pinned-expert slabs (weights + scales) into physical RAM with `mlock`, so
they actually stay resident. Everything is guarded by preprocessor directives: **no-op off
POSIX** (Windows, etc.).

### What changes

- New `mem_wire()` helper → `mlock` on `__APPLE__`/`__linux__`, no-op elsewhere.
- `pin_wire()` wires all pinned slabs right after `pin_load`, with one stderr confirmation
  line (`[PIN] mlock: X GB wired...`). Non-fatal on failure.
- `MLOCK` env var: `-1` = auto (**ON on macOS**, where the compressor bites and
  `RLIMIT_MEMLOCK` is permissive; **OFF elsewhere**, where the limit is usually tiny and
  must be raised by hand), `0` = off, `1` = force.

The conservative default (OFF on Linux) is deliberate: Linux's default `ulimit -l` is small
and an `mlock` of tens of GB would fail; Linux users opt in with `MLOCK=1` (after raising
the limit). macOS is ON because that's where it's needed.

### Why

On a slow SSD (your reference setup) `PIN` is a big win — it avoids disk reads for hot
experts. But if the pin gets compressed under pressure, the benefit silently vanishes.
`mlock` makes `PIN` **trustworthy**: what you pin actually stays in RAM.

### Testing

- **Measured on macOS (Apple Silicon, 128 GB), same prompt, `PIN_GB 80`:**
  - BEFORE (no mlock): intended resident 87.6 GB, but actual `ru_maxrss` peaked at only
    **56.95 GB** → ~29 GB of the pin was compressed; 38% hit-rate yet tok/s *worse* than the
    no-pin path.
  - AFTER (with mlock): the `[PIN] mlock: 77.5 GB wired in physical RAM` line appears and
    final `RSS` **holds at 84.68 GB** for the whole run — the pin is no longer compressed.
- Clean `cc -O3 -c c/glm.c` on Apple Silicon; the non-POSIX no-op branch also compiles clean
  (verified `mem_wire` without `mlock` is well-formed C).
- `MLOCK=0` restores the current behavior byte-for-byte (unchanged path).
