### PR TITLE
Add support for amd gpus and decouple vram from system memory

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -67,6 +67,22 @@ LDFLAGS  += -L$(CUDA_HOME)/lib64 -Wl,-rpath,$(CUDA_HOME)/lib64 -lcudart -lstdc++
 CUDA_OBJ  = backend_cuda.o
 endif
 
+# HIP=1 builds the same backend for AMD ROCm (asgard: gfx1100) via hipcc.
+HIP        ?= 0
+HIPCC      ?= /opt/rocm/bin/hipcc
+HIP_ARCH   ?= gfx1100
+ROCM_HOME  ?= /opt/rocm
+HIPCCFLAGS ?= -O3 -std=c++17 --offload-arch=$(HIP_ARCH) -I$(ROCM_HOME)/include -L$(ROCM_HOME)/lib -Wl,-rpath,$(ROCM_HOME)/lib -Wall -Wextra -Wno-unused-parameter
+GPU_TEST_DEVICES ?= 0
+ifeq ($(HIP),1)
+CFLAGS   += -DCOLI_CUDA
+LDFLAGS  += -L$(ROCM_HOME)/lib -Wl,-rpath,$(ROCM_HOME)/lib -lamdhip64 -lstdc++
+CUDA_OBJ  = backend_cuda.o
+GPU_CC    = $(HIPCC) $(HIPCCFLAGS) -DCOLI_HIP -DCOLI_CUDA
+else
+GPU_CC    = $(NVCC) $(NVCCFLAGS)
+endif
+
 all: glm$(EXE)
 
 # phony 'glm' → 'glm.exe' on Windows (so 'make glm' and 'coli build' work on every platform)
@@ -76,13 +92,11 @@ glm$(EXE): glm.c st.h json.h tok.h tok_unicode.h compat.h grammar.h $(CUDA_OBJ)
 	$(CC) $(CFLAGS) glm.c $(CUDA_OBJ) -o glm$(EXE) $(LDFLAGS)
 
 backend_cuda.o: backend_cuda.cu backend_cuda.h
-	@command -v $(NVCC) >/dev/null 2>&1 || { echo "nvcc not found: set CUDA_HOME or NVCC" >&2; exit 1; }
-	$(NVCC) $(NVCCFLAGS) -c backend_cuda.cu -o $@
+	$(GPU_CC) -c backend_cuda.cu -o $@
 
 cuda-test: backend_cuda.cu backend_cuda.h tests/test_backend_cuda.cu
-	@command -v $(NVCC) >/dev/null 2>&1 || { echo "nvcc not found: set CUDA_HOME or NVCC" >&2; exit 1; }
-	$(NVCC) $(NVCCFLAGS) backend_cuda.cu tests/test_backend_cuda.cu -o backend_cuda_test$(EXE)
-	./backend_cuda_test$(EXE)
+	$(GPU_CC) backend_cuda.cu tests/test_backend_cuda.cu -o backend_cuda_test$(EXE)
+	./backend_cuda_test$(EXE) $(GPU_TEST_DEVICES)
 
 olmoe$(EXE): olmoe.c st.h json.h compat.h
 	$(CC) $(CFLAGS) olmoe.c -o olmoe$(EXE) $(LDFLAGS)

