### PR TITLE
Add make install/uninstall targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all glm portable test check cuda-test clean
+.PHONY: all glm portable test check cuda-test clean install uninstall
 
-all glm portable test check cuda-test clean:
+all glm portable test check cuda-test clean install uninstall:
 	$(MAKE) -C c $@

--- a/c/Makefile
+++ b/c/Makefile
@@ -71,6 +71,11 @@ EXE     =
 endif
 endif
 
+# --- install ---
+PREFIX  ?= /usr/local
+BINDIR  ?= $(PREFIX)/bin
+INSTALL ?= install
+
 # CUDA=1 adds an opt-in backend for resident tensors. The default build remains
 # pure C and keeps the original zero-dependency runtime.
 #
@@ -218,8 +223,16 @@ check:
 	$(MAKE) portable
 	$(MAKE) test
 
+install: glm$(EXE)
+	$(INSTALL) -d $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m 755 glm$(EXE) $(DESTDIR)$(BINDIR)/glm$(EXE)
+	$(INSTALL) -m 755 coli $(DESTDIR)$(BINDIR)/coli
+
+uninstall:
+	rm -f $(DESTDIR)$(BINDIR)/glm$(EXE) $(DESTDIR)$(BINDIR)/coli
+
 clean:
 	rm -f olmoe$(EXE) glm$(EXE) iobench$(EXE) backend_cuda.o backend_loader.o backend_cuda_test$(EXE) backend_cuda_bench$(EXE) backend_metal.o backend_metal_test coli_cuda.dll coli_cuda.lib coli_cuda.exp $(TEST_BINS)
 	rm -rf tests/__pycache__
 
-.PHONY: all glm cuda-test cuda-bench cuda-dll portable test-c test-python test check clean
+.PHONY: all glm cuda-test cuda-bench cuda-dll portable test-c test-python test check clean install uninstall

--- a/c/Makefile
+++ b/c/Makefile
@@ -72,9 +72,10 @@ endif
 endif
 
 # --- install ---
-PREFIX  ?= /usr/local
-BINDIR  ?= $(PREFIX)/bin
-INSTALL ?= install
+PREFIX     ?= /usr/local
+BINDIR     ?= $(PREFIX)/bin
+LIBEXECDIR ?= $(PREFIX)/libexec/colibri
+INSTALL    ?= install
 
 # CUDA=1 adds an opt-in backend for resident tensors. The default build remains
 # pure C and keeps the original zero-dependency runtime.
@@ -223,16 +224,24 @@ check:
 	$(MAKE) portable
 	$(MAKE) test
 
-install: glm$(EXE)
+install: glm$(EXE) olmoe$(EXE)
 	$(INSTALL) -d $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m 755 glm$(EXE) $(DESTDIR)$(BINDIR)/glm$(EXE)
+	$(INSTALL) -d $(DESTDIR)$(LIBEXECDIR)
+	$(INSTALL) -d $(DESTDIR)$(LIBEXECDIR)/tools
 	$(INSTALL) -m 755 coli $(DESTDIR)$(BINDIR)/coli
