### PR TITLE
doctor: platform-aware engine.binary check (fixes #141)

### DIFF
--- a/c/doctor.py
+++ b/c/doctor.py
@@ -2,6 +2,7 @@
 """Read-only installation diagnostics for colibri."""
 
 import os
+import sys
 import json
 import subprocess
 from pathlib import Path
@@ -63,7 +64,16 @@ def run_doctor(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0, *,
         checks.append(_check("storage.persistence", "skip", "persistence requires a model directory"))
 
     engine = Path(engine_path)
-    if engine.is_file() and os.access(engine, os.X_OK):
+    # On Windows, os.access(X_OK) always returns True for any existing file
+    # (NTFS has no execute bit; executability is governed by file extension).
+    # So a chmod(0o644) "non-executable" scenario can't be detected via X_OK
+    # on Windows. Use a platform-aware check: on POSIX, honor the mode bits;
+    # on Windows, any existing file is treated as executable. (#141)
+    if sys.platform == "win32":
+        engine_ok = engine.is_file()
+    else:
+        engine_ok = engine.is_file() and os.access(engine, os.X_OK)
+    if engine_ok:
         checks.append(_check("engine.binary", "pass", "engine executable is ready", path=str(engine)))
     elif engine.is_file():
         checks.append(_check("engine.binary", "fail", "engine exists but is not executable", path=str(engine)))

--- a/c/tests/test_doctor.py
+++ b/c/tests/test_doctor.py
@@ -104,7 +104,14 @@ class DoctorTest(unittest.TestCase):
         report = self.report(ram_gb=40)
         checks = self.checks_by_id(report)
 
-        self.assertEqual(checks["engine.binary"]["status"], "fail")
+        # On Windows chmod(0o644) does not remove executability (NTFS has no
+        # execute bit; os.access(X_OK) is always True for existing files), so
+        # the engine.binary check stays "pass" there. The excessive-RAM check
+        # (memory.ram) is platform-independent and must still fail. (#141)
+        if sys.platform == "win32":
+            self.assertEqual(checks["engine.binary"]["status"], "pass")
+        else:
+            self.assertEqual(checks["engine.binary"]["status"], "fail")
         self.assertEqual(checks["memory.ram"]["status"], "fail")
         self.assertEqual(report["status"], "error")
 


### PR DESCRIPTION
## Problem

`test_non_executable_engine_and_excessive_ram_budget_fail` in `tests/test_doctor.py` fails on Windows. The test does `self.engine.chmod(0o644)` (removing execute permission) and expects `doctor`'s `engine.binary` check to report `"fail"`.

**Reproduce:**
```bash
# On Windows (any shell):
cd c
python -m unittest tests.test_doctor.DoctorTest.test_non_executable_engine_and_excessive_ram_budget_fail
# Result: FAIL — checks["engine.binary"]["status"] is "pass", expected "fail"
```

**Root cause:** On Windows, `os.access(path, os.X_OK)` always returns `True` for any existing file. NTFS has no execute permission bit — executability is determined by file extension (`.exe`), not POSIX mode bits. Python's `os.chmod(0o644)` on Windows only clears the read-only flag; the execute bits (`0o111`) are silently ignored. So `doctor.py` line 66 (`os.access(engine, os.X_OK)`) reports the engine as executable regardless of what `chmod` did.

This is a Windows semantics mismatch, not a bug in the engine or test logic — the test is correct on Linux/macOS.

## Fix

Two changes, both platform-aware:

### 1. `c/doctor.py` — engine.binary check (the production code)

```diff
- if engine.is_file() and os.access(engine, os.X_OK):
+ if sys.platform == "win32":
+     engine_ok = engine.is_file()
+ else:
+     engine_ok = engine.is_file() and os.access(engine, os.X_OK)
+ if engine_ok:
      checks.append(_check("engine.binary", "pass", ...))
```

On Windows: any existing file is considered executable (since executability is extension-based, and the engine path is always `glm.exe` or a configured path). On POSIX: honor the mode bits via `os.access(X_OK)` exactly as before — no behavior change for Linux/macOS.

Added `import sys` to doctor.py (was not previously imported).

### 2. `c/tests/test_doctor.py` — the test assertion

```diff
  def test_non_executable_engine_and_excessive_ram_budget_fail(self):
      self.engine.chmod(0o644)
      report = self.report(ram_gb=40)
      checks = self.checks_by_id(report)
-     self.assertEqual(checks["engine.binary"]["status"], "fail")
+     if sys.platform == "win32":
+         self.assertEqual(checks["engine.binary"]["status"], "pass")
+     else:
+         self.assertEqual(checks["engine.binary"]["status"], "fail")
      self.assertEqual(checks["memory.ram"]["status"], "fail")
      self.assertEqual(report["status"], "error")
```

On Windows: assert `"pass"` (chmod is a no-op for executability, so the engine remains executable). On POSIX: assert `"fail"` (chmod actually removed the execute bit). The `memory.ram` assertion (excessive RAM budget → fail) is platform-independent and unchanged.

## Verification

```
# Before: 58 pass, 1 fail
# After:  59 pass, 0 fail
python -m unittest discover -s tests -p "test_*.py"
Ran 59 tests in 1.661s — OK
```

## Files changed
- `c/doctor.py` — `import sys` added; engine.binary check made platform-aware (4 lines changed)
- `c/tests/test_doctor.py` — test assertion made platform-aware (4 lines changed)

Based on current `dev` (`6d3ed7e`).

---

> **Credit / reporter:** this bug was reported by **@galmok** in #141 (Windows build, `test_non_executable_engine_and_excessive_ram_budget_fail`). The platform-aware `engine.binary` check here addresses their report.
<!-- credit-galmok-141 -->
If proper git-native `Co-Authored-By:` attribution is wanted for any of these, it needs a maintainer to file it as a tracked issue/decision on the repo — the commits here are already merged into `origin/dev`, and amending them for trailers would rewrite shared integration history (every contributor's `dev` diverges).