### PR TITLE
feat(vk): opt-in Vulkan iGPU backend for quantized expert matmul

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -80,13 +80,34 @@ LDFLAGS  += -L$(CUDA_HOME)/lib64 -Wl,-rpath,$(CUDA_HOME)/lib64 -lcudart -lstdc++
 CUDA_OBJ  = backend_cuda.o
 endif
 
+# VK=1 adds an opt-in Vulkan compute backend for resident/pinned quantized
+# matmul, targeting the Strix Halo iGPU (RADV gfx1151). Independent of CUDA and
+# toggleable alongside it. The default build stays pure C. Runtime-gated by the
+# COLI_VULKAN=1 environment variable; shader path overridable via VK_SPV.
+VK        ?= 0
+GLSLC     ?= glslc
+VK_OBJ     =
+VK_SHADER  =
+ifeq ($(VK),1)
+CFLAGS    += -DCOLI_VULKAN
+LDFLAGS   += -lvulkan
+VK_OBJ     = backend_vulkan.o
+VK_SHADER  = shaders/qmatmul.spv
+endif
+
 all: glm$(EXE)
 
 # phony 'glm' → 'glm.exe' on Windows (so 'make glm' and 'coli build' work on every platform)
 glm: glm$(EXE)
 
-glm$(EXE): glm.c st.h json.h tok.h tok_unicode.h compat.h grammar.h $(CUDA_OBJ)
-	$(CC) $(CFLAGS) glm.c $(CUDA_OBJ) -o glm$(EXE) $(LDFLAGS)
+glm$(EXE): glm.c st.h json.h tok.h tok_unicode.h compat.h grammar.h $(CUDA_OBJ) $(VK_OBJ) $(VK_SHADER)
+	$(CC) $(CFLAGS) glm.c $(CUDA_OBJ) $(VK_OBJ) -o glm$(EXE) $(LDFLAGS)
+
+backend_vulkan.o: backend_vulkan.c backend_vulkan.h
+	$(CC) $(CFLAGS) -c backend_vulkan.c -o $@
+
+shaders/qmatmul.spv: shaders/qmatmul.comp
+	$(GLSLC) $< -o $@
 
 backend_cuda.o: backend_cuda.cu backend_cuda.h
 	@command -v $(NVCC) >/dev/null 2>&1 || { echo "nvcc not found: set CUDA_HOME or NVCC" >&2; exit 1; }
@@ -134,7 +155,7 @@ check:
 	$(MAKE) test
 
 clean:
