### PR TITLE
aarch64: add runtime i8mm expert kernel

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -229,6 +229,12 @@ cuda-bench: backend_cuda.cu backend_cuda.h tests/bench_tensor_core.cu
 	$(NVCC) $(NVCCFLAGS) backend_cuda.cu tests/bench_tensor_core.cu -o backend_cuda_bench$(EXE)
 	./backend_cuda_bench$(EXE)
 
+i8mm_bench$(EXE): tests/bench_i8mm.c glm.c st.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+i8mm-bench: i8mm_bench$(EXE)
+	./i8mm_bench$(EXE)
+
 olmoe$(EXE): olmoe.c st.h json.h compat.h
 	$(CC) $(CFLAGS) olmoe.c -o olmoe$(EXE) $(LDFLAGS)
 
@@ -299,4 +305,4 @@ clean:
 
 bench: iobench$(EXE)
 	@if [ -n "$(ARGS)" ]; then ./iobench$(EXE) $(ARGS); else echo "built iobench$(EXE) — run: ./iobench$(EXE) <file> <MB> <iters> <threads> <direct 0|1>"; fi
-.PHONY: all glm cuda-test cuda-bench cuda-dll portable test-c test-python test check clean install uninstall bench
+.PHONY: all glm cuda-test cuda-bench cuda-dll i8mm-bench portable test-c test-python test check clean install uninstall bench

--- a/c/glm.c
+++ b/c/glm.c
@@ -27,6 +27,13 @@
 #include <stdatomic.h>                            /* PIPE ready-flags/job queue + PILOT_REAL cross-layer handshake */
 #include <sched.h>                                /* sched_yield: PIPE spin / PILOT barrier */
 #include <unistd.h>
+#if defined(__APPLE__) && defined(__aarch64__)
+#include <sys/types.h>
+#include <sys/sysctl.h>                           /* hw.optional.arm.FEAT_I8MM */
+#elif defined(__linux__) && defined(__aarch64__)
+#include <sys/auxv.h>                            /* getauxval(AT_HWCAP2) */
+#include <elf.h>                                 /* AT_HWCAP2 */
+#endif
 #if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
 #include <sys/select.h>                             /* select() serve-loop polling (#68); not on native MinGW */
 #endif
