### PR TITLE
Windows CUDA (Phase G1): coli_cuda.dll + runtime LoadLibrary shim

### DIFF
--- a/c/.gitignore
+++ b/c/.gitignore
@@ -1,4 +1,10 @@
 *.exe
+*.o
 glm_tiny/
 olmoe_hf/
 olmoe_i4/
+
+# Windows CUDA DLL build artifacts (see Makefile target coli_cuda.dll)
+coli_cuda.dll
+coli_cuda.exp
+coli_cuda.lib

--- a/c/Makefile
+++ b/c/Makefile
@@ -56,15 +56,23 @@ CUDA_OBJ  =
 TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE)
 ifeq ($(CUDA),1)
 ifeq ($(UNAME_S),Darwin)
-$(error CUDA=1 is supported only on Linux)
+$(error CUDA=1 is supported only on Linux and Windows)
 endif
 ifneq ($(IS_WIN),)
-# GPU: stub only in Phase 1 (G0). G1 builds coli_cuda.dll with MSVC+nvcc.
-$(error CUDA=1 on Windows requires G1: build coli_cuda.dll with MSVC+nvcc (see PORT_WINDOWS_PLAN.md §8))
-endif
+# Windows (Phase G1): backend_cuda.cu is built as coli_cuda.dll by a separate
+# rule (nvcc + MSVC host compiler), then loaded at runtime via
+# LoadLibrary/GetProcAddress from compat_cuda.c. This side of the Makefile
+# only pulls in the CPU-side loader; the DLL itself is built with:
+#     make coli_cuda.dll CUDA=1
+# from an environment that has both nvcc and cl.exe on PATH (vcvars64.bat).
+CFLAGS   += -DCOLI_CUDA
+CUDA_OBJ  = compat_cuda.o
+else
+# Linux: compile-time link with the .cu directly (original path, unchanged).
 CFLAGS   += -DCOLI_CUDA
 LDFLAGS  += -L$(CUDA_HOME)/lib64 -Wl,-rpath,$(CUDA_HOME)/lib64 -lcudart -lstdc++
 CUDA_OBJ  = backend_cuda.o
+endif
 endif
 
 all: glm$(EXE)
@@ -79,10 +87,34 @@ backend_cuda.o: backend_cuda.cu backend_cuda.h
 	@command -v $(NVCC) >/dev/null 2>&1 || { echo "nvcc not found: set CUDA_HOME or NVCC" >&2; exit 1; }
 	$(NVCC) $(NVCCFLAGS) -c backend_cuda.cu -o $@
 
+# Windows-only: compile the LoadLibrary shim into an object linkable with the
+# MinGW-built glm.exe. compat_cuda.h/.c must be present alongside glm.c.
+compat_cuda.o: compat_cuda.c compat_cuda.h backend_cuda.h
+	$(CC) $(CFLAGS) -c compat_cuda.c -o $@
+
+# Windows-only DLL build. Uses nvcc (which auto-picks cl.exe as host compiler
+# when both are on PATH). Requires running from a shell where vcvars64.bat has
+# initialized the MSVC toolchain — see README §Windows for details. The .def
+# file drives symbol export; no source changes to backend_cuda.h needed.
+# CUDA_ARCH=native lets nvcc pick the sm_XX matching the current GPU; override
+# with e.g. CUDA_ARCH=sm_86 for portability across a set of known cards.
+coli_cuda.dll: backend_cuda.cu backend_cuda.h coli_cuda.def
+	@command -v $(NVCC) >/dev/null 2>&1 || { echo "nvcc not found: set CUDA_HOME or NVCC" >&2; exit 1; }
+	$(NVCC) $(NVCCFLAGS) --shared -o coli_cuda.dll backend_cuda.cu \
+		-Xlinker /DEF:coli_cuda.def -Xcompiler /MD
+
 cuda-test: backend_cuda.cu backend_cuda.h tests/test_backend_cuda.cu
 	@command -v $(NVCC) >/dev/null 2>&1 || { echo "nvcc not found: set CUDA_HOME or NVCC" >&2; exit 1; }
 	$(NVCC) $(NVCCFLAGS) backend_cuda.cu tests/test_backend_cuda.cu -o backend_cuda_test$(EXE)
 	./backend_cuda_test$(EXE)
