### PR TITLE
resource_plan: count physical cores on Windows (GetLogicalProcessorInformationEx)

### DIFF
--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -167,6 +167,30 @@ def discover_gpus():
 
 
 def physical_cpu_count():
+    if sys.platform == "win32":
+        # os.cpu_count() conta i processori logici (SMT): 2 thread/core saturano
+        # le unita' AVX-512 e peggiorano il matmul. Contiamo i core fisici veri
+        # con GetLogicalProcessorInformationEx(RelationProcessorCore).
+        try:
+            import ctypes
+            k32 = ctypes.windll.kernel32
+            need = ctypes.c_ulong(0)
+            k32.GetLogicalProcessorInformationEx(0, None, ctypes.byref(need))
+            buf = (ctypes.c_char * need.value)()
+            if k32.GetLogicalProcessorInformationEx(0, buf, ctypes.byref(need)):
+                raw, cores, off = bytes(buf), 0, 0
+                while off + 8 <= need.value:
+                    relationship = int.from_bytes(raw[off:off + 4], "little")
+                    size = int.from_bytes(raw[off + 4:off + 8], "little")
+                    if size <= 0:
+                        break
+                    if relationship == 0:  # RelationProcessorCore
+                        cores += 1
+                    off += size
+                if cores:
+                    return cores
+        except (OSError, ValueError, AttributeError):
+            pass
     try:
         result = subprocess.run(["lscpu", "-p=core,socket"], text=True,
                                 capture_output=True, check=True, timeout=5)


### PR DESCRIPTION
On Windows `physical_cpu_count()` falls straight through to `os.cpu_count()`, which returns *logical* processors. On SMT machines the plan then sets `OMP_NUM_THREADS` to 2 threads per core, which oversubscribes the vector units during expert matmul (on a 9950X3D: 32 logical vs 16 physical).

This adds a win32 branch that counts `RelationProcessorCore` records via `GetLogicalProcessorInformationEx` (ctypes, no new dependency), SMT-agnostic, with the existing `lscpu`/`os.cpu_count()` fallbacks intact and the whole thing wrapped in try/except.

Verified on a 9950X3D (16C/32T): returns 16. Existing tests pass; the plan JSON's `physical_cores` now reads 16 instead of 32 on that box.