@@ -73,6 +80,21 @@ static inline float hsum256(__m256 v){            /* somma orizzontale di 8 floa
 #undef vector                                     /* igiene: si usano __vector/__bool espliciti */
 #undef pixel
 #undef bool
+#endif
+
+/* Build SMMLA in an isolated function while keeping the rest of the binary at
+ * baseline AArch64. GCC and Clang spell the per-function extension differently. */
+#if defined(__aarch64__) && defined(__ARM_NEON) && \
+    ((defined(__clang__) && __clang_major__ >= 10) || \
+     (!defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 10))
+#define COLI_HAVE_I8MM 1
+#if defined(__clang__)
+#define COLI_TARGET_I8MM __attribute__((target("i8mm")))
+#else
+#define COLI_TARGET_I8MM __attribute__((target("+i8mm")))
+#endif
+#else
+#define COLI_HAVE_I8MM 0
 #endif
 #ifdef __APPLE__
 #include <mach/mach.h>                            /* host_statistics64: MemAvailable di macOS */
@@ -487,6 +509,48 @@ static void matmul_i2(float *y, const float *x, const uint8_t *q2, const float *
 #define IDOT_KERNEL "scalar"
 #endif
 static int g_idot=1;
+#if COLI_HAVE_I8MM
+static int g_i8mm=-1;  /* -1=runtime auto, 0=force NEON for A/B, 1=SMMLA available */
+static int cpu_has_i8mm(void){
+#if defined(__APPLE__)
+    int value=0; size_t size=sizeof(value);
+    return sysctlbyname("hw.optional.arm.FEAT_I8MM",&value,&size,NULL,0)==0 && value;
+#elif defined(__linux__)
+    /* Stable arm64 Linux UAPI bit; define it locally for older libc headers. */
+#ifndef HWCAP2_I8MM
+#define HWCAP2_I8MM (1UL << 13)
+#endif
+    return (getauxval(AT_HWCAP2)&HWCAP2_I8MM)!=0;
+#else
+    return 0;
+#endif
+}
+static int i8mm_enabled(void){
+    if(g_i8mm<0) g_i8mm=cpu_has_i8mm();
+    return g_i8mm;
+}
+typedef struct { int8_t *data; size_t cap; } I8mmScratch;
+static _Thread_local I8mmScratch g_i8mm_scratch;
+static void i8mm_pack_pair(int8_t *dst, const int8_t *x0, const int8_t *x1, int I){
+    for(int i=0;i+8<=I;i+=8){ memcpy(dst+2*i,x0+i,8); memcpy(dst+2*i+8,x1+i,8); }
+}
+static const int8_t *i8mm_pack_x(const int8_t *x, int S, int I, size_t *pair_stride){
+    size_t stride=(size_t)(I/8)*16, need=(size_t)((S+1)/2)*stride;
+    if(need>g_i8mm_scratch.cap){
+        int8_t *p=realloc(g_i8mm_scratch.data,need);
+        if(!p){ fprintf(stderr,"OOM i8mm scratch\n"); exit(1); }
+        g_i8mm_scratch.data=p; g_i8mm_scratch.cap=need;
+    }
+    for(int s=0;s<S;s+=2){
+        const int8_t *x0=x+(int64_t)s*I;
+        const int8_t *x1=s+1<S?x0+I:x0;
+        i8mm_pack_pair(g_i8mm_scratch.data+(size_t)(s/2)*stride,x0,x1,I);
+    }
+    *pair_stride=stride; return g_i8mm_scratch.data;
+}
+#else
+static int i8mm_enabled(void){ return 0; }
+#endif
 #if defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
 static int g_i4s=1;   /* SDOT presente: int4 IDOT conviene anche a S=1 (decode). Misurato
                        * su Apple M-series: +14%%, expert-matmul -16%%. EN: with SDOT, int4
@@ -701,14 +765,170 @@ static inline int32_t dot_i4i8(const uint8_t *w4, const int8_t *x, int I){
     if(i<I){ uint8_t b=w4[i>>1]; sum+=((int)(b&0xF)-8)*x[i]; }
     return sum;
 }
+
+#if COLI_HAVE_I8MM
+/* SMMLA treats its operands as [2,8] and [2,8], and returns the four row
+ * products as {w0*x0, w0*x1, w1*x0, w1*x1}. Pairing two output rows and two
+ * activation rows is what exposes all four dot products instead of wasting
+ * three quarters of the instruction. Scalar tails preserve arbitrary shapes. */
+COLI_TARGET_I8MM __attribute__((always_inline))
+static inline void dot_i8i8_2x2_i8mm(int32_t out[4], const int8_t *w0, const int8_t *w1,
+                                     const int8_t *xp, const int8_t *x0, const int8_t *x1, int I){
+    int32x4_t a0=vdupq_n_s32(0),a1=a0,a2=a0,a3=a0; int i=0;
+    for(;i+32<=I;i+=32){
+        int8x16_t wv=vcombine_s8(vld1_s8(w0+i),vld1_s8(w1+i));
+        a0=vmmlaq_s32(a0,wv,vld1q_s8(xp+2*i));
+        wv=vcombine_s8(vld1_s8(w0+i+8),vld1_s8(w1+i+8));
+        a1=vmmlaq_s32(a1,wv,vld1q_s8(xp+2*i+16));
+        wv=vcombine_s8(vld1_s8(w0+i+16),vld1_s8(w1+i+16));
+        a2=vmmlaq_s32(a2,wv,vld1q_s8(xp+2*i+32));
+        wv=vcombine_s8(vld1_s8(w0+i+24),vld1_s8(w1+i+24));
+        a3=vmmlaq_s32(a3,wv,vld1q_s8(xp+2*i+48));
+    }
+    int32x4_t acc=vaddq_s32(vaddq_s32(a0,a1),vaddq_s32(a2,a3));
+    for(;i+8<=I;i+=8){
+        int8x16_t wv=vcombine_s8(vld1_s8(w0+i),vld1_s8(w1+i));
+        int8x16_t xv=vld1q_s8(xp+2*i);
+        acc=vmmlaq_s32(acc,wv,xv);
+    }
+    vst1q_s32(out,acc);
+    for(;i<I;i++){
+        out[0]+=(int32_t)w0[i]*x0[i]; out[1]+=(int32_t)w0[i]*x1[i];
+        out[2]+=(int32_t)w1[i]*x0[i]; out[3]+=(int32_t)w1[i]*x1[i];
+    }
+}
+
+COLI_TARGET_I8MM __attribute__((always_inline))
+static inline int8x16_t unpack_i4_pair_i8mm(const uint8_t *w0, const uint8_t *w1, int i,
+                                             uint8x8_t m4, int8x8_t b8){
+    uint32_t d0,d1; memcpy(&d0,w0+(i>>1),4); memcpy(&d1,w1+(i>>1),4);
+    uint8x8_t p0=vreinterpret_u8_u32(vdup_n_u32(d0));
+    uint8x8_t p1=vreinterpret_u8_u32(vdup_n_u32(d1));
+    uint8x8x2_t z0=vzip_u8(vand_u8(p0,m4),vshr_n_u8(p0,4));
+    uint8x8x2_t z1=vzip_u8(vand_u8(p1,m4),vshr_n_u8(p1,4));
+    return vcombine_s8(vsub_s8(vreinterpret_s8_u8(z0.val[0]),b8),
+                       vsub_s8(vreinterpret_s8_u8(z1.val[0]),b8));
+}
+
+COLI_TARGET_I8MM __attribute__((always_inline))
+static inline void dot_i4i8_2x2_i8mm(int32_t out[4], const uint8_t *w0, const uint8_t *w1,
+                                     const int8_t *xp, const int8_t *x0, const int8_t *x1, int I){
+    const uint8x8_t m4=vdup_n_u8(0x0F); const int8x8_t b8=vdup_n_s8(8);
+    int32x4_t a0=vdupq_n_s32(0),a1=a0,a2=a0,a3=a0; int i=0;
+    for(;i+32<=I;i+=32){
+        a0=vmmlaq_s32(a0,unpack_i4_pair_i8mm(w0,w1,i,m4,b8),vld1q_s8(xp+2*i));
+        a1=vmmlaq_s32(a1,unpack_i4_pair_i8mm(w0,w1,i+8,m4,b8),vld1q_s8(xp+2*i+16));
+        a2=vmmlaq_s32(a2,unpack_i4_pair_i8mm(w0,w1,i+16,m4,b8),vld1q_s8(xp+2*i+32));
+        a3=vmmlaq_s32(a3,unpack_i4_pair_i8mm(w0,w1,i+24,m4,b8),vld1q_s8(xp+2*i+48));
+    }
+    int32x4_t acc=vaddq_s32(vaddq_s32(a0,a1),vaddq_s32(a2,a3));
+    for(;i+8<=I;i+=8){
+        int8x16_t wv=unpack_i4_pair_i8mm(w0,w1,i,m4,b8);
+        int8x16_t xv=vld1q_s8(xp+2*i);
+        acc=vmmlaq_s32(acc,wv,xv);
+    }
+    vst1q_s32(out,acc);
+    for(;i<I;i++){
+        uint8_t b0v=w0[i>>1], b1v=w1[i>>1];
+        int a0=(i&1)?(int)(b0v>>4)-8:(int)(b0v&0xF)-8;
+        int a1=(i&1)?(int)(b1v>>4)-8:(int)(b1v&0xF)-8;
+        out[0]+=a0*x0[i]; out[1]+=a0*x1[i]; out[2]+=a1*x0[i]; out[3]+=a1*x1[i];
+    }
+}
+
+/* Non-inlined entries let the baseline-ISA exactness test exercise each tile
+ * directly. Hot matmul loops call the always-inline helpers above instead. */
+COLI_TARGET_I8MM __attribute__((noinline))
+static void dot_i8i8_2x2_i8mm_entry(int32_t out[4], const int8_t *w0, const int8_t *w1,
+                                    const int8_t *x0, const int8_t *x1, int I){
+    size_t n=(size_t)(I/8)*16; int8_t *xp=malloc(n?n:1);
+    if(!xp){ fprintf(stderr,"OOM i8mm test entry\n"); exit(1); }
+    i8mm_pack_pair(xp,x0,x1,I); dot_i8i8_2x2_i8mm(out,w0,w1,xp,x0,x1,I); free(xp);
+}
+COLI_TARGET_I8MM __attribute__((noinline))
+static void dot_i4i8_2x2_i8mm_entry(int32_t out[4], const uint8_t *w0, const uint8_t *w1,
+                                    const int8_t *x0, const int8_t *x1, int I){
+    size_t n=(size_t)(I/8)*16; int8_t *xp=malloc(n?n:1);
+    if(!xp){ fprintf(stderr,"OOM i8mm test entry\n"); exit(1); }
+    i8mm_pack_pair(xp,x0,x1,I); dot_i4i8_2x2_i8mm(out,w0,w1,xp,x0,x1,I); free(xp);
+}
+
+COLI_TARGET_I8MM __attribute__((noinline))
+static void matmul_q_i8mm(float *y, const int8_t *xq, const float *sx, const int8_t *q,
+                          const float *scale, const int8_t *xp, size_t xp_stride,
+                          int S, int I, int O){
+    #pragma omp parallel for schedule(static)
+    for(int o=0;o<O-1;o+=2){
+        const int8_t *w0=q+(int64_t)o*I, *w1=w0+I; int s=0;
+        for(;s+1<S;s+=2){
+            const int8_t *x0=xq+(int64_t)s*I, *x1=x0+I;
+            int32_t d[4]; dot_i8i8_2x2_i8mm(d,w0,w1,xp+(size_t)(s/2)*xp_stride,x0,x1,I);
+            y[(int64_t)s*O+o]=(float)d[0]*scale[o]*sx[s];
+            y[(int64_t)(s+1)*O+o]=(float)d[1]*scale[o]*sx[s+1];
+            y[(int64_t)s*O+o+1]=(float)d[2]*scale[o+1]*sx[s];
+            y[(int64_t)(s+1)*O+o+1]=(float)d[3]*scale[o+1]*sx[s+1];
+        }
+        if(s<S){
+            int32_t d[4]; const int8_t *xs=xq+(int64_t)s*I;
+            dot_i8i8_2x2_i8mm(d,w0,w1,xp+(size_t)(s/2)*xp_stride,xs,xs,I);
+            y[(int64_t)s*O+o]=(float)d[0]*scale[o]*sx[s];
+            y[(int64_t)s*O+o+1]=(float)d[2]*scale[o+1]*sx[s];
+        }
+    }
+    if(O&1){ int o=O-1; const int8_t *w=q+(int64_t)o*I;
+        for(int s=0;s<S;s++) y[(int64_t)s*O+o]=(float)dot_i8i8(w,xq+(int64_t)s*I,I)*scale[o]*sx[s]; }
+}
+
+COLI_TARGET_I8MM __attribute__((noinline))
+static void matmul_i4_i8mm(float *y, const int8_t *xq, const float *sx, const uint8_t *q4,
+                           const float *scale, const int8_t *xp, size_t xp_stride,
+                           int S, int I, int O){
+    int rb=(I+1)/2;
+    #pragma omp parallel for schedule(static)
+    for(int o=0;o<O-1;o+=2){
+        const uint8_t *w0=q4+(int64_t)o*rb, *w1=w0+rb; int s=0;
+        for(;s+1<S;s+=2){
+            const int8_t *x0=xq+(int64_t)s*I, *x1=x0+I;
+            int32_t d[4]; dot_i4i8_2x2_i8mm(d,w0,w1,xp+(size_t)(s/2)*xp_stride,x0,x1,I);
+            y[(int64_t)s*O+o]=(float)d[0]*scale[o]*sx[s];
+            y[(int64_t)(s+1)*O+o]=(float)d[1]*scale[o]*sx[s+1];
+            y[(int64_t)s*O+o+1]=(float)d[2]*scale[o+1]*sx[s];
+            y[(int64_t)(s+1)*O+o+1]=(float)d[3]*scale[o+1]*sx[s+1];
+        }
+        if(s<S){
+            int32_t d[4]; const int8_t *xs=xq+(int64_t)s*I;
+            dot_i4i8_2x2_i8mm(d,w0,w1,xp+(size_t)(s/2)*xp_stride,xs,xs,I);
+            y[(int64_t)s*O+o]=(float)d[0]*scale[o]*sx[s];
+            y[(int64_t)s*O+o+1]=(float)d[2]*scale[o+1]*sx[s];
+        }
+    }
+    if(O&1){ int o=O-1; const uint8_t *w=q4+(int64_t)o*rb;
+        for(int s=0;s<S;s++) y[(int64_t)s*O+o]=(float)dot_i4i8(w,xq+(int64_t)s*I,I)*scale[o]*sx[s]; }
+}
+#endif
+
 static void matmul_q_idot(float *y, const int8_t *xq, const float *sx, const int8_t *q,
                           const float *scale, int S, int I, int O){
+#if COLI_HAVE_I8MM
+    if(I>=8 && O>=2 && i8mm_enabled()){
+        size_t stride; const int8_t *xp=i8mm_pack_x(xq,S,I,&stride);
+        matmul_q_i8mm(y,xq,sx,q,scale,xp,stride,S,I,O); return;
+    }
+#endif
     #pragma omp parallel for schedule(static)
     for(int o=0;o<O;o++){ const int8_t *w=q+(int64_t)o*I; float sc=scale[o];
         for(int s=0;s<S;s++) y[(int64_t)s*O+o]=(float)dot_i8i8(w,xq+(int64_t)s*I,I)*sc*sx[s]; }
 }
 static void matmul_i4_idot(float *y, const int8_t *xq, const float *sx, const uint8_t *q4,
                            const float *scale, int S, int I, int O){
+#if COLI_HAVE_I8MM
+    /* At S=1, int4 unpack dominates short (I=2048) down-projection rows on
+     * M-series. Keep those on SDOT; paired rows or GLM's I=6144 gate/up rows win. */
+    if(I>=8 && O>=2 && (S>=2 || I>=6144) && i8mm_enabled()){
+        size_t stride; const int8_t *xp=i8mm_pack_x(xq,S,I,&stride);
+        matmul_i4_i8mm(y,xq,sx,q4,scale,xp,stride,S,I,O); return;
+    }
+#endif
     int rb=(I+1)/2;
     #pragma omp parallel for schedule(static)
     for(int o=0;o<O;o++){ const uint8_t *w=q4+(int64_t)o*rb; float sc=scale[o];
@@ -4810,6 +5030,10 @@ int main(int argc, char **argv){
     if(g_pipe_nw<1) g_pipe_nw=1;
     g_direct = getenv("DIRECT")?atoi(getenv("DIRECT")):0;
     g_idot = getenv("IDOT")?atoi(getenv("IDOT")):1;        /* 0 = kernel f32 esatti (A/B) */
+#if COLI_HAVE_I8MM
+    g_i8mm=cpu_has_i8mm();
+    if(getenv("I8MM") && atoi(getenv("I8MM"))==0) g_i8mm=0; /* A/B kill switch; cannot force unsupported silicon */
+#endif
     if(getenv("ROUTE_TRACE")&&*getenv("ROUTE_TRACE")){
         g_route_fp=fopen(getenv("ROUTE_TRACE"),"w");
         if(!g_route_fp) fprintf(stderr,"[ROUTE_TRACE] cannot open %s\n",getenv("ROUTE_TRACE"));
@@ -4884,6 +5108,9 @@ int main(int argc, char **argv){
     }
 #endif
     printf("== GLM C engine (glm_moe_dsa), cache=%d experts/layer | experts@%d-bit dense@%d-bit | idot: " IDOT_KERNEL " ==\n", cap, ebits, dbits);
+#if COLI_HAVE_I8MM
+    if(i8mm_enabled()) printf("[i8mm] SMMLA 2x2 expert kernel active (I8MM=0 disables for A/B)\n");
+#endif
     g_mem_avail_boot = mem_available_gb();
     Model m; double t0=now_s(); model_init(&m,snap,cap,ebits,dbits);
     if(g_draft<0){

--- a/c/tests/bench_i8mm.c
+++ b/c/tests/bench_i8mm.c
@@ -1,0 +1,71 @@
+/* Same-binary A/B microbenchmark for the runtime-dispatched AArch64 SMMLA
+ * expert kernel. Uses the real GLM-5.2 expert shapes and reports medians after
+ * alternating path order, so neither path always receives the warmer cache. */
+#define main coli_glm_main_unused
+#include "../glm.c"
+#undef main
+
+#if COLI_HAVE_I8MM
+static uint32_t rng_state=0x9e3779b9u;
+static uint32_t xr(void){ rng_state^=rng_state<<13; rng_state^=rng_state>>17; rng_state^=rng_state<<5; return rng_state; }
+static int cmp_double(const void *a,const void *b){
+    double x=*(const double*)a,y=*(const double*)b; return (x>y)-(x<y);
+}
+
+static void call_path(int fmt, int use_i8mm, float *y, const int8_t *x, const float *sx,
+                      const uint8_t *w, const float *sc, int S, int I, int O){
+    g_i8mm=use_i8mm;
+    if(fmt==1) matmul_q_idot(y,x,sx,(const int8_t*)w,sc,S,I,O);
+    else matmul_i4_idot(y,x,sx,w,sc,S,I,O);
+}
+
+static int bench_shape(int fmt, int S, int I, int O, const char *label){
+    enum { REPS=21 };
+    int rb=(I+1)/2; size_t wn=fmt==1?(size_t)O*I:(size_t)O*rb;
+    uint8_t *w=malloc(wn); int8_t *x=malloc((size_t)S*I);
+    float *yn=malloc((size_t)S*O*sizeof(float)),*ym=malloc((size_t)S*O*sizeof(float));
+    float *sc=malloc((size_t)O*sizeof(float)),*sx=malloc((size_t)S*sizeof(float));
+    if(!w||!x||!yn||!ym||!sc||!sx){ fprintf(stderr,"bench_i8mm: OOM\n"); return 0; }
+    for(size_t i=0;i<wn;i++) w[i]=(uint8_t)xr();
+    for(int i=0;i<S*I;i++) x[i]=(int8_t)((int)(xr()%255)-127);
+    for(int i=0;i<O;i++) sc[i]=0.001f+(float)(i%17)*0.0001f;
+    for(int i=0;i<S;i++) sx[i]=0.002f+(float)i*0.0001f;
+
+    call_path(fmt,0,yn,x,sx,w,sc,S,I,O);
+    call_path(fmt,1,ym,x,sx,w,sc,S,I,O);
+    if(memcmp(yn,ym,(size_t)S*O*sizeof(float))!=0){
+        fprintf(stderr,"bench_i8mm: numeric mismatch: %s\n",label); return 0;
+    }
+    double tn[REPS],tm[REPS]; volatile float sink=0;
+    for(int r=0;r<REPS;r++){
+        int first=r&1;
+        double t=now_s(); call_path(fmt,first,first?ym:yn,x,sx,w,sc,S,I,O); double dt0=now_s()-t;
+        t=now_s(); call_path(fmt,!first,first?yn:ym,x,sx,w,sc,S,I,O); double dt1=now_s()-t;
+        if(first){ tm[r]=dt0; tn[r]=dt1; } else { tn[r]=dt0; tm[r]=dt1; }
+        sink+=yn[r%(S*O)]+ym[(r*7)%(S*O)];
+    }
+    qsort(tn,REPS,sizeof(double),cmp_double); qsort(tm,REPS,sizeof(double),cmp_double);
+    const char *selected=(fmt==2&&S==1&&I<6144)?"NEON guard":"SMMLA";
+    printf("%-4s %-18s S=%-2d %7.3f %8.3f %7.3fx  %s\n",
+           fmt==1?"i8":"i4",label,S,tn[REPS/2]*1e3,tm[REPS/2]*1e3,
+           tn[REPS/2]/tm[REPS/2],selected);
+    (void)sink; free(w);free(x);free(yn);free(ym);free(sc);free(sx); return 1;
+}
+
+int main(void){
+    if(!cpu_has_i8mm()){ puts("i8mm benchmark: skipped (SMMLA unavailable)"); return 0; }
+    puts("format shape              S   NEON-ms SMMLA-ms speedup  dispatch");
+    int ok=1;
+    for(int fmt=1;fmt<=2;fmt++){
+        ok&=bench_shape(fmt,1,6144,2048,"gate/up");
+        ok&=bench_shape(fmt,1,2048,6144,"down");
+        ok&=bench_shape(fmt,2,6144,2048,"gate/up");
+        ok&=bench_shape(fmt,2,2048,6144,"down");
+        ok&=bench_shape(fmt,4,6144,2048,"gate/up");
+        ok&=bench_shape(fmt,4,2048,6144,"down");
+    }
+    return ok?0:1;
+}
+#else
+int main(void){ puts("i8mm benchmark: skipped (not an AArch64 i8mm build)"); return 0; }
+#endif

--- a/c/tests/bench_i8mm.c
+++ b/c/tests/bench_i8mm.c
@@ -21,11 +21,12 @@ static void call_path(int fmt, int use_i8mm, float *y, const int8_t *x, const fl
 
 static int bench_shape(int fmt, int S, int I, int O, const char *label){
     enum { REPS=21 };
+    double tn[REPS],tm[REPS]; volatile float sink=0; int ok=0;
     int rb=(I+1)/2; size_t wn=fmt==1?(size_t)O*I:(size_t)O*rb;
     uint8_t *w=malloc(wn); int8_t *x=malloc((size_t)S*I);
     float *yn=malloc((size_t)S*O*sizeof(float)),*ym=malloc((size_t)S*O*sizeof(float));
     float *sc=malloc((size_t)O*sizeof(float)),*sx=malloc((size_t)S*sizeof(float));
-    if(!w||!x||!yn||!ym||!sc||!sx){ fprintf(stderr,"bench_i8mm: OOM\n"); return 0; }
+    if(!w||!x||!yn||!ym||!sc||!sx){ fprintf(stderr,"bench_i8mm: OOM\n"); goto cleanup; }
     for(size_t i=0;i<wn;i++) w[i]=(uint8_t)xr();
     for(int i=0;i<S*I;i++) x[i]=(int8_t)((int)(xr()%255)-127);
     for(int i=0;i<O;i++) sc[i]=0.001f+(float)(i%17)*0.0001f;
@@ -34,9 +35,8 @@ static int bench_shape(int fmt, int S, int I, int O, const char *label){
     call_path(fmt,0,yn,x,sx,w,sc,S,I,O);
     call_path(fmt,1,ym,x,sx,w,sc,S,I,O);
     if(memcmp(yn,ym,(size_t)S*O*sizeof(float))!=0){
-        fprintf(stderr,"bench_i8mm: numeric mismatch: %s\n",label); return 0;
+        fprintf(stderr,"bench_i8mm: numeric mismatch: %s\n",label); goto cleanup;
     }
-    double tn[REPS],tm[REPS]; volatile float sink=0;
     for(int r=0;r<REPS;r++){
         int first=r&1;
         double t=now_s(); call_path(fmt,first,first?ym:yn,x,sx,w,sc,S,I,O); double dt0=now_s()-t;
@@ -49,7 +49,9 @@ static int bench_shape(int fmt, int S, int I, int O, const char *label){
     printf("%-4s %-18s S=%-2d %7.3f %8.3f %7.3fx  %s\n",
            fmt==1?"i8":"i4",label,S,tn[REPS/2]*1e3,tm[REPS/2]*1e3,
            tn[REPS/2]/tm[REPS/2],selected);
-    (void)sink; free(w);free(x);free(yn);free(ym);free(sc);free(sx); return 1;
+    (void)sink; ok=1;
+cleanup:
+    free(w);free(x);free(yn);free(ym);free(sc);free(sx); return ok;
 }
 
 int main(void){

--- a/c/tests/test_idot.c
+++ b/c/tests/test_idot.c
@@ -24,21 +24,60 @@ static int32_t ref_i4i8(const uint8_t *w4, const int8_t *x, int I){
 
 int main(void){
     static const int sizes[]={1,2,15,16,17,31,32,33,63,64,65,100,127,128,1408,4096,4097};
-    static int8_t w[8192], x[8192]; static uint8_t w4[4096];
+    static int8_t w[8192], w1[8192], x[8192], x1[8192];
+    static uint8_t w4[4096], w41[4096];
+    int have_i8mm=i8mm_enabled();
     for(unsigned t=0;t<sizeof(sizes)/sizeof(sizes[0]);t++){
         int I=sizes[t];
         for(int rep=0;rep<64;rep++){
             for(int i=0;i<I;i++) x[i]=(int8_t)((int)(xr()%255)-127);      /* [-127,127]: contratto di qrow_i8 */
             for(int i=0;i<I;i++) w[i]=(int8_t)((int)(xr()%256)-128);      /* [-128,127]: range pieno */
+            for(int i=0;i<I;i++){ x1[i]=(int8_t)((int)(xr()%255)-127); w1[i]=(int8_t)((int)(xr()%256)-128); }
             if(rep==0) for(int i=0;i<I;i++) w[i]=-128;                    /* caso limite del trucco del segno */
             if(rep==1) for(int i=0;i<I;i++){ w[i]=127; x[i]=(int8_t)(i&1?-127:127); }
-            for(int i=0;i<(I+1)/2;i++) w4[i]=(uint8_t)(xr()&0xFF);
+            for(int i=0;i<(I+1)/2;i++){ w4[i]=(uint8_t)(xr()&0xFF); w41[i]=(uint8_t)(xr()&0xFF); }
             int32_t got=dot_i8i8(w,x,I), want=ref_i8i8(w,x,I);
             if(got!=want){ fprintf(stderr,"FAIL dot_i8i8 I=%d rep=%d: %d != %d\n",I,rep,got,want); return 1; }
             got=dot_i4i8(w4,x,I); want=ref_i4i8(w4,x,I);
             if(got!=want){ fprintf(stderr,"FAIL dot_i4i8 I=%d rep=%d: %d != %d\n",I,rep,got,want); return 1; }
+#if COLI_HAVE_I8MM
+            if(have_i8mm){
+                int32_t d[4], r[4]={ref_i8i8(w,x,I),ref_i8i8(w,x1,I),ref_i8i8(w1,x,I),ref_i8i8(w1,x1,I)};
+                dot_i8i8_2x2_i8mm_entry(d,w,w1,x,x1,I);
+                for(int j=0;j<4;j++) if(d[j]!=r[j]){
+                    fprintf(stderr,"FAIL i8mm int8 I=%d rep=%d lane=%d: %d != %d\n",I,rep,j,d[j],r[j]); return 1; }
+                r[0]=ref_i4i8(w4,x,I); r[1]=ref_i4i8(w4,x1,I);
+                r[2]=ref_i4i8(w41,x,I); r[3]=ref_i4i8(w41,x1,I);
+                dot_i4i8_2x2_i8mm_entry(d,w4,w41,x,x1,I);
+                for(int j=0;j<4;j++) if(d[j]!=r[j]){
+                    fprintf(stderr,"FAIL i8mm int4 I=%d rep=%d lane=%d: %d != %d\n",I,rep,j,d[j],r[j]); return 1; }
+            }
+#endif
         }
     }
-    printf("idot kernel exactness (%s): ok\n", IDOT_KERNEL);
+
+#if COLI_HAVE_I8MM
+    if(have_i8mm){
+        static int8_t qm8[5*8192], xm[3*8192]; static uint8_t qm4[5*4096];
+        float sc[5]={0.25f,0.5f,1.f,1.5f,2.f}, sx[3]={0.125f,0.75f,1.25f};
+        float ref8[15],got8[15],ref4[15],got4[15];
+        static const int msizes[]={8,15,32,127,1408,4097,6144};
+        for(unsigned t=0;t<sizeof(msizes)/sizeof(msizes[0]);t++){
+            int I=msizes[t],rb=(I+1)/2;
+            for(int i=0;i<3*I;i++) xm[i]=(int8_t)((int)(xr()%255)-127);
+            for(int i=0;i<5*I;i++) qm8[i]=(int8_t)((int)(xr()%256)-128);
+            for(int i=0;i<5*rb;i++) qm4[i]=(uint8_t)xr();
+            for(int S=1;S<=3;S++) for(int O=2;O<=5;O++){
+                g_i8mm=0; matmul_q_idot(ref8,xm,sx,qm8,sc,S,I,O);
+                g_i8mm=1; matmul_q_idot(got8,xm,sx,qm8,sc,S,I,O);
+                g_i8mm=0; matmul_i4_idot(ref4,xm,sx,qm4,sc,S,I,O);
+                g_i8mm=1; matmul_i4_idot(got4,xm,sx,qm4,sc,S,I,O);
+                for(int i=0;i<S*O;i++) if(got8[i]!=ref8[i] || got4[i]!=ref4[i]){
+                    fprintf(stderr,"FAIL i8mm matmul I=%d S=%d O=%d at %d\n",I,S,O,i); return 1; }
+            }
+        }
+    }
+#endif
+    printf("idot kernel exactness (%s%s): ok\n", IDOT_KERNEL,have_i8mm?"+i8mm":"");
     return 0;
 }

--- a/c/tools/clean.py
+++ b/c/tools/clean.py
@@ -16,6 +16,7 @@ FILES = [
     "backend_cuda.o", "backend_loader.o",
     "backend_cuda_test", "backend_cuda_test.exe",
     "backend_cuda_bench", "backend_cuda_bench.exe",
+    "i8mm_bench", "i8mm_bench.exe",
     "backend_metal.o", "backend_metal_test",
     "coli_cuda.dll", "coli_cuda.lib", "coli_cuda.exp",
 ]

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -61,6 +61,7 @@ Format: `VAR` — default — effect.
 | `ROUTE_AGREE` | auto | Overlap% + KL vs true top-K; auto-on when `CACHE_ROUTE=1`. |
 | `ABSORB` | `-1` (auto: absorbed for S≤4) | MLA attention absorption mode. |
 | `IDOT` | `1` | Integer dot-product kernel. `IDOT=0` uses exact f32 kernels (for A/B numerical checks). |
+| `I8MM` | auto | On supported AArch64 CPUs, use the runtime-dispatched SMMLA expert kernel. `I8MM=0` forces the existing NEON/SDOT path for same-binary A/B measurements. |
 | `COLI_POLICY` | `quality` | Resource policy: `quality`, `balanced`, or `experimental-fast`. |
 
 ---


### PR DESCRIPTION
## Summary

Add a runtime-dispatched AArch64 i8mm expert kernel for the existing int8-activation IDOT path.

- compile `SMMLA` only inside per-function i8mm targets, preserving the baseline AArch64 binary
- detect i8mm at runtime with `hw.optional.arm.FEAT_I8MM` on macOS and `AT_HWCAP2/HWCAP2_I8MM` on Linux
- compute a 2-output × 2-activation tile so all four `SMMLA` lanes do useful work
- use four independent accumulators to hide matrix-dot latency
- support both int8 and packed-int4 weights, arbitrary tails, odd `S`, and odd output counts
- keep the measured-slower int4 `S=1, I<6144` case on the existing NEON path
- add `I8MM=0` for same-binary A/B measurements

This keeps the dependency-free default CPU path and file formats unchanged.

## Why

The warm profile in #136 is matmul-bound on AArch64, while the current NEON IDOT path uses SDOT but not the available i8mm/SMMLA instructions. A direct instruction substitution was slower; the useful unit is a 2×2 tile with activation-pair packing and multiple independent accumulators.

## Validation

Apple M2 Pro (12 cores, 32 GB), macOS arm64, Apple Clang 21.0.0. The benchmark was single-threaded because local libomp headers were unavailable. It uses the real GLM-5.2 expert shapes, one untimed call per path, 21 timed A/B pairs with alternating order, and reports medians.

```text
$ make -C c OMPDIR= i8mm-bench
format shape              S   NEON-ms SMMLA-ms speedup  dispatch
i8   gate/up            S=1    0.867    0.526   1.648x  SMMLA
i8   down               S=1    0.652    0.529   1.233x  SMMLA
i8   gate/up            S=2    1.737    0.542   3.205x  SMMLA
i8   down               S=2    1.423    0.556   2.559x  SMMLA
i8   gate/up            S=4    3.445    1.015   3.394x  SMMLA
i8   down               S=4    2.638    0.986   2.675x  SMMLA
i4   gate/up            S=1    0.863    0.853   1.012x  SMMLA
i4   down               S=1    0.656    0.653   1.005x  NEON guard
i4   gate/up            S=2    1.725    0.850   2.029x  SMMLA
i4   down               S=2    1.305    0.853   1.530x  SMMLA
i4   gate/up            S=4    3.493    1.730   2.019x  SMMLA
i4   down               S=4    2.658    1.703   1.561x  SMMLA
```

Checks run:

- `make check OMPDIR=` — clean CPU build, C suite, and 62 Python tests pass with zero compiler warnings
- `./c/tests/test_idot` — exact against scalar references for int8/int4 tiles, random full-range weights, `-128` edges, tails, and `S=1..3` / odd-output dispatch
- x86_64 compile-only checks for `glm.c`, `test_idot.c`, and `bench_i8mm.c` — clean compile-out of the AArch64 path
- `git diff --check`

## Still needed before ready

I do not have the full model snapshot locally. Please run the token-exact oracle (32/32 TF + 20/20 greedy) and `OMP_NUM_THREADS=1 make -C c i8mm-bench` on an i8mm Linux machine/GB10 or Grace. `I8MM=0` provides the same-binary NEON control.

Tracks the aarch64 i8mm frontier item in discussion #209.