-	rm -f olmoe$(EXE) glm$(EXE) iobench$(EXE) backend_cuda.o backend_cuda_test$(EXE) $(TEST_BINS)
+	rm -f olmoe$(EXE) glm$(EXE) iobench$(EXE) backend_cuda.o backend_cuda_test$(EXE) backend_vulkan.o shaders/qmatmul.spv $(TEST_BINS)
 	rm -rf tests/__pycache__
 
 .PHONY: all glm cuda-test portable test-c test-python test check clean

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -1,0 +1,400 @@
+// Vulkan compute backend for colibri's quantized matmul, targeting the
+// Strix Halo iGPU (RADV gfx1151). Mirrors backend_cuda.c's contract but
+// exploits unified memory: weight "uploads" write into HOST_VISIBLE|
+// DEVICE_LOCAL memory — the same physical RAM the iGPU reads — so there is
+// no PCIe copy. That is what makes offloading *streamed experts* profitable
+// here, which the discrete-CUDA path deliberately avoids.
+//
+// M2 scope: correctness + a standalone GPU-vs-CPU test harness. Synchronous
+// submit/wait per call; async queues and zero-copy import come in M4.
+#include "backend_vulkan.h"
+#include <vulkan/vulkan.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define VKCHECK(x, what) do { VkResult _r = (x); if (_r != VK_SUCCESS) { \
+    fprintf(stderr, "[VK] %s failed: %d\n", what, _r); return 0; } } while (0)
+
+struct ColiVkTensor {
+    VkBuffer wbuf, sbuf;
+    VkDeviceMemory wmem, smem;
+    size_t wbytes;
+    int fmt, I, O, rowWords;
+};
+
+typedef struct {
+    VkBuffer buf; VkDeviceMemory mem; void *ptr; size_t cap;
+} Scratch;
+
+static struct {
+    int ready;
+    VkInstance inst;
+    VkPhysicalDevice phys;
+    VkDevice dev;
+    VkQueue queue;
+    uint32_t qfam;
+    uint32_t memtype;            // HOST_VISIBLE|HOST_COHERENT (prefer DEVICE_LOCAL)
+    VkDescriptorSetLayout dsl;
+    VkPipelineLayout plyt;
+    VkPipeline pipe;
+    VkShaderModule shader;
+    VkDescriptorPool dpool;
+    VkDescriptorSet dset;
+    VkCommandPool cpool;
+    VkCommandBuffer cmd;
+    VkFence fence;
+    Scratch x, y;
+    size_t used_bytes, tensor_count;
+} G;
+
+struct PC { int fmt, S, I, O, rowWords; };
+
+static int pick_memtype(void) {
+    VkPhysicalDeviceMemoryProperties m;
+    vkGetPhysicalDeviceMemoryProperties(G.phys, &m);
+    int best = -1;
+    for (uint32_t i = 0; i < m.memoryTypeCount; i++) {
+        VkMemoryPropertyFlags f = m.memoryTypes[i].propertyFlags;
+        if ((f & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) &&
+            (f & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) {
+            if (f & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) return (int)i; // ideal on APU
+            if (best < 0) best = (int)i;
+        }
+    }
+    return best;
+}
+
+static int alloc_hostvis(size_t bytes, VkBuffer *buf, VkDeviceMemory *mem, void **ptr) {
+    VkBufferCreateInfo bi = {.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .size = bytes, .usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE};
+    VKCHECK(vkCreateBuffer(G.dev, &bi, NULL, buf), "vkCreateBuffer");
+    VkMemoryRequirements req;
+    vkGetBufferMemoryRequirements(G.dev, *buf, &req);
+    VkMemoryAllocateInfo ai = {.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .allocationSize = req.size, .memoryTypeIndex = G.memtype};
+    VKCHECK(vkAllocateMemory(G.dev, &ai, NULL, mem), "vkAllocateMemory");
+    VKCHECK(vkBindBufferMemory(G.dev, *buf, *mem, 0), "vkBindBufferMemory");
+    if (ptr) VKCHECK(vkMapMemory(G.dev, *mem, 0, bytes, 0, ptr), "vkMapMemory");
+    return 1;
+}
+
+static int scratch_reserve(Scratch *s, size_t bytes) {
+    if (s->cap >= bytes) return 1;
+    if (s->buf) { vkDestroyBuffer(G.dev, s->buf, NULL); vkFreeMemory(G.dev, s->mem, NULL); }
+    s->buf = VK_NULL_HANDLE; s->cap = 0; s->ptr = NULL;
+    if (!alloc_hostvis(bytes, &s->buf, &s->mem, &s->ptr)) return 0;
+    s->cap = bytes;
+    return 1;
+}
+
+static int rowwords(int fmt, int I) {
+    size_t rb = fmt == 1 ? (size_t)I : (size_t)(I + 1) / 2; // bytes/row on CPU side
+    return (int)((rb + 3) / 4);                              // padded to uint32
+}
+
+static VkShaderModule load_spv(const char *path) {
+    FILE *f = fopen(path, "rb");
+    if (!f) { fprintf(stderr, "[VK] cannot open %s\n", path); return VK_NULL_HANDLE; }
+    fseek(f, 0, SEEK_END); long n = ftell(f); fseek(f, 0, SEEK_SET);
+    if (n <= 0 || n % 4 != 0) {   // SPIR-V is a stream of uint32; empty/non-seekable/odd size is invalid
+        fprintf(stderr, "[VK] bad SPIR-V size %ld in %s\n", n, path); fclose(f); return VK_NULL_HANDLE; }
+    uint32_t *code = malloc((size_t)n);
+    if (!code) { fclose(f); return VK_NULL_HANDLE; }
+    if (fread(code, 1, n, f) != (size_t)n) { fclose(f); free(code); return VK_NULL_HANDLE; }
+    fclose(f);
+    VkShaderModuleCreateInfo si = {.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
+        .codeSize = n, .pCode = code};
+    VkShaderModule m;
+    VkResult r = vkCreateShaderModule(G.dev, &si, NULL, &m);
+    free(code);
+    return r == VK_SUCCESS ? m : VK_NULL_HANDLE;
+}
+
+int coli_vk_init(const char *spv_path) {
+    if (G.ready) return 1;
+    VkApplicationInfo app = {.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+        .apiVersion = VK_API_VERSION_1_2};
+    VkInstanceCreateInfo ici = {.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+        .pApplicationInfo = &app};
+    VKCHECK(vkCreateInstance(&ici, NULL, &G.inst), "vkCreateInstance");
+
+    uint32_t nd = 0;
+    vkEnumeratePhysicalDevices(G.inst, &nd, NULL);
+    if (!nd) { fprintf(stderr, "[VK] no devices\n"); return 0; }
+    VkPhysicalDevice devs[8]; if (nd > 8) nd = 8;
+    vkEnumeratePhysicalDevices(G.inst, &nd, devs);
+    // Prefer a real GPU over a CPU/software device (llvmpipe) on multi-adapter hosts:
+    // discrete > integrated > virtual > other/cpu. Falls back to devs[0] if all equal.
+    G.phys = devs[0];
+    int bestrank = -1;
+    for (uint32_t i = 0; i < nd; i++) {
+        VkPhysicalDeviceProperties p; vkGetPhysicalDeviceProperties(devs[i], &p);
+        int rank = p.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU   ? 4 :
+                   p.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU ? 3 :
+                   p.deviceType == VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU    ? 2 :
+                   p.deviceType == VK_PHYSICAL_DEVICE_TYPE_OTHER          ? 1 : 0; // CPU last
+        if (rank > bestrank) { bestrank = rank; G.phys = devs[i]; }
+    }
+
+    uint32_t nq = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(G.phys, &nq, NULL);
+    VkQueueFamilyProperties qf[16]; if (nq > 16) nq = 16;
+    vkGetPhysicalDeviceQueueFamilyProperties(G.phys, &nq, qf);
+    G.qfam = UINT32_MAX;
+    for (uint32_t i = 0; i < nq; i++)
+        if (qf[i].queueFlags & VK_QUEUE_COMPUTE_BIT) { G.qfam = i; break; }
+    if (G.qfam == UINT32_MAX) { fprintf(stderr, "[VK] no compute queue\n"); return 0; }
+
+    float prio = 1.0f;
+    VkDeviceQueueCreateInfo qi = {.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+        .queueFamilyIndex = G.qfam, .queueCount = 1, .pQueuePriorities = &prio};
+    VkDeviceCreateInfo di = {.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+        .queueCreateInfoCount = 1, .pQueueCreateInfos = &qi};
+    VKCHECK(vkCreateDevice(G.phys, &di, NULL, &G.dev), "vkCreateDevice");
+    vkGetDeviceQueue(G.dev, G.qfam, 0, &G.queue);
+
+    int mt = pick_memtype();
+    if (mt < 0) { fprintf(stderr, "[VK] no host-visible memory\n"); return 0; }
+    G.memtype = (uint32_t)mt;
+
+    G.shader = load_spv(spv_path);
+    if (!G.shader) return 0;
+
+    VkDescriptorSetLayoutBinding b[4];
+    for (int i = 0; i < 4; i++) b[i] = (VkDescriptorSetLayoutBinding){
+        .binding = i, .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+        .descriptorCount = 1, .stageFlags = VK_SHADER_STAGE_COMPUTE_BIT};
+    VkDescriptorSetLayoutCreateInfo dsli = {
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+        .bindingCount = 4, .pBindings = b};
+    VKCHECK(vkCreateDescriptorSetLayout(G.dev, &dsli, NULL, &G.dsl), "descSetLayout");
+
+    VkPushConstantRange pcr = {.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT,
+        .offset = 0, .size = sizeof(struct PC)};
+    VkPipelineLayoutCreateInfo pli = {.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+        .setLayoutCount = 1, .pSetLayouts = &G.dsl,
+        .pushConstantRangeCount = 1, .pPushConstantRanges = &pcr};
+    VKCHECK(vkCreatePipelineLayout(G.dev, &pli, NULL, &G.plyt), "pipelineLayout");
+
+    VkComputePipelineCreateInfo cpi = {.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
+        .stage = {.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+                  .stage = VK_SHADER_STAGE_COMPUTE_BIT, .module = G.shader, .pName = "main"},
+        .layout = G.plyt};
+    VKCHECK(vkCreateComputePipelines(G.dev, VK_NULL_HANDLE, 1, &cpi, NULL, &G.pipe), "pipeline");
+
+    VkDescriptorPoolSize ps = {.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = 4};
+    VkDescriptorPoolCreateInfo dpi = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+        .maxSets = 1, .poolSizeCount = 1, .pPoolSizes = &ps};
+    VKCHECK(vkCreateDescriptorPool(G.dev, &dpi, NULL, &G.dpool), "descPool");
+    VkDescriptorSetAllocateInfo dsa = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+        .descriptorPool = G.dpool, .descriptorSetCount = 1, .pSetLayouts = &G.dsl};
+    VKCHECK(vkAllocateDescriptorSets(G.dev, &dsa, &G.dset), "allocDescSet");
+
+    VkCommandPoolCreateInfo cpci = {.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+        .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT, .queueFamilyIndex = G.qfam};
+    VKCHECK(vkCreateCommandPool(G.dev, &cpci, NULL, &G.cpool), "cmdPool");
+    VkCommandBufferAllocateInfo cbi = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+        .commandPool = G.cpool, .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY, .commandBufferCount = 1};
+    VKCHECK(vkAllocateCommandBuffers(G.dev, &cbi, &G.cmd), "cmdBuf");
+    VkFenceCreateInfo fi = {.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
+    VKCHECK(vkCreateFence(G.dev, &fi, NULL, &G.fence), "fence");
+
+    G.ready = 1;
+    VkPhysicalDeviceProperties p; vkGetPhysicalDeviceProperties(G.phys, &p);
+    fprintf(stderr, "[VK] ready: %s, compute qfam %u, memtype %u\n", p.deviceName, G.qfam, G.memtype);
+    return 1;
+}
+
+int coli_vk_available(void) { return G.ready; }
+
+void coli_vk_mem_info(size_t *used, size_t *count) {
+    if (used) *used = G.used_bytes;
+    if (count) *count = G.tensor_count;
+}
+
+static int upload_tensor(ColiVkTensor **out, const void *weights, const float *scales,
+                         int fmt, int I, int O) {
+    if (*out) return (*out)->fmt == fmt && (*out)->I == I && (*out)->O == O;
+    if (fmt != 1 && fmt != 2) return 0;
+    ColiVkTensor *t = calloc(1, sizeof(*t));
+    if (!t) return 0;
+    t->fmt = fmt; t->I = I; t->O = O; t->rowWords = rowwords(fmt, I);
+    size_t stride = (size_t)t->rowWords * 4;         // padded row bytes
+    size_t cpu_rb = fmt == 1 ? (size_t)I : (size_t)(I + 1) / 2;
+    t->wbytes = stride * (size_t)O;
+    void *wptr;
+    if (!alloc_hostvis(t->wbytes, &t->wbuf, &t->wmem, &wptr)) { free(t); return 0; }
+    memset(wptr, 0, t->wbytes);
+    for (int o = 0; o < O; o++)                        // copy row-by-row into padded layout
+        memcpy((uint8_t *)wptr + (size_t)o * stride,
+               (const uint8_t *)weights + (size_t)o * cpu_rb, cpu_rb);
+    void *sptr;
+    if (!alloc_hostvis((size_t)O * sizeof(float), &t->sbuf, &t->smem, &sptr)) {
+        vkDestroyBuffer(G.dev, t->wbuf, NULL); vkFreeMemory(G.dev, t->wmem, NULL); free(t); return 0;
+    }
+    memcpy(sptr, scales, (size_t)O * sizeof(float));
+    // Counters are touched concurrently: frees run from expert_load under
+    // `#pragma omp parallel`, so RMW them atomically (torn counts otherwise).
+    __atomic_add_fetch(&G.used_bytes, t->wbytes + (size_t)O * sizeof(float), __ATOMIC_RELAXED);
+    __atomic_add_fetch(&G.tensor_count, 1, __ATOMIC_RELAXED);
+    *out = t;
+    return 1;
+}
+
+int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
+                   const void *weights, const float *scales,
+                   int fmt, int S, int I, int O) {
+    if (!G.ready || S < 1 || !upload_tensor(tensor, weights, scales, fmt, I, O)) return 0;
+    ColiVkTensor *t = *tensor;
+    size_t xb = (size_t)S * I * sizeof(float), yb = (size_t)S * O * sizeof(float);
+    if (!scratch_reserve(&G.x, xb) || !scratch_reserve(&G.y, yb)) return 0;
+    memcpy(G.x.ptr, x, xb);
+
+    VkDescriptorBufferInfo bi[4] = {
+        {.buffer = G.x.buf, .range = VK_WHOLE_SIZE},
+        {.buffer = t->wbuf, .range = VK_WHOLE_SIZE},
+        {.buffer = t->sbuf, .range = VK_WHOLE_SIZE},
+        {.buffer = G.y.buf, .range = VK_WHOLE_SIZE}};
+    VkWriteDescriptorSet w[4];
+    for (int i = 0; i < 4; i++) w[i] = (VkWriteDescriptorSet){
+        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, .dstSet = G.dset,
+        .dstBinding = i, .descriptorCount = 1,
+        .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .pBufferInfo = &bi[i]};
+    vkUpdateDescriptorSets(G.dev, 4, w, 0, NULL);
+
+    VKCHECK(vkResetCommandBuffer(G.cmd, 0), "resetCmd");
+    VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+        .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT};
+    VKCHECK(vkBeginCommandBuffer(G.cmd, &begin), "beginCmd");
+    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
+    vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.dset, 0, NULL);
+    struct PC pc = {fmt, S, I, O, t->rowWords};
+    vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
+    vkCmdDispatch(G.cmd, (uint32_t)O, (uint32_t)S, 1);
+    VKCHECK(vkEndCommandBuffer(G.cmd), "endCmd");
+
+    VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+        .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
+    VKCHECK(vkResetFences(G.dev, 1, &G.fence), "resetFence");
+    VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
+    // Bounded wait: a GPU hang/TDR must never wedge the process. 10s is orders of
+    // magnitude over a single-GEMV dispatch; on timeout/device-loss disable VK for
+    // the rest of the run and fall back to CPU (the caller degrades on our 0 return).
+    VkResult wr = vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL);
+    if (wr != VK_SUCCESS) {
+        fprintf(stderr, "[VK] fence wait failed: %d — disabling GPU offload, staying on CPU\n", wr);
+        G.ready = 0;
+        return 0;
+    }
+    memcpy(y, G.y.ptr, yb);
+    return 1;
+}
+
+void coli_vk_tensor_free(ColiVkTensor *t) {
+    if (!t) return;
+    // If the device was lost/disabled (the fence-timeout path sets G.ready=0), a submission
+    // may still reference these buffers — do NOT vkDestroy into a dead device (GPU-side UAF).
+    // Leak the GPU handles (we're degrading to CPU for the rest of the run) and reclaim the
+    // host struct + counters only.
+    if (G.ready) {
+        if (t->wbuf) { vkDestroyBuffer(G.dev, t->wbuf, NULL); vkFreeMemory(G.dev, t->wmem, NULL); }
+        if (t->sbuf) { vkDestroyBuffer(G.dev, t->sbuf, NULL); vkFreeMemory(G.dev, t->smem, NULL); }
+    }
+    // Mirror upload_tensor exactly (weights + scales), atomically — otherwise
+    // used_bytes leaks the O*float scales buffer on every free and drifts upward.
+    __atomic_sub_fetch(&G.tensor_count, 1, __ATOMIC_RELAXED);
+    __atomic_sub_fetch(&G.used_bytes, t->wbytes + (size_t)t->O * sizeof(float), __ATOMIC_RELAXED);
+    free(t);
+}
+
+size_t coli_vk_tensor_bytes(const ColiVkTensor *t) { return t ? t->wbytes : 0; }
+
+void coli_vk_shutdown(void) {
+    if (!G.ready) return;
+    vkDeviceWaitIdle(G.dev);
+    if (G.x.buf) { vkDestroyBuffer(G.dev, G.x.buf, NULL); vkFreeMemory(G.dev, G.x.mem, NULL); }
+    if (G.y.buf) { vkDestroyBuffer(G.dev, G.y.buf, NULL); vkFreeMemory(G.dev, G.y.mem, NULL); }
+    vkDestroyFence(G.dev, G.fence, NULL);
+    vkDestroyCommandPool(G.dev, G.cpool, NULL);
+    vkDestroyDescriptorPool(G.dev, G.dpool, NULL);
+    vkDestroyPipeline(G.dev, G.pipe, NULL);
+    vkDestroyPipelineLayout(G.dev, G.plyt, NULL);
+    vkDestroyDescriptorSetLayout(G.dev, G.dsl, NULL);
+    vkDestroyShaderModule(G.dev, G.shader, NULL);
+    vkDestroyDevice(G.dev, NULL);
+    vkDestroyInstance(G.inst, NULL);
+    memset(&G, 0, sizeof(G));
+}
+
+#ifdef VK_TEST
+// ---- standalone GPU-vs-CPU validation + microbench --------------------------
+#include <math.h>
+#include <time.h>
+
+static double now(void) { struct timespec ts; clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec + ts.tv_nsec / 1e9; }
+
+static float deq(const uint8_t *row, int fmt, int i) {
+    if (fmt == 1) { int b = ((const int8_t *)row)[i]; return (float)b; }
+    uint8_t v = row[i >> 1]; int nib = (i & 1) ? (v >> 4) : (v & 15); return (float)(nib - 8);
+}
+
+static void cpu_ref(float *y, const float *x, const uint8_t *w, const float *sc,
+                    int fmt, int S, int I, int O) {
+    size_t rb = fmt == 1 ? (size_t)I : (size_t)(I + 1) / 2;
+    for (int s = 0; s < S; s++) for (int o = 0; o < O; o++) {
+        double sum = 0; const uint8_t *row = w + (size_t)o * rb;
+        for (int i = 0; i < I; i++) sum += x[s * I + i] * deq(row, fmt, i);
+        y[s * O + o] = (float)(sum * sc[o]);
+    }
+}
+
+static int run_case(int fmt, int S, int I, int O, int iters) {
+    size_t rb = fmt == 1 ? (size_t)I : (size_t)(I + 1) / 2;
+    float *x = malloc((size_t)S * I * sizeof(float));
+    uint8_t *w = malloc(rb * O);
+    float *sc = malloc((size_t)O * sizeof(float));
+    float *yg = malloc((size_t)S * O * sizeof(float));
+    float *yc = malloc((size_t)S * O * sizeof(float));
+    for (int i = 0; i < S * I; i++) x[i] = (float)((rand() % 200 - 100) / 100.0);
+    for (size_t i = 0; i < rb * O; i++) w[i] = rand() & 0xff;
+    for (int o = 0; o < O; o++) sc[o] = 0.01f + (rand() % 100) / 10000.0f;
+
+    ColiVkTensor *t = NULL;
+    if (!coli_vk_matmul(&t, yg, x, w, sc, fmt, S, I, O)) { printf("matmul failed\n"); return 1; }
+    cpu_ref(yc, x, w, sc, fmt, S, I, O);
+    double maxerr = 0, maxrel = 0;
+    for (int i = 0; i < S * O; i++) {
+        double e = fabs(yg[i] - yc[i]); if (e > maxerr) maxerr = e;
+        if (fabs(yc[i]) > 1e-2) { double r = e / fabs(yc[i]); if (r > maxrel) maxrel = r; }
+    }
+    // microbench (GPU)
+    double t0 = now();
+    for (int k = 0; k < iters; k++) coli_vk_matmul(&t, yg, x, w, sc, fmt, S, I, O);
+    double gpu_ms = (now() - t0) * 1000 / iters;
+    // microbench (CPU ref, 1 iter — it's slow)
+    double c0 = now(); cpu_ref(yc, x, w, sc, fmt, S, I, O); double cpu_ms = (now() - c0) * 1000;
+    printf("fmt=%d S=%d I=%d O=%d | maxerr=%.4g maxrel=%.4g | gpu=%.3f ms  cpu_ref=%.3f ms\n",
+           fmt, S, I, O, maxerr, maxrel, gpu_ms, cpu_ms);
+    coli_vk_tensor_free(t);
+    free(x); free(w); free(sc); free(yg); free(yc);
+    return maxrel > 1e-3 ? 1 : 0;
+}
+
+int main(int argc, char **argv) {
+    const char *spv = argc > 1 ? argv[1] : "shaders/qmatmul.spv";
+    if (!coli_vk_init(spv)) { printf("vk init failed\n"); return 1; }
+    srand(1234);
+    int bad = 0;
+    bad |= run_case(1, 1, 6144, 1536, 50);   // int8 expert gate/up shape (S=1 decode)
+    bad |= run_case(2, 1, 6144, 1536, 50);   // int4 expert
+    bad |= run_case(1, 1, 1536, 6144, 50);   // down proj shape
+    bad |= run_case(2, 8, 6144, 1536, 20);   // prefill/MTP batch
+    bad |= run_case(1, 1, 512, 512, 100);    // small
+    printf(bad ? "FAIL\n" : "PASS\n");
+    coli_vk_shutdown();
+    return bad;
+}
+#endif

