### PR TITLE
openai_server: COLI_DEBUG levels — 1 = output, 2 = both sides

### DIFF
--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -750,6 +750,16 @@ class APIHandler(BaseHTTPRequestHandler):
                 pass
 
     def generation(self, body, prompt, request_id, chat):
+        # COLI_DEBUG tees the engine transaction to stderr: 1 = decoded output stream only,
+        # 2 = both sides (rendered prompt + output). render_chat already folds prior turns and
+        # tool results into `prompt`, so level 2 is the full conversation the engine saw.
+        try:
+            dbg = int(os.environ.get("COLI_DEBUG", "0"))
+        except ValueError:
+            dbg = 0
+        if dbg >= 2:
+            sys.stderr.write(f"\n===== PROMPT [{request_id}] =====\n{prompt}\n===== OUTPUT [{request_id}] =====\n")
+            sys.stderr.flush()
         maximum, temperature, top_p = generation_options(body, self.server.max_tokens)
         tools = (body.get("tools") or body.get("functions") or None) if chat else None
         if body.get("tool_choice") == "none":
@@ -819,7 +829,7 @@ class APIHandler(BaseHTTPRequestHandler):
             last_write = [time.time()]
             ka_stop = threading.Event()
             KA_GAP = 10.0
-            dbg_echo = os.environ.get("COLI_DEBUG", "0") == "1"   # tee decoded tokens to stderr
+            dbg_echo = dbg >= 1   # tee decoded tokens to stderr (COLI_DEBUG level parsed in generation())
 
             def event(choices, usage_marker=False):
                 nonlocal connected


### PR DESCRIPTION
Extends the existing COLI_DEBUG stderr tee into backward-compatible verbosity levels:

- COLI_DEBUG=1 — decoded output stream only (unchanged from today).
- COLI_DEBUG=2 — both sides: the fully-rendered prompt the engine sees, then the output
  stream, correlated by request id. render_chat already folds prior turns + tool results
  into the prompt, so level 2 reads as the complete conversation — very useful for debugging
  OpenCode/agent sessions (what the model received vs. produced).

Backward-compatible: =1 keeps its exact meaning; parsing is int-based with a safe fallback
(unset/non-numeric => off), matching the prior "only literal 1 counted" behavior. Single-method
change; no new imports.