+
+# Windows-only: validate coli_cuda.dll via LoadLibrary + GetProcAddress from a
+# separate binary. Proves the DLL loading path is functional independently of
+# the full glm.exe. Requires coli_cuda.dll built (run `make coli_cuda.dll` first).
+cuda-dll-test: tests/test_dll_loadlib.c coli_cuda.dll
+	$(CC) $(CFLAGS) -c tests/test_dll_loadlib.c -o tests/test_dll_loadlib.o
+	$(CC) tests/test_dll_loadlib.o -o tests/test_dll_loadlib$(EXE) -lm
+	./tests/test_dll_loadlib$(EXE)
 
 olmoe$(EXE): olmoe.c st.h json.h compat.h
 	$(CC) $(CFLAGS) olmoe.c -o olmoe$(EXE) $(LDFLAGS)

--- a/c/coli_cuda.def
+++ b/c/coli_cuda.def
@@ -1,0 +1,17 @@
+; Windows DLL export table for coli_cuda.dll.
+; Enumerates the 8 public C-linkage symbols from backend_cuda.h so they show up
+; in the DLL export table without touching the .cu source. Loaded at runtime
+; from glm.exe via LoadLibrary + GetProcAddress (see compat.h Windows shims).
+LIBRARY coli_cuda
+EXPORTS
+    coli_cuda_init
+    coli_cuda_shutdown
+    coli_cuda_device_count
+    coli_cuda_device_at
+    coli_cuda_mem_info
+    coli_cuda_stats
+    coli_cuda_tensor_upload
+    coli_cuda_matmul
+    coli_cuda_tensor_free
+    coli_cuda_tensor_bytes
+    coli_cuda_tensor_device

--- a/c/compat_cuda.c
+++ b/c/compat_cuda.c
@@ -1,0 +1,87 @@
+/* compat_cuda.c — Definition of the runtime loader for coli_cuda.dll.
+ *
+ * Compiled only on Windows with COLI_CUDA=1. Owns the 11 function-pointer
+ * definitions declared extern in compat_cuda.h and the LoadLibrary logic
+ * that populates them. */
+
+#if defined(_WIN32) && defined(COLI_CUDA)
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <stdio.h>
+
+/* Include the shim header. Its call-site redirection macros do NOT interfere
+ * with the pointer-variable definitions below because none of those lines
+ * contain a bare coli_cuda_* identifier — they contain fn_coli_cuda_* (a
+ * typedef name) and p_coli_cuda_* (the pointer variable), both of which are
+ * distinct from the macro left-hand side. */
+#include "compat_cuda.h"
+
+fn_coli_cuda_init          p_coli_cuda_init          = NULL;
+fn_coli_cuda_shutdown      p_coli_cuda_shutdown      = NULL;
+fn_coli_cuda_device_count  p_coli_cuda_device_count  = NULL;
+fn_coli_cuda_device_at     p_coli_cuda_device_at     = NULL;
+fn_coli_cuda_mem_info      p_coli_cuda_mem_info      = NULL;
+fn_coli_cuda_stats         p_coli_cuda_stats         = NULL;
+fn_coli_cuda_tensor_upload p_coli_cuda_tensor_upload = NULL;
+fn_coli_cuda_matmul        p_coli_cuda_matmul        = NULL;
+fn_coli_cuda_tensor_free   p_coli_cuda_tensor_free   = NULL;
+fn_coli_cuda_tensor_bytes  p_coli_cuda_tensor_bytes  = NULL;
+fn_coli_cuda_tensor_device p_coli_cuda_tensor_device = NULL;
+
+/* -1 = attempted and failed; 0 = not attempted yet; 1 = loaded OK. */
+static int g_loaded_state = 0;
+static HMODULE g_dll = NULL;
+
+/* Resolve a single symbol. Uses stringification to avoid quoting the name
+ * at the call site — safe here because ## and # inhibit macro expansion. */
+#define RESOLVE(name) do {                                                     \
+    p_##name = (fn_##name)(void *)GetProcAddress(g_dll, #name);                \
+    if (!p_##name) {                                                           \
+        fprintf(stderr, "[compat_cuda] symbol %s missing in coli_cuda.dll\n",  \
+                #name);                                                        \
+        goto fail;                                                             \
+    }                                                                          \
+} while (0)
+
+int compat_cuda_load(void) {
+    if (g_loaded_state) return g_loaded_state > 0;
+    g_loaded_state = -1;  /* mark attempted */
+
+    g_dll = LoadLibraryA("coli_cuda.dll");
+    if (!g_dll) {
+        fprintf(stderr,
+            "[compat_cuda] LoadLibrary(\"coli_cuda.dll\") failed (Windows err %lu).\n"
+            "  On Windows the CUDA backend lives in a separate DLL built with\n"
+            "  MSVC + nvcc. Build it with:  make coli_cuda.dll CUDA=1\n"
+            "  and ensure coli_cuda.dll is in the working directory or PATH.\n",
+            GetLastError());
+        return 0;
+    }
+
+    RESOLVE(coli_cuda_init);
+    RESOLVE(coli_cuda_shutdown);
+    RESOLVE(coli_cuda_device_count);
+    RESOLVE(coli_cuda_device_at);
+    RESOLVE(coli_cuda_mem_info);
+    RESOLVE(coli_cuda_stats);
+    RESOLVE(coli_cuda_tensor_upload);
+    RESOLVE(coli_cuda_matmul);
+    RESOLVE(coli_cuda_tensor_free);
+    RESOLVE(coli_cuda_tensor_bytes);
+    RESOLVE(coli_cuda_tensor_device);
+
+    g_loaded_state = 1;
+    return 1;
+
+fail:
+    FreeLibrary(g_dll);
+    g_dll = NULL;
+    return 0;
+}
+
+#undef RESOLVE
+
+#endif /* _WIN32 && COLI_CUDA */