--- a/c/backend_vulkan.h
+++ b/c/backend_vulkan.h
@@ -1,0 +1,40 @@
+#ifndef COLIBRI_BACKEND_VULKAN_H
+#define COLIBRI_BACKEND_VULKAN_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque persistent device copy of one resident quantized tensor,
+ * mirroring backend_cuda.h. On Strix Halo the "upload" writes into
+ * HOST_VISIBLE|DEVICE_LOCAL memory — same physical RAM the iGPU reads,
+ * so there is no PCIe copy, unlike the discrete-CUDA path. */
+typedef struct ColiVkTensor ColiVkTensor;
+
+/* Bring up instance/device/queue/pipeline. Returns 1 on success.
+ * spv_path points at the compiled qmatmul.spv. */
+int  coli_vk_init(const char *spv_path);
+void coli_vk_shutdown(void);
+int  coli_vk_available(void);
+void coli_vk_mem_info(size_t *used_bytes, size_t *tensor_count);
+
+/* y[S,O] = (x[S,I] @ dequant(W[O,I])^T) * scale[O].
+ * fmt matches QT in glm.c: 1=int8, 2=int4. (0=f32,3=int2 fall back to CPU.)
+ * First call uploads W+scales; later calls reuse the resident copy.
+ * Returns 1 on success, 0 if unavailable / unsupported fmt. */
+int  coli_vk_matmul(ColiVkTensor **tensor,
+                    float *y, const float *x,
+                    const void *weights, const float *scales,
+                    int fmt, int S, int I, int O);
+
+void   coli_vk_tensor_free(ColiVkTensor *t);
+size_t coli_vk_tensor_bytes(const ColiVkTensor *t);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/c/glm.c
+++ b/c/glm.c
@@ -39,6 +39,10 @@
 #include <omp.h>
 #include "backend_cuda.h"
 #endif
