### PR TITLE
Fix: set stdout to O_BINARY on Windows to fix READY sentinel

### DIFF
--- a/c/glm.c
+++ b/c/glm.c
@@ -5749,6 +5749,9 @@ int main(int argc, char **argv){
         perror("[OMP] execv self-reexec failed, running untuned");
 #endif
     }
+#ifdef _WIN32
+    _setmode(fileno(stdout), O_BINARY);
+#endif
 #if defined(__AVX512F__) && defined(__AVX512BW__)
     if(getenv("I4_ACC512")) g_i4_acc512=atoi(getenv("I4_ACC512"))!=0;
     if(getenv("I4_ACC512_TEST")){


### PR DESCRIPTION
## Summary

Describe the problem and the smallest change that solves it.

## Validation

- [ ] `make -C c check`
- [ ] CUDA changes were tested with `make -C c cuda-test` (if applicable)
- [ ] Performance claims include hardware, commands, and repeatable measurements

## Compatibility

- [ ] The default CPU build remains dependency-free
- [ ] No model files, generated binaries, or benchmark artifacts are included
