### PR TITLE
fix: 8k-token stack overflow in MLA attention (fixed sc[8192] score buffer)

### DIFF
--- a/c/glm.c
+++ b/c/glm.c
@@ -472,6 +472,22 @@ static void quant_scratch(size_t xn, size_t sn, int8_t **xq, float **sx){
     *xq=g_qscratch.xq; *sx=g_qscratch.sx;
 }
 
+/* Per-thread attention score scratch (mirrors g_qscratch). Holds one score per
+ * attended key; nt reaches the full context on layers without DSA selection, so
+ * a fixed sc[8192] stack array smashed the stack past ~8k tokens. A thread-local
+ * buffer that grows only when a longer context needs it avoids both that overflow
+ * and a malloc/free per (s,h) in the parallel attention loops. */
+static _Thread_local float *g_scscratch=NULL; static _Thread_local size_t g_scscratch_cap=0;
+static float *score_scratch(int nt){
+    size_t n = nt>0 ? (size_t)nt : 1;
+    if(n>g_scscratch_cap){
+        float *p=realloc(g_scscratch,n*sizeof(float));
+        if(!p){ fprintf(stderr,"OOM attention scores\n"); exit(1); }
+        g_scscratch=p; g_scscratch_cap=n;
+    }
+    return g_scscratch;
+}
+
 static void matmul_qt(float *y, const float *x, QT *w, int S){
 #ifdef COLI_CUDA
     /* The CUDA backend owns persistent copies only for model-resident tensors.
@@ -1203,11 +1219,11 @@ static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_ba
             int rbase=h*(c->qk_nope+vh);
             float qabs[512]; memset(qabs,0,kvl*sizeof(float));
             for(int d=0;d<c->qk_nope;d++) qt_addrow(&l->kv_b, rbase+d, qp[d], qabs);
-            float sc[8192];
             int st0=m->kv_start[layer];
             int ns = (dnsel && dnsel[s]>0) ? dnsel[s] : 0;    /* DSA: lista top-k o range pieno */
             const int *tlist = ns ? dsel+(int64_t)s*dtopk : NULL;
             int nt = ns ? ns : pos+1-st0;
+            float *sc = score_scratch(nt);   /* per-thread reused scratch (see score_scratch) */
             for(int jj=0;jj<nt;jj++){ int t = tlist ? tlist[jj] : st0+jj;
                 const float *Lt=m->Lc[layer]+(int64_t)t*kvl;
                 const float *kr=m->Rc[layer]+(int64_t)t*c->qk_rope;
@@ -1239,11 +1255,11 @@ static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_ba
         int pos=pos_base+s;
         const float *qp=Q+(int64_t)s*H*qh+(int64_t)h*qh;          /* [qk_nope | qk_rope] */
         const float *qr=qp+c->qk_nope;
-        float sc[8192];
         int st0=m->kv_start[layer];
         int ns = (dnsel && dnsel[s]>0) ? dnsel[s] : 0;        /* DSA: lista top-k o range pieno */
         const int *tlist = ns ? dsel+(int64_t)s*dtopk : NULL;
         int nt = ns ? ns : pos+1-st0;
+        float *sc = score_scratch(nt);   /* per-thread reused scratch (see score_scratch) */
         for(int jj=0;jj<nt;jj++){ int t = tlist ? tlist[jj] : st0+jj;
             const float *kn=kvb_all+(int64_t)t*kvb_dim+(int64_t)h*(c->qk_nope+vh);
             const float *kr=m->Rc[layer]+(int64_t)t*c->qk_rope;


### PR DESCRIPTION
## The bug

The MLA attention path holds one score per attended key in a fixed-size `float sc[8192]` on the stack (both the absorb/decode loop and the dense/prefill loop). On layers that run DSA sparse selection, `nt` is capped at `index_topk` (~2048), so it fits. But on layers **without** selection — the `first_k_dense_replace` dense layers, or any run with the indexer off — `nt` is the full context length. Prefill a prompt longer than **~8192 tokens** and the score loop writes past `sc[8192]` and smashes the stack.

## Reproduction

On GLM-5.2, any prompt over ~8k tokens crashes at `prefill layer 1` (a dense layer). Captured on a POWER8 build: a SIGSEGV with the fault address in the stack region and a float-store faulting instruction — textbook stack overflow. A 2,827-token prompt worked; a 12,334-token prompt died ~40s in, every time.

Raising the stack limit only *hides* it: the out-of-bounds writes still clobber adjacent stack state, so a longer prompt would produce silently wrong output rather than crash. The buffer has to leave the stack.

## The fix

Heap-size the score buffer to `nt` in both attention loops. No behavioral change on prompts that already fit — the computation is identical, the buffer is just correctly sized.

## Validation

- Token-exact after the change: teacher-forcing 32/32 and greedy 20/20 vs the transformers oracle.
- The 12,334-token prompt that reliably segfaulted at ~40s now runs 18+ minutes past that point with no crash.

Arch-independent: reproduced on a POWER build, but the fixed stack array overflows the same way on x86 at the same context length.