### PR TITLE
ci: GitHub Actions — engine/web/python/cuda-syntax on ubuntu/macos/windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,16 +62,11 @@ jobs:
   cuda-syntax:
     name: CUDA syntax
     runs-on: ubuntu-latest
+    container: nvidia/cuda:12.4.0-devel-ubuntu22.04
     defaults:
       run:
         working-directory: c
     steps:
       - uses: actions/checkout@v4
-      - name: Install nvcc
-        run: |
-          wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
-          sudo dpkg -i cuda-keyring_1.1-1_all.deb
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends cuda-nvcc-12-4
       - name: Syntax check (no GPU needed)
         run: nvcc -c backend_cuda.cu -std=c++17 -O0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install nvcc
         run: |
+          wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+          sudo dpkg -i cuda-keyring_1.1-1_all.deb
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends cuda-nvcc-12-4
       - name: Syntax check (no GPU needed)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,12 @@ on:
     branches: [main, dev]
 
 jobs:
-  engine:
+  engine-linux-windows:
     name: Engine (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
     defaults:
       run:
         working-directory: c
@@ -20,6 +20,23 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build (portable)
         run: make portable
+      - name: C unit tests
+        run: make test-c
+      - name: Python tests
+        run: make test-python
+
+  engine-macos:
+    name: Engine (macos-latest)
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: c
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install libomp
+        run: brew install libomp
+      - name: Build
+        run: make glm
       - name: C unit tests
         run: make test-c
       - name: Python tests
@@ -50,7 +67,7 @@ jobs:
         working-directory: c
     steps:
       - uses: actions/checkout@v4
-      - uses: Jimver/cuda-toolkit@v0.2.19
+      - uses: Jimver/cuda-toolkit@v0.2.35
         with:
           cuda: '12.4.0'
           method: network

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,9 @@ jobs:
         working-directory: c
     steps:
       - uses: actions/checkout@v4
-      - uses: Jimver/cuda-toolkit@v0.2.35
-        with:
-          cuda: '12.4.0'
-          method: network
-          sub-packages: '["nvcc"]'
+      - name: Install nvcc
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends cuda-nvcc-12-4
       - name: Syntax check (no GPU needed)
         run: nvcc -c backend_cuda.cu -std=c++17 -O0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  engine:
+    name: Engine (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    defaults:
+      run:
+        working-directory: c
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build (portable)
+        run: make portable
+      - name: C unit tests
+        run: make test-c
+      - name: Python tests
+        run: make test-python
+
+  web:
+    name: Web UI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
+  cuda-syntax:
+    name: CUDA syntax
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: c
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Jimver/cuda-toolkit@v0.2.19
+        with:
+          cuda: '12.4.0'
+          method: network
+          sub-packages: '["nvcc"]'
+      - name: Syntax check (no GPU needed)
+        run: nvcc -c backend_cuda.cu -std=c++17 -O0


### PR DESCRIPTION
## What

Adds the CI workflow requested in #140 / #143 / #144.

## Jobs

| Job | Platforms | What it catches | Time |
|-----|-----------|-----------------|------|
| **Engine** | ubuntu-latest, windows-latest | `make portable` + `make test-c` + `make test-python` | ~30s |
| **Engine (macOS)** | macos-latest (ARM) | `make glm` + full test suite (separate job: `portable` target is x86-only) | ~60s |
| **Web UI** | ubuntu-latest | `npm ci` + `npm run build` + `npm test` | ~17s |
| **CUDA syntax** | ubuntu-latest (nvidia/cuda:12.4 container) | `nvcc -c backend_cuda.cu` — no GPU needed | ~67s |

Triggers on push/PR to `main` and `dev`.

## Notes

- macOS is a separate job because `make portable` hard-codes `ARCH=x86-64-v3` which clang rejects on ARM — macOS uses `make glm` instead (no `-march` flag, NEON is baseline per the Makefile comment)
- CUDA syntax uses the `nvidia/cuda:12.4.0-devel-ubuntu22.04` container — simpler than fighting the apt repo on ubuntu-24.04 runners

Closes #140