### PR TITLE
glm: pin draft+verify to one kernel family during speculation; soften the MTP guard (#163)

### DIFF
--- a/c/glm.c
+++ b/c/glm.c
@@ -483,8 +483,24 @@ static int g_no_fused_pair=0;  /* COLI_NO_FUSED_PAIR=1: disable the gate+up kern
  * that changes OMP scheduling vs separate matmul_qt calls — this
  * shifts floating-point accumulation order and can collapse MTP
  * draft acceptance by flipping near-ties (#163). */
+/* #163: l'acceptance MTP crolla quando il forward di draft (S=1) e quello di verifica
+ * (S>=2) non calcolano la STESSA funzione. Tre interruttori dipendono da S: il gate
+ * int4-IDOT (S>=g_i4s — asimmetrico proprio dove g_i4s>1), la fusione gate+up solo-S==1,
+ * e la soglia righe del GEMM Metal. Con SPEC_PIN=1 (default) ogni forward emesso mentre
+ * i draft del modello sono attivi resta sulla famiglia di kernel di S=1: draft e verifica
+ * coincidono per costruzione. Prefill e decode non speculativo sono intoccati.
+ * EN: MTP acceptance collapses when the draft (S=1) and verify (S>=2) forwards do not
+ * compute the SAME function. Three switches are S-dependent: the int4 IDOT gate
+ * (S>=g_i4s — asymmetric exactly on ISAs where g_i4s>1), the S==1-only gate+up fusion,
+ * and the Metal GEMM row threshold. SPEC_PIN=1 (default) pins every forward issued
+ * while model drafts are live to the platform's S=1 kernel family, so draft and verify
+ * agree by construction; prefill and non-speculative decode are untouched.
+ * SPEC_PIN=0 restores the S-dependent gates (A/B). */
+static int g_spec_pin=1;
+static int g_spec_live=0;                    /* set by spec_decode while drafts are live */
+static inline int spec_pinned(void){ return g_spec_pin && g_spec_live; }
 static void expert_gate_up(float *g,float *u,const float *x,QT *wg,QT *wu,int S){
-    if(!g_no_fused_pair&&S==1&&wg->fmt==2&&wu->fmt==2&&wg->I==wu->I&&wg->O==wu->O)
+    if(!g_no_fused_pair&&!spec_pinned()&&S==1&&wg->fmt==2&&wu->fmt==2&&wg->I==wu->I&&wg->O==wu->O)
         matmul_i4_pair(g,u,x,wg->q4,wg->s,wu->q4,wu->s,wg->I,wg->O);
     else { matmul_qt(g,x,wg,S); matmul_qt(u,x,wu,S); }
 }
@@ -961,7 +977,7 @@ static void matmul_qt_ex(float *y, const float *x, QT *w, int S, int allow_idot)
     /* Large row-batches (prefill: kv_b reconstruction, o_proj, dense MLP, step_all logits)
      * amortize Metal's ~5ms submit latency; small-S decode matmuls stay on CPU (NEON wins).
      * Weights must be registered (all dense QT allocs are, via qalloc). */
-    if(g_metal_enabled && S>=g_metal_gemm_min && (w->fmt==1||w->fmt==2) && !omp_in_parallel()){
+    if(g_metal_enabled && S>=g_metal_gemm_min && !spec_pinned() && (w->fmt==1||w->fmt==2) && !omp_in_parallel()){
         const void *wp = w->fmt==1 ? (const void*)w->q8 : (const void*)w->q4;
         if(coli_metal_gemm(y,x,wp,w->s,w->fmt,S,w->I,w->O)) return;
     }
@@ -990,7 +1006,13 @@ static void matmul_qt_ex(float *y, const float *x, QT *w, int S, int allow_idot)
      * EN: int8 IDOT always wins (1.4-2.5x). int4 IDOT: on AVX2 the author found S=1 didn't
      * pay (S>=2 gate); on ARM/SDOT single-token DOES pay (see g_i4s / PR #9 for the VNNI
      * twin). Threshold configurable via I4S. */
-    if(allow_idot && g_idot && (w->fmt==1 || (w->fmt==2 && S>=g_i4s))){
+    /* #163: sotto SPEC_PIN il gate int4-IDOT usa la decisione di S=1 per OGNI S, cosi'
+     * draft e verifica restano sulla stessa famiglia. (CUDA non e' toccato: la sua
+     * condizione non dipende da S, quindi e' gia' coerente tra draft e verifica.)
+     * EN: under SPEC_PIN the int4 IDOT gate uses the S=1 decision for EVERY S, so draft
+     * and verify stay in one family. (CUDA untouched: its condition is S-independent,
+     * hence already draft/verify-consistent.) */
+    if(allow_idot && g_idot && (w->fmt==1 || (w->fmt==2 && (spec_pinned() ? g_i4s<=1 : S>=g_i4s)))){
         int I=w->I; int8_t *xq; float *sx;
         if(S<0 || I<0 || (size_t)S>SIZE_MAX/(size_t)(I?I:1)){ fprintf(stderr,"matmul_qt: shape overflow\n"); exit(1); }
         quant_scratch((size_t)S*I,(size_t)S,&xq,&sx);
@@ -4077,6 +4099,18 @@ static int spec_decode(Model *m, int *all, int kv, int n_new, int eos, float *lo
     Cfg *c=&m->c; int V=c->vocab; int emitted=0, done=0;
     int draft[64]; if(g_draft>63) g_draft=63;
     int carry_ban=-1;                    /* token rifiutato dalla verifica: escluso dal resample */
+    /* #163: draft del modello attivi -> pin della famiglia di kernel per draft+verifica.
+     * EN: model drafts live -> pin the kernel family for draft+verify forwards. */
+    g_spec_live = (g_draft>0);
+    if(spec_pinned() && m->has_mtp){ static int once=0; if(!once){ once=1;
+        fprintf(stderr,"[SPEC_PIN] draft+verify pinned to the S=1 kernel family: int4=%s int8=%s (#163; SPEC_PIN=0 for A/B)\n",
+            (g_idot&&g_i4s<=1)?"idot":"exact", g_idot?"idot":"exact"); } }
+    /* guardia MTP morbida (#163): finestra di 24 proposte, pausa e ri-arma invece del
+     * latch permanente — una regressione transitoria non spegne MTP per tutta la sessione.
+     * EN: soft MTP guard (#163): 24-proposal window, pause and re-arm instead of the
+     * permanent latch — a transient collapse no longer kills MTP for the whole session. */
+    enum { GUARD_PAUSE_TOKENS = 256 };
+    uint64_t gd_prop0=m->mtp_prop, gd_acc0=m->mtp_acc; int gd_pause=0;
     while(emitted<n_new && !done && !g_intr){   /* g_intr: stessa uscita del tetto n_new */
         int next=pick_tok(logit,V,carry_ban); carry_ban=-1; free(logit); logit=NULL;
         if((eos>=0 && next==eos) || is_stop(next)) break;
@@ -4089,15 +4123,19 @@ static int spec_decode(Model *m, int *all, int kv, int n_new, int eos, float *lo
             g=grammar_draft(draft,g_gr_max);
             if(g>0) gsrc=1;
         }
-        if(!g && g_draft>0){
-            /* auto-off adattivo: draft che non vengono mai accettati = solo tassa disco */
-            if(m->has_mtp && m->mtp_prop>=24 && m->mtp_acc*10 < m->mtp_prop){
-                g_draft=0;
-                fprintf(stderr,"[MTP] %.0f%% acceptance after %llu proposals: drafts disabled\n",
-                    100.0*m->mtp_acc/m->mtp_prop, (unsigned long long)m->mtp_prop);
+        if(!g && g_draft>0 && m->has_mtp){
+            /* pausa adattiva: draft che non vengono mai accettati = solo tassa disco,
+             * ma il vecchio g_draft=0 era permanente. EN: adaptive pause; the old
+             * g_draft=0 latch was permanent. */
+            if(gd_pause>0){ gd_pause--; if(!gd_pause){ gd_prop0=m->mtp_prop; gd_acc0=m->mtp_acc; } }
+            else if(m->mtp_prop-gd_prop0>=24 && (m->mtp_acc-gd_acc0)*10 < m->mtp_prop-gd_prop0){
+                fprintf(stderr,"[MTP] %.0f%% acceptance over the last %llu proposals: drafts paused for %d tokens\n",
+                    100.0*(m->mtp_acc-gd_acc0)/(m->mtp_prop-gd_prop0),
+                    (unsigned long long)(m->mtp_prop-gd_prop0), (int)GUARD_PAUSE_TOKENS);
+                gd_pause=GUARD_PAUSE_TOKENS;
             }
         }
-        if(!g && g_draft>0){
+        if(!g && g_draft>0 && !(m->has_mtp && gd_pause>0)){
             if(m->has_mtp){ g=mtp_draft(m,next,kv,g_draft,draft); m->mtp_prop+=g; if(g)gsrc=2; }
             else { g=ngram_draft(all,kv+1,g_draft,draft); if(g)gsrc=2; }
         }
@@ -4129,6 +4167,7 @@ static int spec_decode(Model *m, int *all, int kv, int n_new, int eos, float *lo
         logit=falloc(V); memcpy(logit, lo+(int64_t)k*V, V*sizeof(float)); free(lo);
         repin_pass(m);                                  /* safe point: all device work is synchronized */
     }
+    g_spec_live = 0;                     /* prefill/decode successivi: gate normali / next prefill: normal gates */
     if(logit) free(logit);
     if(kv_out) *kv_out=kv;
     return emitted;
@@ -5630,6 +5669,7 @@ int main(int argc, char **argv){
 #endif
     }
     g_idot = getenv("IDOT")?atoi(getenv("IDOT")):1;        /* 0 = kernel f32 esatti (A/B) */
+    g_spec_pin = getenv("SPEC_PIN")?atoi(getenv("SPEC_PIN")):1; /* #163: 0 = gate S-dipendenti storici / legacy S-dependent gates */
     if(getenv("ROUTE_TRACE")&&*getenv("ROUTE_TRACE")){
         g_route_fp=fopen(getenv("ROUTE_TRACE"),"w");
         if(!g_route_fp) fprintf(stderr,"[ROUTE_TRACE] cannot open %s\n",getenv("ROUTE_TRACE"));


### PR DESCRIPTION
## What

Fixes the MTP acceptance regression in #163 by implementing the fix the thread converged on: **draft and verify must compute the same function.**

Three switches in `glm.c` were S-dependent, so the draft-side forwards (S=1) and the
verify batch (S≥2) could silently run different kernel families:

1. the int4 IDOT gate `S>=g_i4s` — asymmetric exactly on ISAs where `g_i4s>1`
   (x86: S=1 exact / S≥2 IDOT; ARM SDOT and POWER are S-independent, which is why
   the failure signature reversed across ISAs);
2. the S==1-only fused gate+up pair kernel;
3. the Metal GEMM row threshold (`S>=16`, reachable by verify batches at DRAFT≥15).

`SPEC_PIN=1` (default) pins every forward issued while model drafts are live to the
platform's **S=1 kernel family**, so draft and verify agree by construction — whatever
that family is on the host, per the thread's conclusion (a per-ISA "disable IDOT"
would fix x86 and re-break ARM). Prefill and non-speculative decode keep their
existing gates and their IDOT speed. `SPEC_PIN=0` restores the old behavior for A/B.

Also softens the 24-proposal <10% guard (as suggested in the thread): instead of
latching `g_draft=0` for the whole session, drafting pauses for 256 tokens and
re-arms on a fresh window — a future rounding regression degrades MTP instead of
silently shutting it down.

## Validation

OP's exact config: "Summarize the plot of Romeo and Juliet in three sentences.",
`--topp 0.7 --ngen 32`, int8 MTP head, `DRAFT=3`, `SEED=1234`, single run per cell.

### x86 — AMD Ryzen 9 9955HX (Zen 5, AVX-512 VNNI), 92 GB, Linux, --ram 78

| arm | SPEC_PIN=0 (old) | SPEC_PIN=1 (this PR) |
|---|---|---|
| default kernels (IDOT on), greedy | **8% (2/24) → guard trip**, 1.10 tok/fw | **33% (16/48), 2.00 tok/fw** |
| default kernels (IDOT on), sampled | **8% (2/24) → guard trip**, 1.10 tok/fw | **29% (15/51), 1.88 tok/fw** |
| IDOT=0, greedy | 18% (11/60), 1.60 tok/fw | 18% (11/60), 1.60 tok/fw — output text byte-identical |
| IDOT=0, sampled | 21% (12/57), 1.68 tok/fw | 21% (12/57), 1.68 tok/fw — output text byte-identical |

The pinned default restores the OP's pre-#68 numbers **exactly**: 33% (16/48),
2.00 tok/forward — the same cells he reported for `main @ 1bdaeee`. The greedy
off-distribution opening heals too: old default opens "### Plot Summary",
pinned default opens "Here's a concise summary of the plot of *Romeo and Juliet*…".
Where both forwards were already exact (IDOT=0), the pin is a proven no-op
(byte-identical text, identical accept counts).

### ARM — Apple M4 Pro (NEON/SDOT), 48 GB, macOS CPU-only build, --ram 38

| arm | SPEC_PIN=0 (old) | SPEC_PIN=1 (this PR) |
|---|---|---|
| default kernels (IDOT on), greedy | 20% (12/60), 1.60 tok/fw | **23% (13/57), 1.68 tok/fw** |
| default kernels (IDOT on), sampled | 18% (11/60), 1.60 tok/fw | 18% (11/60), 1.60 tok/fw |
| IDOT=0, greedy | 18% (11/60) | 18% (11/60) — output text byte-identical |
| IDOT=0, sampled | 21% (12/57) | 21% (12/57) — output text byte-identical |

On ARM the pin resolves to `int4=idot int8=idot` — today's healthy default family —
so nothing collapses and nothing regresses. The small greedy gain is principled, not
noise-mining: under the pin the rare S=1 main-layer forwards (iterations where no
draft is proposed) go through the same IDOT family as the verify batches instead of
the S==1-only fused-pair kernel, removing the last S-dependent switch.

Two cross-checks worth calling out:

- **The exact path is ISA-portable**: the IDOT=0 cells are the *same counts on both
  machines* (11/60 greedy, 12/57 sampled at SEED=1234) — Zen 5 AVX-512 and M4 Pro
  NEON agree run-for-run at exact kernels, extending @ZacharyZcR's faithfulness
  trace across ISAs.
- **My earlier ARM IDOT=0 collapse (0/24) does not reproduce on current dev**:
  four runs today (one seeded + three unseeded) give 21%, 27%, 27%, 24% — 0/24 is
  far outside that spread. That datapoint was n=1 on a build from before #264's
  4-accumulator SDOT rework merged; I'm not claiming causality, just updating the
  record: on today's dev both ARM families are healthy and S-independent.

(Note: the x86 rig had an idle ollama daemon resident during runs — no model loaded,
acceptance unaffected, tok/s at most slightly conservative.)

`make test`: 62/62 pass on both hosts. `[SPEC_PIN]` banner reports the pinned family
at first speculation, e.g. on Zen 5: `int4=exact int8=idot`; on M4 Pro: `int4=idot int8=idot`.

## What this does NOT claim

- CUDA path untouched: its dispatch condition is S-independent, hence already
  draft/verify-consistent.
- Acceptance percentages under `--topp` remain non-portable across engine versions
  (discontinuous expert pruning) — the tables compare arms within one build only.
- Speed: this is a correctness fix, not a speed win. On x86 the pinned default runs
  verify batches on exact int4 kernels (slower per forward) but needs ~45% fewer
  forwards (16 vs 29 per 32 tokens); measured end-to-end decode is neutral on this
  host (greedy 0.66→0.71 tok/s, sampled 0.67→0.65). What the fix buys is MTP that
  stays alive and correct — with IDOT prefill untouched.

Closes #163 (with the guard-softening suggestion from the thread included).
