### PR TITLE
benchmark_cuda_fixture: accept the current PROFILE service/wait format

### DIFF
--- a/c/tools/benchmark_cuda_fixture.py
+++ b/c/tools/benchmark_cuda_fixture.py
@@ -10,8 +10,10 @@ from pathlib import Path
 
 
 SPEED_RE = re.compile(r"REPLAY decode:.*\| ([0-9.]+) tok/s")
+# accetta sia il formato storico "expert-disk 0.123s |" sia quello attuale
+# "expert-disk 0.123s service / 0.045s wait |" (glm.c profile_print)
 PROFILE_RE = re.compile(
-    r"PROFILE: expert-disk ([0-9.]+)s \| expert-matmul ([0-9.]+)s "
+    r"PROFILE: expert-disk ([0-9.]+)s(?: service / ([0-9.]+)s wait)? \| expert-matmul ([0-9.]+)s "
     r"\| attention ([0-9.]+)s .* lm_head ([0-9.]+)s \| other ([0-9.-]+)s"
 )
 PROFILE_KEYS = ("disk", "expert_matmul", "attention", "lm_head", "other")
@@ -23,7 +25,9 @@ def parse_output(stdout: str, stderr: str = "") -> tuple[float, list[float]]:
     profile = PROFILE_RE.search(stdout)
     if not speed or not profile:
         raise RuntimeError(f"benchmark output missing\nstdout:\n{stdout}\nstderr:\n{stderr}")
-    return float(speed.group(1)), [float(value) for value in profile.groups()]
+    service, wait, *rest = profile.groups()
+    disk = float(service) + (float(wait) if wait else 0.0)
+    return float(speed.group(1)), [disk] + [float(value) for value in rest]
 
 
 def execute(engine: str, env: dict[str, str]) -> tuple[float, list[float]]:


### PR DESCRIPTION
`profile_print` now emits `expert-disk N.NNNs service / N.NNNs wait`, but the harness regex still expects the old single `expert-disk N.NNNs` field — so every run of `tools/benchmark_cuda_fixture.py` dies with `RuntimeError: benchmark output missing` even though the engine output is fine.

This makes the regex accept both formats and reports `disk = service + wait`, keeping the JSON schema unchanged.

Found and verified on Windows 11 running the 313M fixture (all 5 modes produce medians again).