### PR TITLE
glm: fix kv_alloc double-free on KV re-allocation (stale pre-Metal free block)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -146,7 +146,7 @@ else
 PYTHON    ?= python3
 endif
 CUDA_OBJ  =
-TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE)
+TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_kv_alloc$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE)
 
 # Windows CUDA DLL path: host links the loader, NOT cudart.
 ifneq ($(IS_WIN),)
@@ -258,6 +258,9 @@ tests/test_decode_batch$(EXE): tests/test_decode_batch.c decode_batch.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_idot$(EXE): tests/test_idot.c glm.c st.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+tests/test_kv_alloc$(EXE): tests/test_kv_alloc.c glm.c st.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_i4_acc512$(EXE): tests/test_i4_acc512.c

--- a/c/glm.c
+++ b/c/glm.c
@@ -3066,7 +3066,6 @@ static void kv_alloc(Model *m, int max_t){
         m->kv_dev_valid[i]=0;
     }
 #endif
-    if(k->Lc){ for(int i=0;i<c->n_layers+1;i++){ free(k->Lc[i]); free(k->Rc[i]); } free(k->Lc); free(k->Rc); }
     if(k->Lc){ for(int i=0;i<c->n_layers+1;i++){
 #ifdef COLI_METAL
         if(g_metal_enabled){ coli_metal_unregister(k->Lc[i]); coli_metal_unregister(k->Rc[i]); }

--- a/c/tests/test_kv_alloc.c
+++ b/c/tests/test_kv_alloc.c
@@ -1,0 +1,23 @@
+/* kv_alloc must survive re-allocation on the same KVState: every free path is
+ * guarded by if(k->Lc) precisely so callers (context resize, slot re-init) can
+ * call it again. A stale duplicate free block frees every Lc[i]/Rc[i] and both
+ * arrays twice on the second call -> allocator abort. No model file needed:
+ * the CPU path of kv_alloc only reads c->n_layers/kv_lora/qk_rope. */
+#define main coli_glm_main_unused
+#include "../glm.c"
+#undef main
+
+int main(void){
+    static Model m;
+    m.c.n_layers=2; m.c.kv_lora=8; m.c.qk_rope=4;
+    m.kv=calloc(1,sizeof(KVState));
+    kv_alloc(&m,16);
+    for(int i=0;i<m.c.n_layers+1;i++){ m.Lc[i][0]=1.0f; m.Rc[i][0]=1.0f; }
+    kv_alloc(&m,32);                       /* the re-allocation path under test */
+    for(int i=0;i<m.c.n_layers+1;i++){
+        m.Lc[i][(int64_t)32*m.c.kv_lora-1]=2.0f;
+        m.Rc[i][(int64_t)32*m.c.qk_rope-1]=2.0f;
+    }
+    printf("OK kv_alloc re-allocation\n");
+    return 0;
+}


### PR DESCRIPTION
## The bug

`kv_alloc()` in `c/glm.c` contained two consecutive `if(k->Lc)` free blocks:

```c
if(k->Lc){ for(int i=0;i<c->n_layers+1;i++){ free(k->Lc[i]); free(k->Rc[i]); } free(k->Lc); free(k->Rc); }
if(k->Lc){ for(int i=0;i<c->n_layers+1;i++){
#ifdef COLI_METAL
    if(g_metal_enabled){ coli_metal_unregister(k->Lc[i]); coli_metal_unregister(k->Rc[i]); }
#endif
    free(k->Lc[i]); free(k->Rc[i]); } free(k->Lc); free(k->Rc); }
```

The first block frees every `k->Lc[i]`/`k->Rc[i]` and both arrays without unregistering from Metal and without nulling `k->Lc`. The second block then re-tests the dangling `k->Lc`, reads element pointers out of freed memory, calls `coli_metal_unregister` on already-freed pointers, and frees everything a second time. On macOS the second `kv_alloc` call on the same `KVState` aborts:

```
test_kv_alloc(41889,0x1f5b61d80) malloc: *** error for object 0x7: pointer being freed was not allocated
```

(the `0x7` is a stale value read from the freed `k->Lc` array).

## How it got there

`git log -L` on the block shows the first line is the pre-Metal version of the free path left behind in a merge:

- 3716e40 (Metal backend) **replaced** the plain free line with the Metal-aware unregister block.
- ec89136 (GPU resident pipeline, #111) **re-added** the old plain line above it.

## Reach

Every current entry point (`run_text`, `run_score`, `run_replay`, `generate`, `forward_all`, `serve_ctx_init`) happens to call `kv_alloc` exactly once per fresh calloc'd `KVState`, so the shipped modes don't hit it today. But the `if(k->Lc)` guard exists precisely so `kv_alloc` can be called again on the same state (context resize, slot re-init), and any such call — including from future callers — double-frees. In a Metal build the stale block alone is also wrong on that path: it plain-frees page-aligned, Metal-registered buffers without `coli_metal_unregister`.

## The fix

Delete the stale block; the Metal-aware block is the only free path. One line removed.

## Verification

- New regression test `tests/test_kv_alloc.c` (follows the `test_idot.c` include pattern, no model file needed, wired into `TEST_BINS`). Commit ordering: the test lands first and fails with the abort above (exit 134); the fix commit makes it pass (`OK kv_alloc re-allocation`, exit 0).
- `make glm METAL=1` builds clean (macOS arm64, Homebrew libomp).
- `make metal-test`: all kernel/moe/gemm/attention tests ok.
- `make test-c`: all tests ok, including the new one.

Note (pre-existing, not touched here): `tests/test_schema_gbnf` and `tests/test_compat_direct` are committed as Linux x86-64 ELF binaries, so `make test-c` on macOS fails with `Exec format error` until they're deleted and rebuilt locally. Happy to file that separately.