### PR TITLE
Fix GPU silently dropped on comma-in-name + API key timing side-channel

### DIFF
--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -672,9 +672,13 @@ class APIHandler(BaseHTTPRequestHandler):
             self.send_header("Vary", "Origin")
 
     def require_auth(self):
-        if self.server.api_key and self.headers.get("Authorization") != f"Bearer {self.server.api_key}":
-            raise APIError(401, "Invalid or missing API key.", None, "invalid_api_key",
-                           "authentication_error")
+        if self.server.api_key:
+            import hmac
+            provided = self.headers.get("Authorization", "")
+            expected = f"Bearer {self.server.api_key}"
+            if not hmac.compare_digest(provided, expected):
+                raise APIError(401, "Invalid or missing API key.", None, "invalid_api_key",
+                               "authentication_error")
 
     def read_json(self):
         try:

--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -127,8 +127,9 @@ def discover_gpus():
     except (OSError, subprocess.SubprocessError):
         return []
     devices = []
-    for line in result.stdout.splitlines():
-        fields = [field.strip() for field in line.split(",", 3)]
+    import csv
+    for fields in csv.reader(result.stdout.splitlines()):
+        fields = [f.strip() for f in fields]
         if len(fields) != 4:
             continue
         try:


### PR DESCRIPTION
Two bugs found by static analysis: (1) discover_gpus used str.split to parse nvidia-smi CSV, dropping GPUs whose name contains a comma; (2) API key auth used plain != comparison (timing side-channel). Fixed with csv.reader and hmac.compare_digest. 58/59 tests pass (the 1 failure is #141, not related). Based on dev.

---

> **Credit / reporter:** the GPU-dropped-on-comma-name bug was exposed during **@galmok**'s Windows build in #141; this fix addresses a failure mode from their report.
<!-- credit-galmok-141 -->
If proper git-native `Co-Authored-By:` attribution is wanted for any of these, it needs a maintainer to file it as a tracked issue/decision on the repo — the commits here are already merged into `origin/dev`, and amending them for trailers would rewrite shared integration history (every contributor's `dev` diverges).