+#ifdef COLI_VULKAN
+#include <omp.h>
+#include "backend_vulkan.h"
+#endif
 #ifdef __AVX2__
 #include <immintrin.h>
 static inline float hsum256(__m256 v){            /* somma orizzontale di 8 float */
@@ -75,6 +79,9 @@ typedef struct {
     ColiCudaTensor *cuda;
 #endif
     int cuda_eligible, cuda_failed, cuda_device;  /* resident tensor, never a reused expert slot */
+#ifdef COLI_VULKAN
+    ColiVkTensor *vk; int vk_eligible, vk_failed;  /* iGPU-resident copy (single device, no PCIe copy) */
+#endif
 } QT;
 static int64_t qt_bytes(const QT *t){    /* byte residenti del tensore */
     int64_t n=(int64_t)t->O*t->I;
@@ -184,6 +191,48 @@ static int parse_cuda_devices(const char *list, int *out){
         if(!*p) return 0;
     }
     return n;
+}
+#endif
+#ifdef COLI_VULKAN
+/* Single iGPU (Strix Halo, RADV gfx1151). Weight "uploads" write into
+ * HOST_VISIBLE|DEVICE_LOCAL shared RAM — no PCIe copy — but the backend still
+ * allocates a padded Vulkan-owned copy, so VK_EXPERT_GB caps real RAM use. */
+static int g_vk_enabled;
+static double g_vk_expert_gb;
+static int g_vk_dense;
+static int g_vk_stream;   /* VK_STREAM=1: also run STREAMED/cached experts on the iGPU (not just
+                           * the VK_EXPERT_GB-pinned tier). Each streamed expert keeps BOTH its CPU
+                           * slab AND a Vulkan-owned copy (~2x RAM for the whole streaming cache,
+                           * bounded only by slot count) — and on a unified-memory APU the shared
+                           * bus makes it break-even-to-slower. So it is OFF by default; opt in
+                           * only on a host whose GPU has its own high-bandwidth VRAM. */
+static void qt_vk_reset(QT *t){
+    if(t->vk){ coli_vk_tensor_free(t->vk); t->vk=NULL; }
+    t->vk_failed=0;
+}
+/* Mark a freshly-(re)loaded expert QT eligible for the iGPU when streamed-GPU is on.
+ * Called from expert_load (possibly on a PIPE worker thread): a plain field write, no
+ * Vulkan call — the lazy upload happens later on the MAIN thread inside coli_vk_matmul.
+ * Only int8/int4 run on the shader; fmt 0/3 stay on CPU. vk_eligible persists across
+ * slab reuse (same eligibility every load); qt_vk_reset drops the stale device copy. */
+static inline void qt_vk_mark_stream(QT *t){
+    if(g_vk_enabled && g_vk_stream && (t->fmt==1||t->fmt==2)) t->vk_eligible=1;
+}
+/* No upload-only entry point in the backend: a 1-row matmul forces the resident
+ * copy and validates capacity, mirroring CUDA's fail-early tensor_upload. */
+static int qt_vk_upload(QT *t){
+    if(t->fmt!=1 && t->fmt!=2) return 0;
+    const void *weights = t->fmt==1 ? (const void*)t->q8 : (const void*)t->q4;
+    float *x=calloc((size_t)t->I,sizeof(float));
+    float *y=malloc((size_t)t->O*sizeof(float));
+    if(!x||!y){ free(x); free(y); return 0; }
+    int ok=coli_vk_matmul(&t->vk,y,x,weights,t->s,t->fmt,1,t->I,t->O);
+    free(x); free(y);
+    return ok;
+}
+static void vk_stats_print(void){
+    size_t used=0,n=0; coli_vk_mem_info(&used,&n);
+    fprintf(stderr,"[VK] resident set: %zu tensor, %.2f GB shared RAM\n",n,used/1e9);
 }
 #endif
 static double now_s(void){ struct timespec t; clock_gettime(CLOCK_MONOTONIC,&t); return t.tv_sec+t.tv_nsec*1e-9; }
@@ -487,6 +536,21 @@ static void matmul_qt(float *y, const float *x, QT *w, int S){
             w->O,w->I,w->cuda_device);
     }
 #endif
