### PR TITLE
IDOT: NEON single-token int4 gate (g_i4s/I4S) — SDOT makes S=1 decode…

### DIFF
--- a/c/glm.c
+++ b/c/glm.c
@@ -229,6 +229,14 @@ static void matmul_i2(float *y, const float *x, const uint8_t *q2, const float *
  * f32 dei pesi nel ciclo caldo. ~2-3x sui matmul quantizzati; errore aggiunto ~0.3%
  * RMS per matmul (attivazione int8), IDOT=0 torna al percorso f32 esatto. */
 static int g_idot=1;
+#if defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
+static int g_i4s=1;   /* SDOT presente: int4 IDOT conviene anche a S=1 (decode). Misurato
+                       * su Apple M-series: +14%%, expert-matmul -16%%. EN: with SDOT, int4
+                       * IDOT pays even at S=1 (decode); measured on Apple M-series. */
+#else
+static int g_i4s=2;   /* senza SDOT / altrove: soglia originale (misura AVX2 dell'autore).
+                       * EN: without SDOT / elsewhere: original threshold (author's AVX2). */
+#endif
 static inline float qrow_i8(const float *x, int8_t *q, int I){
     float amax=0; for(int i=0;i<I;i++){ float a=fabsf(x[i]); if(a>amax)amax=a; }
     float s=amax/127.f; if(s<1e-12f) s=1e-12f; float inv=1.f/s;
@@ -333,9 +341,13 @@ static void matmul_i4_idot(float *y, const int8_t *xq, const float *sx, const ui
 
 static void matmul_qt(float *y, const float *x, const QT *w, int S){
     if(w->fmt==0){ matmul(y,x,w->qf,S,w->I,w->O); return; }
-    /* misurato (mmbench, 12 core): int8 IDOT vince sempre (1.4-2.5x); int4 IDOT vince
-     * solo con S>=2 (1.8x) e PERDE a S=1 (unpack+sign non ripagano su una riga) */
-    if(g_idot && (w->fmt==1 || (w->fmt==2 && S>=2))){
+    /* int8 IDOT vince sempre (1.4-2.5x). int4 IDOT: l'autore su AVX2 trovo' che a S=1
+     * non ripaga (soglia S>=2); ma su ARM/SDOT il singolo token CONVIENE (vedi g_i4s /
+     * PR #9 per il gemello VNNI). Soglia configurabile con I4S.
+     * EN: int8 IDOT always wins (1.4-2.5x). int4 IDOT: on AVX2 the author found S=1 didn't
+     * pay (S>=2 gate); on ARM/SDOT single-token DOES pay (see g_i4s / PR #9 for the VNNI
+     * twin). Threshold configurable via I4S. */
+    if(g_idot && (w->fmt==1 || (w->fmt==2 && S>=g_i4s))){
         int I=w->I;
         int8_t *xq=malloc((size_t)S*I); float sxb[64]; float *sx=S<=64?sxb:falloc(S);
         for(int s=0;s<S;s++) sx[s]=qrow_i8(x+(int64_t)s*I, xq+(int64_t)s*I, I);
@@ -1708,6 +1720,7 @@ int main(int argc, char **argv){
     g_draft = getenv("DRAFT")?atoi(getenv("DRAFT")):-1;   /* -1 = auto: 3 se MTP, 0 senza */
     g_direct = getenv("DIRECT")?atoi(getenv("DIRECT")):0;
     g_idot = getenv("IDOT")?atoi(getenv("IDOT")):1;        /* 0 = kernel f32 esatti (A/B) */
+    g_i4s  = getenv("I4S")?atoi(getenv("I4S")):g_i4s;      /* soglia S per int4 IDOT (default: 1 con SDOT) / S threshold for int4 IDOT (default 1 with SDOT) */
     g_absorb = getenv("ABSORB")?atoi(getenv("ABSORB")):-1; /* -1 auto: assorbita per S<=4 */
     g_dsa_force = getenv("DSA_FORCE")?atoi(getenv("DSA_FORCE")):0;
     g_temp = getenv("TEMP")?atof(getenv("TEMP")):-1;       /* -1 = auto (1.0 chat/testo, greedy altrove) */


### PR DESCRIPTION
## 🇮🇹 Italiano

### Sommario

[PR #9](https://github.com/JustVugg/colibri/pull/9) ha mostrato che la soglia `S>=2` per l'int4
IDOT — ereditata da una misura **AVX2** ("una riga singola non ripaga unpack+sign") — lascia
prestazioni sul tavolo per il *decode* a token singolo, e l'ha riaperta sotto VNNI. **Questa
è la controparte NEON.** Su Apple Silicon con SDOT (`vdotq_s32`), instradare il decode int4
a `S=1` attraverso il kernel integer-dot `dot_i4i8` **già esistente** — invece del percorso
f32 — dà **+14% end-to-end** (misurato). La soglia `S=1`/`S>=2` diventa la variabile `g_i4s`,
con default **1 quando SDOT è presente**, invariata (2) altrove.

### Cosa cambia

- Nuovo `g_i4s`: soglia `S` sopra cui l'int4 usa l'IDOT. Default **1** sotto
  `__ARM_NEON && __ARM_FEATURE_DOTPROD`, **2** altrimenti (senza SDOT / x86).
- Il gate diventa `w->fmt==2 && S>=g_i4s` (prima: `S>=2` fisso). Env `I4S=n` per override/A-B;
  `I4S=2` ripristina esattamente il comportamento odierno.
- **Nessun kernel nuovo:** riusa `dot_i4i8` (SDOT) che c'è già; cambia solo la soglia del gate.
- x86/AVX2 invariato — quel caso è coperto da PR #9 (VNNI).

### Perché

Il percorso f32 dequantizza ogni nibble int4 → f32 e fa FMA in virgola mobile; SDOT salta la
conversione (dot int8→int32 diretto, scala alla fine). È lì che va il tempo a token singolo.
Microbench su una riga (ARM+dotprod): il kernel SDOT è **~3×** dell'f32. End-to-end il guadagno
è minore (il matmul è solo una parte del token), ma reale — vedi sotto.

### Test — A/B su Apple M5 Max (128 GB), motore con absorption+SDOT, MTP off, `--ram 80 --ngen 128`, stesso prompt

| config | tok/s | expert-matmul |
| --- | --- | --- |
| `I4S=2` (soglia attuale) | 1.07 | 45.4 s |
| `I4S=1` (default SDOT di questa PR) | **1.22 (+14%)** | **38.2 s (−16%)** |

Il segnale meccanico è `expert-matmul −16%`: è il matmul a token singolo che si accorcia.
Compila pulito su aarch64 **con e senza** `+dotprod` (rami `#if/#else`); x86 invariato. Output
greedy coerente. **Tradeoff:** a `S=1` l'int4 usa attivazioni quantizzate int8 (~0.3% RMS) —
lo stesso compromesso che l'IDOT già fa per `S>=2`. `I4S=2` o `IDOT=0` ripristinano il percorso
f32 esatto.

---

## 🇬🇧 English

### Summary

[PR #9](https://github.com/JustVugg/colibri/pull/9) showed that the int4 IDOT `S>=2` gate —
inherited from an **AVX2** measurement ("a single row doesn't pay for unpack+sign") — leaves
performance on the table for single-token *decode*, and re-opened it under VNNI. **This is the
NEON counterpart.** On Apple Silicon with SDOT (`vdotq_s32`), routing single-token (`S=1`) int4
decode through the **already-present** `dot_i4i8` integer-dot kernel — instead of the f32 path —
gives **+14% end-to-end** (measured). The `S=1`/`S>=2` threshold becomes `g_i4s`, defaulting to
**1 when SDOT is present**, unchanged (2) elsewhere.

### What changes

- New `g_i4s`: the `S` threshold above which int4 uses IDOT. Default **1** under
  `__ARM_NEON && __ARM_FEATURE_DOTPROD`, **2** otherwise (no SDOT / x86).
- The gate becomes `w->fmt==2 && S>=g_i4s` (was hardcoded `S>=2`). `I4S=n` overrides for A/B;
  `I4S=2` restores today's behavior exactly.
- **No new kernel:** reuses the existing `dot_i4i8` (SDOT); only the gate threshold changes.
- x86/AVX2 unchanged — that case is handled by PR #9 (VNNI).

### Why

The f32 path dequantizes every int4 nibble → f32 and does float FMA; SDOT skips the conversion
(int8→int32 dot directly, scale at the end). That conversion is where the single-token time
goes. Single-row microbench (ARM+dotprod): the SDOT kernel is **~3×** the f32 one. End-to-end
the gain is smaller (matmul is only part of a token), but real — see below.

### Testing — A/B on Apple M5 Max (128 GB), engine with absorption+SDOT, MTP off, `--ram 80 --ngen 128`, same prompt

| config | tok/s | expert-matmul |
| --- | --- | --- |
| `I4S=2` (current gate) | 1.07 | 45.4 s |
| `I4S=1` (this PR's SDOT default) | **1.22 (+14%)** | **38.2 s (−16%)** |

The mechanistic signal is `expert-matmul −16%` — the single-token matmul is what shrinks.
Compiles clean on aarch64 **with and without** `+dotprod` (`#if/#else` branches); x86 unchanged.
Greedy output stays coherent. **Tradeoff:** at `S=1`, int4 uses int8-quantized activations
(~0.3% RMS) — the same tradeoff IDOT already makes for `S>=2`. `I4S=2` or `IDOT=0` restore the
exact f32 path.
