### PR TITLE
serve: fix Windows mux-loop busy-spin — winsock select() cannot poll stdin (#139)

### DIFF
--- a/c/glm.c
+++ b/c/glm.c
@@ -3142,10 +3142,20 @@ static void run_serve_mux(Model *m, const char *snap){
     int eof=0;
     for(;;){
         int active=0; for(int i=0;i<nctx;i++) active+=req[i].active;
+#ifndef _WIN32
         fd_set rfds; FD_ZERO(&rfds); FD_SET(STDIN_FILENO,&rfds);
         struct timeval tv={0,0}, *ptv=active?&tv:NULL;
         int ready=eof?0:select(STDIN_FILENO+1,&rfds,NULL,NULL,ptv);
         if(ready>0 && FD_ISSET(STDIN_FILENO,&rfds)) if(mux_submit(m,&T,ctx,req,nctx,maxctx,eos)<0) eof=1;
+#else
+        /* Native Windows: MinGW resolves select() to winsock, which needs WSAStartup and
+         * only accepts sockets — polling STDIN_FILENO returns SOCKET_ERROR every time, so
+         * the loop spins and no request is ever read (#139). Fall back to a BLOCKING
+         * submit whenever no slot is decoding: sequential serve, POSIX path untouched.
+         * (A WaitForSingleObject(GetStdHandle(STD_INPUT_HANDLE)) poll can restore
+         * submit-while-decoding later.) */
+        if(!eof && !active) if(mux_submit(m,&T,ctx,req,nctx,maxctx,eos)<0) eof=1;
+#endif
         active=0; for(int i=0;i<nctx;i++) active+=req[i].active;
         if(!active){ if(eof) break; continue; }
         DecodeRow rows[16]; int slots[16], S=0;


### PR DESCRIPTION
## Summary

Fixes #139. On native Windows the SERVE mux loop's `select(STDIN_FILENO+1, ...)` resolves to **winsock** `select()` — which needs `WSAStartup` and only accepts sockets — so polling fd 0 returns `SOCKET_ERROR` every iteration, `mux_submit` is never reached, and serve mode busy-spins forever after printing `READY`. #131 fixed the *compile* (guarded include); this fixes the *runtime*.

Smallest change: keep the POSIX poll byte-identical; on `_WIN32`, block in `mux_submit` whenever no slot is decoding (sequential serve). A `WaitForSingleObject(GetStdHandle(STD_INPUT_HANDLE))` poll can restore submit-while-decoding on Windows later without touching this structure.

## Validation

- [x] `make -C c check` — C suites 6/6 on MSYS2 UCRT64 (gcc 16.1, Core Ultra 9 285K); tiny oracle **TF 32/32 + greedy 20/20** on the patched binary
- [ ] CUDA changes — n/a
- [x] No performance claims

Note: 3 warnings exist on this toolchain **before** this diff (compat.h:187 `#pragma comment` under gcc, glm.c:1219 `-Wformat-truncation`) — pre-existing on `dev`, untouched here, happy to fix separately if wanted. Full runtime serve round-trip on Windows is still blocked by the in-tree fixture gap from #139 (glm_tiny ships no tokenizer.json) — verified instead: build, unit suites, oracle, and that the POSIX branch is preprocessor-identical to current dev.

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
