### PR TITLE
metal: guard fused decode fast-paths on !kvs (fixes #285, #286 — serve+Metal 1-token replies)

### DIFF
--- a/c/glm.c
+++ b/c/glm.c
@@ -1789,8 +1789,12 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
     double ta0=now_s();
 #ifdef COLI_METAL
     /* Fused decode attention on GPU: whole layer in one command buffer (keeps the GPU hot).
-     * S<=4 absorption path with st0==0, DSA selection inactive, and GLM-5.2 int4 dims. */
-    if(g_metal_enabled && S<=4 && (g_absorb==1||(g_absorb<0&&S<=4)) && m->kv_start[layer]==0
+     * S<=4 absorption path with st0==0, DSA selection inactive, and GLM-5.2 int4 dims.
+     * kvs==NULL: the contiguous, currently-bound KV path. When the multiplexed server
+     * (run_serve_mux) forwards ragged rows, kvs[]/positions[] are per-sequence and the
+     * fused kernel must NOT run — it binds m->Lc/m->Rc and pos_base, which would attend at
+     * the wrong position and corrupt KV (#285/#286: serve+Metal → 1-token replies). */
+    if(g_metal_enabled && !kvs && S<=4 && (g_absorb==1||(g_absorb<0&&S<=4)) && m->kv_start[layer]==0
        && D==6144 && H==64 && c->q_lora==2048 && c->kv_lora==512 && c->qk_nope==192
        && c->qk_rope==64 && vh==256 && l->kv_b.fmt==2){
         int sel_active = m->has_dsa && layer<c->n_layers && c->idx_type[layer] && (pos_base+S) > c->index_topk;
@@ -2925,8 +2929,12 @@ static void layer_forward_rows(Model *m, Layer *l, int li, float *x, int S, int 
 #ifdef COLI_METAL
     /* FULL-LAYER CB: in_ln + attention + residuo + post_ln + shared expert + router/top-K
      * in un solo submit GPU; la CPU legge il routing e fa solo resolve/disk/expert-CB.
-     * Fallback: qualsiasi condizione mancante -> percorso CPU intero qui sotto. */
-    if(g_metal_enabled && S<=4 && li<c->n_layers && l->sparse
+     * Fallback: qualsiasi condizione mancante -> percorso CPU intero qui sotto.
+     * !kvs: contiguous single-sequence decode only — ragged mux rows take the CPU path
+     * below, which honours per-row kvs[]/positions[] (#285/#286). Routed experts still
+     * run on the GPU via the batched-expert path; only the fused attention/layer CB is
+     * gated off here. */
+    if(g_metal_enabled && !kvs && !positions && S<=4 && li<c->n_layers && l->sparse
        && (g_absorb==1||(g_absorb<0&&S<=4)) && m->kv_start[li]==0
        && D==6144 && c->n_heads==64 && c->q_lora==2048 && c->kv_lora==512
        && c->qk_nope==192 && c->qk_rope==64 && c->v_head==256 && l->kv_b.fmt==2


### PR DESCRIPTION
## What

Fixes the **serve + Metal** bug where every `/v1/chat/completions` reply is truncated to a single token (or streams garbage). Reported independently by two reporters — #285 and #286 are the same root cause.

Closes #285. Closes #286.

## Root cause

`run_serve_mux` decodes through `step_decode_batch`, which forwards **ragged rows**: per-row `kvs[]` / `positions[]`, `pos_base=0` (the contract documented on `attention_rows`). The two Metal fused fast paths checked `S<=4`, the GLM-5.2 dims, and `m->kv_start[layer]==0` — but **not `kvs == NULL`**:

1. `attention_rows` (`coli_metal_attn_decode`) — binds the contiguous `m->Lc[layer]` / `m->Rc[layer]` and `pos_base`, ignoring the per-row arrays.
2. `layer_forward_rows` (full-layer command buffer, `coli_metal_layer_decode`) — same problem, and it runs *before* `attention_rows`, so guarding only (1) still yields garbage.

With `pos_base=0` the GPU kernel attends at position 0 (start of context) and writes KV rows to the wrong place → near-random logits → the sampler frequently draws a stop token immediately. The first token is fine (prefill goes through the contiguous `step()` path); every subsequent token comes from the broken batched forward.

## Fix

Add the missing ragged-batch guard to both gates, exactly as the contract comment prescribes:

```c
/* attention_rows */
if(g_metal_enabled && !kvs && S<=4 && ...)

/* layer_forward_rows, full-layer CB */
if(g_metal_enabled && !kvs && !positions && S<=4 && li<c->n_layers && l->sparse && ...)
```

Ragged batches now take the CPU absorb path, which handles `kvs[]`/`positions[]` per row. Routed experts still run on the GPU (the `[METAL] mode: batched routed experts on GPU` path is unaffected). `coli run` / `coli chat` are unaffected — `kvs==NULL` there, so the fused paths still engage.

## Important: users who hit this should delete `.coli_kv`

Per #285: while the unguarded paths were active, the misplaced KV writes were persisted to `<model>/.coli_kv` (KVSAVE=1 default) and **survive restarts** — outputs show doubled tokens / repetition loops. Anyone who ran serve+Metal on affected code should delete `<model>/.coli_kv*` after upgrading, or the fix will appear not to work.

## Validation

- [x] `make glm` — compiles clean (Windows, default CPU build)
- [x] `gcc -DCOLI_METAL -fsyntax-only glm.c` — guards parse clean inside the `#ifdef COLI_METAL` block
- [ ] Metal runtime — verified end-to-end by the #285 reporter (Mac Studio M4 Max): serve+Metal now streams coherent answers; `coli run`/`chat` unaffected
- [x] No performance claims — `coli run`/`chat` keeps the fused paths; only serve+Metal (the broken combo) changes

## Compatibility

- [x] Default CPU build unaffected (`!kvs` guards live inside `#ifdef COLI_METAL`)
- [x] No model files, binaries, or benchmark artifacts
- [x] No CUDA changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)