### PR TITLE
bench: use XDG cache home for --data default

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -621,7 +621,13 @@ def main():
     ps.add_argument("--queue-timeout",type=float,default=float(os.environ.get("COLI_QUEUE_TIMEOUT","300")))
     ps.add_argument("--kv-slots",type=int,default=int(os.environ.get("COLI_KV_SLOTS","1")))
     pb=sub.add_parser("bench", parents=[common]); pb.add_argument("tasks", nargs="*")
-    pb.add_argument("--limit",type=int,default=40); pb.add_argument("--data",default=os.path.join(HERE,"bench"))
+    pb.add_argument("--limit",type=int,default=40)
+    if sys.platform == "win32":
+        _cache_root = os.environ.get("LOCALAPPDATA", os.path.expanduser("~\\AppData\\Local"))
+    else:
+        _cache_root = os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
+    _bench_cache = os.path.join(_cache_root, "colibri", "bench")
+    pb.add_argument("--data",default=_bench_cache)
     pc=sub.add_parser("convert", parents=[common]); pc.add_argument("--repo",default="zai-org/GLM-5.2-FP8")
     pc.add_argument("--ebits",type=int,default=4); pc.add_argument("--io-bits",type=int,default=8); pc.add_argument("--xbits",type=int,default=0)
     pc.add_argument("--no-mtp",action="store_true",help="skip the MTP head (no speculative drafts)")


### PR DESCRIPTION
## Summary

- Move bench `--data` default from `c/bench/` (source tree) to the platform cache directory
  - Linux/macOS: `$XDG_CACHE_HOME/colibri/bench` (defaults to `~/.cache/colibri/bench`)
  - Windows: `%LOCALAPPDATA%\colibri\bench` (defaults to `C:\Users\<user>\AppData\Local\colibri\bench`)
- Benchmark datasets are downloaded artifacts, not source files, so they belong in the user's cache directory
- `fetch_benchmarks.py` already calls `os.makedirs(out, exist_ok=True)`, so the new path is created on first use

## Test plan

- [ ] Run `coli bench --help` and verify `--data` default shows the cache path
- [ ] Run `coli bench` and verify datasets download to `~/.cache/colibri/bench/`
- [ ] Verify `--data /custom/path` still overrides the default