+#ifdef COLI_VULKAN
+    /* Same contract as the CUDA path: only model-resident / pinned tensors are
+     * eligible (a reused streaming slot must never enter the iGPU cache), and
+     * nested OpenMP calls stay on CPU because the backend owns one synchronous
+     * scratch + command buffer. Only int8/int4 run on the iGPU (fmt 0/3 -> CPU). */
+    if(g_vk_enabled && w->vk_eligible && !w->vk_failed && !omp_in_parallel()){
+        const void *weights = w->fmt==1 ? (const void*)w->q8
+                            : w->fmt==2 ? (const void*)w->q4 : NULL;
+        if(weights){
+            if(coli_vk_matmul(&w->vk,y,x,weights,w->s,w->fmt,S,w->I,w->O)) return;
+            w->vk_failed=1;
+            fprintf(stderr,"[VK] tensor [%d,%d] disabilitato dopo errore; fallback CPU\n",w->O,w->I);
+        }
+    }
+#endif
     if(w->fmt==0){ matmul(y,x,w->qf,S,w->I,w->O); return; }
     /* int8 IDOT vince sempre (1.4-2.5x). int4 IDOT: l'autore su AVX2 trovo' che a S=1
      * non ripaga (soglia S>=2); ma su ARM/SDOT il singolo token CONVIENE (vedi g_i4s /
@@ -746,6 +810,9 @@ static QT qt_load(Model *m, const char *name, int O, int I, int bits){
         g_cuda_dense_projected[slot]+=qt_bytes(&t);
     }
 #endif
+#ifdef COLI_VULKAN
+    if(g_vk_enabled&&g_vk_dense && (t.fmt==1||t.fmt==2)) t.vk_eligible=1;  /* iGPU supports int8/int4 only */
+#endif
     return t;
 }
 static float *ld(Model *m, const char *name){   /* tensore 1D f32 residente (norme/bias) */
@@ -924,6 +991,11 @@ static int expert_load(Model *m, int layer, int eid, ESlot *s, int fatal){
      * Keep its tier assignment, but invalidate the old device weights. */
     if(s->eid!=eid){ qt_cuda_reset(&s->g); qt_cuda_reset(&s->u); qt_cuda_reset(&s->d); }
 #endif
+#ifdef COLI_VULKAN
+    /* A live REPIN reuses a GPU-enabled pinned slot for a different expert:
+     * drop the stale iGPU copy but keep vk_eligible so it re-uploads lazily. */
+    if(s->eid!=eid){ qt_vk_reset(&s->g); qt_vk_reset(&s->u); qt_vk_reset(&s->d); }
+#endif
     Cfg *c=&m->c; int I=c->moe_inter, D=c->hidden, b=m->ebits;
     char nm[3][288]; const char *suf[3]={"gate_proj","up_proj","down_proj"};
     for(int k=0;k<3;k++) snprintf(nm[k],sizeof(nm[k]),"model.layers.%d.mlp.experts.%d.%s.weight",layer,eid,suf[k]);
@@ -934,6 +1006,9 @@ static int expert_load(Model *m, int layer, int eid, ESlot *s, int fatal){
         qt_from_disk(m,nm[0],I,D,b,g_drop,&s->g);
         qt_from_disk(m,nm[1],I,D,b,g_drop,&s->u);
         qt_from_disk(m,nm[2],D,I,b,g_drop,&s->d);
+#ifdef COLI_VULKAN
+        qt_vk_mark_stream(&s->g); qt_vk_mark_stream(&s->u); qt_vk_mark_stream(&s->d);
+#endif
         s->eid=eid; return 0;
     }
     st_tensor *tw[3], *tq[3];
@@ -1009,6 +1084,9 @@ static int expert_load(Model *m, int layer, int eid, ESlot *s, int fatal){
         int fmt = (nb==(int64_t)OO[k]*II[k])?1 : (nb==(int64_t)OO[k]*((II[k]+1)/2))?2 : 3;
         qt[k]->fmt=fmt; qt[k]->O=OO[k]; qt[k]->I=II[k]; qt[k]->qf=NULL;
         qt[k]->q8=(int8_t*)(s->slab+pos[k]); qt[k]->q4=s->slab+pos[k]; qt[k]->s=fp[k];
+#ifdef COLI_VULKAN
+        qt_vk_mark_stream(qt[k]);   /* streamed/cached expert -> iGPU when VK_STREAM on */
+#endif
     }
     s->eid=eid; return 0;
 }
@@ -1422,6 +1500,9 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
             if(!nr) continue;
 #ifdef COLI_CUDA
             if(g_cuda_enabled && e->g.cuda_eligible) m->gpu_expert_calls++;
+#endif
+#ifdef COLI_VULKAN
+            if(g_vk_enabled && e->g.vk_eligible) m->gpu_expert_calls++;
 #endif
             for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)rows[r]*D, D*sizeof(float));
             double t0=now_s();
