### PR TITLE
run_tests: normpath test binaries (forward-slash relative paths fail CreateProcess on Windows)

### DIFF
--- a/c/tools/run_tests.py
+++ b/c/tools/run_tests.py
@@ -5,12 +5,13 @@ Used by `make test-c` so the test runner works from any shell (cmd.exe,
 PowerShell, Git Bash, MSYS2) without a POSIX `for` loop. Each test binary
 is a positional argument.
 """
+import os
 import subprocess
 import sys
 
 failed = []
 for binary in sys.argv[1:]:
-    rc = subprocess.call([binary])
+    rc = subprocess.call([os.path.normpath(binary)])
     if rc != 0:
         failed.append(binary)
 if failed:


### PR DESCRIPTION
One-liner: `make test-c` invokes this runner with `tests/test_json.exe`-style paths; on Windows `CreateProcess` rejects forward-slash relative executable paths (WinError 2), so the runner — which exists specifically so tests run from any Windows shell — failed on every binary. `os.path.normpath` fixes Windows and is a no-op on POSIX.

Verified on Windows 11 (MinGW GCC 16.1): all 8 suites pass via `make test-c`; POSIX paths unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)