### PR TITLE
fix(build): make portable checks target-aware

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -14,7 +14,6 @@ TRIPLET   := $(shell $(DETECT_CC) -dumpmachine 2>/dev/null)
 MINGW  := $(findstring mingw,$(TRIPLET))
 CYGWIN := $(findstring cygwin,$(TRIPLET))
 DARWIN := $(findstring darwin,$(TRIPLET))
-PPC64  := $(findstring powerpc64,$(TRIPLET))
 LINUX  := $(findstring linux,$(TRIPLET))
 IS_WIN := $(MINGW)$(CYGWIN)
 
@@ -27,7 +26,6 @@ ifeq ($(IS_WIN),)
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
 DARWIN  := $(findstring Darwin,$(UNAME_S))
-PPC64   := $(findstring ppc64,$(UNAME_M))
 endif
 endif
 
@@ -37,6 +35,7 @@ TARGET_CPU := $(UNAME_M)
 endif
 X86_64  := $(filter x86_64 amd64,$(TARGET_CPU))
 AARCH64 := $(filter aarch64 arm64,$(TARGET_CPU))
+PPC64   := $(filter powerpc64% ppc64%,$(TARGET_CPU))
 
 ifneq (,$(DARWIN))
 # --- macOS / Apple Silicon ---
@@ -47,7 +46,7 @@ CC      = clang
 OMPDIR := $(shell brew --prefix libomp 2>/dev/null)
 # `brew --prefix libomp` can print the formula's prospective path even when it
 # is not installed, so verify both artifacts before adding unusable flags.
-ifneq ($(and $(wildcard $(OMPDIR)/include/omp.h),$(wildcard $(OMPDIR)/lib/libomp.*)),)
+ifneq ($(and $(OMPDIR),$(wildcard $(OMPDIR)/include/omp.h),$(wildcard $(OMPDIR)/lib/libomp.*)),)
 OMPC    = -Xclang -fopenmp -I$(OMPDIR)/include
 OMPL    = -L$(OMPDIR)/lib -lomp
 else

--- a/c/Makefile
+++ b/c/Makefile
@@ -31,6 +31,13 @@ PPC64   := $(findstring ppc64,$(UNAME_M))
 endif
 endif
 
+TARGET_CPU := $(firstword $(subst -, ,$(TRIPLET)))
+ifeq ($(TARGET_CPU),)
+TARGET_CPU := $(UNAME_M)
+endif
+X86_64  := $(filter x86_64 amd64,$(TARGET_CPU))
+AARCH64 := $(filter aarch64 arm64,$(TARGET_CPU))
+
 ifneq (,$(DARWIN))
 # --- macOS / Apple Silicon ---
 # Apple clang non include il runtime OpenMP: se c'e' libomp di Homebrew lo usa
@@ -38,7 +45,9 @@ ifneq (,$(DARWIN))
 # Niente -march: su arm64 NEON e' baseline (i kernel __ARM_NEON si attivano da soli).
 CC      = clang
 OMPDIR := $(shell brew --prefix libomp 2>/dev/null)
-ifneq ($(OMPDIR),)
+# `brew --prefix libomp` can print the formula's prospective path even when it
+# is not installed, so verify both artifacts before adding unusable flags.
+ifneq ($(and $(wildcard $(OMPDIR)/include/omp.h),$(wildcard $(OMPDIR)/lib/libomp.*)),)
 OMPC    = -Xclang -fopenmp -I$(OMPDIR)/include
 OMPL    = -L$(OMPDIR)/lib -lomp
 else
@@ -247,9 +256,23 @@ cuda-bench: backend_cuda.cu backend_cuda.h tests/bench_tensor_core.cu
 olmoe$(EXE): olmoe.c st.h json.h compat.h
 	$(CC) $(CFLAGS) olmoe.c -o olmoe$(EXE) $(LDFLAGS)
 
-# binario portabile da distribuire su altre macchine x86-64
+# Use a baseline that matches the compiler target. macOS already targets a
+# portable baseline when ARCH is empty; forcing the x86 value there breaks
+# Apple Silicon. Unknown targets use native rather than an invalid x86 flag.
+ifneq (,$(DARWIN))
+PORTABLE_ARCH =
+else ifneq (,$(AARCH64))
+PORTABLE_ARCH = armv8-a
+else ifneq (,$(PPC64))
+PORTABLE_ARCH = power8
+else ifneq (,$(X86_64))
+PORTABLE_ARCH = x86-64-v3
+else
+PORTABLE_ARCH = native
+endif
+
 portable:
