### PR TITLE
OpenAI tool calling for GLM-5.2 (+ prefill keepalive)

### DIFF
--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -588,6 +588,17 @@ class APIHandler(BaseHTTPRequestHandler):
             self.send_cors_headers()
             self.end_headers()
             connected = True
+            # KEEPALIVE: engine.generate() blocks SILENTLY during the (minutes-long) cold
+            # prefill, and the client drops the socket after its idle timeout. A background pump
+            # emits a reasoning_content "." delta (the channel that reliably resets the client's
+            # timer and lands in the thinking panel, so answer content stays clean) whenever no
+            # event has been written for KA_GAP seconds. All wfile writes share ka_lock so the
+            # pump and event() never interleave; last_write gates the pump so it stays quiet
+            # while real tokens are flowing (e.g. during decode).
+            ka_lock = threading.Lock()
+            last_write = [time.time()]
+            ka_stop = threading.Event()
+            KA_GAP = 10.0
 
             def event(choices, usage_marker=False):
                 nonlocal connected
@@ -597,12 +608,23 @@ class APIHandler(BaseHTTPRequestHandler):
                               "model": self.server.model_id, "choices": choices}
                 if include_usage:
                     event_body["usage"] = None if not usage_marker else usage_marker
-                try:
-                    data = json.dumps(event_body, ensure_ascii=False, separators=(",", ":"))
-                    self.wfile.write(f"data: {data}\n\n".encode())
-                    self.wfile.flush()
-                except OSError:
-                    connected = False
+                data = json.dumps(event_body, ensure_ascii=False, separators=(",", ":"))
+                with ka_lock:
+                    try:
+                        self.wfile.write(f"data: {data}\n\n".encode())
+                        self.wfile.flush()
+                        last_write[0] = time.time()
+                    except OSError:
+                        connected = False
+
+            def _keepalive():
+                ping = [{"index": 0, "delta": ({"reasoning_content": "."} if chat else {"content": ""}),
+                         "logprobs": None, "finish_reason": None}]
+                while not ka_stop.wait(1.0):
+                    if not connected:
+                        return
+                    if time.time() - last_write[0] >= KA_GAP:
+                        event(ping)
 
             if chat:
                 event([{"index": 0, "delta": {"role": "assistant", "content": ""},
@@ -614,6 +636,8 @@ class APIHandler(BaseHTTPRequestHandler):
                           {"index": 0, "text": text, "logprobs": None, "finish_reason": None})
                 event([choice])
 
+            ka_thread = threading.Thread(target=_keepalive, daemon=True)
+            ka_thread.start()
             if chat and tools:
                 # Suppress tool-call markers from the streamed content and parse the authoritative
                 # calls from the FULL reply after generation. Hold back a marker-length tail so a
@@ -652,6 +676,8 @@ class APIHandler(BaseHTTPRequestHandler):
                 stats = self.server.engine.generate(
                     prompt, maximum, temperature, top_p, emit, cache_slot)
                 finish = "length" if stats["length_limited"] else "stop"
+            ka_stop.set()                          # generation done: stop the keepalive pump
+            ka_thread.join(timeout=2)
             final_choice = ({"index": 0, "delta": {}, "logprobs": None, "finish_reason": finish}
                             if chat else {"index": 0, "text": "", "logprobs": None,
                                           "finish_reason": finish})

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -151,7 +151,87 @@ def content_text(content, param):
     return "".join(parts)
 
 
-def render_chat(messages, enable_thinking=False, reasoning_effort=None):
+# ---- GLM-5.2 tool calling -----------------------------------------------------------------
+# The model expresses tool calls as ordinary text (from chat_template.jinja):
+#   <tool_call>{name}<arg_key>{k}</arg_key><arg_value>{v}</arg_value>...</tool_call>
+# and tool results come back as <|observation|><tool_response>{content}</tool_response>.
+# We render those markers into the prompt and parse them back into OpenAI `tool_calls`.
+import re
+
+BOX_START, BOX_END = "<tool_call>", "</tool_call>"
+TR_OPEN,  TR_CLOSE = "<tool_response>", "</tool_response>"
+THINK_OPEN, THINK_CLOSE = "<think>", "</think>"
+
+_BOX_RE  = re.compile(re.escape(BOX_START) + r"(.*?)" + re.escape(BOX_END), re.DOTALL)
+_ARG_RE  = re.compile(r"<arg_key>([^<]*)</arg_key><arg_value>(.*?)</arg_value>", re.DOTALL)
+_NAME_RE = re.compile(r"\s*([A-Za-z0-9_.\-]+)")
+_TAG_RE  = re.compile(r"</?arg_key>|</?arg_value>")
+
+# De-mangler: opt-in recovery for heavily-quantized models that drop the
+# <arg_key>K</arg_key><arg_value> structure. Default OFF (never rewrites well-formed output).
+_SALVAGE = os.environ.get("COLI_TOOL_SALVAGE", "0") == "1"
+
+
+def _tool_param_order(tools):
+    """name -> ordered param names (required first) from the request schema, for de-mangling."""
+    out = {}
+    for tool in (tools or []):
+        fn = tool.get("function", tool) if isinstance(tool, dict) else {}
+        name = fn.get("name")
+        if not name:
+            continue
+        params = ((fn.get("parameters") or {}).get("properties") or {})
+        required = list((fn.get("parameters") or {}).get("required") or [])
+        out[name] = required + [p for p in params if p not in required]
+    return out
+
+
+def parse_tool_calls(reply, tools=None):
+    """Return (content, tool_calls). Strict GLM parse; optional de-mangler (COLI_TOOL_SALVAGE=1)
+    rescues malformed int4 output by mapping a lone payload onto the tool's primary parameter."""
+    param_order = _tool_param_order(tools)
+    calls, salvaged = [], []
+    for match in _BOX_RE.finditer(reply):
+        inner = match.group(1)
+        name_match = _NAME_RE.match(inner)
+        name = name_match.group(1) if name_match else inner.strip()
+        args = {}
+        for arg in _ARG_RE.finditer(inner):
+            key, value = arg.group(1), arg.group(2)
+            try:
+                value = json.loads(value)
+            except (json.JSONDecodeError, TypeError):
+                pass
+            args[key] = value
+        if not args and _SALVAGE:
+            rest = inner[name_match.end():] if name_match else ""
+            payload = _TAG_RE.sub("", rest).strip()
+            if payload.startswith("(") and payload.endswith(")"):
+                payload = payload[1:-1].strip()
+            if payload:
+                key = (param_order.get(name) or ["input"])[0]
+                try:
+                    payload = json.loads(payload)
+                except (json.JSONDecodeError, TypeError, ValueError):
+                    pass
+                args = {key: payload}
+                salvaged.append(name)
+        calls.append({"id": "call_" + uuid.uuid4().hex[:24], "type": "function",
+                      "function": {"name": name, "arguments": json.dumps(args, ensure_ascii=False)}})
+    text = _BOX_RE.sub("", reply)
+    if THINK_CLOSE in text:
+        text = text.split(THINK_CLOSE, 1)[1]
+    text = text.replace(THINK_OPEN, "").replace(THINK_CLOSE, "")
+    if calls:
+        dm = len(salvaged)
+        sys.stderr.write("[api] tool-calls: %d total, %d strict, %d de-mangled [%s]%s\n"
+                         % (len(calls), len(calls) - dm, dm, "CLEAN" if dm == 0 else "DE-MANGLED",
+                            (" -> " + ", ".join(salvaged)) if dm else ""))
+        sys.stderr.flush()
+    return text.strip(), calls
+
+
+def render_chat(messages, enable_thinking=False, reasoning_effort=None, tools=None):
     """Render the text-only subset of the official GLM-5.2 chat template."""
     if not isinstance(messages, list) or not messages:
         raise APIError(400, "`messages` must be a non-empty array.", "messages")
@@ -159,20 +239,52 @@ def render_chat(messages, enable_thinking=False, reasoning_effort=None):
     if enable_thinking:
         effort = "High" if reasoning_effort == "high" else "Max"
         prompt.append(f"<|system|>Reasoning Effort: {effort}")
+    if tools:
+        decl = ["<|system|>Available tools. To call a tool, emit exactly:",
+                "<tool_call>{function-name}<arg_key>{arg-key}</arg_key>"
+                "<arg_value>{arg-value}</arg_value></tool_call>"]
+        for tool in tools:
+            fn = tool.get("function", tool) if isinstance(tool, dict) else {}
+            clean = {"name": fn.get("name"), "description": fn.get("description", ""),
+                     "parameters": fn.get("parameters", {})}
+            decl.append(json.dumps(clean, ensure_ascii=False))
+        prompt.append("\n".join(decl))
+    prev_tool = False
     for index, message in enumerate(messages):
         if not isinstance(message, dict):
             raise APIError(400, "Each message must be an object.", f"messages.{index}")
         role = message.get("role")
-        text = content_text(message.get("content"), f"messages.{index}.content")
         if role in ("system", "developer"):
-            prompt.append(f"<|system|>{text}")
+            prompt.append(f"<|system|>{content_text(message.get('content'), f'messages.{index}.content')}")
         elif role == "user":
-            prompt.append(f"<|user|>{text}")
+            prompt.append(f"<|user|>{content_text(message.get('content'), f'messages.{index}.content')}")
         elif role == "assistant":
+            # content may be null when the message is purely tool_calls
+            raw = message.get("content")
+            text = content_text(raw, f"messages.{index}.content") if raw is not None else ""
             prompt.append(f"<|assistant|><think></think>{text.strip()}")
+            for tc in (message.get("tool_calls") or []):
+                fn = tc.get("function", tc) if isinstance(tc, dict) else {}
+                args = fn.get("arguments", "{}")
+                if isinstance(args, str):
+                    try:
+                        args = json.loads(args)
+                    except (json.JSONDecodeError, TypeError):
+                        args = {}
+                prompt.append(BOX_START + (fn.get("name") or ""))
+                for key, value in (args or {}).items():
+                    prompt.append(f"<arg_key>{key}</arg_key><arg_value>"
+                                  + (value if isinstance(value, str)
+                                     else json.dumps(value, ensure_ascii=False)) + "</arg_value>")
+                prompt.append(BOX_END)
+        elif role == "tool":
+            if not prev_tool:                       # one <|observation|> per consecutive tool run
+                prompt.append("<|observation|>")
+            prompt.append(TR_OPEN + content_text(message.get("content"), f"messages.{index}.content") + TR_CLOSE)
         else:
             raise APIError(400, f"Unsupported message role: {role!r}.",
                            f"messages.{index}.role", "unsupported_role")
+        prev_tool = (role == "tool")
     prompt.append("<|assistant|><think>" if enable_thinking else
                   "<|assistant|><think></think>")
     return "".join(prompt)
@@ -181,9 +293,7 @@ def render_chat(messages, enable_thinking=False, reasoning_effort=None):
 def generation_options(body, limit):
     if body.get("n", 1) != 1:
         raise APIError(400, "Colibri currently supports `n=1` only.", "n", "unsupported_value")
-    for name in ("tools", "functions"):
-        if body.get(name):
-            raise APIError(400, f"`{name}` is not supported yet.", name, "unsupported_parameter")
+    # `tools`/`functions` are handled by render_chat (declaration) + parse_tool_calls (output).
     if body.get("stop") is not None:
         raise APIError(400, "Custom stop sequences are not supported yet.", "stop", "unsupported_parameter")
     if body.get("logprobs"):
@@ -427,6 +537,7 @@ class APIHandler(BaseHTTPRequestHandler):
 
     def generation(self, body, prompt, request_id, chat):
         maximum, temperature, top_p = generation_options(body, self.server.max_tokens)
+        tools = (body.get("tools") or body.get("functions") or None) if chat else None
         cache_slot = body.get("cache_slot", 0)
         if isinstance(cache_slot, bool) or not isinstance(cache_slot, int) or not 0 <= cache_slot < self.server.kv_slots:
             raise APIError(400, f"`cache_slot` must be an integer between 0 and {self.server.kv_slots - 1}.",
@@ -450,10 +561,18 @@ class APIHandler(BaseHTTPRequestHandler):
                 stats = self.server.engine.generate(
                     prompt, maximum, temperature, top_p, output.append, cache_slot)
                 text = "".join(output)
-                finish = "length" if stats["length_limited"] else "stop"
-                choice = ({"index": 0, "message": {"role": "assistant", "content": text,
-                           "refusal": None}, "logprobs": None, "finish_reason": finish} if chat else
-                          {"index": 0, "text": text, "logprobs": None, "finish_reason": finish})
+                length_finish = "length" if stats["length_limited"] else "stop"
+                if chat and tools:
+                    content, calls = parse_tool_calls(text, tools)
+                    message = {"role": "assistant", "content": content or None, "refusal": None}
+                    if calls:
+                        message["tool_calls"] = calls
+                    finish = "tool_calls" if calls else length_finish
+                    choice = {"index": 0, "message": message, "logprobs": None, "finish_reason": finish}
+                else:
+                    choice = ({"index": 0, "message": {"role": "assistant", "content": text,
+                               "refusal": None}, "logprobs": None, "finish_reason": length_finish} if chat else
+                              {"index": 0, "text": text, "logprobs": None, "finish_reason": length_finish})
                 self.send_json(200, {"id": completion_id, "object": object_name, "created": created,
                     "model": self.server.model_id, "choices": [choice], "usage": self.usage(stats)},
                     request_id, queue_headers)
@@ -495,9 +614,44 @@ class APIHandler(BaseHTTPRequestHandler):
                           {"index": 0, "text": text, "logprobs": None, "finish_reason": None})
                 event([choice])
 
-            stats = self.server.engine.generate(
-                prompt, maximum, temperature, top_p, emit, cache_slot)
-            finish = "length" if stats["length_limited"] else "stop"
+            if chat and tools:
+                # Suppress tool-call markers from the streamed content and parse the authoritative
+                # calls from the FULL reply after generation. Hold back a marker-length tail so a
+                # <tool_call> split across engine chunks is still caught.
+                sp = {"buf": "", "tool": False}
+                hold = len(BOX_START) - 1
+                raw = []
+                def emit_tools(chunk):
+                    raw.append(chunk)
+                    if sp["tool"]:
+                        return
+                    sp["buf"] += chunk
+                    cut = sp["buf"].find(BOX_START)
+                    if cut >= 0:
+                        if cut:
+                            emit(sp["buf"][:cut])
+                        sp["buf"] = ""
+                        sp["tool"] = True
+                        return
+                    flush = max(0, len(sp["buf"]) - hold)
+                    if flush:
+                        emit(sp["buf"][:flush])
+                        sp["buf"] = sp["buf"][flush:]
+                stats = self.server.engine.generate(
+                    prompt, maximum, temperature, top_p, emit_tools, cache_slot)
+                if not sp["tool"] and sp["buf"]:
+                    emit(sp["buf"])                     # no tool call happened: flush held tail
+                _content, calls = parse_tool_calls("".join(raw), tools)
+                for i, tc in enumerate(calls):
+                    event([{"index": 0, "delta": {"tool_calls": [{"index": i, "id": tc["id"],
+                             "type": "function", "function": {"name": tc["function"]["name"],
+                             "arguments": tc["function"]["arguments"]}}]},
+                            "logprobs": None, "finish_reason": None}])
+                finish = "tool_calls" if calls else ("length" if stats["length_limited"] else "stop")
+            else:
+                stats = self.server.engine.generate(
+                    prompt, maximum, temperature, top_p, emit, cache_slot)
+                finish = "length" if stats["length_limited"] else "stop"
             final_choice = ({"index": 0, "delta": {}, "logprobs": None, "finish_reason": finish}
                             if chat else {"index": 0, "text": "", "logprobs": None,
                                           "finish_reason": finish})
@@ -538,7 +692,8 @@ class APIHandler(BaseHTTPRequestHandler):
         enable_thinking = body.get("enable_thinking", reasoning_effort not in (None, "none"))
         if not isinstance(enable_thinking, bool):
             raise APIError(400, "`enable_thinking` must be a boolean.", "enable_thinking")
-        prompt = render_chat(body.get("messages"), enable_thinking, reasoning_effort)
+        tools = body.get("tools") or body.get("functions") or None
+        prompt = render_chat(body.get("messages"), enable_thinking, reasoning_effort, tools)
         self.generation(body, prompt, request_id, True)
 
     def completion(self, body, request_id):

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -240,15 +240,20 @@ def render_chat(messages, enable_thinking=False, reasoning_effort=None, tools=No
         effort = "High" if reasoning_effort == "high" else "Max"
         prompt.append(f"<|system|>Reasoning Effort: {effort}")
     if tools:
-        decl = ["<|system|>Available tools. To call a tool, emit exactly:",
-                "<tool_call>{function-name}<arg_key>{arg-key}</arg_key>"
-                "<arg_value>{arg-value}</arg_value></tool_call>"]
+        # AUTHORITATIVE GLM-5.2 tool-declaration block (byte-matches chat_template.jinja): the
+        # `# Tools` + <tools></tools> XML structure is what the model was trained on. A made-up
+        # preamble makes it hallucinate other frameworks' syntax (e.g. `end_action`).
+        prompt.append("<|system|>\n# Tools\n\nYou may call one or more functions to assist with the "
+                      "user query.\n\nYou are provided with function signatures within <tools></tools> "
+                      "XML tags:\n<tools>\n")
         for tool in tools:
             fn = tool.get("function", tool) if isinstance(tool, dict) else {}
-            clean = {"name": fn.get("name"), "description": fn.get("description", ""),
-                     "parameters": fn.get("parameters", {})}
-            decl.append(json.dumps(clean, ensure_ascii=False))
-        prompt.append("\n".join(decl))
+            clean = {k: v for k, v in fn.items() if k not in ("defer_loading", "strict")}
+            prompt.append(json.dumps(clean, ensure_ascii=False) + "\n")
+        prompt.append("</tools>\n\nFor each function call, output the function name and arguments "
+                      "within the following XML format:\n<tool_call>{function-name}"
+                      "<arg_key>{arg-key-1}</arg_key><arg_value>{arg-value-1}</arg_value>"
+                      "<arg_key>{arg-key-2}</arg_key><arg_value>{arg-value-2}</arg_value>...</tool_call>")
     prev_tool = False
     for index, message in enumerate(messages):
         if not isinstance(message, dict):

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -599,6 +599,7 @@ class APIHandler(BaseHTTPRequestHandler):
             last_write = [time.time()]
             ka_stop = threading.Event()
             KA_GAP = 10.0
+            dbg_echo = os.environ.get("COLI_DEBUG", "0") == "1"   # tee decoded tokens to stderr
 
             def event(choices, usage_marker=False):
                 nonlocal connected
@@ -647,6 +648,8 @@ class APIHandler(BaseHTTPRequestHandler):
                 raw = []
                 def emit_tools(chunk):
                     raw.append(chunk)
+                    if dbg_echo:
+                        sys.stderr.write(chunk); sys.stderr.flush()
                     if sp["tool"]:
                         return
                     sp["buf"] += chunk
@@ -673,8 +676,12 @@ class APIHandler(BaseHTTPRequestHandler):
                             "logprobs": None, "finish_reason": None}])
                 finish = "tool_calls" if calls else ("length" if stats["length_limited"] else "stop")
             else:
+                def emit_plain(chunk):
+                    if dbg_echo:
+                        sys.stderr.write(chunk); sys.stderr.flush()
+                    emit(chunk)
                 stats = self.server.engine.generate(
-                    prompt, maximum, temperature, top_p, emit, cache_slot)
+                    prompt, maximum, temperature, top_p, emit_plain, cache_slot)
                 finish = "length" if stats["length_limited"] else "stop"
             ka_stop.set()                          # generation done: stop the keepalive pump
             ka_thread.join(timeout=2)

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -689,6 +689,12 @@ class APIHandler(BaseHTTPRequestHandler):
         if reasoning_effort not in efforts:
             raise APIError(400, "`reasoning_effort` must be none, minimal, low, medium, high, or xhigh.",
                            "reasoning_effort")
+        # COLI_THINK=1 makes thinking the default when the client sends NEITHER reasoning_effort
+        # nor enable_thinking (a global switch, like the old server's --think). An explicit
+        # client value always wins. Default off => exact OpenAI-standard behavior.
+        if (reasoning_effort is None and "enable_thinking" not in body
+                and os.environ.get("COLI_THINK", "0") == "1"):
+            reasoning_effort = "high"
         enable_thinking = body.get("enable_thinking", reasoning_effort not in (None, "none"))
         if not isinstance(enable_thinking, bool):
             raise APIError(400, "`enable_thinking` must be a boolean.", "enable_thinking")