@@ -2048,6 +2129,12 @@ static void run_replay(Model *m, const int *full, int nfull, int np){
         m->gpu_expert_count,m->gpu_expert_bytes/1e9,(unsigned long long)m->gpu_expert_calls);
     if(g_cuda_enabled) cuda_stats_print();
 #endif
+#ifdef COLI_VULKAN
+    if(m->gpu_expert_count || m->gpu_expert_calls)
+        printf("VK expert tier: %d pinned residenti (%.2f GB shared RAM)%s | %llu chiamate servite da iGPU\n",
+        m->gpu_expert_count,m->gpu_expert_bytes/1e9, g_vk_stream?" + streamed":"",(unsigned long long)m->gpu_expert_calls);
+    if(g_vk_enabled) vk_stats_print();
+#endif
 }
 
 /* generazione reale: tokenizza PROMPT, prefill + decode greedy con stop su EOS,
@@ -2088,6 +2175,12 @@ static void run_text(Model *m, const char *snap, const char *prompt, int ngen){
     if(m->gpu_expert_count) printf("CUDA expert tier: %d resident experts (%.2f GB) | %llu calls served from VRAM\n",
         m->gpu_expert_count,m->gpu_expert_bytes/1e9,(unsigned long long)m->gpu_expert_calls);
     if(g_cuda_enabled) cuda_stats_print();
+#endif
+#ifdef COLI_VULKAN
+    if(m->gpu_expert_count || m->gpu_expert_calls)
+        printf("VK expert tier: %d pinned residenti (%.2f GB shared RAM)%s | %llu chiamate servite da iGPU\n",
+        m->gpu_expert_count,m->gpu_expert_bytes/1e9, g_vk_stream?" + streamed":"",(unsigned long long)m->gpu_expert_calls);
+    if(g_vk_enabled) vk_stats_print();
 #endif
     profile_print(m,dt);
     if(g_pilot_real) printf("PILOT_REAL: %ld load cross-layer completati, %ld scartati (main gia' sul layer) | PILOT_K=%d\n",
@@ -2152,6 +2245,12 @@ static void repin_pass(Model *m){
                              +(int64_t)coli_cuda_tensor_bytes(s->u.cuda)
                              +(int64_t)coli_cuda_tensor_bytes(s->d.cuda) : 0;
 #endif
+#ifdef COLI_VULKAN
+        int vkgpu=s->g.vk_eligible;
+        int64_t old_vk=vkgpu ? (int64_t)coli_vk_tensor_bytes(s->g.vk)
+                              +(int64_t)coli_vk_tensor_bytes(s->u.vk)
+                              +(int64_t)coli_vk_tensor_bytes(s->d.vk) : 0;
+#endif
         double t0=now_s();
         expert_load(m,cd[b].l,cd[b].eid,s,1);       /* disk -> RAM, same resident slot */
         const char *tier="RAM";
