### PR TITLE
Make adaptive prefetch lifecycle safe

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -37,7 +37,7 @@ CUDA_ARCH ?= native
 NVCCFLAGS ?= -O3 -std=c++17 -arch=$(CUDA_ARCH) -Xcompiler=-Wall,-Wextra
 PYTHON    ?= python3
 CUDA_OBJ  =
-TEST_BINS = tests/test_json tests/test_st tests/test_tier
+TEST_BINS = tests/test_json tests/test_st tests/test_tier tests/test_prefetch_queue
 ifeq ($(CUDA),1)
 ifeq ($(UNAME_S),Darwin)
 $(error CUDA=1 is supported only on Linux)
@@ -49,7 +49,7 @@ endif
 
 all: glm
 
-glm: glm.c st.h json.h tok.h tok_unicode.h compat.h $(CUDA_OBJ)
+glm: glm.c st.h json.h tok.h tok_unicode.h compat.h tier.h prefetch_queue.h $(CUDA_OBJ)
 	$(CC) $(CFLAGS) glm.c $(CUDA_OBJ) -o glm $(LDFLAGS)
 
 backend_cuda.o: backend_cuda.cu backend_cuda.h
@@ -75,6 +75,9 @@ tests/test_st: tests/test_st.c st.h json.h compat.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_tier: tests/test_tier.c tier.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+tests/test_prefetch_queue: tests/test_prefetch_queue.c prefetch_queue.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 test-c: $(TEST_BINS)

--- a/c/glm.c
+++ b/c/glm.c
@@ -32,6 +32,7 @@
 #include "st.h"
 #include "tok.h"
 #include "tier.h"
+#include "prefetch_queue.h"
 #ifdef COLI_CUDA
 #include <omp.h>
 #include "backend_cuda.h"
