### PR TITLE
web: fallback when crypto.randomUUID() is unavailable

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,7 +34,11 @@ import { Brain } from "./Brain"
 import { persistPublicSettings, stored } from "@/lib/storage"
 import { cn } from "@/lib/utils"
 
-const message = (role: ChatMessage["role"], content: string): ChatMessage => ({ id: crypto.randomUUID(), role, content })
+const message = (role: ChatMessage["role"], content: string): ChatMessage => {
+  let id: string
+  try { id = crypto.randomUUID() } catch { id = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => { const r = Math.random() * 16 | 0; return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16) }) }
+  return { id, role, content }
+}
 
 export default function App() {
   // When the page is served by the engine itself (coli web), same-origin is the


### PR DESCRIPTION
## Summary

The web dashboard crashes before sending the first message in browsers that don't support `crypto.randomUUID()` (e.g. Opera, older Chromium builds, or any browser running the page over plain HTTP in restricted contexts). The error surfaces as a silent `TypeError` in the console – the chat never starts.

## Root cause

`App.tsx` uses `crypto.randomUUID()` to generate unique message IDs. This API is only available in secure contexts (HTTPS) in some browsers, and is missing entirely in older ones. Since `coli web` serves the dashboard over plain HTTP, the function can throw on the very first keystroke or send attempt, preventing any interaction.

## Fix

Wrap the call in a try/catch and fall back to a standard UUID v4 generator when `crypto.randomUUID()` is unavailable. The fallback uses `Math.random()` – not cryptographically secure, but perfectly adequate for ephemeral UI message IDs.

Same behaviour on modern browsers (Chrome 92+, Firefox 95+, Safari 15.4+, Edge 92+), works everywhere else.
