### PR TITLE
IDOT: AVX-512 VNNI kernel paths + batch-size gate for single-row int4 decode (+20% end-to-end on Xeon)

### DIFF
--- a/c/glm.c
+++ b/c/glm.c
@@ -228,7 +228,17 @@ static void matmul_i2(float *y, const float *x, const uint8_t *q2, const float *
  * stile Q8_0), prodotto scalare INTERO via maddubs/madd AVX2 — niente conversione
  * f32 dei pesi nel ciclo caldo. ~2-3x sui matmul quantizzati; errore aggiunto ~0.3%
  * RMS per matmul (attivazione int8), IDOT=0 torna al percorso f32 esatto. */
+#if defined(__AVX512VNNI__) && defined(__AVX512BW__)
+#define IDOT_KERNEL "avx512-vnni"
+#elif defined(__AVX2__)
+#define IDOT_KERNEL "avx2"
+#elif defined(__ARM_NEON)
+#define IDOT_KERNEL "neon"
+#else
+#define IDOT_KERNEL "scalar"
+#endif
 static int g_idot=1;
+static int g_i4s=2;   /* min batch S for int4 IDOT; VNNI default 1 (set in main), I4S=n overrides */
 static inline float qrow_i8(const float *x, int8_t *q, int I){
     float amax=0; for(int i=0;i<I;i++){ float a=fabsf(x[i]); if(a>amax)amax=a; }
     float s=amax/127.f; if(s<1e-12f) s=1e-12f; float inv=1.f/s;
@@ -246,7 +256,21 @@ static inline int hsum256_i32(__m256i v){
  * coppie <= 128*127*2 = 32512 < 32767, accumulo s32 fino a I=16384. */
 static inline int32_t dot_i8i8(const int8_t *w, const int8_t *x, int I){
     int32_t sum=0; int i=0;
-#ifdef __AVX2__
+#if defined(__AVX512VNNI__) && defined(__AVX512BW__)
+    /* VNNI: vpdpbusd u8*s8 -> s32 directly, 64 bytes/iter, no 16-bit intermediate.
+     * AVX-512 has no vpsignb: |w| via abs, sign folded into x with a mask-negate
+     * (w==0 -> product 0 either way). |x|<=127 (qrow_i8), |w|<=128 as u8: each
+     * s32 lane adds <= 4*128*127, safe up to I=16384 like the AVX2 bound. */
+    __m512i acc=_mm512_setzero_si512();
+    for(;i+64<=I;i+=64){
+        __m512i wv=_mm512_loadu_si512((const void*)(w+i));
+        __m512i xv=_mm512_loadu_si512((const void*)(x+i));
+        __mmask64 neg=_mm512_movepi8_mask(wv);
+        __m512i xs=_mm512_mask_sub_epi8(xv,neg,_mm512_setzero_si512(),xv);
+        acc=_mm512_dpbusd_epi32(acc,_mm512_abs_epi8(wv),xs);
+    }
+    sum=_mm512_reduce_add_epi32(acc);
+#elif defined(__AVX2__)
     __m256i acc=_mm256_setzero_si256(); const __m256i ones=_mm256_set1_epi16(1);
     for(;i+32<=I;i+=32){
         __m256i wv=_mm256_loadu_si256((const __m256i*)(w+i));
@@ -277,7 +301,27 @@ static inline int32_t dot_i8i8(const int8_t *w, const int8_t *x, int I){
 /* dot int4(packed)·int8: nibble -> int8 [-8,7] al volo, poi stesso trucco */
 static inline int32_t dot_i4i8(const uint8_t *w4, const int8_t *x, int I){
     int32_t sum=0; int i=0;
-#ifdef __AVX2__
+#if defined(__AVX512VNNI__) && defined(__AVX512BW__)
+    /* 32 bytes = 64 nibbles -> int8 in [-8,7], one vpdpbusd per 64 values.
+     * 256-bit unpack leaves values in per-128-lane order [0-15][32-47]/[16-31][48-63];
+     * dot pairing is order-invariant, so permute x's 128-bit blocks to match
+     * instead of re-ordering w (one vpermq per iter, off the critical unpack path). */
+    const __m256i m4v=_mm256_set1_epi8(0x0F);
+    const __m512i b8v=_mm512_set1_epi8(8);
+    const __m512i xidx=_mm512_setr_epi64(0,1,4,5,2,3,6,7);
+    __m512i acc=_mm512_setzero_si512();
+    for(;i+64<=I;i+=64){
+        __m256i by=_mm256_loadu_si256((const __m256i*)(w4+(i>>1)));
+        __m256i lo=_mm256_and_si256(by,m4v), hi=_mm256_and_si256(_mm256_srli_epi16(by,4),m4v);
+        __m256i z0=_mm256_unpacklo_epi8(lo,hi), z1=_mm256_unpackhi_epi8(lo,hi);
+        __m512i wv=_mm512_sub_epi8(_mm512_inserti64x4(_mm512_castsi256_si512(z0),z1,1),b8v);
+        __m512i xv=_mm512_permutexvar_epi64(xidx,_mm512_loadu_si512((const void*)(x+i)));
+        __mmask64 neg=_mm512_movepi8_mask(wv);
+        __m512i xs=_mm512_mask_sub_epi8(xv,neg,_mm512_setzero_si512(),xv);
+        acc=_mm512_dpbusd_epi32(acc,_mm512_abs_epi8(wv),xs);
+    }
+    sum=_mm512_reduce_add_epi32(acc);
+#elif defined(__AVX2__)
     const __m128i m4=_mm_set1_epi8(0x0F); const __m256i b8=_mm256_set1_epi8(8);
     const __m256i ones=_mm256_set1_epi16(1);
     __m256i acc=_mm256_setzero_si256();
@@ -335,7 +379,7 @@ static void matmul_qt(float *y, const float *x, const QT *w, int S){
     if(w->fmt==0){ matmul(y,x,w->qf,S,w->I,w->O); return; }
     /* misurato (mmbench, 12 core): int8 IDOT vince sempre (1.4-2.5x); int4 IDOT vince
      * solo con S>=2 (1.8x) e PERDE a S=1 (unpack+sign non ripagano su una riga) */
-    if(g_idot && (w->fmt==1 || (w->fmt==2 && S>=2))){
+    if(g_idot && (w->fmt==1 || (w->fmt==2 && S>=g_i4s))){
         int I=w->I;
         int8_t *xq=malloc((size_t)S*I); float sxb[64]; float *sx=S<=64?sxb:falloc(S);
         for(int s=0;s<S;s++) sx[s]=qrow_i8(x+(int64_t)s*I, xq+(int64_t)s*I, I);
@@ -1708,6 +1752,11 @@ int main(int argc, char **argv){
     g_draft = getenv("DRAFT")?atoi(getenv("DRAFT")):-1;   /* -1 = auto: 3 se MTP, 0 senza */
     g_direct = getenv("DIRECT")?atoi(getenv("DIRECT")):0;
     g_idot = getenv("IDOT")?atoi(getenv("IDOT")):1;        /* 0 = kernel f32 esatti (A/B) */
+#if defined(__AVX512VNNI__) && defined(__AVX512BW__)
+    g_i4s = getenv("I4S")?atoi(getenv("I4S")):1;           /* VNNI: int4 IDOT pays even at S=1 */
+#else
+    g_i4s = getenv("I4S")?atoi(getenv("I4S")):2;           /* AVX2: single row loses (mmbench) */
+#endif
     g_absorb = getenv("ABSORB")?atoi(getenv("ABSORB")):-1; /* -1 auto: assorbita per S<=4 */
     g_dsa_force = getenv("DSA_FORCE")?atoi(getenv("DSA_FORCE")):0;
     g_temp = getenv("TEMP")?atof(getenv("TEMP")):-1;       /* -1 = auto (1.0 chat/testo, greedy altrove) */
@@ -1718,7 +1767,7 @@ int main(int argc, char **argv){
     int cap  = argc>1?atoi(argv[1]):64;
     int ebits= argc>2?atoi(argv[2]):8;
     int dbits= argc>3?atoi(argv[3]):ebits;
-    printf("== Motore C GLM (glm_moe_dsa), cache=%d expert/layer | expert@%d-bit densa@%d-bit ==\n", cap, ebits, dbits);
+    printf("== Motore C GLM (glm_moe_dsa), cache=%d expert/layer | expert@%d-bit densa@%d-bit | idot: " IDOT_KERNEL " ==\n", cap, ebits, dbits);
     g_mem_avail_boot = mem_available_gb();
     Model m; double t0=now_s(); model_init(&m,snap,cap,ebits,dbits);
     if(g_draft<0) g_draft = m.has_mtp ? 3 : 0;


### PR DESCRIPTION
## What this adds

Your README's scaling table ends with *"same RAM + 24–32 cores, or AVX-512/VNNI kernels — kernel work is the multiplier."* This PR is that row: guarded AVX-512 VNNI variants of the two integer-dot kernels, plus one gate change that turned out to matter more than the kernels themselves.

- `dot_i8i8` / `dot_i4i8` gain `#if defined(__AVX512VNNI__) && defined(__AVX512BW__)` branches: one `vpdpbusd` per 64 bytes (u8·s8 → s32 directly), replacing the 3-instruction `maddubs`/`madd`/`add` sequence per 32 bytes. AVX-512 has no `vpsignb`, so the sign trick becomes `abs(w)` + mask-negate on `x` — same result, `w==0` safe either way.
- In `dot_i4i8`, the 256-bit nibble unpack leaves values in per-lane order `[0-15][32-47]/[16-31][48-63]`; since dot pairing is order-invariant, the activation vector's 128-bit blocks are permuted to match (one `vpermq`) instead of re-sorting the weights.
- The int4 IDOT gate — hardcoded `S>=2` from your AVX2 mmbench finding that single rows don't pay for unpack+sign — becomes `g_i4s`: **default 1 under VNNI, unchanged 2 everywhere else**, `I4S=n` env override for A/B. This is where the speedup lives: single-row *decode* now runs the integer path. `I4S=2` restores today's behavior exactly.
- The startup banner reports the active kernel (`idot: avx512-vnni/avx2/neon/scalar`) so benchmark logs self-document.

## Correctness

- Where the integer paths already ran (int8 always; int4 at S≥2 — i.e. all prefill/scoring), outputs are **bit-identical**: s32 adds are associative and the existing bounds (pairs ≤ 32512, I ≤ 16384) hold unchanged. Verified empirically with greedy same-prompt runs.
- Single-row int4 under VNNI adopts the same int8-activation tradeoff IDOT already makes for S≥2 (~0.3% RMS per matmul, per the comment in the source). Greedy outputs on our test prompts stayed fully coherent. `IDOT=0` or `I4S=2` recover the exact f32 path.
- Non-VNNI builds are untouched: AVX2/NEON/scalar branches unmodified, `x86-64-v3` portable build verified clean, zero warnings on gcc 13.3.

## Measured

Hardware: Xeon 6 (24C/48T, AVX512-VNNI + AMX), 128GB DDR5-5600, 3× Samsung 990 Pro in VROC RAID 0 (iobench: 19.8 GB/s O_DIRECT, 8 threads), WSL2, gcc 13.3, `ARCH="native -mprefer-vector-width=512"`. Runtime config: `DIRECT=1 TOPP=0.7 cap=64`, 24 threads pinned to physical cores, greedy decoding, cold expert cache per run.

| workload | I4S=2 (old behavior) | I4S=1 (this PR's default) |
|---|---|---|
| short story, 256 tok | 1.72 tok/s (expert-matmul 41.5s) | **2.08 tok/s (+21%)** (expert-matmul 31.7s) |
| prose explainer, 128 tok | 1.45 tok/s (expert-matmul 21.3s) | **1.74 tok/s (+20%)** (expert-matmul 14.7s) |

For context, this machine's full ladder from stock defaults to this PR lands at 0.55 → 2.08 tok/s on the same workload.

Happy to follow up with: a README community-benchmark row for this hardware, MMLU/HellaSwag/ARC quality numbers (queued to run overnight on this rig), and an issue #8 datapoint — with the int8 MTP head on x86, `DRAFT=1` gets 59% acceptance and is a wash here rather than a loss (measured with these kernels active).
