### PR TITLE
Makefile: detect Windows from $(OS) so make works from native PowerShell/CMD

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1,7 +1,18 @@
-UNAME_S := $(shell uname -s)
-MINGW    := $(findstring MINGW,$(UNAME_S))
-MSYS     := $(findstring MSYS,$(UNAME_S))
-IS_WIN   := $(MINGW)$(MSYS)
+# --- OS detection ---
+# On Windows the OS env var is 'Windows_NT' in EVERY shell (cmd, PowerShell,
+# MSYS2, Git-Bash), and GNU Make imports it. Detect Windows from it FIRST so
+# `make` works from a native PowerShell/CMD shell — there `uname` is not on
+# PATH, so the old uname-only check returned empty and fell through to the
+# Linux branch (no .exe, no -static). We only call `uname` when NOT on Windows.
+ifeq ($(OS),Windows_NT)
+IS_WIN   := 1
+UNAME_S  :=
+UNAME_M  :=
+else
+IS_WIN   :=
+UNAME_S  := $(shell uname -s)
+UNAME_M  := $(shell uname -m)
+endif
 
 ifeq ($(UNAME_S),Darwin)
 # --- macOS / Apple Silicon ---


### PR DESCRIPTION
Follow-up to #113 (first native-Windows benchmark datapoint). Fixes the Makefile Windows-detection papercut noted there.

## Problem
`c/Makefile` gates the Windows branch on `uname -s` (matching `MINGW*`/`MSYS*`). But `uname` is not on `PATH` in a plain **PowerShell/CMD** shell, so `$(shell uname -s)` returns empty. The `Darwin` and `IS_WIN` checks then both fail and the build falls through to the **Linux branch**, producing an extensionless, non-static binary instead of a static `glm.exe`. Today the only native-shell workaround is compiling `glm.c` directly.

## Fix
Detect Windows from the **`OS` environment variable** instead. GNU Make imports it, and Windows sets it to `Windows_NT` in **every** shell — cmd, PowerShell, MSYS2, and Git-Bash. `uname` is now only invoked when *not* on Windows.

- Native PowerShell/CMD: `make` now takes the Windows branch → `-march=x86-64-v3 -static`, emits `glm.exe`.
- MSYS2 / Git-Bash: **unchanged** — they also see `OS=Windows_NT`, so they take the same Windows branch and emit the same binary as before.
- macOS / Linux / PowerPC branches: untouched (`uname -s`/`uname -m` still drive them).

## Verification
`mingw32-make glm` from a **native PowerShell** shell (no MSYS2, no Git-Bash) with WinLibs MinGW-w64 GCC 16.1.0:

```
gcc -D_FILE_OFFSET_BITS=64 -O3 -march=x86-64-v3 -fopenmp ... glm.c -o glm.exe -lm -fopenmp -static
```

Exit 0, `glm.exe` produced. Top-level `mingw32-make` delegation into `c/` also works from the native shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)