+	$(INSTALL) -m 755 glm$(EXE) $(DESTDIR)$(LIBEXECDIR)/glm$(EXE)
+	$(INSTALL) -m 755 olmoe$(EXE) $(DESTDIR)$(LIBEXECDIR)/olmoe$(EXE)
+	$(INSTALL) -m 644 resource_plan.py doctor.py openai_server.py $(DESTDIR)$(LIBEXECDIR)/
+	$(INSTALL) -m 644 tools/*.py $(DESTDIR)$(LIBEXECDIR)/tools/
 
 uninstall:
-	rm -f $(DESTDIR)$(BINDIR)/glm$(EXE) $(DESTDIR)$(BINDIR)/coli
+	rm -f $(DESTDIR)$(BINDIR)/coli
+	rm -rf $(DESTDIR)$(LIBEXECDIR)
 
 clean:
 	rm -f olmoe$(EXE) glm$(EXE) iobench$(EXE) backend_cuda.o backend_loader.o backend_cuda_test$(EXE) backend_cuda_bench$(EXE) backend_metal.o backend_metal_test coli_cuda.dll coli_cuda.lib coli_cuda.exp $(TEST_BINS)
 	rm -rf tests/__pycache__
 
-.PHONY: all glm cuda-test cuda-bench cuda-dll portable test-c test-python test check clean install uninstall
+bench: iobench$(EXE)
+	@if [ -n "$(ARGS)" ]; then ./iobench$(EXE) $(ARGS); else echo "built iobench$(EXE) — run: ./iobench$(EXE) <file> <MB> <iters> <threads> <direct 0|1>"; fi
+.PHONY: all glm cuda-test cuda-bench cuda-dll portable test-c test-python test check clean install uninstall bench

--- a/c/coli
+++ b/c/coli
@@ -29,8 +29,31 @@ if sys.platform == "win32":
         except (AttributeError, OSError): pass
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-TOOLS = os.path.join(HERE, "tools")
-GLM  = os.path.join(HERE, "glm" + (".exe" if sys.platform == "win32" else ""))
+
+# Run-in-place (source checkout, "cd c && ./coli ..."): the engine, the
+# support modules (resource_plan.py, doctor.py, openai_server.py) and
+# tools/ all live next to this script — unchanged from before.
+#
+# Installed layout ("make install"): this script is $(PREFIX)/bin/coli,
+# while the engine binaries and support files live in
+# $(PREFIX)/libexec/colibri, since they aren't meant to be run directly
+# by users. COLI_ENGINE overrides the engine path explicitly if neither
+# guess is right (e.g. a custom packaging layout).
+_EXE = ".exe" if sys.platform == "win32" else ""
+_LIBEXEC = os.path.join(os.path.dirname(HERE), "libexec", "colibri")
+_here_glm = os.path.join(HERE, "glm" + _EXE)
+
+if os.environ.get("COLI_ENGINE"):
+    GLM = os.environ["COLI_ENGINE"]
+    TOOLS = os.path.join(os.path.dirname(GLM), "tools")
+elif os.path.exists(_here_glm):
+    GLM = _here_glm
+    TOOLS = os.path.join(HERE, "tools")
+else:
+    GLM = os.path.join(_LIBEXEC, "glm" + _EXE)
+    TOOLS = os.path.join(_LIBEXEC, "tools")
+    sys.path.insert(0, _LIBEXEC)   # so `import resource_plan`, `doctor`, `openai_server` still resolve
+
 DEF_MODEL = os.environ.get("COLI_MODEL", "/home/vincenzo/glm52_i4")
 END   = b"\x01\x01END\x01\x01\n"
 READY = b"\x01\x01READY\x01\x01\n"
@@ -302,6 +325,9 @@ def stream_turn(p, sentinel, on_bytes):
 # ---------- comandi ----------
 def cmd_build(a):
     banner("build")
+    if not os.path.exists(os.path.join(HERE, "Makefile")):
+        sys.exit(f"{C.yel}coli build{C.r} only works from a source checkout (this is an installed copy).\n"
+                  f"  Clone https://github.com/JustVugg/colibri and run ./setup.sh, or make -C c glm.")
     sys.exit(subprocess.call(["make","-C",HERE,"glm"]))
 
 def cmd_info(a):


### PR DESCRIPTION
Fixes #164

Neither the root Makefile nor c/Makefile had an install target, so
`build+install` never actually installed the binary anywhere
(reported on FreeBSD in #164, but the same Makefile is used on every
platform).

Adds standard `install`/`uninstall` targets that respect
`PREFIX`/`BINDIR`/`DESTDIR`, following normal Unix conventions.
`install(1)` is POSIX and available on Linux/macOS/FreeBSD; Windows
`.exe` handling follows the existing `$(EXE)` pattern already used
throughout the file.

Tested locally (WSL2/Ubuntu):

    make install PREFIX=$HOME/.local
    make uninstall PREFIX=$HOME/.local

Both installed and removed `glm` and `coli` correctly.