--- a/c/compat_cuda.h
+++ b/c/compat_cuda.h
@@ -1,0 +1,76 @@
+/* compat_cuda.h — Runtime loader shim for coli_cuda.dll on Windows.
+ *
+ * On Linux/macOS the CUDA backend is compile-time linked (backend_cuda.o
+ * produced by nvcc directly from the .cu). On Windows the CPU engine
+ * builds with MinGW-w64 GCC, but nvcc requires MSVC as its host compiler,
+ * so backend_cuda.cu is built as a separate MSVC-produced DLL and
+ * loaded at runtime via LoadLibrary + GetProcAddress. C linkage is
+ * stable across the MSVC/MinGW x64 ABI, so the boundary is safe.
+ *
+ * MUST be included AFTER "backend_cuda.h" in the same translation unit.
+ * The backend_cuda.h declarations must be visible first so the macros
+ * below (which redirect the CALL SITE only) do not accidentally rewrite
+ * the function declarations themselves.
+ *
+ * On Linux/macOS this header is a no-op.
+ */
+#ifndef COMPAT_CUDA_H
+#define COMPAT_CUDA_H
+
+#if defined(_WIN32) && defined(COLI_CUDA)
+
+#include "backend_cuda.h"
+#include <stddef.h>
+
+/* Function-pointer types matching each coli_cuda_* signature. */
+typedef int    (*fn_coli_cuda_init)         (const int *devices, int count);
+typedef void   (*fn_coli_cuda_shutdown)     (void);
+typedef int    (*fn_coli_cuda_device_count) (void);
+typedef int    (*fn_coli_cuda_device_at)    (int index);
+typedef int    (*fn_coli_cuda_mem_info)     (int device, size_t *free_bytes, size_t *total_bytes);
+typedef void   (*fn_coli_cuda_stats)        (int device, size_t *tensor_count, size_t *tensor_bytes);
+typedef int    (*fn_coli_cuda_tensor_upload)(ColiCudaTensor **tensor, const void *weights,
+                                             const float *scales, int fmt, int I, int O, int device);
+typedef int    (*fn_coli_cuda_matmul)       (ColiCudaTensor **tensor, float *y, const float *x,
+                                             const void *weights, const float *scales,
+                                             int fmt, int S, int I, int O, int device);
+typedef void   (*fn_coli_cuda_tensor_free)  (ColiCudaTensor *tensor);
+typedef size_t (*fn_coli_cuda_tensor_bytes) (const ColiCudaTensor *tensor);
+typedef int    (*fn_coli_cuda_tensor_device)(const ColiCudaTensor *tensor);
+
+extern fn_coli_cuda_init          p_coli_cuda_init;
+extern fn_coli_cuda_shutdown      p_coli_cuda_shutdown;
+extern fn_coli_cuda_device_count  p_coli_cuda_device_count;
+extern fn_coli_cuda_device_at     p_coli_cuda_device_at;
+extern fn_coli_cuda_mem_info      p_coli_cuda_mem_info;
+extern fn_coli_cuda_stats         p_coli_cuda_stats;
+extern fn_coli_cuda_tensor_upload p_coli_cuda_tensor_upload;
+extern fn_coli_cuda_matmul        p_coli_cuda_matmul;
+extern fn_coli_cuda_tensor_free   p_coli_cuda_tensor_free;
+extern fn_coli_cuda_tensor_bytes  p_coli_cuda_tensor_bytes;
+extern fn_coli_cuda_tensor_device p_coli_cuda_tensor_device;
+
+/* Redirect the 11 call sites. Macros affect only function-call syntax; the
+ * prototype declarations already parsed from backend_cuda.h above are not
+ * touched. C function pointers accept plain f(a,b) syntax — no (*f)(a,b). */
+#define coli_cuda_init          p_coli_cuda_init
+#define coli_cuda_shutdown      p_coli_cuda_shutdown
+#define coli_cuda_device_count  p_coli_cuda_device_count
+#define coli_cuda_device_at     p_coli_cuda_device_at
+#define coli_cuda_mem_info      p_coli_cuda_mem_info
+#define coli_cuda_stats         p_coli_cuda_stats
+#define coli_cuda_tensor_upload p_coli_cuda_tensor_upload
+#define coli_cuda_matmul        p_coli_cuda_matmul
+#define coli_cuda_tensor_free   p_coli_cuda_tensor_free
+#define coli_cuda_tensor_bytes  p_coli_cuda_tensor_bytes
+#define coli_cuda_tensor_device p_coli_cuda_tensor_device
+
+/* Load coli_cuda.dll (from cwd or PATH) and resolve all 11 exports.
+ * Returns 1 on success, 0 on failure (with an explanatory line on stderr).
+ * Must be called ONCE before the first coli_cuda_* call. Idempotent: a
+ * successful load is cached; a failed load is not retried. */
+int compat_cuda_load(void);
+
+#endif /* _WIN32 && COLI_CUDA */
+
+#endif /* COMPAT_CUDA_H */

