### PR TITLE
Makefile: fix Linux build on PowerPC (ppc64le), validated on POWER8

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -33,6 +33,18 @@ CFLAGS  = -D_FILE_OFFSET_BITS=64 -O3 -march=$(ARCH) -fopenmp -Wall -Wextra -Wno-
 LDFLAGS = -lm -fopenmp -static
 EXE     = .exe
 else
+UNAME_M := $(shell uname -m)
+ifneq (,$(filter ppc64le ppc64,$(UNAME_M)))
+# --- Linux PowerPC (POWER8/POWER9/POWER10) ---
+# PowerPC GCC uses -mcpu, not -march. ARCH=native works on gcc >= 4.7.
+# The AVX2/NEON kernels fall back to the portable scalar C path
+# (validated token-exact vs the transformers oracle on a POWER8 S824).
+CC      = gcc
+ARCH   ?= native
+CFLAGS  = -O3 -mcpu=$(ARCH) -fopenmp -Wall -Wextra -Wno-unused-parameter -Wno-misleading-indentation -Wno-unused-function
+LDFLAGS = -lm -fopenmp
+EXE     =
+else
 # --- Linux x86-64 (percorso originale, invariato) ---
 CC      = gcc
 # ARCH=native -> ottimizzato per QUESTA macchina (default, piu' veloce).
@@ -42,6 +54,7 @@ ARCH   ?= native
 CFLAGS  = -O3 -march=$(ARCH) -fopenmp -Wall -Wextra -Wno-unused-parameter -Wno-misleading-indentation -Wno-unused-function
 LDFLAGS = -lm -fopenmp
 EXE     =
+endif
 endif
 
 # CUDA=1 adds an opt-in backend for resident tensors. The default build remains


### PR DESCRIPTION
The Linux branch of the Makefile hardcodes -march=$(ARCH), which PowerPC GCC rejects (PowerPC targets use -mcpu). This adds a uname -m check so ppc64le/ppc64 builds get -mcpu=$(ARCH) instead. The x86-64 path is unchanged, ARCH=native stays the default and works on PowerPC gcc too.

Tested on an IBM POWER8 S824 (dual 8-core, 128 threads, 512GB RAM, Ubuntu 20.04 ppc64le, gcc 9.4.0):

- `make glm` builds clean with default flags (one pre-existing snprintf truncation warning in expert_load, harmless)
- `make test-c`: all 4 suites pass (json, safetensors, tier, grammar)
- Token-exact validation with the tiny oracle from tools/make_glm_oracle.py. I generated the oracle with HF transformers on an x86 machine and copied the snapshot plus ref_glm.json over, so this also checks cross-architecture reproducibility:
  - teacher forcing: 32/32 positions
  - greedy generation: 20/20 tokens
- Banner reports `idot: scalar`, so all 8 AVX2 guarded blocks fall through to the portable C path correctly. No endianness surprises since ppc64le is little endian like the safetensors container.

The scalar path is correct but slow, so the natural follow-up is VSX kernels: vec_msum is close to a drop-in for the AVX2 maddubs int8 dot, and the int4 unpack maps to vec_perm. I plan to send that as a separate PR once the full int4 container finishes downloading here. This box has 512GB RAM, so the whole 370GB container fits in page cache, which makes it a good testbed for the warm-cache limit of the streaming design.