### PR TITLE
Add decode-only continuous batching

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -37,7 +37,7 @@ CUDA_ARCH ?= native
 NVCCFLAGS ?= -O3 -std=c++17 -arch=$(CUDA_ARCH) -Xcompiler=-Wall,-Wextra
 PYTHON    ?= python3
 CUDA_OBJ  =
-TEST_BINS = tests/test_json tests/test_st tests/test_tier
+TEST_BINS = tests/test_json tests/test_st tests/test_tier tests/test_decode_batch
 ifeq ($(CUDA),1)
 ifeq ($(UNAME_S),Darwin)
 $(error CUDA=1 is supported only on Linux)
@@ -75,6 +75,9 @@ tests/test_st: tests/test_st.c st.h json.h compat.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_tier: tests/test_tier.c tier.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+tests/test_decode_batch: tests/test_decode_batch.c decode_batch.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 test-c: $(TEST_BINS)

--- a/c/decode_batch.h
+++ b/c/decode_batch.h
@@ -1,0 +1,13 @@
+#ifndef COLIBRI_DECODE_BATCH_H
+#define COLIBRI_DECODE_BATCH_H
+
+#include <stddef.h>
+
+/* `base` belongs to one sequence's KV state.  Keeping this arithmetic in a
+ * model-independent seam makes ragged decode row ownership directly testable. */
+static inline float *coli_kv_row(float *base, int position, int width)
+{
+    return base + (size_t)position * (size_t)width;
+}
+
+#endif

--- a/c/decode_batch.h
+++ b/c/decode_batch.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdio.h>
+#include <math.h>
 
 /* `base` belongs to one sequence's KV state.  Keeping this arithmetic in a
  * model-independent seam makes ragged decode row ownership directly testable. */
@@ -27,7 +28,8 @@ static inline int coli_submit_parse(const char *line, ColiSubmit *s)
                &s->bytes, &s->max_tokens, &s->temperature, &s->top_p,
                &tail) != 6)
         return 0;
-    return s->bytes <= (16u << 20) && s->slot >= 0 && s->max_tokens >= 1 &&
+    return s->id > 0 && s->bytes <= (16u << 20) && s->slot >= 0 && s->max_tokens >= 1 &&
+           isfinite(s->temperature) && isfinite(s->top_p) &&
            s->temperature >= 0 && s->temperature <= 2 &&
            s->top_p > 0 && s->top_p <= 1;
 }

--- a/c/decode_batch.h
+++ b/c/decode_batch.h
@@ -2,12 +2,34 @@
 #define COLIBRI_DECODE_BATCH_H
 
 #include <stddef.h>
+#include <stdio.h>
 
 /* `base` belongs to one sequence's KV state.  Keeping this arithmetic in a
  * model-independent seam makes ragged decode row ownership directly testable. */
 static inline float *coli_kv_row(float *base, int position, int width)
 {
     return base + (size_t)position * (size_t)width;
+}
+
+typedef struct {
+    unsigned long long id, bytes;
+    int slot, max_tokens;
+    float temperature, top_p;
+} ColiSubmit;
+
+/* Parse the textual header. The payload is read separately using `bytes`, so
+ * it may contain newlines. Reject trailing fields to keep framing unambiguous. */
+static inline int coli_submit_parse(const char *line, ColiSubmit *s)
+{
+    char tail;
+    if (!line || !s ||
+        sscanf(line, "SUBMIT %llu %d %llu %d %f %f %c", &s->id, &s->slot,
+               &s->bytes, &s->max_tokens, &s->temperature, &s->top_p,
+               &tail) != 6)
+        return 0;
+    return s->bytes <= (16u << 20) && s->slot >= 0 && s->max_tokens >= 1 &&
+           s->temperature >= 0 && s->temperature <= 2 &&
+           s->top_p > 0 && s->top_p <= 1;
 }
 
 #endif

--- a/c/glm.c
+++ b/c/glm.c
@@ -32,6 +32,7 @@
 #include "st.h"
 #include "tok.h"
 #include "tier.h"
+#include "decode_batch.h"
 #ifdef COLI_CUDA
 #include <omp.h>
 #include "backend_cuda.h"
@@ -106,6 +107,11 @@ typedef struct {
     int disk_nrec;
     char disk_path[2048];
 } KVState;
