### PR TITLE
fix: add tokenizers and datasets dependencies to run coli bench

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,8 @@
           safetensors
           huggingface-hub
           numpy
+          tokenizers
+          datasets
         ]);
 
         colibri = pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
## Summary

Adds the `datasets` and `tokenizers` dependencies to the python environment of the `flake.nix`. This allows running `coli bench` which throws import errors otherwise.

## Validation

- [x] `make -C c check`
- [ ] CUDA changes were tested with `make -C c cuda-test` (if applicable)
- [ ] Performance claims include hardware, commands, and repeatable measurements

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included