@@ -1303,24 +1304,39 @@ static void la_predict(Model *m, int target, const float *h, int kind){
  * del fadvise BLOCCA (~0.5ms x 169k chiamate = +92s/48 token, misurato) — inline
  * il pilota costava piu' di quanto rendesse. Ring lock-free 1P/1C; pieno = scarta
  * (un hint perso non e' un errore). */
-static struct { int l,e; } pilot_q[4096];
-static volatile unsigned pilot_w=0, pilot_r=0;
-static Model *pilot_m=NULL;
+static ColiPrefetchQueue pilot_q;
+static Model *pilot_m=NULL; static pthread_t pilot_thread; static int pilot_started;
+static uint64_t pilot_queued,pilot_deduped,pilot_dropped,pilot_processed;
 static void *pilot_worker(void *arg){
     (void)arg;
-    for(;;){
-        unsigned r=__atomic_load_n(&pilot_r,__ATOMIC_ACQUIRE);
-        unsigned w=__atomic_load_n(&pilot_w,__ATOMIC_ACQUIRE);
-        if(r==w){ usleep(200); continue; }
-        expert_prefetch(pilot_m, pilot_q[r&4095].l, pilot_q[r&4095].e);
-        __atomic_store_n(&pilot_r,r+1,__ATOMIC_RELEASE);
+    ColiPrefetchItem item;
+    while(coli_prefetch_pop(&pilot_q,&item)){
+        expert_prefetch(pilot_m,item.layer,item.expert);
+        coli_prefetch_done(&pilot_q,item); pilot_processed++;
     }
     return NULL;
+}
+static void pilot_shutdown(void){
+    if(!pilot_started) return;
+    coli_prefetch_stop(&pilot_q); pthread_join(pilot_thread,NULL);
+    fprintf(stderr,"[PILOT] prefetch: %llu eseguiti, %llu accodati, %llu deduplicati, %llu scartati\n",
+        (unsigned long long)pilot_processed,(unsigned long long)pilot_queued,
+        (unsigned long long)pilot_deduped,(unsigned long long)pilot_dropped);
+    coli_prefetch_destroy(&pilot_q); pilot_started=0;
+}
+static int pilot_start(Model *m){
+    if(pilot_started) return 1;
+    if(!coli_prefetch_init(&pilot_q,m->c.n_layers+1,m->c.n_experts)) return 0;
+    pilot_m=m;
+    if(pthread_create(&pilot_thread,NULL,pilot_worker,NULL)){
+        coli_prefetch_destroy(&pilot_q); pilot_m=NULL; return 0;
+    }
+    pilot_started=1; atexit(pilot_shutdown); return 1;
 }
 static void pilot_prefetch(Model *m, int lnext, const float *x, int S){
     Cfg *c=&m->c; Layer *l=&m->L[lnext]; int D=c->hidden, E=c->n_experts;
     int K = g_pilot_k<c->topk ? g_pilot_k : c->topk;
-    if(!pilot_m){ pilot_m=m; pthread_t t; pthread_create(&t,NULL,pilot_worker,NULL); }
+    if(!pilot_start(m)) return;
     float *nrm=falloc(D), *ch=falloc(E);
     for(int s=0;s<S;s++){
         rmsnorm(nrm, x+(int64_t)s*D, l->post_ln, D, c->eps);
@@ -1334,11 +1350,8 @@ static void pilot_prefetch(Model *m, int lnext, const float *x, int S){
             ESlot *Sl=m->ecache[lnext];
             for(int z=0;z<m->ecn[lnext] && !found;z++) if(Sl[z].eid==best) found=1;
             if(!found){
-                unsigned w=__atomic_load_n(&pilot_w,__ATOMIC_RELAXED);
-                if(w-__atomic_load_n(&pilot_r,__ATOMIC_ACQUIRE)<4096){
-                    pilot_q[w&4095].l=lnext; pilot_q[w&4095].e=best;
-                    __atomic_store_n(&pilot_w,w+1,__ATOMIC_RELEASE);
-                }
+                int rc=coli_prefetch_push(&pilot_q,lnext,best);
+                if(rc>0) pilot_queued++; else if(!rc) pilot_deduped++; else pilot_dropped++;
             }
         }
     }

--- a/c/prefetch_queue.h
+++ b/c/prefetch_queue.h
@@ -1,0 +1,63 @@
+#ifndef COLIBRI_PREFETCH_QUEUE_H
+#define COLIBRI_PREFETCH_QUEUE_H
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define COLI_PREFETCH_CAP 4096
+typedef struct { int layer, expert; } ColiPrefetchItem;
+typedef struct {
+    pthread_mutex_t mu; pthread_cond_t ready;
+    ColiPrefetchItem items[COLI_PREFETCH_CAP];
+    unsigned read, write; int stopped, layers, experts; unsigned char *pending;
+} ColiPrefetchQueue;
+
+static inline int coli_prefetch_init(ColiPrefetchQueue *q, int layers, int experts){
+    if(!q||layers<1||experts<1) return 0;
+    memset(q,0,sizeof(*q)); q->layers=layers; q->experts=experts;
+    q->pending=calloc((size_t)layers*experts,1); if(!q->pending) return 0;
+    if(pthread_mutex_init(&q->mu,NULL)||pthread_cond_init(&q->ready,NULL)){
+        free(q->pending); q->pending=NULL; return 0;
+    }
+    return 1;
+}
+
+/* 1 queued, 0 duplicate, -1 full/stopped/invalid. */
+static inline int coli_prefetch_push(ColiPrefetchQueue *q, int layer, int expert){
+    if(!q||layer<0||layer>=q->layers||expert<0||expert>=q->experts) return -1;
+    pthread_mutex_lock(&q->mu);
+    size_t key=(size_t)layer*q->experts+expert;
+    int rc;
+    if(q->stopped||q->write-q->read>=COLI_PREFETCH_CAP) rc=-1;
+    else if(q->pending[key]) rc=0;
+    else { q->pending[key]=1; q->items[q->write++&(COLI_PREFETCH_CAP-1)]=(ColiPrefetchItem){layer,expert};
+           pthread_cond_signal(&q->ready); rc=1; }
+    pthread_mutex_unlock(&q->mu); return rc;
+}
+
+static inline int coli_prefetch_pop(ColiPrefetchQueue *q, ColiPrefetchItem *item){
+    pthread_mutex_lock(&q->mu);
+    while(q->read==q->write&&!q->stopped) pthread_cond_wait(&q->ready,&q->mu);
+    if(q->stopped){ pthread_mutex_unlock(&q->mu); return 0; }
+    *item=q->items[q->read++&(COLI_PREFETCH_CAP-1)];
+    pthread_mutex_unlock(&q->mu); return 1;
+}
+
+static inline void coli_prefetch_done(ColiPrefetchQueue *q, ColiPrefetchItem item){
+    pthread_mutex_lock(&q->mu);
+    q->pending[(size_t)item.layer*q->experts+item.expert]=0;
+    pthread_mutex_unlock(&q->mu);
+}
+
+static inline void coli_prefetch_stop(ColiPrefetchQueue *q){
+    pthread_mutex_lock(&q->mu); q->stopped=1; pthread_cond_broadcast(&q->ready);
+    pthread_mutex_unlock(&q->mu);
+}
+
+static inline void coli_prefetch_destroy(ColiPrefetchQueue *q){
+    pthread_cond_destroy(&q->ready); pthread_mutex_destroy(&q->mu);
+    free(q->pending); q->pending=NULL;
+}
+
+#endif

--- a/c/tests/test_prefetch_queue.c
+++ b/c/tests/test_prefetch_queue.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+#include <stdio.h>
+#include "../prefetch_queue.h"
+
+int main(void){
+    ColiPrefetchQueue q; ColiPrefetchItem item;
+    assert(coli_prefetch_init(&q,3,4));
+    assert(coli_prefetch_push(&q,1,2)==1);
+    assert(coli_prefetch_push(&q,1,2)==0);
+    assert(coli_prefetch_pop(&q,&item)==1 && item.layer==1 && item.expert==2);
+    assert(coli_prefetch_push(&q,1,2)==0);
+    coli_prefetch_done(&q,item);
+    assert(coli_prefetch_push(&q,1,2)==1);
+    assert(coli_prefetch_push(&q,3,0)==-1);
+    assert(coli_prefetch_pop(&q,&item)==1); coli_prefetch_done(&q,item);
+    coli_prefetch_stop(&q);
+    assert(coli_prefetch_pop(&q,&item)==0);
+    assert(coli_prefetch_push(&q,0,0)==-1);
+    coli_prefetch_destroy(&q);
+    puts("prefetch queue tests: ok");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- replace the router-guided prefetch worker's permanent 200 us busy-poll loop with a blocking condition-variable queue
- deduplicate in-flight `(layer, expert)` hints
- add bounded enqueue, clean shutdown, and worker join semantics
- report queued, processed, deduplicated, and dropped hints
- retain the existing responsibility split: PILOT predicts and warms disk pages; live heat + REPIN performs persistent Disk→RAM→VRAM promotion and cold-tier eviction
- add dependency-free queue lifecycle and deduplication tests

## Motivation

The current worker never exits, spins while idle, silently drops full-queue hints, and may issue the same readahead repeatedly. Those behaviors make the adaptive tier difficult to tune and waste I/O bandwidth—the exact resource this runtime is trying to hide.

## Validation

- `make check`: portable build, 4 C tests, 27 Python/API tests
- `git diff --check`

## Draft gate

Keep Draft until a full-model PILOT run verifies shutdown, queue metrics, deduplication rate, and no regression in expert-disk time.