### PR TITLE
ci: make check on ubuntu / windows (MSYS2 UCRT64) / macos — and it already caught a Windows test bug (#140)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,49 @@
+# CI: run the repo's own dependency-free gate (`make check` = clean + portable
+# CPU build + C unit suites + Python stdlib tests) on the three claimed
+# platforms. No model downloads, no CUDA, no external deps — by design (#140).
+name: check
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: make check
+        run: make -C c check
+
+  windows:
+    # The job that would have caught #68/#137 pre-merge: native MinGW-w64
+    # (MSYS2/UCRT64), the exact toolchain the README's Windows port targets.
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: false
+          install: >-
+            make
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-python
+      - name: make check
+        run: make -C c check
+
+  macos:
+    # clang; libomp for the threaded path (Makefile falls back to
+    # single-threaded automatically if it's ever missing).
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: install libomp
+        run: brew install libomp
+      - name: make check
+        run: make -C c check


### PR DESCRIPTION
## Summary

Implements #140: a `check` workflow running the repo's own dependency-free gate (`make -C c check`) on **ubuntu-latest**, **windows-latest** (MSYS2/UCRT64 — the toolchain from #137, the job that would have caught #68 pre-merge), and **macos-latest** (clang + libomp), on every PR and push to `main`/`dev`. No CUDA, no Metal, no model downloads — v1 is exactly the gate CONTRIBUTING already requires, automated.

It caught its first bug before it was even filed as a PR: on native Windows, `make check` was **58/59** — `test_doctor.test_non_executable_engine_and_excessive_ram_budget_fail` asserts that `chmod(0o644)` makes the engine non-executable, but Windows has no executable bit, so `os.access(X_OK)` legitimately passes. Second commit guards that single POSIX-semantics assertion (the RAM-overbudget half still runs everywhere). With it, `make check` is fully green on all three platforms I can test (ubuntu via WSL2 gcc 15.2, native Windows MSYS2/UCRT64 gcc 16.1; macos job is standard clang + libomp per the Makefile's existing Darwin branch).

## Validation

- [x] `make -C c check` — green on native Windows (MSYS2 UCRT64) and Linux with these changes; 59 python tests OK, C suites 6/6
- [ ] CUDA changes — n/a
- [x] No performance claims

## Compatibility

- [x] The default CPU build remains dependency-free (workflow-only + one test guard)
- [x] No model files, generated binaries, or benchmark artifacts are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
