### PR TITLE
coli: raise RLIMIT_NOFILE at startup — fixes "Too many open files" on macOS

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -22,6 +22,17 @@ Configuration through environment variables or flags (also valid after the subco
 """
 import os, sys, subprocess, argparse, json, time, signal, shutil, threading, re, codecs, tempfile, textwrap
 
+# The engine mmaps every shard (144+ files); macOS default RLIMIT_NOFILE is 256.
+if sys.platform != "win32":
+    try:
+        import resource
+        _soft, _hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        _want = min(65536 if _hard == resource.RLIM_INFINITY else _hard, 65536)
+        if _soft < _want:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (_want, _hard))
+    except (ImportError, ValueError, OSError):
+        pass
+
 # Windows: forza output UTF-8 (console cp1252 tronca Unicode box-drawing/emoji)
 if sys.platform == "win32":
     for s in (sys.stdout, sys.stderr):


### PR DESCRIPTION
## Problem

On macOS the default per-shell soft fd limit is **256**, but the engine opens/mmaps every safetensors shard (144+ files for GLM-5.2). Running from a stock Terminal:

```
[METAL] mode: batched routed experts on GPU (unified-memory zero-copy)
/Users/harvad/models/glm52_i4/out-00125.safetensors: Too many open files

the engine exited while loading
```

Every macOS user following the README quick start hits this unless they happen to run `ulimit -n` first — and it silently comes back in every new terminal tab.

## Fix

The `coli` launcher raises its own `RLIMIT_NOFILE` soft limit toward the hard limit (capped at 65536) before spawning the engine, via the stdlib `resource` module. Child processes inherit it. No-op on Windows (`resource` unavailable / not needed) and on shells whose limit is already sufficient; failures are swallowed so it can never make things worse.

## Tested

Apple M5 Max, macOS (Darwin 25.5.0), 128 GB, GLM-5.2 int4 (150-file model dir):

- before: load fails as above in a default shell (`ulimit -n` = 256)
- after, simulated worst case `zsh -c 'ulimit -n 256; ./coli run ...'`: `loaded in 7.17s | resident dense: 9912.75 MB | MTP ACTIVE (draft=3)` and generation completes
- `./coli chat` from a fresh stock terminal now works with no manual ulimit

🤖 Generated with [Claude Code](https://claude.com/claude-code)