--- a/c/glm.c
+++ b/c/glm.c
@@ -36,6 +36,7 @@
 #ifdef COLI_CUDA
 #include <omp.h>
 #include "backend_cuda.h"
+#include "compat_cuda.h"   /* Windows: LoadLibrary shim (no-op on Linux/macOS) */
 #endif
 #ifdef __AVX2__
 #include <immintrin.h>
@@ -2533,6 +2534,12 @@ int main(int argc, char **argv){
         else if(one) g_cuda_ndev=parse_cuda_devices(one,g_cuda_devices);
         else { g_cuda_ndev=1; g_cuda_devices[0]=0; }
         if(g_cuda_ndev<1){ fprintf(stderr,"COLI_GPUS non valido: usa una lista come 0,1,2\n"); return 2; }
+#ifdef _WIN32
+        /* Windows: coli_cuda.dll is loaded at runtime; symbols must be resolved
+         * before the first coli_cuda_* call so the redirect macros have a
+         * valid function pointer. Linux/macOS use compile-time linking. */
+        if(!compat_cuda_load()){ return 2; }
+#endif
         g_cuda_enabled=coli_cuda_init(g_cuda_devices,g_cuda_ndev);
         if(!g_cuda_enabled){ fprintf(stderr,"[CUDA] backend richiesto ma non disponibile\n"); return 2; }
     }

