### PR TITLE
serve: emit the [API] KV prefix-reuse diagnostic in mux mode (#153)

### DIFF
--- a/c/glm.c
+++ b/c/glm.c
@@ -4070,6 +4070,7 @@ static int mux_submit(Model *m, Tok *T, ServeCtx *ctx, ServeReq *req, int nctx,
         kv_disk_truncate(m,sc->len); }
     int add=nt-sc->len;
     if(add>0) memcpy(sc->hist+sc->len,tmp+sc->len,(size_t)add*sizeof(int));
+    fprintf(stderr,"[API] KV slot %d prefix %d/%d token, prefill %d\n",sub.slot,sc->len,nt,add);
     free(tmp);
     float *logit = add>0 ? step(m,sc->hist+sc->len,add,sc->len)
                          : step(m,sc->hist+sc->len-1,1,sc->len-1);


### PR DESCRIPTION
Answers the open question at the end of #153: the `[API] KV slot %d prefix %d/%d token, prefill %d` line was never wrong and never swallowed — it lives only in the **legacy** serve loop (`run_serve`, the `\x02PROMPT` length-prefixed protocol). `openai_server.py` launches the engine with `SERVE_BATCH=1`, which takes `run_serve_mux` instead, and `mux_submit`'s prefix-reuse logic (the exact same match-truncate-extend dance) prints nothing. So @dnnspaul was measuring the right mechanism in the wrong function: `raw_mode` is simply never reached from the server.

One line: mux mode now emits the same diagnostic, same format, so cache behaviour can be read off the log instead of inferred from wall-clock (528s → 23s style archaeology).

```
[API] KV slot 0 prefix 999/1024 token, prefill 25
```

stderr only, no protocol change.