### PR DESCRIPTION
# PR: OpenAI tool calling for GLM-5.2 (+ prefill keepalive) — `c/openai_server.py`

**Branch:** `feat/glm-tool-calling` off `upstream/main` (`e945b43`) · **One file:** `c/openai_server.py`

## What

`generation_options()` currently rejects `tools`/`functions` with *"not supported yet."* This
implements them end to end, so an OpenAI-style agent client (OpenCode, the SDKs) can drive
GLM-5.2 through real tool calls. Five small, independent commits:

1. **parse GLM tool calls → `tool_calls`** — `render_chat` gains a tools-declaration block,
   replays `role:"tool"` results as `<|observation|><tool_response>…`, and reconstructs prior
   assistant `tool_calls` as `<tool_call>…`; `parse_tool_calls` turns the model's `<tool_call>`
   markers back into OpenAI `tool_calls`; `generation` emits them for both non-stream (in the
   message) and stream (marker-suppressing splitter + `tool_calls` deltas) with
   `finish_reason:"tool_calls"`.
2. **authoritative tool-declaration block** — the `# Tools` + `<tools></tools>` structure
   byte-matches `chat_template.jinja`. (A hand-written preamble made the model hallucinate other
   frameworks' syntax; the trained format fixes it.)
3. **keepalive during long prefill** — `engine.generate()` is silent for the whole cold prefill
   (minutes on a large prompt) and clients drop the socket; a background pump emits a
   `reasoning_content "."` SSE delta every 10s of silence (resets the client timer, lands in the
   thinking panel), gated so it's quiet while real tokens flow, stopped when generation returns.
4. **`COLI_THINK`** (default off) — global thinking default when a request sends neither
   `reasoning_effort` nor `enable_thinking` (client value always wins).
5. **`COLI_DEBUG`** (default off) — echo decoded tokens to stderr (visibility when the client
   disconnects or for local debugging).

## Default-safe

- **No `tools` in the request ⇒ byte-identical to current behavior** — render and streaming take
  the exact existing path; all tool handling is gated on `tools` being present.
- `COLI_THINK`, `COLI_DEBUG`, and the salvage parser (below) are all **default-off**.

## Validation

- **Offline unit tests** (no model): strict parse is byte-exact (`read` →
  `{"filePath":"/x"}`); `render_chat` round-trips an assistant `tool_calls` message + a following
  `tool` message; a no-tools reply is unchanged (regression); the malformed variants map onto the
  primary param.
- **Live, on GLM-5.2 int4:** a clean call — `get_weather` → `{"city":"Paris"}`,
  `finish_reason:"tool_calls"`, 10 completion tokens.
- **Keepalive live:** streamed request shows `reasoning_content:"."` pings every ~10s through the
  prefill, then the `tool_calls` delta and `[DONE]`.

## Candid caveat (int4 formatting) — and the opt-in salvage

On the int4 quant, GLM-5.2's tool-call formatting is **variable**: sometimes a clean call,
sometimes it fumbles the `<arg_key>/<arg_value>` structure (e.g. smears the key name into the
value) or emits an extra hallucinated call. This is a **model/quantization trait, not the parser**
— the strict path is byte-exact on well-formed output, and higher-precision weights format
cleanly. An **opt-in** best-effort recovery, `COLI_TOOL_SALVAGE=1` (default off), reconstructs a
malformed call by mapping its lone payload onto the tool's primary parameter; it never rewrites
well-formed output and is **recommended for int4 deployments** as a robustness net (it turns
"unusable — model name is a garbled blob" into "structurally valid, occasionally wrong value"). A
`[api] tool-calls: N total, S strict, D de-mangled` line reports which path each turn took.

## Notes

- Marker/format authority: GLM-5.2 `chat_template.jinja` (`zai-org/GLM-5.2-FP8`).
- The five commits are independent and cleanly separable — happy to split into multiple PRs
  (e.g. tool-calling vs. keepalive vs. the two env toggles) if you prefer.
- Deliberately **not** bundled: KV persistence and SSE `Connection: close` (already upstream),
  and any engine changes (this is server-only).