--- a/c/tests/test_dll_loadlib.c
+++ b/c/tests/test_dll_loadlib.c
@@ -1,0 +1,84 @@
+/* test_dll_loadlib.c — validates coli_cuda.dll loads via LoadLibrary +
+ * GetProcAddress on Windows. This is the exact pattern compat.h will use in
+ * Bloque 5 to wire the engine to the CUDA backend. Standalone C99, no
+ * dependency on backend_cuda.h — we redeclare the types locally to prove
+ * that a downstream consumer only needs the DLL + its ABI, not the .cu source. */
+
+#include <windows.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+
+typedef struct ColiCudaTensor ColiCudaTensor;
+
+/* Function-pointer types matching backend_cuda.h signatures. */
+typedef int  (*fn_init)(const int *devices, int count);
+typedef void (*fn_shutdown)(void);
+typedef int  (*fn_device_count)(void);
+typedef int  (*fn_mem_info)(int device, size_t *free_bytes, size_t *total_bytes);
+typedef int  (*fn_tensor_upload)(ColiCudaTensor **tensor, const void *weights,
+                                 const float *scales, int fmt, int I, int O, int device);
+typedef int  (*fn_matmul)(ColiCudaTensor **tensor, float *y, const float *x,
+                          const void *weights, const float *scales,
+                          int fmt, int S, int I, int O, int device);
+typedef void (*fn_tensor_free)(ColiCudaTensor *tensor);
+
+#define REQUIRE(cond, msg) do { if(!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); return 1; } } while(0)
+
+int main(void) {
+    HMODULE dll = LoadLibraryA("coli_cuda.dll");
+    if (!dll) {
+        fprintf(stderr, "FAIL: LoadLibrary(coli_cuda.dll) returned NULL (err %lu)\n",
+                GetLastError());
+        return 1;
+    }
+    fprintf(stderr, "OK: DLL loaded at %p\n", (void *)dll);
+
+    fn_init init = (fn_init)(void *)GetProcAddress(dll, "coli_cuda_init");
+    fn_shutdown shutdown = (fn_shutdown)(void *)GetProcAddress(dll, "coli_cuda_shutdown");
+    fn_device_count devcount = (fn_device_count)(void *)GetProcAddress(dll, "coli_cuda_device_count");
+    fn_mem_info meminfo = (fn_mem_info)(void *)GetProcAddress(dll, "coli_cuda_mem_info");
+    fn_tensor_upload upload = (fn_tensor_upload)(void *)GetProcAddress(dll, "coli_cuda_tensor_upload");
+    fn_matmul matmul = (fn_matmul)(void *)GetProcAddress(dll, "coli_cuda_matmul");
+    fn_tensor_free tfree = (fn_tensor_free)(void *)GetProcAddress(dll, "coli_cuda_tensor_free");
+
+    REQUIRE(init && shutdown && devcount && meminfo && upload && matmul && tfree,
+            "GetProcAddress for one of the 7 required symbols returned NULL");
+    fprintf(stderr, "OK: 7 symbols resolved via GetProcAddress\n");
+
+    int devices[] = {0};
+    REQUIRE(init(devices, 1), "coli_cuda_init failed");
+    fprintf(stderr, "OK: coli_cuda_init(devices=[0], count=1) succeeded\n");
+
+    REQUIRE(devcount() == 1, "coli_cuda_device_count != 1");
+    fprintf(stderr, "OK: coli_cuda_device_count() == 1\n");
+
+    size_t free_b = 0, total_b = 0;
+    REQUIRE(meminfo(0, &free_b, &total_b), "coli_cuda_mem_info failed");
+    fprintf(stderr, "OK: coli_cuda_mem_info(dev=0) -> free=%.2f GB / total=%.2f GB\n",
+            (double)free_b / 1e9, (double)total_b / 1e9);
+
+    /* Numerical: 1x4 @ 4x2 int8 matmul. Same as author's test row 1. */
+    const float x[4] = {1, -2, 3, -4};
+    const int8_t q8[8] = {1, 2, 3, 4, -1, 2, -3, 4};
+    const float scales[2] = {0.5f, 2.0f};
+    const float expected[2] = {-5.0f, -60.0f};
+    float y[2] = {0, 0};
+    ColiCudaTensor *t = NULL;
+
+    REQUIRE(matmul(&t, y, x, q8, scales, /*fmt=int8*/1, /*S=*/1, /*I=*/4, /*O=*/2, 0),
+            "coli_cuda_matmul (int8) failed");
+    for (int i = 0; i < 2; i++) {
+        if (fabsf(y[i] - expected[i]) > 1e-4f) {
+            fprintf(stderr, "FAIL: matmul[%d] = %.6f, expected %.6f\n", i, y[i], expected[i]);
+            return 1;
+        }
+    }
+    fprintf(stderr, "OK: int8 matmul via DLL matches expected (%.2f, %.2f)\n", y[0], y[1]);
+
+    tfree(t);
+    shutdown();
+    FreeLibrary(dll);
+    fprintf(stderr, "OK: shutdown + FreeLibrary clean\n\nALL_GREEN\n");
+    return 0;
+}


