### PR TITLE
Makefile: select $(PYTHON) from the host, not the target triple

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -129,10 +129,16 @@ NVCCFLAGS ?= -O3 -std=c++17 -arch=$(CUDA_ARCH) -Xcompiler=-W3
 else
 NVCCFLAGS ?= -O3 -std=c++17 -arch=$(CUDA_ARCH) -Xcompiler=-Wall,-Wextra
 endif
-ifeq ($(IS_WIN),)
-PYTHON    ?= python3
-else
+# PYTHON is a HOST tool (clean/test-c/test-python run it on the build machine),
+# so key it off the host, NOT $(IS_WIN) — which is derived from the *target*
+# triple ($(CC) -dumpmachine). Otherwise a cross build (make CC=x86_64-w64-
+# mingw32-gcc ... on Linux) sets IS_WIN and picks `python`, breaking clean/test
+# on hosts where only `python3` exists. $(OS)=Windows_NT in every Windows shell
+# (the #129 signal) and is empty on Linux/macOS.
+ifeq ($(OS),Windows_NT)
 PYTHON    ?= python
+else
+PYTHON    ?= python3
 endif
 CUDA_OBJ  =
 TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE)


### PR DESCRIPTION
## Problem

`clean`, `test-c`, and `test-python` invoke `$(PYTHON)` on the **build host**, but `$(PYTHON)` is selected from `$(IS_WIN)` (Makefile L132–135), and `IS_WIN` is derived from the **target** triple (`$(CC) -dumpmachine`, L18). Host tool, target signal — so a cross build picks the wrong interpreter:

```
make CC=x86_64-w64-mingw32-gcc clean
#  TRIPLET=x86_64-w64-mingw32 → IS_WIN=mingw → PYTHON=python
#  → fails on a host where `python` is python3-only (e.g. Debian/Ubuntu)
```

This is the host-vs-target split @rofl0r flagged on #171, and it bites the very cross-compile path #171 was added to support.

## Fix

`PYTHON` is a host tool, so key it off the host — reusing the #129 `$(OS)==Windows_NT` signal (set in every Windows shell, empty on Linux/macOS). `EXE` stays correctly driven by the target triple.

```diff
-ifeq ($(IS_WIN),)
-PYTHON    ?= python3
-else
+ifeq ($(OS),Windows_NT)
 PYTHON    ?= python
+else
+PYTHON    ?= python3
 endif
```

## Validation

- **Native Windows** (WinLibs GCC 16.1.0, PowerShell, no MSYS2): `make -n clean` → `python tools/clean.py`, and full `make check` is green (9/9 C, 60 Python) — unchanged, since `$(OS)=Windows_NT` → `python`.
- **Linux/macOS**: `$(OS)` is empty → `python3`, matching the prior non-Windows default.

Behavior-preserving for every native build; only the cross case changes (and only for the better).

---

Based on `main`, since that's where the `PYTHON`/`IS_WIN` coupling (from #179) currently lives — `dev` doesn't have it yet. Happy to rebase onto `dev` once it's caught up if you prefer.