### PR TITLE
Run q4 expert down projection on the CPU pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,13 @@ one thread-team launch per RAM expert without activation requantization or a
 lower-precision fallback. It is a stepping stone toward a persistent native
 CPU expert pool, not a replacement for one.
 
+`CPU_POOL_THREADS=n` opts the fused q4 gate/up path into a persistent native
+pthread pool. Workers are created once and reused for the process lifetime;
+the default remains OpenMP until hardware planning can select a topology-aware
+size. On a 2-socket Xeon Silver 4510, 48 workers reduced identical-output
+expert time from 51.61 s to 36.67 s and 16-token wall time from 129.42 s to
+113.73 s. Twenty-four workers were slightly slower (114.35 s wall time).
+
 **The expert cache auto-sizes to your RAM** (since 2026-07-10): the engine now *raises* the LRU cap to fill your `--ram` budget instead of only lowering it. Before this fix a 128 GB machine ran with the same 8-experts/layer cache as a 16 GB one (issue #12) — **if you benchmarked colibrì before this date, rerun: your numbers were capped.**
 
 **Router-lookahead prefetch** (`PILOT=1`, experimental): GLM-5.2's expert routing is measurably predictable *ahead of time* — applying layer L+1's router to layer L's post-attention state recalls **71.6%** of the true top-8 (vs 41.3% for "same experts as last token"). `PILOT=1` uses this to issue next-layer expert readahead from a dedicated I/O thread while the current layer computes. On our dev box the disk is already ~80% saturated, so it measures neutral; on machines where compute and disk are balanced (like the Ryzen AI 9 in issue #12: 43% disk / 46% matmul) it should overlap real work — measurements welcome.

--- a/README.md
+++ b/README.md
@@ -297,6 +297,13 @@ Disk is an immutable recovery source, not a normal decode target. If the plan
 leaves cold expert bytes on disk, speed depends on cache hit rate; output
 quality does not.
 
+Cold expert reads use a deferred pipeline: resident RAM/VRAM experts execute
+while missing experts are loaded in a bounded background I/O pool, then the
+cold results join before the layer completes. `IO_THREADS=n` overrides the
+default eight loader threads when foreground work exists. Profiling reports
+both disk service time and the smaller foreground-visible wait time so overlap
+is explicit rather than credited as unexplained speedup.
+
 **The expert cache auto-sizes to your RAM** (since 2026-07-10): the engine now *raises* the LRU cap to fill your `--ram` budget instead of only lowering it. Before this fix a 128 GB machine ran with the same 8-experts/layer cache as a 16 GB one (issue #12) — **if you benchmarked colibrì before this date, rerun: your numbers were capped.**
 
 **Router-lookahead prefetch** (`PILOT=1`, experimental): GLM-5.2's expert routing is measurably predictable *ahead of time* — applying layer L+1's router to layer L's post-attention state recalls **71.6%** of the true top-8 (vs 41.3% for "same experts as last token"). `PILOT=1` uses this to issue next-layer expert readahead from a dedicated I/O thread while the current layer computes. On our dev box the disk is already ~80% saturated, so it measures neutral; on machines where compute and disk are balanced (like the Ryzen AI 9 in issue #12: 43% disk / 46% matmul) it should overlap real work — measurements welcome.

--- a/README.md
+++ b/README.md
@@ -322,7 +322,10 @@ pthread pool. Workers are created once and reused for the process lifetime;
 the default remains OpenMP until hardware planning can select a topology-aware
 size. On a 2-socket Xeon Silver 4510, 48 workers reduced identical-output
 expert time from 51.61 s to 36.67 s and 16-token wall time from 129.42 s to
-113.73 s. Twenty-four workers were slightly slower (114.35 s wall time).
+113.73 s. Twenty-four workers were slightly slower (114.35 s wall time). The
+same pool also handles the q4 expert down projection: on that host it reduced
+expert time further from 36.67 s to 25.74 s and wall time to 105.07 s, with
+identical greedy output.
 
 **The expert cache auto-sizes to your RAM** (since 2026-07-10): the engine now *raises* the LRU cap to fill your `--ram` budget instead of only lowering it. Before this fix a 128 GB machine ran with the same 8-experts/layer cache as a 16 GB one (issue #12) — **if you benchmarked colibrì before this date, rerun: your numbers were capped.**
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 **Tiny engine, immense model.** Run **GLM-5.2 (744B-parameter MoE)** on a consumer machine with ~25 GB of RAM — in pure C, with zero dependencies, by streaming experts from disk.
 
+Colibrì is a lightweight, quality-preserving MoE runtime that treats VRAM,
+RAM, and storage as one managed memory hierarchy. Insufficient fast memory may
+reduce speed, but the default policy never silently changes model precision or
+router semantics.
+
 ```
 $ ./coli chat
   🐦 colibrì v1.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
@@ -272,6 +277,25 @@ compatible endpoint. Nothing leaves the endpoint you configure. The terminal
 `coli chat` remains the first-class interface.
 
 Useful knobs (env or flags): `--temp T` token sampling temperature (default 0.7 + nucleus 0.90 — tuned for int4; 0 = greedy), `--topp 0.7` adaptive expert top-p (30–40% less disk), `--ngen N` max tokens per answer (`:piu` in chat continues a truncated one), `--repin N` adapt RAM/VRAM hot experts every N emitted tokens, `AUTOPIN=0` disable the learning cache's auto-pin, `THINK=1` enable GLM-5.2's reasoning block, `DRAFT=n` MTP draft depth, `TF=1` teacher-forcing validation, `PILOT=1` router-lookahead disk prefetch (experimental — see below), `CAP_RAISE=0` don't auto-grow the expert cache.
+
+### Resource policy
+
+`coli plan` reports the planned hot (VRAM), warm (RAM), and cold backing
+(disk) tiers, the reason for each placement, and the expected bottleneck. The
+default `--policy quality` and `--policy balanced` modes preserve checkpoint
+quantization and the original router decisions. Lossy `TOPK`/`TOPP` overrides
+require the explicit `--policy experimental-fast` opt-in.
+
+```bash
+coli plan --model /models/glm52_i4 --policy quality
+coli run --auto-tier --policy quality "Explain MoE offloading"
+# Explicit research-only router reduction:
+coli run --policy experimental-fast --topk 4 "Benchmark prompt"
+```
+
+Disk is an immutable recovery source, not a normal decode target. If the plan
+leaves cold expert bytes on disk, speed depends on cache hit rate; output
+quality does not.
 
 **The expert cache auto-sizes to your RAM** (since 2026-07-10): the engine now *raises* the LRU cap to fill your `--ram` budget instead of only lowering it. Before this fix a 128 GB machine ran with the same 8-experts/layer cache as a 16 GB one (issue #12) — **if you benchmarked colibrì before this date, rerun: your numbers were capped.**
 

--- a/README.md
+++ b/README.md
@@ -304,6 +304,13 @@ default eight loader threads when foreground work exists. Profiling reports
 both disk service time and the smaller foreground-visible wait time so overlap
 is explicit rather than credited as unexplained speedup.
 
+`--policy balanced` enables lossless live placement (`REPIN=64`). At safe
+request boundaries, a per-layer LFRU score combines decaying session frequency
+with recent access and replaces at most four sufficiently colder pinned
+experts. `--policy quality` leaves live replacement off by default; `REPIN=0`
+always disables it. Persistent `.coli_usage` history and session-local LFRU
+state remain separate.
+
 **The expert cache auto-sizes to your RAM** (since 2026-07-10): the engine now *raises* the LRU cap to fill your `--ram` budget instead of only lowering it. Before this fix a 128 GB machine ran with the same 8-experts/layer cache as a 16 GB one (issue #12) — **if you benchmarked colibrì before this date, rerun: your numbers were capped.**
 
 **Router-lookahead prefetch** (`PILOT=1`, experimental): GLM-5.2's expert routing is measurably predictable *ahead of time* — applying layer L+1's router to layer L's post-attention state recalls **71.6%** of the true top-8 (vs 41.3% for "same experts as last token"). `PILOT=1` uses this to issue next-layer expert readahead from a dedicated I/O thread while the current layer computes. On our dev box the disk is already ~80% saturated, so it measures neutral; on machines where compute and disk are balanced (like the Ryzen AI 9 in issue #12: 43% disk / 46% matmul) it should overlap real work — measurements welcome.

--- a/README.md
+++ b/README.md
@@ -212,9 +212,9 @@ VRAM tier while keeping the rest in RAM:
 STATS=stats.txt SNAP=/nvme/glm52_i4 ./glm 64 4 4   # collect routing frequencies first
 COLI_CUDA=1 COLI_GPU=0 CUDA_EXPERT_GB=16 \
 PIN=stats.txt PIN_GB=160 SNAP=/nvme/glm52_i4 ./glm 64 4 4
-# multi-GPU expert tier, 96 GB total budget across six devices
-COLI_CUDA=1 COLI_GPUS=0,1,2,3,4,5 CUDA_EXPERT_GB=96 \
-PIN=stats.txt PIN_GB=160 SNAP=/nvme/glm52_i4 ./glm 64 4 4
+# multi-GPU expert tier, 150 GB total budget across six 32 GB devices
+COLI_CUDA=1 COLI_GPUS=0,1,2,3,4,5 CUDA_EXPERT_GB=150 \
+PIN=stats.txt PIN_GB=150 SNAP=/nvme/glm52_i4 ./glm 64 4 4
 ```
 
 Selected experts are uploaded during startup, so capacity failures occur before
@@ -222,14 +222,26 @@ inference and the log reports their exact tensor footprint. The budget is clampe
 against free VRAM after reserving the projected dense resident set and 2 GB of
 runtime headroom per selected device. With `COLI_GPUS`, `CUDA_EXPERT_GB` is a
 total budget across the device set; experts are assigned whole to the
-least-loaded device that can hold them. A NUMA-local RAM backing store is not
-implemented yet.
+least-loaded device that can hold them. Multi-GPU runs also default to
+`PIN_FILL=1`: the measured hot set is placed first, then unused VRAM is filled
+with zero-heat experts. `CUDA_RELEASE_HOST=1` (the multi-GPU default) releases
+the RAM copy after a successful upload and reloads it from disk only if CUDA
+later fails. Set either variable to `0` to restore the conservative behavior.
+MTP speculation defaults off on CUDA because cold draft routes increase expert
+traffic; an explicit `DRAFT=n` still overrides the default.
+
+On six RTX 5090 32 GB cards with GLM-5.2 int4, a 150 GB hot-first tier sustained
+0.94 token/s over a 64-token varied prompt (87.8% expert hit rate), and reached
+1.64 token/s on a warmed short prompt (99.3% hit rate). The same capacity filled
+without routing heat managed only 0.29 token/s, so profile quality matters more
+than raw VRAM capacity. These are single-run engineering measurements, not a
+portable performance guarantee.
 
 Current limitations: devices use independent contexts and synchronous
-host-staged activation copies—there is no P2P/NCCL dependency yet. The kernels
-are correctness-first custom kernels rather than cuBLAS/Tensor Core kernels.
-This draft intentionally makes no end-to-end speedup claim before the full model
-is benchmarked.
+host-staged activation copies—there is no P2P/NCCL dependency yet. Independent
+expert groups execute concurrently across devices, but a single expert is not
+sharded. The kernels are correctness-first custom kernels rather than
+cuBLAS/Tensor Core kernels.
 
 For a reproducible backend A/B without the full checkpoint, generate the
 deterministic 313M-parameter `glm_moe_dsa` fixture and run fixed-token replay:

--- a/README.md
+++ b/README.md
@@ -311,6 +311,12 @@ experts. `--policy quality` leaves live replacement off by default; `REPIN=0`
 always disables it. Persistent `.coli_usage` history and session-local LFRU
 state remain separate.
 
+For single-token q4 CPU experts, gate and up projections share one OpenMP
+dispatch while retaining the same per-row AVX2/NEON arithmetic. This removes
+one thread-team launch per RAM expert without activation requantization or a
+lower-precision fallback. It is a stepping stone toward a persistent native
+CPU expert pool, not a replacement for one.
+
 **The expert cache auto-sizes to your RAM** (since 2026-07-10): the engine now *raises* the LRU cap to fill your `--ram` budget instead of only lowering it. Before this fix a 128 GB machine ran with the same 8-experts/layer cache as a 16 GB one (issue #12) — **if you benchmarked colibrì before this date, rerun: your numbers were capped.**
 
 **Router-lookahead prefetch** (`PILOT=1`, experimental): GLM-5.2's expert routing is measurably predictable *ahead of time* — applying layer L+1's router to layer L's post-attention state recalls **71.6%** of the true top-8 (vs 41.3% for "same experts as last token"). `PILOT=1` uses this to issue next-layer expert readahead from a dedicated I/O thread while the current layer computes. On our dev box the disk is already ~80% saturated, so it measures neutral; on machines where compute and disk are balanced (like the Ryzen AI 9 in issue #12: 43% disk / 46% matmul) it should overlap real work — measurements welcome.

--- a/c/Makefile
+++ b/c/Makefile
@@ -37,7 +37,7 @@ CUDA_ARCH ?= native
 NVCCFLAGS ?= -O3 -std=c++17 -arch=$(CUDA_ARCH) -Xcompiler=-Wall,-Wextra
 PYTHON    ?= python3
 CUDA_OBJ  =
-TEST_BINS = tests/test_json tests/test_st tests/test_tier
+TEST_BINS = tests/test_json tests/test_st tests/test_tier tests/test_cpu_pool
 ifeq ($(CUDA),1)
 ifeq ($(UNAME_S),Darwin)
 $(error CUDA=1 is supported only on Linux)
@@ -49,7 +49,7 @@ endif
 
 all: glm
 
-glm: glm.c st.h json.h tok.h tok_unicode.h compat.h $(CUDA_OBJ)
+glm: glm.c st.h json.h tok.h tok_unicode.h compat.h cpu_pool.h $(CUDA_OBJ)
 	$(CC) $(CFLAGS) glm.c $(CUDA_OBJ) -o glm $(LDFLAGS)
 
 backend_cuda.o: backend_cuda.cu backend_cuda.h
@@ -75,6 +75,9 @@ tests/test_st: tests/test_st.c st.h json.h compat.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_tier: tests/test_tier.c tier.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+tests/test_cpu_pool: tests/test_cpu_pool.c cpu_pool.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 test-c: $(TEST_BINS)

--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -22,6 +22,8 @@ typedef struct {
 
 static DeviceContext g_ctx[COLI_CUDA_MAX_DEVICES];
 static int g_nctx;
+static uint64_t g_group_calls,g_group_experts,g_group_rows;
+static double g_group_h2d_ms,g_group_kernel_ms,g_group_d2h_ms;
 
 static int cuda_ok(cudaError_t err, const char *what) {
     if (err == cudaSuccess) return 1;
@@ -165,6 +167,13 @@ extern "C" void coli_cuda_stats(int device, size_t *tensor_count, size_t *tensor
     if (tensor_bytes) *tensor_bytes = bytes;
 }
 
+extern "C" void coli_cuda_group_stats(uint64_t *calls, uint64_t *experts, uint64_t *rows,
+                                        double *h2d_ms, double *kernel_ms, double *d2h_ms) {
+    if(calls) *calls=g_group_calls; if(experts) *experts=g_group_experts; if(rows) *rows=g_group_rows;
+    if(h2d_ms) *h2d_ms=g_group_h2d_ms; if(kernel_ms) *kernel_ms=g_group_kernel_ms;
+    if(d2h_ms) *d2h_ms=g_group_d2h_ms;
+}
+
 extern "C" int coli_cuda_tensor_upload(ColiCudaTensor **tensor,
                                         const void *weights, const float *scales,
                                         int fmt, int I, int O, int device) {
@@ -265,7 +274,12 @@ extern "C" int coli_cuda_expert_group(ColiCudaTensor *const *gates,
     size_t xb=(size_t)total*D*sizeof(float), ib=(size_t)total*I*sizeof(float);
     if(!reserve(&ctx->x,&ctx->x_cap,xb)||!reserve(&ctx->y,&ctx->y_cap,xb)||
        !reserve(&ctx->gate,&ctx->gate_cap,ib)||!reserve(&ctx->up,&ctx->up_cap,ib)) return 0;
+    int profile=getenv("COLI_CUDA_PROFILE")&&atoi(getenv("COLI_CUDA_PROFILE"));
+    cudaEvent_t ev[4]={};
+    if(profile) for(int i=0;i<4;i++) if(!cuda_ok(cudaEventCreate(&ev[i]),"profile event")) profile=0;
+    if(profile) cudaEventRecord(ev[0]);
     if(!cuda_ok(cudaMemcpy(ctx->x,x,xb,cudaMemcpyHostToDevice),"expert group input upload")) return 0;
+    if(profile) cudaEventRecord(ev[1]);
     int base=0;
     for(int c=0;c<count;c++){
         int S=rows[c]; ColiCudaTensor *g=gates[c],*u=ups[c],*d=downs[c];
@@ -279,8 +293,17 @@ extern "C" int coli_cuda_expert_group(ColiCudaTensor *const *gates,
         quant_matmul<<<og,256>>>(dy,dg,d->weights,d->scales,d->fmt,S,I,D,row_bytes(d->fmt,I));
         base+=S;
     }
+    if(profile) cudaEventRecord(ev[2]);
     if(!cuda_ok(cudaGetLastError(),"expert group launch")||
        !cuda_ok(cudaMemcpy(y,ctx->y,xb,cudaMemcpyDeviceToHost),"expert group output download")) return 0;
+    if(profile){
+        cudaEventRecord(ev[3]); cudaEventSynchronize(ev[3]); float a=0,b=0,c=0;
+        cudaEventElapsedTime(&a,ev[0],ev[1]); cudaEventElapsedTime(&b,ev[1],ev[2]);
+        cudaEventElapsedTime(&c,ev[2],ev[3]);
+        g_group_h2d_ms+=a; g_group_kernel_ms+=b; g_group_d2h_ms+=c;
+        for(int i=0;i<4;i++) cudaEventDestroy(ev[i]);
+    }
+    g_group_calls++; g_group_experts+=(uint64_t)count; g_group_rows+=(uint64_t)total;
     return 1;
 }
 

--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -4,6 +4,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <mutex>
 
 struct ColiCudaTensor {
     void *weights;
@@ -24,6 +25,7 @@ static DeviceContext g_ctx[COLI_CUDA_MAX_DEVICES];
 static int g_nctx;
 static uint64_t g_group_calls,g_group_experts,g_group_rows;
 static double g_group_h2d_ms,g_group_kernel_ms,g_group_d2h_ms;
+static std::mutex g_group_stats_mu;
 
 static int cuda_ok(cudaError_t err, const char *what) {
     if (err == cudaSuccess) return 1;
@@ -300,10 +302,12 @@ extern "C" int coli_cuda_expert_group(ColiCudaTensor *const *gates,
         cudaEventRecord(ev[3]); cudaEventSynchronize(ev[3]); float a=0,b=0,c=0;
         cudaEventElapsedTime(&a,ev[0],ev[1]); cudaEventElapsedTime(&b,ev[1],ev[2]);
         cudaEventElapsedTime(&c,ev[2],ev[3]);
-        g_group_h2d_ms+=a; g_group_kernel_ms+=b; g_group_d2h_ms+=c;
+        { std::lock_guard<std::mutex> lock(g_group_stats_mu);
+          g_group_h2d_ms+=a; g_group_kernel_ms+=b; g_group_d2h_ms+=c; }
         for(int i=0;i<4;i++) cudaEventDestroy(ev[i]);
     }
-    g_group_calls++; g_group_experts+=(uint64_t)count; g_group_rows+=(uint64_t)total;
+    { std::lock_guard<std::mutex> lock(g_group_stats_mu);
+      g_group_calls++; g_group_experts+=(uint64_t)count; g_group_rows+=(uint64_t)total; }
     return 1;
 }
 

--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -15,8 +15,8 @@ struct ColiCudaTensor {
 
 typedef struct {
     int device;
-    float *x, *y;
-    size_t x_cap, y_cap;
+    float *x, *y, *gate, *up;
+    size_t x_cap, y_cap, gate_cap, up_cap;
     size_t tensor_count, tensor_bytes;
 } DeviceContext;
 
@@ -81,6 +81,14 @@ __global__ static void quant_matmul(float *y, const float *x, const void *weight
         y[(size_t)s * O + o] = partial[0] * (fmt ? scales[o] : 1.0f);
 }
 
+__global__ static void silu_mul(float *gate, const float *up, size_t n) {
+    size_t i = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) {
+        float v = gate[i];
+        gate[i] = (v / (1.0f + expf(-v))) * up[i];
+    }
+}
+
 static int reserve(float **ptr, size_t *cap, size_t bytes) {
     if (*cap >= bytes) return 1;
     if (*ptr) cudaFree(*ptr);
@@ -127,8 +135,10 @@ extern "C" void coli_cuda_shutdown(void) {
         if (!select_ctx(ctx)) continue;
         if (ctx->x) cudaFree(ctx->x);
         if (ctx->y) cudaFree(ctx->y);
-        ctx->x = ctx->y = nullptr;
-        ctx->x_cap = ctx->y_cap = 0;
+        if (ctx->gate) cudaFree(ctx->gate);
+        if (ctx->up) cudaFree(ctx->up);
+        ctx->x = ctx->y = ctx->gate = ctx->up = nullptr;
+        ctx->x_cap = ctx->y_cap = ctx->gate_cap = ctx->up_cap = 0;
     }
     g_nctx = 0;
 }
@@ -204,6 +214,35 @@ extern "C" int coli_cuda_matmul(ColiCudaTensor **tensor,
     quant_matmul<<<grid, 256>>>(ctx->y, ctx->x, t->weights, t->scales, fmt, S, I, O, rb);
     if (!cuda_ok(cudaGetLastError(), "matmul launch") ||
         !cuda_ok(cudaMemcpy(y, ctx->y, yb, cudaMemcpyDeviceToHost), "output download")) return 0;
+    return 1;
+}
+
+extern "C" int coli_cuda_expert_mlp(ColiCudaTensor *gate, ColiCudaTensor *up,
+                                      ColiCudaTensor *down, float *y,
+                                      const float *x, int S) {
+    if (!gate || !up || !down || !x || !y || S < 1 ||
+        gate->device != up->device || gate->device != down->device ||
+        gate->I != up->I || gate->O != up->O ||
+        down->I != gate->O || down->O != gate->I) return 0;
+    DeviceContext *ctx = find_ctx(gate->device);
+    if (!select_ctx(ctx)) return 0;
+    int D = gate->I, I = gate->O;
+    size_t xb=(size_t)S*D*sizeof(float), ib=(size_t)S*I*sizeof(float);
+    size_t yb=(size_t)S*D*sizeof(float);
+    if (!reserve(&ctx->x,&ctx->x_cap,xb) || !reserve(&ctx->y,&ctx->y_cap,yb) ||
+        !reserve(&ctx->gate,&ctx->gate_cap,ib) || !reserve(&ctx->up,&ctx->up_cap,ib)) return 0;
+    if (!cuda_ok(cudaMemcpy(ctx->x,x,xb,cudaMemcpyHostToDevice),"expert input upload")) return 0;
+    dim3 hidden_grid((unsigned)I,(unsigned)S), output_grid((unsigned)D,(unsigned)S);
+    quant_matmul<<<hidden_grid,256>>>(ctx->gate,ctx->x,gate->weights,gate->scales,
+        gate->fmt,S,D,I,row_bytes(gate->fmt,D));
+    quant_matmul<<<hidden_grid,256>>>(ctx->up,ctx->x,up->weights,up->scales,
+        up->fmt,S,D,I,row_bytes(up->fmt,D));
+    size_t n=(size_t)S*I;
+    silu_mul<<<(unsigned)((n+255)/256),256>>>(ctx->gate,ctx->up,n);
+    quant_matmul<<<output_grid,256>>>(ctx->y,ctx->gate,down->weights,down->scales,
+        down->fmt,S,I,D,row_bytes(down->fmt,I));
+    if (!cuda_ok(cudaGetLastError(),"expert MLP launch") ||
+        !cuda_ok(cudaMemcpy(y,ctx->y,yb,cudaMemcpyDeviceToHost),"expert output download")) return 0;
     return 1;
 }
 

--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -246,6 +246,44 @@ extern "C" int coli_cuda_expert_mlp(ColiCudaTensor *gate, ColiCudaTensor *up,
     return 1;
 }
 
+extern "C" int coli_cuda_expert_group(ColiCudaTensor *const *gates,
+                                        ColiCudaTensor *const *ups,
+                                        ColiCudaTensor *const *downs,
+                                        const int *rows, int count,
+                                        float *y, const float *x) {
+    if (!gates || !ups || !downs || !rows || !x || !y || count < 1) return 0;
+    ColiCudaTensor *first=gates[0];
+    if (!first) return 0;
+    int device=first->device,D=first->I,I=first->O,total=0;
+    for(int c=0;c<count;c++){
+        ColiCudaTensor *g=gates[c],*u=ups[c],*d=downs[c];
+        if(!g||!u||!d||rows[c]<1||g->device!=device||u->device!=device||d->device!=device||
+           g->I!=D||u->I!=D||g->O!=I||u->O!=I||d->I!=I||d->O!=D) return 0;
+        total+=rows[c];
+    }
+    DeviceContext *ctx=find_ctx(device); if(!select_ctx(ctx)) return 0;
+    size_t xb=(size_t)total*D*sizeof(float), ib=(size_t)total*I*sizeof(float);
+    if(!reserve(&ctx->x,&ctx->x_cap,xb)||!reserve(&ctx->y,&ctx->y_cap,xb)||
+       !reserve(&ctx->gate,&ctx->gate_cap,ib)||!reserve(&ctx->up,&ctx->up_cap,ib)) return 0;
+    if(!cuda_ok(cudaMemcpy(ctx->x,x,xb,cudaMemcpyHostToDevice),"expert group input upload")) return 0;
+    int base=0;
+    for(int c=0;c<count;c++){
+        int S=rows[c]; ColiCudaTensor *g=gates[c],*u=ups[c],*d=downs[c];
+        float *dx=ctx->x+(size_t)base*D,*dg=ctx->gate+(size_t)base*I;
+        float *du=ctx->up+(size_t)base*I,*dy=ctx->y+(size_t)base*D;
+        dim3 hg((unsigned)I,(unsigned)S),og((unsigned)D,(unsigned)S);
+        quant_matmul<<<hg,256>>>(dg,dx,g->weights,g->scales,g->fmt,S,D,I,row_bytes(g->fmt,D));
+        quant_matmul<<<hg,256>>>(du,dx,u->weights,u->scales,u->fmt,S,D,I,row_bytes(u->fmt,D));
+        size_t n=(size_t)S*I;
+        silu_mul<<<(unsigned)((n+255)/256),256>>>(dg,du,n);
+        quant_matmul<<<og,256>>>(dy,dg,d->weights,d->scales,d->fmt,S,I,D,row_bytes(d->fmt,I));
+        base+=S;
+    }
+    if(!cuda_ok(cudaGetLastError(),"expert group launch")||
+       !cuda_ok(cudaMemcpy(y,ctx->y,xb,cudaMemcpyDeviceToHost),"expert group output download")) return 0;
+    return 1;
+}
+
 extern "C" void coli_cuda_tensor_free(ColiCudaTensor *tensor) {
     if (!tensor) return;
     DeviceContext *ctx = find_ctx(tensor->device);

--- a/c/backend_cuda.h
+++ b/c/backend_cuda.h
@@ -38,6 +38,12 @@ int coli_cuda_matmul(ColiCudaTensor **tensor,
                      const void *weights, const float *scales,
                      int fmt, int S, int I, int O, int device);
 
+/* Fused expert pipeline: y = down(silu(gate(x)) * up(x)).  All three tensors
+ * must already be resident on one device.  Activations cross PCIe once in
+ * each direction instead of once per matrix. */
+int coli_cuda_expert_mlp(ColiCudaTensor *gate, ColiCudaTensor *up,
+                         ColiCudaTensor *down, float *y, const float *x, int S);
+
 void coli_cuda_tensor_free(ColiCudaTensor *tensor);
 size_t coli_cuda_tensor_bytes(const ColiCudaTensor *tensor);
 int coli_cuda_tensor_device(const ColiCudaTensor *tensor);

--- a/c/backend_cuda.h
+++ b/c/backend_cuda.h
@@ -44,6 +44,14 @@ int coli_cuda_matmul(ColiCudaTensor **tensor,
 int coli_cuda_expert_mlp(ColiCudaTensor *gate, ColiCudaTensor *up,
                          ColiCudaTensor *down, float *y, const float *x, int S);
 
+/* Packed group of same-shaped experts. Inputs and outputs contain sum(rows)
+ * consecutive [D] rows in call order. */
+int coli_cuda_expert_group(ColiCudaTensor *const *gates,
+                           ColiCudaTensor *const *ups,
+                           ColiCudaTensor *const *downs,
+                           const int *rows, int count,
+                           float *y, const float *x);
+
 void coli_cuda_tensor_free(ColiCudaTensor *tensor);
 size_t coli_cuda_tensor_bytes(const ColiCudaTensor *tensor);
 int coli_cuda_tensor_device(const ColiCudaTensor *tensor);

--- a/c/backend_cuda.h
+++ b/c/backend_cuda.h
@@ -21,6 +21,8 @@ int coli_cuda_device_at(int index);
 int coli_cuda_mem_info(int device, size_t *free_bytes, size_t *total_bytes);
 /* device < 0 returns aggregate statistics for all configured devices. */
 void coli_cuda_stats(int device, size_t *tensor_count, size_t *tensor_bytes);
+void coli_cuda_group_stats(uint64_t *calls, uint64_t *experts, uint64_t *rows,
+                           double *h2d_ms, double *kernel_ms, double *d2h_ms);
 
 /* Upload without executing, so capacity failures happen during model startup. */
 int coli_cuda_tensor_upload(ColiCudaTensor **tensor,

--- a/c/coli
+++ b/c/coli
@@ -120,6 +120,7 @@ def resource_request(a, env):
 
 def env_for(a):
     e = dict(os.environ, SNAP=a.model)
+    e["COLI_POLICY"]=a.policy
     if a.ram:  e["RAM_GB"]=str(a.ram)
     if a.ngen: e["NGEN"]=str(a.ngen)
     if a.topp: e["TOPP"]=str(a.topp)
@@ -140,7 +141,7 @@ def env_for(a):
         if a.vram and a.gpu!="none": e["CUDA_EXPERT_GB"]=str(a.vram)
         try:
             ram,ctx,devices,vram=resource_request(a,e)
-            plan=build_plan(a.model,ram,ctx,devices,vram)
+            plan=build_plan(a.model,ram,ctx,devices,vram,policy=a.policy)
         except (OSError,ValueError,json.JSONDecodeError) as error:
             sys.exit(f"{C.yel}piano risorse non valido:{C.r} {error}")
         has_cuda=cuda_binary()
@@ -315,7 +316,7 @@ def cmd_plan(a):
         ram,ctx,devices,vram=resource_request(a,os.environ)
         if ctx<1: raise ValueError("--ctx deve essere positivo")
         if a.vram<0: raise ValueError("--vram non puo essere negativo")
-        plan=build_plan(a.model,ram,ctx,devices,vram)
+        plan=build_plan(a.model,ram,ctx,devices,vram,policy=a.policy)
     except (OSError, ValueError, json.JSONDecodeError) as error:
         sys.exit(f"{C.yel}impossibile creare il piano:{C.r} {error}")
     if a.json:
@@ -489,6 +490,9 @@ def main():
     common.add_argument("--ctx",type=int,default=0)
     common.add_argument("--gpu",default=None,help="auto, none oppure lista device, es. 0,1")
     common.add_argument("--vram",type=float,default=0,help="budget VRAM totale in GB (0=auto)")
+    common.add_argument("--policy",choices=("quality","balanced","experimental-fast"),
+                        default=os.environ.get("COLI_POLICY","quality"),
+                        help="quality policy; only experimental-fast permits lossy routing")
     common.add_argument("--repin", type=int, default=0, help="adatta gli expert RAM/VRAM ogni N token")
     common.add_argument("--cap", type=int, default=8); common.add_argument("--ngen", type=int, default=1024)  # rete di sicurezza: la fine vera la decidono gli stop token
     common.add_argument("--topp", type=float, default=0); common.add_argument("--topk", type=int, default=0)

--- a/c/cpu_pool.h
+++ b/c/cpu_pool.h
@@ -1,0 +1,74 @@
+#ifndef COLIBRI_CPU_POOL_H
+#define COLIBRI_CPU_POOL_H
+
+#include <pthread.h>
+#include <stdlib.h>
+
+typedef void (*CpuPoolFn)(void *ctx, int begin, int end);
+
+typedef struct CpuPool CpuPool;
+typedef struct { CpuPool *pool; int id; } CpuPoolWorker;
+struct CpuPool {
+    pthread_mutex_t mu;
+    pthread_cond_t work, done;
+    pthread_t *threads;
+    CpuPoolWorker *workers;
+    CpuPoolFn fn;
+    void *ctx;
+    int count, items, completed, generation, stop;
+};
+
+static void *cpu_pool_worker(void *opaque){
+    CpuPoolWorker *w=opaque; CpuPool *p=w->pool; int seen=0;
+    pthread_mutex_lock(&p->mu);
+    for(;;){
+        while(!p->stop&&seen==p->generation) pthread_cond_wait(&p->work,&p->mu);
+        if(p->stop) break;
+        seen=p->generation; CpuPoolFn fn=p->fn; void *ctx=p->ctx; int n=p->items;
+        int begin=(int)((long long)n*w->id/p->count);
+        int end=(int)((long long)n*(w->id+1)/p->count);
+        pthread_mutex_unlock(&p->mu);
+        if(begin<end) fn(ctx,begin,end);
+        pthread_mutex_lock(&p->mu);
+        if(++p->completed==p->count) pthread_cond_signal(&p->done);
+    }
+    pthread_mutex_unlock(&p->mu); return NULL;
+}
+
+static int cpu_pool_init(CpuPool *p,int count){
+    if(!p||count<1) return 0;
+    *p=(CpuPool){0}; p->count=count;
+    if(pthread_mutex_init(&p->mu,NULL)||pthread_cond_init(&p->work,NULL)||
+       pthread_cond_init(&p->done,NULL)) return 0;
+    p->threads=calloc((size_t)count,sizeof(*p->threads));
+    p->workers=calloc((size_t)count,sizeof(*p->workers));
+    if(!p->threads||!p->workers) return 0;
+    for(int i=0;i<count;i++){
+        p->workers[i]=(CpuPoolWorker){p,i};
+        if(pthread_create(&p->threads[i],NULL,cpu_pool_worker,&p->workers[i])){
+            pthread_mutex_lock(&p->mu); p->stop=1; pthread_cond_broadcast(&p->work); pthread_mutex_unlock(&p->mu);
+            for(int j=0;j<i;j++) pthread_join(p->threads[j],NULL);
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static void cpu_pool_for(CpuPool *p,int items,CpuPoolFn fn,void *ctx){
+    if(!p||!p->threads||items<1||!fn) return;
+    pthread_mutex_lock(&p->mu);
+    p->items=items; p->fn=fn; p->ctx=ctx; p->completed=0; p->generation++;
+    pthread_cond_broadcast(&p->work);
+    while(p->completed<p->count) pthread_cond_wait(&p->done,&p->mu);
+    pthread_mutex_unlock(&p->mu);
+}
+
+static void cpu_pool_destroy(CpuPool *p){
+    if(!p||!p->threads) return;
+    pthread_mutex_lock(&p->mu); p->stop=1; pthread_cond_broadcast(&p->work); pthread_mutex_unlock(&p->mu);
+    for(int i=0;i<p->count;i++) pthread_join(p->threads[i],NULL);
+    free(p->threads); free(p->workers); p->threads=NULL; p->workers=NULL;
+    pthread_cond_destroy(&p->work); pthread_cond_destroy(&p->done); pthread_mutex_destroy(&p->mu);
+}
+
+#endif

--- a/c/glm.c
+++ b/c/glm.c
@@ -1279,23 +1279,35 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
             m->t_emm += now_s()-t0;
         }
 #ifdef COLI_CUDA
+        ColiCudaTensor *dev_g[COLI_CUDA_MAX_DEVICES][64],*dev_u[COLI_CUDA_MAX_DEVICES][64];
+        ColiCudaTensor *dev_d[COLI_CUDA_MAX_DEVICES][64];
+        int dev_rows[COLI_CUDA_MAX_DEVICES][64],dev_which[COLI_CUDA_MAX_DEVICES][64];
+        int dev_nc[COLI_CUDA_MAX_DEVICES]={0},dev_total[COLI_CUDA_MAX_DEVICES]={0};
+        int dev_off[COLI_CUDA_MAX_DEVICES]={0},dev_ok[COLI_CUDA_MAX_DEVICES]={0};
+        for(int di=0;di<g_cuda_ndev;di++) for(int q=0;q<ngroup;q++)
+            if(group_e[q]->g.cuda_device==g_cuda_devices[di]) dev_total[di]+=group_n[q];
+        for(int di=1;di<g_cuda_ndev;di++) dev_off[di]=dev_off[di-1]+dev_total[di-1];
         for(int di=0;di<g_cuda_ndev;di++){
-            ColiCudaTensor *gates[64],*ups[64],*downs[64]; int nrows[64], which[64];
-            int nc=0,total=0,device=g_cuda_devices[di];
+            int cursor=0,device=g_cuda_devices[di];
             for(int q=0;q<ngroup;q++) if(group_e[q]->g.cuda_device==device){
-                ESlot *e=group_e[q]; gates[nc]=e->g.cuda; ups[nc]=e->u.cuda; downs[nc]=e->d.cuda;
-                nrows[nc]=group_n[q]; which[nc]=q;
-                for(int r=0;r<group_n[q];r++) memcpy(group_x+(int64_t)(total+r)*D,
+                int nc=dev_nc[di]++; ESlot *e=group_e[q];
+                dev_g[di][nc]=e->g.cuda; dev_u[di][nc]=e->u.cuda; dev_d[di][nc]=e->d.cuda;
+                dev_rows[di][nc]=group_n[q]; dev_which[di][nc]=q;
+                for(int r=0;r<group_n[q];r++) memcpy(group_x+(int64_t)(dev_off[di]+cursor+r)*D,
                     x+(int64_t)group_row[(int64_t)q*S+r]*D,D*sizeof(float));
-                total+=group_n[q]; nc++;
+                cursor+=group_n[q];
             }
-            if(!nc) continue;
-            double t0=now_s();
-            int ok=coli_cuda_expert_group(gates,ups,downs,nrows,nc,group_y,group_x);
-            int off=0;
-            for(int q=0;q<nc;q++){
-                int gi=which[q],nr=group_n[gi]; ESlot *e=group_e[gi];
-                if(!ok){
+        }
+        double tg=now_s();
+        #pragma omp parallel for if(g_cuda_ndev>1) schedule(static)
+        for(int di=0;di<g_cuda_ndev;di++) if(dev_nc[di])
+            dev_ok[di]=coli_cuda_expert_group(dev_g[di],dev_u[di],dev_d[di],dev_rows[di],dev_nc[di],
+                group_y+(int64_t)dev_off[di]*D,group_x+(int64_t)dev_off[di]*D);
+        for(int di=0;di<g_cuda_ndev;di++){
+            int off=dev_off[di];
+            for(int q=0;q<dev_nc[di];q++){
+                int gi=dev_which[di][q],nr=group_n[gi]; ESlot *e=group_e[gi];
+                if(!dev_ok[di]){
                     for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D,x+(int64_t)group_row[(int64_t)gi*S+r]*D,D*sizeof(float));
                     if(!coli_cuda_expert_mlp(e->g.cuda,e->u.cuda,e->d.cuda,hh,xg,nr)){
                         matmul_qt(gg,xg,&e->g,nr); matmul_qt(uu,xg,&e->u,nr);
@@ -1303,13 +1315,13 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
                         matmul_qt(hh,gg,&e->d,nr);
                     }
                 }
-                float *src=ok?group_y+(int64_t)off*D:hh;
-                for(int r=0;r<nr;r++){ float *os=out+(int64_t)group_row[(int64_t)gi*S+r]*D, wgt=group_weight[(int64_t)gi*S+r];
+                float *src=dev_ok[di]?group_y+(int64_t)off*D:hh;
+                for(int r=0;r<nr;r++){ float *os=out+(int64_t)group_row[(int64_t)gi*S+r]*D,wgt=group_weight[(int64_t)gi*S+r];
                     for(int d=0;d<D;d++) os[d]+=wgt*src[(int64_t)r*D+d]; }
                 off+=nr;
             }
-            m->t_emm+=now_s()-t0;
         }
+        m->t_emm+=now_s()-tg;
 #endif
         { ESlot *Sl=m->ecache[layer]; int *nn=&m->ecn[layer];   /* promozione LRU (swap buffer) */
           int promo = nmiss<m->ecap ? nmiss : m->ecap;

--- a/c/glm.c
+++ b/c/glm.c
@@ -2505,6 +2505,14 @@ int main(int argc, char **argv){
     g_prefetch = getenv("PREFETCH")?atoi(getenv("PREFETCH")):0;
     g_topk = getenv("TOPK")?atoi(getenv("TOPK")):0;
     g_topp = getenv("TOPP")?atof(getenv("TOPP")):0;
+    const char *policy=getenv("COLI_POLICY"); if(!policy) policy="quality";
+    int experimental=!strcmp(policy,"experimental-fast");
+    if(strcmp(policy,"quality")&&strcmp(policy,"balanced")&&!experimental){
+        fprintf(stderr,"COLI_POLICY non valida: quality, balanced o experimental-fast\n"); return 2;
+    }
+    if(!experimental&&(g_topk>0||g_topp>0)){
+        fprintf(stderr,"TOPK/TOPP modificano il router; usa COLI_POLICY=experimental-fast esplicitamente\n"); return 2;
+    }
     g_mlock  = getenv("MLOCK")?atoi(getenv("MLOCK")):-1;   /* -1 auto (ON macOS), 0 off, 1 force / auto (ON macOS), 0 off, 1 force */
     g_spec = getenv("SPEC")?atoi(getenv("SPEC")):1;
     g_draft = getenv("DRAFT")?atoi(getenv("DRAFT")):-1;   /* -1 = auto: 3 se MTP, 0 senza */

--- a/c/glm.c
+++ b/c/glm.c
@@ -1210,9 +1210,11 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
     float *xg=falloc((int64_t)S*D), *gg=falloc((int64_t)S*I), *uu=falloc((int64_t)S*I), *hh=falloc((int64_t)S*D);
     int *rows=malloc(S*sizeof(int)); float *rw=malloc(S*sizeof(float));
 #ifdef COLI_CUDA
-    float *group_x=falloc((int64_t)S*K*D), *group_y=falloc((int64_t)S*K*D);
-    int *group_row=malloc((size_t)64*S*sizeof(int));
-    float *group_weight=malloc((size_t)64*S*sizeof(float));
+    int group_enabled=S<=64;
+    float *group_x=group_enabled?falloc((int64_t)S*K*D):NULL;
+    float *group_y=group_enabled?falloc((int64_t)S*K*D):NULL;
+    int *group_row=group_enabled?malloc((size_t)64*S*sizeof(int)):NULL;
+    float *group_weight=group_enabled?malloc((size_t)64*S*sizeof(float)):NULL;
 #endif
     for(int base=0;base<nu;base+=64){
         int nb = nu-base<64 ? nu-base : 64;
@@ -1250,7 +1252,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
             if(!nr) continue;
 #ifdef COLI_CUDA
             if(g_cuda_enabled && e->g.cuda_eligible) m->gpu_expert_calls++;
-            if(g_cuda_enabled && e->g.cuda_eligible && e->u.cuda_eligible && e->d.cuda_eligible &&
+            if(group_enabled && g_cuda_enabled && e->g.cuda_eligible && e->u.cuda_eligible && e->d.cuda_eligible &&
                !omp_in_parallel()){
                 group_e[ngroup]=e; group_n[ngroup]=nr;
                 for(int r=0;r<nr;r++){ group_row[(int64_t)ngroup*S+r]=rows[r]; group_weight[(int64_t)ngroup*S+r]=rw[r]; }
@@ -1259,6 +1261,15 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
 #endif
             for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)rows[r]*D, D*sizeof(float));
             double t0=now_s();
+#ifdef COLI_CUDA
+            if(!group_enabled && g_cuda_enabled && e->g.cuda_eligible && e->u.cuda_eligible &&
+               e->d.cuda_eligible && !omp_in_parallel() &&
+               coli_cuda_expert_mlp(e->g.cuda,e->u.cuda,e->d.cuda,hh,xg,nr)){
+                for(int r=0;r<nr;r++){ float *os=out+(int64_t)rows[r]*D,wgt=rw[r],*hr=hh+(int64_t)r*D;
+                    for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
+                m->t_emm+=now_s()-t0; continue;
+            }
+#endif
             matmul_qt(gg, xg, &e->g, nr);
             matmul_qt(uu, xg, &e->u, nr);
             for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];

--- a/c/glm.c
+++ b/c/glm.c
@@ -165,6 +165,14 @@ static void cuda_stats_print(void){
         coli_cuda_stats(g_cuda_devices[i],&n,&b);
         fprintf(stderr,"[CUDA]   device %d: %zu tensor, %.2f GB\n",g_cuda_devices[i],n,b/1e9);
     }
+    uint64_t calls=0,experts=0,rows=0; double h2d=0,kernel=0,d2h=0;
+    coli_cuda_group_stats(&calls,&experts,&rows,&h2d,&kernel,&d2h);
+    if(calls) fprintf(stderr,"[CUDA] expert groups: %llu call, %llu expert, %llu righe "
+        "(%.2f expert/call)%s\n",(unsigned long long)calls,(unsigned long long)experts,
+        (unsigned long long)rows,(double)experts/calls,
+        getenv("COLI_CUDA_PROFILE")?"; timing sotto":"");
+    if(calls&&getenv("COLI_CUDA_PROFILE")) fprintf(stderr,
+        "[CUDA] expert groups timing: H2D %.1f ms | kernel %.1f ms | D2H %.1f ms\n",h2d,kernel,d2h);
 }
 static int parse_cuda_devices(const char *list, int *out){
     if(!list||!*list) return 0;

--- a/c/glm.c
+++ b/c/glm.c
@@ -147,6 +147,7 @@ static void usage_save(Model *m);        /* cache che impara: definita accanto a
 static int g_cuda_enabled;
 static double g_cuda_expert_gb;
 static int g_cuda_dense;
+static int g_cuda_release_host;
 static int g_cuda_devices[COLI_CUDA_MAX_DEVICES], g_cuda_ndev, g_cuda_rr;
 static int64_t g_cuda_dense_projected[COLI_CUDA_MAX_DEVICES];
 static void qt_cuda_reset(QT *t){
@@ -950,6 +951,24 @@ static void expert_load(Model *m, int layer, int eid, ESlot *s){
     s->eid=eid;
 }
 
+#ifdef COLI_CUDA
+static void expert_host_release(Model *m, ESlot *s){
+    if(!s->slab&&!s->fslab) return;
+#if defined(__APPLE__) || defined(__linux__)
+    if(s->slab) munlock(s->slab,(size_t)s->slab_cap);
+    if(s->fslab) munlock(s->fslab,(size_t)s->fslab_cap*sizeof(float));
+#endif
+    int64_t bytes=qt_bytes(&s->g)+qt_bytes(&s->u)+qt_bytes(&s->d);
+    free(s->slab); free(s->fslab); s->slab=NULL; s->fslab=NULL; s->slab_cap=s->fslab_cap=0;
+    QT *q[3]={&s->g,&s->u,&s->d};
+    for(int k=0;k<3;k++){ q[k]->qf=NULL; q[k]->q8=NULL; q[k]->q4=NULL; q[k]->s=NULL; }
+    m->resident_bytes-=bytes; if(m->resident_bytes<0) m->resident_bytes=0;
+}
+static void expert_host_ensure(Model *m, int layer, ESlot *s){
+    if(!s->slab) expert_load(m,layer,s->eid,s);
+}
+#endif
+
 /* prefetch asincrono dei pesi di un expert (e delle sue scale .qs): avvia il readahead
  * cosi' le letture sincrone successive trovano la page-cache calda. */
 static void expert_prefetch(Model *m, int layer, int eid){
@@ -1269,6 +1288,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
                     for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
                 m->t_emm+=now_s()-t0; continue;
             }
+            if(!e->slab) expert_host_ensure(m,layer,e);
 #endif
             matmul_qt(gg, xg, &e->g, nr);
             matmul_qt(uu, xg, &e->u, nr);
@@ -1310,6 +1330,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
                 if(!dev_ok[di]){
                     for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D,x+(int64_t)group_row[(int64_t)gi*S+r]*D,D*sizeof(float));
                     if(!coli_cuda_expert_mlp(e->g.cuda,e->u.cuda,e->d.cuda,hh,xg,nr)){
+                        expert_host_ensure(m,layer,e);
                         matmul_qt(gg,xg,&e->g,nr); matmul_qt(uu,xg,&e->u,nr);
                         for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
                         matmul_qt(hh,gg,&e->d,nr);
@@ -1921,6 +1942,7 @@ static void repin_pass(Model *m){
                                +(int64_t)coli_cuda_tensor_bytes(s->u.cuda)
                                +(int64_t)coli_cuda_tensor_bytes(s->d.cuda);
                 m->gpu_expert_bytes+=now_gpu-old_gpu; tier="VRAM";
+                if(g_cuda_release_host) expert_host_release(m,s);
             } else {
                 qt_cuda_reset(&s->g); qt_cuda_reset(&s->u); qt_cuda_reset(&s->d);
                 s->g.cuda_eligible=s->u.cuda_eligible=s->d.cuda_eligible=0;
@@ -2270,25 +2292,36 @@ static void pin_wire(Model *m){
             "(niente compressione/no compression) in %.0fs\n", wired/1e9, now_s()-t0);
 }
 
+typedef struct { int l,e; uint32_t c; } PinRec;
+static int pin_rec_cmp(const void *a,const void *b){
+    const PinRec *x=a,*y=b; return x->c<y->c?1:x->c>y->c?-1:0;
+}
 static void pin_load(Model *m, const char *statspath, double gb){
     FILE *f=fopen(statspath,"r"); if(!f){ perror(statspath); return; }
-    typedef struct { int l,e; uint32_t c; } Rec;
     Cfg *c=&m->c; int cap=(c->n_layers+1)*c->n_experts;
-    Rec *r=malloc((size_t)cap*sizeof(Rec)); int n=0;
+    PinRec *r=malloc((size_t)cap*sizeof(PinRec)); int n=0;
+    unsigned char *seen=calloc((size_t)(c->n_layers+1)*c->n_experts,1);
     int l,e; uint32_t cnt;
     while(n<cap && fscanf(f,"%d %d %u",&l,&e,&cnt)==3){
         int ok = l>=0 && e>=0 && e<c->n_experts &&
                  ((l<c->n_layers && m->L[l].sparse) || (l==c->n_layers && m->has_mtp));
-        if(ok) r[n++]=(Rec){l,e,cnt};
+        int64_t key=(int64_t)l*c->n_experts+e;
+        if(ok&&!seen[key]){ r[n++]=(PinRec){l,e,cnt}; seen[key]=1; }
     }
     fclose(f);
-    for(int a=0;a<n;a++){ int best=a;                       /* selection sort parziale, poi taglio */
-        for(int b=a+1;b<n;b++) if(r[b].c>r[best].c) best=b;
-        Rec t=r[a]; r[a]=r[best]; r[best]=t;
-        if(a>4095) break;                                    /* bastano i top ~4k */
+    int fill=getenv("PIN_FILL")?atoi(getenv("PIN_FILL")):0;
+#ifdef COLI_CUDA
+    if(!getenv("PIN_FILL")&&g_cuda_release_host) fill=1;
+#endif
+    if(fill) for(int li=0;li<=c->n_layers;li++){
+        int sparse=(li<c->n_layers&&m->L[li].sparse)||(li==c->n_layers&&m->has_mtp);
+        if(sparse) for(int ei=0;ei<c->n_experts;ei++) if(!seen[(int64_t)li*c->n_experts+ei])
+            r[n++]=(PinRec){li,ei,0};
     }
+    free(seen);
+    qsort(r,(size_t)n,sizeof(*r),pin_rec_cmp);
     int64_t eb=expert_bytes_probe(m,m->ebits);
-    int npin=(int)(gb*1e9/eb); if(npin>n) npin=n; if(npin>4096) npin=4096;
+    int npin=(int)(gb*1e9/eb); if(npin>n) npin=n;
     if(npin<1){ free(r); return; }
     int *cnt_l=calloc(c->n_layers+1,sizeof(int));   /* +1: riga MTP */
     for(int a=0;a<npin;a++) cnt_l[r[a].l]++;
@@ -2341,6 +2374,7 @@ static void pin_load(Model *m, const char *statspath, double gb){
                                       +(int64_t)coli_cuda_tensor_bytes(s->d.cuda);
                         m->gpu_expert_count++; m->gpu_expert_bytes+=actual;
                         remaining[best]-=actual; placed_b[best]+=actual; placed_n[best]++;
+                        if(g_cuda_release_host) expert_host_release(m,s);
                         placed=1;
                     } else {
                         qt_cuda_reset(&s->g); qt_cuda_reset(&s->u); qt_cuda_reset(&s->d);
@@ -2507,10 +2541,13 @@ int main(int argc, char **argv){
     }
     g_cuda_dense=getenv("CUDA_DENSE")?atoi(getenv("CUDA_DENSE")):0;
     g_cuda_expert_gb=getenv("CUDA_EXPERT_GB")?atof(getenv("CUDA_EXPERT_GB")):0;
+    g_cuda_release_host=getenv("CUDA_RELEASE_HOST")?atoi(getenv("CUDA_RELEASE_HOST")):(g_cuda_ndev>1);
     if((getenv("COLI_GPU")||getenv("COLI_GPUS"))&&!g_cuda_enabled){ fprintf(stderr,"COLI_GPU(S) richiede COLI_CUDA=1\n"); return 2; }
     if(g_cuda_dense&&!g_cuda_enabled){ fprintf(stderr,"CUDA_DENSE richiede COLI_CUDA=1\n"); return 2; }
     if(g_cuda_expert_gb>0 && !g_cuda_enabled){ fprintf(stderr,"CUDA_EXPERT_GB richiede COLI_CUDA=1\n"); return 2; }
-    if(g_cuda_enabled) fprintf(stderr,"[CUDA] mode: routed experts%s\n",g_cuda_dense?" + resident dense tensors":" only (resident dense on CPU)");
+    if(g_cuda_enabled) fprintf(stderr,"[CUDA] mode: routed experts%s%s\n",
+        g_cuda_dense?" + resident dense tensors":" only (resident dense on CPU)",
+        g_cuda_release_host?"; VRAM experts senza host backing":"");
 #else
     if((getenv("COLI_CUDA") && atoi(getenv("COLI_CUDA"))) ||
        getenv("COLI_GPU") || getenv("COLI_GPUS") ||
@@ -2523,7 +2560,13 @@ int main(int argc, char **argv){
     printf("== Motore C GLM (glm_moe_dsa), cache=%d expert/layer | expert@%d-bit densa@%d-bit | idot: " IDOT_KERNEL " ==\n", cap, ebits, dbits);
     g_mem_avail_boot = mem_available_gb();
     Model m; double t0=now_s(); model_init(&m,snap,cap,ebits,dbits);
-    if(g_draft<0) g_draft = m.has_mtp ? 3 : 0;
+    if(g_draft<0){
+#ifdef COLI_CUDA
+        g_draft = (m.has_mtp&&!g_cuda_enabled) ? 3 : 0;
+#else
+        g_draft = m.has_mtp ? 3 : 0;
+#endif
+    }
     if(getenv("DSA_TOPK")) m.c.index_topk=atoi(getenv("DSA_TOPK"));   /* override per test */
     printf("caricato in %.2fs | densa residente: %.2f MB | layers=%d experts=%d | MTP %s (draft=%d)\n",
            now_s()-t0, m.resident_bytes/(1024.0*1024.0), m.c.n_layers, m.c.n_experts,

--- a/c/glm.c
+++ b/c/glm.c
@@ -323,12 +323,20 @@ static void matmul_i4_pair(float *yg, float *yu, const float *x,
         for(int z=0;z<2*O;z++) matmul_i4_pair_rows(&job,z,z+1);
     }
 }
+static void matmul_i4_pool(float *y,const float *x,const uint8_t *q,const float *s,int I,int O){
+    I4PairJob job={y,NULL,x,q,NULL,s,NULL,I,O,(I+1)/2};
+    cpu_pool_for(&g_cpu_pool,O,matmul_i4_pair_rows,&job);
+}
 
 static void matmul_qt(float *y,const float *x,QT *w,int S);
 static void expert_gate_up(float *g,float *u,const float *x,QT *wg,QT *wu,int S){
     if(S==1&&wg->fmt==2&&wu->fmt==2&&wg->I==wu->I&&wg->O==wu->O)
         matmul_i4_pair(g,u,x,wg->q4,wg->s,wu->q4,wu->s,wg->I,wg->O);
     else { matmul_qt(g,x,wg,S); matmul_qt(u,x,wu,S); }
+}
+static void expert_down(float *y,const float *x,QT *w,int S){
+    if(g_cpu_pool_enabled&&S==1&&w->fmt==2) matmul_i4_pool(y,x,w->q4,w->s,w->I,w->O);
+    else matmul_qt(y,x,w,S);
 }
 /* y[S,O] = x[S,I] @ W^T con W int2 impacchettato (4 valori/byte) + scala[O]. nibble 2-bit -> [-2,1]. */
 static void matmul_i2(float *y, const float *x, const uint8_t *q2, const float *scale, int S, int I, int O){
@@ -1380,7 +1388,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
 #endif
             expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
             for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
-            matmul_qt(hh, gg, &e->d, nr);
+            expert_down(hh,gg,&e->d,nr);
             for(int r=0;r<nr;r++){ float *os=out+(int64_t)rows[r]*D, wgt=rw[r], *hr=hh+(int64_t)r*D;
                 for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
             m->t_emm += now_s()-t0;
@@ -1420,7 +1428,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
                         expert_host_ensure(m,layer,e);
                         expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
                         for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
-                        matmul_qt(hh,gg,&e->d,nr);
+                        expert_down(hh,gg,&e->d,nr);
                     }
                 }
                 float *src=dev_ok[di]?group_y+(int64_t)off*D:hh;
@@ -1449,7 +1457,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
                 double tc=now_s();
                 expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
                 for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
-                matmul_qt(hh,gg,&e->d,nr);
+                expert_down(hh,gg,&e->d,nr);
                 for(int r=0;r<nr;r++){ float *os=out+(int64_t)rows[r]*D,wgt=rw[r],*hr=hh+(int64_t)r*D;
                     for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
                 m->t_emm+=now_s()-tc;

--- a/c/glm.c
+++ b/c/glm.c
@@ -1201,6 +1201,11 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
     /* ---- FASE C/D: risolvi (pin/cache/disco) e calcola, a blocchi di 64 unici ---- */
     float *xg=falloc((int64_t)S*D), *gg=falloc((int64_t)S*I), *uu=falloc((int64_t)S*I), *hh=falloc((int64_t)S*D);
     int *rows=malloc(S*sizeof(int)); float *rw=malloc(S*sizeof(float));
+#ifdef COLI_CUDA
+    float *group_x=falloc((int64_t)S*K*D), *group_y=falloc((int64_t)S*K*D);
+    int *group_row=malloc((size_t)64*S*sizeof(int));
+    float *group_weight=malloc((size_t)64*S*sizeof(float));
+#endif
     for(int base=0;base<nu;base+=64){
         int nb = nu-base<64 ? nu-base : 64;
         ESlot *use[64]; int missk[64]; int nmiss=0;
@@ -1227,6 +1232,9 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
                 if(!found) expert_prefetch(m,layer,eid);
             }
         }
+#ifdef COLI_CUDA
+        ESlot *group_e[64]; int group_n[64]; int ngroup=0;
+#endif
         for(int j=0;j<nb;j++){ int eid=uniq[base+j]; ESlot *e=use[j];
             int nr=0;                                 /* righe (posizioni) che usano questo expert */
             for(int s=0;s<S;s++) for(int kk=0;kk<keff[s];kk++)
@@ -1234,18 +1242,15 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
             if(!nr) continue;
 #ifdef COLI_CUDA
             if(g_cuda_enabled && e->g.cuda_eligible) m->gpu_expert_calls++;
+            if(g_cuda_enabled && e->g.cuda_eligible && e->u.cuda_eligible && e->d.cuda_eligible &&
+               !omp_in_parallel()){
+                group_e[ngroup]=e; group_n[ngroup]=nr;
+                for(int r=0;r<nr;r++){ group_row[(int64_t)ngroup*S+r]=rows[r]; group_weight[(int64_t)ngroup*S+r]=rw[r]; }
+                ngroup++; continue;
+            }
 #endif
             for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)rows[r]*D, D*sizeof(float));
             double t0=now_s();
-#ifdef COLI_CUDA
-            if(g_cuda_enabled && e->g.cuda_eligible && e->u.cuda_eligible && e->d.cuda_eligible &&
-               !omp_in_parallel() && coli_cuda_expert_mlp(e->g.cuda,e->u.cuda,e->d.cuda,hh,xg,nr)){
-                for(int r=0;r<nr;r++){ float *os=out+(int64_t)rows[r]*D, wgt=rw[r], *hr=hh+(int64_t)r*D;
-                    for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
-                m->t_emm += now_s()-t0;
-                continue;
-            }
-#endif
             matmul_qt(gg, xg, &e->g, nr);
             matmul_qt(uu, xg, &e->u, nr);
             for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
@@ -1254,6 +1259,39 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
                 for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
             m->t_emm += now_s()-t0;
         }
+#ifdef COLI_CUDA
+        for(int di=0;di<g_cuda_ndev;di++){
+            ColiCudaTensor *gates[64],*ups[64],*downs[64]; int nrows[64], which[64];
+            int nc=0,total=0,device=g_cuda_devices[di];
+            for(int q=0;q<ngroup;q++) if(group_e[q]->g.cuda_device==device){
+                ESlot *e=group_e[q]; gates[nc]=e->g.cuda; ups[nc]=e->u.cuda; downs[nc]=e->d.cuda;
+                nrows[nc]=group_n[q]; which[nc]=q;
+                for(int r=0;r<group_n[q];r++) memcpy(group_x+(int64_t)(total+r)*D,
+                    x+(int64_t)group_row[(int64_t)q*S+r]*D,D*sizeof(float));
+                total+=group_n[q]; nc++;
+            }
+            if(!nc) continue;
+            double t0=now_s();
+            int ok=coli_cuda_expert_group(gates,ups,downs,nrows,nc,group_y,group_x);
+            int off=0;
+            for(int q=0;q<nc;q++){
+                int gi=which[q],nr=group_n[gi]; ESlot *e=group_e[gi];
+                if(!ok){
+                    for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D,x+(int64_t)group_row[(int64_t)gi*S+r]*D,D*sizeof(float));
+                    if(!coli_cuda_expert_mlp(e->g.cuda,e->u.cuda,e->d.cuda,hh,xg,nr)){
+                        matmul_qt(gg,xg,&e->g,nr); matmul_qt(uu,xg,&e->u,nr);
+                        for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
+                        matmul_qt(hh,gg,&e->d,nr);
+                    }
+                }
+                float *src=ok?group_y+(int64_t)off*D:hh;
+                for(int r=0;r<nr;r++){ float *os=out+(int64_t)group_row[(int64_t)gi*S+r]*D, wgt=group_weight[(int64_t)gi*S+r];
+                    for(int d=0;d<D;d++) os[d]+=wgt*src[(int64_t)r*D+d]; }
+                off+=nr;
+            }
+            m->t_emm+=now_s()-t0;
+        }
+#endif
         { ESlot *Sl=m->ecache[layer]; int *nn=&m->ecn[layer];   /* promozione LRU (swap buffer) */
           int promo = nmiss<m->ecap ? nmiss : m->ecap;
           for(int a=0;a<promo;a++){ int q=nmiss-1-a; ESlot *dst;
@@ -1271,6 +1309,9 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
     for(int64_t z=0;z<(int64_t)S*D;z++) out[z]+=hh[z];
     free(logit); free(sig); free(choice); free(idxs); free(ws); free(keff); free(uniq);
     free(xg); free(gg); free(uu); free(hh); free(rows); free(rw); free(sg); free(su);
+#ifdef COLI_CUDA
+    free(group_x); free(group_y); free(group_row); free(group_weight);
+#endif
 }
 
 static void dense_mlp(Layer *l, float *x, int S, int D, int I, float *out){

--- a/c/glm.c
+++ b/c/glm.c
@@ -138,7 +138,7 @@ typedef struct {
     uint64_t eclock, hits, miss, ereq;
     uint64_t gpu_expert_calls; int gpu_expert_count; int64_t gpu_expert_bytes;
     uint64_t n_fw, n_emit;                       /* metodo E: forward di decode / token emessi */
-    double t_edisk, t_emm, t_attn, t_kvb, t_head;/* profiling: dove va il tempo (sempre attivo) */
+    double t_edisk, t_ewait, t_emm, t_attn, t_kvb, t_head;/* profiling: dove va il tempo */
     int64_t resident_bytes;
 } Model;
 
@@ -969,6 +969,19 @@ static void expert_host_ensure(Model *m, int layer, ESlot *s){
 }
 #endif
 
+typedef struct {
+    Model *model; int layer,base,nmiss,threads;
+    int *uniq,*missk; double seconds;
+} ExpertLoadJob;
+static void *expert_load_run(void *opaque){
+    ExpertLoadJob *j=opaque; double t0=now_s();
+    #pragma omp parallel for schedule(dynamic,1) num_threads(j->threads)
+    for(int q=0;q<j->nmiss;q++)
+        expert_load(j->model,j->layer,j->uniq[j->base+j->missk[q]],&j->model->ws[q]);
+    j->seconds=now_s()-t0;
+    return NULL;
+}
+
 /* prefetch asincrono dei pesi di un expert (e delle sue scale .qs): avvia il readahead
  * cosi' le letture sincrone successive trovano la page-cache calda. */
 static void expert_prefetch(Model *m, int layer, int eid){
@@ -1237,18 +1250,24 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
 #endif
     for(int base=0;base<nu;base+=64){
         int nb = nu-base<64 ? nu-base : 64;
-        ESlot *use[64]; int missk[64]; int nmiss=0;
+        ESlot *use[64]; int missk[64],miss_pos[64]={0}; int nmiss=0;
         for(int j=0;j<nb;j++){ int eid=uniq[base+j]; use[j]=NULL;
             ESlot *P=m->pin[layer];
             for(int z=0;z<m->npin[layer];z++) if(P[z].eid==eid){ m->hits++; use[j]=&P[z]; break; }
             if(!use[j]){ ESlot *Sl=m->ecache[layer]; int nn=m->ecn[layer];
                 for(int z=0;z<nn;z++) if(Sl[z].eid==eid){ m->hits++; Sl[z].used=++m->eclock; use[j]=&Sl[z]; break; } }
-            if(!use[j]){ use[j]=&m->ws[nmiss]; missk[nmiss++]=j; m->miss++; }
+            if(!use[j]){ use[j]=&m->ws[nmiss]; missk[nmiss++]=j; miss_pos[j]=1; m->miss++; }
         }
-        if(nmiss){ double t0=now_s();
-            #pragma omp parallel for schedule(dynamic,1)
-            for(int q=0;q<nmiss;q++) expert_load(m,layer,uniq[base+missk[q]],&m->ws[q]);
-            m->t_edisk += now_s()-t0; }
+        pthread_t load_thread; int load_threaded=0;
+        int io_threads=nmiss<8?nmiss:8;
+        if(nmiss==nb) io_threads=nmiss;            /* no foreground work: retain full I/O fan-out */
+        ExpertLoadJob load_job={m,layer,base,nmiss,io_threads,uniq,missk,0};
+        if(getenv("IO_THREADS")) load_job.threads=atoi(getenv("IO_THREADS"));
+        if(load_job.threads<1) load_job.threads=1;
+        if(nmiss){
+            load_threaded=!pthread_create(&load_thread,NULL,expert_load_run,&load_job);
+            if(!load_threaded) expert_load_run(&load_job);
+        }
         /* I/O ASINCRONO: readahead (WILLNEED) del blocco SUCCESSIVO mentre calcoliamo
          * questo — il kernel legge in background, le pread dopo trovano cache calda */
         if(base+64<nu){
@@ -1265,6 +1284,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
         ESlot *group_e[64]; int group_n[64]; int ngroup=0;
 #endif
         for(int j=0;j<nb;j++){ int eid=uniq[base+j]; ESlot *e=use[j];
+            if(miss_pos[j]) continue;                    /* loader owns this slot for now */
             int nr=0;                                 /* righe (posizioni) che usano questo expert */
             for(int s=0;s<S;s++) for(int kk=0;kk<keff[s];kk++)
                 if(idxs[(int64_t)s*K+kk]==eid){ rows[nr]=s; rw[nr]=ws[(int64_t)s*K+kk]; nr++; break; }
@@ -1344,6 +1364,30 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
         }
         m->t_emm+=now_s()-tg;
 #endif
+        if(nmiss){
+            double tw=now_s();
+            if(load_threaded) pthread_join(load_thread,NULL);
+            m->t_ewait+=now_s()-tw;
+            m->t_edisk+=load_job.seconds;
+            /* Deferred cold experts: hot RAM/VRAM work above ran while their
+             * reads were in flight. Router choices and weights are unchanged. */
+            for(int q=0;q<nmiss;q++){
+                int j=missk[q],eid=uniq[base+j],nr=0; ESlot *e=use[j];
+                (void)eid;
+                for(int s=0;s<S;s++) for(int kk=0;kk<keff[s];kk++)
+                    if(idxs[(int64_t)s*K+kk]==uniq[base+j]){
+                        rows[nr]=s; rw[nr]=ws[(int64_t)s*K+kk]; nr++; break;
+                    }
+                for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D,x+(int64_t)rows[r]*D,D*sizeof(float));
+                double tc=now_s();
+                matmul_qt(gg,xg,&e->g,nr); matmul_qt(uu,xg,&e->u,nr);
+                for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
+                matmul_qt(hh,gg,&e->d,nr);
+                for(int r=0;r<nr;r++){ float *os=out+(int64_t)rows[r]*D,wgt=rw[r],*hr=hh+(int64_t)r*D;
+                    for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
+                m->t_emm+=now_s()-tc;
+            }
+        }
         { ESlot *Sl=m->ecache[layer]; int *nn=&m->ecn[layer];   /* promozione LRU (swap buffer) */
           int promo = nmiss<m->ecap ? nmiss : m->ecap;
           for(int a=0;a<promo;a++){ int q=nmiss-1-a; ESlot *dst;
@@ -1807,10 +1851,10 @@ static void generate(Model *m, const int *prompt, int np, int n_new, int *out){
 }
 
 static void profile_print(Model *m, double elapsed){
-    double accounted=m->t_edisk+m->t_emm+m->t_attn+m->t_head;
-    printf("PROFILO: expert-disk %.3fs | expert-matmul %.3fs | attention %.3fs "
+    double accounted=m->t_ewait+m->t_emm+m->t_attn+m->t_head;
+    printf("PROFILO: expert-disk %.3fs service / %.3fs wait | expert-matmul %.3fs | attention %.3fs "
            "(di cui kvb %.3fs) | lm_head %.3fs | altro %.3fs\n",
-        m->t_edisk,m->t_emm,m->t_attn,m->t_kvb,m->t_head,elapsed-accounted);
+        m->t_edisk,m->t_ewait,m->t_emm,m->t_attn,m->t_kvb,m->t_head,elapsed-accounted);
 }
 
 /* Fixed-token decode benchmark: prefill all but the prompt's last token, then
@@ -1821,7 +1865,7 @@ static void run_replay(Model *m, const int *full, int nfull, int np){
     kv_alloc(m,nfull+2);
     float *logit=step(m,full,np-1,0); free(logit);
     m->hits=m->miss=m->ereq=m->gpu_expert_calls=0;
-    m->t_edisk=m->t_emm=m->t_attn=m->t_kvb=m->t_head=0;
+    m->t_edisk=m->t_ewait=m->t_emm=m->t_attn=m->t_kvb=m->t_head=0;
     double t0=now_s(); int steps=0;
     for(int i=np-1;i<nfull-1;i++){
         logit=step(m,full+i,1,i); free(logit); steps++;

--- a/c/glm.c
+++ b/c/glm.c
@@ -1237,6 +1237,15 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
 #endif
             for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)rows[r]*D, D*sizeof(float));
             double t0=now_s();
+#ifdef COLI_CUDA
+            if(g_cuda_enabled && e->g.cuda_eligible && e->u.cuda_eligible && e->d.cuda_eligible &&
+               !omp_in_parallel() && coli_cuda_expert_mlp(e->g.cuda,e->u.cuda,e->d.cuda,hh,xg,nr)){
+                for(int r=0;r<nr;r++){ float *os=out+(int64_t)rows[r]*D, wgt=rw[r], *hr=hh+(int64_t)r*D;
+                    for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
+                m->t_emm += now_s()-t0;
+                continue;
+            }
+#endif
             matmul_qt(gg, xg, &e->g, nr);
             matmul_qt(uu, xg, &e->u, nr);
             for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];

--- a/c/glm.c
+++ b/c/glm.c
@@ -32,10 +32,15 @@
 #include "st.h"
 #include "tok.h"
 #include "tier.h"
+#include "cpu_pool.h"
 #ifdef COLI_CUDA
 #include <omp.h>
 #include "backend_cuda.h"
 #endif
+
+static CpuPool g_cpu_pool;
+static int g_cpu_pool_enabled;
+static void cpu_pool_shutdown_global(void){ if(g_cpu_pool_enabled) cpu_pool_destroy(&g_cpu_pool); }
 #ifdef __AVX2__
 #include <immintrin.h>
 static inline float hsum256(__m256 v){            /* somma orizzontale di 8 float */
@@ -270,13 +275,14 @@ static void matmul_i4(float *y, const float *x, const uint8_t *q4, const float *
 /* Decode hot path for gate+up: same exact q4 dot products as matmul_i4, but one
  * OpenMP dispatch covers both matrices. KTransformers uses persistent pools;
  * this keeps colibri dependency-free while removing one team launch/expert. */
-static void matmul_i4_pair(float *yg, float *yu, const float *x,
-                           const uint8_t *qg, const float *sg,
-                           const uint8_t *qu, const float *su, int I, int O){
-    int rb=(I+1)/2;
-    #pragma omp parallel for schedule(static)
-    for(int z=0;z<2*O;z++){
-        int o=z<O?z:z-O; const uint8_t *w=(z<O?qg:qu)+(int64_t)o*rb;
+typedef struct { float *yg,*yu; const float *x; const uint8_t *qg,*qu;
+                 const float *sg,*su; int I,O,rb; } I4PairJob;
+static void matmul_i4_pair_rows(void *opaque,int begin,int end){
+    I4PairJob *j=opaque;
+    for(int z=begin;z<end;z++){
+        int o=z<j->O?z:z-j->O;
+        const uint8_t *w=(z<j->O?j->qg:j->qu)+(int64_t)o*j->rb;
+        const float *x=j->x; int I=j->I;
         float a=0; int i=0;
 #ifdef __AVX2__
         const __m128i m4=_mm_set1_epi8(0x0F); const __m256i b8=_mm256_set1_epi32(8);
@@ -304,7 +310,17 @@ static void matmul_i4_pair(float *yg, float *yu, const float *x,
 #endif
         for(;i+1<I;i+=2){ uint8_t b=w[i>>1]; a+=x[i]*(float)((b&15)-8)+x[i+1]*(float)((b>>4)-8); }
         if(i<I) a+=x[i]*(float)((w[i>>1]&15)-8);
-        (z<O?yg:yu)[o]=a*(z<O?sg:su)[o];
+        (z<j->O?j->yg:j->yu)[o]=a*(z<j->O?j->sg:j->su)[o];
+    }
+}
+static void matmul_i4_pair(float *yg, float *yu, const float *x,
+                           const uint8_t *qg, const float *sg,
+                           const uint8_t *qu, const float *su, int I, int O){
+    I4PairJob job={yg,yu,x,qg,qu,sg,su,I,O,(I+1)/2};
+    if(g_cpu_pool_enabled) cpu_pool_for(&g_cpu_pool,2*O,matmul_i4_pair_rows,&job);
+    else {
+        #pragma omp parallel for schedule(static)
+        for(int z=0;z<2*O;z++) matmul_i4_pair_rows(&job,z,z+1);
     }
 }
 
@@ -2596,6 +2612,13 @@ static void cap_for_ram(Model *m, double ram_gb, int ebits, int max_ctx){
 int main(int argc, char **argv){
     /* i thread OMP non devono girare a vuoto mentre il main aspetta il disco */
     if(!getenv("OMP_WAIT_POLICY")) setenv("OMP_WAIT_POLICY","passive",1);
+    int pool_threads=getenv("CPU_POOL_THREADS")?atoi(getenv("CPU_POOL_THREADS")):0;
+    if(pool_threads>0){
+        g_cpu_pool_enabled=cpu_pool_init(&g_cpu_pool,pool_threads);
+        if(!g_cpu_pool_enabled){ fprintf(stderr,"CPU_POOL_THREADS: impossibile creare il pool\n"); return 2; }
+        atexit(cpu_pool_shutdown_global);
+        fprintf(stderr,"[CPU] persistent expert pool: %d thread\n",pool_threads);
+    }
     const char *snap=getenv("SNAP"); if(!snap){fprintf(stderr,"SNAP=<dir>\n");return 1;}
     g_nopack = getenv("NOPACK")?1:0;
     g_drop = getenv("DROP")?1:0;

--- a/c/glm.c
+++ b/c/glm.c
@@ -123,6 +123,7 @@ typedef struct {
     ESlot **pin; int *npin;                      /* HOT-STORE: expert pinnati in RAM (mai evicted) */
     uint32_t **eusage;                           /* contatori persistenti (per STATS/PIN) */
     uint32_t **eheat;                            /* calore recente per promotion/demotion live */
+    uint32_t **elast, eaccess_clock;              /* recency per LFRU session-local */
     /* DSA lightning indexer (attivo solo se i pesi out-idx-* sono presenti) */
     int has_dsa;
     QT *ix_wq, *ix_wk, *ix_wp;                   /* per layer FULL: wq_b, wk, weights_proj */
@@ -728,6 +729,7 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
     m->eroute=calloc(NR,sizeof(int*)); m->enr=calloc(NR,sizeof(int));
     m->pin=calloc(NR,sizeof(ESlot*)); m->npin=calloc(NR,sizeof(int));
     m->eusage=calloc(NR,sizeof(uint32_t*)); m->eheat=calloc(NR,sizeof(uint32_t*));
+    m->elast=calloc(NR,sizeof(uint32_t*));
     m->kv=calloc(1,sizeof(KVState));
     m->kv_start=m->kv->kv_start=calloc(NR,sizeof(int));
     for(int i=0;i<c->n_layers;i++){
@@ -758,6 +760,7 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
             m->eroute[i]=calloc(c->topk,sizeof(int));      /* metodo C: ultimo routing del layer */
             m->eusage[i]=calloc(c->n_experts,sizeof(uint32_t));
             m->eheat[i]=calloc(c->n_experts,sizeof(uint32_t));
+            m->elast[i]=calloc(c->n_experts,sizeof(uint32_t));
         }
         #undef P
     }
@@ -803,6 +806,7 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
             m->eroute[i]=calloc(c->topk,sizeof(int));
             m->eusage[i]=calloc(c->n_experts,sizeof(uint32_t));
             m->eheat[i]=calloc(c->n_experts,sizeof(uint32_t));
+            m->elast[i]=calloc(c->n_experts,sizeof(uint32_t));
             m->kv_start[i]=-1;                    /* KV MTP: parte dalla prima posizione di decode */
             #undef PM
         }
@@ -1213,6 +1217,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
         for(int kk=0;kk<Ke;kk++){
             m->eusage[layer][idx[kk]]++;
             if(m->eheat[layer][idx[kk]]<UINT32_MAX) m->eheat[layer][idx[kk]]++;
+            m->elast[layer][idx[kk]]=++m->eaccess_clock;
         }
         if(c->norm_topk){ float sm=0; for(int kk=0;kk<Ke;kk++) sm+=w[kk]; sm+=1e-20f; for(int kk=0;kk<Ke;kk++) w[kk]/=sm; }
         for(int kk=0;kk<Ke;kk++) w[kk]*=c->routed_scale;
@@ -1954,7 +1959,8 @@ static int repin_pick(Model *m, RepinCand *out, int maxc){
         ESlot *P=m->pin[l]; int ids[4096], zp, eu; long g;
         int np=m->npin[l]; if(np>4096) np=4096;
         for(int z=0;z<np;z++) ids[z]=P[z].eid;
-        if(!tier_pick_swap(m->eheat[l],c->n_experts,ids,np,&zp,&eu,&g)) continue;
+        if(!tier_pick_lfru(m->eheat[l],m->elast[l],m->eaccess_clock,
+                           c->n_experts,ids,np,&zp,&eu,&g)) continue;
         if(nb<maxc){ out[nb].gain=g; out[nb].l=l; out[nb].slot=zp; out[nb].eid=eu; nb++; }
         else { int w=0; for(int b=1;b<maxc;b++) if(out[b].gain<out[w].gain) w=b;
                if(g>out[w].gain){ out[w].gain=g; out[w].l=l; out[w].slot=zp; out[w].eid=eu; } }
@@ -2225,6 +2231,7 @@ static void run_serve(Model *m, const char *snap){
         free(raw); g_temp=base_temp; g_nuc=base_nuc;
         usage_save(m);                   /* la cache che impara: storia aggiornata a ogni turno */
         kv_disk_append(m,hist,len);      /* KV su disco: il prossimo avvio riparte da qui */
+        repin_pass(m);                   /* safe request boundary: adapt session-local hot tier */
     }
     free(line); free(buf);
     usage_save(m);

--- a/c/glm.c
+++ b/c/glm.c
@@ -267,6 +267,53 @@ static void matmul_i4(float *y, const float *x, const uint8_t *q4, const float *
             if(i<I){ uint8_t byte=w[i>>1]; int lo=(int)(byte&0xF)-8; a += xs[i]*(float)lo; }
             y[(int64_t)s*O+o]=a*sc; } }
 }
+/* Decode hot path for gate+up: same exact q4 dot products as matmul_i4, but one
+ * OpenMP dispatch covers both matrices. KTransformers uses persistent pools;
+ * this keeps colibri dependency-free while removing one team launch/expert. */
+static void matmul_i4_pair(float *yg, float *yu, const float *x,
+                           const uint8_t *qg, const float *sg,
+                           const uint8_t *qu, const float *su, int I, int O){
+    int rb=(I+1)/2;
+    #pragma omp parallel for schedule(static)
+    for(int z=0;z<2*O;z++){
+        int o=z<O?z:z-O; const uint8_t *w=(z<O?qg:qu)+(int64_t)o*rb;
+        float a=0; int i=0;
+#ifdef __AVX2__
+        const __m128i m4=_mm_set1_epi8(0x0F); const __m256i b8=_mm256_set1_epi32(8);
+        __m256 acc=_mm256_setzero_ps();
+        for(;i+16<=I;i+=16){ __m128i by=_mm_loadl_epi64((const __m128i*)(w+(i>>1)));
+            __m128i lo=_mm_and_si128(by,m4),hi=_mm_and_si128(_mm_srli_epi16(by,4),m4);
+            __m128i nib=_mm_unpacklo_epi8(lo,hi);
+            __m256 w0=_mm256_cvtepi32_ps(_mm256_sub_epi32(_mm256_cvtepu8_epi32(nib),b8));
+            __m256 w1=_mm256_cvtepi32_ps(_mm256_sub_epi32(_mm256_cvtepu8_epi32(_mm_srli_si128(nib,8)),b8));
+            acc=_mm256_fmadd_ps(_mm256_loadu_ps(x+i),w0,acc);
+            acc=_mm256_fmadd_ps(_mm256_loadu_ps(x+i+8),w1,acc); }
+        a=hsum256(acc);
+#elif defined(__ARM_NEON)
+        const uint8x8_t m4=vdup_n_u8(0x0F); const int8x8_t b8=vdup_n_s8(8);
+        float32x4_t ac0=vdupq_n_f32(0),ac1=vdupq_n_f32(0);
+        for(;i+16<=I;i+=16){ uint8x8_t by=vld1_u8(w+(i>>1));
+            uint8x8x2_t n=vzip_u8(vand_u8(by,m4),vshr_n_u8(by,4));
+            int16x8_t w0=vmovl_s8(vsub_s8(vreinterpret_s8_u8(n.val[0]),b8));
+            int16x8_t w1=vmovl_s8(vsub_s8(vreinterpret_s8_u8(n.val[1]),b8));
+            ac0=vfmaq_f32(ac0,vld1q_f32(x+i),vcvtq_f32_s32(vmovl_s16(vget_low_s16(w0))));
+            ac1=vfmaq_f32(ac1,vld1q_f32(x+i+4),vcvtq_f32_s32(vmovl_s16(vget_high_s16(w0))));
+            ac0=vfmaq_f32(ac0,vld1q_f32(x+i+8),vcvtq_f32_s32(vmovl_s16(vget_low_s16(w1))));
+            ac1=vfmaq_f32(ac1,vld1q_f32(x+i+12),vcvtq_f32_s32(vmovl_s16(vget_high_s16(w1)))); }
+        a=vaddvq_f32(vaddq_f32(ac0,ac1));
+#endif
+        for(;i+1<I;i+=2){ uint8_t b=w[i>>1]; a+=x[i]*(float)((b&15)-8)+x[i+1]*(float)((b>>4)-8); }
+        if(i<I) a+=x[i]*(float)((w[i>>1]&15)-8);
+        (z<O?yg:yu)[o]=a*(z<O?sg:su)[o];
+    }
+}
+
+static void matmul_qt(float *y,const float *x,QT *w,int S);
+static void expert_gate_up(float *g,float *u,const float *x,QT *wg,QT *wu,int S){
+    if(S==1&&wg->fmt==2&&wu->fmt==2&&wg->I==wu->I&&wg->O==wu->O)
+        matmul_i4_pair(g,u,x,wg->q4,wg->s,wu->q4,wu->s,wg->I,wg->O);
+    else { matmul_qt(g,x,wg,S); matmul_qt(u,x,wu,S); }
+}
 /* y[S,O] = x[S,I] @ W^T con W int2 impacchettato (4 valori/byte) + scala[O]. nibble 2-bit -> [-2,1]. */
 static void matmul_i2(float *y, const float *x, const uint8_t *q2, const float *scale, int S, int I, int O){
     int rb=(I+3)/4;
@@ -1315,8 +1362,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
             }
             if(!e->slab) expert_host_ensure(m,layer,e);
 #endif
-            matmul_qt(gg, xg, &e->g, nr);
-            matmul_qt(uu, xg, &e->u, nr);
+            expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
             for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
             matmul_qt(hh, gg, &e->d, nr);
             for(int r=0;r<nr;r++){ float *os=out+(int64_t)rows[r]*D, wgt=rw[r], *hr=hh+(int64_t)r*D;
@@ -1356,7 +1402,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
                     for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D,x+(int64_t)group_row[(int64_t)gi*S+r]*D,D*sizeof(float));
                     if(!coli_cuda_expert_mlp(e->g.cuda,e->u.cuda,e->d.cuda,hh,xg,nr)){
                         expert_host_ensure(m,layer,e);
-                        matmul_qt(gg,xg,&e->g,nr); matmul_qt(uu,xg,&e->u,nr);
+                        expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
                         for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
                         matmul_qt(hh,gg,&e->d,nr);
                     }
@@ -1385,7 +1431,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
                     }
                 for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D,x+(int64_t)rows[r]*D,D*sizeof(float));
                 double tc=now_s();
-                matmul_qt(gg,xg,&e->g,nr); matmul_qt(uu,xg,&e->u,nr);
+                expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
                 for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
                 matmul_qt(hh,gg,&e->d,nr);
                 for(int r=0;r<nr;r++){ float *os=out+(int64_t)rows[r]*D,wgt=rw[r],*hr=hh+(int64_t)r*D;

--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -104,8 +104,18 @@ def discover_gpus():
     return devices
 
 
+POLICIES = {
+    "quality": {"preserve_quantization": True, "preserve_router": True},
+    "balanced": {"preserve_quantization": True, "preserve_router": True},
+    "experimental-fast": {"preserve_quantization": False, "preserve_router": False},
+}
+
+
 def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
-               available_memory=None, available_disk=None, gpus=None):
+               available_memory=None, available_disk=None, gpus=None,
+               policy="quality"):
+    if policy not in POLICIES:
+        raise ValueError(f"unknown policy: {policy}")
     info = analyze_model(model)
     cfg = info["config"]
     available_memory = memory_available() if available_memory is None else available_memory
@@ -142,8 +152,13 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
         safe_vram += usable
         gpu_plan.append(dict(gpu, reserve_bytes=reserve, usable_bytes=usable))
     requested_vram = int(vram_gb * GB) if vram_gb > 0 else safe_vram
-    vram_budget = min(requested_vram, safe_vram, cache_bytes)
+    # VRAM-resident experts do not need duplicate RAM backing: the checkpoint is
+    # their recovery source. RAM is therefore an independent warm compute tier.
+    vram_budget = min(requested_vram, safe_vram, info["expert_bytes"])
     vram_experts = int(vram_budget // typical) if typical else 0
+    hot_bytes = min(info["expert_bytes"], vram_experts * typical)
+    warm_bytes = min(max(0, info["expert_bytes"] - hot_bytes), cache_bytes)
+    cold_bytes = max(0, info["expert_bytes"] - hot_bytes - warm_bytes)
 
     warnings = []
     if cap < 1:
@@ -151,21 +166,39 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
     if gpu_indices is not None and len(gpus) != len(set(gpu_indices)):
         warnings.append("one or more requested GPUs were not detected")
     if gpus and vram_budget < requested_vram:
-        warnings.append("VRAM tier was clamped by free VRAM or its required RAM backing")
+        warnings.append("VRAM tier was clamped by free VRAM or model expert size")
+    if cold_bytes:
+        warnings.append("cold expert misses may reach disk; normal decode speed depends on hit rate")
+
+    if cold_bytes:
+        bottleneck = "disk expert misses"
+    elif warm_bytes:
+        bottleneck = "CPU expert compute and RAM bandwidth"
+    else:
+        bottleneck = "GPU compute and interconnect"
 
     return {
-        "version": 1,
+        "version": 2,
+        "policy": {"name": policy, **POLICIES[policy],
+                   "quality_preserving": policy != "experimental-fast"},
         "model": {key: value for key, value in info.items() if key != "config"},
         "tiers": {
-            "disk": {"role": "backing", "model_bytes": info["model_bytes"],
-                     "available_bytes": available_disk},
-            "ram": {"role": "resident+cache", "available_bytes": available_memory,
+            "disk": {"role": "cold-backing", "model_bytes": info["model_bytes"],
+                     "available_bytes": available_disk, "cold_expert_bytes": cold_bytes},
+            "ram": {"role": "resident+warm-experts", "available_bytes": available_memory,
                     "budget_bytes": ram_budget, "dense_bytes": info["dense_bytes"],
                     "runtime_bytes": runtime_bytes, "expert_cache_bytes": cache_bytes,
-                    "cache_slots_per_layer": cap},
+                    "warm_expert_bytes": warm_bytes, "cache_slots_per_layer": cap},
             "vram": {"role": "hot-experts", "devices": gpu_plan,
-                     "budget_bytes": vram_budget, "expert_capacity": vram_experts},
+                     "budget_bytes": vram_budget, "hot_expert_bytes": hot_bytes,
+                     "expert_capacity": vram_experts, "requires_host_backing": False},
         },
+        "expected_bottleneck": bottleneck,
+        "decisions": [
+            {"target": "VRAM", "reason": "profile-ranked hot experts"},
+            {"target": "RAM", "reason": "warm experts execute on CPU without quality loss"},
+            {"target": "Disk", "reason": "immutable recovery source for cold experts"},
+        ],
         "warnings": warnings,
     }
 
@@ -173,6 +206,7 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
 def environment_for_plan(plan, env=None, cuda_enabled=True):
     """Apply a plan without overriding explicit user environment settings."""
     result = dict(env or {})
+    result.setdefault("COLI_POLICY", plan["policy"]["name"])
     ram = plan["tiers"]["ram"]
     result.setdefault("RAM_GB", f"{ram['budget_bytes'] / GB:.3f}")
 
@@ -199,11 +233,15 @@ def format_bytes(value):
 
 def format_plan(plan):
     model, tiers = plan["model"], plan["tiers"]
-    lines = [f"model  {model['shards']} shards · {format_bytes(model['model_bytes'])}",
-             f"disk   backing store · {format_bytes(tiers['disk']['available_bytes'])} free",
+    policy=plan["policy"]
+    lines = [f"policy {policy['name']} · quality-preserving {'yes' if policy['quality_preserving'] else 'no'}",
+             f"model  {model['shards']} shards · {format_bytes(model['model_bytes'])}",
+             f"disk   {format_bytes(tiers['disk']['cold_expert_bytes'])} cold experts · "
+             f"{format_bytes(tiers['disk']['available_bytes'])} free",
              f"RAM    {format_bytes(tiers['ram']['budget_bytes'])} budget · "
              f"{format_bytes(tiers['ram']['dense_bytes'])} dense · "
              f"{format_bytes(tiers['ram']['runtime_bytes'])} runtime · "
+             f"{format_bytes(tiers['ram']['warm_expert_bytes'])} warm experts · "
              f"cap {tiers['ram']['cache_slots_per_layer']}/layer"]
     vram = tiers["vram"]
     if vram["devices"]:
@@ -212,5 +250,6 @@ def format_plan(plan):
                      f"~{vram['expert_capacity']} experts · {names}")
     else:
         lines.append("VRAM   no NVIDIA device detected · CPU path")
+    lines.append(f"limit  {plan['expected_bottleneck']}")
     lines.extend(f"warn   {warning}" for warning in plan["warnings"])
     return "\n".join(lines)

--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -207,6 +207,8 @@ def environment_for_plan(plan, env=None, cuda_enabled=True):
     """Apply a plan without overriding explicit user environment settings."""
     result = dict(env or {})
     result.setdefault("COLI_POLICY", plan["policy"]["name"])
+    if plan["policy"]["name"] == "balanced":
+        result.setdefault("REPIN", "64")
     ram = plan["tiers"]["ram"]
     result.setdefault("RAM_GB", f"{ram['budget_bytes'] / GB:.3f}")
 

--- a/c/tests/test_backend_cuda.cu
+++ b/c/tests/test_backend_cuda.cu
@@ -55,8 +55,25 @@ int main(int argc, char **argv) {
     ColiCudaTensor *tf = nullptr;
     if (!coli_cuda_matmul(&tf, got, x, wf, nullptr, 0, 1, 4, 2, d0) || !close_enough(got, wantf, 2)) return 1;
 
+    const float eg[8] = {1,0,0,0, 0,1,0,0};
+    const float eu[8] = {1,0,0,0, 0,1,0,0};
+    const float ed[8] = {1,0, 0,1, 1,1, 1,-1};
+    ColiCudaTensor *tg=nullptr,*tu=nullptr,*td=nullptr;
+    if (!coli_cuda_tensor_upload(&tg,eg,nullptr,0,4,2,d0) ||
+        !coli_cuda_tensor_upload(&tu,eu,nullptr,0,4,2,d0) ||
+        !coli_cuda_tensor_upload(&td,ed,nullptr,0,2,4,d0)) return 1;
+    float expert[8], want_expert[8];
+    for(int s=0;s<2;s++){
+        float a=x[s*4], b=x[s*4+1];
+        a=(a/(1.0f+std::exp(-a)))*a; b=(b/(1.0f+std::exp(-b)))*b;
+        want_expert[s*4]=a; want_expert[s*4+1]=b;
+        want_expert[s*4+2]=a+b; want_expert[s*4+3]=a-b;
+    }
+    if (!coli_cuda_expert_mlp(tg,tu,td,expert,x,2) ||
+        !close_enough(expert,want_expert,8)) return 1;
+
     coli_cuda_stats(-1, &count, &bytes);
-    if (count != 4 || bytes != 70) {
+    if (count != 7 || bytes != 166) {
         std::fprintf(stderr, "unexpected CUDA stats: %zu tensors, %zu bytes\n", count, bytes);
         return 1;
     }
@@ -64,15 +81,18 @@ int main(int argc, char **argv) {
         coli_cuda_tensor_device(t4) != d1 || coli_cuda_tensor_device(t2) != d1) return 1;
     coli_cuda_stats(d0, &count, &bytes);
     if (ndev > 1) {
-        if (count != 2 || bytes != 48) return 1;
+        if (count != 5 || bytes != 144) return 1;
         coli_cuda_stats(d1, &count, &bytes);
         if (count != 2 || bytes != 22) return 1;
-    } else if (count != 4 || bytes != 70) return 1;
+    } else if (count != 7 || bytes != 166) return 1;
 
     coli_cuda_tensor_free(t8);
     coli_cuda_tensor_free(t4);
     coli_cuda_tensor_free(t2);
     coli_cuda_tensor_free(tf);
+    coli_cuda_tensor_free(tg);
+    coli_cuda_tensor_free(tu);
+    coli_cuda_tensor_free(td);
     coli_cuda_stats(-1, &count, &bytes);
     if (count || bytes) return 1;
     coli_cuda_shutdown();

--- a/c/tests/test_backend_cuda.cu
+++ b/c/tests/test_backend_cuda.cu
@@ -71,6 +71,10 @@ int main(int argc, char **argv) {
     }
     if (!coli_cuda_expert_mlp(tg,tu,td,expert,x,2) ||
         !close_enough(expert,want_expert,8)) return 1;
+    ColiCudaTensor *gates[2]={tg,tg},*ups[2]={tu,tu},*downs[2]={td,td};
+    int group_rows[2]={1,1}; float grouped[8];
+    if (!coli_cuda_expert_group(gates,ups,downs,group_rows,2,grouped,x) ||
+        !close_enough(grouped,want_expert,8)) return 1;
 
     coli_cuda_stats(-1, &count, &bytes);
     if (count != 7 || bytes != 166) {

--- a/c/tests/test_backend_cuda.cu
+++ b/c/tests/test_backend_cuda.cu
@@ -75,6 +75,9 @@ int main(int argc, char **argv) {
     int group_rows[2]={1,1}; float grouped[8];
     if (!coli_cuda_expert_group(gates,ups,downs,group_rows,2,grouped,x) ||
         !close_enough(grouped,want_expert,8)) return 1;
+    uint64_t group_calls=0,group_experts=0,group_total_rows=0;
+    coli_cuda_group_stats(&group_calls,&group_experts,&group_total_rows,nullptr,nullptr,nullptr);
+    if(group_calls!=1||group_experts!=2||group_total_rows!=2) return 1;
 
     coli_cuda_stats(-1, &count, &bytes);
     if (count != 7 || bytes != 166) {

--- a/c/tests/test_cpu_pool.c
+++ b/c/tests/test_cpu_pool.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include "../cpu_pool.h"
+
+typedef struct { int *seen; } Ctx;
+static void mark(void *opaque,int begin,int end){
+    Ctx *ctx=opaque; for(int i=begin;i<end;i++) ctx->seen[i]++;
+}
+int main(void){
+    CpuPool pool={0}; int seen[257]={0}; Ctx ctx={seen};
+    if(!cpu_pool_init(&pool,7)) return 1;
+    for(int pass=0;pass<1000;pass++) cpu_pool_for(&pool,257,mark,&ctx);
+    cpu_pool_destroy(&pool);
+    for(int i=0;i<257;i++) if(seen[i]!=1000){ fprintf(stderr,"pool index %d ran %d times\n",i,seen[i]); return 1; }
+    puts("cpu pool tests: ok"); return 0;
+}

--- a/c/tests/test_resource_plan.py
+++ b/c/tests/test_resource_plan.py
@@ -118,6 +118,15 @@ class ResourcePlanTest(unittest.TestCase):
         self.assertFalse(plan["policy"]["quality_preserving"])
         self.assertFalse(plan["policy"]["preserve_router"])
 
+    def test_balanced_policy_enables_lossless_live_repin(self):
+        plan = build_plan(self.model, available_memory=16 * GB, available_disk=1,
+                          gpus=[], policy="balanced")
+        env = environment_for_plan(plan)
+        self.assertEqual(env["COLI_POLICY"], "balanced")
+        self.assertEqual(env["REPIN"], "64")
+        explicit = environment_for_plan(plan, {"REPIN": "0"})
+        self.assertEqual(explicit["REPIN"], "0")
+
     def test_plan_explains_hot_warm_and_cold_placement(self):
         plan = build_plan(self.model, ram_gb=4, vram_gb=0,
                           available_memory=4 * GB, available_disk=1, gpus=[])

--- a/c/tests/test_resource_plan.py
+++ b/c/tests/test_resource_plan.py
@@ -58,10 +58,13 @@ class ResourcePlanTest(unittest.TestCase):
                  "free_bytes": 10 * GB}]
         plan = build_plan(self.model, ram_gb=16, context=32, vram_gb=20,
                           available_memory=32 * GB, available_disk=100 * GB, gpus=gpus)
-        self.assertEqual(plan["version"], 1)
+        self.assertEqual(plan["version"], 2)
+        self.assertEqual(plan["policy"]["name"], "quality")
+        self.assertTrue(plan["policy"]["preserve_quantization"])
+        self.assertFalse(plan["tiers"]["vram"]["requires_host_backing"])
         self.assertEqual(plan["tiers"]["ram"]["budget_bytes"], 16 * GB)
         self.assertLessEqual(plan["tiers"]["vram"]["budget_bytes"], 8 * GB)
-        self.assertIn("required RAM backing", plan["warnings"][0])
+        self.assertIn("clamped", plan["warnings"][0])
         self.assertIn("0:test-gpu", format_plan(plan))
 
     def test_filters_requested_devices(self):
@@ -78,7 +81,7 @@ class ResourcePlanTest(unittest.TestCase):
             "--gpu", "none", "--json",
         ], text=True, capture_output=True, check=True)
         plan = json.loads(run.stdout)
-        self.assertEqual(plan["version"], 1)
+        self.assertEqual(plan["version"], 2)
         self.assertEqual(plan["model"]["expert_count"], 2)
 
     def test_applies_plan_without_overriding_explicit_settings(self):
@@ -105,6 +108,23 @@ class ResourcePlanTest(unittest.TestCase):
         disabled = environment_for_plan(plan, {"COLI_CUDA": "0"}, cuda_enabled=True)
         self.assertNotIn("COLI_GPU", disabled)
         self.assertNotIn("CUDA_EXPERT_GB", disabled)
+
+    def test_rejects_unknown_policy_and_marks_experimental_policy(self):
+        with self.assertRaisesRegex(ValueError, "unknown policy"):
+            build_plan(self.model, available_memory=16 * GB, available_disk=1,
+                       gpus=[], policy="fast-ish")
+        plan = build_plan(self.model, available_memory=16 * GB, available_disk=1,
+                          gpus=[], policy="experimental-fast")
+        self.assertFalse(plan["policy"]["quality_preserving"])
+        self.assertFalse(plan["policy"]["preserve_router"])
+
+    def test_plan_explains_hot_warm_and_cold_placement(self):
+        plan = build_plan(self.model, ram_gb=4, vram_gb=0,
+                          available_memory=4 * GB, available_disk=1, gpus=[])
+        self.assertEqual([item["target"] for item in plan["decisions"]],
+                         ["VRAM", "RAM", "Disk"])
+        self.assertIn("quality-preserving yes", format_plan(plan))
+        self.assertIn("expected_bottleneck", plan)
 
 
 if __name__ == "__main__":

--- a/c/tests/test_tier.c
+++ b/c/tests/test_tier.c
@@ -17,6 +17,11 @@ int main(void){
 
     tier_decay(heat,6);
     if(heat[0]!=10 || heat[1]!=1 || heat[4]!=15) return fail("heat decay");
+
+    uint32_t freq[5]={10,10,2,18,18}, last[5]={10,90,95,20,99};
+    int live[2]={0,1};
+    if(!tier_pick_lfru(freq,last,100,5,live,2,&slot,&eid,&gain)) return fail("LFRU promotion");
+    if(slot!=0||eid!=4) return fail("LFRU did not prefer recent ties");
     puts("tier tests: ok");
     return 0;
 }

--- a/c/tier.h
+++ b/c/tier.h
@@ -24,6 +24,35 @@ static int tier_pick_swap(const uint32_t *heat, int nexpert,
     return 1;
 }
 
+/* LFRU: frequency is the primary signal; recency breaks close calls. A recent
+ * access contributes at most 255 points while one frequency count is worth
+ * 256, so a merely recent expert cannot displace a genuinely hotter one. */
+static uint64_t tier_lfru_score(uint32_t heat, uint32_t last, uint32_t clock){
+    uint32_t age=clock-last, recent=age<255?255-age:0;
+    return ((uint64_t)heat<<8)|recent;
+}
+
+static int tier_pick_lfru(const uint32_t *heat, const uint32_t *last, uint32_t clock,
+                          int nexpert, const int *pinned, int npin,
+                          int *slot, int *eid, long *gain){
+    if(!heat||!last||!pinned||npin<1||nexpert<1) return 0;
+    int cold=0;
+    for(int z=1;z<npin;z++)
+        if(tier_lfru_score(heat[pinned[z]],last[pinned[z]],clock)<
+           tier_lfru_score(heat[pinned[cold]],last[pinned[cold]],clock)) cold=z;
+    int hot=-1; uint64_t hs=0;
+    for(int e=0;e<nexpert;e++){
+        int resident=0; for(int z=0;z<npin;z++) if(pinned[z]==e){resident=1;break;}
+        uint64_t score=tier_lfru_score(heat[e],last[e],clock);
+        if(!resident&&(hot<0||score>hs)){ hot=e; hs=score; }
+    }
+    if(hot<0) return 0;
+    uint64_t cs=tier_lfru_score(heat[pinned[cold]],last[pinned[cold]],clock);
+    /* Retain the existing 25%+4-frequency hysteresis in score units. */
+    if(hs<=cs+(cs>>2)+(4u<<8)) return 0;
+    *slot=cold; *eid=hot; *gain=(long)((hs-cs)>>8); return 1;
+}
+
 static void tier_decay(uint32_t *heat, int nexpert){
     for(int e=0;e<nexpert;e++) heat[e]>>=1;
 }


### PR DESCRIPTION
## Summary

- reuse the persistent native CPU pool for single-token q4 expert down projections
- share the exact existing q4 row kernel with the gate/up pool job
- cover resident RAM experts, deferred cold experts, and CUDA fallback
- leave batched, non-q4, shared-expert, attention, and default OpenMP paths unchanged

## Full-model A/B

Six RTX 5090 cards, GLM-5.2 int4, original top-8 router, 48 pool workers, identical greedy output:

| pool coverage | expert matmul | 16-token wall |
|---|---:|---:|
| gate + up | 36.67 s | 113.73 s |
| gate + up + down | 25.74 s | 105.07 s |

This step reduced expert time by another 29.8% and wall time by 7.6%. Relative to the fused OpenMP baseline in #55, full expert-pool coverage reduced wall time from 129.42 s to 105.07 s (18.8%).

## Quality

The greedy output, expert hit rate, and CUDA call count were identical. No activation requantization, router reduction, or weight conversion is introduced.

## Validation

- `make check` (4 C tests, 30 Python/API/planner tests)
- CUDA build on the six-card host
- full q4 GLM-5.2 greedy A/B

## Dependencies

Depends on #55 -> #54 -> #53 -> #52 -> #51 -> #50. The commit specific to this PR is `d7b6734`.