### PR TITLE
VSX integer-dot kernels for POWER8: 12.8x int8, 7.6x int4 over scalar

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -66,7 +66,7 @@ CUDA_ARCH ?= native
 NVCCFLAGS ?= -O3 -std=c++17 -arch=$(CUDA_ARCH) -Xcompiler=-Wall,-Wextra
 PYTHON    ?= python3
 CUDA_OBJ  =
-TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE)
+TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_idot$(EXE)
 ifeq ($(CUDA),1)
 ifeq ($(UNAME_S),Darwin)
 $(error CUDA=1 is supported only on Linux)
@@ -117,6 +117,9 @@ tests/test_tier$(EXE): tests/test_tier.c tier.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_grammar$(EXE): tests/test_grammar.c grammar.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+tests/test_idot$(EXE): tests/test_idot.c glm.c st.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 test-c: $(TEST_BINS)

--- a/c/Makefile
+++ b/c/Makefile
@@ -33,6 +33,18 @@ CFLAGS  = -D_FILE_OFFSET_BITS=64 -O3 -march=$(ARCH) -fopenmp -Wall -Wextra -Wno-
 LDFLAGS = -lm -fopenmp -static
 EXE     = .exe
 else
+UNAME_M := $(shell uname -m)
+ifneq (,$(filter ppc64le ppc64,$(UNAME_M)))
+# --- Linux PowerPC (POWER8/POWER9/POWER10) ---
+# PowerPC GCC uses -mcpu, not -march. ARCH=native works on gcc >= 4.7.
+# The AVX2/NEON kernels fall back to the portable scalar C path
+# (validated token-exact vs the transformers oracle on a POWER8 S824).
+CC      = gcc
+ARCH   ?= native
+CFLAGS  = -O3 -mcpu=$(ARCH) -fopenmp -Wall -Wextra -Wno-unused-parameter -Wno-misleading-indentation -Wno-unused-function
+LDFLAGS = -lm -fopenmp
+EXE     =
+else
 # --- Linux x86-64 (percorso originale, invariato) ---
 CC      = gcc
 # ARCH=native -> ottimizzato per QUESTA macchina (default, piu' veloce).
@@ -42,6 +54,7 @@ ARCH   ?= native
 CFLAGS  = -O3 -march=$(ARCH) -fopenmp -Wall -Wextra -Wno-unused-parameter -Wno-misleading-indentation -Wno-unused-function
 LDFLAGS = -lm -fopenmp
 EXE     =
+endif
 endif
 
 # CUDA=1 adds an opt-in backend for resident tensors. The default build remains

