### PR TITLE
coli: honor --gpu/--vram without --auto-tier (fixes the silent CPU fallback, #121)

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -156,6 +156,23 @@ def env_for(a):
         rt=plan["tiers"]["ram"]; vt=plan["tiers"]["vram"]
         gpu=f" · VRAM {format_bytes(vt['budget_bytes'])}" if has_cuda and vt["devices"] else " · CPU"
         print(f"  {C.dim}[PLAN] RAM {format_bytes(rt['budget_bytes'])} · cap {rt['cache_slots_per_layer']}/layer{gpu}{C.r}",file=sys.stderr)
+    else:
+        # --gpu/--vram SENZA --auto-tier: prima venivano ignorati in silenzio e il run
+        # partiva CPU-only senza alcun avviso — benchmark "GPU" pubblicati per errore (#121).
+        if a.gpu is not None:
+            e.pop("COLI_GPU",None); e.pop("COLI_GPUS",None)
+            if a.gpu=="none":
+                e["COLI_CUDA"]="0"; e.pop("CUDA_EXPERT_GB",None); e.pop("CUDA_DENSE",None)
+            else:
+                if not cuda_binary():
+                    sys.exit(f"{C.yel}--gpu needs the CUDA build:{C.r} make glm CUDA=1 (this binary is CPU-only)")
+                e["COLI_CUDA"]="1"
+                if a.gpu!="auto": e["COLI_GPUS"]=a.gpu
+                e.setdefault("CUDA_DENSE","1")
+        if a.vram and a.gpu!="none":
+            if not cuda_binary():
+                sys.exit(f"{C.yel}--vram needs the CUDA build:{C.r} make glm CUDA=1 (this binary is CPU-only)")
+            e["COLI_CUDA"]="1"; e["CUDA_EXPERT_GB"]=str(a.vram)
     return e
 
 # ---------- rendering markdown in STREAMING per il terminale ----------


### PR DESCRIPTION
Fixes the bug half of #121.

`env_for()` only mapped `--gpu`/`--vram` to engine env inside the `--auto-tier` branch, so the standalone form started a **CPU-only engine with no warning** — @ebootheee caught it only by noticing zero `[CUDA]` lines and reading the wrapper source, after nearly publishing a CPU run as a GPU benchmark. This class of silent fallback is also what #82 spent a day digging out of.

Now, without `--auto-tier`:
- `--gpu none` → CUDA off (and clears `CUDA_EXPERT_GB`/`CUDA_DENSE`)
- `--gpu 0,1` / `--gpu auto` → `COLI_CUDA=1` (explicit list sets `COLI_GPUS`; `CUDA_DENSE` defaulted on)
- `--vram N` → `CUDA_EXPERT_GB=N`
- both **fail fast with a clear message on a CPU-only binary** (`ldd` check) instead of quietly falling back — wrong-but-loud beats plausible-but-silent for benchmark hygiene.

`--auto-tier` behavior is unchanged. Python test suite green. The README doc requests in #121 (MTP-on-disk caveat, `DIRECT=1` note) are left for a docs pass — they're measurement claims that deserve their own review.