-	$(MAKE) glm$(EXE) ARCH=x86-64-v3
+	$(MAKE) glm$(EXE) ARCH=$(PORTABLE_ARCH)
 
 iobench$(EXE): iobench.c compat.h
 	$(CC) $(CFLAGS) iobench.c -o iobench$(EXE) $(LDFLAGS)

--- a/c/tests/test_makefile_platform.py
+++ b/c/tests/test_makefile_platform.py
@@ -52,6 +52,7 @@ class MakefilePlatformTests(unittest.TestCase):
             ("x86_64-unknown-linux-gnu", "-march=x86-64-v3"),
             ("aarch64-unknown-linux-gnu", "-march=armv8-a"),
             ("powerpc64le-unknown-linux-gnu", "-mcpu=power8"),
+            ("ppc64le-unknown-linux-gnu", "-mcpu=power8"),
         )
 
         for triplet, expected_flag in cases:

--- a/c/tests/test_makefile_platform.py
+++ b/c/tests/test_makefile_platform.py
@@ -11,6 +11,24 @@ MAKE = shutil.which("make")
 
 @unittest.skipUnless(MAKE, "make is required")
 class MakefilePlatformTests(unittest.TestCase):
+    def _dry_run(self, target, triplet, **variables):
+        args = [
+            MAKE,
+            "--no-print-directory",
+            "-B",
+            "-n",
+            target,
+            f"TRIPLET={triplet}",
+        ]
+        args.extend(f"{name}={value}" for name, value in variables.items())
+        return subprocess.run(
+            args,
+            cwd=C_DIR,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
     def test_windows_nt_without_uname_selects_mingw_build(self):
         env = os.environ.copy()
         env["OS"] = "Windows_NT"
@@ -28,6 +46,29 @@ class MakefilePlatformTests(unittest.TestCase):
         self.assertIn("-o glm.exe", result.stdout)
         self.assertIn("-fopenmp", result.stdout)
         self.assertIn("-static", result.stdout)
+
+    def test_portable_build_uses_target_architecture(self):
+        cases = (
+            ("x86_64-unknown-linux-gnu", "-march=x86-64-v3"),
+            ("aarch64-unknown-linux-gnu", "-march=armv8-a"),
+            ("powerpc64le-unknown-linux-gnu", "-mcpu=power8"),
+        )
+
+        for triplet, expected_flag in cases:
+            with self.subTest(triplet=triplet):
+                result = self._dry_run("portable", triplet)
+                self.assertIn(expected_flag, result.stdout)
+
+    def test_darwin_portable_build_does_not_force_x86_architecture(self):
+        missing_libomp = "/colibri-test/missing-libomp"
+        result = self._dry_run(
+            "portable", "arm64-apple-darwin", OMPDIR=missing_libomp
+        )
+
+        self.assertIn("clang -O3", result.stdout)
+        self.assertNotIn("-mcpu=x86-64-v3", result.stdout)
+        self.assertNotIn(missing_libomp, result.stdout)
+        self.assertNotIn("-fopenmp", result.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- choose the `portable` CPU baseline from the compiler target instead of forcing `x86-64-v3` on every host
- keep macOS on its compiler-default baseline, while preserving the existing x86 baseline and adding explicit AArch64/PowerPC baselines
- enable Homebrew OpenMP flags only when both the `omp.h` header and `libomp` library actually exist
- add Makefile dry-run coverage for x86-64, AArch64, PowerPC, and Apple Silicon

## Why

The documented `make check` command failed on Apple Silicon before reaching the tests. The `portable` target passed `ARCH=x86-64-v3`, which Apple Clang translated to the invalid `-mcpu=x86-64-v3` flag.

After removing that mismatch, a dependency-free macOS build could still fail when Homebrew was installed but `libomp` was not: `brew --prefix libomp` reports the formula's prospective path even when its header and library are absent. The Makefile then added a nonexistent include directory and failed on `#include <omp.h>` instead of using its intended single-threaded fallback.

This keeps the existing x86 behavior unchanged and makes the portable check match the compiler's actual target.

## Validation

- `python3 -m unittest c/tests/test_makefile_platform.py`
- `make check` on Apple Silicon/macOS
  - portable CPU build succeeds without `libomp`
  - all C tests pass
  - all 64 Python tests pass

The token-exact model oracle was not run locally because this build/test-only change does not include the `glm_tiny` fixture.
