### PR TITLE
test(build): cover native Windows detection without uname

### DIFF
--- a/c/tests/test_makefile_platform.py
+++ b/c/tests/test_makefile_platform.py
@@ -1,0 +1,34 @@
+import os
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+C_DIR = Path(__file__).resolve().parents[1]
+MAKE = shutil.which("make")
+
+
+@unittest.skipUnless(MAKE, "make is required")
+class MakefilePlatformTests(unittest.TestCase):
+    def test_windows_nt_without_uname_selects_mingw_build(self):
+        env = os.environ.copy()
+        env["OS"] = "Windows_NT"
+        env["PATH"] = ""
+
+        result = subprocess.run(
+            [MAKE, "--no-print-directory", "-B", "-n", "glm"],
+            cwd=C_DIR,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+        self.assertIn("-o glm.exe", result.stdout)
+        self.assertIn("-fopenmp", result.stdout)
+        self.assertIn("-static", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add a regression test for the native Windows build detection introduced in #129.

The test simulates PowerShell/CMD by setting `OS=Windows_NT` and clearing `PATH`, so `uname` is unavailable. It dry-runs the `glm` build and verifies that the Makefile selects the MinGW output and flags: `glm.exe`, OpenMP, and static linking.

## Why

The original bug occurred because native Windows shells do not necessarily provide `uname`; the Makefile then fell through to its Linux branch. The fix is now on `dev`, but without a test a future platform-detection refactor could silently reintroduce the failure.

This test requires no compiler, model download, CUDA installation, or additional Python dependency.

## Validation

- [x] `python3 -m unittest c/tests/test_makefile_platform.py`
- [x] `make check OMPDIR=` — the portable build and all C tests pass with zero compiler warnings; the Python suite currently has one unrelated failure on upstream `dev`: `test_resource_plan.ResourcePlanTest.test_memory_available_is_positive` receives `0` from `memory_available()` on macOS. The new regression test passes within that suite.
- [ ] Token-exact oracle — not run; the `glm_tiny` fixture is not available locally and this PR changes tests only.

## Compatibility

- [x] The default dependency-free CPU build is unchanged.
- [x] No generated binaries, model files, CUDA code, or benchmark artifacts are included.
