### PR TITLE
coli: consume the engine's TIERS line at startup so it doesn't leak into the first answer

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -438,6 +438,8 @@ def cmd_chat(a):
         try: errlog.write(p.stderr.read().decode("utf-8","replace"))
         except (OSError, ValueError): pass
         errlog.seek(0); print(errlog.read()[-1500:]); sys.exit("the engine exited while loading")
+    p.stdout.readline()   # TIERS line (web-dashboard protocol): emitted once right after STAT;
+                          # left unread it leaks into the first answer's text
     # READY received. Drain the child's stderr into errlog without blocking:
     # the engine is still alive (blocked on stdin), so a plain read() would
     # hang forever waiting for EOF. A short bounded drain grabs the ~400 bytes


### PR DESCRIPTION
## Summary

After the READY handshake, `run_serve` emits one `TIERS` status line (the
web-dashboard expert-pyramid snapshot). `cmd_chat` never consumed it, so in
interactive chat it surfaced as literal `TIERS 0 181 19275 0.00 ...` text
prepended to the first response. This reads and discards that one line after
READY, matching how the other status frames are handled. Chat-only; the HTTP
serve path already drains it.

## Validation

- [x] `coli` byte-compiles
- [x] Reproduced on Apple M4: before, the first chat answer began with a
      `TIERS ...` line; after, the first answer is clean

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included
