### PR TITLE
PIN=auto: seed the pin from the live usage history

### DIFF
--- a/c/glm.c
+++ b/c/glm.c
@@ -5915,8 +5915,27 @@ int main(int argc, char **argv){
     /* HOT-STORE: PIN=<statsfile> [PIN_GB=g] -> top expert per frequenza fissi in RAM.
      * Va PRIMA di cap_for_ram: i pinnati contano nel residente. */
     if(getenv("PIN")){
-        const char *pin_gb=getenv("PIN_GB");
-        pin_load(&m,getenv("PIN"),pin_gb&&!strcmp(pin_gb,"all")?-1.0:pin_gb?atof(pin_gb):10.0);   /* PIN_GB=all (#80) */
+        const char *pin=getenv("PIN"); char pauto[2100];
+        if(!strcmp(pin,"auto")){
+            /* PIN=auto: la storia VIVA <SNAP>/.coli_usage (appesa a ogni turno) batte il
+             * profilo congelato stats.txt — il pin di ogni riavvio riflette il carico reale
+             * accumulato, non il prompt di bootstrap. Fallback stats.txt per una dir vergine;
+             * nessuno dei due -> nessun pin (AUTOPIN piu' sotto resta escluso: PIN e' settato).
+             * EN: prefer the live usage history over the frozen one-shot profile, so each
+             * reload's pin placement follows the accumulated real workload. */
+            snprintf(pauto,sizeof(pauto),"%s/.coli_usage",snap);
+            FILE *pf=fopen(pauto,"rb"); long psz=0;
+            if(pf){ fseek(pf,0,SEEK_END); psz=ftell(pf); fclose(pf); }
+            if(psz<=0){ snprintf(pauto,sizeof(pauto),"%s/stats.txt",snap);
+                pf=fopen(pauto,"rb"); psz=0;
+                if(pf){ fseek(pf,0,SEEK_END); psz=ftell(pf); fclose(pf); } }
+            if(psz>0){ pin=pauto; fprintf(stderr,"[PIN] auto: seeding from %s\n",pauto); }
+            else { pin=NULL; fprintf(stderr,"[PIN] auto: no .coli_usage or stats.txt in %s yet (no pin this run)\n",snap); }
+        }
+        if(pin){
+            const char *pin_gb=getenv("PIN_GB");
+            pin_load(&m,pin,pin_gb&&!strcmp(pin_gb,"all")?-1.0:pin_gb?atof(pin_gb):10.0);   /* PIN_GB=all (#80) */
+        }
     }
     if(getenv("COUPLE")&&*getenv("COUPLE")){    /* coupling-scored cross-layer prefetch (#176) */
         g_couple_k=getenv("COUPLE_K")?atoi(getenv("COUPLE_K")):8;

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -47,7 +47,7 @@ Format: `VAR` — default — effect.
 | `CAP_RAISE` | `1` (on) | Let the engine raise the expert-cache cap above `topk` when RAM allows (bigger batches). `0` fixes the cap. |
 | `PREFETCH` | `0` | Prefetch depth for streamed experts. |
 | `COLI_MMAP` | `0` | `mmap` the weights instead of read()-ing into slabs. |
-| `PIN` | unset | Path to a `.coli_usage` file; pins the hottest experts into a resident "hot store" at startup. |
+| `PIN` | unset | Path to a `.coli_usage`/stats file; pins the hottest experts into a resident "hot store" at startup. **`PIN=auto`** seeds from the model dir's live `.coli_usage` (appended after every turn, so each restart's pin placement follows the accumulated real workload) with `stats.txt` as the fallback for a virgin model dir; neither present → no pin this run. |
 | `PIN_GB` | `10.0` | Size budget (GB) for the pinned hot store when `PIN` is set. |
 | `AUTOPIN` | `1` (on) | Auto-pin the hot store from usage history once ≥5000 selections are recorded. |
 | `REPIN` | `0` (off) | Live re-pin the hot store every N emitted tokens (RFC). |


### PR DESCRIPTION
Small ergonomics feature in the spirit of `PIN_GB=all` (#80): `PIN=auto` resolves the pin source to `<model>/.coli_usage` — the history serve mode appends after every turn — so each restart's hot-store placement follows the accumulated real workload instead of a frozen one-shot profile. `stats.txt` is the fallback for a virgin model dir; with neither present the run simply starts unpinned (with a clear stderr note).

Explicit `PIN=<path>` and the `AUTOPIN` flow are unchanged (`PIN` set still skips `AUTOPIN`). This lifts the "prefer `.coli_usage` over `stats.txt`" shell plumbing that deployment entrypoints end up writing into the engine itself. Docs row added to ENVIRONMENT.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)