### PR TITLE
attention: heap per-thread score buffers — fix segfault past 8192 context without DSA

### DIFF
--- a/c/glm.c
+++ b/c/glm.c
@@ -35,8 +35,13 @@
 #include "tok.h"
 #include "tier.h"
 #include "grammar.h"                              /* metodo F: draft grammaticali (#48) */
+#ifdef _OPENMP
+#include <omp.h>                                  /* scratch per-thread nell'attention */
+#else
+static inline int omp_get_max_threads(void){ return 1; }
+static inline int omp_get_thread_num(void){ return 0; }
+#endif
 #ifdef COLI_CUDA
-#include <omp.h>
 #include "backend_cuda.h"
 #endif
 #ifdef __AVX2__
@@ -1290,6 +1295,12 @@ static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_ba
     int absorb = g_absorb==1 || (g_absorb<0 && S<=4);
     if(absorb && c->kv_lora<=512){
         int kvl=c->kv_lora, r0v=c->qk_nope;      /* offset righe V dentro il blocco di testa */
+        /* punteggi per-thread sul HEAP: un sc[8192] fisso sullo stack va in overflow quando
+         * il layer attende su tutto il contesto (nessuna selezione DSA: snapshot senza
+         * indexer, o layer MTP) e nt supera 8192 — scrittura oltre lo stack del worker
+         * OMP => segfault (e poco sotto il limite: corruzione SILENZIOSA dello stack). */
+        int64_t sc_cap = Tk - m->kv_start[layer]; /* nt massimo (kv_start=-1 del MTP: +1, ok) */
+        float *sc_all = falloc((int64_t)omp_get_max_threads()*sc_cap);
         #pragma omp parallel for collapse(2) schedule(static)
         for(int s=0;s<S;s++) for(int h=0;h<H;h++){
             int pos=pos_base+s;
@@ -1298,7 +1309,7 @@ static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_ba
             int rbase=h*(c->qk_nope+vh);
             float qabs[512]; memset(qabs,0,kvl*sizeof(float));
             for(int d=0;d<c->qk_nope;d++) qt_addrow(&l->kv_b, rbase+d, qp[d], qabs);
-            float sc[8192];
+            float *sc = sc_all + (int64_t)omp_get_thread_num()*sc_cap;
             int st0=m->kv_start[layer];
             int ns = (dnsel && dnsel[s]>0) ? dnsel[s] : 0;    /* DSA: lista top-k o range pieno */
             const int *tlist = ns ? dsel+(int64_t)s*dtopk : NULL;
@@ -1318,7 +1329,7 @@ static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_ba
             qt_matvec_rows(&l->kv_b, rbase+r0v, vh, clat, ctx+((int64_t)s*H+h)*vh);
         }
         matmul_qt(out, ctx, &l->o, S);
-        free(ctx); free(Q); free(QR); free(comp);
+        free(ctx); free(Q); free(QR); free(comp); free(sc_all);
         m->t_attn += now_s()-ta0;
         return;
     }
@@ -1328,13 +1339,16 @@ static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_ba
     float *kvb_all=falloc((int64_t)Tk*kvb_dim);
     matmul_qt(kvb_all+(int64_t)stL*kvb_dim, m->Lc[layer]+(int64_t)stL*c->kv_lora, &l->kv_b, Tk-stL);
     m->t_kvb += now_s()-tk0;
-    /* 3) attenzione causale: score = q_pass·k_nope + q_rot·k_rot */
+    /* 3) attenzione causale: score = q_pass·k_nope + q_rot·k_rot
+     * (punteggi sul heap, per-thread: vedi il commento nel ramo absorb) */
+    int64_t sc_cap = Tk - stL;
+    float *sc_all = falloc((int64_t)omp_get_max_threads()*sc_cap);
     #pragma omp parallel for collapse(2) schedule(static)
     for(int s=0;s<S;s++) for(int h=0;h<H;h++){
         int pos=pos_base+s;
         const float *qp=Q+(int64_t)s*H*qh+(int64_t)h*qh;          /* [qk_nope | qk_rope] */
         const float *qr=qp+c->qk_nope;
-        float sc[8192];
+        float *sc = sc_all + (int64_t)omp_get_thread_num()*sc_cap;
         int st0=m->kv_start[layer];
         int ns = (dnsel && dnsel[s]>0) ? dnsel[s] : 0;        /* DSA: lista top-k o range pieno */
         const int *tlist = ns ? dsel+(int64_t)s*dtopk : NULL;
@@ -1353,7 +1367,7 @@ static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_ba
             float a=sc[jj]; for(int d=0;d<vh;d++) cx[d]+=a*vv[d]; }
     }
     matmul_qt(out, ctx, &l->o, S);
-    free(ctx); free(Q); free(QR); free(comp); free(kvb_all);
+    free(ctx); free(Q); free(QR); free(comp); free(kvb_all); free(sc_all);
     m->t_attn += now_s()-ta0;
 }
 


### PR DESCRIPTION
## human note
pending human self-review, the bug is definitely real

## Bug

Both attention score buffers are fixed stack arrays, `float sc[8192]` (absorb
path and dense path). The score count `nt` is only bounded by `index_topk`
(2048) when DSA selection covers the layer. When it does not — snapshot
converted **without** `--indexer` (`has_dsa=0`), `DSA=0`, or the MTP layer —
`nt = pos+1-kv_start`, i.e. the full context width.

So on a non-indexer snapshot, any request whose context passes ~8192 tokens
writes past the end of `sc[]` on every OpenMP worker's stack:

- positions ~8192–9400: **silent stack corruption** (no fault, wrong results
  possible);
- beyond that: segfault when the writes reach the thread-stack guard page.

Observed in production on a Framework Desktop (Ryzen AI Max+ 395), int4
snapshot without indexer weights, 14.7k-token prompt at `--ctx 32768`: engine
segfaulted seconds after `[prefill] layer 1/78`, kernel log showing three OMP
workers faulting simultaneously in `attention._omp_fn.2` on the
`sc[jj]=a*c->attn_scale` store (fault address = score index ~9400).

## Fix

Allocate the score scratch once per attention call on the heap, sized
`omp_get_max_threads() × (Tk - kv_start)` (the true `nt` upper bound for both
the dense range and the DSA top-k list), and give each worker its slice via
`omp_get_thread_num()`. Non-OpenMP builds get inline fallbacks (1 thread /
id 0), keeping the dependency-free CPU path intact.

Cost: one `falloc` per attention call — e.g. 32 threads × 14.7k tokens ≈ 1.9 MB,
freed on exit; no change to the inner loops.

## Validation

- `make check`: portable build (0 warnings), C unit tests, 38 Python tests pass.
- Build without `-fopenmp` compiles (fallback path).
- Real snapshot (GLM-5.2 int4, no indexer, `KVSAVE=0 CTX=10240 DRAFT=0`),
  same binary flags, two-turn session per binary:
  - short greedy turn: **old and fixed binaries emit identical tokens**
    (`' they came into the harbor. He counted 18 ships at'` — no numeric
    change);
  - 10,232-token prompt: **old binary segfaults (rc=-11) during
    `[prefill] layer 1/78`** (reproduces the production crash); **fixed
    binary prefills layers 1–9+ cleanly** (~78 s/layer, expert-streaming
    disk bound; killed after layer 9 as the attention code under test had
    long since passed the old crash point).

Hardware: Framework Desktop (Ryzen AI Max+ 395, 128 GB), avx512-vnni build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
