### PR TITLE
Fix METAL=1 build on Apple clang 16: add -std=gnu++17 to METALXX

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -197,7 +197,7 @@ endif
 # runtime, so no Xcode / offline metal compiler is required. Default build unchanged.
 METAL     ?= 0
 METAL_OBJ  =
-METALXX    = clang++ -x objective-c++ -fobjc-arc -O3
+METALXX    = clang++ -x objective-c++ -std=gnu++17 -fobjc-arc -O3
 ifeq ($(METAL),1)
 ifeq (,$(DARWIN))
 $(error METAL=1 is supported only on macOS)


### PR DESCRIPTION
## Problem

On a stock macOS toolchain (Apple clang 16, `clang-1600.0.26.6`, no Xcode project involved), `make glm METAL=1` fails to compile the Metal backend:

```
backend_metal.mm:12:30: warning: missing terminating '"' character [-Winvalid-pp-token]
backend_metal.mm:12:29: error: use of undeclared identifier 'R'
backend_metal.mm:13:10: fatal error: 'metal_stdlib' file not found
```

The shader source in `backend_metal.mm` is held in a C++11 raw string literal (`R"METAL(...)METAL"`). Apple clang 16 compiles `-x objective-c++` in a pre-C++11 dialect by default, so the raw string is not recognized, and the preprocessor then trips over the `#include <metal_stdlib>` line *inside* the string.

## Fix

Pin the C++ standard on `METALXX` (one line):

```make
METALXX    = clang++ -x objective-c++ -std=gnu++17 -fobjc-arc -O3
```

## Verified

On macOS 15 / M4 Max (16-core, 64 GB), from a clean tree:

- `make glm METAL=1` builds
- `make metal-test` builds and all metal backend tests pass (gemv/moe/gemm/fused attention, nerr ~1e-6)
- Full model runs with the Metal backend: GLM-5.2 int4, warm decode 0.32–0.35 tok/s on this 64 GB config (initial run 0.07, CPU reference 0.13)

Happy to add the 64 GB M4 Max numbers to the README benchmark table in a separate PR if useful.