### PR TITLE
profile: account expert-disk stall as wait, not other

### DIFF
--- a/c/glm.c
+++ b/c/glm.c
@@ -2509,7 +2509,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
             } else { double t0=now_s();             /* ORIGINALE: blocking parallel load */
                 #pragma omp parallel for schedule(dynamic,1)
                 for(int q=0;q<nmiss;q++) expert_load(m,layer,uniq[base+missk[q]],&m->ws[q],1);
-                m->t_edisk += now_s()-t0; }
+                m->t_ewait += now_s()-t0; }        /* blocking: whole load stalls compute */
         }
         /* I/O ASINCRONO: readahead (WILLNEED) del blocco SUCCESSIVO mentre calcoliamo
          * questo — il kernel legge in background, le pread dopo trovano cache calda */
@@ -2538,7 +2538,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
              * correct (and free) when a subset falls back to the CPU. */
             if(g_pipe && nmiss){ double tw=now_s();
                 for(int q=0;q<nmiss;q++) pipe_wait(q);
-                m->t_edisk += now_s()-tw; }
+                m->t_ewait += now_s()-tw; }        /* blocking: drain stalled compute */
             MB_BUILD(1, 0);                                   /* missed experts, now loaded */
             if(nbb>0){
                 double t0=now_s();
@@ -2562,7 +2562,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
              * Stays ABOVE the METAL skip: a subset that fell back to the CPU still needs its
              * slot drained here, and under METAL the block-level drain above already ran (this
              * spin is then a no-op). */
-            if(g_pipe && qof[j]>=0){ double tw=now_s(); pipe_wait(qof[j]); m->t_edisk += now_s()-tw; }
+            if(g_pipe && qof[j]>=0){ double tw=now_s(); pipe_wait(qof[j]); m->t_ewait += now_s()-tw; }  /* blocking */
 #ifdef COLI_METAL
             /* skip the subsets already computed on GPU */
             if(g_metal_enabled && ((is_miss[j] && !cpu_miss) || (!is_miss[j] && !cpu_res))) continue;
@@ -3689,7 +3689,7 @@ static void generate(Model *m, const int *prompt, int np, int n_new, int *out){
 }
 
 static void profile_print(Model *m, double elapsed){
-    double accounted=m->t_ewait+m->t_emm+m->t_attn+m->t_head;
+    double accounted=m->t_edisk+m->t_ewait+m->t_emm+m->t_attn+m->t_head;
     printf("PROFILE: expert-disk %.3fs service / %.3fs wait | expert-matmul %.3fs | attention %.3fs "
            "(including kvb %.3fs) | lm_head %.3fs | other %.3fs\n",
         m->t_edisk,m->t_ewait,m->t_emm,m->t_attn,m->t_kvb,m->t_head,elapsed-accounted);


### PR DESCRIPTION
## The bug

The `PROFILE:` line splits expert-disk time into **service** (overlapped async dispatch) and **wait** (blocking stalls):

```
PROFILE: expert-disk %.3fs service / %.3fs wait | ...
```

But every disk-timing site accumulates into `t_edisk`, and nothing ever writes `t_ewait` — so the *wait* column always prints `0.000s`. More consequentially, `profile_print` computes:

```c
double accounted = m->t_ewait + m->t_emm + m->t_attn + m->t_head;  // t_ewait is always 0
```

Because it sums the dead `t_ewait` instead of `t_edisk`, the **entire expert-load stall is excluded from `accounted` and silently falls into the `other` bucket.**

On a disk-streaming MoE this is the dominant term. Profiling a 168-expert GLM-5.2 (REAP-pruned) at 128-token greedy decode, `other` read as **~58% of decode wall** — which looks like a mysterious unoptimized hot path, but is really the expert-streaming stall wearing a disguise. It sent me chasing compute optimizations that couldn't possibly help before the profiler pointed at the real bottleneck.

## The fix

Route the three **blocking** sites to `t_ewait` and keep the one **async-dispatch** site in `t_edisk`, then include both in `accounted`:

- non-PIPE parallel `expert_load` (blocking) → `t_ewait`
- the Metal PIPE drain barrier (`for q: pipe_wait(q)`) → `t_ewait`
- the per-expert `pipe_wait(qof[j])` in the CPU matmul loop → `t_ewait`
- PIPE `pipe_dispatch` ("real reads hide behind matmul") stays `t_edisk`

This matches the evident intent of the two field names and the `service / wait` label. Profiling-only — no behavioural change to inference.

## Before / after

Same model, same prompt, decode:

```
# before
PROFILE: expert-disk 25.077s service / 0.000s wait | expert-matmul 12.320s | attention 8.265s | lm_head 0.000s | other 28.401s
# after
PROFILE: expert-disk 0.111s service / 26.948s wait | expert-matmul 13.938s | attention 8.498s | lm_head 0.000s | other 3.390s
```

`wait` now reflects the real disk stall, and `other` collapses to the genuinely-unbucketed work (router + top-K, norms, residuals).

## Testing

`make test-c` and `make metal-test` green (macOS/arm64, METAL=1). The diff is 4 lines, all in profiling accumulators.