### PR TITLE
Fix converter crashes on Windows: fcntl import, 999-retry hang, empty shards NameError

### DIFF
--- a/c/tools/convert_fp8_to_int4.py
+++ b/c/tools/convert_fp8_to_int4.py
@@ -208,11 +208,21 @@ def main():
 
     # lock anti-doppione: DUE convertitori sulla stessa outdir si corrompono a vicenda.
     # EN: anti-duplicate lock: TWO converters on the same outdir corrupt each other.
-    import fcntl
+    # fcntl is Unix-only; on Windows use msvcrt or skip locking.
     lock = open(os.path.join(a.outdir, ".convert.lock"), "w")
-    try: fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except OSError:
-        print("ERROR: another converter is already using this output directory. Exiting."); return
+    try:
+        import fcntl
+        try: fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            print("ERROR: another converter is already using this output directory. Exiting."); return
+    except ImportError:
+        try:
+            import msvcrt
+            try: msvcrt.locking(lock.fileno(), msvcrt.LK_NBLCK, 1)
+            except OSError:
+                print("ERROR: another converter is already using this output directory. Exiting."); return
+        except ImportError:
+            pass  # no locking available — single-user converter, acceptable
 
     # dimensioni note dei file, riempite dopo repo_info: il downloader multi-stream le usa
     # per calcolare i confini dei segmenti e per sapere quando un file e' completo.
@@ -372,7 +382,8 @@ def main():
 
     from safetensors.numpy import save_file
     import time as _t
-    for att in range(999):
+    info = None
+    for att in range(10):
         try:
             info = HfApi().repo_info(a.repo, files_metadata=True)
             # dimensioni note dallo store: abilitano il download multi-stream a segmenti.
@@ -382,7 +393,13 @@ def main():
         except KeyboardInterrupt: raise
         except Exception as ex:
             w = min(60, 5*(att+1)); print(f"repo_info failed ({type(ex).__name__}); retrying in {w}s", flush=True); _t.sleep(w)
+    if info is None:
+        print("ERROR: could not reach the repository after 10 retries. Check your network and repo name.", flush=True)
+        return
     shards = sorted(s.rfilename for s in info.siblings if s.rfilename.endswith(".safetensors"))
+    if not shards:
+        print("ERROR: no .safetensors shards found in this repository.", flush=True)
+        return
     for fn in ["config.json", "tokenizer.json", "tokenizer_config.json", "generation_config.json"]:
         try: shutil.copy(hf_hub_download(a.repo, fn, local_dir=a.outdir+"/_meta"), a.outdir)
         except Exception: pass


### PR DESCRIPTION
## Problem

Three crash bugs in `c/tools/convert_fp8_to_int4.py`, all on the download/convert path (`--repo` mode). The `--indir` test path returns before reaching them, so tests pass but real conversion on Windows crashes.

### P3: `import fcntl` crashes on Windows (line 211)

**Reproduce:** Run `python tools/convert_fp8_to_int4.py --repo <hf-repo> --outdir <dir>` on Windows.

**What happens:** `import fcntl` is Unix-only. On Windows it raises `ModuleNotFoundError`, crashing the converter immediately. The lock is there to prevent two converters from corrupting the same output directory.

**Fix:** Guard the import — try `fcntl` (Unix), fall back to `msvcrt.locking` (Windows), skip locking if neither is available (acceptable for a single-user converter):
```python
try:
    import fcntl
    fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
except ImportError:
    try:
        import msvcrt
        msvcrt.locking(lock.fileno(), msvcrt.LK_NBLCK, 1)
    except ImportError:
        pass  # no locking available
```

### P4: 999-retry loop hangs up to 16 hours, then `NameError` (line 385)

**Reproduce:** Run conversion with a bad network, wrong repo name, or DNS failure.

**What happens:**
```python
for att in range(999):
    try:
        info = HfApi().repo_info(...)
        break
    except Exception:
        _t.sleep(min(60, 5*(att+1)))  # up to 60s × ~960 retries = ~16 hours
shards = sorted(... for s in info.siblings ...)  # info is UNBOUND if all 999 failed
```

If all 999 retries fail, `info` is never bound, and the next line raises `NameError`. The user waits up to 16 hours first.

**Fix:** Cap at 10 retries (~5 min max), check `info is None` after the loop, print a clear error and return. Also added an early return if no `.safetensors` shards are found in the repo.

### P5: Empty shards list → `NameError` (line 460)

**Reproduce:** Point `--repo` at a repository with no safetensors files.

**What happens:** `shards` is empty → `for i, sh in enumerate(shards)` never executes → `i` is unbound at `print("DONE." if i == len(shards)-1 ...)` → `NameError`.

**Fix:** Handled by the early return from P4 (`if not shards: print error; return`).

## Files changed
- `c/tools/convert_fp8_to_int4.py` — 3 locations (22 insertions, 5 deletions)

Based on `dev` (`6d3ed7e`).