### PR TITLE
bench: pass resolved GLM engine path to eval_glm.py

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -585,7 +585,7 @@ def cmd_bench(a):
         print(f"  {C.dim}downloading missing datasets: {', '.join(missing)}{C.r}")
         subprocess.call([py, os.path.join(TOOLS,"fetch_benchmarks.py"),
                          "--out", a.data, "--tasks", ",".join(missing), "--limit", str(max(a.limit,200))])
-    cmd=[py, os.path.join(TOOLS,"eval_glm.py"), "--snap",a.model,
+    cmd=[py, os.path.join(TOOLS,"eval_glm.py"), "--glm", GLM, "--snap",a.model,
          "--tasks", tasks, "--limit", str(a.limit), "--data", a.data]
     if a.ram: cmd+=["--ram",str(a.ram)]
     e=env_for(a)


### PR DESCRIPTION
## Summary

- `cmd_bench` builds the `eval_glm.py` command but did not pass `--glm`, so `eval_glm.py` fell back to `./glm` which breaks when running from any directory other than the source tree
- Pass the already-resolved `GLM` variable via `--glm`, matching how `--data` and `--snap` are already passed

Fixes #37, follows up on #109.

## Test plan

- [ ] Run `coli bench` from a directory other than the source tree and confirm it finds the engine binary
- [ ] Run `coli bench` from the source tree and confirm no regression