### PR TITLE
Windows 11 nativo + tier VRAM additivi: cascata heat-driven, FFN batc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,13 @@ The engine at runtime is pure C — python is only used by the one-time converte
 
 ### Windows 11 (native, no WSL)
 
-colibrì builds and runs natively on Windows 11 x86-64 with MinGW-w64. The port adds
-a `_WIN32` compatibility layer in `c/compat.h` that maps POSIX I/O to the Windows API
-(pread → ReadFile+OVERLAPPED, posix_fadvise no-op, aligned allocation, MoveFileEx rename,
-GlobalMemoryStatusEx RAM detection). All platform differences stay in `compat.h`; the
-engine source is unchanged.
+colibrì builds and runs natively on Windows 11 x86-64. The port adds a `_WIN32`
+compatibility layer in `c/compat.h` that maps POSIX I/O to the Windows API
+(pread → ReadFile+OVERLAPPED, posix_fadvise WILLNEED → dedicated readahead thread
+that keeps the async I/O/compute overlap alive, aligned allocation, MoveFileEx
+rename, GlobalMemoryStatusEx RAM detection; on the clang/MSVC target compat.h also
+supplies dirent/pthread/clock_gettime shims that MinGW has natively). All platform
+differences stay in `compat.h`; the engine source is unchanged.
 
 **Toolchain:** GCC via [winlibs](https://winlibs.com/) or MSYS2 MinGW-w64. Tested with
 GCC 16.1.0 (x86_64-ucrt-posix-seh).
@@ -161,9 +163,25 @@ python coli chat --model D:\glm52_i4            # interactive chat
 python coli serve --model D:\glm52_i4            # OpenAI-compatible API
 ```
 
-**Status:** Phase 1 complete (compiles, correct, static-linked). O_DIRECT (Phase 2),
-GPU via `LoadLibrary` on `coli_cuda.dll` (Phases G0–G2), and full-model validation
-are separate workstreams. See `PORT_WINDOWS_PLAN.md` for the full plan.
+**Alternative toolchain — clang + CUDA (GPU tier on Windows):** with LLVM/clang
+(MSVC target) and CUDA Toolkit 13.x, `build_win.ps1` builds the engine *with the
+VRAM expert tier* — nvcc's object links directly into the clang binary, no DLL
+needed. O_DIRECT is active on this path (`FILE_FLAG_NO_BUFFERING`). Validated
+token-exact (oracle TF 32/32, CPU and CUDA):
+
+```powershell
+cd c
+powershell -ExecutionPolicy Bypass -File build_win.ps1          # CPU engine + tests
+powershell -ExecutionPolicy Bypass -File build_win.ps1 -Cuda    # + VRAM tier (default sm_120)
+```
+
+Requires Visual Studio with an nvcc-supported MSVC toolset (v14.4x — the script
+selects it and runs nvcc inside `vcvars64` automatically). Tip: exclude the model
+directory from Windows Defender (Windows Security → Exclusions), or every expert
+read gets re-scanned.
+
+**Status:** MinGW path — Phase 1 complete (compiles, correct, static-linked), see
+`PORT_WINDOWS_PLAN.md`. clang path — CPU + CUDA both validated 32/32 on an RTX 5090.
 
 ### OpenAI-compatible API
 
@@ -255,11 +273,15 @@ cross-compiling. Requesting CUDA with a CPU-only binary, an invalid device, or
 an unavailable runtime fails at startup instead of silently falling back.
 
 The normal `make` build and runtime behavior are unchanged. CUDA defaults to an
-expert-only accelerator: resident dense/attention tensors stay on CPU because
-fixture measurements show that moving them does not help while expert I/O is
-the bottleneck. `CUDA_DENSE=1` keeps the earlier all-resident experimental path.
-A measured `PIN` profile can promote its hottest experts into the persistent
-VRAM tier while keeping the rest in RAM:
+expert-only accelerator; `CUDA_DENSE=1` also moves the resident dense tensors.
+The expert tier is a **heat-driven cascade over additive tiers**: the hottest
+experts go to VRAM (their host copy is freed — VRAM *adds* to RAM instead of
+mirroring it), the next band stays pinned in RAM (`PIN_GB`), the rest lives on
+LRU + disk. VRAM-resident experts run as a **fused FFN batched on an async
+stream per device**, overlapping with the CPU experts of the same block
+(`CUDA_FFN=0` restores the synchronous per-tensor path; measured +35–40% on the
+fixture's `cuda_pin` mode). On CUDA runtime failure a VRAM-only slot demotes
+loudly: reloaded from disk, recomputed on CPU — never silently wrong.
 
 ```bash
 STATS=stats.txt SNAP=/nvme/glm52_i4 ./glm 64 4 4   # collect routing frequencies first
@@ -270,19 +292,27 @@ COLI_CUDA=1 COLI_GPUS=0,1,2,3,4,5 CUDA_EXPERT_GB=96 \
 PIN=stats.txt PIN_GB=160 SNAP=/nvme/glm52_i4 ./glm 64 4 4
 ```
 
-Selected experts are uploaded during startup, so capacity failures occur before
-inference and the log reports their exact tensor footprint. The budget is clamped
-against free VRAM after reserving the projected dense resident set and 2 GB of
-runtime headroom per selected device. With `COLI_GPUS`, `CUDA_EXPERT_GB` is a
-total budget across the device set; experts are assigned whole to the
-least-loaded device that can hold them. A NUMA-local RAM backing store is not
-implemented yet.
+Selected experts are uploaded during startup in blocks (parallel disk read,
+upload, host copy freed immediately — the transient RAM peak stays ~one block
+even on small machines), so capacity failures occur before inference. The budget
+is clamped against free VRAM after reserving the projected dense resident set
+and 2 GB of runtime headroom per selected device. With `COLI_GPUS`,
+`CUDA_EXPERT_GB` is a total budget across the device set; experts are assigned
+whole to the least-loaded device that can hold them. Because the VRAM tier
+needs no RAM backing, a small-RAM machine with a large GPU can now run a
+VRAM-only hot tier.
 
-Current limitations: devices use independent contexts and synchronous
-host-staged activation copies—there is no P2P/NCCL dependency yet. The kernels
-are correctness-first custom kernels rather than cuBLAS/Tensor Core kernels.
-This draft intentionally makes no end-to-end speedup claim before the full model
-is benchmarked.
+`COLI_PROFILE=<name>` (or `coli --profile <name>`) keeps a separate expert-usage
+history per usage domain (`.coli_usage.<name>`): coherent workloads (coding,
+writing, ...) route to coherent expert sets, so the cascade pre-loads the right
+experts from the first token. `MEMWATCH=0` disables the runtime RAM monitor
+(default on: at each turn boundary the LRU shrinks under memory pressure and
+grows when RAM frees up; the static auto-budget margin is 10%).
+
+Current limitations: devices use independent contexts (no P2P/NCCL); the dense
+path still uses synchronous copies; kernels are correctness-first custom kernels
+rather than cuBLAS/Tensor Core kernels. Fixture A/B numbers exist (see above);
+full-model end-to-end numbers are still to be measured.
 
 For a reproducible backend A/B without the full checkpoint, generate the
 deterministic 313M-parameter `glm_moe_dsa` fixture and run fixed-token replay:

--- a/c/.gitignore
+++ b/c/.gitignore
@@ -2,3 +2,4 @@
 glm_tiny/
 olmoe_hf/
 olmoe_i4/
+*.obj

--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -18,6 +18,17 @@ typedef struct {
     float *x, *y;
     size_t x_cap, y_cap;
     size_t tensor_count, tensor_bytes;
+    /* Fase 2: pool FFN fusa — uno stream per device, staging host pinned e buffer
+     * device dimensionati alla begin (mai riallocati con lavoro in volo). dm0/dm1
+     * (intermedi gate/up) sono condivisi tra gli expert del blocco: lo stream
+     * serializza i kernel, quindi il riuso a offset 0 e' sicuro. */
+    cudaStream_t stream;
+    float *hx, *hy;                 /* host pinned: input staging / output */
+    size_t hx_cap, hy_cap;
+    float *dx, *dy, *dm0, *dm1;     /* device: input, output, intermedi [rows,I] */
+    size_t dx_cap, dy_cap, dm0_cap, dm1_cap;
+    long long ffn_off;              /* righe gia' impegnate nel blocco corrente */
+    int ffn_D, ffn_I, ffn_err, ffn_open;
 } DeviceContext;
 
 static DeviceContext g_ctx[COLI_CUDA_MAX_DEVICES];
@@ -91,6 +102,76 @@ static int reserve(float **ptr, size_t *cap, size_t bytes) {
     return 1;
 }
 
+static int reserve_pinned(float **ptr, size_t *cap, size_t bytes) {
+    if (*cap >= bytes) return 1;
+    if (*ptr) cudaFreeHost(*ptr);
+    *ptr = nullptr;
+    *cap = 0;
+    if (!cuda_ok(cudaHostAlloc(ptr, bytes, cudaHostAllocDefault), "pinned allocation")) return 0;
+    *cap = bytes;
+    return 1;
+}
+
+__global__ static void silu_mul(float *g, const float *u, long long n) {
+    long long i = blockIdx.x * (long long)blockDim.x + threadIdx.x;
+    if (i < n) { float v = g[i]; g[i] = v / (1.0f + expf(-v)) * u[i]; }
+}
+
+extern "C" int coli_cuda_ffn_begin(int device, long long rows, int D, int I) {
+    DeviceContext *ctx = find_ctx(device);
+    if (rows < 1 || D < 1 || I < 1 || !select_ctx(ctx)) return 0;
+    if (!ctx->stream && !cuda_ok(cudaStreamCreate(&ctx->stream), "stream create")) return 0;
+    /* gli out del blocco precedente puntano in hy: sincronizza PRIMA di riallocare */
+    if (!cuda_ok(cudaStreamSynchronize(ctx->stream), "ffn begin sync")) return 0;
+    size_t xb = (size_t)rows * D * sizeof(float), mb = (size_t)rows * I * sizeof(float);
+    if (!reserve_pinned(&ctx->hx, &ctx->hx_cap, xb) || !reserve_pinned(&ctx->hy, &ctx->hy_cap, xb) ||
+        !reserve(&ctx->dx, &ctx->dx_cap, xb) || !reserve(&ctx->dy, &ctx->dy_cap, xb) ||
+        !reserve(&ctx->dm0, &ctx->dm0_cap, mb) || !reserve(&ctx->dm1, &ctx->dm1_cap, mb)) return 0;
+    ctx->ffn_off = 0; ctx->ffn_D = D; ctx->ffn_I = I;
+    ctx->ffn_err = 0; ctx->ffn_open = 1;
+    return 1;
+}
+
+extern "C" int coli_cuda_ffn_enqueue(ColiCudaTensor *gate, ColiCudaTensor *up, ColiCudaTensor *down,
+                                     const float *x, int nr, const float **out_host) {
+    if (!gate || !up || !down || !x || !out_host || nr < 1) return 0;
+    if (gate->device != up->device || up->device != down->device) return 0;
+    DeviceContext *ctx = find_ctx(gate->device);
+    if (!ctx || !ctx->ffn_open) return 0;
+    int D = ctx->ffn_D, I = ctx->ffn_I;
+    if (gate->I != D || gate->O != I || up->I != D || up->O != I || down->I != I || down->O != D) return 0;
+    size_t need = ((size_t)ctx->ffn_off + nr) * D * sizeof(float);
+    if (need > ctx->hx_cap || need > ctx->hy_cap) return 0;   /* begin sottodimensionata */
+    if (!select_ctx(ctx)) return 0;
+    long long off = ctx->ffn_off;
+    float *hx = ctx->hx + off * D, *hy = ctx->hy + off * D;
+    float *dx = ctx->dx + off * D, *dy = ctx->dy + off * D;
+    size_t xb = (size_t)nr * D * sizeof(float);
+    memcpy(hx, x, xb);                            /* il chiamante riusa x subito dopo */
+    cudaMemcpyAsync(dx, hx, xb, cudaMemcpyHostToDevice, ctx->stream);
+    quant_matmul<<<dim3((unsigned)I, (unsigned)nr), 256, 0, ctx->stream>>>(
+        ctx->dm0, dx, gate->weights, gate->scales, gate->fmt, nr, D, I, row_bytes(gate->fmt, D));
+    quant_matmul<<<dim3((unsigned)I, (unsigned)nr), 256, 0, ctx->stream>>>(
+        ctx->dm1, dx, up->weights, up->scales, up->fmt, nr, D, I, row_bytes(up->fmt, D));
+    long long n = (long long)nr * I;
+    silu_mul<<<(unsigned)((n + 255) / 256), 256, 0, ctx->stream>>>(ctx->dm0, ctx->dm1, n);
+    quant_matmul<<<dim3((unsigned)D, (unsigned)nr), 256, 0, ctx->stream>>>(
+        dy, ctx->dm0, down->weights, down->scales, down->fmt, nr, I, D, row_bytes(down->fmt, I));
+    cudaMemcpyAsync(hy, dy, xb, cudaMemcpyDeviceToHost, ctx->stream);
+    if (cudaGetLastError() != cudaSuccess) ctx->ffn_err = 1;
+    *out_host = hy;
+    ctx->ffn_off += nr;
+    return 1;
+}
+
+extern "C" int coli_cuda_ffn_sync(int device) {
+    DeviceContext *ctx = find_ctx(device);
+    if (!ctx || !ctx->ffn_open || !select_ctx(ctx)) return 0;
+    ctx->ffn_open = 0;
+    if (!cuda_ok(cudaStreamSynchronize(ctx->stream), "ffn sync")) return 0;
+    return !ctx->ffn_err;
+}
+
 extern "C" int coli_cuda_init(const int *devices, int count) {
     int available = 0;
     if (!devices || count < 1 || count > COLI_CUDA_MAX_DEVICES) return 0;
@@ -125,10 +206,16 @@ extern "C" void coli_cuda_shutdown(void) {
     for (int i = 0; i < g_nctx; i++) {
         DeviceContext *ctx = &g_ctx[i];
         if (!select_ctx(ctx)) continue;
+        if (ctx->stream) { cudaStreamSynchronize(ctx->stream); cudaStreamDestroy(ctx->stream); }
         if (ctx->x) cudaFree(ctx->x);
         if (ctx->y) cudaFree(ctx->y);
-        ctx->x = ctx->y = nullptr;
-        ctx->x_cap = ctx->y_cap = 0;
+        if (ctx->dx) cudaFree(ctx->dx);
+        if (ctx->dy) cudaFree(ctx->dy);
+        if (ctx->dm0) cudaFree(ctx->dm0);
+        if (ctx->dm1) cudaFree(ctx->dm1);
+        if (ctx->hx) cudaFreeHost(ctx->hx);
+        if (ctx->hy) cudaFreeHost(ctx->hy);
+        *ctx = {};
     }
     g_nctx = 0;
 }
@@ -159,13 +246,16 @@ extern "C" int coli_cuda_tensor_upload(ColiCudaTensor **tensor,
                                         const void *weights, const float *scales,
                                         int fmt, int I, int O, int device) {
     DeviceContext *ctx = find_ctx(device);
-    if (!tensor || !weights || I < 1 || O < 1 || !select_ctx(ctx)) return 0;
+    if (!tensor || I < 1 || O < 1 || !select_ctx(ctx)) return 0;
     size_t rb = row_bytes(fmt, I);
-    if (!rb || (fmt && !scales)) return 0;
+    if (!rb) return 0;
     if (*tensor) {
+        /* Riuso di una copia gia' residente: i dati host possono essere NULL
+         * (tier VRAM senza backing RAM — la copia host e' stata liberata). */
         ColiCudaTensor *t = *tensor;
         return t->fmt == fmt && t->I == I && t->O == O && t->device == device;
     }
+    if (!weights || (fmt && !scales)) return 0;  /* il PRIMO upload richiede i dati host */
     ColiCudaTensor *t = static_cast<ColiCudaTensor *>(std::calloc(1, sizeof(*t)));
     if (!t) return 0;
     t->fmt = fmt; t->I = I; t->O = O; t->device = device; t->weight_bytes = rb * (size_t)O;

--- a/c/backend_cuda.h
+++ b/c/backend_cuda.h
@@ -42,6 +42,19 @@ void coli_cuda_tensor_free(ColiCudaTensor *tensor);
 size_t coli_cuda_tensor_bytes(const ColiCudaTensor *tensor);
 int coli_cuda_tensor_device(const ColiCudaTensor *tensor);
 
+/*
+ * FFN di expert FUSA e ASINCRONA (Fase 2): out = down( silu(gate(x)) * up(x) ).
+ * Protocollo per blocco: begin (riserva i buffer per `rows` righe totali e apre lo
+ * stream) -> N enqueue (una per expert residente: x host [nr,D] -> *out_host pinned
+ * [nr,D], valido DOPO la sync) -> sync (attende lo stream; 0 = un lancio e' fallito).
+ * begin sincronizza prima di riallocare: gli out del blocco precedente restano validi
+ * solo fino alla begin successiva. Il chiamante puo' riusare x subito dopo l'enqueue.
+ */
+int coli_cuda_ffn_begin(int device, long long rows, int D, int I);
+int coli_cuda_ffn_enqueue(ColiCudaTensor *gate, ColiCudaTensor *up, ColiCudaTensor *down,
+                          const float *x, int nr, const float **out_host);
+int coli_cuda_ffn_sync(int device);
+
 #ifdef __cplusplus
 }
 #endif

--- a/c/build_win.ps1
+++ b/c/build_win.ps1
@@ -1,0 +1,62 @@
+# build_win.ps1 — build nativa Windows del motore colibrì (clang, target MSVC).
+# Uso:  .\build_win.ps1            # motore CPU-only + test C
+#       .\build_win.ps1 -Cuda     # + backend CUDA (richiede nvcc e toolset MSVC v143)
+#       .\build_win.ps1 -Arch x86-64-v3   # binario portabile (default: native)
+param(
+    [switch]$Cuda,
+    [string]$Arch = "native",
+    [string]$CudaArch = "sm_120"        # RTX 5090 (Blackwell). Cambiare per altre GPU.
+)
+$ErrorActionPreference = "Stop"
+Set-Location $PSScriptRoot
+
+$cflags = @("-O3", "-march=$Arch", "-fopenmp",
+            "-D_FILE_OFFSET_BITS=64",   # richiesto dal guard di compat.h (belt-and-braces)
+            "-D_CRT_SECURE_NO_WARNINGS", "-D_CRT_NONSTDC_NO_DEPRECATE",
+            "-Wall", "-Wextra", "-Wno-unused-parameter", "-Wno-misleading-indentation",
+            "-Wno-unused-function", "-Wno-deprecated-declarations")
+
+$objs = @()
+if ($Cuda) {
+    # nvcc su Windows esige cl.exe (MSVC) come host compiler. CUDA 13.x supporta
+    # i toolset fino a VS 2022 (v143): con MSVC piu' nuovi cudafe++ crasha.
+    $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+    $vs = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+    $msvc = Get-ChildItem "$vs\VC\Tools\MSVC" | Where-Object { $_.Name -lt "14.50" } |
+            Sort-Object Name -Descending | Select-Object -First 1
+    if (-not $msvc) { throw "Nessun toolset MSVC <= v143 trovato: installare 'MSVC v143' dal Visual Studio Installer" }
+    # nvcc va invocato DENTRO vcvars64 (INCLUDE/LIB di MSVC) e SENZA -std:
+    # con -std=c++17 forwardato a MSVC 14.44+, cudafe++ crasha (0xC0000409, CUDA 13.1).
+    $vcvars = "$vs\VC\Auxiliary\Build\vcvars64.bat"
+    $ver = ($msvc.Name -split "\.")[0..1] -join "."
+    cmd /c "`"$vcvars`" -vcvars_ver=$ver >nul 2>&1 && set CL= && nvcc -O3 -arch=$CudaArch -c backend_cuda.cu -o backend_cuda.obj"
+    if ($LASTEXITCODE) { throw "nvcc fallito" }
+    $cflags += "-DCOLI_CUDA"
+    $objs += "backend_cuda.obj"
+    $cudaLib = Join-Path $env:CUDA_PATH "lib\x64"
+    $ldflags = @("-L$cudaLib", "-lcudart")
+} else {
+    $ldflags = @()
+}
+
+clang @cflags glm.c @objs -o glm.exe @ldflags
+if ($LASTEXITCODE) { throw "build glm.exe fallita" }
+Write-Host "glm.exe ok ($Arch$(if($Cuda){" + CUDA $CudaArch"}))"
+
+foreach ($t in "test_json", "test_st", "test_tier", "test_tok") {
+    clang -O2 -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE -Wno-deprecated-declarations `
+        "tests\$t.c" -o "tests\$t.exe"
+    if ($LASTEXITCODE) { throw "build $t fallita" }
+}
+foreach ($t in "test_json", "test_st", "test_tier") {   # test_tok richiede tokenizer.json + casi
+    & ".\tests\$t.exe"
+    if ($LASTEXITCODE) { throw "$t FALLITO" }
+}
+Write-Host "test C: ok"
+
+if (Test-Path glm_tiny) {
+    $env:SNAP = ".\glm_tiny"; $env:TF = "1"
+    $out = .\glm.exe 64 16 16 2>&1 | Select-String "posizioni"
+    Write-Host "self-test oracolo: $out"
+    Remove-Item Env:SNAP, Env:TF
+}

--- a/c/coli
+++ b/c/coli
@@ -107,7 +107,13 @@ def need_model(model):
         sys.exit(f"{C.yel}motore non compilato.{C.r} Esegui:  coli build")
 
 def cuda_binary():
-    if not os.path.exists(GLM) or sys.platform != "linux": return False
+    if not os.path.exists(GLM): return False
+    if sys.platform == "win32":
+        # niente ldd: la import table PE contiene "cudart64_*.dll" se linkato con CUDA
+        try:
+            with open(GLM, "rb") as f: return b"cudart" in f.read()
+        except OSError: return False
+    if sys.platform != "linux": return False
     try:
         linked=subprocess.run(["ldd",GLM],capture_output=True,text=True,timeout=3)
         return any("libcudart" in line and "not found" not in line
@@ -133,6 +139,7 @@ def env_for(a):
     if a.topk: e["TOPK"]=str(a.topk)
     if a.temp is not None: e["TEMP"]=str(a.temp)   # 0 = greedy; default motore: 1.0 + nucleus 0.95
     if a.repin: e["REPIN"]=str(a.repin)
+    if a.profile: e["COLI_PROFILE"]=a.profile
     if a.ctx: e["CTX"]=str(a.ctx)
     if a.auto_tier:
         from resource_plan import build_plan, environment_for_plan, format_bytes
@@ -284,6 +291,10 @@ def stream_turn(p, sentinel, on_bytes):
 # ---------- comandi ----------
 def cmd_build(a):
     banner("build")
+    if sys.platform == "win32" and not shutil.which("make"):
+        # senza MinGW make: build clang/nvcc via PowerShell (vedi build_win.ps1)
+        sys.exit(subprocess.call(["powershell","-ExecutionPolicy","Bypass",
+                                  "-File",os.path.join(HERE,"build_win.ps1")]))
     sys.exit(subprocess.call(["make","-C",HERE,"glm"]))
 
 def cmd_info(a):
@@ -517,6 +528,8 @@ def main():
     common.add_argument("--gpu",default=None,help="auto, none oppure lista device, es. 0,1")
     common.add_argument("--vram",type=float,default=0,help="budget VRAM totale in GB (0=auto)")
     common.add_argument("--repin", type=int, default=0, help="adatta gli expert RAM/VRAM ogni N token")
+    common.add_argument("--profile", default=os.environ.get("COLI_PROFILE",""),
+                        help="storia expert separata per dominio d'uso (es. coding, scrittura)")
     common.add_argument("--cap", type=int, default=8); common.add_argument("--ngen", type=int, default=1024)  # rete di sicurezza: la fine vera la decidono gli stop token
     common.add_argument("--topp", type=float, default=0); common.add_argument("--topk", type=int, default=0)
     common.add_argument("--temp", type=float, default=None)  # temperatura token (0=greedy, default 1.0+nucleus .95)

--- a/c/compat.h
+++ b/c/compat.h
@@ -77,12 +77,95 @@ static inline int compat_open_direct(const char *path){
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #include <io.h>
 #include <process.h>
 #include <malloc.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#ifndef __MINGW32__
+/* ================= clang/MSVC (UCRT): cio' che MinGW ha nativo e MSVC no =================
+ * MinGW-w64 fornisce ssize_t/dirent/pthread(winpthreads)/clock_gettime/usleep;
+ * il target MSVC no: gli shim vivono qui e restano invisibili alla build MinGW. */
+#ifndef _SSIZE_T_DEFINED
+typedef intptr_t ssize_t;
+#define _SSIZE_T_DEFINED
+#endif
+
+/* --- dirent: il minimo che serve a st_init (elenco *.safetensors) --- */
+struct dirent { char d_name[260]; };
+typedef struct { HANDLE h; WIN32_FIND_DATAA fd; int first; struct dirent ent; } DIR;
+static inline DIR *opendir(const char *path){
+    DIR *d = (DIR*)calloc(1, sizeof *d);
+    char pat[1024]; snprintf(pat, sizeof pat, "%s\\*", path);
+    d->h = FindFirstFileA(pat, &d->fd);
+    if(d->h==INVALID_HANDLE_VALUE){ free(d); return NULL; }
+    d->first = 1;
+    return d;
+}
+static inline struct dirent *readdir(DIR *d){
+    if(!d) return NULL;
+    if(d->first) d->first = 0;
+    else if(!FindNextFileA(d->h, &d->fd)) return NULL;
+    strncpy(d->ent.d_name, d->fd.cFileName, sizeof d->ent.d_name - 1);
+    d->ent.d_name[sizeof d->ent.d_name - 1] = 0;
+    return &d->ent;
+}
+static inline int closedir(DIR *d){
+    if(!d) return -1;
+    FindClose(d->h); free(d);
+    return 0;
+}
+
+/* --- tempo: CLOCK_MONOTONIC via QueryPerformanceCounter --- */
+#ifndef CLOCK_MONOTONIC
+#define CLOCK_MONOTONIC 1
+#endif
+static inline int compat_clock_gettime(int id, struct timespec *ts){
+    (void)id;
+    static LARGE_INTEGER freq;                   /* race benigna: scrittori identici */
+    LARGE_INTEGER c;
+    if(!freq.QuadPart) QueryPerformanceFrequency(&freq);
+    QueryPerformanceCounter(&c);
+    ts->tv_sec  = (time_t)(c.QuadPart / freq.QuadPart);
+    ts->tv_nsec = (long)((c.QuadPart % freq.QuadPart) * 1000000000LL / freq.QuadPart);
+    return 0;
+}
+#define clock_gettime compat_clock_gettime
+
+static inline int compat_usleep(long us){ Sleep(us >= 1000 ? (DWORD)(us/1000) : 1); return 0; }
+#define usleep compat_usleep
+
+/* --- pthread: il motore usa solo create+detach (thread PILOT) --- */
+typedef HANDLE pthread_t;
+typedef struct { int unused; } pthread_attr_t;
+typedef struct { void *(*fn)(void*); void *arg; } coli_thr_tramp_t;
+static unsigned __stdcall coli_thr_entry(void *p){
+    coli_thr_tramp_t t = *(coli_thr_tramp_t*)p; free(p);
+    t.fn(t.arg);
+    return 0;
+}
+static inline int pthread_create(pthread_t *t, const pthread_attr_t *attr,
+                                 void *(*fn)(void*), void *arg){
+    (void)attr;
+    coli_thr_tramp_t *tr = (coli_thr_tramp_t*)malloc(sizeof *tr);
+    if(!tr) return -1;
+    tr->fn = fn; tr->arg = arg;
+    uintptr_t h = _beginthreadex(NULL, 0, coli_thr_entry, tr, 0, NULL);
+    if(!h){ free(tr); return -1; }
+    *t = (HANDLE)h;
+    return 0;
+}
+#endif /* !__MINGW32__ */
 
 /* --- O_BINARY: belt-and-braces vs CRT text-mode (0x0A byte corruption) --- */
 #ifndef O_BINARY
@@ -94,22 +177,13 @@ static inline int compat_open_direct(const char *path){
  * prevents 0x0A bytes from being silently translated to \r\n. */
 #define COMPAT_O_RDONLY (O_RDONLY | O_BINARY)
 
-/* --- posix_fadvise: no-op (advisory only; safe to ignore) --- */
-#ifndef POSIX_FADV_NORMAL
-#define POSIX_FADV_NORMAL      0
-#define POSIX_FADV_RANDOM      1
-#define POSIX_FADV_SEQUENTIAL  2
-#define POSIX_FADV_WILLNEED    3
-#define POSIX_FADV_DONTNEED    4
-#define POSIX_FADV_NOREUSE     5
-#endif
-#define posix_fadvise(fd,off,len,advice) do{(void)(fd);(void)(off);(void)(len);(void)(advice);}while(0)
-
 /* --- pread -> ReadFile + OVERLAPPED su raw OS handle ---
  * Thread-safe (no shared seek position). Gestisce offset >4 GB e chunking
  * per letture >2 GB (anche se i tensori individuali sono nell'ordine dei
- * MB-centinaia di MB, il wrapper e' robusto per ogni taglia). */
-static inline ssize_t compat_pread(int fd, void *buf, size_t n, off_t off){
+ * MB-centinaia di MB, il wrapper e' robusto per ogni taglia).
+ * NB: offset `long long`, non off_t — sul target MSVC off_t e' long a 32 bit
+ * e _FILE_OFFSET_BITS non lo allarga: con off_t il wrap era silenzioso. */
+static inline ssize_t compat_pread(int fd, void *buf, size_t n, long long off){
     intptr_t osfh = _get_osfhandle(fd);
     if(osfh == -1 || osfh == -2){ errno = EBADF; return -1; }
     HANDLE h = (HANDLE)osfh;
@@ -118,8 +192,8 @@ static inline ssize_t compat_pread(int fd, void *buf, size_t n, off_t off){
         size_t chunk = n - total;
         DWORD chunk32 = (chunk > 0x7FFFFFFF) ? 0x7FFFFFFF : (DWORD)chunk;
         OVERLAPPED ov = {0};
-        ov.Offset     = (DWORD)( (off + (off_t)total)        & 0xFFFFFFFFULL);
-        ov.OffsetHigh = (DWORD)(((off + (off_t)total) >> 32) & 0xFFFFFFFFULL);
+        ov.Offset     = (DWORD)( (off + (long long)total)        & 0xFFFFFFFFULL);
+        ov.OffsetHigh = (DWORD)(((off + (long long)total) >> 32) & 0xFFFFFFFFULL);
         DWORD rd = 0;
         if(!ReadFile(h, (char*)buf + total, chunk32, &rd, &ov)){
             DWORD err = GetLastError();
@@ -134,6 +208,69 @@ static inline ssize_t compat_pread(int fd, void *buf, size_t n, off_t off){
     return (ssize_t)total;
 }
 #define pread(fd,buf,n,off) compat_pread(fd,buf,n,off)
+
+/* --- posix_fadvise: WILLNEED = readahead da un thread dedicato ---
+ * Windows non ha un equivalente advisory per-range su fd; il no-op perdeva
+ * l'overlap I/O-calcolo del readahead (expert del blocco successivo + PILOT).
+ * Qui un worker legge il range a blocchi in un buffer di scarto sul fd
+ * BUFFERIZZATO: le pagine restano nella system cache e le pread sincrone
+ * successive le trovano calde — stessa semantica del WILLNEED del kernel.
+ * Ring MPSC advisory: pieno = scarta (un hint perso non e' un errore,
+ * stessa scelta del ring del PILOT in glm.c). DONTNEED resta no-op. */
+#ifndef POSIX_FADV_NORMAL
+#define POSIX_FADV_NORMAL      0
+#define POSIX_FADV_RANDOM      1
+#define POSIX_FADV_SEQUENTIAL  2
+#define POSIX_FADV_WILLNEED    3
+#define POSIX_FADV_DONTNEED    4
+#define POSIX_FADV_NOREUSE     5
+#endif
+typedef struct { int fd; long long off, len; } coli_pf_req_t;
+static coli_pf_req_t coli_pf_q[1024];
+static volatile unsigned coli_pf_w, coli_pf_r;
+static CRITICAL_SECTION coli_pf_cs;
+static HANDLE coli_pf_sem;
+static INIT_ONCE coli_pf_once = INIT_ONCE_STATIC_INIT;
+static unsigned __stdcall coli_pf_worker(void *arg){
+    (void)arg;
+    static char coli_pf_buf[1u<<21];             /* 2 MB di scarto, un solo worker */
+    for(;;){
+        WaitForSingleObject(coli_pf_sem, INFINITE);
+        coli_pf_req_t rq; int have = 0;
+        EnterCriticalSection(&coli_pf_cs);
+        if(coli_pf_r != coli_pf_w){ rq = coli_pf_q[coli_pf_r & 1023]; coli_pf_r++; have = 1; }
+        LeaveCriticalSection(&coli_pf_cs);
+        if(!have) continue;
+        for(long long o = 0; o < rq.len; o += (long long)sizeof coli_pf_buf){
+            long long nb = rq.len - o; if(nb > (long long)sizeof coli_pf_buf) nb = (long long)sizeof coli_pf_buf;
+            if(compat_pread(rq.fd, coli_pf_buf, (size_t)nb, rq.off + o) <= 0) break;
+        }
+    }
+    return 0;
+}
+static BOOL CALLBACK coli_pf_init(PINIT_ONCE io, PVOID p, PVOID *ctx){
+    (void)io; (void)p; (void)ctx;
+    InitializeCriticalSection(&coli_pf_cs);
+    coli_pf_sem = CreateSemaphoreA(NULL, 0, 1u<<20, NULL);
+    _beginthreadex(NULL, 0, coli_pf_worker, NULL, 0, NULL);
+    return TRUE;
+}
+static inline int compat_fadvise(int fd, long long off, long long len, int advice){
+    if(advice != POSIX_FADV_WILLNEED || len <= 0) return 0;
+    InitOnceExecuteOnce(&coli_pf_once, coli_pf_init, NULL, NULL);
+    int queued = 0;
+    EnterCriticalSection(&coli_pf_cs);
+    if(coli_pf_w - coli_pf_r < 1024){
+        coli_pf_q[coli_pf_w & 1023].fd = fd;
+        coli_pf_q[coli_pf_w & 1023].off = off;
+        coli_pf_q[coli_pf_w & 1023].len = len;
+        coli_pf_w++; queued = 1;
+    }
+    LeaveCriticalSection(&coli_pf_cs);
+    if(queued) ReleaseSemaphore(coli_pf_sem, 1, NULL);
+    return 0;
+}
+#define posix_fadvise(fd,off,len,advice) compat_fadvise(fd,off,len,advice)
 
 /* --- posix_memalign -> _aligned_malloc ---
  * ATTN: memoria allocata con _aligned_malloc DEVE essere liberata con
@@ -215,10 +352,14 @@ static inline ssize_t compat_getline(char **lineptr, size_t *n, FILE *stream){
 }
 #define getline(lineptr,n,stream) compat_getline(lineptr,n,stream)
 
-/* --- setenv -> SetEnvironmentVariableA (POSIX setenv assente su Windows) --- */
+/* --- setenv -> _putenv_s (POSIX setenv assente su Windows) ---
+ * NON SetEnvironmentVariableA: quella aggiorna solo l'ambiente Win32, non la
+ * copia CRT letta da getenv() — e libomp legge OMP_WAIT_POLICY via getenv,
+ * quindi il setenv di glm.c verrebbe silenziosamente ignorato dal runtime OMP.
+ * _putenv_s aggiorna entrambe (CRT + processo). */
 static inline int compat_setenv(const char *name, const char *value, int overwrite){
     if(!overwrite && getenv(name)) return 0;
-    return SetEnvironmentVariableA(name, value) ? 0 : -1;
+    return _putenv_s(name, value);
 }
 #define setenv(name,value,overwrite) compat_setenv(name,value,overwrite)
 

--- a/c/glm.c
+++ b/c/glm.c
@@ -23,8 +23,10 @@
 #include <math.h>
 #include <time.h>
 #include <limits.h>
-#include <pthread.h>                              /* thread I/O del PILOTA */
+#if !defined(_WIN32) || defined(__MINGW32__)
+#include <pthread.h>                              /* thread I/O del PILOTA (MSVC: shim in compat.h) */
 #include <unistd.h>
+#endif
 #if defined(__APPLE__) || defined(__linux__)
 #include <sys/resource.h>
 #include <sys/mman.h>                             /* mlock: inchioda le pagine in RAM / wire pages into RAM */
@@ -98,7 +100,8 @@ typedef struct {
  * slab_cap/fslab_cap: capienza allocata — gli slot ws[] sono riusati TRA layer e gli
  * expert non hanno tutti la stessa taglia (layer MTP int8 = 2x i layer int4). */
 typedef struct { int eid; QT g,u,d; uint8_t *slab; float *fslab;
-                 int64_t slab_cap, fslab_cap; uint64_t used; } ESlot;
+                 int64_t slab_cap, fslab_cap; uint64_t used;
+                 int vram_only; } ESlot;   /* 1 = pesi SOLO in VRAM, backing host liberato */
 
 typedef struct {
     float **Lc, **Rc, **Ic;
@@ -482,6 +485,12 @@ static void matmul_qt(float *y, const float *x, QT *w, int S){
         w->cuda_failed=1;
         fprintf(stderr,"[CUDA] tensor [%d,%d] su device %d disabilitato dopo errore; fallback CPU\n",
             w->O,w->I,w->cuda_device);
+    }
+    if(!w->qf && !w->q8 && !w->q4){
+        /* slot VRAM-only col CUDA appena fallito: nessun peso host. Output azzerato;
+         * il chiamante (moe) vede cuda_failed, rimaterializza da disco e ricalcola. */
+        memset(y,0,(size_t)S*w->O*sizeof(float));
+        return;
     }
 #endif
     if(w->fmt==0){ matmul(y,x,w->qf,S,w->I,w->O); return; }
@@ -892,7 +901,7 @@ static void expert_load(Model *m, int layer, int eid, ESlot *s){
         qt_from_disk(m,nm[0],I,D,b,g_drop,&s->g);
         qt_from_disk(m,nm[1],I,D,b,g_drop,&s->u);
         qt_from_disk(m,nm[2],D,I,b,g_drop,&s->d);
-        s->eid=eid; return;
+        s->eid=eid; s->vram_only=0; return;
     }
     st_tensor *tw[3], *tq[3];
     for(int k=0;k<3;k++){
@@ -955,7 +964,71 @@ static void expert_load(Model *m, int layer, int eid, ESlot *s){
         qt[k]->fmt=fmt; qt[k]->O=OO[k]; qt[k]->I=II[k]; qt[k]->qf=NULL;
         qt[k]->q8=(int8_t*)(s->slab+pos[k]); qt[k]->q4=s->slab+pos[k]; qt[k]->s=fp[k];
     }
-    s->eid=eid;
+    s->eid=eid; s->vram_only=0;
+}
+
+#ifdef COLI_CUDA
+/* ---- Fase 1: tier VRAM SENZA backing RAM ----
+ * Dopo l'upload in VRAM il backing host dello slot pinnato viene liberato: i tier
+ * diventano ADDITIVI (VRAM + RAM), non un mirror. I QT restano con i puntatori host
+ * a NULL; se CUDA fallisce a runtime, vram_slot_demote() rimaterializza da disco. */
+static int64_t eslot_host_bytes(ESlot *s){
+    if(s->slab) return s->slab_cap + s->fslab_cap*(int64_t)sizeof(float);
+    return qt_bytes(&s->g)+qt_bytes(&s->u)+qt_bytes(&s->d);
+}
+static void eslot_host_free(ESlot *s){
+    QT *q[3]={&s->g,&s->u,&s->d};
+    if(s->slab){                                 /* container pre-quantizzato: g/u/d sono VISTE nello slab */
+        compat_aligned_free(s->slab); s->slab=NULL; s->slab_cap=0;
+        free(s->fslab); s->fslab=NULL; s->fslab_cap=0;
+        for(int k=0;k<3;k++){ q[k]->qf=NULL; q[k]->q8=NULL; q[k]->q4=NULL; q[k]->s=NULL; }
+    } else {                                     /* fallback (oracolo/tiny): buffer propri per-tensore */
+        for(int k=0;k<3;k++){
+            free(q[k]->qf); free(q[k]->q8); free(q[k]->q4); free(q[k]->s);
+            q[k]->qf=NULL; q[k]->q8=NULL; q[k]->q4=NULL; q[k]->s=NULL;
+        }
+    }
+    s->vram_only=1;
+}
+/* CUDA morto sotto uno slot VRAM-only: libera i tensori device, ricarica i pesi da
+ * disco nello stesso slot e degrada a RAM. Percorso raro (driver reset): rumoroso. */
+static void vram_slot_demote(Model *m, int layer, ESlot *s){
+    int64_t old=(int64_t)coli_cuda_tensor_bytes(s->g.cuda)
+               +(int64_t)coli_cuda_tensor_bytes(s->u.cuda)
+               +(int64_t)coli_cuda_tensor_bytes(s->d.cuda);
+    qt_cuda_reset(&s->g); qt_cuda_reset(&s->u); qt_cuda_reset(&s->d);
+    s->g.cuda_eligible=s->u.cuda_eligible=s->d.cuda_eligible=0;
+    if(m->gpu_expert_count) m->gpu_expert_count--;
+    m->gpu_expert_bytes-=old;
+    s->vram_only=0;
+    expert_load(m,layer,s->eid,s);
+    m->resident_bytes += eslot_host_bytes(s);
+    fprintf(stderr,"[CUDA] slot VRAM-only degradato: expert %d layer %d ricaricato in RAM\n",s->eid,layer);
+}
+/* Fase 2: uno slot e' batchabile sulla FFN fusa solo se TUTTI e tre i tensori
+ * sono gia' residenti sul device e senza errori pregressi. */
+static int eslot_gpu_ready(ESlot *e){
+    return e->g.cuda_eligible && e->u.cuda_eligible && e->d.cuda_eligible
+        && !e->g.cuda_failed && !e->u.cuda_failed && !e->d.cuda_failed
+        && e->g.cuda && e->u.cuda && e->d.cuda;
+}
+static int cuda_dev_index(int device){
+    for(int i=0;i<g_cuda_ndev;i++) if(g_cuda_devices[i]==device) return i;
+    return -1;
+}
+static int g_ffn=1;      /* CUDA_FFN=0 -> path sincrono per-tensore (A/B) */
+#endif
+
+/* righe del batch che instradano su eid; rows/rw NULL = solo conteggio */
+static int moe_rows(const int *idxs, const int *keff, const float *wsr,
+                    int S, int K, int eid, int *rows, float *rw){
+    int nr=0;
+    for(int s=0;s<S;s++) for(int kk=0;kk<keff[s];kk++)
+        if(idxs[(int64_t)s*K+kk]==eid){
+            if(rows){ rows[nr]=s; rw[nr]=wsr[(int64_t)s*K+kk]; }
+            nr++; break;
+        }
+    return nr;
 }
 
 /* prefetch asincrono dei pesi di un expert (e delle sue scale .qs): avvia il readahead
@@ -1244,10 +1317,42 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
                 if(!found) expert_prefetch(m,layer,eid);
             }
         }
+#ifdef COLI_CUDA
+        /* ---- Fase 2: batching asincrono degli expert VRAM-residenti ----
+         * FFN fusa (gate -> SiLU*up -> down) accodata su uno stream per device;
+         * la CPU calcola i propri expert MENTRE la GPU lavora; UNA sync per
+         * device a fine blocco. CUDA_FFN=0 ripristina il path sincrono. */
+        char gbat[64]={0}; const float *gout[64]={0};
+        int ffn_used[COLI_CUDA_MAX_DEVICES]={0}, ffn_ok[COLI_CUDA_MAX_DEVICES]={0};
+        int ngb=0;
+        if(g_cuda_enabled && g_ffn && !omp_in_parallel()){
+            long long rows_dev[COLI_CUDA_MAX_DEVICES]={0};
+            for(int j=0;j<nb;j++){ ESlot *e=use[j];
+                if(!eslot_gpu_ready(e)) continue;
+                int di=cuda_dev_index(e->g.cuda_device); if(di<0) continue;
+                int nr=moe_rows(idxs,keff,ws,S,K,uniq[base+j],NULL,NULL);
+                if(nr){ rows_dev[di]+=nr; ffn_used[di]=1; }
+            }
+            for(int i=0;i<g_cuda_ndev;i++) if(ffn_used[i])
+                ffn_ok[i]=coli_cuda_ffn_begin(g_cuda_devices[i],rows_dev[i],D,I);
+            for(int j=0;j<nb;j++){ ESlot *e=use[j];
+                if(!eslot_gpu_ready(e)) continue;
+                int di=cuda_dev_index(e->g.cuda_device);
+                if(di<0 || !ffn_ok[di]) continue;
+                int nr=moe_rows(idxs,keff,ws,S,K,uniq[base+j],rows,rw);
+                if(!nr) continue;
+                for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)rows[r]*D, D*sizeof(float));
+                if(coli_cuda_ffn_enqueue(e->g.cuda,e->u.cuda,e->d.cuda,xg,nr,&gout[j])){
+                    gbat[j]=1; ngb++;
+                }
+            }
+        }
+#endif
         for(int j=0;j<nb;j++){ int eid=uniq[base+j]; ESlot *e=use[j];
-            int nr=0;                                 /* righe (posizioni) che usano questo expert */
-            for(int s=0;s<S;s++) for(int kk=0;kk<keff[s];kk++)
-                if(idxs[(int64_t)s*K+kk]==eid){ rows[nr]=s; rw[nr]=ws[(int64_t)s*K+kk]; nr++; break; }
+#ifdef COLI_CUDA
+            if(gbat[j]) continue;                     /* in volo sulla GPU: raccolto dopo */
+#endif
+            int nr=moe_rows(idxs,keff,ws,S,K,eid,rows,rw);
             if(!nr) continue;
 #ifdef COLI_CUDA
             if(g_cuda_enabled && e->g.cuda_eligible) m->gpu_expert_calls++;
@@ -1258,10 +1363,49 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
             matmul_qt(uu, xg, &e->u, nr);
             for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
             matmul_qt(hh, gg, &e->d, nr);
+#ifdef COLI_CUDA
+            if(e->vram_only && (e->g.cuda_failed||e->u.cuda_failed||e->d.cuda_failed)){
+                vram_slot_demote(m,layer,e);     /* host rimaterializzato: ricalcolo CPU pulito */
+                matmul_qt(gg, xg, &e->g, nr);
+                matmul_qt(uu, xg, &e->u, nr);
+                for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
+                matmul_qt(hh, gg, &e->d, nr);
+            }
+#endif
             for(int r=0;r<nr;r++){ float *os=out+(int64_t)rows[r]*D, wgt=rw[r], *hr=hh+(int64_t)r*D;
                 for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
             m->t_emm += now_s()-t0;
         }
+#ifdef COLI_CUDA
+        if(ngb){                                      /* raccolta del lavoro GPU in volo */
+            double t0=now_s();
+            int sync_ok[COLI_CUDA_MAX_DEVICES]={0};
+            for(int i=0;i<g_cuda_ndev;i++) if(ffn_used[i]&&ffn_ok[i])
+                sync_ok[i]=coli_cuda_ffn_sync(g_cuda_devices[i]);
+            for(int j=0;j<nb;j++){ if(!gbat[j]) continue;
+                ESlot *e=use[j]; int eid=uniq[base+j];
+                int nr=moe_rows(idxs,keff,ws,S,K,eid,rows,rw);
+                int di=cuda_dev_index(e->g.cuda_device);
+                if(di>=0 && sync_ok[di]){
+                    const float *hr=gout[j];
+                    for(int r=0;r<nr;r++){ float *os=out+(int64_t)rows[r]*D; float wgt=rw[r];
+                        for(int d=0;d<D;d++) os[d]+=wgt*hr[(int64_t)r*D+d]; }
+                    m->gpu_expert_calls++;
+                } else {                              /* stream fallito: demozione rumorosa + CPU */
+                    e->g.cuda_failed=e->u.cuda_failed=e->d.cuda_failed=1;
+                    if(e->vram_only) vram_slot_demote(m,layer,e);
+                    for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)rows[r]*D, D*sizeof(float));
+                    matmul_qt(gg, xg, &e->g, nr);
+                    matmul_qt(uu, xg, &e->u, nr);
+                    for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
+                    matmul_qt(hh, gg, &e->d, nr);
+                    for(int r=0;r<nr;r++){ float *os=out+(int64_t)rows[r]*D, wgt=rw[r], *hr=hh+(int64_t)r*D;
+                        for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
+                }
+            }
+            m->t_emm += now_s()-t0;
+        }
+#endif
         { ESlot *Sl=m->ecache[layer]; int *nn=&m->ecn[layer];   /* promozione LRU (swap buffer) */
           int promo = nmiss<m->ecap ? nmiss : m->ecap;
           for(int a=0;a<promo;a++){ int q=nmiss-1-a; ESlot *dst;
@@ -1857,10 +2001,12 @@ static void repin_pass(Model *m){
                                +(int64_t)coli_cuda_tensor_bytes(s->u.cuda)
                                +(int64_t)coli_cuda_tensor_bytes(s->d.cuda);
                 m->gpu_expert_bytes+=now_gpu-old_gpu; tier="VRAM";
+                eslot_host_free(s);               /* Fase 1: il nuovo expert resta VRAM-only */
             } else {
                 qt_cuda_reset(&s->g); qt_cuda_reset(&s->u); qt_cuda_reset(&s->d);
                 s->g.cuda_eligible=s->u.cuda_eligible=s->d.cuda_eligible=0;
                 m->gpu_expert_count--; m->gpu_expert_bytes-=old_gpu;
+                s->vram_only=0;                   /* host appena rimaterializzato da expert_load */
                 fprintf(stderr,"[REPIN] upload VRAM fallito; slot degradato a RAM\n");
             }
         }
@@ -1869,6 +2015,63 @@ static void repin_pass(Model *m){
             tier,cd[b].l,old,old_heat,cd[b].eid,new_heat,(now_s()-t0)*1e3);
     }
     for(int l=0;l<m->c.n_layers;l++) if(m->eheat[l]) tier_decay(m->eheat[l],m->c.n_experts);
+}
+
+/* ---- Fase 4: RAM DINAMICA a runtime ----
+ * Il budget non e' piu' una fotografia del boot: a ogni confine di turno si rimisura
+ * MemAvailable e la LRU si adatta — si RESTRINGE sotto pressione (altri processi
+ * hanno preso RAM: liberare slot batte swap/OOM-kill) e si ALLARGA quando la RAM
+ * torna libera. Banda morta 3.5-6 GB liberi contro il churn. E' questa rete di
+ * sicurezza che permette i margini statici piu' aggressivi (90% del boot, autopin
+ * 85%). MEMWATCH=0 disattiva. */
+static int g_memwatch=1;
+static double mem_available_gb(void);
+static int64_t expert_bytes_probe(Model *m, int ebits);
+static void eslot_release(ESlot *s){          /* libera il backing host di uno slot LRU */
+    QT *q[3]={&s->g,&s->u,&s->d};
+    if(s->slab){ compat_aligned_free(s->slab); free(s->fslab); }
+    else for(int k=0;k<3;k++){ free(q[k]->qf); free(q[k]->q8); free(q[k]->q4); free(q[k]->s); }
+    memset(s,0,sizeof(*s));
+}
+static void mem_watch_pass(Model *m){
+    if(!g_memwatch) return;
+    double avail=mem_available_gb(); if(avail<=0) return;
+    Cfg *c=&m->c; int nsp=0; for(int i=0;i<c->n_layers;i++) if(m->L[i].sparse) nsp++;
+    if(m->has_mtp) nsp+=2;
+    if(nsp<1) return;
+    int64_t eb=expert_bytes_probe(m,m->ebits);
+    double slot_gb=(double)nsp*eb/1e9;        /* costo di +-1 cap su tutti i layer */
+    if(slot_gb<=0) return;
+    if(avail<3.5){                            /* pressione: riserva page-cache+OS a rischio */
+        int drop=(int)((3.5-avail)/slot_gb)+1;
+        int newcap=m->ecap-drop; if(newcap<1) newcap=1;
+        if(newcap>=m->ecap) return;
+        for(int i=0;i<=c->n_layers;i++){
+            if(!m->ecache[i]) continue;
+            while(m->ecn[i]>newcap){          /* evict LRU: la RAM va liberata DAVVERO */
+                int lru=0;
+                for(int z=1;z<m->ecn[i];z++) if(m->ecache[i][z].used<m->ecache[i][lru].used) lru=z;
+                eslot_release(&m->ecache[i][lru]);
+                m->ecache[i][lru]=m->ecache[i][m->ecn[i]-1];
+                memset(&m->ecache[i][m->ecn[i]-1],0,sizeof(ESlot));
+                m->ecn[i]--;
+            }
+        }
+        fprintf(stderr,"[RAM] pressione: %.1f GB liberi -> cap %d->%d (slot LRU liberati)\n",
+            avail,m->ecap,newcap);
+        m->ecap=newcap;
+    } else if(avail>6.0 && m->ecap<c->n_experts){   /* margine: la LRU puo' crescere */
+        int grow=(int)((avail-6.0)*0.90/slot_gb);
+        if(grow<1) return;
+        int newcap=m->ecap+grow; if(newcap>c->n_experts) newcap=c->n_experts;
+        for(int i=0;i<=c->n_layers;i++) if(m->ecache[i]){
+            m->ecache[i]=realloc(m->ecache[i],(size_t)newcap*sizeof(ESlot));
+            memset(m->ecache[i]+m->ecap,0,(size_t)(newcap-m->ecap)*sizeof(ESlot));
+        }
+        fprintf(stderr,"[RAM] margine: %.1f GB liberi -> cap ALZATO %d->%d (MEMWATCH=0 disattiva)\n",
+            avail,m->ecap,newcap);
+        m->ecap=newcap;
+    }
 }
 /* ---- KV SU DISCO: la conversazione si riapre CALDA (KVSAVE=0 disattiva) ----
  * Il re-prefill di una chat riaperta costa ore su questo disco; la KV compressa MLA
@@ -2015,7 +2218,7 @@ static void run_serve(Model *m, const char *snap){
             double dh=(double)(m->hits-h0), dm=(double)(m->miss-ms0);
             printf("\n\x01\x01" "END" "\x01\x01\n");
             printf("STAT %d %.2f %.1f %.2f\n", prod, prod/tdt, (dh+dm)>0?100.0*dh/(dh+dm):0.0, rss_gb());
-            fflush(stdout); kv_disk_append(m,hist,len); repin_pass(m); continue; }   /* RFC: re-pin a caldo tra i turni / live re-pin between turns */
+            fflush(stdout); kv_disk_append(m,hist,len); mem_watch_pass(m); repin_pass(m); continue; }   /* RFC: re-pin a caldo tra i turni / live re-pin between turns */
         if(nr<1){ printf("\x01\x01" "END" "\x01\x01\n"); printf("STAT 0 0.00 0.0 %.2f\n", rss_gb()); fflush(stdout); continue; }
         /* API mode: an exact, length-prefixed prompt. Unlike the interactive
          * line protocol this accepts newlines. The tokenized prompt is matched
@@ -2224,27 +2427,17 @@ static void pin_load(Model *m, const char *statspath, double gb){
         if(a>4095) break;                                    /* bastano i top ~4k */
     }
     int64_t eb=expert_bytes_probe(m,m->ebits);
-    int npin=(int)(gb*1e9/eb); if(npin>n) npin=n; if(npin>4096) npin=4096;
-    if(npin<1){ free(r); return; }
-    int *cnt_l=calloc(c->n_layers+1,sizeof(int));   /* +1: riga MTP */
-    for(int a=0;a<npin;a++) cnt_l[r[a].l]++;
-    for(int i=0;i<=c->n_layers;i++) if(cnt_l[i]) m->pin[i]=calloc(cnt_l[i],sizeof(ESlot));
-    double t0=now_s();
-    #pragma omp parallel for schedule(dynamic,1)
-    for(int a=0;a<npin;a++){
-        int li=r[a].l, slot;
-        #pragma omp critical
-        slot=m->npin[li]++;
-        expert_load(m,li,r[a].e,&m->pin[li][slot]);
-    }
-    m->resident_bytes += (int64_t)npin*eb;
-    fprintf(stderr,"[PIN] hot-store: %d expert in RAM (%.1f GB) in %.0fs da %s\n",
-        npin, npin*eb/1e9, now_s()-t0, statspath);
+    /* ---- Fase 3: allocatore a CASCATA guidato dal calore ----
+     * La lista ordinata per frequenza scende sui tier dal piu' veloce al piu' lento:
+     * banda VRAM (upload a blocchi, backing host liberato subito: il picco RAM
+     * transitorio resta ~un blocco), poi banda RAM fino a `gb`; il resto vive di
+     * LRU+disco. `gb` e' il SOLO budget RAM: la capienza VRAM si AGGIUNGE. */
+    double vram_budget=0;
 #ifdef COLI_CUDA
+    double remaining[COLI_CUDA_MAX_DEVICES]={0}, placed_b[COLI_CUDA_MAX_DEVICES]={0};
+    int placed_n[COLI_CUDA_MAX_DEVICES]={0};
     if(g_cuda_enabled && g_cuda_expert_gb>0){
-        double remaining[COLI_CUDA_MAX_DEVICES]={0}, placed_b[COLI_CUDA_MAX_DEVICES]={0};
-        int placed_n[COLI_CUDA_MAX_DEVICES]={0};
-        double budget=g_cuda_expert_gb*1e9, safe_total=0;
+        double safe_total=0;
         for(int i=0;i<g_cuda_ndev;i++){
             size_t free_b=0,total_b=0;
             if(coli_cuda_mem_info(g_cuda_devices[i],&free_b,&total_b)){
@@ -2255,43 +2448,90 @@ static void pin_load(Model *m, const char *statspath, double gb){
                 safe_total+=remaining[i];
             }
         }
-        if(budget>safe_total) budget=safe_total;
-        for(int a=0;a<npin && m->gpu_expert_bytes<budget;a++){
-            int li=r[a].l;
-            for(int z=0;z<m->npin[li];z++) if(m->pin[li][z].eid==r[a].e){
-                ESlot *s=&m->pin[li][z];
-                int64_t need=qt_bytes(&s->g)+qt_bytes(&s->u)+qt_bytes(&s->d);
-                if(m->gpu_expert_bytes+need>budget) break;
-                int tried[COLI_CUDA_MAX_DEVICES]={0}, placed=0;
-                for(int attempt=0;attempt<g_cuda_ndev && !placed;attempt++){
-                    int best=-1;
-                    for(int i=0;i<g_cuda_ndev;i++) if(!tried[i] && remaining[i]>=need &&
-                        (best<0||placed_b[i]<placed_b[best])) best=i;
-                    if(best<0) break;
-                    tried[best]=1;
-                    s->g.cuda_device=s->u.cuda_device=s->d.cuda_device=g_cuda_devices[best];
-                    s->g.cuda_eligible=s->u.cuda_eligible=s->d.cuda_eligible=1;
-                    if(qt_cuda_upload(&s->g) && qt_cuda_upload(&s->u) && qt_cuda_upload(&s->d)){
-                        int64_t actual=(int64_t)coli_cuda_tensor_bytes(s->g.cuda)
-                                      +(int64_t)coli_cuda_tensor_bytes(s->u.cuda)
-                                      +(int64_t)coli_cuda_tensor_bytes(s->d.cuda);
-                        m->gpu_expert_count++; m->gpu_expert_bytes+=actual;
-                        remaining[best]-=actual; placed_b[best]+=actual; placed_n[best]++;
-                        placed=1;
-                    } else {
-                        qt_cuda_reset(&s->g); qt_cuda_reset(&s->u); qt_cuda_reset(&s->d);
-                        s->g.cuda_eligible=s->u.cuda_eligible=s->d.cuda_eligible=0;
-                        remaining[best]=0;             /* device rejected its projected capacity */
-                    }
-                }
-                break;
-            }
-        }
-        fprintf(stderr,"[CUDA] hot expert tier: %d/%d expert, VRAM %.2f GB (budget totale %.1f GB)\n",
-            m->gpu_expert_count,npin,m->gpu_expert_bytes/1e9,g_cuda_expert_gb);
-        for(int i=0;i<g_cuda_ndev;i++) fprintf(stderr,"[CUDA]   device %d: %d expert, %.2f GB\n",
-            g_cuda_devices[i],placed_n[i],placed_b[i]/1e9);
+        vram_budget=g_cuda_expert_gb*1e9;
+        if(vram_budget>safe_total) vram_budget=safe_total;
     }
+#endif
+    int nram_max=(int)(gb*1e9/eb), nvram_max=(int)(vram_budget/eb);
+    int npin=nram_max+nvram_max;
+    if(npin>n) npin=n; if(npin>4096) npin=4096;
+    if(npin<1){ free(r); return; }
+    int *cnt_l=calloc(c->n_layers+1,sizeof(int));   /* +1: riga MTP */
+    for(int a=0;a<npin;a++) cnt_l[r[a].l]++;
+    for(int i=0;i<=c->n_layers;i++) if(cnt_l[i]) m->pin[i]=calloc(cnt_l[i],sizeof(ESlot));
+    double t0=now_s();
+    int64_t ram_bytes=0, freed_host=0; int nvram=0, a0=0;
+#ifdef COLI_CUDA
+    /* banda VRAM: blocchi di 32 — load parallelo dal disco, upload+free seriale.
+     * Doppio tetto (byte reali E conteggio da stima eb): cosi' la banda RAM riceve
+     * la sua quota anche quando eb sovrastima la taglia reale degli expert. */
+    while(a0<npin && vram_budget>0 && nvram<nvram_max &&
+          (double)m->gpu_expert_bytes+eb<=vram_budget){
+        int blk = npin-a0<32 ? npin-a0 : 32;
+        int slot_of[32];
+        #pragma omp parallel for schedule(dynamic,1)
+        for(int b=0;b<blk;b++){
+            int li=r[a0+b].l, slot;
+            #pragma omp critical
+            { slot=m->npin[li]++; slot_of[b]=slot; }
+            expert_load(m,li,r[a0+b].e,&m->pin[li][slot]);
+        }
+        for(int b=0;b<blk;b++){
+            ESlot *s=&m->pin[r[a0+b].l][slot_of[b]];
+            int64_t need=qt_bytes(&s->g)+qt_bytes(&s->u)+qt_bytes(&s->d);
+            if(nvram>=nvram_max || (double)m->gpu_expert_bytes+need>vram_budget){
+                ram_bytes+=eslot_host_bytes(s); continue; }
+            int tried[COLI_CUDA_MAX_DEVICES]={0}, placed=0;
+            for(int attempt=0;attempt<g_cuda_ndev && !placed;attempt++){
+                int best=-1;
+                for(int i=0;i<g_cuda_ndev;i++) if(!tried[i] && remaining[i]>=need &&
+                    (best<0||placed_b[i]<placed_b[best])) best=i;
+                if(best<0) break;
+                tried[best]=1;
+                s->g.cuda_device=s->u.cuda_device=s->d.cuda_device=g_cuda_devices[best];
+                s->g.cuda_eligible=s->u.cuda_eligible=s->d.cuda_eligible=1;
+                if(qt_cuda_upload(&s->g) && qt_cuda_upload(&s->u) && qt_cuda_upload(&s->d)){
+                    int64_t actual=(int64_t)coli_cuda_tensor_bytes(s->g.cuda)
+                                  +(int64_t)coli_cuda_tensor_bytes(s->u.cuda)
+                                  +(int64_t)coli_cuda_tensor_bytes(s->d.cuda);
+                    m->gpu_expert_count++; m->gpu_expert_bytes+=actual;
+                    remaining[best]-=actual; placed_b[best]+=actual; placed_n[best]++;
+                    placed=1; nvram++;
+                    freed_host+=eslot_host_bytes(s);
+                    eslot_host_free(s);              /* Fase 1: niente mirror in RAM */
+                } else {
+                    qt_cuda_reset(&s->g); qt_cuda_reset(&s->u); qt_cuda_reset(&s->d);
+                    s->g.cuda_eligible=s->u.cuda_eligible=s->d.cuda_eligible=0;
+                    remaining[best]=0;               /* device rejected its projected capacity */
+                }
+            }
+            if(!placed) ram_bytes+=eslot_host_bytes(s);   /* resta in RAM: e' comunque caldo */
+        }
+        a0+=blk;
+        double left=0; for(int i=0;i<g_cuda_ndev;i++) left+=remaining[i];
+        if(left<eb) break;                           /* VRAM fisicamente esaurita */
+    }
+#endif
+    /* banda RAM: si prosegue lungo la lista fino al budget RAM residuo */
+    int nram_left = nram_max-(int)(ram_bytes/eb);
+    int a_end = a0 + (nram_left>0 ? nram_left : 0);
+    if(a_end>npin) a_end=npin;
+    #pragma omp parallel for schedule(dynamic,1)
+    for(int a=a0;a<a_end;a++){
+        int li=r[a].l, slot;
+        #pragma omp critical
+        slot=m->npin[li]++;
+        expert_load(m,li,r[a].e,&m->pin[li][slot]);
+    }
+    ram_bytes += (int64_t)(a_end-a0)*eb;
+    m->resident_bytes += ram_bytes;
+    fprintf(stderr,"[PIN] cascata: %d expert in VRAM (%.2f GB, host liberato %.2f GB) + "
+        "%d in RAM (%.1f GB) in %.0fs da %s\n",
+        nvram, m->gpu_expert_bytes/1e9, freed_host/1e9,
+        a_end-nvram, ram_bytes/1e9, now_s()-t0, statspath);
+#ifdef COLI_CUDA
+    if(nvram) for(int i=0;i<g_cuda_ndev;i++) fprintf(stderr,
+        "[CUDA]   device %d: %d expert, %.2f GB\n", g_cuda_devices[i],placed_n[i],placed_b[i]/1e9);
 #endif
     pin_wire(m);                                   /* inchioda in RAM (no compressione) / wire in RAM (no compression) */
     free(r); free(cnt_l);
@@ -2337,7 +2577,7 @@ static double kv_pool_bytes(Model *m, int max_ctx){
 /* byte disponibili per gli expert (pin + LRU) nel budget — specchio del conto di cap_for_ram */
 static double expert_avail(Model *m, double ram_gb, int ebits, int max_ctx){
     Cfg *c=&m->c; int64_t eb=expert_bytes_probe(m,ebits);
-    if(ram_gb<=0){ ram_gb=g_mem_avail_boot*0.88; if(ram_gb<4) ram_gb=8; }
+    if(ram_gb<=0){ ram_gb=g_mem_avail_boot*0.90; if(ram_gb<4) ram_gb=8; }   /* Fase 4: margine 10%, il monitor runtime fa da rete */
     double slack = 1.2e9 + 2.5e9 + 64.0*(double)eb
         + kv_pool_bytes(m,max_ctx)
         + (double)max_ctx*c->n_heads*(c->qk_nope+c->v_head)*4.0;
@@ -2345,14 +2585,16 @@ static double expert_avail(Model *m, double ram_gb, int ebits, int max_ctx){
 }
 
 /* clampa la cache expert a un budget RAM (GB): cap t.c. residente + cache + slack <= budget.
- * ram_gb<=0 -> budget AUTO = 88% della RAM disponibile adesso (lascia respiro a OS+wrapper:
- * sforare = OOM-kill del kernel a meta' generazione, molto peggio di una cache piu' piccola). */
+ * ram_gb<=0 -> budget AUTO = 90% della RAM disponibile adesso (lascia respiro a OS+wrapper:
+ * sforare = OOM-kill del kernel a meta' generazione, molto peggio di una cache piu' piccola.
+ * Fase 4: il margine statico e' sceso da 12% a 10% perche' mem_watch_pass rimisura la
+ * pressione a ogni turno e restringe la LRU PRIMA che il kernel debba intervenire). */
 static void cap_for_ram(Model *m, double ram_gb, int ebits, int max_ctx){
     Cfg *c=&m->c; int nsp=0; for(int i=0;i<c->n_layers;i++) if(m->L[i].sparse) nsp++;
     if(m->has_mtp) nsp+=2;                       /* riga cache MTP: conta ~doppia (expert int8 = 2x int4) */
     int64_t eb=expert_bytes_probe(m,ebits);
     int auto_b = ram_gb<=0;
-    if(auto_b){ ram_gb = g_mem_avail_boot*0.88;   /* misurata PRIMA del load: il residente gia'
+    if(auto_b){ ram_gb = g_mem_avail_boot*0.90;   /* misurata PRIMA del load: il residente gia'
                                                    * allocato viene sottratto sotto, non due volte */
         if(ram_gb<4){ fprintf(stderr,"[RAM] MemAvailable illeggibile/troppo bassa, assumo 8 GB\n"); ram_gb=8; } }
     /* slack ONESTO, non forfettario (l'OOM del 2026-07-04 veniva da qui):
@@ -2421,6 +2663,7 @@ int main(int argc, char **argv){
     g_direct = getenv("DIRECT")?atoi(getenv("DIRECT")):0;
     g_idot = getenv("IDOT")?atoi(getenv("IDOT")):1;        /* 0 = kernel f32 esatti (A/B) */
     g_repin = getenv("REPIN")?atoi(getenv("REPIN")):0;     /* RFC: re-pin ogni n token emessi (0=off) / live re-pin every n emitted tokens (0=off) */
+    g_memwatch = getenv("MEMWATCH")?atoi(getenv("MEMWATCH")):1;   /* Fase 4: adattamento RAM a ogni turno */
     g_absorb = getenv("ABSORB")?atoi(getenv("ABSORB")):-1; /* -1 auto: assorbita per S<=4 */
     g_dsa_force = getenv("DSA_FORCE")?atoi(getenv("DSA_FORCE")):0;
     g_temp = getenv("TEMP")?atof(getenv("TEMP")):-1;       /* -1 = auto (1.0 chat/testo, greedy altrove) */
@@ -2446,6 +2689,7 @@ int main(int argc, char **argv){
         if(!g_cuda_enabled){ fprintf(stderr,"[CUDA] backend richiesto ma non disponibile\n"); return 2; }
     }
     g_cuda_dense=getenv("CUDA_DENSE")?atoi(getenv("CUDA_DENSE")):0;
+    g_ffn=getenv("CUDA_FFN")?atoi(getenv("CUDA_FFN")):1;   /* Fase 2: batching FFN (0 = A/B sincrono) */
     g_cuda_expert_gb=getenv("CUDA_EXPERT_GB")?atof(getenv("CUDA_EXPERT_GB")):0;
     if((getenv("COLI_GPU")||getenv("COLI_GPUS"))&&!g_cuda_enabled){ fprintf(stderr,"COLI_GPU(S) richiede COLI_CUDA=1\n"); return 2; }
     if(g_cuda_dense&&!g_cuda_enabled){ fprintf(stderr,"CUDA_DENSE richiede COLI_CUDA=1\n"); return 2; }
@@ -2481,17 +2725,29 @@ int main(int argc, char **argv){
      * conosce la TUA storia, la LRU si adatta alla sessione). AUTOPIN=0 disattiva. */
     { double ram_env = getenv("RAM_GB")?atof(getenv("RAM_GB")):0.0;
       int est_ctx = getenv("CTX")?atoi(getenv("CTX")):4096;   /* stesso default di run_serve */
-      snprintf(g_usage_path,sizeof(g_usage_path),"%s/.coli_usage",snap);
+      /* Fase 3: PROFILI DI DOMINIO — usi coerenti (coding, scrittura, ...) hanno
+       * routing coerente: una storia separata per profilo pre-carica in VRAM/RAM
+       * gli expert giusti dal primo token. COLI_PROFILE=<nome> la seleziona. */
+      const char *prof=getenv("COLI_PROFILE");
+      if(prof && *prof) snprintf(g_usage_path,sizeof(g_usage_path),"%s/.coli_usage.%s",snap,prof);
+      else snprintf(g_usage_path,sizeof(g_usage_path),"%s/.coli_usage",snap);
       int64_t hist = usage_load(&m,g_usage_path);
       if(hist>0) fprintf(stderr,"[USAGE] storia expert: %lld selezioni (%s)\n",(long long)hist,g_usage_path);
       int autopin = getenv("AUTOPIN")?atoi(getenv("AUTOPIN")):1;
       if(!getenv("PIN") && autopin && hist>=5000){
           /* quota pin proporzionale alla FIDUCIA nella storia: con pochi dati il pin
            * sbaglia expert e ruba slot alla LRU adattiva; a regime (>=200k selezioni,
-           * qualche ora di chat) arriva a meta' del budget expert. */
+           * qualche ora di chat) arriva all'85% del budget expert (Fase 4: prima era
+           * il 50% — il monitor runtime e il repin fanno da rete di sicurezza). */
           double conf = (double)hist/200000.0; if(conf>1) conf=1;
-          double pin_gb = expert_avail(&m,ram_env,ebits,est_ctx)*0.5*conf/1e9;
-          if(pin_gb>=0.5) pin_load(&m, g_usage_path, pin_gb);
+          double pin_gb = expert_avail(&m,ram_env,ebits,est_ctx)*0.85*conf/1e9;
+          int vram_tier=0;
+#ifdef COLI_CUDA
+          /* Fase 3: la cascata riempie la VRAM anche quando la RAM libera e' poca
+           * (macchina piccola + GPU grande): il tier VRAM non richiede backing. */
+          vram_tier = g_cuda_enabled && g_cuda_expert_gb>0;
+#endif
+          if(pin_gb>=0.5 || vram_tier) pin_load(&m, g_usage_path, pin_gb>=0.5?pin_gb:0);
       }
       /* SEMPRE: senza clamp la LRU cresce fino a cap*76 layer = decine di GB -> OOM-kill.
        * RAM_GB assente o <=0 = budget automatico da MemAvailable. */

--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -76,6 +76,18 @@ def analyze_model(model):
 
 
 def memory_available():
+    if os.name == "nt":
+        import ctypes
+        class _MSX(ctypes.Structure):
+            _fields_ = ([("dwLength", ctypes.c_uint32), ("dwMemoryLoad", ctypes.c_uint32)] +
+                        [(n, ctypes.c_uint64) for n in (
+                            "ullTotalPhys", "ullAvailPhys", "ullTotalPageFile",
+                            "ullAvailPageFile", "ullTotalVirtual", "ullAvailVirtual",
+                            "ullAvailExtendedVirtual")])
+        ms = _MSX(); ms.dwLength = ctypes.sizeof(_MSX)
+        if ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(ms)):
+            return int(ms.ullAvailPhys)
+        return 0
     try:
         text = Path("/proc/meminfo").read_text()
         return int(re.search(r"MemAvailable:\s+(\d+)", text).group(1)) * 1024
@@ -145,8 +157,10 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
         usable = max(0, gpu["free_bytes"] - reserve)
         safe_vram += usable
         gpu_plan.append(dict(gpu, reserve_bytes=reserve, usable_bytes=usable))
+    # Il tier VRAM non richiede piu' backing RAM (gli slot caricati liberano la copia
+    # host): il budget e' limitato solo dalla VRAM fisica, i tier sono additivi.
     requested_vram = int(vram_gb * GB) if vram_gb > 0 else safe_vram
-    vram_budget = min(requested_vram, safe_vram, cache_bytes)
+    vram_budget = min(requested_vram, safe_vram)
     vram_experts = int(vram_budget // typical) if typical else 0
 
     warnings = []
@@ -155,7 +169,7 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
     if gpu_indices is not None and len(gpus) != len(set(gpu_indices)):
         warnings.append("one or more requested GPUs were not detected")
     if gpus and vram_budget < requested_vram:
-        warnings.append("VRAM tier was clamped by free VRAM or its required RAM backing")
+        warnings.append("VRAM tier was clamped by free VRAM")
 
     return {
         "version": 1,

--- a/c/st.h
+++ b/c/st.h
@@ -12,8 +12,10 @@
 #include <string.h>
 #include <stdint.h>
 #include <fcntl.h>
-#include <unistd.h>
+#if !defined(_WIN32) || defined(__MINGW32__)
+#include <unistd.h>                /* MSVC: pread/dirent arrivano da compat.h */
 #include <dirent.h>
+#endif
 #include "json.h"
 #include "compat.h"
 

--- a/c/tests/test_doctor.py
+++ b/c/tests/test_doctor.py
@@ -99,6 +99,7 @@ class DoctorTest(unittest.TestCase):
         self.assertIsNone(report["plan"])
         self.assertEqual(exit_code(report), 1)
 
+    @unittest.skipIf(sys.platform == "win32", "Windows non ha il bit di esecuzione: chmod 644 non rende un file non-eseguibile")
     def test_non_executable_engine_and_excessive_ram_budget_fail(self):
         self.engine.chmod(0o644)
         report = self.report(ram_gb=40)

--- a/c/tests/test_resource_plan.py
+++ b/c/tests/test_resource_plan.py
@@ -60,8 +60,10 @@ class ResourcePlanTest(unittest.TestCase):
                           available_memory=32 * GB, available_disk=100 * GB, gpus=gpus)
         self.assertEqual(plan["version"], 1)
         self.assertEqual(plan["tiers"]["ram"]["budget_bytes"], 16 * GB)
-        self.assertLessEqual(plan["tiers"]["vram"]["budget_bytes"], 8 * GB)
-        self.assertIn("required RAM backing", plan["warnings"][0])
+        # il tier VRAM e' limitato solo dalla VRAM libera (meno la riserva),
+        # NON dalla cache RAM: gli slot caricati liberano il backing host
+        self.assertEqual(plan["tiers"]["vram"]["budget_bytes"], 8 * GB)
+        self.assertIn("clamped by free VRAM", plan["warnings"][0])
         self.assertIn("0:test-gpu", format_plan(plan))
 
     def test_filters_requested_devices(self):

--- a/c/tests/test_tok.c
+++ b/c/tests/test_tok.c
@@ -2,6 +2,7 @@
  * build da c/: gcc -O2 tests/test_tok.c -o tok_test
  * uso:  ./tok_test <tokenizer.json>   (legge righe "TEXT\tID,ID,.." da stdin) */
 #define _GNU_SOURCE
+#include "../compat.h"   /* Windows: getline/ssize_t; Linux/macOS: no-op */
 #include "../tok.h"
 
 int main(int argc, char **argv){


### PR DESCRIPTION
…hed, RAM dinamica

PORT WINDOWS NATIVO (validato token-exact: oracolo TF 32/32, CPU e CUDA su RTX 5090)
- compat.h: ramo _WIN32 completo — pread posizionale thread-safe (ReadFile+OVERLAPPED), O_DIRECT via FILE_FLAG_NO_BUFFERING, fadvise WILLNEED con thread di readahead dedicato, shim dirent/pthread/getline/getrusage/clock_gettime, open forzato _O_BINARY, rename con MOVEFILE_REPLACE_EXISTING, MemAvailable via GlobalMemoryStatusEx. posix_memalign accoppiato a coli_afree (_aligned_free).
- build_win.ps1: build clang (target MSVC) + nvcc dentro vcvars64 con toolset <=14.4x e senza -std (con MSVC 14.5x cudafe++ crasha, CUDA 13.1); l'obj nvcc si linka direttamente nel motore clang.
- coli: binario .exe, rilevamento CUDA dalla import table PE, build via ps1; resource_plan: statvfs -> shutil.disk_usage, MemAvailable via ctypes.

TIER GPU (fasi 1-4)
- VRAM senza backing RAM: gli slot pinnati caricati in VRAM liberano la copia host (tier ADDITIVI: 128GB RAM + 32GB VRAM = 160GB caldi); su errore CUDA demozione rumorosa con ricarica da disco, mai risultati silenziosamente sbagliati. Fix in coli_cuda_tensor_upload: il riuso di un tensore residente non richiede piu' i puntatori host.
- FFN expert fusa e batched (gate->SiLU*up->down) su stream asincrono per device, in overlap con gli expert CPU dello stesso blocco; staging host pinned; CUDA_FFN=0 per l'A/B. Fixture 313M: cuda_pin 45->61 tok/s (+35-40%, 12 run interleaved); cuda_pin_dense 13.3 tok/s vs 2.4-4.5 cpu_stream.
- Allocatore a cascata heat-driven: banda VRAM (upload a blocchi, picco RAM transitorio ~1 blocco) -> banda RAM (PIN_GB) -> LRU+disco; capienza totale RAM+VRAM; AUTOPIN parte anche con sola VRAM. Profili di dominio: COLI_PROFILE=<nome> -> storia expert separata (.coli_usage.<nome>).
- RAM dinamica a runtime: mem_watch_pass a ogni confine di turno — sotto 3.5GB liberi la LRU si restringe con evict reale, sopra 6GB cresce (MEMWATCH=0 disattiva). Margine statico auto 12%->10%, AUTOPIN 50%->85% x confidenza.
- resource_plan: rimosso il clamp min(vram, cache_bytes) — il tier VRAM e' limitato solo dalla VRAM fisica.

Test: 27 python + 3 C + cuda-test verdi; oracolo TF 32/32 in tutte le combinazioni (CPU, CUDA, pin RAM, pin VRAM-only, batched e sincrono).

## Summary

Describe the problem and the smallest change that solves it.

## Validation

- [ ] `make -C c check`
- [ ] CUDA changes were tested with `make -C c cuda-test` (if applicable)
- [ ] Performance claims include hardware, commands, and repeatable measurements

## Compatibility

- [ ] The default CPU build remains dependency-free
- [ ] No model files, generated binaries, or benchmark artifacts are included