+
+typedef struct {
+    KVState *kv;
+    int token, pos;
+} DecodeRow;
 
 typedef struct {
     Cfg c; shards S;
@@ -987,7 +993,10 @@ static int cmp_fdesc(const void *a,const void *b){
     float x=*(const float*)a, y=*(const float*)b; return x<y?1:x>y?-1:0; }
 
 /* attenzione MLA con KV-cache compressa, su token nuovi x[S,hidden], pos_base = pos del primo */
-static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_base, float *out){
+/* kvs/pos describe a ragged decode batch: each row may belong to a different
+ * sequence.  NULL keeps the original contiguous, currently-bound KV path. */
+static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int pos_base,
+                           KVState *const *kvs, const int *positions, float *out){
     Cfg *c=&m->c; int H=c->n_heads, D=c->hidden, qh=c->qk_head, vh=c->v_head;
     int kvb_dim=H*(c->qk_nope+vh), Tk=pos_base+S;
     double ta0=now_s();
@@ -997,14 +1006,16 @@ static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_ba
     /* 1) per ogni token nuovo: query roped + latente normato e k_rot roped -> in cache.
      * QR tiene il residuo q_a per TUTTE le posizioni: serve anche all'indexer DSA. */
     for(int s=0;s<S;s++){
-        const float *xs=x+(int64_t)s*D; int pos=pos_base+s;
+        KVState *ks=kvs?kvs[s]:m->kv;
+        const float *xs=x+(int64_t)s*D; int pos=positions?positions[s]:pos_base+s;
         float *qresid=QR+(int64_t)s*c->q_lora;
         matmul_qt(qresid, xs, &l->q_a, 1);
         rmsnorm(qresid, qresid, l->q_a_ln, c->q_lora, c->eps);
         float *qfull=Q+(int64_t)s*H*qh; matmul_qt(qfull, qresid, &l->q_b, 1);
         for(int h=0;h<H;h++) rope_interleave(qfull+(int64_t)h*qh+c->qk_nope, pos, c);
         matmul_qt(comp, xs, &l->kv_a, 1);
-        float *Ldst=m->Lc[layer]+(int64_t)pos*c->kv_lora, *Rdst=m->Rc[layer]+(int64_t)pos*c->qk_rope;
+        float *Ldst=coli_kv_row(ks->Lc[layer],pos,c->kv_lora);
+        float *Rdst=coli_kv_row(ks->Rc[layer],pos,c->qk_rope);
         memcpy(Ldst, comp, c->kv_lora*sizeof(float));
         rmsnorm(Ldst, Ldst, l->kv_a_ln, c->kv_lora, c->eps);     /* latente normato */
         memcpy(Rdst, comp+c->kv_lora, c->qk_rope*sizeof(float));
@@ -1015,12 +1026,13 @@ static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_ba
      * dai layer SHARED successivi). Selezione attiva solo con contesto > index_topk
      * (o DSA_FORCE=1 per il test: selezionare TUTTO deve dare l'output denso esatto). */
     const int *dsel=NULL, *dnsel=NULL; int dtopk=0;
-    if(m->has_dsa && layer<c->n_layers && m->kv_start[layer]==0){
+    if(m->has_dsa && layer<c->n_layers && ((!kvs && m->kv_start[layer]==0) || kvs)){
         int nh=c->index_nh, hd=c->index_hd; dtopk=c->index_topk;
         if(c->idx_type[layer]){
             for(int s=0;s<S;s++){
-                const float *xs=x+(int64_t)s*D; int pos=pos_base+s;
-                float *kd=m->Ic[layer]+(int64_t)pos*hd;
+                KVState *ks=kvs?kvs[s]:m->kv;
+                const float *xs=x+(int64_t)s*D; int pos=positions?positions[s]:pos_base+s;
+                float *kd=coli_kv_row(ks->Ic[layer],pos,hd);
                 matmul_qt(kd, xs, &m->ix_wk[layer], 1);
                 layernorm(kd, m->ix_knw[layer], m->ix_knb[layer], hd, 1e-6f);
                 rope_interleave(kd, pos, c);                 /* primi qk_rope dim, interleaved */
@@ -1033,7 +1045,9 @@ static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_ba
             }
             #pragma omp parallel for schedule(dynamic,1)
             for(int s=0;s<S;s++){
-                int pos=pos_base+s, nk=pos+1;
+                KVState *ks=kvs?kvs[s]:m->kv;
+                int pos=positions?positions[s]:pos_base+s, nk=pos+1;
+                if(ks->kv_start[layer]!=0){ m->dsa_nsel[s]=0; continue; }
                 if(nk<=dtopk && !g_dsa_force){ m->dsa_nsel[s]=0; continue; }
                 int keep = nk<dtopk ? nk : dtopk;
                 float *qi=falloc((int64_t)nh*hd);
@@ -1044,7 +1058,7 @@ static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_ba
                 float wsc=1.f/sqrtf((float)nh), rs=1.f/sqrtf((float)hd);
                 float *isc=falloc(nk);
                 for(int t=0;t<nk;t++){
-                    const float *kt=m->Ic[layer]+(int64_t)t*hd;
+                    const float *kt=coli_kv_row(ks->Ic[layer],t,hd);
                     float a=0;
                     for(int h=0;h<nh;h++){ const float *qhp=qi+(int64_t)h*hd;
                         float d0=0; for(int i=0;i<hd;i++) d0+=qhp[i]*kt[i];
@@ -1069,25 +1083,26 @@ static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_ba
      * k/v per ogni token del contesto. Per linearita':
      *   q·k_nope_t = (W_K^hT q_nope)·L_t      ctx^h = W_V^h (Σ_t a_t L_t)
      * costo per step ~O(T·kv_lora) invece di O(T·H·(nope+vh)) del matmul kvb_all. */
-    int absorb = g_absorb==1 || (g_absorb<0 && S<=4);
+    int absorb = kvs || g_absorb==1 || (g_absorb<0 && S<=4);
     if(absorb && c->kv_lora<=512){
         int kvl=c->kv_lora, r0v=c->qk_nope;      /* offset righe V dentro il blocco di testa */
         #pragma omp parallel for collapse(2) schedule(static)
         for(int s=0;s<S;s++) for(int h=0;h<H;h++){
-            int pos=pos_base+s;
+            KVState *ks=kvs?kvs[s]:m->kv;
+            int pos=positions?positions[s]:pos_base+s;
             const float *qp=Q+(int64_t)s*H*qh+(int64_t)h*qh;
             const float *qr=qp+c->qk_nope;
             int rbase=h*(c->qk_nope+vh);
             float qabs[512]; memset(qabs,0,kvl*sizeof(float));
             for(int d=0;d<c->qk_nope;d++) qt_addrow(&l->kv_b, rbase+d, qp[d], qabs);
             float sc[8192];
-            int st0=m->kv_start[layer];
+            int st0=ks->kv_start[layer];
             int ns = (dnsel && dnsel[s]>0) ? dnsel[s] : 0;    /* DSA: lista top-k o range pieno */
             const int *tlist = ns ? dsel+(int64_t)s*dtopk : NULL;
             int nt = ns ? ns : pos+1-st0;
             for(int jj=0;jj<nt;jj++){ int t = tlist ? tlist[jj] : st0+jj;
-                const float *Lt=m->Lc[layer]+(int64_t)t*kvl;
-                const float *kr=m->Rc[layer]+(int64_t)t*c->qk_rope;
+                const float *Lt=coli_kv_row(ks->Lc[layer],t,kvl);
+                const float *kr=coli_kv_row(ks->Rc[layer],t,c->qk_rope);
                 float a=0; for(int i=0;i<kvl;i++) a+=qabs[i]*Lt[i];
                 for(int d=0;d<c->qk_rope;d++) a+=qr[d]*kr[d];
                 sc[jj]=a*c->attn_scale;
@@ -1095,7 +1110,7 @@ static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_ba
             softmax(sc,nt);
             float clat[512]; memset(clat,0,kvl*sizeof(float));
             for(int jj=0;jj<nt;jj++){ int t = tlist ? tlist[jj] : st0+jj;
-                const float *Lt=m->Lc[layer]+(int64_t)t*kvl;
+                const float *Lt=coli_kv_row(ks->Lc[layer],t,kvl);
                 float a=sc[jj]; for(int i=0;i<kvl;i++) clat[i]+=a*Lt[i]; }
             qt_matvec_rows(&l->kv_b, rbase+r0v, vh, clat, ctx+((int64_t)s*H+h)*vh);
         }
@@ -1137,6 +1152,10 @@ static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_ba
     matmul_qt(out, ctx, &l->o, S);
     free(ctx); free(Q); free(QR); free(comp); free(kvb_all);
     m->t_attn += now_s()-ta0;
+}
+
+static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_base, float *out){
+    attention_rows(m,l,layer,x,S,pos_base,NULL,NULL,out);
 }
 
 /* MoE GLM su x[S,hidden] -> out (router sigmoid/noaux_tc, n_group=1, + shared expert).
@@ -1346,13 +1365,14 @@ static void pilot_prefetch(Model *m, int lnext, const float *x, int S){
 }
 
 /* forward di UN layer (usato dai 78 principali e dal layer MTP) */
-static void layer_forward(Model *m, Layer *l, int li, float *x, int S, int pos_base, float *nrm, float *tmp){
+static void layer_forward_rows(Model *m, Layer *l, int li, float *x, int S, int pos_base,
+                               KVState *const *kvs, const int *positions, float *nrm, float *tmp){
     Cfg *c=&m->c; int D=c->hidden;
     if(g_spec && g_prefetch && l->sparse && m->enr[li]>0)
         for(int z=0;z<m->enr[li];z++) expert_prefetch(m,li,m->eroute[li][z]);
     if(g_looka && S==1 && li<c->n_layers && l->sparse) la_predict(m,li,x,0);
     for(int s=0;s<S;s++) rmsnorm(nrm+(int64_t)s*D, x+(int64_t)s*D, l->in_ln, D, c->eps);
-    attention(m,l,li,nrm,S,pos_base,tmp);
+    attention_rows(m,l,li,nrm,S,pos_base,kvs,positions,tmp);
     for(int64_t j=0;j<(int64_t)S*D;j++) x[j]+=tmp[j];
     if(g_pilot && S<=8 && li+1<c->n_layers && m->L[li+1].sparse) pilot_prefetch(m,li+1,x,S);
     if(g_looka && S==1 && li+1<c->n_layers && m->L[li+1].sparse) la_predict(m,li+1,x,1);
@@ -1360,7 +1380,11 @@ static void layer_forward(Model *m, Layer *l, int li, float *x, int S, int pos_b
     if(l->sparse) moe(m,l,li,nrm,S,tmp); else dense_mlp(l,nrm,S,D,c->dense_inter,tmp);
     for(int64_t j=0;j<(int64_t)S*D;j++) x[j]+=tmp[j];
 }
-static void layers_forward(Model *m, float *x, int S, int pos_base){
+static void layer_forward(Model *m, Layer *l, int li, float *x, int S, int pos_base, float *nrm, float *tmp){
+    layer_forward_rows(m,l,li,x,S,pos_base,NULL,NULL,nrm,tmp);
+}
+static void layers_forward_rows(Model *m, float *x, int S, int pos_base,
+                                KVState *const *kvs, const int *positions){
     Cfg *c=&m->c; int D=c->hidden;
     float *nrm=falloc((int64_t)S*D), *tmp=falloc((int64_t)S*D);
     for(int i=0;i<c->n_layers;i++){
@@ -1368,9 +1392,12 @@ static void layers_forward(Model *m, float *x, int S, int pos_base){
          * puo' arrivare dopo MINUTI di streaming — al buio sembra un blocco. */
         if(S>=8 && (i%4==0 || i==c->n_layers-1))
             fprintf(stderr,"[prefill] layer %d/%d · %d token\n", i+1, c->n_layers, S);
-        layer_forward(m,&m->L[i],i,x,S,pos_base,nrm,tmp);
+        layer_forward_rows(m,&m->L[i],i,x,S,pos_base,kvs,positions,nrm,tmp);
     }
     free(nrm); free(tmp);
+}
+static void layers_forward(Model *m, float *x, int S, int pos_base){
+    layers_forward_rows(m,x,S,pos_base,NULL,NULL);
 }
 
 static void kv_alloc(Model *m, int max_t){
@@ -1422,6 +1449,35 @@ static float *step_all(Model *m, const int *ids, int S, int pos_base){
     for(int s=0;s<S;s++){ rmsnorm(row, x+(int64_t)s*D, m->final_norm, D, c->eps);
         matmul_qt(lo+(int64_t)s*c->vocab, row, &m->lm_head, 1); }
     free(x); free(row); return lo;
+}
+
+/* One decode token from each independent sequence, evaluated as a single MoE
+ * batch.  Prefill and speculative batches retain their contiguous-KV path. */
+static float *step_decode_batch(Model *m, const DecodeRow *rows, int S){
+    Cfg *c=&m->c; int D=c->hidden;
+    /* Ragged KV currently uses MLA absorption; the stack kernel is sized to 512. */
+    if(S<1 || S>64 || c->kv_lora>512) return NULL;
+    KVState *kvs[64]; int positions[64];
+    float *x=falloc((int64_t)S*D);
+    for(int s=0;s<S;s++){
+        if(!rows[s].kv || !rows[s].kv->Lc || rows[s].token<0 || rows[s].token>=c->vocab ||
+           rows[s].pos<0 || rows[s].pos>=rows[s].kv->max_t){
+            free(x); return NULL;
+        }
+        for(int p=0;p<s;p++) if(rows[p].kv==rows[s].kv){ free(x); return NULL; }
+        kvs[s]=rows[s].kv; positions[s]=rows[s].pos;
+        embed_row(m,rows[s].token,x+(int64_t)s*D);
+    }
+    layers_forward_rows(m,x,S,0,kvs,positions);
+    float *norm=falloc((int64_t)S*D);
+    for(int s=0;s<S;s++)
+        rmsnorm(norm+(int64_t)s*D,x+(int64_t)s*D,m->final_norm,D,c->eps);
+    double th0=now_s();
+    float *logit=falloc((int64_t)S*c->vocab);
+    matmul_qt(logit,norm,&m->lm_head,S);
+    m->t_head+=now_s()-th0;
+    free(x); free(norm);
+    return logit;
 }
 
 /* METODO E — prompt-lookup: cerca l'occorrenza piu' recente dell'ultimo bigramma nel

--- a/c/glm.c
+++ b/c/glm.c
@@ -2058,13 +2058,20 @@ static int mux_submit(Model *m, Tok *T, ServeCtx *ctx, ServeReq *req, int nctx,
     char *raw=malloc((size_t)sub.bytes+1);
     if(!raw){ fprintf(stderr,"OOM multiplex payload\n"); exit(1); }
     if(fread(raw,1,(size_t)sub.bytes,stdin)!=(size_t)sub.bytes){ free(raw); free(line); return -1; }
-    int delim=fgetc(stdin); if(delim!='\n' && delim!=EOF) ungetc(delim,stdin);
+    int delim=fgetc(stdin);
+    if(delim!='\n'){
+        printf("ERROR %llu BAD_FRAME\n",sub.id); fflush(stdout);
+        free(raw); free(line); return -1;
+    }
     raw[sub.bytes]=0;
     if(sub.slot>=nctx || memchr(raw,0,(size_t)sub.bytes)){
         printf("ERROR %llu BAD_REQUEST\n",sub.id); fflush(stdout); free(raw); free(line); return 0;
     }
     if(req[sub.slot].active){
         printf("ERROR %llu SLOT_BUSY\n",sub.id); fflush(stdout); free(raw); free(line); return 0;
+    }
+    for(int i=0;i<nctx;i++) if(req[i].active && req[i].id==sub.id){
+        printf("ERROR %llu DUPLICATE_ID\n",sub.id); fflush(stdout); free(raw); free(line); return 0;
     }
     ServeCtx *sc=&ctx[sub.slot]; kv_bind(m,&sc->kv);
     int *tmp=malloc(maxctx*sizeof(int));

--- a/c/glm.c
+++ b/c/glm.c
@@ -2053,6 +2053,18 @@ static int mux_submit(Model *m, Tok *T, ServeCtx *ctx, ServeReq *req, int nctx,
     char *line=NULL; size_t cap=0; ssize_t nr=getline(&line,&cap,stdin);
     if(nr<0){ free(line); return -1; }
     if(nr && line[nr-1]=='\n') line[--nr]=0;
+    if(!strncmp(line,"CANCEL ",7)){
+        unsigned long long id=0; char tail;
+        if(sscanf(line+7,"%llu %c",&id,&tail)!=1 || id==0){
+            printf("ERROR 0 BAD_REQUEST\n"); fflush(stdout); free(line); return 0;
+        }
+        for(int i=0;i<nctx;i++) if(req[i].active && req[i].id==id){
+            req[i].active=0; kv_bind(m,&ctx[i].kv);
+            kv_disk_append(m,ctx[i].hist,ctx[i].len);
+            printf("ERROR %llu CANCELLED\n",id); fflush(stdout); free(line); return 0;
+        }
+        printf("ERROR %llu NOT_FOUND\n",id); fflush(stdout); free(line); return 0;
+    }
     ColiSubmit sub; int valid=coli_submit_parse(line,&sub);
     if(!valid){ printf("ERROR 0 BAD_REQUEST\n"); fflush(stdout); free(line); return 0; }
     char *raw=malloc((size_t)sub.bytes+1);
@@ -2120,6 +2132,7 @@ static void run_serve_mux(Model *m, const char *snap){
         struct timeval tv={0,0}, *ptv=active?&tv:NULL;
         int ready=eof?0:select(STDIN_FILENO+1,&rfds,NULL,NULL,ptv);
         if(ready>0 && FD_ISSET(STDIN_FILENO,&rfds)) if(mux_submit(m,&T,ctx,req,nctx,maxctx,eos)<0) eof=1;
+        active=0; for(int i=0;i<nctx;i++) active+=req[i].active;
         if(!active){ if(eof) break; continue; }
         DecodeRow rows[16]; int slots[16], S=0;
         for(int i=0;i<nctx;i++) if(req[i].active){

--- a/c/glm.c
+++ b/c/glm.c
@@ -25,6 +25,7 @@
 #include <limits.h>
 #include <pthread.h>                              /* thread I/O del PILOTA */
 #include <unistd.h>
+#include <sys/select.h>
 #include <sys/resource.h>
 #if defined(__APPLE__) || defined(__linux__)
 #include <sys/mman.h>                             /* mlock: inchioda le pagine in RAM / wire pages into RAM */
@@ -1053,7 +1054,7 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
                 float *qi=falloc((int64_t)nh*hd);
                 matmul_qt(qi, QR+(int64_t)s*c->q_lora, &m->ix_wq[layer], 1);
                 for(int h=0;h<nh;h++) rope_interleave(qi+(int64_t)h*hd, pos, c);
-                float w32[64];
+                float *w32=falloc(nh);
                 matmul_qt(w32, x+(int64_t)s*D, &m->ix_wp[layer], 1);
                 float wsc=1.f/sqrtf((float)nh), rs=1.f/sqrtf((float)hd);
                 float *isc=falloc(nk);
@@ -1074,7 +1075,7 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
                 for(int t=0;t<nk && nd<keep;t++) if(isc[t]>thr) dst[nd++]=t;
                 for(int t=0;t<nk && nd<keep;t++) if(isc[t]==thr) dst[nd++]=t;
                 m->dsa_nsel[s]=nd;
-                free(qi); free(isc); free(tmp);
+                free(qi); free(w32); free(isc); free(tmp);
             }
         }
         if(m->dsa_nsel){ dsel=m->dsa_sel; dnsel=m->dsa_nsel; }
@@ -1095,11 +1096,11 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
             int rbase=h*(c->qk_nope+vh);
             float qabs[512]; memset(qabs,0,kvl*sizeof(float));
             for(int d=0;d<c->qk_nope;d++) qt_addrow(&l->kv_b, rbase+d, qp[d], qabs);
-            float sc[8192];
             int st0=ks->kv_start[layer];
             int ns = (dnsel && dnsel[s]>0) ? dnsel[s] : 0;    /* DSA: lista top-k o range pieno */
             const int *tlist = ns ? dsel+(int64_t)s*dtopk : NULL;
             int nt = ns ? ns : pos+1-st0;
+            float *sc=falloc(nt);
             for(int jj=0;jj<nt;jj++){ int t = tlist ? tlist[jj] : st0+jj;
                 const float *Lt=coli_kv_row(ks->Lc[layer],t,kvl);
                 const float *kr=coli_kv_row(ks->Rc[layer],t,c->qk_rope);
@@ -1113,6 +1114,7 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
                 const float *Lt=coli_kv_row(ks->Lc[layer],t,kvl);
                 float a=sc[jj]; for(int i=0;i<kvl;i++) clat[i]+=a*Lt[i]; }
             qt_matvec_rows(&l->kv_b, rbase+r0v, vh, clat, ctx+((int64_t)s*H+h)*vh);
+            free(sc);
         }
         matmul_qt(out, ctx, &l->o, S);
         free(ctx); free(Q); free(QR); free(comp);
@@ -1131,11 +1133,11 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
         int pos=pos_base+s;
         const float *qp=Q+(int64_t)s*H*qh+(int64_t)h*qh;          /* [qk_nope | qk_rope] */
         const float *qr=qp+c->qk_nope;
-        float sc[8192];
         int st0=m->kv_start[layer];
         int ns = (dnsel && dnsel[s]>0) ? dnsel[s] : 0;        /* DSA: lista top-k o range pieno */
         const int *tlist = ns ? dsel+(int64_t)s*dtopk : NULL;
         int nt = ns ? ns : pos+1-st0;
+        float *sc=falloc(nt);
         for(int jj=0;jj<nt;jj++){ int t = tlist ? tlist[jj] : st0+jj;
             const float *kn=kvb_all+(int64_t)t*kvb_dim+(int64_t)h*(c->qk_nope+vh);
             const float *kr=m->Rc[layer]+(int64_t)t*c->qk_rope;
@@ -1148,6 +1150,7 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
         for(int jj=0;jj<nt;jj++){ int t = tlist ? tlist[jj] : st0+jj;
             const float *vv=kvb_all+(int64_t)t*kvb_dim+(int64_t)h*(c->qk_nope+vh)+c->qk_nope;
             float a=sc[jj]; for(int d=0;d<vh;d++) cx[d]+=a*vv[d]; }
+        free(sc);
     }
     matmul_qt(out, ctx, &l->o, S);
     free(ctx); free(Q); free(QR); free(comp); free(kvb_all);
@@ -1456,13 +1459,20 @@ static float *step_all(Model *m, const int *ids, int S, int pos_base){
 static float *step_decode_batch(Model *m, const DecodeRow *rows, int S){
     Cfg *c=&m->c; int D=c->hidden;
     /* Ragged KV currently uses MLA absorption; the stack kernel is sized to 512. */
-    if(S<1 || S>64 || c->kv_lora>512) return NULL;
+    if(!rows || S<1 || S>64 || c->kv_lora>512) return NULL;
     KVState *kvs[64]; int positions[64];
     float *x=falloc((int64_t)S*D);
     for(int s=0;s<S;s++){
-        if(!rows[s].kv || !rows[s].kv->Lc || rows[s].token<0 || rows[s].token>=c->vocab ||
+        if(!rows[s].kv || !rows[s].kv->Lc || !rows[s].kv->Rc || !rows[s].kv->kv_start ||
+           rows[s].token<0 || rows[s].token>=c->vocab ||
            rows[s].pos<0 || rows[s].pos>=rows[s].kv->max_t){
             free(x); return NULL;
+        }
+        for(int l=0;l<c->n_layers;l++){
+            if(!rows[s].kv->Lc[l] || !rows[s].kv->Rc[l] ||
+               rows[s].kv->kv_start[l]<0 || rows[s].kv->kv_start[l]>rows[s].pos ||
+               (m->has_dsa && c->idx_type[l] &&
+                (!rows[s].kv->Ic || !rows[s].kv->Ic[l]))){ free(x); return NULL; }
         }
         for(int p=0;p<s;p++) if(rows[p].kv==rows[s].kv){ free(x); return NULL; }
         kvs[s]=rows[s].kv; positions[s]=rows[s].pos;
@@ -2011,6 +2021,121 @@ static void serve_ctx_free(Model *m, ServeCtx *s){
     free(k->Lc); free(k->Rc); free(k->Ic); free(k->kv_start); free(s->hist);
 }
 
+typedef struct {
+    int active, pending, emitted, maximum, prompt_tokens, length_limited;
+    unsigned long long id;
+    float temp, top_p;
+    double started;
+    uint64_t hits0, miss0;
+} ServeReq;
+
+static void mux_data(Tok *T, unsigned long long id, int token){
+    char out[256]; int n=tok_decode(T,&token,1,out,sizeof(out));
+    printf("DATA %llu %d\n",id,n); if(n>0) fwrite(out,1,(size_t)n,stdout); putchar('\n');
+    fflush(stdout);
+}
+
+static void mux_done(Model *m, ServeCtx *sc, ServeReq *r){
+    double dt=now_s()-r->started; if(dt<1e-6) dt=1e-6;
+    double dh=(double)(m->hits-r->hits0), dm=(double)(m->miss-r->miss0);
+    printf("DONE %llu STAT %d %.2f %.1f %.2f %d %d\n",r->id,r->emitted,
+           r->emitted/dt,(dh+dm)>0?100.0*dh/(dh+dm):0.0,rss_gb(),
+           r->prompt_tokens,r->length_limited);
+    fflush(stdout); kv_bind(m,&sc->kv); kv_disk_append(m,sc->hist,sc->len);
+    r->active=0;
+}
+
+/* Read and prefill one request. Returns -1 on EOF, 0 for a rejected frame and
+ * 1 for an accepted request. Prefill deliberately remains serial: continuous
+ * batching starts at decode, where every active slot contributes one row. */
+static int mux_submit(Model *m, Tok *T, ServeCtx *ctx, ServeReq *req, int nctx,
+                      int maxctx, int eos){
+    char *line=NULL; size_t cap=0; ssize_t nr=getline(&line,&cap,stdin);
+    if(nr<0){ free(line); return -1; }
+    if(nr && line[nr-1]=='\n') line[--nr]=0;
+    ColiSubmit sub; int valid=coli_submit_parse(line,&sub);
+    if(!valid){ printf("ERROR 0 BAD_REQUEST\n"); fflush(stdout); free(line); return 0; }
+    char *raw=malloc((size_t)sub.bytes+1);
+    if(!raw){ fprintf(stderr,"OOM multiplex payload\n"); exit(1); }
+    if(fread(raw,1,(size_t)sub.bytes,stdin)!=(size_t)sub.bytes){ free(raw); free(line); return -1; }
+    int delim=fgetc(stdin); if(delim!='\n' && delim!=EOF) ungetc(delim,stdin);
+    raw[sub.bytes]=0;
+    if(sub.slot>=nctx || memchr(raw,0,(size_t)sub.bytes)){
+        printf("ERROR %llu BAD_REQUEST\n",sub.id); fflush(stdout); free(raw); free(line); return 0;
+    }
+    if(req[sub.slot].active){
+        printf("ERROR %llu SLOT_BUSY\n",sub.id); fflush(stdout); free(raw); free(line); return 0;
+    }
+    ServeCtx *sc=&ctx[sub.slot]; kv_bind(m,&sc->kv);
+    int *tmp=malloc(maxctx*sizeof(int));
+    int nt=tok_encode(T,raw,(int)sub.bytes,tmp,maxctx-2);
+    free(raw); free(line);
+    if(nt<1){ free(tmp); printf("ERROR %llu EMPTY_PROMPT\n",sub.id); fflush(stdout); return 0; }
+    int prefix=0; while(prefix<sc->len && prefix<nt && sc->hist[prefix]==tmp[prefix]) prefix++;
+    if(prefix<sc->len){ sc->len=prefix; if(m->has_mtp) m->kv_start[m->c.n_layers]=-1;
+        kv_disk_truncate(m,sc->len); }
+    int add=nt-sc->len;
+    if(add>0) memcpy(sc->hist+sc->len,tmp+sc->len,(size_t)add*sizeof(int));
+    free(tmp);
+    float *logit = add>0 ? step(m,sc->hist+sc->len,add,sc->len)
+                         : step(m,sc->hist+sc->len-1,1,sc->len-1);
+    sc->len+=add; sc->first=0;
+    ServeReq *r=&req[sub.slot]; memset(r,0,sizeof(*r));
+    r->id=sub.id; r->maximum=sub.max_tokens; r->temp=sub.temperature; r->top_p=sub.top_p;
+    r->prompt_tokens=nt; r->started=now_s(); r->hits0=m->hits; r->miss0=m->miss;
+    int room=maxctx-sc->len-1; if(r->maximum>room){r->maximum=room; r->length_limited=1;}
+    g_temp=r->temp; g_nuc=r->top_p;
+    int next=pick_tok(logit,m->c.vocab,-1); free(logit);
+    if(r->maximum<=0 || next==eos || is_stop(next)){ mux_done(m,sc,r); return 1; }
+    r->pending=next; r->emitted=1; r->active=1; sc->hist[sc->len]=next; m->n_emit++;
+    mux_data(T,r->id,next);
+    if(r->emitted>=r->maximum) mux_done(m,sc,r);
+    return 1;
+}
+
+static void run_serve_mux(Model *m, const char *snap){
+    char tkp[2048]; snprintf(tkp,sizeof(tkp),"%s/tokenizer.json",snap);
+    Tok T; tok_load(&T,tkp); int eos=tok_id_of(&T,"<|endoftext|>"); stops_arm(&m->c,eos);
+    g_draft=0; /* one scheduler owns every forward; MTP/speculation is not ragged-safe */
+    int maxctx=getenv("CTX")?atoi(getenv("CTX")):4096;
+    int nctx=getenv("KV_SLOTS")?atoi(getenv("KV_SLOTS")):1;
+    if(nctx<1||nctx>16){fprintf(stderr,"KV_SLOTS deve essere tra 1 e 16\n");exit(2);}
+    g_kvsave=getenv("KVSAVE")?atoi(getenv("KVSAVE")):1;
+    KVState *initial=m->kv; free(initial->kv_start); free(initial);
+    ServeCtx *ctx=calloc(nctx,sizeof(*ctx)); ServeReq *req=calloc(nctx,sizeof(*req));
+    for(int i=0;i<nctx;i++) serve_ctx_init(m,&ctx[i],snap,i,maxctx);
+    setvbuf(stdin,NULL,_IONBF,0);
+    printf("\x01\x01READY\x01\x01\nSTAT 0 0.00 0.0 %.2f\n",rss_gb()); fflush(stdout);
+    int eof=0;
+    for(;;){
+        int active=0; for(int i=0;i<nctx;i++) active+=req[i].active;
+        fd_set rfds; FD_ZERO(&rfds); FD_SET(STDIN_FILENO,&rfds);
+        struct timeval tv={0,0}, *ptv=active?&tv:NULL;
+        int ready=eof?0:select(STDIN_FILENO+1,&rfds,NULL,NULL,ptv);
+        if(ready>0 && FD_ISSET(STDIN_FILENO,&rfds)) if(mux_submit(m,&T,ctx,req,nctx,maxctx,eos)<0) eof=1;
+        if(!active){ if(eof) break; continue; }
+        DecodeRow rows[16]; int slots[16], S=0;
+        for(int i=0;i<nctx;i++) if(req[i].active){
+            rows[S]=(DecodeRow){&ctx[i].kv,req[i].pending,ctx[i].len}; slots[S++]=i;
+        }
+        float *lo=step_decode_batch(m,rows,S); if(!lo){fprintf(stderr,"decode batch failed\n");break;}
+        m->n_fw++;
+        for(int s=0;s<S;s++){
+            int i=slots[s]; ServeCtx *sc=&ctx[i]; ServeReq *r=&req[i];
+            sc->len++; g_temp=r->temp; g_nuc=r->top_p;
+            int next=pick_tok(lo+(int64_t)s*m->c.vocab,m->c.vocab,-1);
+            if(next==eos || is_stop(next)){mux_done(m,sc,r);continue;}
+            r->pending=next; sc->hist[sc->len]=next; r->emitted++; m->n_emit++;
+            mux_data(&T,r->id,next);
+            if(r->emitted>=r->maximum) mux_done(m,sc,r);
+        }
+        free(lo);
+    }
+    usage_save(m);
+    for(int i=0;i<nctx;i++) serve_ctx_free(m,&ctx[i]); free(ctx); free(req);
+    m->kv=NULL; m->Lc=m->Rc=m->Ic=NULL; m->kv_start=NULL; m->max_t=0;
+}
+
 static void run_serve(Model *m, const char *snap){
     char tkp[2048]; snprintf(tkp,sizeof(tkp),"%s/tokenizer.json",snap);
     Tok T; tok_load(&T,tkp);
@@ -2537,7 +2662,11 @@ int main(int argc, char **argv){
     if(getenv("SCORE")){ run_score(&m, getenv("SCORE")); if(stats) stats_dump(&m,stats); return 0; }
 
     /* modo serve persistente per la CLI 'coli': SERVE=1 */
-    if(getenv("SERVE")){ run_serve(&m, snap); if(stats) stats_dump(&m,stats); return 0; }
+    if(getenv("SERVE")){
+        if(getenv("SERVE_BATCH") && atoi(getenv("SERVE_BATCH"))) run_serve_mux(&m,snap);
+        else run_serve(&m,snap);
+        if(stats) stats_dump(&m,stats); return 0;
+    }
 
     /* modo testo reale: PROMPT="..." [NGEN=n] -> tokenizza, genera, detokenizza */
     if(getenv("PROMPT")){

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -6,6 +6,7 @@ import codecs
 import collections
 import contextlib
 import json
+import math
 import os
 import select
 import queue
@@ -215,9 +216,11 @@ def generation_options(body, limit):
     top_p = 0.9 if top_p is None else top_p
     if isinstance(maximum, bool) or not isinstance(maximum, int) or not 1 <= maximum <= limit:
         raise APIError(400, f"`{maximum_param}` must be an integer between 1 and {limit}.", maximum_param)
-    if isinstance(temperature, bool) or not isinstance(temperature, (int, float)) or not 0 <= temperature <= 2:
+    if (isinstance(temperature, bool) or not isinstance(temperature, (int, float)) or
+            not math.isfinite(temperature) or not 0 <= temperature <= 2):
         raise APIError(400, "`temperature` must be between 0 and 2.", "temperature")
-    if isinstance(top_p, bool) or not isinstance(top_p, (int, float)) or not 0 < top_p <= 1:
+    if (isinstance(top_p, bool) or not isinstance(top_p, (int, float)) or
+            not math.isfinite(top_p) or not 0 < top_p <= 1):
         raise APIError(400, "`top_p` must be greater than 0 and at most 1.", "top_p")
     return maximum, float(temperature), float(top_p)
 
@@ -315,6 +318,8 @@ class Engine:
                 if kind == "DATA" and len(fields) == 3:
                     request_id = fields[1]
                     size = int(fields[2])
+                    if not 0 <= size <= 65536:
+                        raise RuntimeError("invalid engine DATA size")
                     data = self._read_exact(size)
                     if self._read_exact(1) != b"\n":
                         raise RuntimeError("invalid engine DATA terminator")
@@ -358,6 +363,8 @@ class Engine:
 
         events = queue.Queue()
         with self.pending_lock:
+            if self.closed:
+                raise RuntimeError("colibri engine is shutting down")
             if self.dispatcher_error is not None:
                 raise RuntimeError("colibri engine dispatcher stopped") from self.dispatcher_error
             if self.process.poll() is not None:
@@ -391,7 +398,10 @@ class Engine:
                 raise value
 
     def close(self):
-        self.closed = True
+        with self.pending_lock:
+            if self.closed:
+                return
+            self.closed = True
         self._fail_pending(RuntimeError("colibri engine is shutting down"))
         if self.process.poll() is None:
             self.process.terminate()
@@ -399,6 +409,9 @@ class Engine:
                 self.process.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 self.process.kill()
+                self.process.wait(timeout=5)
+        if self.dispatcher is not threading.current_thread():
+            self.dispatcher.join(timeout=5)
 
 
 def model_object(model_id, created):

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -8,6 +8,7 @@ import contextlib
 import json
 import os
 import select
+import queue
 import signal
 import socket
 import subprocess
@@ -54,18 +55,21 @@ def error_object(error):
 
 
 class GenerationScheduler:
-    """Bounded FIFO admission for the engine's single mutable KV context."""
+    """Bounded FIFO admission for the engine's independent KV contexts."""
 
-    def __init__(self, max_queue=8, queue_timeout=300):
+    def __init__(self, max_queue=8, queue_timeout=300, capacity=1):
         if max_queue < 0:
             raise ValueError("max_queue cannot be negative")
         if queue_timeout <= 0:
             raise ValueError("queue_timeout must be positive")
+        if capacity < 1:
+            raise ValueError("capacity must be positive")
         self.max_queue = max_queue
         self.queue_timeout = queue_timeout
+        self.capacity = capacity
         self.condition = threading.Condition()
         self.queue = collections.deque()
-        self.active = False
+        self.active = 0
         self.closed = False
         self.admitted = 0
         self.completed = 0
@@ -81,7 +85,7 @@ class GenerationScheduler:
             if self.closed:
                 raise APIError(503, "The inference scheduler is shutting down.", None,
                                "scheduler_closed", "server_error")
-            if (self.active or self.queue) and len(self.queue) >= self.max_queue:
+            if (self.active >= self.capacity or self.queue) and len(self.queue) >= self.max_queue:
                 self.rejected += 1
                 raise APIError(429, "The inference queue is full.", None, "queue_full",
                                "rate_limit_error", {"Retry-After": "1"})
@@ -93,7 +97,7 @@ class GenerationScheduler:
                     self.condition.notify_all()
                     raise APIError(503, "The inference scheduler is shutting down.", None,
                                    "scheduler_closed", "server_error")
-                if not self.active and self.queue[0] is ticket:
+                if self.active < self.capacity and self.queue[0] is ticket:
                     break
                 if cancelled and cancelled():
                     self.queue.remove(ticket)
@@ -109,20 +113,21 @@ class GenerationScheduler:
                                    "queue_timeout", "rate_limit_error", {"Retry-After": "1"})
                 self.condition.wait(min(remaining, 0.25))
             self.queue.popleft()
-            self.active = True
+            self.active += 1
             self.admitted += 1
             wait_seconds = time.monotonic() - queued_at
         try:
             yield wait_seconds
         finally:
             with self.condition:
-                self.active = False
+                self.active -= 1
                 self.completed += 1
                 self.condition.notify_all()
 
     def snapshot(self):
         with self.condition:
             return {"active": self.active, "queued": len(self.queue),
+                    "capacity": self.capacity,
                     "max_queue": self.max_queue, "queue_timeout_seconds": self.queue_timeout,
                     "admitted": self.admitted, "completed": self.completed,
                     "rejected": self.rejected, "timed_out": self.timed_out,
@@ -248,15 +253,95 @@ def read_engine_turn(stream, sentinel, on_bytes):
 
 class Engine:
     def __init__(self, executable, model, cap=8, max_tokens=1024, env=None, kv_slots=1):
-        child_env = dict(env or os.environ, SNAP=str(model), SERVE="1", NGEN=str(max_tokens),
-                         KV_SLOTS=str(kv_slots))
+        child_env = dict(env or os.environ, SNAP=str(model), SERVE="1", SERVE_BATCH="1",
+                         NGEN=str(max_tokens), KV_SLOTS=str(kv_slots))
         self.process = subprocess.Popen(
             [str(executable), str(cap)], env=child_env, stdin=subprocess.PIPE,
             stdout=subprocess.PIPE, bufsize=0,
         )
-        self.lock = threading.Lock()
+        self.write_lock = threading.Lock()
+        self.pending_lock = threading.Lock()
+        self.pending = {}
+        self.next_request_id = 1
+        self.closed = False
+        self.dispatcher_error = None
         self.kv_slots = kv_slots
         read_engine_turn(self.process.stdout, READY, lambda _: None)
+        self.dispatcher = threading.Thread(target=self._dispatch_stdout,
+                                           name="colibri-stdout", daemon=True)
+        self.dispatcher.start()
+
+    @staticmethod
+    def _stats(fields):
+        if len(fields) < 5 or fields[0] != "STAT":
+            raise RuntimeError(f"invalid engine status: {' '.join(fields)}")
+        return {
+            "completion_tokens": int(fields[1]),
+            "tokens_per_second": float(fields[2]),
+            "cache_hit_percent": float(fields[3]),
+            "rss_gb": float(fields[4]),
+            "prompt_tokens": int(fields[5]) if len(fields) > 5 else 0,
+            "length_limited": bool(int(fields[6])) if len(fields) > 6 else False,
+        }
+
+    def _fail_pending(self, error):
+        with self.pending_lock:
+            requests = list(self.pending.values())
+            self.pending.clear()
+        for events in requests:
+            events.put(("error", error))
+
+    def _read_exact(self, size):
+        chunks = []
+        remaining = size
+        while remaining:
+            chunk = self.process.stdout.read(remaining)
+            if chunk == b"":
+                raise RuntimeError("truncated engine DATA payload")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+    def _dispatch_stdout(self):
+        try:
+            while True:
+                line = self.process.stdout.readline()
+                if line == b"":
+                    raise RuntimeError("colibri engine exited unexpectedly")
+                fields = line.decode("utf-8", "replace").strip().split()
+                if not fields:
+                    continue
+                kind = fields[0]
+                if kind == "DATA" and len(fields) == 3:
+                    request_id = fields[1]
+                    size = int(fields[2])
+                    data = self._read_exact(size)
+                    if self._read_exact(1) != b"\n":
+                        raise RuntimeError("invalid engine DATA terminator")
+                    with self.pending_lock:
+                        events = self.pending.get(request_id)
+                    if events is not None:
+                        events.put(("data", data))
+                elif kind == "DONE" and len(fields) >= 7:
+                    request_id = fields[1]
+                    stats = self._stats(fields[2:])
+                    with self.pending_lock:
+                        events = self.pending.pop(request_id, None)
+                    if events is not None:
+                        events.put(("done", stats))
+                elif kind == "ERROR" and len(fields) >= 2:
+                    request_id = fields[1]
+                    message = " ".join(fields[2:]) or "engine request failed"
+                    with self.pending_lock:
+                        events = self.pending.pop(request_id, None)
+                    if events is not None:
+                        events.put(("error", RuntimeError(message)))
+                else:
+                    raise RuntimeError(f"invalid engine response: {' '.join(fields)}")
+        except Exception as error:
+            if not self.closed:
+                self.dispatcher_error = error
+                self._fail_pending(error)
 
     def generate(self, prompt, max_tokens, temperature, top_p, on_text, cache_slot=0):
         if isinstance(cache_slot, bool) or not isinstance(cache_slot, int) or not 0 <= cache_slot < self.kv_slots:
@@ -271,20 +356,43 @@ class Engine:
             if text:
                 on_text(text)
 
-        with self.lock:
+        events = queue.Queue()
+        with self.pending_lock:
+            if self.dispatcher_error is not None:
+                raise RuntimeError("colibri engine dispatcher stopped") from self.dispatcher_error
             if self.process.poll() is not None:
                 raise RuntimeError("colibri engine is not running")
-            header = (f"\x02PROMPT {len(payload)} {max_tokens} {temperature:.8g} "
-                      f"{top_p:.8g} {cache_slot}\n").encode()
-            self.process.stdin.write(header + payload + b"\n")
-            self.process.stdin.flush()
-            stats = read_engine_turn(self.process.stdout, END, decode)
-            tail = decoder.decode(b"", final=True)
-            if tail:
-                on_text(tail)
-            return stats
+            request_id = str(self.next_request_id)
+            self.next_request_id += 1
+            self.pending[request_id] = events
+        header = (f"SUBMIT {request_id} {cache_slot} {len(payload)} {max_tokens} "
+                  f"{temperature:.8g} {top_p:.8g}\n").encode()
+        try:
+            with self.write_lock:
+                if self.process.poll() is not None:
+                    raise RuntimeError("colibri engine is not running")
+                self.process.stdin.write(header + payload + b"\n")
+                self.process.stdin.flush()
+        except Exception:
+            with self.pending_lock:
+                self.pending.pop(request_id, None)
+            raise
+
+        while True:
+            kind, value = events.get()
+            if kind == "data":
+                decode(value)
+            elif kind == "done":
+                tail = decoder.decode(b"", final=True)
+                if tail:
+                    on_text(tail)
+                return value
+            else:
+                raise value
 
     def close(self):
+        self.closed = True
+        self._fail_pending(RuntimeError("colibri engine is shutting down"))
         if self.process.poll() is None:
             self.process.terminate()
             try:
@@ -308,7 +416,7 @@ class APIServer(ThreadingHTTPServer):
         self.model_id = model_id
         self.api_key = api_key
         self.max_tokens = max_tokens
-        self.scheduler = GenerationScheduler(max_queue, queue_timeout)
+        self.scheduler = GenerationScheduler(max_queue, queue_timeout, kv_slots)
         self.kv_slots = kv_slots
         self.cors_origins = tuple(cors_origins)
         self.created = int(time.time())

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -696,20 +696,25 @@ def serve(model, host="127.0.0.1", port=8000, model_id="glm-5.2-colibri", api_ke
         raise ValueError("kv_slots must be between 1 and 16")
     if host not in ("127.0.0.1", "localhost", "::1") and not api_key:
         print("WARNING: API is listening beyond localhost without COLI_API_KEY", file=sys.stderr)
-    runtime = Engine(engine,model,cap,max_tokens,env,kv_slots)
     origins = DEFAULT_CORS_ORIGINS if cors_origins is None else tuple(cors_origins)
-    server = APIServer((host, port), runtime, model_id, api_key, max_tokens, origins,
+    # Bind before starting the 744B engine. A stale/occupied port must fail in
+    # milliseconds rather than loading hundreds of GB and leaking a child.
+    server = APIServer((host, port), None, model_id, api_key, max_tokens, origins,
                        max_queue, queue_timeout, kv_slots)
-    print(f"OpenAI-compatible API listening on http://{host}:{port}/v1", file=sys.stderr)
+    runtime = None
     previous_sigterm = signal.getsignal(signal.SIGTERM)
-    signal.signal(signal.SIGTERM, lambda *_: threading.Thread(target=server.shutdown, daemon=True).start())
     try:
+        runtime = Engine(engine,model,cap,max_tokens,env,kv_slots)
+        server.engine = runtime
+        print(f"OpenAI-compatible API listening on http://{host}:{port}/v1", file=sys.stderr)
+        signal.signal(signal.SIGTERM, lambda *_: threading.Thread(target=server.shutdown, daemon=True).start())
         server.serve_forever()
     finally:
         signal.signal(signal.SIGTERM, previous_sigterm)
         server.scheduler.close()
         server.server_close()
-        runtime.close()
+        if runtime is not None:
+            runtime.close()
 
 
 def main():

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -348,7 +348,8 @@ class Engine:
                 self.dispatcher_error = error
                 self._fail_pending(error)
 
-    def generate(self, prompt, max_tokens, temperature, top_p, on_text, cache_slot=0):
+    def generate(self, prompt, max_tokens, temperature, top_p, on_text, cache_slot=0,
+                 cancelled=None):
         if isinstance(cache_slot, bool) or not isinstance(cache_slot, int) or not 0 <= cache_slot < self.kv_slots:
             raise APIError(400, "Invalid cache slot.", "cache_slot")
         payload = prompt.encode("utf-8")
@@ -385,15 +386,24 @@ class Engine:
                 self.pending.pop(request_id, None)
             raise
 
+        cancel_sent = False
         while True:
             kind, value = events.get()
             if kind == "data":
-                decode(value)
+                if not cancel_sent:
+                    decode(value)
+                    if cancelled and cancelled():
+                        cancel_sent = True
+                        with self.write_lock:
+                            self.process.stdin.write(f"CANCEL {request_id}\n".encode())
+                            self.process.stdin.flush()
             elif kind == "done":
                 tail = decoder.decode(b"", final=True)
                 if tail:
                     on_text(tail)
                 return value
+            elif cancel_sent and isinstance(value, RuntimeError) and str(value) == "CANCELLED":
+                raise ClientCancelled()
             else:
                 raise value
 
@@ -569,7 +579,8 @@ class APIHandler(BaseHTTPRequestHandler):
             if not stream:
                 output = []
                 stats = self.server.engine.generate(
-                    prompt, maximum, temperature, top_p, output.append, cache_slot)
+                    prompt, maximum, temperature, top_p, output.append, cache_slot,
+                    self.client_disconnected)
                 text = "".join(output)
                 finish = "length" if stats["length_limited"] else "stop"
                 choice = ({"index": 0, "message": {"role": "assistant", "content": text,
@@ -617,7 +628,8 @@ class APIHandler(BaseHTTPRequestHandler):
                 event([choice])
 
             stats = self.server.engine.generate(
-                prompt, maximum, temperature, top_p, emit, cache_slot)
+                prompt, maximum, temperature, top_p, emit, cache_slot,
+                lambda: not connected)
             finish = "length" if stats["length_limited"] else "stop"
             final_choice = ({"index": 0, "delta": {}, "logprobs": None, "finish_reason": finish}
                             if chat else {"index": 0, "text": "", "logprobs": None,

--- a/c/tests/test_decode_batch.c
+++ b/c/tests/test_decode_batch.c
@@ -1,0 +1,38 @@
+#include <assert.h>
+#include <stdio.h>
+
+#include "../decode_batch.h"
+
+static void test_rows_use_their_own_sequence_storage(void)
+{
+    float sequence_a[4 * 3] = {0};
+    float sequence_b[4 * 3] = {0};
+
+    float *a2 = coli_kv_row(sequence_a, 2, 3);
+    float *b1 = coli_kv_row(sequence_b, 1, 3);
+    a2[0] = 20.0f;
+    b1[2] = 12.0f;
+
+    assert(a2 == &sequence_a[6]);
+    assert(b1 == &sequence_b[3]);
+    assert(sequence_a[6] == 20.0f);
+    assert(sequence_b[5] == 12.0f);
+    assert(sequence_a[5] == 0.0f);
+    assert(sequence_b[6] == 0.0f);
+}
+
+static void test_const_reader_selects_the_same_row(void)
+{
+    float storage[5 * 7] = {0};
+    const float *row = coli_kv_row(storage, 4, 7);
+
+    assert(row == &storage[28]);
+}
+
+int main(void)
+{
+    test_rows_use_their_own_sequence_storage();
+    test_const_reader_selects_the_same_row();
+    puts("decode batch helper tests: ok");
+    return 0;
+}

--- a/c/tests/test_decode_batch.c
+++ b/c/tests/test_decode_batch.c
@@ -38,6 +38,11 @@ static void test_submit_header(void)
     assert(!coli_submit_parse("SUBMIT 1 -1 2 3 0.7 1", &sub));
     assert(!coli_submit_parse("SUBMIT 1 0 2 0 0.7 1", &sub));
     assert(!coli_submit_parse("SUBMIT 1 0 2 3 4 1", &sub));
+    assert(!coli_submit_parse("SUBMIT 0 0 2 3 1 1", &sub));
+    assert(!coli_submit_parse("SUBMIT 1 0 2 3 nan 1", &sub));
+    assert(!coli_submit_parse("SUBMIT 1 0 2 3 1 inf", &sub));
+    assert(coli_submit_parse("SUBMIT 1 0 16777216 3 1 1", &sub));
+    assert(!coli_submit_parse("SUBMIT 1 0 16777217 3 1 1", &sub));
     assert(!coli_submit_parse("SUBMIT 1 0 2 3 1 1 trailing", &sub));
 }
 

--- a/c/tests/test_decode_batch.c
+++ b/c/tests/test_decode_batch.c
@@ -29,10 +29,23 @@ static void test_const_reader_selects_the_same_row(void)
     assert(row == &storage[28]);
 }
 
+static void test_submit_header(void)
+{
+    ColiSubmit sub;
+    assert(coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95", &sub));
+    assert(sub.id == 42 && sub.slot == 3 && sub.bytes == 17);
+    assert(sub.max_tokens == 64 && sub.temperature > .69f && sub.top_p > .94f);
+    assert(!coli_submit_parse("SUBMIT 1 -1 2 3 0.7 1", &sub));
+    assert(!coli_submit_parse("SUBMIT 1 0 2 0 0.7 1", &sub));
+    assert(!coli_submit_parse("SUBMIT 1 0 2 3 4 1", &sub));
+    assert(!coli_submit_parse("SUBMIT 1 0 2 3 1 1 trailing", &sub));
+}
+
 int main(void)
 {
     test_rows_use_their_own_sequence_storage();
     test_const_reader_selects_the_same_row();
+    test_submit_header();
     puts("decode batch helper tests: ok");
     return 0;
 }

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -16,7 +16,8 @@ class FakeEngine:
     def __init__(self):
         self.calls = []
 
-    def generate(self, prompt, maximum, temperature, top_p, on_text, cache_slot=0):
+    def generate(self, prompt, maximum, temperature, top_p, on_text, cache_slot=0,
+                 cancelled=None):
         self.calls.append((prompt, maximum, temperature, top_p, cache_slot))
         on_text("Hé")
         on_text("llo")
@@ -29,10 +30,12 @@ class BlockingEngine(FakeEngine):
         self.entered = threading.Event()
         self.release = threading.Event()
 
-    def generate(self, prompt, maximum, temperature, top_p, on_text, cache_slot=0):
+    def generate(self, prompt, maximum, temperature, top_p, on_text, cache_slot=0,
+                 cancelled=None):
         self.entered.set()
         self.release.wait(2)
-        return super().generate(prompt, maximum, temperature, top_p, on_text, cache_slot)
+        return super().generate(prompt, maximum, temperature, top_p, on_text, cache_slot,
+                                cancelled)
 
 
 class TemplateTest(unittest.TestCase):
@@ -355,6 +358,29 @@ class DispatcherTest(unittest.TestCase):
         engine.generate("hello", 4, 0.7, 0.9, chunks.append)
         engine.close()
         self.assertEqual(chunks, ["é"])
+
+    def test_cancels_generation_after_consumer_disconnects(self):
+        request_id = None
+
+        def respond(process, frame):
+            nonlocal request_id
+            fields = frame.split()
+            if fields[0] == b"SUBMIT":
+                request_id = fields[1]
+                process.stdout.feed(b"DATA " + request_id + b" 1\nx\n")
+            elif fields[0] == b"CANCEL":
+                self.assertEqual(fields[1], request_id)
+                process.stdout.feed(b"ERROR " + request_id + b" CANCELLED\n")
+
+        process = FakeProcess(respond)
+        with patch("openai_server.subprocess.Popen", return_value=process):
+            engine = Engine("glm", "model")
+        output = []
+        with self.assertRaises(ClientCancelled):
+            engine.generate("hello", 8, 0.7, 0.9, output.append, cancelled=lambda: True)
+        engine.close()
+        self.assertEqual(output, ["x"])
+        self.assertEqual(process.writes[-1].split(), [b"CANCEL", request_id])
 
 
 class HTTPTest(unittest.TestCase):

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -2,11 +2,13 @@ import io
 import json
 import threading
 import unittest
+from unittest.mock import patch
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 from openai_server import (APIError, APIServer, ClientCancelled, END, GenerationScheduler,
-                           generation_options, read_engine_turn, render_chat, serve)
+                           READY, Engine, generation_options, read_engine_turn, render_chat,
+                           serve)
 
 
 class FakeEngine:
@@ -84,6 +86,12 @@ class ProtocolTest(unittest.TestCase):
 
 
 class SchedulerTest(unittest.TestCase):
+    def test_admits_up_to_capacity_without_serializing(self):
+        scheduler = GenerationScheduler(max_queue=0, queue_timeout=1, capacity=2)
+        with scheduler.admit():
+            with scheduler.admit():
+                self.assertEqual(scheduler.snapshot()["active"], 2)
+
     def test_rejects_when_waiting_queue_is_full(self):
         scheduler = GenerationScheduler(max_queue=0, queue_timeout=1)
         with scheduler.admit():
@@ -158,6 +166,131 @@ class SchedulerTest(unittest.TestCase):
         second = threading.Thread(target=waiting); second.start()
         scheduler.close(); release.set(); first.join(1); second.join(1)
         self.assertEqual(errors, ["scheduler_closed"])
+
+
+class BlockingStream:
+    def __init__(self, initial=b""):
+        self.buffer = bytearray(initial)
+        self.closed = False
+        self.condition = threading.Condition()
+
+    def feed(self, data):
+        with self.condition:
+            self.buffer.extend(data)
+            self.condition.notify_all()
+
+    def read(self, size=1):
+        with self.condition:
+            while len(self.buffer) < size and not self.closed:
+                self.condition.wait()
+            if not self.buffer and self.closed:
+                return b""
+            size = min(size, len(self.buffer))
+            data = bytes(self.buffer[:size])
+            del self.buffer[:size]
+            return data
+
+    def readline(self):
+        with self.condition:
+            while b"\n" not in self.buffer and not self.closed:
+                self.condition.wait()
+            if not self.buffer and self.closed:
+                return b""
+            end = self.buffer.find(b"\n")
+            size = len(self.buffer) if end < 0 else end + 1
+            data = bytes(self.buffer[:size])
+            del self.buffer[:size]
+            return data
+
+    def close(self):
+        with self.condition:
+            self.closed = True
+            self.condition.notify_all()
+
+
+class FakeProcess:
+    def __init__(self, on_write):
+        self.stdout = BlockingStream(READY + b"STAT 0 0 0 0\n")
+        self.stdin = self
+        self.on_write = on_write
+        self.writes = []
+        self.returncode = None
+
+    def write(self, data):
+        self.writes.append(data)
+        self.on_write(self, data)
+        return len(data)
+
+    def flush(self):
+        pass
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.returncode = 0
+        self.stdout.close()
+
+    def wait(self, timeout=None):
+        return self.returncode
+
+    def kill(self):
+        self.terminate()
+
+
+class DispatcherTest(unittest.TestCase):
+    def test_dispatches_interleaved_requests_by_id(self):
+        submitted = []
+
+        def respond(process, frame):
+            fields = frame.split(b"\n", 1)[0].split()
+            self.assertEqual(fields[0], b"SUBMIT")
+            submitted.append(fields[1])
+            if len(submitted) == 2:
+                first, second = submitted
+                process.stdout.feed(b"DATA " + second + b" 3\nB-2\n")
+                process.stdout.feed(b"DATA " + first + b" 3\nA-1\n")
+                process.stdout.feed(b"DONE " + second + b" STAT 1 2.5 0 1.0 4 0\n")
+                process.stdout.feed(b"DATA " + first + b" 3\nA-2\n")
+                process.stdout.feed(b"DONE " + first + b" STAT 2 3.5 0 1.0 5 1\n")
+
+        process = FakeProcess(respond)
+        with patch("openai_server.subprocess.Popen", return_value=process):
+            engine = Engine("glm", "model", kv_slots=2)
+        results = {}
+
+        def generate(name, prompt, slot):
+            chunks = []
+            stats = engine.generate(prompt, 8, 0.7, 0.9, chunks.append, slot)
+            results[name] = ("".join(chunks), stats)
+
+        threads = [threading.Thread(target=generate, args=("a", "alpha", 0)),
+                   threading.Thread(target=generate, args=("b", "beta", 1))]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=2)
+            self.assertFalse(thread.is_alive())
+        engine.close()
+
+        self.assertEqual(results["a"][0], "A-1A-2")
+        self.assertTrue(results["a"][1]["length_limited"])
+        self.assertEqual(results["b"][0], "B-2")
+        headers = [frame.split(b"\n", 1)[0].split() for frame in process.writes]
+        self.assertEqual({int(header[2]) for header in headers}, {0, 1})
+        self.assertEqual({header[3] for header in headers}, {b"4", b"5"})
+
+    def test_routes_engine_error_to_request(self):
+        def respond(process, frame):
+            request_id = frame.split()[1]
+            process.stdout.feed(b"ERROR " + request_id + b" slot is busy\n")
+
+        process = FakeProcess(respond)
+        with patch("openai_server.subprocess.Popen", return_value=process):
+            engine = Engine("glm", "model")
+        with self.assertRaisesRegex(RuntimeError, "slot is busy"):
+            engine.generate("hello", 4, 0.7, 0.9, lambda _: None)
+        engine.close()
 
 
 class HTTPTest(unittest.TestCase):

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -1,6 +1,7 @@
 import io
 import json
 import math
+import socket
 import threading
 import unittest
 from unittest.mock import patch
@@ -91,6 +92,18 @@ class ProtocolTest(unittest.TestCase):
     def test_rejects_invalid_kv_pool_before_engine_start(self):
         with self.assertRaisesRegex(ValueError, "kv_slots"):
             serve("/missing", kv_slots=0)
+
+    def test_occupied_port_fails_before_engine_start(self):
+        listener = socket.socket()
+        listener.bind(("127.0.0.1", 0))
+        listener.listen()
+        try:
+            with patch("openai_server.subprocess.Popen") as popen:
+                with self.assertRaises(OSError):
+                    serve("/missing", port=listener.getsockname()[1])
+            popen.assert_not_called()
+        finally:
+            listener.close()
 
 
 class SchedulerTest(unittest.TestCase):

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -1,5 +1,6 @@
 import io
 import json
+import math
 import threading
 import unittest
 from unittest.mock import patch
@@ -67,6 +68,10 @@ class TemplateTest(unittest.TestCase):
                          (4, 0.0, 1.0))
         with self.assertRaises(APIError):
             generation_options({"max_tokens": 9}, 8)
+        with self.assertRaises(APIError):
+            generation_options({"temperature": math.nan}, 8)
+        with self.assertRaises(APIError):
+            generation_options({"top_p": math.inf}, 8)
         self.assertEqual(generation_options({"temperature": None, "top_p": None}, 8),
                          (8, 0.7, 0.9))
 
@@ -291,6 +296,65 @@ class DispatcherTest(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "slot is busy"):
             engine.generate("hello", 4, 0.7, 0.9, lambda _: None)
         engine.close()
+
+    def test_close_wakes_pending_generation_and_is_idempotent(self):
+        process = FakeProcess(lambda _process, _frame: None)
+        with patch("openai_server.subprocess.Popen", return_value=process):
+            engine = Engine("glm", "model")
+        errors = []
+
+        def generate():
+            try:
+                engine.generate("hello", 4, 0.7, 0.9, lambda _: None)
+            except RuntimeError as error:
+                errors.append(str(error))
+
+        thread = threading.Thread(target=generate)
+        thread.start()
+        for _ in range(100):
+            with engine.pending_lock:
+                if engine.pending:
+                    break
+            threading.Event().wait(0.01)
+        engine.close()
+        engine.close()
+        thread.join(timeout=2)
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(errors, ["colibri engine is shutting down"])
+        self.assertFalse(engine.dispatcher.is_alive())
+        with engine.pending_lock:
+            self.assertFalse(engine.pending)
+        with self.assertRaisesRegex(RuntimeError, "shutting down"):
+            engine.generate("again", 4, 0.7, 0.9, lambda _: None)
+
+    def test_protocol_corruption_fails_request_and_stops_dispatcher(self):
+        def respond(process, frame):
+            request_id = frame.split()[1]
+            process.stdout.feed(b"DATA " + request_id + b" -1\n")
+
+        process = FakeProcess(respond)
+        with patch("openai_server.subprocess.Popen", return_value=process):
+            engine = Engine("glm", "model")
+        with self.assertRaisesRegex(RuntimeError, "DATA size"):
+            engine.generate("hello", 4, 0.7, 0.9, lambda _: None)
+        with self.assertRaisesRegex(RuntimeError, "dispatcher stopped"):
+            engine.generate("again", 4, 0.7, 0.9, lambda _: None)
+        engine.close()
+
+    def test_decodes_utf8_split_across_data_frames(self):
+        def respond(process, frame):
+            request_id = frame.split()[1]
+            process.stdout.feed(b"DATA " + request_id + b" 1\n\xc3\n")
+            process.stdout.feed(b"DATA " + request_id + b" 1\n\xa9\n")
+            process.stdout.feed(b"DONE " + request_id + b" STAT 1 1 0 1 1 0\n")
+
+        process = FakeProcess(respond)
+        with patch("openai_server.subprocess.Popen", return_value=process):
+            engine = Engine("glm", "model")
+        chunks = []
+        engine.generate("hello", 4, 0.7, 0.9, chunks.append)
+        engine.close()
+        self.assertEqual(chunks, ["é"])
 
 
 class HTTPTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add a `DecodeRow` descriptor carrying one sequence's KV owner, token, and absolute position
- evaluate up to 16 active serve slots in one ragged decode forward while retaining one shared dense/MoE batch
- select MLA L/R KV and DSA index storage independently for every row
- keep prefill serial, then admit requests between decode rounds and compact completed slots naturally
- add a multiplexed `SUBMIT` / `DATA` / `DONE` / `ERROR` / `CANCEL` engine protocol
- route concurrent OpenAI-compatible API requests through one scheduler and per-request output queues
- reject simultaneous ownership of the same cache slot
- cancel disconnected clients between decode rounds and release their slot
- bind the HTTP port before loading the model, so occupied-port startup fails immediately
- retain the legacy SERVE protocol for non-HTTP callers

## Execution model

Prefill remains serial because prompts have different lengths. During decode, every active request contributes one `(KVState, token, position)` row. Attention reads and writes that row's independent cache, while dense and routed-expert layers share the batch. The scheduler remains the only forward owner.

This is decode-only continuous batching. It does not claim batched prefill or MTP/speculative batching. Different batch shapes may produce different greedy token choices near close logits due to floating-point non-associativity; fixed-shape runs remain reproducible and KV ownership remains isolated.

## Validation

- rebased onto current `main` after #29 merged; scoped delta is six commits
- `make check`: portable build, 4 C tests, 35 Python/API tests
- protocol coverage for malformed frames, duplicate IDs, non-finite sampling values, cancellation, split UTF-8, shutdown races, and queue saturation
- occupied-port live check: failure before engine spawn in about 66 ms
- streaming disconnect live check: active slot returned to zero and was immediately reusable
- GLM-5.2 744B INT4 on RTX 5090:
  - two CPU-expert requests: 46.82 s concurrent vs 50.18 s sequential
  - 32 GB host hot tier + 20 GB CUDA expert tier: 33.96 s concurrent, 28.4 GB GPU usage, no process swap
  - oversized 100 GB host tier regressed to 73.65 s and caused heavy swap, motivating conservative tier budgets
- CUDA q8/q4/q2/f32 correctness fixture passed on sm_120
- `git diff --check`

## Series

Final runtime-series piece after merged #26 adaptive tiers, #27 resource planning, #28 bounded scheduling, and #29 isolated KV contexts.