--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -179,13 +179,17 @@ extern "C" int coli_cuda_tensor_upload(ColiCudaTensor **tensor,
                                         const void *weights, const float *scales,
                                         int fmt, int I, int O, int device) {
     DeviceContext *ctx = find_ctx(device);
-    if (!tensor || !weights || I < 1 || O < 1 || !select_ctx(ctx)) return 0;
-    size_t rb = row_bytes(fmt, I);
-    if (!rb || (fmt && !scales)) return 0;
+    if (!tensor || I < 1 || O < 1 || !select_ctx(ctx)) return 0;
+    /* Cache hit: the device already owns this tensor, so validate shape only.
+     * Host weights/scales are NOT required here -- a GPU-resident expert may have
+     * released its RAM copy (weights==NULL) and still reuse the uploaded copy. */
     if (*tensor) {
         ColiCudaTensor *t = *tensor;
         return t->fmt == fmt && t->I == I && t->O == O && t->device == device;
     }
+    /* First upload: source data must be present. */
+    size_t rb = row_bytes(fmt, I);
+    if (!weights || !rb || (fmt && !scales)) return 0;
     ColiCudaTensor *t = static_cast<ColiCudaTensor *>(std::calloc(1, sizeof(*t)));
     if (!t) return 0;
     t->fmt = fmt; t->I = I; t->O = O; t->device = device; t->weight_bytes = rb * (size_t)O;
@@ -224,6 +228,20 @@ extern "C" int coli_cuda_matmul(ColiCudaTensor **tensor,
     quant_matmul<<<grid, 256>>>(ctx->y, ctx->x, t->weights, t->scales, fmt, S, I, O, rb);
     if (!cuda_ok(cudaGetLastError(), "matmul launch") ||
         !cuda_ok(cudaMemcpy(y, ctx->y, yb, cudaMemcpyDeviceToHost), "output download")) return 0;
+    return 1;
+}
+
+extern "C" int coli_cuda_tensor_download(const ColiCudaTensor *tensor, void *weights, float *scales) {
+    if (!tensor || !weights) return 0;
+    DeviceContext *ctx = find_ctx(tensor->device);
+    if (!select_ctx(ctx)) return 0;
+    if (!cuda_ok(cudaMemcpy(weights, tensor->weights, tensor->weight_bytes,
+                            cudaMemcpyDeviceToHost), "tensor download")) return 0;
+    if (tensor->fmt && tensor->scales) {
+        if (!scales) return 0;
+        if (!cuda_ok(cudaMemcpy(scales, tensor->scales, (size_t)tensor->O * sizeof(float),
+                                cudaMemcpyDeviceToHost), "scale download")) return 0;
+    }
     return 1;
 }
 

--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -1,6 +1,26 @@
 #include "backend_cuda.h"
 
+#ifdef COLI_HIP
+/* asgard/AMD ROCm build: compile this CUDA backend under HIP by aliasing the
+   small runtime surface it uses. One source, dual target (nvcc or hipcc). */
+#include <hip/hip_runtime.h>
+#define cudaError_t             hipError_t
+#define cudaSuccess             hipSuccess
+#define cudaGetErrorString      hipGetErrorString
+#define cudaGetLastError        hipGetLastError
+#define cudaSetDevice           hipSetDevice
+#define cudaGetDeviceCount      hipGetDeviceCount
+#define cudaGetDeviceProperties hipGetDeviceProperties
+#define cudaDeviceProp          hipDeviceProp_t
+#define cudaMalloc              hipMalloc
+#define cudaFree                hipFree
+#define cudaMemcpy              hipMemcpy
+#define cudaMemcpyHostToDevice  hipMemcpyHostToDevice
+#define cudaMemcpyDeviceToHost  hipMemcpyDeviceToHost
+#define cudaMemGetInfo          hipMemGetInfo
+#else
 #include <cuda_runtime.h>
+#endif
 
 #include <cstdio>
 #include <cstdlib>

--- a/c/backend_cuda.h
+++ b/c/backend_cuda.h
@@ -38,6 +38,10 @@ int coli_cuda_matmul(ColiCudaTensor **tensor,
                      const void *weights, const float *scales,
                      int fmt, int S, int I, int O, int device);
 
+/* Copy a resident tensor device->host: weights (weight_bytes) and, when fmt!=0,
+ * O row scales. Lets a VRAM expert return to RAM without re-reading disk. */
+int coli_cuda_tensor_download(const ColiCudaTensor *tensor, void *weights, float *scales);
+
 void coli_cuda_tensor_free(ColiCudaTensor *tensor);
 size_t coli_cuda_tensor_bytes(const ColiCudaTensor *tensor);
 int coli_cuda_tensor_device(const ColiCudaTensor *tensor);

--- a/c/doctor.py
+++ b/c/doctor.py
@@ -25,7 +25,8 @@ def cuda_linkage(engine_path):
                                 timeout=3, check=False)
     except (OSError, subprocess.SubprocessError):
         return {"linked": False, "missing": False}
-    lines = [line for line in result.stdout.splitlines() if "libcudart" in line]
+    lines = [line for line in result.stdout.splitlines()
+             if ("libcudart" in line or "libamdhip64" in line)]
     return {"linked": any("not found" not in line for line in lines),
             "missing": any("not found" in line for line in lines)}
 

--- a/c/glm.c
+++ b/c/glm.c
@@ -156,6 +156,7 @@ static void qt_cuda_reset(QT *t){
     if(t->cuda){ coli_cuda_tensor_free(t->cuda); t->cuda=NULL; }
     t->cuda_failed=0;
 }
+static void expert_ram_release(Model *m, ESlot *s);   /* fwd: defined near pin_load */
 static int qt_cuda_upload(QT *t){
     const void *weights = t->fmt==0 ? (const void*)t->qf
                         : t->fmt==1 ? (const void*)t->q8 : (const void*)t->q4;
@@ -487,6 +488,11 @@ static void matmul_qt(float *y, const float *x, QT *w, int S){
             w->O,w->I,w->cuda_device);
     }
 #endif