### PR DESCRIPTION
﻿## Summary

Adds native Windows support for `CUDA=1` by building `backend_cuda.cu` as a separate `coli_cuda.dll` (MSVC + nvcc) and loading it at runtime via `LoadLibrary` + `GetProcAddress`. Matches the Phase G1 roadmap literally noted in the current Makefile.

The CPU engine (`glm.c`) still builds with MinGW-w64 GCC as before. C linkage is stable across the MSVC/MinGW x64 ABI so the DLL boundary requires **zero source changes** to `backend_cuda.h` or `backend_cuda.cu`.

## Design

- **`c/coli_cuda.def`** — DLL export table (11 `coli_cuda_*` symbols); drives export without touching the .cu source
- **`c/compat_cuda.h`** — function-pointer typedefs, `extern` pointer declarations, call-site redirect macros (only active on Windows + COLI_CUDA); no-op on Linux/macOS
- **`c/compat_cuda.c`** — `LoadLibraryA("coli_cuda.dll")` + `GetProcAddress` for all 11 symbols; idempotent; friendly error message when DLL is missing
- **`c/glm.c`** — 2 minimal edits, both `#ifdef _WIN32` gated:
  - `#include "compat_cuda.h"` after `backend_cuda.h`
  - `compat_cuda_load()` call before first `coli_cuda_init()`
- **`c/Makefile`** — removes the previous Windows-CUDA error-out block; new rules for `coli_cuda.dll` (nvcc + MSVC) and `compat_cuda.o`; **Linux path unchanged** (verified with `make -n`)

## Testing

Tested on Intel i7-11850H + RTX 3080 Laptop + CUDA 13.2 + MSVC 14.44 + MinGW-w64 GCC 15.2 UCRT.

| Test | Result |
|---|---|
| `make test-c` (all deps-free C tests) | 4/4 PASS |
| `audit_win_shims` | PASS (rename + pread>4GB) |
| `make cuda-test` (kernel correctness) | PASS (q8/q4/q2/f32) |
| `make cuda-dll-test` (new, LoadLibrary path) | PASS (7 symbols + int8 matmul) |
| `glm.exe` CUDA=0 (regression) | PASS (714 KB, engine boots) |
| `glm.exe` CUDA=1 (LoadLibrary shim in action) | PASS (RTX 3080 detected, 17.2 GB VRAM) |
| DLL-missing detection | PASS (clean error message, exit 2) |

Full engine E2E validation with real GLM-5.2 weights not done (would need 370 GB int4 model). All architectural pieces are in place — happy to run a benchmark from Windows once you approve.

## Build commands (Windows)

```powershell
# from a shell with vcvars64.bat active (nvcc + cl.exe on PATH):
mingw32-make coli_cuda.dll CUDA=1
mingw32-make CUDA=1 glm.exe
```

## Notes

- `PORT_WINDOWS_PLAN.md` referenced in the current Makefile isn't in HEAD — feel free to update or drop the reference now that G1 is done
- README's "GPU via LoadLibrary on coli_cuda.dll (Phases G0–G2)" line under Windows section is now outdated for G1 — I didn't touch the README to keep this PR minimal; happy to send a follow-up
- On Windows this is the first CUDA-enabled contribution — a small `README.md` build section for Windows CUDA can go in a follow-up if you'd prefer