--- a/c/glm.c
+++ b/c/glm.c
@@ -48,6 +48,11 @@ static inline float hsum256(__m256 v){            /* somma orizzontale di 8 floa
 }
 #elif defined(__ARM_NEON)
 #include <arm_neon.h>                             /* Apple Silicon / aarch64: kernel NEON */
+#elif defined(__VSX__)
+#include <altivec.h>                              /* POWER8+ (ppc64le): kernel VSX */
+#undef vector                                     /* igiene: si usano __vector/__bool espliciti */
+#undef pixel
+#undef bool
 #endif
 #ifdef __APPLE__
 #include <mach/mach.h>                            /* host_statistics64: MemAvailable di macOS */
@@ -308,6 +313,8 @@ static void matmul_i2(float *y, const float *x, const uint8_t *q2, const float *
 #define IDOT_KERNEL "avx2"
 #elif defined(__ARM_NEON)
 #define IDOT_KERNEL "neon"
+#elif defined(__VSX__)
+#define IDOT_KERNEL "vsx"
 #else
 #define IDOT_KERNEL "scalar"
 #endif
@@ -316,6 +323,11 @@ static int g_idot=1;
 static int g_i4s=1;   /* SDOT presente: int4 IDOT conviene anche a S=1 (decode). Misurato
                        * su Apple M-series: +14%%, expert-matmul -16%%. EN: with SDOT, int4
                        * IDOT pays even at S=1 (decode); measured on Apple M-series. */
+#elif defined(__VSX__)
+static int g_i4s=1;   /* POWER8 vec_msum: qui il fallback f32 e' SCALARE, quindi l'IDOT
+                       * int4 conviene anche a S=1. Misurato su POWER8 S824 (vedi PR).
+                       * EN: on VSX the f32 fallback is plain scalar C, so int4 IDOT
+                       * pays even at S=1. Measured on a POWER8 S824 (see PR). */
 #else
 static int g_i4s=2;   /* senza SDOT / altrove: soglia originale (misura AVX2 dell'autore).
                        * EN: without SDOT / elsewhere: original threshold (author's AVX2). */
@@ -375,6 +387,25 @@ static inline int32_t dot_i8i8(const int8_t *w, const int8_t *x, int I){
 #endif
     }
     sum=vaddvq_s32(acc);
+#elif defined(__VSX__)
+    /* POWER8: vec_msum (s8 x u8 -> s32) somma i prodotti byte DIRETTAMENTE in lane
+     * s32, 16 byte/iter: il bound anti-saturazione a 16 bit di maddubs qui non serve.
+     * Stesso trucco del segno (|w| u8 per x*sign(w) s8), ma |w| via select+sub MODULO
+     * e non vec_abs: -128 deve diventare 128 u8, non saturare a 127.
+     * EN: vec_msum accumulates byte products straight into s32 lanes; |w| is built
+     * with a modulo subtract select instead of vec_abs so w=-128 wraps to 128 (u8)
+     * rather than saturating to 127. |x|<=127 from qrow_i8, so x negation is safe. */
+    __vector signed int acc=vec_splats(0);
+    const __vector signed char vz=vec_splats((signed char)0);
+    for(;i+16<=I;i+=16){
+        __vector signed char wv=vec_xl(0,(const signed char*)(w+i));
+        __vector signed char xv=vec_xl(0,(const signed char*)(x+i));
+        __vector __bool char neg=vec_cmplt(wv,vz);
+        __vector signed char xs=vec_sel(xv,vec_sub(vz,xv),neg);
+        __vector unsigned char wa=(__vector unsigned char)vec_sel(wv,vec_sub(vz,wv),neg);
+        acc=vec_msum(xs,wa,acc);
+    }
+    sum=vec_extract(acc,0)+vec_extract(acc,1)+vec_extract(acc,2)+vec_extract(acc,3);
 #endif
     for(;i<I;i++) sum+=(int32_t)w[i]*x[i];
     return sum;
@@ -437,6 +468,31 @@ static inline int32_t dot_i4i8(const uint8_t *w4, const int8_t *x, int I){
 #endif
     }
     sum=vaddvq_s32(acc);
+#elif defined(__VSX__)
+    /* 16 byte = 32 nibble. vec_mergeh/vec_mergel su ppc64le (GCC) interallacciano come
+     * unpacklo/unpackhi x86 (verificato empiricamente su POWER8): i nibble escono in
+     * ordine di memoria. |w|<=8 dopo il -8, quindi stesso trucco del segno di dot_i8i8.
+     * EN: vec_mergeh/l on ppc64le interleave like x86 unpacklo/hi (verified on POWER8),
+     * so nibbles come out in memory order; then the same sign trick as dot_i8i8. */
+    const __vector unsigned char m4v=vec_splats((unsigned char)0x0F);
+    const __vector unsigned char sh4=vec_splats((unsigned char)4);
+    const __vector signed char b8v=vec_splats((signed char)8);
+    const __vector signed char vz=vec_splats((signed char)0);
+    __vector signed int acc=vec_splats(0);
+    for(;i+32<=I;i+=32){
+        __vector unsigned char by=vec_xl(0,w4+(i>>1));               /* 16 byte = 32 nibble */
+        __vector unsigned char lo=vec_and(by,m4v), hi=vec_sr(by,sh4);
+        __vector signed char w0=vec_sub((__vector signed char)vec_mergeh(lo,hi),b8v);
+        __vector signed char w1=vec_sub((__vector signed char)vec_mergel(lo,hi),b8v);
+        __vector signed char x0=vec_xl(0,(const signed char*)(x+i));
+        __vector signed char x1=vec_xl(0,(const signed char*)(x+i+16));
+        __vector __bool char n0=vec_cmplt(w0,vz), n1=vec_cmplt(w1,vz);
+        acc=vec_msum(vec_sel(x0,vec_sub(vz,x0),n0),
+                     (__vector unsigned char)vec_sel(w0,vec_sub(vz,w0),n0),acc);
+        acc=vec_msum(vec_sel(x1,vec_sub(vz,x1),n1),
+                     (__vector unsigned char)vec_sel(w1,vec_sub(vz,w1),n1),acc);
+    }
+    sum=vec_extract(acc,0)+vec_extract(acc,1)+vec_extract(acc,2)+vec_extract(acc,3);
 #endif
     for(;i+1<I;i+=2){ uint8_t b=w4[i>>1]; sum+=((int)(b&0xF)-8)*x[i]+((int)(b>>4)-8)*x[i+1]; }
     if(i<I){ uint8_t b=w4[i>>1]; sum+=((int)(b&0xF)-8)*x[i]; }

--- a/c/tests/test_idot.c
+++ b/c/tests/test_idot.c
@@ -1,0 +1,44 @@
+/* Exactness test for the integer-dot kernels: dot_i8i8 and dot_i4i8 must return
+ * EXACTLY the same value as a plain-C reference, whatever SIMD path was compiled
+ * in (avx512-vnni / avx2 / neon / vsx / scalar). Integer arithmetic has no
+ * rounding, so any mismatch is a kernel bug, not noise.
+ *
+ * Covers: odd sizes (scalar tail), sizes below one vector, the w=-128 edge
+ * (sign-trick kernels must treat |−128| as 128 unsigned, not saturate to 127),
+ * and random data at qrow_i8's contract (|x| <= 127, w full int8 range). */
+#define main coli_glm_main_unused
+#include "../glm.c"
+#undef main
+
+static uint32_t rng_state=0x12345678u;
+static uint32_t xr(void){ rng_state^=rng_state<<13; rng_state^=rng_state>>17; rng_state^=rng_state<<5; return rng_state; }
+
+static int32_t ref_i8i8(const int8_t *w, const int8_t *x, int I){
+    int64_t s=0; for(int i=0;i<I;i++) s+=(int32_t)w[i]*x[i]; return (int32_t)s;
+}
+static int32_t ref_i4i8(const uint8_t *w4, const int8_t *x, int I){
+    int64_t s=0;
+    for(int i=0;i<I;i++){ uint8_t b=w4[i>>1]; int v=(i&1)?((int)(b>>4)-8):((int)(b&0xF)-8); s+=v*x[i]; }
+    return (int32_t)s;
+}
+
+int main(void){
+    static const int sizes[]={1,2,15,16,17,31,32,33,63,64,65,100,127,128,1408,4096,4097};
+    static int8_t w[8192], x[8192]; static uint8_t w4[4096];
+    for(unsigned t=0;t<sizeof(sizes)/sizeof(sizes[0]);t++){
+        int I=sizes[t];
+        for(int rep=0;rep<64;rep++){
+            for(int i=0;i<I;i++) x[i]=(int8_t)((int)(xr()%255)-127);      /* [-127,127]: contratto di qrow_i8 */
+            for(int i=0;i<I;i++) w[i]=(int8_t)((int)(xr()%256)-128);      /* [-128,127]: range pieno */
+            if(rep==0) for(int i=0;i<I;i++) w[i]=-128;                    /* caso limite del trucco del segno */
+            if(rep==1) for(int i=0;i<I;i++){ w[i]=127; x[i]=(int8_t)(i&1?-127:127); }
+            for(int i=0;i<(I+1)/2;i++) w4[i]=(uint8_t)(xr()&0xFF);
+            int32_t got=dot_i8i8(w,x,I), want=ref_i8i8(w,x,I);
+            if(got!=want){ fprintf(stderr,"FAIL dot_i8i8 I=%d rep=%d: %d != %d\n",I,rep,got,want); return 1; }
+            got=dot_i4i8(w4,x,I); want=ref_i4i8(w4,x,I);
+            if(got!=want){ fprintf(stderr,"FAIL dot_i4i8 I=%d rep=%d: %d != %d\n",I,rep,got,want); return 1; }
+        }
+    }
+    printf("idot kernel exactness (%s): ok\n", IDOT_KERNEL);
+    return 0;
+}


### PR DESCRIPTION
Follow-up to #97 (this branch includes that Makefile commit and will rebase clean once it merges). This adds a VSX path to the two hot idot kernels, dot_i8i8 and dot_i4i8, plus an exactness test that covers every SIMD backend.

Measured on an IBM POWER8 S824 (dual 8-core, gcc 9.4.0, Ubuntu 20.04 ppc64le), single thread, 1536x6144 expert-like shape:

| kernel | scalar | vsx | speedup |
|---|---|---|---|
| dot_i8i8 | 1.48 Gops/s | 18.99 Gops/s | 12.8x |
| dot_i4i8 | 2.33 Gops/s | 17.72 Gops/s | 7.6x |
| S=1 int4 matmul path (full dispatch incl. qrow_i8) | 3.925 ms/call | 0.505 ms/call | 7.8x |

Implementation notes:

- vec_msum multiplies 16 byte pairs and sums groups of 4 directly into s32 lanes, so there is no 16-bit intermediate and the maddubs saturation bound does not apply on this path. Same sign trick as AVX2: abs(w) as u8 times x*sign(w) as s8.
- abs(w) is built with a modulo-subtract select rather than vec_abs. Depending on how the compiler lowers vec_abs, w=-128 can saturate to 127, which would silently corrupt weights at the quantization edge. The select wraps -128 to 128 as unsigned, matching what _mm256_sign_epi8(wv,wv) does on x86.
- Nibble unpack for int4 uses vec_mergeh/vec_mergel, which on ppc64le with GCC interleave exactly like x86 unpacklo/unpackhi (verified empirically on the hardware, not assumed from the ISA docs).
- g_i4s=1 on VSX: unlike AVX2, the f32 fallback on PowerPC is plain scalar C, so int4 IDOT pays even at S=1 (measured 5.5x within the VSX build). Same reasoning as the ARM SDOT case from PR #9.
- The f32 dequant kernels (matmul_q / matmul_i4 / matmul_i2) intentionally stay scalar on PowerPC: with g_i4s=1 they are only reached with IDOT=0, which is the exact A/B debug path.

Testing:

- New tests/test_idot.c compiles the engine and checks dot_i8i8 / dot_i4i8 exactness against a plain-C reference: odd sizes for the scalar tail, sub-vector sizes, w=-128 everywhere, and 64 random reps per size. Integer kernels have no rounding, so equality is exact. Passes on avx512-vnni (x86) and vsx (POWER8); it is wired into make test-c so it also covers avx2 and neon wherever those build.
- Tiny oracle on the POWER8 VSX build stays token-exact: teacher forcing 32/32, greedy 20/20.
- All pre-existing C test suites still pass on both x86 and POWER8.