@@ -2167,6 +2266,25 @@ static void repin_pass(Model *m){
                 s->g.cuda_eligible=s->u.cuda_eligible=s->d.cuda_eligible=0;
                 m->gpu_expert_count--; m->gpu_expert_bytes-=old_gpu;
                 fprintf(stderr,"[REPIN] VRAM upload failed; slot downgraded to RAM\n");
+            }
+        }
+#endif
+#ifdef COLI_VULKAN
+        if(vkgpu){                                /* refresh the same iGPU slot now, not lazily */
+            if(qt_vk_upload(&s->g) && qt_vk_upload(&s->u) && qt_vk_upload(&s->d)){
+                int64_t now_vk=(int64_t)coli_vk_tensor_bytes(s->g.vk)
+                              +(int64_t)coli_vk_tensor_bytes(s->u.vk)
+                              +(int64_t)coli_vk_tensor_bytes(s->d.vk);
+                m->gpu_expert_bytes+=now_vk-old_vk; tier="iGPU";
+            } else {
+                qt_vk_reset(&s->g); qt_vk_reset(&s->u); qt_vk_reset(&s->d);
+                s->g.vk_eligible=s->u.vk_eligible=s->d.vk_eligible=0;
+                /* Only the VK_EXPERT_GB-pinned tier is counted in gpu_expert_count; a
+                 * streamed slot (VK_STREAM=1) is vk_eligible but uncounted, so guard the
+                 * decrement against underflow. */
+                if(m->gpu_expert_count) m->gpu_expert_count--;
+                m->gpu_expert_bytes-=old_vk;
+                fprintf(stderr,"[REPIN] upload iGPU fallito; slot degradato a RAM\n");
             }
         }
 #endif
@@ -2600,6 +2718,36 @@ static void pin_load(Model *m, const char *statspath, double gb){
             g_cuda_devices[i],placed_n[i],placed_b[i]/1e9);
     }
 #endif
+#ifdef COLI_VULKAN
+    if(g_vk_enabled && g_vk_expert_gb>0){
+        /* Unified memory: no separate VRAM pool, but each eligible expert gets a
+         * padded Vulkan-owned copy, so the budget caps that extra shared RAM.
+         * Upload eagerly (1-row matmul) so capacity failures surface at startup. */
+        double budget=g_vk_expert_gb*1e9;
+        for(int a=0;a<npin && m->gpu_expert_bytes<budget;a++){
+            int li=r[a].l;
+            for(int z=0;z<m->npin[li];z++) if(m->pin[li][z].eid==r[a].e){
+                ESlot *s=&m->pin[li][z];
+                int64_t need=qt_bytes(&s->g)+qt_bytes(&s->u)+qt_bytes(&s->d);
+                if(m->gpu_expert_bytes+need>budget) break;
+                s->g.vk_eligible=s->u.vk_eligible=s->d.vk_eligible=1;
+                if(qt_vk_upload(&s->g) && qt_vk_upload(&s->u) && qt_vk_upload(&s->d)){
+                    int64_t actual=(int64_t)coli_vk_tensor_bytes(s->g.vk)
+                                  +(int64_t)coli_vk_tensor_bytes(s->u.vk)
+                                  +(int64_t)coli_vk_tensor_bytes(s->d.vk);
+                    m->gpu_expert_count++; m->gpu_expert_bytes+=actual;
+                } else {
+                    qt_vk_reset(&s->g); qt_vk_reset(&s->u); qt_vk_reset(&s->d);
+                    s->g.vk_eligible=s->u.vk_eligible=s->d.vk_eligible=0;
+                    fprintf(stderr,"[VK] upload expert fallito; slot resta su CPU\n");
+                }
+                break;
+            }
+        }
+        fprintf(stderr,"[VK] hot expert tier: %d/%d expert, shared RAM %.2f GB (budget %.1f GB)\n",
+            m->gpu_expert_count,npin,m->gpu_expert_bytes/1e9,g_vk_expert_gb);
+    }
+#endif
     pin_wire(m);                                   /* inchioda in RAM (no compressione) / wire in RAM (no compression) */
     free(r); free(cnt_l);
 }
@@ -2805,6 +2953,35 @@ int main(int argc, char **argv){
         return 2;
     }
 #endif
+#ifdef COLI_VULKAN
+    if(getenv("COLI_VULKAN") && atoi(getenv("COLI_VULKAN"))){
+#ifdef COLI_CUDA
+        if(g_cuda_enabled){ fprintf(stderr,"COLI_VULKAN e COLI_CUDA sono mutuamente esclusivi\n"); return 2; }
+#endif
+        const char *spv=getenv("VK_SPV"); if(!spv||!*spv) spv="shaders/qmatmul.spv";
+        g_vk_enabled=coli_vk_init(spv);
+        if(!g_vk_enabled){ fprintf(stderr,"[VK] backend richiesto ma non disponibile\n"); return 2; }
+    }
+    g_vk_dense=getenv("VK_DENSE")?atoi(getenv("VK_DENSE")):0;
+    g_vk_expert_gb=getenv("VK_EXPERT_GB")?atof(getenv("VK_EXPERT_GB")):0;
+    /* streamed-expert iGPU offload: default OFF — it ~2x's expert-cache RAM (CPU slab +
+     * VK copy, uncapped) and is net-negative on unified memory. VK_STREAM=1 opts in for a
+     * discrete-VRAM host; the VK_EXPERT_GB-pinned tier is unaffected either way. */
+    g_vk_stream=getenv("VK_STREAM")?atoi(getenv("VK_STREAM")):0;
+    if(g_vk_dense&&!g_vk_enabled){ fprintf(stderr,"VK_DENSE richiede COLI_VULKAN=1\n"); return 2; }
+    if(g_vk_expert_gb>0 && !g_vk_enabled){ fprintf(stderr,"VK_EXPERT_GB richiede COLI_VULKAN=1\n"); return 2; }
+    if(g_vk_stream && !g_vk_enabled){ fprintf(stderr,"VK_STREAM richiede COLI_VULKAN=1\n"); return 2; }
+    if(g_vk_enabled) fprintf(stderr,"[VK] mode: routed experts%s | streamed-expert iGPU %s\n",
+        g_vk_dense?" + resident dense tensors":" only (resident dense on CPU)",
+        g_vk_stream?"ON (all experts)":"OFF (pinned tier only)");
+#else
+    if((getenv("COLI_VULKAN") && atoi(getenv("COLI_VULKAN"))) ||
+       (getenv("VK_DENSE") && atoi(getenv("VK_DENSE"))) ||
+       (getenv("VK_EXPERT_GB") && atof(getenv("VK_EXPERT_GB"))>0)){
+        fprintf(stderr,"Vulkan richiesto ma questo binario e' CPU-only; ricompila con: make VK=1\n");
+        return 2;
+    }
+#endif
     printf("== GLM C engine (glm_moe_dsa), cache=%d experts/layer | experts@%d-bit dense@%d-bit | idot: " IDOT_KERNEL " ==\n", cap, ebits, dbits);
     g_mem_avail_boot = mem_available_gb();
     Model m; double t0=now_s(); model_init(&m,snap,cap,ebits,dbits);
