### PR TITLE
RFC: live re-pin of the hot-store between turns (REPIN=n, opt-in, def…

### DIFF
--- a/c/glm.c
+++ b/c/glm.c
@@ -1464,6 +1464,55 @@ static void run_text(Model *m, const char *snap, const char *prompt, int ngen){
  * piu' umano, piu' veloce). Template chat GLM con token speciali (CHAT_TEMPLATE=0 -> grezzo).
  * Protocollo: "\x01\x01" "READY" "\x01\x01\n" dopo il load; risposta in streaming; "\x01\x01" "END" "\x01\x01\n" a fine turno.
  * ":reset" (riga "\x02RESET") azzera la memoria. EOF -> esce. */
+/* ---- RFC: RE-PIN A CALDO / LIVE RE-PIN (opt-in, REPIN=n, default OFF) ----
+ * Upstream fa AUTOPIN allo START (dalla storia .coli_usage). Questo aggiunge un re-pin
+ * TRA I TURNI: nel punto sicuro dopo la risposta scambia i pin peggiori con i non-pinnati
+ * piu' caldi, cosi' l'hot-store insegue il carico VIVO senza un profilo a parte. Isteresi
+ * 25% (+4) contro il ping-pong; max 4 scambi/passata (~20 MB di disco l'uno). Usa eusage
+ * cumulativo (l'aging LFU del mio fork non e' incluso qui: vedi PR.md).
+ * EN: upstream AUTOPINs at START (from .coli_usage). This adds a between-turns re-pin: at
+ * the safe point after the reply, swap the worst pins for the hottest unpinned, so the
+ * hot-store tracks the LIVE workload without a separate profile. 25% (+4) hysteresis vs
+ * ping-pong; max 4 swaps/pass (~20 MB disk each). Uses cumulative eusage (my fork's LFU
+ * aging is NOT included here: see PR.md). */
+static int g_repin=0;
+static uint64_t g_last_repin=0;
+typedef struct { long gain; int l, slot, eid; } RepinCand;
+static int repin_pick(Model *m, RepinCand *out, int maxc){
+    Cfg *c=&m->c; int nb=0;
+    for(int l=0;l<c->n_layers;l++){
+        if(!m->npin || m->npin[l]<1 || !m->eusage[l]) continue;
+        uint32_t *u=m->eusage[l]; ESlot *P=m->pin[l];
+        int zp=0; for(int z=1;z<m->npin[l];z++) if(u[P[z].eid]<u[P[zp].eid]) zp=z;   /* pin piu' freddo / coldest pin */
+        int eu=-1; uint32_t fu=0;
+        for(int e=0;e<c->n_experts;e++){
+            int pinned=0; for(int z=0;z<m->npin[l];z++) if(P[z].eid==e){pinned=1;break;}
+            if(!pinned && u[e]>fu){ fu=u[e]; eu=e; }                                 /* non-pin piu' caldo / hottest unpinned */
+        }
+        if(eu<0) continue;
+        uint32_t fp=u[P[zp].eid];
+        if(fu <= fp + (fp>>2) + 4) continue;                                         /* isteresi 25% / hysteresis */
+        long g=(long)fu-(long)fp;
+        if(nb<maxc){ out[nb].gain=g; out[nb].l=l; out[nb].slot=zp; out[nb].eid=eu; nb++; }
+        else { int w=0; for(int b=1;b<maxc;b++) if(out[b].gain<out[w].gain) w=b;
+               if(g>out[w].gain){ out[w].gain=g; out[w].l=l; out[w].slot=zp; out[w].eid=eu; } }
+    }
+    return nb;
+}
+static void repin_pass(Model *m){
+    if(g_repin<=0) return;
+    if(m->n_emit - g_last_repin < (uint64_t)g_repin) return;
+    g_last_repin = m->n_emit;
+    RepinCand cd[4]; int nb=repin_pick(m,cd,4);
+    for(int b=0;b<nb;b++){
+        int old=m->pin[cd[b].l][cd[b].slot].eid;
+        double t0=now_s();
+        expert_load(m, cd[b].l, cd[b].eid, &m->pin[cd[b].l][cd[b].slot]);
+        fprintf(stderr,"[REPIN] layer %d: esce/out %d (f=%u) <- entra/in %d (f=%u) in %.0f ms\n",
+            cd[b].l, old, m->eusage[cd[b].l][old], cd[b].eid, m->eusage[cd[b].l][cd[b].eid],
+            (now_s()-t0)*1e3);
+    }
+}
 static void run_serve(Model *m, const char *snap){
     char tkp[2048]; snprintf(tkp,sizeof(tkp),"%s/tokenizer.json",snap);
     Tok T; tok_load(&T,tkp);
@@ -1498,7 +1547,7 @@ static void run_serve(Model *m, const char *snap){
             double dh=(double)(m->hits-h0), dm=(double)(m->miss-ms0);
             printf("\n\x01\x01" "END" "\x01\x01\n");
             printf("STAT %d %.2f %.1f %.2f\n", prod, prod/tdt, (dh+dm)>0?100.0*dh/(dh+dm):0.0, rss_gb());
-            fflush(stdout); continue; }
+            fflush(stdout); repin_pass(m); continue; }   /* RFC: re-pin a caldo tra i turni / live re-pin between turns */
         if(nr<1){ printf("\x01\x01" "END" "\x01\x01\n"); printf("STAT 0 0.00 0.0 %.2f\n", rss_gb()); fflush(stdout); continue; }
         int bl=0;                                /* costruisce il testo del turno (con template) */
         /* template UFFICIALE GLM-5.2 (chat_template.jinja): niente \n dopo i ruoli, e dopo
@@ -1708,6 +1757,7 @@ int main(int argc, char **argv){
     g_draft = getenv("DRAFT")?atoi(getenv("DRAFT")):-1;   /* -1 = auto: 3 se MTP, 0 senza */
     g_direct = getenv("DIRECT")?atoi(getenv("DIRECT")):0;
     g_idot = getenv("IDOT")?atoi(getenv("IDOT")):1;        /* 0 = kernel f32 esatti (A/B) */
+    g_repin = getenv("REPIN")?atoi(getenv("REPIN")):0;     /* RFC: re-pin ogni n token emessi (0=off) / live re-pin every n emitted tokens (0=off) */
     g_absorb = getenv("ABSORB")?atoi(getenv("ABSORB")):-1; /* -1 auto: assorbita per S<=4 */
     g_dsa_force = getenv("DSA_FORCE")?atoi(getenv("DSA_FORCE")):0;
     g_temp = getenv("TEMP")?atof(getenv("TEMP")):-1;       /* -1 = auto (1.0 chat/testo, greedy altrove) */


### PR DESCRIPTION
## 🇮🇹 Italiano

### Cosa propongo

Oggi `AUTOPIN` fissa gli expert caldi **una volta all'avvio**, dalla storia `.coli_usage`.
Questa RFC aggiunge un re-pin **a caldo, tra i turni**: nel punto sicuro dopo che la risposta
è stata inviata (serve mode), scambia i pin peggiori con i non-pinnati più caldi, così
l'hot-store **insegue il carico vivo** durante una sessione lunga, senza rieseguire un profilo.

### Come è implementato (in questa PR)

- `repin_pick()`: per layer, trova il pin a frequenza minima e il non-pinnato a frequenza
  massima (da `eusage`, che upstream già mantiene); propone lo scambio **solo** se il secondo
  batte il primo di **>25% (+4)** — isteresi contro il ping-pong. Sceglie i 4 scambi migliori.
- `repin_pass()`: al massimo 4 scambi per passata (~20 MB di disco l'uno, il client ha già la
  risposta); chiamato dopo lo `STAT` di fine turno in `run_serve`.
- `REPIN=n`: attiva e regola la cadenza (ogni *n* token emessi). **Default 0 = OFF**: byte per
  byte identico a oggi finché non lo attivi.
- **Zero modifiche all'hot path** (routing/eviction) e nessun nuovo campo nel `Model`
  (uso una `static` per l'ultimo re-pin). Riusa `eusage`, `pin`, `expert_load` esistenti.

### Quanto è invasivo

Questa PR è **poco invasiva** (opt-in, +51 righe, solo `run_serve` + due funzioni). MA è solo
un **sottoinsieme** di un sistema più grande che ho nel mio fork (TIER-3), che include anche:

1. **Eviction LFU con aging** (stile TinyLFU): la vittima è l'expert a frequenza minima
   *decaduta* (i contatori si dimezzano ogni `LFU_W` selezioni), così "caldo" = "caldo di
   recente". Questo **tocca l'hot path** del routing MoE ed è più invasivo.
2. **Seeding del profilo** in `esel` normalizzato, così la storia parte avvantaggiata ma
   l'uso vivo può superarla.

Il re-pin di questa PR funziona anche da solo (con `eusage` cumulativo), ma rende il massimo
insieme all'aging LFU (frequenza recente invece che storica).

### Onestà sui numeri

**Non ho una misura di guadagno sul mio hardware.** Sul mio Mac (M5 Max, 128 GB) sono
matmul/banda-bound: la hit-rate del pin è ininfluente sul tok/s, quindi il re-pin non sposta i
miei tempi. Il valore atteso è su macchine **disk-bound** (come il tuo riferimento ~1 GB/s),
dove ogni miss costa una lettura da disco e un hot-store che insegue il carico vivo dovrebbe
alzare la hit-rate a regime. Non posso testarlo io — da qui l'RFC.

### Le domande per te

- Ti interessa il re-pin a caldo? Se sì, va bene **opt-in (REPIN, default off)** o lo vorresti
  legato ad `AUTOPIN`?
- Vuoi anche il **TIER-3 completo** (aging LFU + seeding)? Posso prepararlo, ma tocca l'hot
  path — meglio decidere prima.

---

## 🇬🇧 English

### What I'm proposing

Today `AUTOPIN` fixes the hot experts **once at startup**, from the `.coli_usage` history.
This RFC adds a **live, between-turns** re-pin: at the safe point after the reply is sent
(serve mode), it swaps the worst pins for the hottest unpinned experts, so the hot-store
**tracks the live workload** over a long session, without re-running a profile.

### How it's implemented (in this PR)

- `repin_pick()`: per layer, finds the lowest-frequency pin and the highest-frequency unpinned
  (from `eusage`, which upstream already maintains); proposes a swap **only** if the latter
  beats the former by **>25% (+4)** — hysteresis against ping-pong. Picks the best 4 swaps.
- `repin_pass()`: at most 4 swaps per pass (~20 MB disk each, the client already has its
  reply); called after the end-of-turn `STAT` in `run_serve`.
- `REPIN=n`: enables it and sets the cadence (every *n* emitted tokens). **Default 0 = OFF**:
  byte-for-byte identical to today until you turn it on.
- **Zero hot-path changes** (routing/eviction) and no new `Model` field (I use a `static` for
  the last re-pin mark). Reuses existing `eusage`, `pin`, `expert_load`.

### How invasive it is

This PR is **low-impact** (opt-in, +51 lines, just `run_serve` + two functions). BUT it's only
a **subset** of a larger system I have in my fork (TIER-3), which also includes:

1. **LFU eviction with aging** (TinyLFU-style): the victim is the lowest *decayed*-frequency
   expert (counters halve every `LFU_W` selections), so "hot" means "recently hot." This
   **touches the MoE routing hot path** and is more invasive.
2. **Profile seeding** into a normalized `esel`, so history starts ahead but live usage can
   overtake it.

The re-pin in this PR works on its own (with cumulative `eusage`), but it's most effective
together with LFU aging (recent frequency rather than all-time).

### Honesty about numbers

**I don't have a speedup measurement on my hardware.** On my Mac (M5 Max, 128 GB) I'm
matmul/bandwidth-bound: pin hit-rate doesn't move tok/s, so re-pin doesn't change my timings.
The expected value is on **disk-bound** machines (like your ~1 GB/s reference), where every
miss costs a disk read and a hot-store that follows the live workload should raise steady-state
hit-rate. I can't test that — hence the RFC.

### Questions for you

- Do you want live re-pin at all? If so, is **opt-in (REPIN, default off)** fine, or would you
  rather tie it to `AUTOPIN`?
- Do you also want the **full TIER-3** (LFU aging + seeding)? I can prepare it, but it touches
  the hot path — better to decide first.
