### PR TITLE
fix: heap-buffer-overflow in serve mode — coli serve dies on the first request (ASan-confirmed)

### DIFF
--- a/c/glm.c
+++ b/c/glm.c
@@ -1581,9 +1581,20 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
     if(absorb && c->kv_lora<=512){
         m->t_aproj+=now_s()-ta0; double tac=now_s();
         int kvl=c->kv_lora, r0v=c->qk_nope;      /* offset righe V dentro il blocco di testa */
-        /* punteggi per-thread sul HEAP (vedi dev): cap Tk+1 copre anche il kv_start
-         * per-slot del percorso kvs (MTP: kv_start=-1 -> nt=Tk+1). */
-        int64_t sc_cap = (int64_t)Tk+1;
+        /* Punteggi per-thread sul HEAP. Il cap DEVE essere il massimo nt effettivo del
+         * batch, non Tk+1: Tk=pos_base+S vale solo quando pos==pos_base+s. Il percorso
+         * batched (step_decode_batch da run_serve_mux) passa positions[] e kv_start
+         * per-slot, quindi nt=pos+1-st0 puo' superare Tk+1 -> heap-buffer-overflow su
+         * sc[jj]. Si conta esattamente come il loop sotto. */
+        int64_t sc_cap = 1;
+        for(int s=0;s<S;s++){
+            KVState *ks=kvs?kvs[s]:m->kv;
+            int pos=positions?positions[s]:pos_base+s;
+            int st0=ks->kv_start[layer];
+            int ns=(dnsel && dnsel[s]>0)?dnsel[s]:0;      /* DSA: top-k, altrimenti range pieno */
+            int64_t nt = ns ? (int64_t)ns : (int64_t)pos+1-st0;
+            if(nt>sc_cap) sc_cap=nt;
+        }
         float *sc_all = falloc((int64_t)omp_get_max_threads()*sc_cap);
         int cuda_core=0;
 #ifdef COLI_CUDA


### PR DESCRIPTION
## `coli serve` is currently broken on the real model — every request kills the engine

On current `main`/`dev`, the **first** `/v1/chat/completions` request against the real GLM-5.2 model corrupts the heap and takes the engine down:

```
[api] 127.0.0.1 - request failed: colibri engine exited unexpectedly
[api] 127.0.0.1 - "POST /v1/chat/completions HTTP/1.1" 500 -
```
```
free(): corrupted unsorted chunks          # glibc abort
glm: exe: potentially unexpected fatal signal 11   # or SIGSEGV, depending where it lands
```

`coli run` / `coli chat` are **unaffected** — which is the clue.

## Root cause: score buffer sized by `Tk`, written by per-slot `positions[]`

`attention_rows` sizes the per-thread score buffer from `Tk`:

```c
int kvb_dim=H*(c->qk_nope+vh), Tk=pos_base+S;      // glm.c:1418
int64_t sc_cap = (int64_t)Tk+1;
float *sc_all = falloc(omp_get_max_threads()*sc_cap);
```

but the loop that writes into it bounds by the **per-slot** position and `kv_start`:

```c
int pos = positions ? positions[s] : pos_base+s;
int st0 = ks->kv_start[layer];
int nt  = ns ? ns : pos+1-st0;
for(int jj=0; jj<nt; jj++) sc[jj] = ...;           // writes nt floats into a Tk+1 buffer
```

`Tk = pos_base+S` is a valid bound **only** when `pos == pos_base+s`. The batched decode path (`step_decode_batch`, reached from `run_serve_mux`) passes an explicit `positions[]` array and per-slot `kv_start`, so `nt` has no relation to `pos_base+S` and can exceed `sc_cap`. That is exactly why only **serve** is affected: `run`/`chat` never pass `positions[]`.

## AddressSanitizer (before)

```
ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 4 at 0x50c00002e080 thread T15
    #0 attention_rows._omp_fn.1   c/glm.c:1574

0x50c00002e080 is located 0 bytes after 128-byte region
allocated by thread T0 here:
    #0 falloc               c/glm.c:239
    #1 attention_rows       c/glm.c:1537
    #2 layer_forward_rows   c/glm.c:2172
    #3 layers_forward_rows  c/glm.c:2197
    #4 step_decode_batch    c/glm.c:2297
    #5 run_serve_mux        c/glm.c:3049
```

## Fix

Compute `sc_cap` as the largest `nt` actually reachable in this batch, counted **exactly the way the write loop counts it** — per-slot `positions[]`, per-slot `kv_start`, and the DSA top-k selection when active. On the non-batched paths the new cap reduces to the old `Tk+1`, so there is no behavioural change there.

## Verification (real 744B model)

Ryzen 7 9800X3D · RTX 5090 · 384 GB int4 container · WSL2:

| | before | after |
|---|---|---|
| `POST /v1/chat/completions` | engine dies, HTTP 500 | completes normally |
| AddressSanitizer | heap-buffer-overflow | **0 errors** |
| tool calling end-to-end | never reached | works (`finish_reason: tool_calls`) |
| oracle `SNAP=./glm_tiny TF=1 ./glm 64 16 16` | 32/32 | **32/32** |
| `make check` | pass | **pass**, 0 build warnings |

Standalone reproducer (no HTTP): drive `./glm` with `SERVE=1` and one `SUBMIT` line — it corrupts the heap on the first request with `SERVE_BATCH` either `0` or `1`.

Two OpenAI tool-calling spec bugs turned up while testing this (string-typed args coerced to ints; `tool_choice` ignored entirely) — I'll send those as a separate PR against `openai_server.py`, since they're independent of this crash.