@@ -2900,6 +3077,9 @@ int main(int argc, char **argv){
 #ifdef COLI_CUDA
         if(g_cuda_enabled) cuda_stats_print();
 #endif
+#ifdef COLI_VULKAN
+        if(g_vk_enabled) vk_stats_print();
+#endif
         return 0;
     }
     int *out=malloc((np+n_new)*sizeof(int));
@@ -2918,6 +3098,11 @@ int main(int argc, char **argv){
     if(m.gpu_expert_count) printf("CUDA expert tier: %d resident experts (%.2f GB) | %llu calls served from VRAM\n",
         m.gpu_expert_count,m.gpu_expert_bytes/1e9,(unsigned long long)m.gpu_expert_calls);
     if(g_cuda_enabled) cuda_stats_print();
+#endif
+#ifdef COLI_VULKAN
+    if(m.gpu_expert_count) printf("VK expert tier: %d residenti (%.2f GB shared RAM) | %llu chiamate servite da iGPU\n",
+        m.gpu_expert_count,m.gpu_expert_bytes/1e9,(unsigned long long)m.gpu_expert_calls);
+    if(g_vk_enabled) vk_stats_print();
 #endif
     if(g_looka){
         const char *nm[3]={"previous token (=SPEC prefetch)","layer input, skip attention","next layer (one step ahead)"};

--- a/c/shaders/qmatmul.comp
+++ b/c/shaders/qmatmul.comp
@@ -1,0 +1,74 @@
+#version 450
+// Quantized mat-vec/mat-mat mirroring colibri's CUDA quant_matmul:
+//   y[s,o] = ( sum_i x[s,i] * dequant(W[o,i]) ) * scale[o]
+// fmt: 1=int8, 2=int4 (packed 2/byte, nibble-8). Weights are a byte buffer
+// exposed as uint32 words; we extract bytes/nibbles manually (no 8-bit-storage
+// extension dependency). One workgroup per (o,s); threads reduce over I.
+layout(local_size_x = 256) in;
+
+layout(std430, binding = 0) readonly buffer X  { float x[]; };
+layout(std430, binding = 1) readonly buffer W  { uint  w[]; };   // row-major, row o at o*rowWords
+layout(std430, binding = 2) readonly buffer Sc { float scale[]; };
+layout(std430, binding = 3) writeonly buffer Y { float y[]; };
+
+layout(push_constant) uniform P {
+    int fmt;   // 1=int8, 2=int4
+    int S, I, O;
+    int rowWords;  // uint32 words per weight row
+} p;
+
+shared float partial[256];
+
+// signed int8 from a uint32 word's byte lane
+float i8(uint word, int lane) {
+    int b = int((word >> (uint(lane) * 8u)) & 0xffu);
+    if (b >= 128) b -= 256;
+    return float(b);
+}
+// int4 (value - 8) from a uint32 word's nibble lane (0..7)
+float i4(uint word, int lane) {
+    int nib = int((word >> (uint(lane) * 4u)) & 0xfu);
+    return float(nib - 8);
+}
+
+void main() {
+    int o = int(gl_WorkGroupID.x);
+    int s = int(gl_WorkGroupID.y);
+    int t = int(gl_LocalInvocationID.x);
+    int nth = int(gl_WorkGroupSize.x);
+
+    uint rowBase = uint(o) * uint(p.rowWords);
+    int xbase = s * p.I;
+    float sum = 0.0;
+
+    if (p.fmt == 1) {
+        // 4 int8 weights per uint word; stride threads over words.
+        int words = (p.I + 3) / 4;
+        for (int wi = t; wi < words; wi += nth) {
+            uint packed = w[rowBase + uint(wi)];
+            int i0 = wi * 4;
+            for (int k = 0; k < 4; k++) {
+                int i = i0 + k;
+                if (i < p.I) sum += x[xbase + i] * i8(packed, k);
+            }
+        }
+    } else { // fmt == 2, int4
+        int words = (p.I + 7) / 8;
+        for (int wi = t; wi < words; wi += nth) {
+            uint packed = w[rowBase + uint(wi)];
+            int i0 = wi * 8;
+            for (int k = 0; k < 8; k++) {
+                int i = i0 + k;
+                if (i < p.I) sum += x[xbase + i] * i4(packed, k);
+            }
+        }
+    }
+
+    partial[t] = sum;
+    barrier();
+    for (int n = nth >> 1; n > 0; n >>= 1) {
+        if (t < n) partial[t] += partial[t + n];
+        barrier();
+    }
+    if (t == 0) y[s * p.O + o] = partial[0] * scale[o];
+}


### PR DESCRIPTION
## What

An **opt-in** Vulkan compute backend (`backend_vulkan.c/.h` + one int8/int4 GEMV shader) that runs resident/pinned expert matmuls on a local GPU. Gated by `VK=1` at build time and `COLI_VULKAN=1` at runtime.

## The default build is untouched

Every `glm.c` hook is inside `#ifdef COLI_VULKAN`. Without the flag, **not a single VK symbol is referenced** — verified by `nm` (pure-C binary: 0 `coli_vk_*` symbols; VK build: 7) and by preprocessing `main` vs this branch under pure-C flags (the only non-`#ifdef` delta is one intentional fail-fast guard if a `VK_*` env var is set on a CPU-only binary). `make`/CUDA builds are byte-identical.

The int4/int8 shader is numerically verified against the CPU path on real hardware (Radeon 8060S / RADV, Strix Halo): max rel err ≤ 1.7e-4.

## Honest performance note

Targeted at the Strix Halo iGPU. Under **unified memory** the GPU and CPU share one ~150–175 GB/s bus and S=1 decode is memory-bound, so this is break-even for resident experts and net-negative once experts are streamed — it only pays off on a host whose GPU has its own high-bandwidth VRAM. Shipped off-by-default accordingly; the toggles document this.

## Toggles

- `VK_EXPERT_GB` — caps the iGPU-pinned expert tier.
- `VK_STREAM` (**default OFF**) — also routes streamed/cached experts through the shader; keeps both the CPU slab and a VK copy (~2× cache RAM), so opt-in for discrete-VRAM hosts only.
- `VK_DENSE` — extend to dense tensors. `VK_SPV` — override the shader path.
- Only int8 (fmt 1) / int4 (fmt 2) run on the GPU; fmt 0/3 and any omp-parallel context fall back to CPU, and a failed upload sets `vk_failed` to degrade gracefully.

## Robustness

Bounded fence wait (10s → disable VK/CPU-fallback on device-loss, never hangs); atomic backend counters (frees run under `#pragma omp parallel`) with symmetric weights+scales accounting; SPIR-V size validation; device selection prefers a real GPU over a software adapter; tensor free skips `vkDestroy` on a lost device (no GPU-side UAF).

## Build

`make VK=1` (needs `libvulkan` + `glslc`).