+    /* GPU-only expert: RAM slab released after VRAM upload. If the GPU path above
+     * failed (or was skipped) there is nothing to run on CPU; the expert loop sees
+     * cuda_failed, reloads from disk, and recomputes. */
+    if((w->fmt==0 ? (const void*)w->qf : w->fmt==1 ? (const void*)w->q8 : (const void*)w->q4)==NULL)
+        return;
     if(w->fmt==0){ matmul(y,x,w->qf,S,w->I,w->O); return; }
     /* int8 IDOT vince sempre (1.4-2.5x). int4 IDOT: l'autore su AVX2 trovo' che a S=1
      * non ripaga (soglia S>=2); ma su ARM/SDOT il singolo token CONVIENE (vedi g_i4s /
@@ -1375,8 +1381,21 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out){
             double t0=now_s();
             matmul_qt(gg, xg, &e->g, nr);
             matmul_qt(uu, xg, &e->u, nr);
+#ifdef COLI_CUDA
+            if(!e->slab && (e->g.cuda_failed||e->u.cuda_failed)){
+                expert_load(m,layer,eid,e);          /* GPU faulted: restore RAM copy */
+                matmul_qt(gg, xg, &e->g, nr);
+                matmul_qt(uu, xg, &e->u, nr);
+            }
+#endif
             for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
             matmul_qt(hh, gg, &e->d, nr);
+#ifdef COLI_CUDA
+            if(!e->slab && e->d.cuda_failed){
+                expert_load(m,layer,eid,e);
+                matmul_qt(hh, gg, &e->d, nr);
+            }
+#endif
             for(int r=0;r<nr;r++){ float *os=out+(int64_t)rows[r]*D, wgt=rw[r], *hr=hh+(int64_t)r*D;
                 for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
             m->t_emm += now_s()-t0;
@@ -2002,6 +2021,83 @@ static void run_text(Model *m, const char *snap, const char *prompt, int ngen){
  * piu' umano, piu' veloce). Template chat GLM con token speciali (CHAT_TEMPLATE=0 -> grezzo).
  * Protocollo: "\x01\x01" "READY" "\x01\x01\n" dopo il load; risposta in streaming; "\x01\x01" "END" "\x01\x01\n" a fine turno.
  * ":reset" (riga "\x02RESET") azzera la memoria. EOF -> esce. */
+#ifdef COLI_CUDA
+/* Resident weight bytes of one quantized proj (no scales), matching the CUDA
+ * backend row layout. Used to size a slab when pulling a tensor back from VRAM. */
+static int64_t qt_weight_bytes(const QT *t){
+    int64_t rb = t->fmt==0 ? (int64_t)t->I*4
+               : t->fmt==1 ? (int64_t)t->I
+               : t->fmt==3 ? (int64_t)((t->I+3)/4)
+                           : (int64_t)((t->I+1)/2);
+    return rb*(int64_t)t->O;
+}
+/* Demote a VRAM-resident expert to RAM WITHOUT touching disk: copy its quantized
+ * weights + scales device->host into a fresh slab, then free the VRAM tensor.
+ * Returns 0 (VRAM copy left intact) if any download fails. */
+static int expert_gpu_to_ram(Model *m, ESlot *s){
+    (void)m; QT *qt[3]={&s->g,&s->u,&s->d};
+    int64_t wb[3], wtot=0, ftot=0;
+    for(int k=0;k<3;k++){ wb[k]=qt_weight_bytes(qt[k]); wtot+=wb[k]; if(qt[k]->fmt) ftot+=qt[k]->O; }
+    uint8_t *slab=NULL; if(posix_memalign((void**)&slab,4096,(size_t)wtot+8192)) return 0;
+    float *fslab = ftot? falloc(ftot) : NULL;
+    int64_t wo=0, fo=0;
+    for(int k=0;k<3;k++){
+        float *sc = qt[k]->fmt ? fslab+fo : NULL;
+        if(!coli_cuda_tensor_download(qt[k]->cuda, slab+wo, sc)){ compat_aligned_free(slab); free(fslab); return 0; }
+        qt[k]->qf = qt[k]->fmt? NULL : (float*)(slab+wo);
+        qt[k]->q8 = (int8_t*)(slab+wo); qt[k]->q4 = slab+wo; qt[k]->s = sc;
+        wo+=wb[k]; if(qt[k]->fmt) fo+=qt[k]->O;
+    }
+    s->slab=slab; s->slab_cap=(int64_t)wtot+8192; s->fslab=fslab; s->fslab_cap=ftot;
+    qt_cuda_reset(&s->g); qt_cuda_reset(&s->u); qt_cuda_reset(&s->d);
+    s->g.cuda_eligible=s->u.cuda_eligible=s->d.cuda_eligible=0;
+    return 1;
+}
+/* Tier rebalance: per layer, if the hottest RAM-resident expert clearly beats the
+ * coldest VRAM-resident one, swap their tiers so the GPUs hold the hottest live
+ * experts. Promote is host->device; demote is device->host. No disk. Bounded per
+ * pass and gated by the same 25%+4 hysteresis as membership swaps. */
+static void repin_retier(Model *m, int maxswaps){
+    Cfg *c=&m->c;
+    for(int l=0;l<c->n_layers && maxswaps>0;l++){
+        if(!m->npin || m->npin[l]<2 || !m->eheat[l]) continue;
+        ESlot *P=m->pin[l]; int np=m->npin[l]; if(np>4096) np=4096;
+        int rhot=-1, vcold=-1; uint32_t *H=m->eheat[l];
+        for(int z=0;z<np;z++){
+            if(P[z].g.cuda_eligible){ if(vcold<0 || H[P[z].eid]<H[P[vcold].eid]) vcold=z; }
+            else                    { if(rhot<0  || H[P[z].eid]>H[P[rhot].eid])  rhot=z;  }
+        }
+        if(rhot<0||vcold<0) continue;
+        ESlot *R=&P[rhot], *V=&P[vcold];
+        uint32_t hr=H[R->eid], hv=H[V->eid];
+        if(hr<=hv+(hv>>2)+4) continue;
+        int dev=V->g.cuda_device; double t0=now_s();
+        int64_t rram=qt_bytes(&R->g)+qt_bytes(&R->u)+qt_bytes(&R->d);
+        /* promote R first (transient +1 expert on dev fits within the 2 GB reserve) */
+        R->g.cuda_device=R->u.cuda_device=R->d.cuda_device=dev;
+        R->g.cuda_eligible=R->u.cuda_eligible=R->d.cuda_eligible=1;
+        if(!(qt_cuda_upload(&R->g)&&qt_cuda_upload(&R->u)&&qt_cuda_upload(&R->d))){
+            qt_cuda_reset(&R->g); qt_cuda_reset(&R->u); qt_cuda_reset(&R->d);
+            R->g.cuda_eligible=R->u.cuda_eligible=R->d.cuda_eligible=0;
+            continue;                              /* no room: leave tiers as-is */
+        }
+        int64_t rgpu=(int64_t)coli_cuda_tensor_bytes(R->g.cuda)+coli_cuda_tensor_bytes(R->u.cuda)+coli_cuda_tensor_bytes(R->d.cuda);
+        int64_t vgpu=(int64_t)coli_cuda_tensor_bytes(V->g.cuda)+coli_cuda_tensor_bytes(V->u.cuda)+coli_cuda_tensor_bytes(V->d.cuda);
+        expert_ram_release(m,R);
+        m->gpu_expert_count++; m->gpu_expert_bytes+=rgpu; m->resident_bytes-=rram;
+        if(!expert_gpu_to_ram(m,V)){               /* rare: fall back to a disk reload */
+            qt_cuda_reset(&V->g); qt_cuda_reset(&V->u); qt_cuda_reset(&V->d);
+            V->g.cuda_eligible=V->u.cuda_eligible=V->d.cuda_eligible=0;
+            expert_load(m,l,V->eid,V);
+        }
+        m->gpu_expert_count--; m->gpu_expert_bytes-=vgpu;
+        m->resident_bytes+=qt_bytes(&V->g)+qt_bytes(&V->u)+qt_bytes(&V->d);
+        maxswaps--;
+        fprintf(stderr,"[REPIN] retier layer %d dev%d: GPU %d(heat=%u)->RAM, RAM %d(heat=%u)->GPU in %.0f ms\n",
+            l,dev,V->eid,hv,R->eid,hr,(now_s()-t0)*1e3);
+    }
+}
+#endif
 /* ---- RFC: RE-PIN A CALDO / LIVE RE-PIN (opt-in, REPIN=n, default OFF) ----
  * Upstream fa AUTOPIN allo START (dalla storia .coli_usage). Questo aggiunge un re-pin
  * TRA I TURNI: nel punto sicuro dopo la risposta scambia i pin peggiori con i non-pinnati
@@ -2055,6 +2151,7 @@ static void repin_pass(Model *m){
                                +(int64_t)coli_cuda_tensor_bytes(s->u.cuda)
                                +(int64_t)coli_cuda_tensor_bytes(s->d.cuda);
                 m->gpu_expert_bytes+=now_gpu-old_gpu; tier="VRAM";
+                expert_ram_release(m,s);          /* keep VRAM-only after re-pin */
             } else {
                 qt_cuda_reset(&s->g); qt_cuda_reset(&s->u); qt_cuda_reset(&s->d);
                 s->g.cuda_eligible=s->u.cuda_eligible=s->d.cuda_eligible=0;
@@ -2066,6 +2163,9 @@ static void repin_pass(Model *m){
         fprintf(stderr,"[REPIN] %s layer %d: evict %d (heat=%u) <- admit %d (heat=%u) in %.0f ms\n",
             tier,cd[b].l,old,old_heat,cd[b].eid,new_heat,(now_s()-t0)*1e3);
     }
+#ifdef COLI_CUDA
+    if(g_cuda_enabled) repin_retier(m,4);          /* keep the hottest live experts on the GPUs */
+#endif
     for(int l=0;l<m->c.n_layers;l++) if(m->eheat[l]) tier_decay(m->eheat[l],m->c.n_experts);
 }
 /* ---- KV SU DISCO: la conversazione si riapre CALDA (KVSAVE=0 disattiva) ----
@@ -2295,6 +2395,7 @@ static void run_serve(Model *m, const char *snap){
         free(raw); g_temp=base_temp; g_nuc=base_nuc;
         usage_save(m);                   /* la cache che impara: storia aggiornata a ogni turno */
         kv_disk_append(m,hist,len);      /* KV su disco: il prossimo avvio riparte da qui */
+        repin_pass(m);                   /* RFC: re-pin a caldo tra i turni anche sul path API */
     }
     free(line); free(buf);
     usage_save(m);
@@ -2406,6 +2507,20 @@ static void pin_wire(Model *m){
             "(no compression) in %.0fs\n", wired/1e9, now_s()-t0);
 }
 
+#ifdef COLI_CUDA
+/* GPU-resident expert: the VRAM copy is authoritative, so drop the RAM slab and
+ * reclaim its cache budget. Weight pointers go NULL so a cuda_failed matmul_qt
+ * bails to the reload path instead of reading freed memory. */
+static void expert_ram_release(Model *m, ESlot *s){
+    (void)m;
+    if(s->slab){ compat_aligned_free(s->slab); s->slab=NULL; s->slab_cap=0; }
+    if(s->fslab){ free(s->fslab); s->fslab=NULL; s->fslab_cap=0; }
+    s->g.q8=s->u.q8=s->d.q8=NULL;
+    s->g.q4=s->u.q4=s->d.q4=NULL;
+    s->g.qf=s->u.qf=s->d.qf=NULL;
+    s->g.s=s->u.s=s->d.s=NULL;
+}
+#endif
 static void pin_load(Model *m, const char *statspath, double gb){
     FILE *f=fopen(statspath,"r"); if(!f){ perror(statspath); return; }
     typedef struct { int l,e; uint32_t c; } Rec;
@@ -2425,13 +2540,26 @@ static void pin_load(Model *m, const char *statspath, double gb){
     }
     int64_t eb=expert_bytes_probe(m,m->ebits);
     int npin=(int)(gb*1e9/eb); if(npin>n) npin=n; if(npin>4096) npin=4096;
-    if(npin<1){ free(r); return; }
+    int nvram=0;
+#ifdef COLI_CUDA
+    /* VRAM experts are DISJOINT from the RAM pins: the hottest experts live only in
+     * VRAM and release their RAM slab, so the GPU tier ADDS capacity instead of
+     * mirroring RAM. Ranking r[] is hottest-first: r[0..nvram) -> VRAM, next -> RAM. */
+    if(g_cuda_enabled && g_cuda_expert_gb>0){
+        nvram=(int)(g_cuda_expert_gb*1e9/eb);
+        if(nvram>n) nvram=n; if(nvram>4096) nvram=4096;
+        if(npin>n-nvram) npin=n-nvram; if(npin<0) npin=0;
+        if(npin+nvram>4096){ npin=4096-nvram; if(npin<0) npin=0; }
+    }
+#endif
+    int nload=npin+nvram;
+    if(nload<1){ free(r); return; }
     int *cnt_l=calloc(c->n_layers+1,sizeof(int));   /* +1: riga MTP */
-    for(int a=0;a<npin;a++) cnt_l[r[a].l]++;
+    for(int a=0;a<nload;a++) cnt_l[r[a].l]++;
     for(int i=0;i<=c->n_layers;i++) if(cnt_l[i]) m->pin[i]=calloc(cnt_l[i],sizeof(ESlot));
     double t0=now_s();
     #pragma omp parallel for schedule(dynamic,1)
-    for(int a=0;a<npin;a++){
+    for(int a=nvram;a<nload;a++){
         int li=r[a].l, slot;
         #pragma omp critical
         slot=m->npin[li]++;
@@ -2441,7 +2569,7 @@ static void pin_load(Model *m, const char *statspath, double gb){
     fprintf(stderr,"[PIN] hot store: %d experts in RAM (%.1f GB) loaded in %.0fs from %s\n",
         npin, npin*eb/1e9, now_s()-t0, statspath);
 #ifdef COLI_CUDA
-    if(g_cuda_enabled && g_cuda_expert_gb>0){
+    if(nvram>0){
         double remaining[COLI_CUDA_MAX_DEVICES]={0}, placed_b[COLI_CUDA_MAX_DEVICES]={0};
         int placed_n[COLI_CUDA_MAX_DEVICES]={0};
         double budget=g_cuda_expert_gb*1e9, safe_total=0;
@@ -2456,39 +2584,43 @@ static void pin_load(Model *m, const char *statspath, double gb){
             }
         }
         if(budget>safe_total) budget=safe_total;
-        for(int a=0;a<npin && m->gpu_expert_bytes<budget;a++){
-            int li=r[a].l;
-            for(int z=0;z<m->npin[li];z++) if(m->pin[li][z].eid==r[a].e){
-                ESlot *s=&m->pin[li][z];
-                int64_t need=qt_bytes(&s->g)+qt_bytes(&s->u)+qt_bytes(&s->d);
-                if(m->gpu_expert_bytes+need>budget) break;
-                int tried[COLI_CUDA_MAX_DEVICES]={0}, placed=0;
-                for(int attempt=0;attempt<g_cuda_ndev && !placed;attempt++){
-                    int best=-1;
-                    for(int i=0;i<g_cuda_ndev;i++) if(!tried[i] && remaining[i]>=need &&
-                        (best<0||placed_b[i]<placed_b[best])) best=i;
-                    if(best<0) break;
-                    tried[best]=1;
-                    s->g.cuda_device=s->u.cuda_device=s->d.cuda_device=g_cuda_devices[best];
-                    s->g.cuda_eligible=s->u.cuda_eligible=s->d.cuda_eligible=1;
-                    if(qt_cuda_upload(&s->g) && qt_cuda_upload(&s->u) && qt_cuda_upload(&s->d)){
-                        int64_t actual=(int64_t)coli_cuda_tensor_bytes(s->g.cuda)
-                                      +(int64_t)coli_cuda_tensor_bytes(s->u.cuda)
-                                      +(int64_t)coli_cuda_tensor_bytes(s->d.cuda);
-                        m->gpu_expert_count++; m->gpu_expert_bytes+=actual;
-                        remaining[best]-=actual; placed_b[best]+=actual; placed_n[best]++;
-                        placed=1;
-                    } else {
-                        qt_cuda_reset(&s->g); qt_cuda_reset(&s->u); qt_cuda_reset(&s->d);
-                        s->g.cuda_eligible=s->u.cuda_eligible=s->d.cuda_eligible=0;
-                        remaining[best]=0;             /* device rejected its projected capacity */
-                    }
+        double tg=now_s();
+        /* Load each VRAM-tier expert disk->RAM into its pin slot, upload to VRAM, then
+         * release the RAM slab. Sequential keeps transient RAM at one expert (~eb),
+         * not nvram*eb, which would blow the RAM budget we just sized. */
+        for(int a=0;a<nvram;a++){
+            int li=r[a].l, slot=m->npin[li]++;
+            ESlot *s=&m->pin[li][slot];
+            expert_load(m,li,r[a].e,s);
+            int64_t need=qt_bytes(&s->g)+qt_bytes(&s->u)+qt_bytes(&s->d);
+            int tried[COLI_CUDA_MAX_DEVICES]={0}, placed=0;
+            if(m->gpu_expert_bytes+need<=budget)
+            for(int attempt=0;attempt<g_cuda_ndev && !placed;attempt++){
+                int best=-1;
+                for(int i=0;i<g_cuda_ndev;i++) if(!tried[i] && remaining[i]>=need &&
+                    (best<0||placed_b[i]<placed_b[best])) best=i;
+                if(best<0) break;
+                tried[best]=1;
+                s->g.cuda_device=s->u.cuda_device=s->d.cuda_device=g_cuda_devices[best];
+                s->g.cuda_eligible=s->u.cuda_eligible=s->d.cuda_eligible=1;
+                if(qt_cuda_upload(&s->g) && qt_cuda_upload(&s->u) && qt_cuda_upload(&s->d)){
+                    int64_t actual=(int64_t)coli_cuda_tensor_bytes(s->g.cuda)
+                                  +(int64_t)coli_cuda_tensor_bytes(s->u.cuda)
+                                  +(int64_t)coli_cuda_tensor_bytes(s->d.cuda);
+                    m->gpu_expert_count++; m->gpu_expert_bytes+=actual;
+                    remaining[best]-=actual; placed_b[best]+=actual; placed_n[best]++;
+                    placed=1;
+                    expert_ram_release(m,s);       /* VRAM copy is authoritative; free RAM slab */
+                } else {
+                    qt_cuda_reset(&s->g); qt_cuda_reset(&s->u); qt_cuda_reset(&s->d);
+                    s->g.cuda_eligible=s->u.cuda_eligible=s->d.cuda_eligible=0;
+                    remaining[best]=0;             /* device rejected its projected capacity */
                 }
-                break;
             }
+            if(!placed) m->resident_bytes+=eb;     /* stayed in RAM: budget full or upload failed */
         }
-        fprintf(stderr,"[CUDA] hot expert tier: %d/%d experts, VRAM %.2f GB (total budget %.1f GB)\n",
-            m->gpu_expert_count,npin,m->gpu_expert_bytes/1e9,g_cuda_expert_gb);
+        fprintf(stderr,"[CUDA] hot expert tier: %d/%d experts, VRAM %.2f GB (total budget %.1f GB) in %.0fs\n",
+            m->gpu_expert_count,nvram,m->gpu_expert_bytes/1e9,g_cuda_expert_gb,now_s()-tg);
         for(int i=0;i<g_cuda_ndev;i++) fprintf(stderr,"[CUDA]   device %d: %d experts, %.2f GB\n",
             g_cuda_devices[i],placed_n[i],placed_b[i]/1e9);
     }

--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -184,7 +184,9 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
         safe_vram += usable
         gpu_plan.append(dict(gpu, reserve_bytes=reserve, usable_bytes=usable))
     requested_vram = int(vram_gb * GB) if vram_gb > 0 else safe_vram
-    vram_budget = min(requested_vram, safe_vram, cache_bytes)
+    # VRAM experts are disjoint from the RAM cache (they release their RAM slab),
+    # so the GPU tier is bounded by free VRAM only, not by leftover RAM.
+    vram_budget = min(requested_vram, safe_vram)
     vram_experts = int(vram_budget // typical) if typical else 0
 
     warnings = []
@@ -193,7 +195,7 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
     if gpu_indices is not None and len(gpus) != len(set(gpu_indices)):
         warnings.append("one or more requested GPUs were not detected")
     if gpus and vram_budget < requested_vram:
-        warnings.append("VRAM tier was clamped by free VRAM or its required RAM backing")
+        warnings.append("VRAM tier was clamped by free VRAM")
 
     return {
         "version": 1,
@@ -231,7 +233,8 @@ def environment_for_plan(plan, env=None, cuda_enabled=True):
         result[key] = ",".join(map(str, devices))
     result.setdefault("CUDA_EXPERT_GB", f"{vram['budget_bytes'] / GB:.3f}")
     if result.get("PIN"):
-        result.setdefault("PIN_GB", f"{vram['budget_bytes'] / GB:.3f}")
+        # RAM pins and the VRAM tier are disjoint: size RAM pins to the RAM cache.
+        result.setdefault("PIN_GB", f"{ram['expert_cache_bytes'] / GB:.3f}")
     return result
 
 

--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -84,6 +84,13 @@ def memory_available():
 
 
 def discover_gpus():
+    # NVIDIA first; fall back to ROCm/AMD (asgard: gfx1100) so the HIP engine build
+    # gets a VRAM tier instead of silently dropping to the CPU path.
+    devices = _discover_nvidia_gpus()
+    return devices if devices else _discover_amd_gpus()
+
+
+def _discover_nvidia_gpus():
     command = ["nvidia-smi", "--query-gpu=index,name,memory.total,memory.free",
                "--format=csv,noheader,nounits"]
     try:
@@ -102,6 +109,37 @@ def discover_gpus():
         devices.append({"index": index, "name": fields[1],
                         "total_bytes": total * 1024 * 1024,
                         "free_bytes": free * 1024 * 1024})
+    return devices
+
+
+def _discover_amd_gpus():
+    """Parse `rocm-smi --showmeminfo vram --csv`. Indices track HIP device ordinals;
+    tiny devices (integrated GPUs) are skipped so COLI_GPUS=0,1 maps to the dGPUs."""
+    for exe in ("/opt/rocm/bin/rocm-smi", "rocm-smi"):
+        try:
+            result = subprocess.run([exe, "--showmeminfo", "vram", "--csv"],
+                                    text=True, capture_output=True, check=True, timeout=5)
+            break
+        except (OSError, subprocess.SubprocessError):
+            result = None
+    if result is None:
+        return []
+    devices = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line or line.lower().startswith("device"):
+            continue
+        fields = [f.strip() for f in line.split(",")]
+        if len(fields) < 3:
+            continue
+        try:
+            total, used = int(fields[1]), int(fields[2])
+        except ValueError:
+            continue
+        if total < (2 << 30):   # skip integrated / tiny GPUs
+            continue
+        devices.append({"index": len(devices), "name": "AMD GPU (ROCm)",
+                        "total_bytes": total, "free_bytes": max(0, total - used)})
     return devices
 
 

--- a/c/tests/test_backend_cuda.cu
+++ b/c/tests/test_backend_cuda.cu
@@ -37,6 +37,12 @@ int main(int argc, char **argv) {
     if (ndev > 1 && coli_cuda_tensor_upload(&t8, q8, s8, 1, 4, 2, d1)) return 1;
     if (!coli_cuda_matmul(&t8, got, x, q8, s8, 1, 2, 4, 2, d0) || !close_enough(got, want8, 4)) return 1;
 
+    /* device->host round-trip: bytes and scales must come back exactly (demote path). */
+    int8_t dq8[8]; float ds8[2];
+    if (!coli_cuda_tensor_download(t8, dq8, ds8)) return 1;
+    for (int i = 0; i < 8; i++) if (dq8[i] != q8[i]) { std::fprintf(stderr, "download w[%d] %d!=%d\n", i, dq8[i], q8[i]); return 1; }
+    for (int i = 0; i < 2; i++) if (ds8[i] != s8[i]) { std::fprintf(stderr, "download s[%d]\n", i); return 1; }
+
     /* Rows [-8,-1,0,7] and [1,2,3,4], packed low nibble first. */
     const uint8_t q4[4] = {0x70, 0xf8, 0xa9, 0xcb};
     const float s4[2] = {1.0f, 0.25f};

--- a/c/tests/test_resource_plan.py
+++ b/c/tests/test_resource_plan.py
@@ -61,7 +61,7 @@ class ResourcePlanTest(unittest.TestCase):
         self.assertEqual(plan["version"], 1)
         self.assertEqual(plan["tiers"]["ram"]["budget_bytes"], 16 * GB)
         self.assertLessEqual(plan["tiers"]["vram"]["budget_bytes"], 8 * GB)
-        self.assertIn("required RAM backing", plan["warnings"][0])
+        self.assertIn("clamped by free VRAM", plan["warnings"][0])
         self.assertIn("0:test-gpu", format_plan(plan))
 
     def test_filters_requested_devices(self):
@@ -93,7 +93,8 @@ class ResourcePlanTest(unittest.TestCase):
         self.assertEqual(env["RAM_GB"], "12")
         self.assertEqual(env["COLI_CUDA"], "1")
         self.assertEqual(env["COLI_GPUS"], "1")
-        self.assertEqual(env["PIN_GB"], env["CUDA_EXPERT_GB"])
+        self.assertEqual(env["PIN_GB"],
+                         f"{plan['tiers']['ram']['expert_cache_bytes'] / GB:.3f}")
 
     def test_cpu_binary_does_not_apply_gpu_tier(self):
         plan = build_plan(self.model, available_memory=16 * GB, available_disk=1,


### PR DESCRIPTION
## Summary

This adds support for gfx1100 (texted on dual rx7900xtx) and decouples gpu vram.

Is it faster? Not enough to notice, disk reads still dominate. But it was a fun weekend project, and it seems like a prerequisite for hardware config changes that will make it faster.

## Validation

- [X] `make -C c check`
- [N/A] CUDA changes were tested with `make -C c cuda-test` (if applicable)
- [X] Performance claims include hardware, commands, and repeatable measurements

## Compatibility

- [X] The default CPU build remains dependency-free
- [X] No model files, generated binaries, or benchmark artifacts are included
