### PR TITLE
Inkling (Thinking Machines 975B MoE): new engine, o200k tokenizer, bf16->int4 converter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Build colibri
-        run: cd c && make colibri
+      - name: Build colibri + inkling
+        run: cd c && make colibri inkling
       - name: C test suite
         run: cd c && make test-c
 
@@ -40,6 +40,38 @@ jobs:
           nvcc -O2 -std=c++17 -arch=sm_80 -c backend_cuda.cu -o /dev/null \
             -Xcompiler=-Wall,-Wextra
           echo "CUDA syntax check passed"
+      - name: Compile backend_cuda_ink.cu (syntax only, no GPU)
+        run: |
+          cd c
+          # inkling's own CUDA backend (bf16 residents + int4 expert GEMM); same
+          # no-pipeline rule as above so a compile error can actually fail the job.
+          nvcc -O2 -std=c++17 -arch=sm_80 -c backend_cuda_ink.cu -o /dev/null \
+            -Xcompiler=-Wall,-Wextra
+          echo "inkling CUDA syntax check passed"
+
+  inkling-oracle:
+    name: Inkling oracle (token-exact vs transformers)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: c/tools/oracle-requirements.txt
+      - name: Install torch (CPU) + transformers
+        run: pip install -r c/tools/oracle-requirements.txt
+      - name: Build inkling
+        run: cd c && make inkling
+      - name: Tiny-model fixture + token-exact oracle (f32, bit-exact experts)
+        run: |
+          cd c
+          # Random-init InklingForCausalLM via HF transformers, then the C engine
+          # reproduces it token-for-token. bits=0 keeps experts f32 (bit-exact
+          # forward); the greedy pass exits non-zero on any mismatch, so this
+          # gate fails the moment a shared-code change regresses the engine.
+          python3 tools/make_tiny_inkling.py tiny_inkling
+          SNAP=tiny_inkling ./inkling 8 0 tiny_inkling/ref_inkling.json
 
   engine-hip-syntax:
     name: HIP syntax check

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ olmoe_merged/
 olmoe_i4/
 c/olmoe_merged/
 c/olmoe_i4/
+c/tiny_inkling/

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ c/colibri.exe
 c/glm
 c/glm.exe
 c/olmoe
+c/inkling
 c/olmoe.exe
 c/iobench
 c/iobench.exe

--- a/c/Makefile
+++ b/c/Makefile
@@ -227,6 +227,7 @@ endif
 CFLAGS   += -DCOLI_CUDA
 LDFLAGS  += -L$(CUDA_HOME)/lib64 -Wl,-rpath,$(CUDA_HOME)/lib64 -lcudart -lstdc++
 CUDA_OBJ  = backend_cuda.o
+INK_CUDA_OBJ = backend_cuda_ink.o
 endif
 
 ifeq ($(HIP),1)
@@ -300,6 +301,10 @@ cuda-dll: backend_cuda.cu backend_cuda.h
 		-L"$(CUDA_HOME)/lib/x64" -lcudart \
 		backend_cuda.cu -o coli_cuda.dll
 
+backend_cuda_ink.o: backend_cuda_ink.cu backend_cuda_ink.h .build-config
+	@command -v "$(NVCC)" >/dev/null 2>&1 || { echo "nvcc not found: set CUDA_HOME or NVCC" >&2; exit 1; }
+	"$(NVCC)" $(NVCCFLAGS) -c backend_cuda_ink.cu -o $@
+
 backend_cuda.o: backend_cuda.cu backend_cuda.h backend_gpu_compat.h .build-config
 	@command -v "$(GPUCC)" >/dev/null 2>&1 || { echo "$(GPUCC_NAME) not found" >&2; exit 1; }
 	"$(GPUCC)" $(GPUFLAGS) -c backend_cuda.cu -o $@
@@ -339,8 +344,8 @@ cuda-bench: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/bench_tens
 olmoe$(EXE): olmoe.c st.h json.h compat.h
 	$(CC) $(CFLAGS) olmoe.c -o olmoe$(EXE) $(LDFLAGS)
 
-inkling$(EXE): inkling.c st.h json.h compat.h
-	$(CC) $(CFLAGS) inkling.c -o inkling$(EXE) $(LDFLAGS)
+inkling$(EXE): inkling.c st.h json.h compat.h $(INK_CUDA_OBJ)
+	$(CC) $(CFLAGS) inkling.c $(INK_CUDA_OBJ) -o inkling$(EXE) $(LDFLAGS)
 
 # Use a baseline that matches the compiler target. macOS already targets a
 # portable baseline when ARCH is empty; forcing the x86 value there breaks

--- a/c/Makefile
+++ b/c/Makefile
@@ -339,6 +339,9 @@ cuda-bench: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/bench_tens
 olmoe$(EXE): olmoe.c st.h json.h compat.h
 	$(CC) $(CFLAGS) olmoe.c -o olmoe$(EXE) $(LDFLAGS)
 
+inkling$(EXE): inkling.c st.h json.h compat.h
+	$(CC) $(CFLAGS) inkling.c -o inkling$(EXE) $(LDFLAGS)
+
 # Use a baseline that matches the compiler target. macOS already targets a
 # portable baseline when ARCH is empty; forcing the x86 value there breaks
 # Apple Silicon. Unknown targets use native rather than an invalid x86 flag.

--- a/c/backend_cuda_ink.cu
+++ b/c/backend_cuda_ink.cu
@@ -16,6 +16,10 @@ static size_t g_xcap = 0, g_ycap = 0;
 static int g_ok = 0;
 
 extern "C" int ink_cuda_init(int dev) {
+    /* ~727 tiny matmul calls per decoded token: the default yield-based sync
+     * costs ~0.5-1 ms of wakeup latency per call. Spin-sync in the driver is
+     * one busy thread — affordable since the OMP team no longer spins. */
+    cudaSetDeviceFlags(cudaDeviceScheduleSpin);
     if (cudaSetDevice(dev) != cudaSuccess) return -1;
     if (cudaStreamCreate(&g_st) != cudaSuccess) return -1;
     /* fail fast on a broken runtime instead of at the first matmul */

--- a/c/backend_cuda_ink.cu
+++ b/c/backend_cuda_ink.cu
@@ -1,0 +1,87 @@
+/* CUDA backend for inkling.c — see backend_cuda_ink.h for scope.
+ * One warp per output row, both operands rounded to bf16, f32 accumulate:
+ * the same numeric contract as the CPU vdpbf16ps path (matmul_h), so GPU
+ * and CPU runs stay closely comparable. */
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <stdio.h>
+#include "backend_cuda_ink.h"
+
+static cudaStream_t g_st;
+static float *g_dx = nullptr, *g_dy = nullptr;      /* device activation buffers */
+static float *g_hx = nullptr, *g_hy = nullptr;      /* PINNED host staging: pageable
+                                                     * memcpyAsync degrades to a
+                                                     * synchronous bounce copy */
+static size_t g_xcap = 0, g_ycap = 0;
+static int g_ok = 0;
+
+extern "C" int ink_cuda_init(int dev) {
+    if (cudaSetDevice(dev) != cudaSuccess) return -1;
+    if (cudaStreamCreate(&g_st) != cudaSuccess) return -1;
+    /* fail fast on a broken runtime instead of at the first matmul */
+    void *probe = nullptr;
+    if (cudaMalloc(&probe, 1 << 20) != cudaSuccess) return -1;
+    cudaFree(probe);
+    g_ok = 1;
+    return 0;
+}
+
+extern "C" size_t ink_cuda_free_bytes(void) {
+    size_t fr = 0, to = 0;
+    if (cudaMemGetInfo(&fr, &to) != cudaSuccess) return 0;
+    return fr;
+}
+
+extern "C" void *ink_cuda_upload(const void *h, size_t n) {
+    void *d = nullptr;
+    if (cudaMalloc(&d, n) != cudaSuccess) return nullptr;
+    if (cudaMemcpy(d, h, n, cudaMemcpyHostToDevice) != cudaSuccess) { cudaFree(d); return nullptr; }
+    return d;
+}
+
+/* 4 warps per block, one output row per warp; lanes stride the contraction
+ * dim two bf16 at a time (4-byte coalesced loads of the weight row). */
+__global__ void mm_bf16_kernel(const __nv_bfloat16 * __restrict__ W,
+                               const float * __restrict__ x,
+                               float * __restrict__ y, int I, int O) {
+    int o = blockIdx.x * (blockDim.x >> 5) + (threadIdx.x >> 5);
+    int lane = threadIdx.x & 31;
+    int s = blockIdx.y;
+    if (o >= O) return;
+    const __nv_bfloat16 *w = W + (size_t)o * I;
+    const float *xs = x + (size_t)s * I;
+    float acc = 0.f;
+    for (int i = lane * 2; i < I; i += 64) {
+        __nv_bfloat162 wv = *(const __nv_bfloat162 *)(w + i);
+        float xa = __bfloat162float(__float2bfloat16(xs[i]));
+        float xb = __bfloat162float(__float2bfloat16(xs[i + 1]));
+        acc += __bfloat162float(wv.x) * xa + __bfloat162float(wv.y) * xb;
+    }
+    for (int off = 16; off; off >>= 1) acc += __shfl_down_sync(0xffffffffu, acc, off);
+    if (!lane) y[(size_t)s * O + o] = acc;
+}
+
+extern "C" int ink_cuda_matmul_bf16(float *y, const float *x, const void *W, int S, int I, int O) {
+    if (!g_ok || (I & 1)) return -1;
+    size_t xn = (size_t)S * I * 4, yn = (size_t)S * O * 4;
+    if (xn > g_xcap) {
+        cudaFree(g_dx); cudaFreeHost(g_hx);
+        if (cudaMalloc(&g_dx, xn * 2) != cudaSuccess ||
+            cudaMallocHost(&g_hx, xn * 2) != cudaSuccess) { g_dx = g_hx = nullptr; g_xcap = 0; return -1; }
+        g_xcap = xn * 2;
+    }
+    if (yn > g_ycap) {
+        cudaFree(g_dy); cudaFreeHost(g_hy);
+        if (cudaMalloc(&g_dy, yn * 2) != cudaSuccess ||
+            cudaMallocHost(&g_hy, yn * 2) != cudaSuccess) { g_dy = g_hy = nullptr; g_ycap = 0; return -1; }
+        g_ycap = yn * 2;
+    }
+    memcpy(g_hx, x, xn);
+    cudaMemcpyAsync(g_dx, g_hx, xn, cudaMemcpyHostToDevice, g_st);
+    dim3 grid((unsigned)((O + 3) / 4), (unsigned)S);
+    mm_bf16_kernel<<<grid, 128, 0, g_st>>>((const __nv_bfloat16 *)W, g_dx, g_dy, I, O);
+    cudaMemcpyAsync(g_hy, g_dy, yn, cudaMemcpyDeviceToHost, g_st);
+    if (cudaStreamSynchronize(g_st) != cudaSuccess) return -1;
+    memcpy(y, g_hy, yn);
+    return 0;
+}

--- a/c/backend_cuda_ink.h
+++ b/c/backend_cuda_ink.h
@@ -1,0 +1,23 @@
+/* Minimal CUDA backend for inkling.c: bf16 resident weights live in VRAM,
+ * matmuls run on-device. Motivation is bandwidth, not FLOPs: decode reads
+ * ~35 GB of bf16 residents per token, which caps CPU decode at the DDR5
+ * bandwidth (~1.2 s/token); the GPU's VRAM feeds the same reads at ~12x.
+ * Deliberately tiny API — expert streaming, attention and everything else
+ * stay on the CPU in this phase. */
+#ifndef BACKEND_CUDA_INK_H
+#define BACKEND_CUDA_INK_H
+#include <stddef.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int    ink_cuda_init(int dev);                 /* 0 = ok */
+size_t ink_cuda_free_bytes(void);
+void  *ink_cuda_upload(const void *h, size_t n);   /* NULL = OOM/error */
+/* y[S,O] = x[S,I] @ W^T, W = device bf16 [O,I]; x,y host f32. 0 = ok */
+int    ink_cuda_matmul_bf16(float *y, const float *x, const void *W, int S, int I, int O);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -911,8 +911,9 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
         #pragma omp parallel for schedule(dynamic,1)
         for (int j = 0; j < nfill; j++) slot_fill(m, fl[j], fill[j]);
     }
-    /* pass 3: compute */
-    float *g = falloc(I), *u = falloc(I), *hh = falloc(D);
+    /* pass 3: compute. gate+up run as ONE matmul over the fused 2I rows —
+     * halves the number of (expensive to open) parallel regions per expert */
+    float *g = falloc(2*I), *u = g + I, *hh = falloc(D);
     int q4 = m->xq && m->rb13*2 == D;   /* packed int4 vs int8 container */
     for (int s = 0; s < S; s++) {
         const float *xs = x + (int64_t)s*D;
@@ -922,24 +923,20 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
             Slot *e = use[(int64_t)s*K + kk];
             if (m->xq) {
                 if (q4) {
-                    matmul_q4(g, xs, e->p13,                    e->s13,     D, I);   /* gate rows */
-                    matmul_q4(u, xs, e->p13 + (int64_t)I*m->rb13, e->s13 + I, D, I); /* up rows   */
+                    matmul_q4(g, xs, e->p13, e->s13, D, 2*I);   /* gate rows then up rows */
                     for (int i = 0; i < I; i++) g[i] = siluf(g[i]) * u[i];
                     matmul_q4(hh, g, e->p2, e->s2, I, D);
                 } else {
-                    matmul_q(g, xs, (int8_t*)e->p13,                 e->s13,     D, I);
-                    matmul_q(u, xs, (int8_t*)e->p13 + (int64_t)I*D,  e->s13 + I, D, I);
+                    matmul_q(g, xs, (int8_t*)e->p13, e->s13, D, 2*I);
                     for (int i = 0; i < I; i++) g[i] = siluf(g[i]) * u[i];
                     matmul_q(hh, g, (int8_t*)e->p2, e->s2, I, D);
                 }
             } else if (m->quant_bits) {
-                matmul_q(g, xs, e->q13,                 e->s13,     D, I);
-                matmul_q(u, xs, e->q13 + (int64_t)I*D,  e->s13 + I, D, I);
+                matmul_q(g, xs, e->q13, e->s13, D, 2*I);
                 for (int i = 0; i < I; i++) g[i] = siluf(g[i]) * u[i];
                 matmul_q(hh, g, e->q2, e->s2, I, D);
             } else {
-                matmul(g, xs, e->f13,                1, D, I);
-                matmul(u, xs, e->f13 + (int64_t)I*D, 1, D, I);
+                matmul(g, xs, e->f13, 1, D, 2*I);
                 for (int i = 0; i < I; i++) g[i] = siluf(g[i]) * u[i];
                 matmul(hh, g, e->f2, 1, I, D);
             }
@@ -955,7 +952,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
         }
     }
     free(logits); free(idx); free(wgt); free(use); free(fill); free(fl);
-    free(g); free(u); free(hh);
+    free(g); free(hh);              /* u aliases g+I */
 }
 
 /* ---------- one forward pass over S new tokens ----------
@@ -1080,6 +1077,22 @@ static int *read_int_array(jval *o, const char *key, int *n_out) {
 }
 
 int main(int argc, char **argv) {
+    /* OpenMP hot-thread tuning, same trick (and rationale) as glm.c: the
+     * per-expert matmul regions are tiny and back-to-back; the default passive
+     * wait policy parks the team between regions and re-wake latency dominates.
+     * libgomp reads OMP_/GOMP_ vars before main(), so seed them and re-exec
+     * once (COLI_OMP_TUNED guards the exec; COLI_NO_OMP_TUNE=1 disables). */
+    if (!getenv("COLI_OMP_TUNED") && !getenv("COLI_NO_OMP_TUNE")) {
+        setenv("OMP_WAIT_POLICY","active",0);
+        setenv("GOMP_SPINCOUNT","200000",0);
+        setenv("OMP_PROC_BIND","close",0);
+        setenv("OMP_DYNAMIC","FALSE",0);
+        setenv("COLI_OMP_TUNED","1",1);
+#ifdef __linux__
+        execv("/proc/self/exe", argv);
+        perror("[OMP] execv self-reexec failed, running untuned");
+#endif
+    }
     const char *snap = getenv("SNAP");
     if (!snap) { fprintf(stderr, "set SNAP=<snapshot directory>\n"); return 1; }
     /* flags: -p "prompt" [-n N] -> generate mode; positional: [cap] [bits] [ref.json] */

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -745,7 +745,10 @@ static void pins_load(Model *m, const char *snap) {
         fclose(f); return;
     }
     int cap = m->cache[0].cap;
-    m->npin = getenv("PIN_N") ? atoi(getenv("PIN_N")) : cap/4;
+    /* default: pin half the cap. Measured on the 975B: cap/4 (19/layer) gave
+     * 83.6% hit / 0.32 tok/s; 40/layer gave 95.6% / 0.80 tok/s — decode fills
+     * run at queue depth ~1, so every pinned expert removes a ~35ms stall. */
+    m->npin = getenv("PIN_N") ? atoi(getenv("PIN_N")) : cap/2;
     if (m->npin > cap - 8) m->npin = cap - 8;
     if (m->npin < 0) m->npin = 0;
     uint32_t *tmp = malloc((size_t)E * 4);

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -75,11 +75,17 @@ typedef struct {
     Wt sh_g, sh_u, sh_d;                  /* shared experts [ns][I,D] etc. */
 } Layer;
 
-/* ---------- routed-expert LRU cache ---------- */
+/* ---------- routed-expert cache: LRU + optional pinned set ----------
+ * Container snapshots keep the expert rows PACKED in RAM (int4 stays 4-bit:
+ * ~28 MB/expert instead of ~57 unpacked, so the same budget caches twice the
+ * experts); the matmul kernels unpack nibbles in-register. */
 typedef struct {
     int eid; uint64_t used;
-    int8_t *q13, *q2; float *s13, *s2;    /* bits>0: int-quantized rows */
-    float *f13, *f2;                      /* bits==0: raw f32 */
+    int pinned;                           /* never evicted (usage-history pin) */
+    int filled;                           /* 0 while queued for a parallel fill */
+    uint8_t *p13, *p2; float *s13, *s2;   /* container: packed rows + row scales */
+    int8_t *q13, *q2;                     /* bits>0: runtime-quantized int8 */
+    float *f13, *f2;                      /* bits==0: raw f32 (oracle) */
 } Slot;
 typedef struct { Slot *slots; int n, cap; } LCache;
 
@@ -92,6 +98,9 @@ typedef struct {
     float *embed_norm, *final_norm;
     Layer *L;
     LCache *cache;
+    int64_t rb13, rb2;                    /* container row-bytes (0 = not container) */
+    uint32_t **eusage;                    /* per-layer expert selection counts */
+    int npin;                             /* pinned experts per sparse layer */
     uint64_t clock, hits, miss;
     float **K, **V; int kv_len, max_t;    /* per-layer [kv][max_t][hd] */
     float **cs[4];                        /* conv states, [n_layers][C*(K-1)] */
@@ -235,6 +244,62 @@ static void matmul_q(float *y, const float *x, const int8_t *q, const float *sca
         const int8_t *w = q + (int64_t)o * I;
         float acc = 0.f;
         for (int i = 0; i < I; i++) acc += x[i] * (float)w[i];
+        y[o] = acc * scale[o];
+    }
+}
+
+/* y[1,O] = x @ W^T with W kept PACKED int4 (low nibble = even column, +8
+ * offset, per-row scale — the on-disk container layout, cached as-is).
+ * Nibbles unpack in-register: same numeric result as unpack-to-int8 +
+ * matmul_q, half the cache footprint. IDOT=0 keeps the byte-exact scalar. */
+static void matmul_q4(float *y, const float *x, const uint8_t *p, const float *scale, int I, int O) {
+#if defined(__AVX2__)
+    static int idot = -1;
+    if (idot < 0) { const char *e = getenv("IDOT"); idot = !(e && *e == '0'); }
+    if (idot && I % 32 == 0 && I <= 8192) {
+        int nb = I / 32;
+        int8_t xi[8192]; float xs[256];
+        for (int b = 0; b < nb; b++) {
+            const float *xb = x + b*32;
+            float am = 0.f; for (int i = 0; i < 32; i++) { float a = fabsf(xb[i]); if (a > am) am = a; }
+            float s = am/127.f; if (s < 1e-12f) s = 1e-12f;
+            xs[b] = s; float inv = 1.f/s;
+            for (int i = 0; i < 32; i++) xi[b*32+i] = (int8_t)lrintf(xb[i]*inv);
+        }
+        const __m128i m4 = _mm_set1_epi8(0x0F);
+        const __m256i b8 = _mm256_set1_epi8(8);
+        #pragma omp parallel for schedule(static)
+        for (int o = 0; o < O; o++) {
+            const uint8_t *w = p + (int64_t)o * (I/2);
+            float acc = 0.f;
+            for (int b = 0; b < nb; b++) {
+                __m128i by = _mm_loadu_si128((const __m128i*)(w + b*16));  /* 16 B = 32 nibbles */
+                __m128i lo = _mm_and_si128(by, m4);                        /* even columns */
+                __m128i hi = _mm_and_si128(_mm_srli_epi16(by, 4), m4);     /* odd columns  */
+                __m256i nib = _mm256_set_m128i(_mm_unpackhi_epi8(lo, hi),  /* cols 16..31 */
+                                               _mm_unpacklo_epi8(lo, hi)); /* cols  0..15 */
+                nib = _mm256_sub_epi8(nib, b8);
+                __m256i vacc = i8dot_block(_mm256_setzero_si256(),
+                                           _mm256_loadu_si256((const __m256i*)(xi + b*32)), nib);
+                __m128i l = _mm256_castsi256_si128(vacc), h = _mm256_extracti128_si256(vacc, 1);
+                __m128i s4 = _mm_add_epi32(l, h);
+                s4 = _mm_hadd_epi32(s4, s4); s4 = _mm_hadd_epi32(s4, s4);
+                acc += xs[b] * (float)_mm_cvtsi128_si32(s4);
+            }
+            y[o] = acc * scale[o];
+        }
+        return;
+    }
+#endif
+    #pragma omp parallel for schedule(static)
+    for (int o = 0; o < O; o++) {
+        const uint8_t *w = p + (int64_t)o * (I/2);
+        float acc = 0.f;
+        for (int i = 0; i < I; i += 2) {
+            uint8_t byte = w[i/2];
+            acc += x[i]   * (float)((int)(byte & 0xF) - 8);
+            acc += x[i+1] * (float)((int)(byte >> 4)  - 8);
+        }
         y[o] = acc * scale[o];
     }
 }
@@ -458,6 +523,8 @@ static void unpack_rows(const uint8_t *raw, int8_t *q, int64_t rows, int64_t col
     }
 }
 
+static double mem_avail_bytes(void);
+
 static void model_init(Model *m, const char *snap, int cap, int bits) {
     memset(m, 0, sizeof(*m));
     m->quant_bits = bits;
@@ -508,73 +575,193 @@ static void model_init(Model *m, const char *snap, int cap, int bits) {
             m->cs[j][i] = calloc((int64_t)C * (K-1), sizeof(float));
         }
     }
-    m->cache = calloc(c->n_layers, sizeof(LCache));
-    for (int i = 0; i < c->n_layers; i++) { m->cache[i].cap = cap; m->cache[i].slots = calloc(cap, sizeof(Slot)); }
-    /* container detection: converted snapshots store experts as U8 + .qs */
+    /* container detection: converted snapshots store experts as U8 + .qs.
+     * rb13/rb2 = bytes per packed row (D/2|D and I/2|I for int4|int8) */
+    int64_t I = c->moe_inter, E = c->n_experts;
     for (int i = 0; i < c->n_layers; i++) if (c->sparse[i]) {
         snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.gate_up_proj",i);
         st_tensor *t = st_find(&m->S, nm);
-        if (t) m->xq = (t->dtype == 3);
+        if (t && t->dtype == 3) {
+            m->xq = 1;
+            m->rb13 = t->nbytes / (E * 2*I);
+            snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.down_proj",i);
+            st_tensor *t2 = st_find(&m->S, nm);
+            m->rb2 = t2->nbytes / (E * (int64_t)D);
+            if (m->rb13 != D && m->rb13*2 != D) { fprintf(stderr,"unsupported container row size %lld\n",(long long)m->rb13); exit(1); }
+        }
         break;
     }
+    int nsp = 0; for (int i = 0; i < c->n_layers; i++) nsp += c->sparse[i];
+    int64_t slotb = m->xq ? m->rb13*2*I + m->rb2*D + (2*I+D)*4
+                  : m->quant_bits ? 3*I*D + (2*I+D)*4 : 3*I*D*4;
+    if (cap <= 0) {   /* auto: fit the LRU in available RAM, 20% + 4 GB headroom */
+        double avail = mem_avail_bytes();
+        cap = avail > 0 ? (int)((avail*0.80 - 4e9) / ((double)slotb * (nsp ? nsp : 1))) : 16;
+        if (cap < 4) cap = 4;
+        if (cap > c->n_experts) cap = c->n_experts;
+        fprintf(stderr, "[cap auto] %d experts/layer (%.1f GB cache budget)\n",
+                cap, (double)cap*slotb*nsp/1e9);
+    }
+    m->cache = calloc(c->n_layers, sizeof(LCache));
+    for (int i = 0; i < c->n_layers; i++) { m->cache[i].cap = cap; m->cache[i].slots = calloc(cap, sizeof(Slot)); }
+    /* usage counters; seeded from a previous run's history when present */
+    m->eusage = calloc(c->n_layers, sizeof(uint32_t*));
+    for (int i = 0; i < c->n_layers; i++) if (c->sparse[i]) m->eusage[i] = calloc(E, 4);
     m->dense_load_s = now_s() - t0;
 }
 
-/* ---------- routed-expert fetch: slice of fused tensors, LRU-cached ---------- */
-static void expert_get(Model *m, int layer, int eid, Slot **out) {
+static double mem_avail_bytes(void) {
+#if defined(__linux__)
+    FILE *f = fopen("/proc/meminfo", "r");
+    if (!f) return 0;
+    char ln[256]; double kb = 0;
+    while (fgets(ln, sizeof(ln), f)) if (sscanf(ln, "MemAvailable: %lf", &kb) == 1) break;
+    fclose(f);
+    return kb * 1024.0;
+#else
+    return 0;
+#endif
+}
+
+/* ---------- routed-expert slots: serial bookkeeping, parallel fills ---------- */
+static Slot *slot_find(Model *m, int layer, int eid) {
     LCache *lc = &m->cache[layer];
     for (int i = 0; i < lc->n; i++) if (lc->slots[i].eid == eid) {
-        m->hits++; lc->slots[i].used = ++m->clock; *out = &lc->slots[i]; return;
+        lc->slots[i].used = ++m->clock;
+        return &lc->slots[i];
     }
-    m->miss++;
-    Cfg *c = &m->c;
-    int64_t D = c->hidden, I = c->moe_inter;
-    int64_t n13 = 2*I*D, n2 = D*I;
+    return NULL;
+}
+
+/* allocate a slot (or evict the LRU non-pinned one); serial callers only */
+static Slot *slot_acquire(Model *m, int layer, int eid) {
+    LCache *lc = &m->cache[layer]; Cfg *c = &m->c;
+    int64_t D = c->hidden, I = c->moe_inter, n13 = 2*I*D, n2 = D*I;
     Slot *s;
     if (lc->n < lc->cap) {
         s = &lc->slots[lc->n++];
-        if (m->quant_bits || m->xq) {
-            s->q13 = malloc(n13); s->q2 = malloc(n2);
-            s->s13 = falloc(2*I); s->s2 = falloc(D);
-        } else { s->f13 = falloc(n13); s->f2 = falloc(n2); }
-    } else { int lru = 0; for (int i = 1; i < lc->n; i++) if (lc->slots[i].used < lc->slots[lru].used) lru = i; s = &lc->slots[lru]; }
+        if (m->xq)              { s->p13 = malloc((size_t)(m->rb13*2*I)); s->p2 = malloc((size_t)(m->rb2*D));
+                                  s->s13 = falloc(2*I); s->s2 = falloc(D);
+                                  if (!s->p13 || !s->p2) { fprintf(stderr,"OOM expert slot\n"); exit(1); } }
+        else if (m->quant_bits) { s->q13 = malloc(n13); s->q2 = malloc(n2);
+                                  s->s13 = falloc(2*I); s->s2 = falloc(D);
+                                  if (!s->q13 || !s->q2) { fprintf(stderr,"OOM expert slot\n"); exit(1); } }
+        else                    { s->f13 = falloc(n13); s->f2 = falloc(n2); }
+    } else {
+        int lru = -1;
+        for (int i = 0; i < lc->n; i++)
+            if (!lc->slots[i].pinned && (lru < 0 || lc->slots[i].used < lc->slots[lru].used)) lru = i;
+        if (lru < 0) { fprintf(stderr, "layer %d: cache cap %d entirely pinned\n", layer, lc->cap); exit(1); }
+        s = &lc->slots[lru];
+    }
+    s->eid = eid; s->used = ++m->clock; s->filled = 0; s->pinned = 0;
+    return s;
+}
+
+/* pure I/O (+ optional requant): safe to run in parallel across slots */
+static void slot_fill(Model *m, int layer, Slot *s) {
+    Cfg *c = &m->c;
+    int64_t D = c->hidden, I = c->moe_inter, n13 = 2*I*D, n2 = D*I;
+    int64_t eid = s->eid;
     char nm[320], qs[340];
     if (m->xq) {
-        /* colibri container: packed U8 rows + f32 row scales, raw read, no requant */
         snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.gate_up_proj",layer);
-        st_tensor *t = st_find(&m->S, nm);
-        int64_t rowb = t->nbytes / ((int64_t)c->n_experts * 2*I);   /* D = int8, D/2 = int4 */
-        uint8_t *raw = malloc((size_t)(2*I*rowb));
-        read_u8_slice(&m->S, nm, raw, (int64_t)eid*2*I*rowb, 2*I*rowb);
-        unpack_rows(raw, s->q13, 2*I, D, rowb);
+        read_u8_slice(&m->S, nm, s->p13, eid*2*I*m->rb13, 2*I*m->rb13);
         snprintf(qs,sizeof(qs),"%s.qs",nm);
-        read_f32_slice(&m->S, qs, s->s13, (int64_t)eid*2*I, 2*I);
+        read_f32_slice(&m->S, qs, s->s13, eid*2*I, 2*I);
         snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.down_proj",layer);
-        t = st_find(&m->S, nm);
-        rowb = t->nbytes / ((int64_t)c->n_experts * D);
-        raw = realloc(raw, (size_t)(D*rowb));
-        read_u8_slice(&m->S, nm, raw, (int64_t)eid*D*rowb, D*rowb);
-        unpack_rows(raw, s->q2, D, I, rowb);
+        read_u8_slice(&m->S, nm, s->p2, eid*D*m->rb2, D*m->rb2);
         snprintf(qs,sizeof(qs),"%s.qs",nm);
-        read_f32_slice(&m->S, qs, s->s2, (int64_t)eid*D, D);
-        free(raw);
+        read_f32_slice(&m->S, qs, s->s2, eid*D, D);
     } else if (m->quant_bits) {
         float *tmp = falloc(n13 > n2 ? n13 : n2);
         snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.gate_up_proj",layer);
-        read_f32_slice(&m->S, nm, tmp, (int64_t)eid*n13, n13);
+        read_f32_slice(&m->S, nm, tmp, eid*n13, n13);
         quantize_rows(tmp, s->q13, s->s13, 2*I, D, m->quant_bits);
         snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.down_proj",layer);
-        read_f32_slice(&m->S, nm, tmp, (int64_t)eid*n2, n2);
+        read_f32_slice(&m->S, nm, tmp, eid*n2, n2);
         quantize_rows(tmp, s->q2, s->s2, D, I, m->quant_bits);
         free(tmp);
     } else {
         snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.gate_up_proj",layer);
-        read_f32_slice(&m->S, nm, s->f13, (int64_t)eid*n13, n13);
+        read_f32_slice(&m->S, nm, s->f13, eid*n13, n13);
         snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.down_proj",layer);
-        read_f32_slice(&m->S, nm, s->f2, (int64_t)eid*n2, n2);
+        read_f32_slice(&m->S, nm, s->f2, eid*n2, n2);
     }
-    s->eid = eid; s->used = ++m->clock;
-    *out = s;
+    s->filled = 1;
+}
+
+/* pin the top-N experts per sparse layer from a usage-history file (colibri
+ * .coli_usage convention: one uint32 count per expert per layer). Pins are
+ * regular cache slots flagged non-evictable, filled in parallel at startup. */
+static void pins_load(Model *m, const char *snap) {
+    Cfg *c = &m->c; int E = c->n_experts;
+    char up[2048];
+    const char *env = getenv("PIN");
+    if (env) snprintf(up, sizeof(up), "%s", env);
+    else snprintf(up, sizeof(up), "%s/.coli_usage", snap);
+    FILE *f = fopen(up, "rb");
+    if (!f) return;
+    uint32_t hdr[3];
+    if (fread(hdr, 4, 3, f) != 3 || hdr[0] != 0x31554B49u ||
+        (int)hdr[1] != c->n_layers || (int)hdr[2] != E) {
+        fprintf(stderr, "[pin] %s: not an inkling usage file, ignoring\n", up);
+        fclose(f); return;
+    }
+    int cap = m->cache[0].cap;
+    m->npin = getenv("PIN_N") ? atoi(getenv("PIN_N")) : cap/4;
+    if (m->npin > cap - 8) m->npin = cap - 8;
+    if (m->npin < 0) m->npin = 0;
+    uint32_t *tmp = malloc((size_t)E * 4);
+    Slot **ps = malloc((size_t)c->n_layers * m->npin * sizeof(Slot*));
+    int *pl = malloc((size_t)c->n_layers * m->npin * sizeof(int));
+    int np = 0;
+    for (int i = 0; i < c->n_layers; i++) {
+        if (fread(tmp, 4, E, f) != (size_t)E) break;
+        if (!c->sparse[i] || !m->npin) continue;
+        memcpy(m->eusage[i], tmp, (size_t)E * 4);          /* seed the ranking */
+        for (int r = 0; r < m->npin; r++) {                /* top-N selection */
+            int best = -1; uint32_t bv = 0;
+            for (int e = 0; e < E; e++) {
+                int taken = 0;
+                for (int z = 0; z < r; z++) if (ps[np-r+z]->eid == e) { taken = 1; break; }
+                if (!taken && tmp[e] >= bv && tmp[e] > 0) { bv = tmp[e]; best = e; }
+            }
+            if (best < 0) break;
+            Slot *s = slot_acquire(m, i, best);
+            s->pinned = 1;
+            ps[np] = s; pl[np] = i; np++;
+        }
+    }
+    fclose(f);
+    if (np) {
+        double t0 = now_s();
+        #pragma omp parallel for schedule(dynamic,1)
+        for (int j = 0; j < np; j++) slot_fill(m, pl[j], ps[j]);
+        fprintf(stderr, "[pin] %d experts pinned (%d/layer) from %s in %.1fs\n",
+                np, m->npin, up, now_s()-t0);
+    }
+    free(tmp); free(ps); free(pl);
+}
+
+/* usage snapshot: rewritten after every generation run (same contract as
+ * glm's .coli_usage — copy it aside if you need a stable ranking) */
+static void usage_save(Model *m, const char *snap) {
+    Cfg *c = &m->c; int E = c->n_experts;
+    char up[2048], tp[2060];
+    const char *env = getenv("PIN");
+    if (env) snprintf(up, sizeof(up), "%s", env);
+    else snprintf(up, sizeof(up), "%s/.coli_usage", snap);
+    snprintf(tp, sizeof(tp), "%s.tmp", up);
+    FILE *f = fopen(tp, "wb");
+    if (!f) return;
+    uint32_t hdr[3] = { 0x31554B49u, (uint32_t)c->n_layers, (uint32_t)E };
+    fwrite(hdr, 4, 3, f);
+    uint32_t *zero = calloc(E, 4);
+    for (int i = 0; i < c->n_layers; i++)
+        fwrite(m->eusage[i] ? m->eusage[i] : zero, 4, E, f);
+    free(zero); fclose(f);
+    rename(tp, up);
 }
 
 /* ---------- attention (GQA + sliding/global + relative bias + K/V sconv) ---------- */
@@ -668,7 +855,11 @@ static void dense_mlp(Model *m, Layer *l, float *x, int S, float *out) {
     free(g); free(u);
 }
 
-/* ---------- MoE: sigmoid router + bias top-k, joint routed+shared weights ---------- */
+/* ---------- MoE: sigmoid router + bias top-k, joint routed+shared weights ----------
+ * Three passes per layer call: (1) route every position and acquire slots,
+ * (2) fill ALL missing experts in one parallel burst (the NVMe wants queue
+ * depth — during prefill this batches the whole sequence's misses), then
+ * (3) compute. */
 static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
     Cfg *c = &m->c;
     int D = c->hidden, E = c->n_experts, K = c->topk, I = c->moe_inter, ns = c->n_shared;
@@ -676,41 +867,82 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
     float *logits = falloc((int64_t)S*ET);
     matmul(logits, x, l->router, S, D, ET);
     memset(out, 0, (int64_t)S*D*sizeof(float));
-    float *g = falloc(I), *u = falloc(I), *hh = falloc(D);
+    int   *idx  = malloc((size_t)S*K*sizeof(int));
+    float *wgt  = malloc((size_t)S*(K+ns)*sizeof(float));
+    Slot **use  = malloc((size_t)S*K*sizeof(Slot*));
+    Slot **fill = malloc((size_t)S*K*sizeof(Slot*));
+    int  *fl    = malloc((size_t)S*K*sizeof(int));
+    int nfill = 0;
+    /* pass 1: routing + slot bookkeeping (serial) */
     for (int s = 0; s < S; s++) {
         float *lg = logits + (int64_t)s*ET;
+        int *si = idx + (int64_t)s*K;
         /* selection: sigmoid(routed) + correction bias, top-K */
-        int idx[64];
         for (int kk = 0; kk < K; kk++) {
             int best = -1; float bv = -1e30f;
             for (int e = 0; e < E; e++) {
-                int taken = 0; for (int j = 0; j < kk; j++) if (idx[j]==e){taken=1;break;}
+                int taken = 0; for (int j = 0; j < kk; j++) if (si[j]==e){taken=1;break;}
                 float ch = sigmoidf(lg[e]) + l->rbias[e];
                 if (!taken && ch > bv) { bv = ch; best = e; }
             }
-            idx[kk] = best;
+            si[kk] = best;
         }
         /* combine weights: sigmoids of the raw logits of (topK routed + shared),
          * normalized to sum 1 over all K+ns, x route_scale x gate.global_scale */
-        float w[80]; float sum = 0.f;
-        for (int kk = 0; kk < K; kk++)  { w[kk]   = sigmoidf(lg[idx[kk]]); sum += w[kk]; }
-        for (int j = 0; j < ns; j++)    { w[K+j]  = sigmoidf(lg[E+j]);     sum += w[K+j]; }
+        float *w = wgt + (int64_t)s*(K+ns); float sum = 0.f;
+        for (int kk = 0; kk < K; kk++)  { w[kk]   = sigmoidf(lg[si[kk]]); sum += w[kk]; }
+        for (int j = 0; j < ns; j++)    { w[K+j]  = sigmoidf(lg[E+j]);    sum += w[K+j]; }
         for (int kk = 0; kk < K+ns; kk++) w[kk] *= c->route_scale * l->rgs / sum;
+        for (int kk = 0; kk < K; kk++) {
+            int eid = si[kk];
+            if (m->eusage[layer]) m->eusage[layer][eid]++;
+            Slot *e = slot_find(m, layer, eid);
+            if (e) m->hits++;
+            else {
+                m->miss++;
+                e = slot_acquire(m, layer, eid);
+                fill[nfill] = e; fl[nfill] = layer; nfill++;
+            }
+            use[(int64_t)s*K + kk] = e;
+        }
+    }
+    /* pass 2: one parallel burst for every miss in this layer call */
+    if (nfill) {
+        #pragma omp parallel for schedule(dynamic,1)
+        for (int j = 0; j < nfill; j++) slot_fill(m, fl[j], fill[j]);
+    }
+    /* pass 3: compute */
+    float *g = falloc(I), *u = falloc(I), *hh = falloc(D);
+    int q4 = m->xq && m->rb13*2 == D;   /* packed int4 vs int8 container */
+    for (int s = 0; s < S; s++) {
         const float *xs = x + (int64_t)s*D;
         float *os = out + (int64_t)s*D;
+        float *w = wgt + (int64_t)s*(K+ns);
         for (int kk = 0; kk < K; kk++) {
-            Slot *e; expert_get(m, layer, idx[kk], &e);
-            int qm = m->quant_bits || m->xq;
-            if (qm) {
-                matmul_q(g, xs, e->q13,                 e->s13,     D, I);   /* gate rows  */
-                matmul_q(u, xs, e->q13 + (int64_t)I*D,  e->s13 + I, D, I);   /* up rows    */
+            Slot *e = use[(int64_t)s*K + kk];
+            if (m->xq) {
+                if (q4) {
+                    matmul_q4(g, xs, e->p13,                    e->s13,     D, I);   /* gate rows */
+                    matmul_q4(u, xs, e->p13 + (int64_t)I*m->rb13, e->s13 + I, D, I); /* up rows   */
+                    for (int i = 0; i < I; i++) g[i] = siluf(g[i]) * u[i];
+                    matmul_q4(hh, g, e->p2, e->s2, I, D);
+                } else {
+                    matmul_q(g, xs, (int8_t*)e->p13,                 e->s13,     D, I);
+                    matmul_q(u, xs, (int8_t*)e->p13 + (int64_t)I*D,  e->s13 + I, D, I);
+                    for (int i = 0; i < I; i++) g[i] = siluf(g[i]) * u[i];
+                    matmul_q(hh, g, (int8_t*)e->p2, e->s2, I, D);
+                }
+            } else if (m->quant_bits) {
+                matmul_q(g, xs, e->q13,                 e->s13,     D, I);
+                matmul_q(u, xs, e->q13 + (int64_t)I*D,  e->s13 + I, D, I);
+                for (int i = 0; i < I; i++) g[i] = siluf(g[i]) * u[i];
+                matmul_q(hh, g, e->q2, e->s2, I, D);
             } else {
                 matmul(g, xs, e->f13,                1, D, I);
                 matmul(u, xs, e->f13 + (int64_t)I*D, 1, D, I);
+                for (int i = 0; i < I; i++) g[i] = siluf(g[i]) * u[i];
+                matmul(hh, g, e->f2, 1, I, D);
             }
-            for (int i = 0; i < I; i++) g[i] = siluf(g[i]) * u[i];
-            if (qm) matmul_q(hh, g, e->q2, e->s2, I, D);
-            else matmul(hh, g, e->f2, 1, I, D);
             for (int d = 0; d < D; d++) os[d] += w[kk] * hh[d];
         }
         /* shared experts: gamma inside (before down_proj is linear, so applied at the end) */
@@ -722,7 +954,8 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
             for (int d = 0; d < D; d++) os[d] += w[K+j] * hh[d];
         }
     }
-    free(logits); free(g); free(u); free(hh);
+    free(logits); free(idx); free(wgt); free(use); free(fill); free(fl);
+    free(g); free(u); free(hh);
 }
 
 /* ---------- one forward pass over S new tokens ----------
@@ -851,7 +1084,7 @@ int main(int argc, char **argv) {
     if (!snap) { fprintf(stderr, "set SNAP=<snapshot directory>\n"); return 1; }
     /* flags: -p "prompt" [-n N] -> generate mode; positional: [cap] [bits] [ref.json] */
     const char *prompt = NULL, *refpath = "ref_inkling.json";
-    int cap = 16, bits = 0, n_new = 256, npos = 0;
+    int cap = -1, bits = 0, n_new = 256, npos = 0;
     for (int i = 1; i < argc; i++) {
         if (!strcmp(argv[i], "-p") && i+1 < argc) prompt = argv[++i];
         else if (!strcmp(argv[i], "-n") && i+1 < argc) n_new = atoi(argv[++i]);
@@ -859,15 +1092,22 @@ int main(int argc, char **argv) {
         else if (npos == 1) { bits = atoi(argv[i]); npos++; }
         else refpath = argv[i];
     }
+    if (cap < 0) cap = prompt ? 0 : 16;   /* generate mode defaults to RAM-sized auto cap */
     if (bits && (bits < 2 || bits > 8)) { fprintf(stderr, "quant_bits must be 0 (f32) or 2..8\n"); return 1; }
 
     if (prompt) {
         Model m; model_init(&m, snap, cap, bits);
         printf("== Inkling C engine, %d layers, experts @ %s, cache %d/layer ==\n",
-               m.c.n_layers, m.xq ? "container" : bits ? "int" : "f32", cap);
+               m.c.n_layers, m.xq ? "container" : bits ? "int" : "f32", m.cache[0].cap);
+        pins_load(&m, snap);
         char tkp[2048]; snprintf(tkp, sizeof(tkp), "%s/tokenizer.json", snap);
         Tok T; tok_load(&T, tkp);
         generate_stream(&m, &T, prompt, n_new);
+        usage_save(&m, snap);
+        double tot = m.hits + m.miss;
+        printf("[cache] hit %.1f%% (%llu hit / %llu load) | usage history saved\n",
+               tot ? 100.0*m.hits/tot : 0.0,
+               (unsigned long long)m.hits, (unsigned long long)m.miss);
         return 0;
     }
 

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -109,6 +109,7 @@ typedef struct {
     uint32_t **eusage;                    /* per-layer expert selection counts */
     int npin;                             /* pinned experts per sparse layer */
     uint64_t clock, hits, miss;
+    double t_fill, t_expert, t_shared, t_attn, t_route;   /* phase timers */
     float **K, **V; int kv_len, max_t;    /* per-layer [kv][max_t][hd] */
     float **cs[4];                        /* conv states, [n_layers][C*(K-1)] */
     double dense_load_s;
@@ -943,8 +944,10 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
     }
     /* pass 2: one parallel burst for every miss in this layer call */
     if (nfill) {
+        double tf = now_s();
         #pragma omp parallel for schedule(dynamic,1)
         for (int j = 0; j < nfill; j++) slot_fill(m, fl[j], fill[j]);
+        m->t_fill += now_s() - tf;
     }
     /* pass 3: compute. gate+up run as ONE matmul over the fused 2I rows —
      * halves the number of (expensive to open) parallel regions per expert */
@@ -954,6 +957,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
         const float *xs = x + (int64_t)s*D;
         float *os = out + (int64_t)s*D;
         float *w = wgt + (int64_t)s*(K+ns);
+        double te = now_s();
         for (int kk = 0; kk < K; kk++) {
             Slot *e = use[(int64_t)s*K + kk];
             if (m->xq) {
@@ -977,6 +981,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
             }
             for (int d = 0; d < D; d++) os[d] += w[kk] * hh[d];
         }
+        double ts = now_s(); m->t_expert += ts - te;
         /* shared experts: gamma inside (before down_proj is linear, so applied at the end) */
         for (int j = 0; j < ns; j++) {
             matmul_w(g, xs, wt_off(l->sh_g, (int64_t)j*I*D), 1, D, I);
@@ -985,6 +990,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
             matmul_w(hh, g, wt_off(l->sh_d, (int64_t)j*D*I), 1, I, D);
             for (int d = 0; d < D; d++) os[d] += w[K+j] * hh[d];
         }
+        m->t_shared += now_s() - ts;
     }
     free(logits); free(idx); free(wgt); free(use); free(fill); free(fl);
     free(g); free(hh);              /* u aliases g+I */
@@ -1004,7 +1010,9 @@ static float *step(Model *m, const int *ids, int S, int pos0, int *tf_out) {
     for (int i = 0; i < c->n_layers; i++) {
         Layer *l = &m->L[i];
         for (int s = 0; s < S; s++) rmsnorm_row(nrm + (int64_t)s*D, x + (int64_t)s*D, l->in_ln, D, c->eps);
+        double ta = now_s();
         attention(m, l, i, nrm, S, pos0, tmp);
+        m->t_attn += now_s() - ta;
         sconv_apply(tmp, S, D, l->a_cw, m->cs[2][i], c->conv_k);
         for (int64_t j = 0; j < (int64_t)S*D; j++) x[j] += tmp[j];
         for (int s = 0; s < S; s++) rmsnorm_row(nrm + (int64_t)s*D, x + (int64_t)s*D, l->post_ln, D, c->eps);
@@ -1099,6 +1107,10 @@ static void generate_stream(Model *m, Tok *T, const char *prompt, int n_new) {
     int gen = len - np;
     printf("\n[prefill %.1fs | %d tokens in %.1fs = %.2f tok/s | RSS %.1f GB]\n",
            t1 - t0, gen, dt, gen > 1 ? (gen-1)/dt : 0.0, rss_gb());
+    double wall = now_s() - t0;
+    printf("[phases] fill %.1fs | expert-mm %.1fs | shared %.1fs | attn %.1fs | other %.1fs\n",
+           m->t_fill, m->t_expert, m->t_shared, m->t_attn,
+           wall - m->t_fill - m->t_expert - m->t_shared - m->t_attn);
     free(ids);
 }
 

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -729,11 +729,18 @@ static void slot_fill(Model *m, int layer, Slot *s) {
 
 /* pin the top-N experts per sparse layer from a usage-history file (colibri
  * .coli_usage convention: one uint32 count per expert per layer). Pins are
- * regular cache slots flagged non-evictable, filled in parallel at startup. */
+ * regular cache slots flagged non-evictable, filled in parallel at startup.
+ * Toggles: PIN=off (or PIN=0) skips cache warming entirely (no seeding, no
+ * pins, cold LRU start); PIN_N=0 seeds the ranking from the history but pins
+ * nothing; PIN=<path> uses an alternate history file; PIN_N=<n> pin depth. */
 static void pins_load(Model *m, const char *snap) {
     Cfg *c = &m->c; int E = c->n_experts;
     char up[2048];
     const char *env = getenv("PIN");
+    if (env && (!strcmp(env, "off") || !strcmp(env, "0"))) {
+        fprintf(stderr, "[pin] cache warming disabled (PIN=%s)\n", env);
+        return;
+    }
     if (env) snprintf(up, sizeof(up), "%s", env);
     else snprintf(up, sizeof(up), "%s/.coli_usage", snap);
     FILE *f = fopen(up, "rb");
@@ -784,11 +791,16 @@ static void pins_load(Model *m, const char *snap) {
 }
 
 /* usage snapshot: rewritten after every generation run (same contract as
- * glm's .coli_usage — copy it aside if you need a stable ranking) */
+ * glm's .coli_usage — copy it aside if you need a stable ranking).
+ * USAGE_SAVE=0 skips the rewrite (e.g. benchmark loops that would skew the
+ * ranking); PIN=off also implies no save (that run never seeded counts). */
 static void usage_save(Model *m, const char *snap) {
     Cfg *c = &m->c; int E = c->n_experts;
     char up[2048], tp[2060];
     const char *env = getenv("PIN");
+    const char *sv = getenv("USAGE_SAVE");
+    if (sv && *sv == '0') return;
+    if (env && (!strcmp(env, "off") || !strcmp(env, "0"))) return;
     if (env) snprintf(up, sizeof(up), "%s", env);
     else snprintf(up, sizeof(up), "%s/.coli_usage", snap);
     snprintf(tp, sizeof(tp), "%s.tmp", up);

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -1,0 +1,770 @@
+/* Pure-C inference engine for Thinking Machines "Inkling" (text-only), Stage A.
+ * Goal, like olmoe.c before GLM-5.2: reproduce the EXACT token ids of the HF
+ * transformers reference (ref_inkling.json from tools/make_tiny_inkling.py)
+ * to validate the core math before scaling to the 975B checkpoint.
+ *
+ * Architecture (vs glm.c's MLA/RoPE/DSA — shares almost nothing):
+ *  - hybrid attention: sliding-window layers (window=512, 16 KV heads) and
+ *    global layers (8 KV heads) interleaved 5:1; conventional GQA, no RoPE
+ *  - learned relative-position bias: r_proj(x) mixes a per-layer bank
+ *    proj[d_rel, rel_extent] into one bias per backward distance
+ *  - log-length scaling tau on global layers past n_floor tokens
+ *  - depthwise-causal short convs (kernel 4, residual inside, fp32):
+ *    on K and V inside attention, after attention, and after the MLP
+ *  - MoE: sigmoid router + loss-free bias for top-k selection; combine
+ *    weights are sigmoids of the raw logits jointly normalized over
+ *    topk routed + n_shared shared experts, x route_scale x global_scale
+ *  - logits: hidden / logits_mup_width_multiplier, sliced to unpadded vocab
+ *
+ * Dense weights (attn, norms, convs, router, shared experts, dense MLP)
+ * resident in RAM as f32; routed experts streamed from disk per-expert out
+ * of the fused [E, 2I, D] / [E, D, I] tensors, LRU-cached, optionally
+ * int-quantized (bits=0 keeps them f32 for bit-exact oracle validation).
+ */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
+#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
+#include <sys/resource.h>
+#endif
+#include "st.h"
+#include "tok.h"
+
+#define MAXL 256
+
+/* ---------- config ---------- */
+typedef struct {
+    int hidden, n_layers, vocab, unpad_vocab;
+    int n_heads, n_kv, head_dim;          /* global ("hybrid") layers */
+    int swa_heads, swa_kv, swa_hd;        /* sliding ("hybrid_sliding") layers */
+    int window, d_rel, rel_extent, conv_k;
+    double log_floor;                     /* <=0: log scaling off */
+    float log_alpha;
+    int n_experts, topk, n_shared, moe_inter, dense_inter;
+    int eos;
+    float eps, route_scale, mup;
+    unsigned char local[MAXL];            /* 1 = sliding-window layer */
+    unsigned char sparse[MAXL];           /* 1 = MoE layer, 0 = dense MLP */
+} Cfg;
+
+/* per-layer dims that depend on the attention type */
+#define L_HEADS(c,i) ((c)->local[i] ? (c)->swa_heads : (c)->n_heads)
+#define L_KV(c,i)    ((c)->local[i] ? (c)->swa_kv    : (c)->n_kv)
+#define L_HD(c,i)    ((c)->local[i] ? (c)->swa_hd    : (c)->head_dim)
+#define L_EXT(c,i)   ((c)->local[i] ? (c)->window    : (c)->rel_extent)
+
+/* ---------- resident per-layer weights (f32) ---------- */
+typedef struct {
+    float *in_ln, *post_ln;
+    float *q, *k, *v, *r, *o;             /* projections */
+    float *qn, *kn;                       /* per-head rmsnorm [head_dim] */
+    float *relp;                          /* [d_rel, ext] bias bank */
+    float *k_cw, *v_cw, *a_cw, *m_cw;     /* sconv weights, [C*K] depthwise */
+    /* dense layers */
+    float *dg, *du, *dd, dgs;
+    /* MoE layers */
+    float *router, *rbias, rgs;           /* [E+ns, D], [E], scalar */
+    float *sh_g, *sh_u, *sh_d;            /* shared experts [ns][I,D] etc. */
+} Layer;
+
+/* ---------- routed-expert LRU cache ---------- */
+typedef struct {
+    int eid; uint64_t used;
+    int8_t *q13, *q2; float *s13, *s2;    /* bits>0: int-quantized rows */
+    float *f13, *f2;                      /* bits==0: raw f32 */
+} Slot;
+typedef struct { Slot *slots; int n, cap; } LCache;
+
+typedef struct {
+    Cfg c;
+    shards S;
+    int quant_bits;                       /* 0 = f32 experts (oracle mode) */
+    int xq;                               /* experts on disk are a colibri container (U8 + .qs) */
+    float *embed, *embed_norm, *lm_head, *final_norm;
+    Layer *L;
+    LCache *cache;
+    uint64_t clock, hits, miss;
+    float **K, **V; int kv_len, max_t;    /* per-layer [kv][max_t][hd] */
+    float **cs[4];                        /* conv states, [n_layers][C*(K-1)] */
+    double dense_load_s;
+} Model;
+
+/* ---------- utility ---------- */
+static double now_s(void) { struct timespec t; clock_gettime(CLOCK_MONOTONIC, &t); return t.tv_sec + t.tv_nsec*1e-9; }
+#if defined(__APPLE__)
+static double rss_gb(void) { struct rusage r; getrusage(RUSAGE_SELF, &r); return r.ru_maxrss / (1024.0*1024.0*1024.0); }
+#else
+static double rss_gb(void) { struct rusage r; getrusage(RUSAGE_SELF, &r); return r.ru_maxrss / (1024.0*1024.0); }
+#endif
+static float *falloc(int64_t n) { float *p = malloc(n*sizeof(float)); if(!p){fprintf(stderr,"OOM %ld\n",(long)n);exit(1);} return p; }
+static float sigmoidf(float x) { return 1.f / (1.f + expf(-x)); }
+static float siluf(float x) { return x / (1.f + expf(-x)); }
+
+/* y[S,O] = x[S,I] @ W^T, W row-major [O,I] */
+static void matmul(float *y, const float *x, const float *W, int S, int I, int O) {
+    #pragma omp parallel for schedule(static)
+    for (int o = 0; o < O; o++) {
+        const float *w = W + (int64_t)o * I;
+        for (int s = 0; s < S; s++) {
+            const float *xs = x + (int64_t)s * I;
+            float acc = 0.f;
+            for (int i = 0; i < I; i++) acc += xs[i] * w[i];
+            y[(int64_t)s * O + o] = acc;
+        }
+    }
+}
+
+/* y[1,O] = x @ q^T with per-row int quantization (same container math as olmoe.c) */
+static void matmul_q(float *y, const float *x, const int8_t *q, const float *scale, int I, int O) {
+    #pragma omp parallel for schedule(static)
+    for (int o = 0; o < O; o++) {
+        const int8_t *w = q + (int64_t)o * I;
+        float acc = 0.f;
+        for (int i = 0; i < I; i++) acc += x[i] * (float)w[i];
+        y[o] = acc * scale[o];
+    }
+}
+
+static void quantize_rows(const float *w, int8_t *q, float *scale, int O, int I, int bits) {
+    int qmax = (1 << (bits - 1)) - 1;
+    #pragma omp parallel for schedule(static)
+    for (int o = 0; o < O; o++) {
+        const float *wr = w + (int64_t)o * I;
+        float amax = 0.f; for (int i = 0; i < I; i++) { float a = fabsf(wr[i]); if (a > amax) amax = a; }
+        float s = amax / qmax; if (s < 1e-8f) s = 1e-8f;
+        scale[o] = s;
+        int8_t *qr = q + (int64_t)o * I;
+        for (int i = 0; i < I; i++) {
+            int v = (int)lrintf(wr[i] / s);
+            if (v >  qmax) v =  qmax;
+            if (v < -qmax-1) v = -qmax-1;
+            qr[i] = (int8_t)v;
+        }
+    }
+}
+
+/* rmsnorm computed in f64 accumulate like the f32->f32 reference */
+static void rmsnorm_row(float *out, const float *x, const float *w, int D, float eps) {
+    double ms = 0; for (int i = 0; i < D; i++) ms += (double)x[i]*x[i];
+    float r = 1.f / sqrtf((float)(ms / D) + eps);
+    for (int i = 0; i < D; i++) out[i] = x[i] * r * w[i];
+}
+
+static void softmax_row(float *x, int n) {
+    float m = -1e30f; for (int i = 0; i < n; i++) if (x[i] > m) m = x[i];
+    float s = 0; for (int i = 0; i < n; i++) { x[i] = expf(x[i]-m); s += x[i]; }
+    for (int i = 0; i < n; i++) x[i] /= s;
+}
+
+/* ---------- depthwise causal short conv, residual inside (fp32) ----------
+ * seq[S,C] in-place: out[t] = sum_j w[c,j]*in[t+j-(K-1)] + in[t], history from
+ * state[C*(K-1)] (raw pre-conv inputs), which is updated to the new tail. */
+static void sconv_apply(float *seq, int S, int C, const float *w, float *state, int K) {
+    int P = K - 1;
+    #pragma omp parallel
+    {
+        float *col = malloc((P + S) * sizeof(float));
+        #pragma omp for schedule(static)
+        for (int ch = 0; ch < C; ch++) {
+            for (int j = 0; j < P; j++) col[j] = state[(int64_t)ch*P + j];
+            for (int t = 0; t < S; t++) col[P + t] = seq[(int64_t)t*C + ch];
+            const float *wc = w + (int64_t)ch*K;
+            for (int t = 0; t < S; t++) {
+                float acc = 0.f;
+                for (int j = 0; j < K; j++) acc += wc[j] * col[t + j];
+                seq[(int64_t)t*C + ch] = acc + col[P + t];
+            }
+            for (int j = 0; j < P; j++) state[(int64_t)ch*P + j] = col[S + j];
+        }
+        free(col);
+    }
+}
+
+/* ---------- config loading ----------
+ * Accepts both the flat text config (tiny oracle via InklingForCausalLM) and
+ * the full multimodal config.json (real checkpoint, fields under text_config). */
+static double jnum(jval *o, const char *k, double dflt) {
+    jval *v = json_get(o, k);
+    return (v && v->t == J_NUM) ? v->num : dflt;
+}
+
+static void load_cfg(Cfg *c, const char *snap) {
+    char path[2048]; snprintf(path, sizeof(path), "%s/config.json", snap);
+    FILE *f = fopen(path, "rb"); if(!f){perror(path);exit(1);}
+    fseek(f,0,SEEK_END); long n=ftell(f); fseek(f,0,SEEK_SET);
+    char *buf = malloc(n+1); if(fread(buf,1,n,f)!=(size_t)n){} buf[n]=0; fclose(f);
+    char *arena=NULL; jval *root = json_parse(buf, &arena);
+    jval *r = json_get(root, "text_config"); if (!r) r = root;
+
+    c->hidden      = (int)jnum(r,"hidden_size",6144);
+    c->n_layers    = (int)jnum(r,"num_hidden_layers",66);
+    c->vocab       = (int)jnum(r,"vocab_size",201024);
+    c->unpad_vocab = (int)jnum(r,"unpadded_vocab_size",c->vocab);
+    c->n_heads     = (int)jnum(r,"num_attention_heads",64);
+    c->n_kv        = (int)jnum(r,"num_key_value_heads",8);
+    c->head_dim    = (int)jnum(r,"head_dim",128);
+    c->swa_heads   = (int)jnum(r,"swa_num_attention_heads",c->n_heads);
+    c->swa_kv      = (int)jnum(r,"swa_num_key_value_heads",16);
+    c->swa_hd      = (int)jnum(r,"swa_head_dim",c->head_dim);
+    c->window      = (int)jnum(r,"sliding_window_size",512);
+    c->d_rel       = (int)jnum(r,"d_rel",16);
+    c->rel_extent  = (int)jnum(r,"rel_extent",1024);
+    c->log_floor   = jnum(r,"log_scaling_n_floor",0);
+    c->log_alpha   = (float)jnum(r,"log_scaling_alpha",0.1);
+    c->conv_k      = (int)jnum(r,"sconv_kernel_size", jnum(r,"conv_kernel_size",4));
+    c->n_experts   = (int)jnum(r,"n_routed_experts",256);
+    c->topk        = (int)jnum(r,"num_experts_per_tok",6);
+    c->n_shared    = (int)jnum(r,"n_shared_experts",2);
+    c->eps         = (float)jnum(r,"rms_norm_eps",1e-6);
+    c->route_scale = (float)jnum(r,"route_scale",8.0);
+    c->mup         = (float)jnum(r,"logits_mup_width_multiplier",24.0);
+    /* eos lives at the top level in the real multimodal config, in the text
+     * config for a flat snapshot; may be null (tiny oracle) */
+    jval *eo = json_get(root,"eos_token_id");
+    if (!eo || eo->t != J_NUM) eo = json_get(r,"eos_token_id");
+    c->eos = (eo && eo->t == J_NUM) ? (int)eo->num : -1;
+    /* real config.json: intermediate_size = MoE, dense_intermediate_size = dense.
+     * HF-saved config (post_init applied): intermediate_size = dense, moe_intermediate_size = MoE. */
+    jval *dis = json_get(r,"dense_intermediate_size");
+    if (dis && dis->t == J_NUM) {
+        c->dense_inter = (int)dis->num;
+        c->moe_inter   = (int)jnum(r,"intermediate_size",3072);
+    } else {
+        c->dense_inter = (int)jnum(r,"intermediate_size",24576);
+        c->moe_inter   = (int)jnum(r,"moe_intermediate_size",3072);
+    }
+    if (c->n_layers > MAXL) { fprintf(stderr,"n_layers %d > MAXL\n", c->n_layers); exit(1); }
+
+    /* attention layer types: explicit layer_types[] > local_layer_ids[] > (i+1)%6 rule */
+    jval *lt = json_get(r,"layer_types");
+    jval *ll = json_get(r,"local_layer_ids");
+    for (int i = 0; i < c->n_layers; i++) {
+        if (lt && lt->t == J_ARR) c->local[i] = (strcmp(lt->kids[i]->str,"hybrid_sliding")==0);
+        else if (ll && ll->t == J_ARR) {
+            c->local[i] = 0;
+            for (int j = 0; j < ll->len; j++) if ((int)ll->kids[j]->num == i) { c->local[i] = 1; break; }
+        } else c->local[i] = ((i + 1) % 6) != 0;
+    }
+    /* MLP types: explicit mlp_layer_types[] > dense_mlp_idx (first k layers dense) */
+    jval *mt = json_get(r,"mlp_layer_types");
+    int dense_idx = (int)jnum(r,"dense_mlp_idx",0);
+    for (int i = 0; i < c->n_layers; i++) {
+        if (mt && mt->t == J_ARR) c->sparse[i] = (strcmp(mt->kids[i]->str,"sparse")==0);
+        else c->sparse[i] = (i >= dense_idx);
+    }
+    free(buf); free(arena);
+}
+
+/* ---------- weight loading ---------- */
+static float *load_t(Model *m, const char *name) {
+    int64_t n = st_numel(&m->S, name);
+    if (n < 0) { fprintf(stderr, "missing %s\n", name); exit(1); }
+    float *p = falloc(n);
+    st_read_f32(&m->S, name, p, 0);
+    return p;
+}
+static float load_scalar(Model *m, const char *name, float dflt) {
+    if (!st_has(&m->S, name)) return dflt;
+    float v; st_read_f32(&m->S, name, &v, 0); return v;
+}
+
+/* f32 slice of a (possibly bf16/f16) tensor: element offset + count.
+ * Needed to stream one expert out of the fused [E,2I,D]/[E,D,I] tensors. */
+static void read_f32_slice(shards *S, const char *name, float *out, int64_t off, int64_t cnt) {
+    st_tensor *t = st_find(S, name);
+    if (!t) { fprintf(stderr, "missing tensor: %s\n", name); exit(1); }
+    if (t->dtype == 3) { fprintf(stderr, "%s: U8 container has no f32 view\n", name); exit(1); }
+    int esz = (t->dtype == 2) ? 4 : 2;
+    void *raw = malloc((size_t)cnt * esz);
+    if (!raw) { fprintf(stderr,"OOM slice %s\n",name); exit(1); }
+    if (pread(t->fd, raw, (size_t)cnt*esz, t->off + off*esz) != (ssize_t)(cnt*esz)) { perror("pread slice"); exit(1); }
+    if (t->dtype == 2) memcpy(out, raw, (size_t)cnt*4);
+    else if (t->dtype == 0) { uint16_t *p = raw; for (int64_t i = 0; i < cnt; i++) out[i] = bf16_to_f32(p[i]); }
+    else                    { uint16_t *p = raw; for (int64_t i = 0; i < cnt; i++) out[i] = f16_to_f32(p[i]); }
+    free(raw);
+    posix_fadvise(t->fd, t->off + off*esz, cnt*esz, POSIX_FADV_DONTNEED);
+}
+
+/* raw byte slice of a U8 container tensor */
+static void read_u8_slice(shards *S, const char *name, uint8_t *out, int64_t boff, int64_t nb) {
+    st_tensor *t = st_find(S, name);
+    if (!t) { fprintf(stderr, "missing tensor: %s\n", name); exit(1); }
+    if (pread(t->fd, out, (size_t)nb, t->off + boff) != (ssize_t)nb) { perror("pread u8 slice"); exit(1); }
+    posix_fadvise(t->fd, t->off + boff, nb, POSIX_FADV_DONTNEED);
+}
+
+/* container rows -> int8: rowb==cols is int8 verbatim; rowb==cols/2 is packed
+ * int4 (low nibble = even column, offset +8 — convert_inkling_int4.py / glm.c) */
+static void unpack_rows(const uint8_t *raw, int8_t *q, int64_t rows, int64_t cols, int64_t rowb) {
+    if (rowb == cols) { memcpy(q, raw, (size_t)(rows*cols)); return; }
+    if (rowb*2 != cols) { fprintf(stderr, "container row size %ld vs cols %ld unsupported\n", (long)rowb, (long)cols); exit(1); }
+    for (int64_t r = 0; r < rows; r++) {
+        const uint8_t *b = raw + r*rowb;
+        int8_t *qr = q + r*cols;
+        for (int64_t j = 0; j < rowb; j++) {
+            qr[2*j]   = (int8_t)((b[j] & 0xF) - 8);
+            qr[2*j+1] = (int8_t)((b[j] >> 4) - 8);
+        }
+    }
+}
+
+static void model_init(Model *m, const char *snap, int cap, int bits) {
+    memset(m, 0, sizeof(*m));
+    m->quant_bits = bits;
+    load_cfg(&m->c, snap);
+    st_init(&m->S, snap);
+    Cfg *c = &m->c;
+    int D = c->hidden, K = c->conv_k;
+    double t0 = now_s();
+    m->embed      = load_t(m, "model.embed_tokens.weight");
+    m->embed_norm = st_has(&m->S,"model.embed_norm.weight") ? load_t(m,"model.embed_norm.weight") : NULL;
+    m->final_norm = load_t(m, "model.norm.weight");
+    m->lm_head    = load_t(m, "lm_head.weight");
+    m->L = calloc(c->n_layers, sizeof(Layer));
+    char nm[320];
+    for (int i = 0; i < c->n_layers; i++) {
+        Layer *l = &m->L[i];
+        #define LD(field, suffix) snprintf(nm,sizeof(nm),"model.layers.%d." suffix,i); l->field = load_t(m,nm)
+        LD(in_ln,  "input_layernorm.weight");
+        LD(post_ln,"post_attention_layernorm.weight");
+        LD(q, "self_attn.q_proj.weight"); LD(k, "self_attn.k_proj.weight");
+        LD(v, "self_attn.v_proj.weight"); LD(r, "self_attn.r_proj.weight");
+        LD(o, "self_attn.o_proj.weight");
+        LD(qn,"self_attn.q_norm.weight"); LD(kn,"self_attn.k_norm.weight");
+        LD(relp, "self_attn.rel_logits_proj.proj");
+        LD(k_cw, "self_attn.k_sconv.conv1d.weight");
+        LD(v_cw, "self_attn.v_sconv.conv1d.weight");
+        LD(a_cw, "attn_sconv.conv1d.weight");
+        LD(m_cw, "mlp_sconv.conv1d.weight");
+        if (!c->sparse[i]) {
+            LD(dg, "mlp.gate_proj.weight"); LD(du, "mlp.up_proj.weight"); LD(dd, "mlp.down_proj.weight");
+            snprintf(nm,sizeof(nm),"model.layers.%d.mlp.global_scale",i); l->dgs = load_scalar(m,nm,1.f);
+        } else {
+            LD(router, "mlp.gate.weight");
+            LD(rbias,  "mlp.gate.e_score_correction_bias");
+            snprintf(nm,sizeof(nm),"model.layers.%d.mlp.gate.global_scale",i); l->rgs = load_scalar(m,nm,1.f);
+            LD(sh_g, "mlp.shared_experts.gate_proj");
+            LD(sh_u, "mlp.shared_experts.up_proj");
+            LD(sh_d, "mlp.shared_experts.down_proj");
+        }
+        #undef LD
+        /* conv states: raw inputs of the previous K-1 steps, zero-init */
+        int kvdim = L_KV(c,i) * L_HD(c,i);
+        for (int j = 0; j < 4; j++) {
+            if (!m->cs[j]) m->cs[j] = calloc(c->n_layers, sizeof(float*));
+            int C = (j < 2) ? kvdim : D;
+            m->cs[j][i] = calloc((int64_t)C * (K-1), sizeof(float));
+        }
+    }
+    m->cache = calloc(c->n_layers, sizeof(LCache));
+    for (int i = 0; i < c->n_layers; i++) { m->cache[i].cap = cap; m->cache[i].slots = calloc(cap, sizeof(Slot)); }
+    /* container detection: converted snapshots store experts as U8 + .qs */
+    for (int i = 0; i < c->n_layers; i++) if (c->sparse[i]) {
+        snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.gate_up_proj",i);
+        st_tensor *t = st_find(&m->S, nm);
+        if (t) m->xq = (t->dtype == 3);
+        break;
+    }
+    m->dense_load_s = now_s() - t0;
+}
+
+/* ---------- routed-expert fetch: slice of fused tensors, LRU-cached ---------- */
+static void expert_get(Model *m, int layer, int eid, Slot **out) {
+    LCache *lc = &m->cache[layer];
+    for (int i = 0; i < lc->n; i++) if (lc->slots[i].eid == eid) {
+        m->hits++; lc->slots[i].used = ++m->clock; *out = &lc->slots[i]; return;
+    }
+    m->miss++;
+    Cfg *c = &m->c;
+    int64_t D = c->hidden, I = c->moe_inter;
+    int64_t n13 = 2*I*D, n2 = D*I;
+    Slot *s;
+    if (lc->n < lc->cap) {
+        s = &lc->slots[lc->n++];
+        if (m->quant_bits || m->xq) {
+            s->q13 = malloc(n13); s->q2 = malloc(n2);
+            s->s13 = falloc(2*I); s->s2 = falloc(D);
+        } else { s->f13 = falloc(n13); s->f2 = falloc(n2); }
+    } else { int lru = 0; for (int i = 1; i < lc->n; i++) if (lc->slots[i].used < lc->slots[lru].used) lru = i; s = &lc->slots[lru]; }
+    char nm[320], qs[340];
+    if (m->xq) {
+        /* colibri container: packed U8 rows + f32 row scales, raw read, no requant */
+        snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.gate_up_proj",layer);
+        st_tensor *t = st_find(&m->S, nm);
+        int64_t rowb = t->nbytes / ((int64_t)c->n_experts * 2*I);   /* D = int8, D/2 = int4 */
+        uint8_t *raw = malloc((size_t)(2*I*rowb));
+        read_u8_slice(&m->S, nm, raw, (int64_t)eid*2*I*rowb, 2*I*rowb);
+        unpack_rows(raw, s->q13, 2*I, D, rowb);
+        snprintf(qs,sizeof(qs),"%s.qs",nm);
+        read_f32_slice(&m->S, qs, s->s13, (int64_t)eid*2*I, 2*I);
+        snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.down_proj",layer);
+        t = st_find(&m->S, nm);
+        rowb = t->nbytes / ((int64_t)c->n_experts * D);
+        raw = realloc(raw, (size_t)(D*rowb));
+        read_u8_slice(&m->S, nm, raw, (int64_t)eid*D*rowb, D*rowb);
+        unpack_rows(raw, s->q2, D, I, rowb);
+        snprintf(qs,sizeof(qs),"%s.qs",nm);
+        read_f32_slice(&m->S, qs, s->s2, (int64_t)eid*D, D);
+        free(raw);
+    } else if (m->quant_bits) {
+        float *tmp = falloc(n13 > n2 ? n13 : n2);
+        snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.gate_up_proj",layer);
+        read_f32_slice(&m->S, nm, tmp, (int64_t)eid*n13, n13);
+        quantize_rows(tmp, s->q13, s->s13, 2*I, D, m->quant_bits);
+        snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.down_proj",layer);
+        read_f32_slice(&m->S, nm, tmp, (int64_t)eid*n2, n2);
+        quantize_rows(tmp, s->q2, s->s2, D, I, m->quant_bits);
+        free(tmp);
+    } else {
+        snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.gate_up_proj",layer);
+        read_f32_slice(&m->S, nm, s->f13, (int64_t)eid*n13, n13);
+        snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.down_proj",layer);
+        read_f32_slice(&m->S, nm, s->f2, (int64_t)eid*n2, n2);
+    }
+    s->eid = eid; s->used = ++m->clock;
+    *out = s;
+}
+
+/* ---------- attention (GQA + sliding/global + relative bias + K/V sconv) ---------- */
+static void attention(Model *m, Layer *l, int li, float *x, int S, int pos0, float *out) {
+    Cfg *c = &m->c;
+    int D = c->hidden, H = L_HEADS(c,li), KV = L_KV(c,li), hd = L_HD(c,li), ext = L_EXT(c,li);
+    int local = c->local[li];
+    int qdim = H*hd, kvdim = KV*hd, group = H/KV;
+    float *q  = falloc((int64_t)S*qdim);
+    float *k  = falloc((int64_t)S*kvdim);
+    float *vv = falloc((int64_t)S*kvdim);
+    float *rr = falloc((int64_t)S*H*c->d_rel);
+    matmul(q,  x, l->q, S, D, qdim);
+    matmul(k,  x, l->k, S, D, kvdim);
+    matmul(vv, x, l->v, S, D, kvdim);
+    matmul(rr, x, l->r, S, D, H*c->d_rel);
+    /* short convs on K and V (sequence-wise, over the raw projections) */
+    sconv_apply(k,  S, kvdim, l->k_cw, m->cs[0][li], c->conv_k);
+    sconv_apply(vv, S, kvdim, l->v_cw, m->cs[1][li], c->conv_k);
+    /* per-head q/k rmsnorm (scaling below is 1/hd, not 1/sqrt(hd), because of this) */
+    for (int s = 0; s < S; s++) {
+        for (int h = 0; h < H;  h++) rmsnorm_row(q + (int64_t)s*qdim  + h*hd, q + (int64_t)s*qdim  + h*hd, l->qn, hd, c->eps);
+        for (int h = 0; h < KV; h++) rmsnorm_row(k + (int64_t)s*kvdim + h*hd, k + (int64_t)s*kvdim + h*hd, l->kn, hd, c->eps);
+    }
+    /* append K,V to the cache */
+    for (int s = 0; s < S; s++) for (int h = 0; h < KV; h++) {
+        int t = pos0 + s;
+        memcpy(m->K[li] + ((int64_t)h*m->max_t + t)*hd, k  + (int64_t)s*kvdim + h*hd, hd*sizeof(float));
+        memcpy(m->V[li] + ((int64_t)h*m->max_t + t)*hd, vv + (int64_t)s*kvdim + h*hd, hd*sizeof(float));
+    }
+    float scale = 1.f / (float)hd;
+    float *ctx = falloc((int64_t)S*qdim);
+    #pragma omp parallel
+    {
+        float *rl = malloc(ext * sizeof(float));
+        float *sc = malloc((size_t)m->max_t * sizeof(float));
+        #pragma omp for collapse(2) schedule(static)
+        for (int h = 0; h < H; h++) {
+            for (int s = 0; s < S; s++) {
+                int qpos = pos0 + s;
+                int t0 = local && qpos - c->window + 1 > 0 ? qpos - c->window + 1 : 0;
+                /* mix the relative-bias bank for this (token, head): rl[dist] */
+                const float *rv = rr + (int64_t)s*H*c->d_rel + h*c->d_rel;
+                for (int e = 0; e < ext; e++) {
+                    float acc = 0.f;
+                    for (int d = 0; d < c->d_rel; d++) acc += rv[d] * l->relp[(int64_t)d*ext + e];
+                    rl[e] = acc;
+                }
+                /* tau: log-length scaling on global layers (f32, per query pos) */
+                float tau = 1.f;
+                if (!local && c->log_floor > 0) {
+                    double en = (double)(qpos + 1) / c->log_floor;
+                    if (en > 1.0) tau = 1.f + c->log_alpha * (float)log(en);
+                }
+                const float *qv = q + (int64_t)s*qdim + h*hd;
+                const float *Kh = m->K[li] + ((int64_t)(h/group)*m->max_t)*hd;
+                for (int t = t0; t <= qpos; t++) {
+                    const float *kv = Kh + (int64_t)t*hd;
+                    float acc = 0.f;
+                    for (int d = 0; d < hd; d++) acc += qv[d]*kv[d];
+                    int dist = qpos - t;
+                    sc[t - t0] = tau * (acc*scale + (dist < ext ? rl[dist] : 0.f));
+                }
+                int n = qpos - t0 + 1;
+                softmax_row(sc, n);
+                float *cx = ctx + (int64_t)s*qdim + h*hd;
+                for (int d = 0; d < hd; d++) cx[d] = 0.f;
+                const float *Vh = m->V[li] + ((int64_t)(h/group)*m->max_t)*hd;
+                for (int t = t0; t <= qpos; t++) {
+                    const float *vrow = Vh + (int64_t)t*hd;
+                    float a = sc[t - t0];
+                    for (int d = 0; d < hd; d++) cx[d] += a * vrow[d];
+                }
+            }
+        }
+        free(rl); free(sc);
+    }
+    matmul(out, ctx, l->o, S, qdim, D);
+    free(q); free(k); free(vv); free(rr); free(ctx);
+}
+
+/* ---------- dense MLP ---------- */
+static void dense_mlp(Model *m, Layer *l, float *x, int S, float *out) {
+    Cfg *c = &m->c; int D = c->hidden, I = c->dense_inter;
+    float *g = falloc((int64_t)S*I), *u = falloc((int64_t)S*I);
+    matmul(g, x, l->dg, S, D, I);
+    matmul(u, x, l->du, S, D, I);
+    for (int64_t i = 0; i < (int64_t)S*I; i++) g[i] = siluf(g[i]) * u[i];
+    matmul(out, g, l->dd, S, I, D);
+    for (int64_t i = 0; i < (int64_t)S*D; i++) out[i] *= l->dgs;
+    free(g); free(u);
+}
+
+/* ---------- MoE: sigmoid router + bias top-k, joint routed+shared weights ---------- */
+static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
+    Cfg *c = &m->c;
+    int D = c->hidden, E = c->n_experts, K = c->topk, I = c->moe_inter, ns = c->n_shared;
+    int ET = E + ns;
+    float *logits = falloc((int64_t)S*ET);
+    matmul(logits, x, l->router, S, D, ET);
+    memset(out, 0, (int64_t)S*D*sizeof(float));
+    float *g = falloc(I), *u = falloc(I), *hh = falloc(D);
+    for (int s = 0; s < S; s++) {
+        float *lg = logits + (int64_t)s*ET;
+        /* selection: sigmoid(routed) + correction bias, top-K */
+        int idx[64];
+        for (int kk = 0; kk < K; kk++) {
+            int best = -1; float bv = -1e30f;
+            for (int e = 0; e < E; e++) {
+                int taken = 0; for (int j = 0; j < kk; j++) if (idx[j]==e){taken=1;break;}
+                float ch = sigmoidf(lg[e]) + l->rbias[e];
+                if (!taken && ch > bv) { bv = ch; best = e; }
+            }
+            idx[kk] = best;
+        }
+        /* combine weights: sigmoids of the raw logits of (topK routed + shared),
+         * normalized to sum 1 over all K+ns, x route_scale x gate.global_scale */
+        float w[80]; float sum = 0.f;
+        for (int kk = 0; kk < K; kk++)  { w[kk]   = sigmoidf(lg[idx[kk]]); sum += w[kk]; }
+        for (int j = 0; j < ns; j++)    { w[K+j]  = sigmoidf(lg[E+j]);     sum += w[K+j]; }
+        for (int kk = 0; kk < K+ns; kk++) w[kk] *= c->route_scale * l->rgs / sum;
+        const float *xs = x + (int64_t)s*D;
+        float *os = out + (int64_t)s*D;
+        for (int kk = 0; kk < K; kk++) {
+            Slot *e; expert_get(m, layer, idx[kk], &e);
+            int qm = m->quant_bits || m->xq;
+            if (qm) {
+                matmul_q(g, xs, e->q13,                 e->s13,     D, I);   /* gate rows  */
+                matmul_q(u, xs, e->q13 + (int64_t)I*D,  e->s13 + I, D, I);   /* up rows    */
+            } else {
+                matmul(g, xs, e->f13,                1, D, I);
+                matmul(u, xs, e->f13 + (int64_t)I*D, 1, D, I);
+            }
+            for (int i = 0; i < I; i++) g[i] = siluf(g[i]) * u[i];
+            if (qm) matmul_q(hh, g, e->q2, e->s2, I, D);
+            else matmul(hh, g, e->f2, 1, I, D);
+            for (int d = 0; d < D; d++) os[d] += w[kk] * hh[d];
+        }
+        /* shared experts: gamma inside (before down_proj is linear, so applied at the end) */
+        for (int j = 0; j < ns; j++) {
+            matmul(g, xs, l->sh_g + (int64_t)j*I*D, 1, D, I);
+            matmul(u, xs, l->sh_u + (int64_t)j*I*D, 1, D, I);
+            for (int i = 0; i < I; i++) g[i] = siluf(g[i]) * u[i];
+            matmul(hh, g, l->sh_d + (int64_t)j*D*I, 1, I, D);
+            for (int d = 0; d < D; d++) os[d] += w[K+j] * hh[d];
+        }
+    }
+    free(logits); free(g); free(u); free(hh);
+}
+
+/* ---------- one forward pass over S new tokens ----------
+ * Returns malloc'd logits of the last token (unpadded vocab). If tf_out is
+ * non-NULL also writes the per-position argmax (teacher-forcing check). */
+static float *step(Model *m, const int *ids, int S, int pos0, int *tf_out) {
+    Cfg *c = &m->c; int D = c->hidden;
+    float *x = falloc((int64_t)S*D);
+    for (int s = 0; s < S; s++) {
+        if (m->embed_norm) rmsnorm_row(x + (int64_t)s*D, m->embed + (int64_t)ids[s]*D, m->embed_norm, D, c->eps);
+        else memcpy(x + (int64_t)s*D, m->embed + (int64_t)ids[s]*D, D*sizeof(float));
+    }
+    float *nrm = falloc((int64_t)S*D), *tmp = falloc((int64_t)S*D);
+    for (int i = 0; i < c->n_layers; i++) {
+        Layer *l = &m->L[i];
+        for (int s = 0; s < S; s++) rmsnorm_row(nrm + (int64_t)s*D, x + (int64_t)s*D, l->in_ln, D, c->eps);
+        attention(m, l, i, nrm, S, pos0, tmp);
+        sconv_apply(tmp, S, D, l->a_cw, m->cs[2][i], c->conv_k);
+        for (int64_t j = 0; j < (int64_t)S*D; j++) x[j] += tmp[j];
+        for (int s = 0; s < S; s++) rmsnorm_row(nrm + (int64_t)s*D, x + (int64_t)s*D, l->post_ln, D, c->eps);
+        if (c->sparse[i]) moe(m, l, i, nrm, S, tmp);
+        else dense_mlp(m, l, nrm, S, tmp);
+        sconv_apply(tmp, S, D, l->m_cw, m->cs[3][i], c->conv_k);
+        for (int64_t j = 0; j < (int64_t)S*D; j++) x[j] += tmp[j];
+    }
+    m->kv_len = pos0 + S;
+    float *last = falloc(D);
+    float *logit = falloc(c->unpad_vocab);
+    if (tf_out) {
+        for (int s = 0; s < S; s++) {
+            rmsnorm_row(last, x + (int64_t)s*D, m->final_norm, D, c->eps);
+            for (int d = 0; d < D; d++) last[d] /= c->mup;
+            matmul(logit, last, m->lm_head, 1, D, c->unpad_vocab);
+            int best = 0; for (int i = 1; i < c->unpad_vocab; i++) if (logit[i] > logit[best]) best = i;
+            tf_out[pos0 + s] = best;
+        }
+    }
+    rmsnorm_row(last, x + (int64_t)(S-1)*D, m->final_norm, D, c->eps);
+    for (int d = 0; d < D; d++) last[d] /= c->mup;
+    matmul(logit, last, m->lm_head, 1, D, c->unpad_vocab);
+    free(x); free(nrm); free(tmp); free(last);
+    return logit;
+}
+
+static void state_reset(Model *m) {
+    Cfg *c = &m->c;
+    m->kv_len = 0;
+    for (int i = 0; i < c->n_layers; i++) {
+        int kvdim = L_KV(c,i) * L_HD(c,i);
+        for (int j = 0; j < 4; j++)
+            memset(m->cs[j][i], 0, (int64_t)((j < 2) ? kvdim : c->hidden) * (c->conv_k-1) * sizeof(float));
+    }
+}
+
+static void kv_alloc(Model *m, int max_t) {
+    Cfg *c = &m->c;
+    m->max_t = max_t;
+    m->K = calloc(c->n_layers, sizeof(float*)); m->V = calloc(c->n_layers, sizeof(float*));
+    for (int i = 0; i < c->n_layers; i++) {
+        m->K[i] = falloc((int64_t)L_KV(c,i) * max_t * L_HD(c,i));
+        m->V[i] = falloc((int64_t)L_KV(c,i) * max_t * L_HD(c,i));
+    }
+}
+
+/* greedy generation, olmoe.c-style */
+static void generate(Model *m, const int *prompt, int np, int n_new, int *out) {
+    for (int i = 0; i < np; i++) out[i] = prompt[i];
+    float *logit = step(m, prompt, np, 0, NULL);
+    int len = np;
+    Cfg *c = &m->c;
+    for (int s = 0; s < n_new; s++) {
+        int best = 0; float bv = logit[0];
+        for (int i = 1; i < c->unpad_vocab; i++) if (logit[i] > bv) { bv = logit[i]; best = i; }
+        free(logit);
+        out[len++] = best;
+        if (s == n_new - 1) break;
+        int one = best;
+        logit = step(m, &one, 1, len - 1, NULL);
+    }
+}
+
+/* ---------- interactive prompt mode: greedy, streaming, stop on eos ---------- */
+static void generate_stream(Model *m, Tok *T, const char *prompt, int n_new) {
+    Cfg *c = &m->c;
+    int cap = (int)strlen(prompt) + 16;
+    int *ids = malloc(cap * sizeof(int));
+    int np = tok_encode(T, prompt, (int)strlen(prompt), ids, cap);
+    if (np <= 0) { fprintf(stderr, "empty prompt after tokenization\n"); return; }
+    kv_alloc(m, np + n_new + 8);
+    printf("[%d prompt tokens] %s", np, prompt); fflush(stdout);
+    double t0 = now_s(), t1 = 0;
+    float *logit = step(m, ids, np, 0, NULL);
+    int len = np;
+    char buf[512];
+    for (int s = 0; s < n_new; s++) {
+        int best = 0; float bv = logit[0];
+        for (int i = 1; i < c->unpad_vocab; i++) if (logit[i] > bv) { bv = logit[i]; best = i; }
+        free(logit);
+        if (s == 0) t1 = now_s();
+        if (best == c->eos) { printf("\n[eos after %d tokens]", s); break; }
+        int nb = tok_decode(T, &best, 1, buf, sizeof(buf)-1);
+        buf[nb] = 0; fputs(buf, stdout); fflush(stdout);
+        int one = best;
+        len++;
+        if (s == n_new - 1) break;
+        logit = step(m, &one, 1, len - 1, NULL);
+    }
+    double dt = now_s() - t1;
+    int gen = len - np;
+    printf("\n[prefill %.1fs | %d tokens in %.1fs = %.2f tok/s | RSS %.1f GB]\n",
+           t1 - t0, gen, dt, gen > 1 ? (gen-1)/dt : 0.0, rss_gb());
+    free(ids);
+}
+
+/* ---------- ref_inkling.json harness ---------- */
+static int *read_int_array(jval *o, const char *key, int *n_out) {
+    jval *a = json_get(o, key);
+    if (!a || a->t != J_ARR) { *n_out = 0; return NULL; }
+    int *r = malloc(a->len * sizeof(int));
+    for (int i = 0; i < a->len; i++) r[i] = (int)a->kids[i]->num;
+    *n_out = a->len; return r;
+}
+
+int main(int argc, char **argv) {
+    const char *snap = getenv("SNAP");
+    if (!snap) { fprintf(stderr, "set SNAP=<snapshot directory>\n"); return 1; }
+    /* flags: -p "prompt" [-n N] -> generate mode; positional: [cap] [bits] [ref.json] */
+    const char *prompt = NULL, *refpath = "ref_inkling.json";
+    int cap = 16, bits = 0, n_new = 256, npos = 0;
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "-p") && i+1 < argc) prompt = argv[++i];
+        else if (!strcmp(argv[i], "-n") && i+1 < argc) n_new = atoi(argv[++i]);
+        else if (npos == 0) { cap = atoi(argv[i]); npos++; }
+        else if (npos == 1) { bits = atoi(argv[i]); npos++; }
+        else refpath = argv[i];
+    }
+    if (bits && (bits < 2 || bits > 8)) { fprintf(stderr, "quant_bits must be 0 (f32) or 2..8\n"); return 1; }
+
+    if (prompt) {
+        Model m; model_init(&m, snap, cap, bits);
+        printf("== Inkling C engine, %d layers, experts @ %s, cache %d/layer ==\n",
+               m.c.n_layers, m.xq ? "container" : bits ? "int" : "f32", cap);
+        char tkp[2048]; snprintf(tkp, sizeof(tkp), "%s/tokenizer.json", snap);
+        Tok T; tok_load(&T, tkp);
+        generate_stream(&m, &T, prompt, n_new);
+        return 0;
+    }
+
+    FILE *f = fopen(refpath, "rb"); if(!f){perror(refpath);return 1;}
+    fseek(f,0,SEEK_END); long n=ftell(f); fseek(f,0,SEEK_SET);
+    char *buf=malloc(n+1); if(fread(buf,1,n,f)!=(size_t)n){} buf[n]=0; fclose(f);
+    char *arena=NULL; jval *ref = json_parse(buf, &arena);
+    int np, nfull, ntf;
+    int *pids  = read_int_array(ref,"prompt_ids",&np);
+    int *full  = read_int_array(ref,"full_ids",&nfull);
+    int *tfref = read_int_array(ref,"tf_pred",&ntf);
+    int ngen = nfull - np;
+
+    Model m; model_init(&m, snap, cap, bits);
+    printf("== Inkling C engine (Stage A), cache = %d experts/layer, experts @ %s ==\n",
+           cap, m.xq ? "container (int4/int8 + .qs)" : bits ? "int (runtime quant)" : "f32");
+    printf("cfg: D=%d L=%d V=%d(%d) heads=%d/%d kv=%d/%d hd=%d win=%d d_rel=%d ext=%d E=%d+%d topk=%d\n",
+           m.c.hidden, m.c.n_layers, m.c.vocab, m.c.unpad_vocab, m.c.n_heads, m.c.swa_heads,
+           m.c.n_kv, m.c.swa_kv, m.c.head_dim, m.c.window, m.c.d_rel, m.c.rel_extent,
+           m.c.n_experts, m.c.n_shared, m.c.topk);
+    printf("resident weights loaded in %.1fs | RSS: %.2f GB\n", m.dense_load_s, rss_gb());
+    kv_alloc(&m, nfull + 8);
+
+    /* pass 1: teacher-forced argmax over the full reference sequence */
+    if (tfref && ntf == nfull) {
+        int *tf = malloc(nfull * sizeof(int));
+        float *lg = step(&m, full, nfull, 0, tf);
+        free(lg);
+        int ok = 0; for (int i = 0; i < nfull; i++) ok += (tf[i] == tfref[i]);
+        printf("teacher-forced argmax: %d/%d match\n", ok, nfull);
+        free(tf);
+        state_reset(&m);
+    }
+
+    /* pass 2: greedy generation, token-for-token vs the oracle */
+    int *out = malloc(nfull * sizeof(int));
+    double t = now_s();
+    generate(&m, pids, np, ngen, out);
+    double dt = now_s() - t;
+    int match = 0;
+    printf("Reference: "); for (int i=np;i<nfull;i++) printf("%d ", full[i]);
+    printf("\nC engine : "); for (int i=np;i<nfull;i++) { printf("%d ", out[i]); if (out[i]==full[i]) match++; }
+    printf("\nMatching tokens: %d/%d\n", match, ngen);
+    double tot = m.hits + m.miss;
+    printf("PEAK RSS: %.2f GB | expert cache hit %.1f%% | %.2f tok/s\n",
+           rss_gb(), tot?100.0*m.hits/tot:0.0, ngen/dt);
+    free(buf); free(arena);
+    return (match == ngen) ? 0 : 1;
+}

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -56,18 +56,23 @@ typedef struct {
 #define L_HD(c,i)    ((c)->local[i] ? (c)->swa_hd    : (c)->head_dim)
 #define L_EXT(c,i)   ((c)->local[i] ? (c)->window    : (c)->rel_extent)
 
-/* ---------- resident per-layer weights (f32) ---------- */
+/* ---------- resident weights ----------
+ * Large matmul weights keep their on-disk dtype in RAM: bf16 for the real
+ * 975B checkpoint (f32 residents would need ~172 GB, over sabre's 187),
+ * f32 for the tiny oracle (bit-exact validation). Exactly one pointer set. */
+typedef struct { float *f; uint16_t *h; } Wt;
+
 typedef struct {
     float *in_ln, *post_ln;
-    float *q, *k, *v, *r, *o;             /* projections */
+    Wt q, k, v, r, o;                     /* projections */
     float *qn, *kn;                       /* per-head rmsnorm [head_dim] */
     float *relp;                          /* [d_rel, ext] bias bank */
     float *k_cw, *v_cw, *a_cw, *m_cw;     /* sconv weights, [C*K] depthwise */
     /* dense layers */
-    float *dg, *du, *dd, dgs;
+    Wt dg, du, dd; float dgs;
     /* MoE layers */
     float *router, *rbias, rgs;           /* [E+ns, D], [E], scalar */
-    float *sh_g, *sh_u, *sh_d;            /* shared experts [ns][I,D] etc. */
+    Wt sh_g, sh_u, sh_d;                  /* shared experts [ns][I,D] etc. */
 } Layer;
 
 /* ---------- routed-expert LRU cache ---------- */
@@ -83,7 +88,8 @@ typedef struct {
     shards S;
     int quant_bits;                       /* 0 = f32 experts (oracle mode) */
     int xq;                               /* experts on disk are a colibri container (U8 + .qs) */
-    float *embed, *embed_norm, *lm_head, *final_norm;
+    Wt embed, lm_head;
+    float *embed_norm, *final_norm;
     Layer *L;
     LCache *cache;
     uint64_t clock, hits, miss;
@@ -117,8 +123,113 @@ static void matmul(float *y, const float *x, const float *W, int S, int I, int O
     }
 }
 
-/* y[1,O] = x @ q^T with per-row int quantization (same container math as olmoe.c) */
+#if defined(__AVX512BF16__) && defined(__AVX512F__)
+#include <immintrin.h>
+#define HAVE_BF16_DOT 1
+#endif
+#if defined(__AVX2__)
+#include <immintrin.h>
+#endif
+
+/* bf16-weight matmul: activations rounded to bf16 per row (matches the HF
+ * bf16 reference numerics), hardware vdpbf16ps dot where available,
+ * shift-to-f32 scalar otherwise. */
+static void matmul_h(float *y, const float *x, const uint16_t *W, int S, int I, int O) {
+#ifdef HAVE_BF16_DOT
+    if (I % 32 == 0) {
+        uint16_t *xh = malloc((size_t)S * I * sizeof(uint16_t));
+        for (int s = 0; s < S; s++) {
+            const float *xs = x + (int64_t)s * I;
+            uint16_t *xd = xh + (int64_t)s * I;
+            for (int i = 0; i < I; i += 32) {
+                __m512 a = _mm512_loadu_ps(xs + i), b = _mm512_loadu_ps(xs + i + 16);
+                _mm512_storeu_si512(xd + i, (__m512i)_mm512_cvtne2ps_pbh(b, a));
+            }
+        }
+        #pragma omp parallel for schedule(static)
+        for (int o = 0; o < O; o++) {
+            const uint16_t *w = W + (int64_t)o * I;
+            for (int s = 0; s < S; s++) {
+                const uint16_t *xs = xh + (int64_t)s * I;
+                __m512 acc = _mm512_setzero_ps();
+                for (int i = 0; i < I; i += 32)
+                    acc = _mm512_dpbf16_ps(acc, (__m512bh)_mm512_loadu_si512(xs + i),
+                                                (__m512bh)_mm512_loadu_si512(w + i));
+                y[(int64_t)s * O + o] = _mm512_reduce_add_ps(acc);
+            }
+        }
+        free(xh);
+        return;
+    }
+#endif
+    #pragma omp parallel for schedule(static)
+    for (int o = 0; o < O; o++) {
+        const uint16_t *w = W + (int64_t)o * I;
+        for (int s = 0; s < S; s++) {
+            const float *xs = x + (int64_t)s * I;
+            float acc = 0.f;
+            for (int i = 0; i < I; i++) {
+                union { uint32_t u; float f; } v = { (uint32_t)w[i] << 16 };
+                acc += xs[i] * v.f;
+            }
+            y[(int64_t)s * O + o] = acc;
+        }
+    }
+}
+
+/* dispatch on the weight's resident dtype */
+static void matmul_w(float *y, const float *x, Wt W, int S, int I, int O) {
+    if (W.f) matmul(y, x, W.f, S, I, O);
+    else     matmul_h(y, x, W.h, S, I, O);
+}
+
+/* y[1,O] = x @ q^T, int8 weights + per-row scale. Fast path: activations
+ * quantized Q8 per 32-block, VNNI (or maddubs) int8 dot — same family as
+ * glm.c's IDOT kernels; IDOT=0 falls back to the byte-exact scalar route. */
+#if defined(__AVX2__)
+static inline __m256i i8dot_block(__m256i acc, __m256i a, __m256i b) {
+    __m256i ax = _mm256_sign_epi8(a, a);        /* |a| as u8 */
+    __m256i sy = _mm256_sign_epi8(b, a);        /* b * sign(a) */
+#if defined(__AVX512VNNI__) && defined(__AVX512VL__)
+    return _mm256_dpbusd_epi32(acc, ax, sy);
+#else
+    __m256i p = _mm256_maddubs_epi16(ax, sy);
+    return _mm256_add_epi32(acc, _mm256_madd_epi16(p, _mm256_set1_epi16(1)));
+#endif
+}
+#endif
 static void matmul_q(float *y, const float *x, const int8_t *q, const float *scale, int I, int O) {
+#if defined(__AVX2__)
+    static int idot = -1;
+    if (idot < 0) { const char *e = getenv("IDOT"); idot = !(e && *e == '0'); }
+    if (idot && I % 32 == 0 && I <= 8192) {
+        int nb = I / 32;
+        int8_t xi[8192]; float xs[256];
+        for (int b = 0; b < nb; b++) {
+            const float *xb = x + b*32;
+            float am = 0.f; for (int i = 0; i < 32; i++) { float a = fabsf(xb[i]); if (a > am) am = a; }
+            float s = am/127.f; if (s < 1e-12f) s = 1e-12f;
+            xs[b] = s; float inv = 1.f/s;
+            for (int i = 0; i < 32; i++) xi[b*32+i] = (int8_t)lrintf(xb[i]*inv);
+        }
+        #pragma omp parallel for schedule(static)
+        for (int o = 0; o < O; o++) {
+            const int8_t *w = q + (int64_t)o * I;
+            float acc = 0.f;
+            for (int b = 0; b < nb; b++) {
+                __m256i vacc = i8dot_block(_mm256_setzero_si256(),
+                                           _mm256_loadu_si256((const __m256i*)(xi + b*32)),
+                                           _mm256_loadu_si256((const __m256i*)(w + b*32)));
+                __m128i lo = _mm256_castsi256_si128(vacc), hi = _mm256_extracti128_si256(vacc, 1);
+                __m128i s4 = _mm_add_epi32(lo, hi);
+                s4 = _mm_hadd_epi32(s4, s4); s4 = _mm_hadd_epi32(s4, s4);
+                acc += xs[b] * (float)_mm_cvtsi128_si32(s4);
+            }
+            y[o] = acc * scale[o];
+        }
+        return;
+    }
+#endif
     #pragma omp parallel for schedule(static)
     for (int o = 0; o < O; o++) {
         const int8_t *w = q + (int64_t)o * I;
@@ -271,6 +382,25 @@ static float load_scalar(Model *m, const char *name, float dflt) {
     float v; st_read_f32(&m->S, name, &v, 0); return v;
 }
 
+/* big matmul weights keep their on-disk dtype resident: BF16 raw (real
+ * checkpoint, halves RAM), anything else as f32 (tiny oracle: bit-exact) */
+static Wt load_w(Model *m, const char *name) {
+    Wt w = {0};
+    st_tensor *t = st_find(&m->S, name);
+    if (!t) { fprintf(stderr, "missing %s\n", name); exit(1); }
+    if (t->dtype == 0) { w.h = malloc(t->nbytes); if (!w.h) { fprintf(stderr,"OOM %s\n",name); exit(1); } st_read_raw(&m->S, name, w.h, 0); }
+    else               { w.f = falloc(t->numel); st_read_f32(&m->S, name, w.f, 0); }
+    return w;
+}
+static Wt wt_off(Wt w, int64_t off) {
+    Wt r = { w.f ? w.f + off : NULL, w.h ? w.h + off : NULL };
+    return r;
+}
+static void wt_row_f32(Wt w, int64_t off, float *out, int n) {
+    if (w.f) memcpy(out, w.f + off, n * sizeof(float));
+    else for (int i = 0; i < n; i++) { union { uint32_t u; float f; } v = { (uint32_t)w.h[off + i] << 16 }; out[i] = v.f; }
+}
+
 /* f32 slice of a (possibly bf16/f16) tensor: element offset + count.
  * Needed to stream one expert out of the fused [E,2I,D]/[E,D,I] tensors. */
 static void read_f32_slice(shards *S, const char *name, float *out, int64_t off, int64_t cnt) {
@@ -319,20 +449,21 @@ static void model_init(Model *m, const char *snap, int cap, int bits) {
     Cfg *c = &m->c;
     int D = c->hidden, K = c->conv_k;
     double t0 = now_s();
-    m->embed      = load_t(m, "model.embed_tokens.weight");
+    m->embed      = load_w(m, "model.embed_tokens.weight");
     m->embed_norm = st_has(&m->S,"model.embed_norm.weight") ? load_t(m,"model.embed_norm.weight") : NULL;
     m->final_norm = load_t(m, "model.norm.weight");
-    m->lm_head    = load_t(m, "lm_head.weight");
+    m->lm_head    = load_w(m, "lm_head.weight");
     m->L = calloc(c->n_layers, sizeof(Layer));
     char nm[320];
     for (int i = 0; i < c->n_layers; i++) {
         Layer *l = &m->L[i];
-        #define LD(field, suffix) snprintf(nm,sizeof(nm),"model.layers.%d." suffix,i); l->field = load_t(m,nm)
+        #define LD(field, suffix)  snprintf(nm,sizeof(nm),"model.layers.%d." suffix,i); l->field = load_t(m,nm)
+        #define LDW(field, suffix) snprintf(nm,sizeof(nm),"model.layers.%d." suffix,i); l->field = load_w(m,nm)
         LD(in_ln,  "input_layernorm.weight");
         LD(post_ln,"post_attention_layernorm.weight");
-        LD(q, "self_attn.q_proj.weight"); LD(k, "self_attn.k_proj.weight");
-        LD(v, "self_attn.v_proj.weight"); LD(r, "self_attn.r_proj.weight");
-        LD(o, "self_attn.o_proj.weight");
+        LDW(q, "self_attn.q_proj.weight"); LDW(k, "self_attn.k_proj.weight");
+        LDW(v, "self_attn.v_proj.weight"); LDW(r, "self_attn.r_proj.weight");
+        LDW(o, "self_attn.o_proj.weight");
         LD(qn,"self_attn.q_norm.weight"); LD(kn,"self_attn.k_norm.weight");
         LD(relp, "self_attn.rel_logits_proj.proj");
         LD(k_cw, "self_attn.k_sconv.conv1d.weight");
@@ -340,17 +471,18 @@ static void model_init(Model *m, const char *snap, int cap, int bits) {
         LD(a_cw, "attn_sconv.conv1d.weight");
         LD(m_cw, "mlp_sconv.conv1d.weight");
         if (!c->sparse[i]) {
-            LD(dg, "mlp.gate_proj.weight"); LD(du, "mlp.up_proj.weight"); LD(dd, "mlp.down_proj.weight");
+            LDW(dg, "mlp.gate_proj.weight"); LDW(du, "mlp.up_proj.weight"); LDW(dd, "mlp.down_proj.weight");
             snprintf(nm,sizeof(nm),"model.layers.%d.mlp.global_scale",i); l->dgs = load_scalar(m,nm,1.f);
         } else {
             LD(router, "mlp.gate.weight");
             LD(rbias,  "mlp.gate.e_score_correction_bias");
             snprintf(nm,sizeof(nm),"model.layers.%d.mlp.gate.global_scale",i); l->rgs = load_scalar(m,nm,1.f);
-            LD(sh_g, "mlp.shared_experts.gate_proj");
-            LD(sh_u, "mlp.shared_experts.up_proj");
-            LD(sh_d, "mlp.shared_experts.down_proj");
+            LDW(sh_g, "mlp.shared_experts.gate_proj");
+            LDW(sh_u, "mlp.shared_experts.up_proj");
+            LDW(sh_d, "mlp.shared_experts.down_proj");
         }
         #undef LD
+        #undef LDW
         /* conv states: raw inputs of the previous K-1 steps, zero-init */
         int kvdim = L_KV(c,i) * L_HD(c,i);
         for (int j = 0; j < 4; j++) {
@@ -438,10 +570,10 @@ static void attention(Model *m, Layer *l, int li, float *x, int S, int pos0, flo
     float *k  = falloc((int64_t)S*kvdim);
     float *vv = falloc((int64_t)S*kvdim);
     float *rr = falloc((int64_t)S*H*c->d_rel);
-    matmul(q,  x, l->q, S, D, qdim);
-    matmul(k,  x, l->k, S, D, kvdim);
-    matmul(vv, x, l->v, S, D, kvdim);
-    matmul(rr, x, l->r, S, D, H*c->d_rel);
+    matmul_w(q,  x, l->q, S, D, qdim);
+    matmul_w(k,  x, l->k, S, D, kvdim);
+    matmul_w(vv, x, l->v, S, D, kvdim);
+    matmul_w(rr, x, l->r, S, D, H*c->d_rel);
     /* short convs on K and V (sequence-wise, over the raw projections) */
     sconv_apply(k,  S, kvdim, l->k_cw, m->cs[0][li], c->conv_k);
     sconv_apply(vv, S, kvdim, l->v_cw, m->cs[1][li], c->conv_k);
@@ -503,7 +635,7 @@ static void attention(Model *m, Layer *l, int li, float *x, int S, int pos0, flo
         }
         free(rl); free(sc);
     }
-    matmul(out, ctx, l->o, S, qdim, D);
+    matmul_w(out, ctx, l->o, S, qdim, D);
     free(q); free(k); free(vv); free(rr); free(ctx);
 }
 
@@ -511,10 +643,10 @@ static void attention(Model *m, Layer *l, int li, float *x, int S, int pos0, flo
 static void dense_mlp(Model *m, Layer *l, float *x, int S, float *out) {
     Cfg *c = &m->c; int D = c->hidden, I = c->dense_inter;
     float *g = falloc((int64_t)S*I), *u = falloc((int64_t)S*I);
-    matmul(g, x, l->dg, S, D, I);
-    matmul(u, x, l->du, S, D, I);
+    matmul_w(g, x, l->dg, S, D, I);
+    matmul_w(u, x, l->du, S, D, I);
     for (int64_t i = 0; i < (int64_t)S*I; i++) g[i] = siluf(g[i]) * u[i];
-    matmul(out, g, l->dd, S, I, D);
+    matmul_w(out, g, l->dd, S, I, D);
     for (int64_t i = 0; i < (int64_t)S*D; i++) out[i] *= l->dgs;
     free(g); free(u);
 }
@@ -566,10 +698,10 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
         }
         /* shared experts: gamma inside (before down_proj is linear, so applied at the end) */
         for (int j = 0; j < ns; j++) {
-            matmul(g, xs, l->sh_g + (int64_t)j*I*D, 1, D, I);
-            matmul(u, xs, l->sh_u + (int64_t)j*I*D, 1, D, I);
+            matmul_w(g, xs, wt_off(l->sh_g, (int64_t)j*I*D), 1, D, I);
+            matmul_w(u, xs, wt_off(l->sh_u, (int64_t)j*I*D), 1, D, I);
             for (int i = 0; i < I; i++) g[i] = siluf(g[i]) * u[i];
-            matmul(hh, g, l->sh_d + (int64_t)j*D*I, 1, I, D);
+            matmul_w(hh, g, wt_off(l->sh_d, (int64_t)j*D*I), 1, I, D);
             for (int d = 0; d < D; d++) os[d] += w[K+j] * hh[d];
         }
     }
@@ -583,8 +715,8 @@ static float *step(Model *m, const int *ids, int S, int pos0, int *tf_out) {
     Cfg *c = &m->c; int D = c->hidden;
     float *x = falloc((int64_t)S*D);
     for (int s = 0; s < S; s++) {
-        if (m->embed_norm) rmsnorm_row(x + (int64_t)s*D, m->embed + (int64_t)ids[s]*D, m->embed_norm, D, c->eps);
-        else memcpy(x + (int64_t)s*D, m->embed + (int64_t)ids[s]*D, D*sizeof(float));
+        wt_row_f32(m->embed, (int64_t)ids[s]*D, x + (int64_t)s*D, D);
+        if (m->embed_norm) rmsnorm_row(x + (int64_t)s*D, x + (int64_t)s*D, m->embed_norm, D, c->eps);
     }
     float *nrm = falloc((int64_t)S*D), *tmp = falloc((int64_t)S*D);
     for (int i = 0; i < c->n_layers; i++) {
@@ -606,14 +738,14 @@ static float *step(Model *m, const int *ids, int S, int pos0, int *tf_out) {
         for (int s = 0; s < S; s++) {
             rmsnorm_row(last, x + (int64_t)s*D, m->final_norm, D, c->eps);
             for (int d = 0; d < D; d++) last[d] /= c->mup;
-            matmul(logit, last, m->lm_head, 1, D, c->unpad_vocab);
+            matmul_w(logit, last, m->lm_head, 1, D, c->unpad_vocab);
             int best = 0; for (int i = 1; i < c->unpad_vocab; i++) if (logit[i] > logit[best]) best = i;
             tf_out[pos0 + s] = best;
         }
     }
     rmsnorm_row(last, x + (int64_t)(S-1)*D, m->final_norm, D, c->eps);
     for (int d = 0; d < D; d++) last[d] /= c->mup;
-    matmul(logit, last, m->lm_head, 1, D, c->unpad_vocab);
+    matmul_w(logit, last, m->lm_head, 1, D, c->unpad_vocab);
     free(x); free(nrm); free(tmp); free(last);
     return logit;
 }

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -32,6 +32,10 @@
 #endif
 #include "st.h"
 #include "tok.h"
+#ifdef COLI_CUDA
+#include "backend_cuda_ink.h"
+static int g_cuda = 0;
+#endif
 
 #define MAXL 256
 
@@ -59,8 +63,11 @@ typedef struct {
 /* ---------- resident weights ----------
  * Large matmul weights keep their on-disk dtype in RAM: bf16 for the real
  * 975B checkpoint (f32 residents would need ~172 GB, over sabre's 187),
- * f32 for the tiny oracle (bit-exact validation). Exactly one pointer set. */
-typedef struct { float *f; uint16_t *h; } Wt;
+ * f32 for the tiny oracle (bit-exact validation). Under CUDA, bf16 tensors
+ * move to VRAM (dev set, host freed): decode reads ~35 GB of residents per
+ * token, so this trades the DDR5 bandwidth wall for VRAM bandwidth AND
+ * frees the same RAM for the expert cache. */
+typedef struct { float *f; uint16_t *h; void *dev; } Wt;
 
 typedef struct {
     float *in_ln, *post_ln;
@@ -186,8 +193,14 @@ static void matmul_h(float *y, const float *x, const uint16_t *W, int S, int I, 
     }
 }
 
-/* dispatch on the weight's resident dtype */
+/* dispatch on where the weight lives */
 static void matmul_w(float *y, const float *x, Wt W, int S, int I, int O) {
+#ifdef COLI_CUDA
+    if (W.dev) {
+        if (ink_cuda_matmul_bf16(y, x, W.dev, S, I, O) == 0) return;
+        fprintf(stderr, "cuda matmul failed and host copy was freed\n"); exit(1);
+    }
+#endif
     if (W.f) matmul(y, x, W.f, S, I, O);
     else     matmul_h(y, x, W.h, S, I, O);
 }
@@ -460,14 +473,25 @@ static void pread_all(int fd, void *buf, int64_t nb, int64_t off) {
 }
 
 /* big matmul weights keep their on-disk dtype resident: BF16 raw (real
- * checkpoint, halves RAM), anything else as f32 (tiny oracle: bit-exact) */
-static Wt load_w(Model *m, const char *name) {
+ * checkpoint, halves RAM), anything else as f32 (tiny oracle: bit-exact).
+ * gpu_ok: bf16 tensors move to VRAM while budget lasts (embed stays host —
+ * it's a row lookup, not a matmul). */
+static Wt load_w(Model *m, const char *name, int gpu_ok) {
     Wt w = {0};
     st_tensor *t = st_find(&m->S, name);
     if (!t) { fprintf(stderr, "missing %s\n", name); exit(1); }
     if (t->dtype == 0) {
         w.h = malloc(t->nbytes); if (!w.h) { fprintf(stderr,"OOM %s\n",name); exit(1); }
         pread_all(t->fd, w.h, t->nbytes, t->off);
+#ifdef COLI_CUDA
+        /* keep 3 GB VRAM headroom for the activation buffers + future tiers */
+        if (g_cuda && gpu_ok && ink_cuda_free_bytes() > (size_t)t->nbytes + (3ULL<<30)) {
+            w.dev = ink_cuda_upload(w.h, t->nbytes);
+            if (w.dev) { free(w.h); w.h = NULL; }
+        }
+#else
+        (void)gpu_ok;
+#endif
     } else {
         w.f = falloc(t->numel);
         st_read_f32(&m->S, name, w.f, 0);
@@ -475,7 +499,8 @@ static Wt load_w(Model *m, const char *name) {
     return w;
 }
 static Wt wt_off(Wt w, int64_t off) {
-    Wt r = { w.f ? w.f + off : NULL, w.h ? w.h + off : NULL };
+    Wt r = { w.f ? w.f + off : NULL, w.h ? w.h + off : NULL,
+             w.dev ? (char*)w.dev + off*2 : NULL };   /* dev is always bf16 */
     return r;
 }
 static void wt_row_f32(Wt w, int64_t off, float *out, int n) {
@@ -533,16 +558,26 @@ static void model_init(Model *m, const char *snap, int cap, int bits) {
     Cfg *c = &m->c;
     int D = c->hidden, K = c->conv_k;
     double t0 = now_s();
-    m->embed      = load_w(m, "model.embed_tokens.weight");
+#ifdef COLI_CUDA
+    if (!getenv("NOGPU")) {
+        int dev = getenv("GPU_DEV") ? atoi(getenv("GPU_DEV")) : 0;
+        if (ink_cuda_init(dev) == 0) {
+            g_cuda = 1;
+            fprintf(stderr, "[cuda] device %d ready, %.1f GB free — bf16 residents to VRAM\n",
+                    dev, ink_cuda_free_bytes()/1e9);
+        } else fprintf(stderr, "[cuda] init failed, running on CPU\n");
+    }
+#endif
+    m->embed      = load_w(m, "model.embed_tokens.weight", 0);
     m->embed_norm = st_has(&m->S,"model.embed_norm.weight") ? load_t(m,"model.embed_norm.weight") : NULL;
     m->final_norm = load_t(m, "model.norm.weight");
-    m->lm_head    = load_w(m, "lm_head.weight");
+    m->lm_head    = load_w(m, "lm_head.weight", 1);
     m->L = calloc(c->n_layers, sizeof(Layer));
     char nm[320];
     for (int i = 0; i < c->n_layers; i++) {
         Layer *l = &m->L[i];
         #define LD(field, suffix)  snprintf(nm,sizeof(nm),"model.layers.%d." suffix,i); l->field = load_t(m,nm)
-        #define LDW(field, suffix) snprintf(nm,sizeof(nm),"model.layers.%d." suffix,i); l->field = load_w(m,nm)
+        #define LDW(field, suffix) snprintf(nm,sizeof(nm),"model.layers.%d." suffix,i); l->field = load_w(m,nm,1)
         LD(in_ln,  "input_layernorm.weight");
         LD(post_ln,"post_attention_layernorm.weight");
         LDW(q, "self_attn.q_proj.weight"); LDW(k, "self_attn.k_proj.weight");
@@ -1081,7 +1116,10 @@ int main(int argc, char **argv) {
      * per-expert matmul regions are tiny and back-to-back; the default passive
      * wait policy parks the team between regions and re-wake latency dominates.
      * libgomp reads OMP_/GOMP_ vars before main(), so seed them and re-exec
-     * once (COLI_OMP_TUNED guards the exec; COLI_NO_OMP_TUNE=1 disables). */
+     * once (COLI_OMP_TUNED guards the exec; COLI_NO_OMP_TUNE=1 disables).
+     * NOT under CUDA — same exception glm.c makes: a spinning 24-thread team
+     * starves the CUDA driver during every stream sync. */
+#ifndef COLI_CUDA
     if (!getenv("COLI_OMP_TUNED") && !getenv("COLI_NO_OMP_TUNE")) {
         setenv("OMP_WAIT_POLICY","active",0);
         setenv("GOMP_SPINCOUNT","200000",0);
@@ -1093,6 +1131,7 @@ int main(int argc, char **argv) {
         perror("[OMP] execv self-reexec failed, running untuned");
 #endif
     }
+#endif  /* !COLI_CUDA */
     const char *snap = getenv("SNAP");
     if (!snap) { fprintf(stderr, "set SNAP=<snapshot directory>\n"); return 1; }
     /* flags: -p "prompt" [-n N] -> generate mode; positional: [cap] [bits] [ref.json] */

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -794,25 +794,25 @@ static void pins_load(Model *m, const char *snap) {
  * glm's .coli_usage — copy it aside if you need a stable ranking).
  * USAGE_SAVE=0 skips the rewrite (e.g. benchmark loops that would skew the
  * ranking); PIN=off also implies no save (that run never seeded counts). */
-static void usage_save(Model *m, const char *snap) {
+static int usage_save(Model *m, const char *snap) {
     Cfg *c = &m->c; int E = c->n_experts;
     char up[2048], tp[2060];
     const char *env = getenv("PIN");
     const char *sv = getenv("USAGE_SAVE");
-    if (sv && *sv == '0') return;
-    if (env && (!strcmp(env, "off") || !strcmp(env, "0"))) return;
+    if (sv && *sv == '0') return 0;
+    if (env && (!strcmp(env, "off") || !strcmp(env, "0"))) return 0;
     if (env) snprintf(up, sizeof(up), "%s", env);
     else snprintf(up, sizeof(up), "%s/.coli_usage", snap);
     snprintf(tp, sizeof(tp), "%s.tmp", up);
     FILE *f = fopen(tp, "wb");
-    if (!f) return;
+    if (!f) return 0;
     uint32_t hdr[3] = { 0x31554B49u, (uint32_t)c->n_layers, (uint32_t)E };
     fwrite(hdr, 4, 3, f);
     uint32_t *zero = calloc(E, 4);
     for (int i = 0; i < c->n_layers; i++)
         fwrite(m->eusage[i] ? m->eusage[i] : zero, 4, E, f);
     free(zero); fclose(f);
-    rename(tp, up);
+    return rename(tp, up) == 0;
 }
 
 /* ---------- attention (GQA + sliding/global + relative bias + K/V sconv) ---------- */
@@ -1198,11 +1198,12 @@ int main(int argc, char **argv) {
             }
             fclose(pf);
         }
-        usage_save(&m, snap);
+        int saved = usage_save(&m, snap);
         double tot = m.hits + m.miss;
-        printf("[cache] hit %.1f%% (%llu hit / %llu load) | usage history saved\n",
+        printf("[cache] hit %.1f%% (%llu hit / %llu load)%s\n",
                tot ? 100.0*m.hits/tot : 0.0,
-               (unsigned long long)m.hits, (unsigned long long)m.miss);
+               (unsigned long long)m.hits, (unsigned long long)m.miss,
+               saved ? " | usage history saved" : "");
         return 0;
     }
 

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -1055,6 +1055,9 @@ static void state_reset(Model *m) {
 
 static void kv_alloc(Model *m, int max_t) {
     Cfg *c = &m->c;
+    if (m->K && max_t <= m->max_t) return;   /* reuse across prompts when big enough */
+    if (m->K) for (int i = 0; i < c->n_layers; i++) { free(m->K[i]); free(m->V[i]); }
+    free(m->K); free(m->V);
     m->max_t = max_t;
     m->K = calloc(c->n_layers, sizeof(float*)); m->V = calloc(c->n_layers, sizeof(float*));
     for (int i = 0; i < c->n_layers; i++) {
@@ -1150,26 +1153,39 @@ int main(int argc, char **argv) {
     const char *snap = getenv("SNAP");
     if (!snap) { fprintf(stderr, "set SNAP=<snapshot directory>\n"); return 1; }
     /* flags: -p "prompt" [-n N] -> generate mode; positional: [cap] [bits] [ref.json] */
-    const char *prompt = NULL, *refpath = "ref_inkling.json";
+    const char *prompt = NULL, *pfile = NULL, *refpath = "ref_inkling.json";
     int cap = -1, bits = 0, n_new = 256, npos = 0;
     for (int i = 1; i < argc; i++) {
         if (!strcmp(argv[i], "-p") && i+1 < argc) prompt = argv[++i];
+        else if (!strcmp(argv[i], "-f") && i+1 < argc) pfile = argv[++i];
         else if (!strcmp(argv[i], "-n") && i+1 < argc) n_new = atoi(argv[++i]);
         else if (npos == 0) { cap = atoi(argv[i]); npos++; }
         else if (npos == 1) { bits = atoi(argv[i]); npos++; }
         else refpath = argv[i];
     }
-    if (cap < 0) cap = prompt ? 0 : 16;   /* generate mode defaults to RAM-sized auto cap */
+    if (cap < 0) cap = (prompt || pfile) ? 0 : 16;   /* generate mode defaults to RAM-sized auto cap */
     if (bits && (bits < 2 || bits > 8)) { fprintf(stderr, "quant_bits must be 0 (f32) or 2..8\n"); return 1; }
 
-    if (prompt) {
+    if (prompt || pfile) {
         Model m; model_init(&m, snap, cap, bits);
         printf("== Inkling C engine, %d layers, experts @ %s, cache %d/layer ==\n",
                m.c.n_layers, m.xq ? "container" : bits ? "int" : "f32", m.cache[0].cap);
         pins_load(&m, snap);
         char tkp[2048]; snprintf(tkp, sizeof(tkp), "%s/tokenizer.json", snap);
         Tok T; tok_load(&T, tkp);
-        generate_stream(&m, &T, prompt, n_new);
+        if (prompt) generate_stream(&m, &T, prompt, n_new);
+        else {   /* -f: one prompt per line, model loaded once, usage accumulates */
+            FILE *pf = fopen(pfile, "rb"); if (!pf) { perror(pfile); return 1; }
+            char ln[8192]; int np = 0;
+            while (fgets(ln, sizeof(ln), pf)) {
+                size_t n = strlen(ln); while (n && (ln[n-1]=='\n'||ln[n-1]=='\r')) ln[--n]=0;
+                if (!n || ln[0]=='#') continue;
+                printf("\n===== prompt %d =====\n", ++np);
+                state_reset(&m);
+                generate_stream(&m, &T, ln, n_new);
+            }
+            fclose(pf);
+        }
         usage_save(&m, snap);
         double tot = m.hits + m.miss;
         printf("[cache] hit %.1f%% (%llu hit / %llu load) | usage history saved\n",

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -382,14 +382,31 @@ static float load_scalar(Model *m, const char *name, float dflt) {
     float v; st_read_f32(&m->S, name, &v, 0); return v;
 }
 
+/* chunked pread: a single pread caps at ~2.1 GB on Linux, and the bf16
+ * embed/lm_head tensors are 2.47 GB — loop in 1 GB slices */
+static void pread_all(int fd, void *buf, int64_t nb, int64_t off) {
+    char *p = buf;
+    while (nb > 0) {
+        int64_t chunk = nb < (1<<30) ? nb : (1<<30);
+        ssize_t got = pread(fd, p, (size_t)chunk, off);
+        if (got <= 0) { perror("pread chunk"); exit(1); }
+        p += got; off += got; nb -= got;
+    }
+}
+
 /* big matmul weights keep their on-disk dtype resident: BF16 raw (real
  * checkpoint, halves RAM), anything else as f32 (tiny oracle: bit-exact) */
 static Wt load_w(Model *m, const char *name) {
     Wt w = {0};
     st_tensor *t = st_find(&m->S, name);
     if (!t) { fprintf(stderr, "missing %s\n", name); exit(1); }
-    if (t->dtype == 0) { w.h = malloc(t->nbytes); if (!w.h) { fprintf(stderr,"OOM %s\n",name); exit(1); } st_read_raw(&m->S, name, w.h, 0); }
-    else               { w.f = falloc(t->numel); st_read_f32(&m->S, name, w.f, 0); }
+    if (t->dtype == 0) {
+        w.h = malloc(t->nbytes); if (!w.h) { fprintf(stderr,"OOM %s\n",name); exit(1); }
+        pread_all(t->fd, w.h, t->nbytes, t->off);
+    } else {
+        w.f = falloc(t->numel);
+        st_read_f32(&m->S, name, w.f, 0);
+    }
     return w;
 }
 static Wt wt_off(Wt w, int64_t off) {

--- a/c/tools/convert_inkling_int4.py
+++ b/c/tools/convert_inkling_int4.py
@@ -133,8 +133,12 @@ def map_name(name):
 # ---------- per-shard conversion ----------
 
 def quantize_expert_tensor(f, name, xbits, out, out_name):
-    """Chunked (per-expert) de-interleave/quantize of the fused 3D expert
-    tensors, so peak RAM stays at one expert slice, not one 19 GB tensor."""
+    """Per-expert de-interleave/quantize of the fused 3D expert tensors.
+    Slice reads stay sequential (kind to the HDD); the numpy quantization —
+    the CPU bottleneck, ~95% of the checkpoint flows through here — fans out
+    on a thread pool (ufuncs release the GIL on large arrays). Waves of 16
+    keep peak RAM at ~1.2 GB of pending slices instead of the whole tensor."""
+    from concurrent.futures import ThreadPoolExecutor
     sl = f.get_slice(name)
     E, R, C = sl.get_shape()             # w13: [E,2I,D] (interleaved), w2: [E,D,I]
     is_w13 = name.endswith("w13_weight")
@@ -143,14 +147,20 @@ def quantize_expert_tensor(f, name, xbits, out, out_name):
     else:
         qs = np.empty((E * R, C), np.uint8)
     sc = np.empty(E * R, np.float32)
-    for e in range(E):
-        w = sl[e]                        # [R, C] bf16
+
+    def work(e, w):
         if is_w13:
             w = deinterleave(w, 0)       # -> [gate rows; up rows]
         w = w.float().numpy()
         q, s = quant_int4_rows(w) if xbits == 4 else quant_int8_rows(w)
         qs[e * R:(e + 1) * R] = q
         sc[e * R:(e + 1) * R] = s
+
+    with ThreadPoolExecutor(max_workers=12) as ex:
+        for base in range(0, E, 16):
+            futs = [ex.submit(work, e, sl[e]) for e in range(base, min(base + 16, E))]
+            for fu in futs:
+                fu.result()
     out[out_name] = torch.from_numpy(qs.reshape(-1))
     out[out_name + ".qs"] = torch.from_numpy(sc)
 

--- a/c/tools/convert_inkling_int4.py
+++ b/c/tools/convert_inkling_int4.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Convert the Thinking Machines Inkling BF16 checkpoint (TML-native tensor
+names) into a colibri snapshot readable by inkling.c.
+
+Name mapping follows transformers' checkpoint_conversion_mapping for
+inkling_mm_model verbatim (conversion_mapping.py), including the CRITICAL
+detail that every fused w13 tensor stores gate/up rows INTERLEAVED
+(g0,u0,g1,u1,...): de-interleaving = even rows first, then odd rows.
+Quantization math is bit-identical to convert_fp8_to_int4.py / the C engine
+(np.rint = lrintf, per-row symmetric scales, low nibble = even column).
+
+Output tensor policy (Stage A):
+  - routed experts (95% of the params)  -> int4 (or --xbits) + `.qs` f32 row scales
+  - norms, sconv weights, rel-bias banks, router (+bias/scales) -> f32
+  - everything else (attn projections, dense/shared MLP, embed, lm_head)
+    -> bf16 passthrough (st_read_f32 in the C engine converts on load)
+  - model.audio.* / model.visual.* / model.mtp.* -> skipped (text-only)
+
+Modes:
+  --indir DIR --outdir DIR [--watch]   convert local shards (resumable per
+        shard; --watch polls while `hf download` is still running and exits
+        when every shard in model.safetensors.index.json is converted)
+  --selftest                           numpy-only unit tests (interleave, int4)
+  --selftest-e2e HFDIR OUTBASE         build a fake TML-named checkpoint from a
+        tiny HF-format snapshot (tools/make_tiny_inkling.py), then convert it
+        with passthrough and int4 experts -> OUTBASE-pass/, OUTBASE-i4/
+"""
+import argparse
+import glob
+import json
+import os
+import re
+import shutil
+import sys
+import time
+
+import numpy as np
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+# ---------- quantization (identical to convert_fp8_to_int4.py) ----------
+
+def quant_int8_rows(w):
+    """w: f32 [O,I] -> (int8 bytes [O,I] viewed u8, f32 scales [O])"""
+    s = np.abs(w).max(axis=1, keepdims=True) / 127.0
+    s[s < 1e-8] = 1e-8
+    q = np.clip(np.rint(w / s), -128, 127).astype(np.int8)
+    return q.view(np.uint8), s[:, 0].astype(np.float32)
+
+
+def quant_int4_rows(w):
+    """w: f32 [O,I], I even -> (packed u8 [O,I/2], f32 scales [O]).
+    Low nibble = even column, high nibble = odd column, offset +8."""
+    O, I = w.shape
+    assert I % 2 == 0
+    s = np.abs(w).max(axis=1, keepdims=True) / 7.0
+    s[s < 1e-8] = 1e-8
+    q = np.clip(np.rint(w / s), -8, 7).astype(np.int32)
+    lo = (q[:, 0::2] + 8).astype(np.uint8)
+    hi = (q[:, 1::2] + 8).astype(np.uint8)
+    return (lo | (hi << 4)), s[:, 0].astype(np.float32)
+
+
+def deinterleave(t: torch.Tensor, dim: int) -> torch.Tensor:
+    """TML fused-w13 layout (g0,u0,g1,u1,...) -> grouped ([gate; up]).
+    Matches transformers' Interleave(dim) conversion op."""
+    n = t.shape[dim]
+    idx = torch.cat([torch.arange(0, n, 2), torch.arange(1, n, 2)])
+    return t.index_select(dim, idx)
+
+
+def interleave(t: torch.Tensor, dim: int) -> torch.Tensor:
+    """Inverse of deinterleave (used only to fabricate test checkpoints)."""
+    n = t.shape[dim]
+    idx = torch.empty(n, dtype=torch.long)
+    idx[0::2] = torch.arange(0, n // 2)
+    idx[1::2] = torch.arange(n // 2, n)
+    return t.index_select(dim, idx)
+
+
+# ---------- name mapping (TML native -> HF names inkling.c loads) ----------
+
+SKIP_PREFIXES = ("model.audio.", "model.visual.", "model.mtp.")
+
+RENAMES = [
+    (r"^model\.llm\.embed\.weight$",      "model.embed_tokens.weight"),
+    (r"^model\.llm\.embed_norm\.weight$", "model.embed_norm.weight"),
+    (r"^model\.llm\.norm\.weight$",       "model.norm.weight"),
+    (r"^model\.llm\.unembed\.weight$",    "lm_head.weight"),
+    (r"^model\.llm\.layers\.",            "model.layers."),
+]
+SUBS = [
+    (r"\.attn\.wq_du\.", ".self_attn.q_proj."),
+    (r"\.attn\.wk_dv\.", ".self_attn.k_proj."),
+    (r"\.attn\.wv_dv\.", ".self_attn.v_proj."),
+    (r"\.attn\.wr_du\.", ".self_attn.r_proj."),
+    (r"\.attn\.wo_ud\.", ".self_attn.o_proj."),
+    (r"\.attn\.q_norm\.", ".self_attn.q_norm."),
+    (r"\.attn\.k_norm\.", ".self_attn.k_norm."),
+    (r"\.attn\.k_sconv\.weight$", ".self_attn.k_sconv.conv1d.weight"),
+    (r"\.attn\.v_sconv\.weight$", ".self_attn.v_sconv.conv1d.weight"),
+    (r"\.attn\.rel_logits_proj\.proj$", ".self_attn.rel_logits_proj.proj"),
+    (r"\.attn_sconv\.weight$", ".attn_sconv.conv1d.weight"),
+    (r"\.mlp_sconv\.weight$",  ".mlp_sconv.conv1d.weight"),
+    (r"\.attn_norm\.weight$",  ".input_layernorm.weight"),
+    (r"\.mlp_norm\.weight$",   ".post_attention_layernorm.weight"),
+    (r"\.mlp\.gate\.bias$",    ".mlp.gate.e_score_correction_bias"),
+    (r"\.mlp\.w2_md\.weight$", ".mlp.down_proj.weight"),
+    (r"\.mlp\.experts\.w2_weight$", ".mlp.experts.down_proj"),
+    (r"\.mlp\.shared_experts\.shared_w2_weight$", ".mlp.shared_experts.down_proj"),
+]
+# names that stay f32 in the container (small / numerically sensitive;
+# the reference keeps every sconv in fp32)
+F32_RE = re.compile(
+    r"(norm\.weight$|layernorm\.weight$|rel_logits_proj\.proj$|conv1d\.weight$"
+    r"|global_scale$|e_score_correction_bias$|\.mlp\.gate\.weight$)"
+)
+
+
+def map_name(name):
+    """Simple renames only (fused w13 tensors are handled by the shard loop).
+    Returns the mapped name, or None to skip."""
+    if name.startswith(SKIP_PREFIXES):
+        return None
+    for pat, rep in RENAMES:
+        name = re.sub(pat, rep, name)
+    for pat, rep in SUBS:
+        name = re.sub(pat, rep, name)
+    return name
+
+
+# ---------- per-shard conversion ----------
+
+def quantize_expert_tensor(f, name, xbits, out, out_name):
+    """Chunked (per-expert) de-interleave/quantize of the fused 3D expert
+    tensors, so peak RAM stays at one expert slice, not one 19 GB tensor."""
+    sl = f.get_slice(name)
+    E, R, C = sl.get_shape()             # w13: [E,2I,D] (interleaved), w2: [E,D,I]
+    is_w13 = name.endswith("w13_weight")
+    if xbits == 4:
+        qs = np.empty((E * R, C // 2), np.uint8)
+    else:
+        qs = np.empty((E * R, C), np.uint8)
+    sc = np.empty(E * R, np.float32)
+    for e in range(E):
+        w = sl[e]                        # [R, C] bf16
+        if is_w13:
+            w = deinterleave(w, 0)       # -> [gate rows; up rows]
+        w = w.float().numpy()
+        q, s = quant_int4_rows(w) if xbits == 4 else quant_int8_rows(w)
+        qs[e * R:(e + 1) * R] = q
+        sc[e * R:(e + 1) * R] = s
+    out[out_name] = torch.from_numpy(qs.reshape(-1))
+    out[out_name + ".qs"] = torch.from_numpy(sc)
+
+
+def convert_shard(path, out, xbits):
+    with safe_open(path, framework="pt") as f:
+        for name in f.keys():
+            if name.startswith(SKIP_PREFIXES):
+                continue
+            base = map_name(name)
+            if name.endswith(".mlp.experts.w13_weight"):
+                tgt = base.replace(".w13_weight", ".gate_up_proj")
+                if xbits:
+                    quantize_expert_tensor(f, name, xbits, out, tgt)
+                else:
+                    t = f.get_tensor(name)
+                    out[tgt] = deinterleave(t, 1).contiguous()
+                continue
+            if name.endswith(".mlp.experts.w2_weight"):
+                tgt = map_name(name)
+                if xbits:
+                    quantize_expert_tensor(f, name, xbits, out, tgt)
+                else:
+                    out[tgt] = f.get_tensor(name)
+                continue
+            if name.endswith(".mlp.shared_experts.shared_w13_weight"):
+                t = deinterleave(f.get_tensor(name), 1)      # [ns, 2I, D] -> grouped
+                half = t.shape[1] // 2
+                pref = base.replace(".shared_w13_weight", "")
+                out[pref + ".gate_proj"] = t[:, :half].contiguous()
+                out[pref + ".up_proj"] = t[:, half:].contiguous()
+                continue
+            if name.endswith(".mlp.w13_dn.weight"):
+                t = deinterleave(f.get_tensor(name), 0)      # [2I, D] -> grouped
+                half = t.shape[0] // 2
+                pref = base.replace(".w13_dn.weight", "")
+                out[pref + ".gate_proj.weight"] = t[:half].contiguous()
+                out[pref + ".up_proj.weight"] = t[half:].contiguous()
+                continue
+            t = f.get_tensor(name)
+            if F32_RE.search(base):
+                out[base] = t.float()
+            else:
+                out[base] = t                                 # bf16 passthrough
+
+
+AUX_FILES = ["config.json", "tokenizer.json", "tokenizer_config.json",
+             "special_tokens_map.json", "chat_template.jinja"]
+
+
+def shard_out_name(src):
+    m = re.search(r"model-(\d+)-of-\d+\.safetensors$", os.path.basename(src))
+    return f"out-{m.group(1)}.safetensors" if m else \
+        "out-" + os.path.basename(src)
+
+
+def convert_dir(indir, outdir, xbits, watch=False, delete_src=False):
+    os.makedirs(outdir, exist_ok=True)
+    index_path = os.path.join(indir, "model.safetensors.index.json")
+    done_src = set()
+    while True:
+        shards = sorted(glob.glob(os.path.join(indir, "model-*.safetensors")))
+        if not shards:
+            single = os.path.join(indir, "model.safetensors")
+            if os.path.exists(single):
+                shards = [single]
+        for sp in shards:
+            if sp in done_src:
+                continue
+            dst = os.path.join(outdir, shard_out_name(sp))
+            if os.path.exists(dst):
+                done_src.add(sp)
+                continue
+            t0 = time.time()
+            out = {}
+            convert_shard(sp, out, xbits)
+            if out:
+                save_file(out, dst + ".tmp")
+                os.replace(dst + ".tmp", dst)   # atomic: partial writes never count as done
+            else:                                # shard held only skipped (mm/mtp) tensors
+                open(dst, "wb").close()
+            done_src.add(sp)
+            src_gb = os.path.getsize(sp) / 1e9
+            dst_gb = os.path.getsize(dst) / 1e9
+            print(f"{os.path.basename(sp)} ({src_gb:.1f}G) -> "
+                  f"{os.path.basename(dst)} ({dst_gb:.1f}G) in {time.time()-t0:.0f}s",
+                  flush=True)
+            if delete_src:
+                os.remove(sp)
+        # completion check: every shard named in the index is converted
+        total = None
+        if os.path.exists(index_path):
+            wm = json.load(open(index_path))["weight_map"]
+            total = sorted(set(wm.values()))
+            if all(os.path.exists(os.path.join(outdir, shard_out_name(s))) for s in total):
+                break
+        elif shards and not watch:
+            break
+        if not watch:
+            break
+        time.sleep(60)
+    for fn in AUX_FILES:
+        src = os.path.join(indir, fn)
+        if os.path.exists(src):
+            shutil.copy(src, outdir)
+    print(f"conversion complete -> {outdir}")
+
+
+# ---------- selftests ----------
+
+def selftest():
+    torch.manual_seed(0)
+    # 1) interleave round-trip + semantics
+    g = torch.arange(0, 12).reshape(6, 2).float()
+    u = torch.arange(100, 112).reshape(6, 2).float()
+    fused = interleave(torch.cat([g, u]), 0)
+    assert torch.equal(fused[0], g[0]) and torch.equal(fused[1], u[0]), \
+        "interleave: row 0 must be gate0, row 1 up0"
+    got = deinterleave(fused, 0)
+    assert torch.equal(got[:6], g) and torch.equal(got[6:], u)
+    # 2) int4 pack/unpack round-trip against the C engine's convention
+    w = np.random.randn(16, 32).astype(np.float32)
+    q, s = quant_int4_rows(w)
+    lo = (q & 0x0F).astype(np.int32) - 8
+    hi = ((q >> 4) & 0x0F).astype(np.int32) - 8
+    deq = np.empty_like(w)
+    deq[:, 0::2] = lo
+    deq[:, 1::2] = hi
+    deq *= s[:, None]
+    ref = np.clip(np.rint(w / s[:, None]), -8, 7) * s[:, None]
+    assert np.array_equal(deq, ref), "int4 round-trip mismatch"
+    # 3) name mapping spot checks
+    cases = {
+        "model.llm.embed.weight": "model.embed_tokens.weight",
+        "model.llm.unembed.weight": "lm_head.weight",
+        "model.llm.layers.3.attn.wq_du.weight": "model.layers.3.self_attn.q_proj.weight",
+        "model.llm.layers.3.attn.k_sconv.weight": "model.layers.3.self_attn.k_sconv.conv1d.weight",
+        "model.llm.layers.3.attn_sconv.weight": "model.layers.3.attn_sconv.conv1d.weight",
+        "model.llm.layers.3.attn_norm.weight": "model.layers.3.input_layernorm.weight",
+        "model.llm.layers.3.mlp_norm.weight": "model.layers.3.post_attention_layernorm.weight",
+        "model.llm.layers.3.mlp.gate.bias": "model.layers.3.mlp.gate.e_score_correction_bias",
+        "model.llm.layers.3.mlp.gate.global_scale": "model.layers.3.mlp.gate.global_scale",
+        "model.llm.layers.3.mlp.experts.w2_weight": "model.layers.3.mlp.experts.down_proj",
+        "model.llm.layers.0.mlp.w2_md.weight": "model.layers.0.mlp.down_proj.weight",
+        "model.mtp.layers.0.input_proj.weight": None,
+        "model.audio.encoder.weight": None,
+        "model.visual.final_norm.weight": None,
+    }
+    for src, want in cases.items():
+        got = map_name(src)
+        assert got == want, f"map_name({src}) = {got}, want {want}"
+    print("SELFTEST OK")
+
+
+def selftest_e2e(hfdir, outbase):
+    """Fabricate a TML-named checkpoint from a tiny HF snapshot (inverse
+    mapping, w13 re-fused AND re-interleaved), then convert it back. Validates
+    the converter + the C engine's container reader end-to-end without the
+    real download. Tensors stay f32 so the oracle comparison is exact."""
+    src = os.path.join(hfdir, "model.safetensors")
+    fake = outbase + "-tml"
+    os.makedirs(fake, exist_ok=True)
+    inv = {}
+    with safe_open(src, framework="pt") as f:
+        names = list(f.keys())
+        tensors = {n: f.get_tensor(n) for n in names}
+    layers = {}
+    for n in names:
+        m = re.match(r"model\.layers\.(\d+)\.(.*)", n)
+        if m:
+            layers.setdefault(int(m.group(1)), {})[m.group(2)] = tensors[n]
+    for n, t in tensors.items():
+        if n == "model.embed_tokens.weight": inv["model.llm.embed.weight"] = t
+        elif n == "model.embed_norm.weight": inv["model.llm.embed_norm.weight"] = t
+        elif n == "model.norm.weight":       inv["model.llm.norm.weight"] = t
+        elif n == "lm_head.weight":          inv["model.llm.unembed.weight"] = t
+    for li, lt in layers.items():
+        p = f"model.llm.layers.{li}."
+        for hf, tml in [("self_attn.q_proj.weight", "attn.wq_du.weight"),
+                        ("self_attn.k_proj.weight", "attn.wk_dv.weight"),
+                        ("self_attn.v_proj.weight", "attn.wv_dv.weight"),
+                        ("self_attn.r_proj.weight", "attn.wr_du.weight"),
+                        ("self_attn.o_proj.weight", "attn.wo_ud.weight"),
+                        ("self_attn.q_norm.weight", "attn.q_norm.weight"),
+                        ("self_attn.k_norm.weight", "attn.k_norm.weight"),
+                        ("self_attn.rel_logits_proj.proj", "attn.rel_logits_proj.proj"),
+                        ("self_attn.k_sconv.conv1d.weight", "attn.k_sconv.weight"),
+                        ("self_attn.v_sconv.conv1d.weight", "attn.v_sconv.weight"),
+                        ("attn_sconv.conv1d.weight", "attn_sconv.weight"),
+                        ("mlp_sconv.conv1d.weight", "mlp_sconv.weight"),
+                        ("input_layernorm.weight", "attn_norm.weight"),
+                        ("post_attention_layernorm.weight", "mlp_norm.weight"),
+                        ("mlp.gate.weight", "mlp.gate.weight"),
+                        ("mlp.gate.e_score_correction_bias", "mlp.gate.bias"),
+                        ("mlp.gate.global_scale", "mlp.gate.global_scale"),
+                        ("mlp.global_scale", "mlp.global_scale"),
+                        ("mlp.down_proj.weight", "mlp.w2_md.weight"),
+                        ("mlp.experts.down_proj", "mlp.experts.w2_weight"),
+                        ("mlp.shared_experts.down_proj", "mlp.shared_experts.shared_w2_weight")]:
+            if hf in lt:
+                inv[p + tml] = lt[hf]
+        if "mlp.gate_proj.weight" in lt:      # dense: fuse + interleave
+            inv[p + "mlp.w13_dn.weight"] = interleave(
+                torch.cat([lt["mlp.gate_proj.weight"], lt["mlp.up_proj.weight"]]), 0)
+        if "mlp.experts.gate_up_proj" in lt:  # routed: re-interleave dim1
+            inv[p + "mlp.experts.w13_weight"] = interleave(lt["mlp.experts.gate_up_proj"], 1)
+        if "mlp.shared_experts.gate_proj" in lt:
+            inv[p + "mlp.shared_experts.shared_w13_weight"] = interleave(
+                torch.cat([lt["mlp.shared_experts.gate_proj"],
+                           lt["mlp.shared_experts.up_proj"]], dim=1), 1)
+    save_file({k: v.contiguous() for k, v in inv.items()},
+              os.path.join(fake, "model-00001-of-00001.safetensors"))
+    shutil.copy(os.path.join(hfdir, "config.json"), fake)
+    print(f"fake TML checkpoint: {fake} ({len(inv)} tensors)")
+    for tag, xbits in [("pass", 0), ("i4", 4)]:
+        convert_dir(fake, f"{outbase}-{tag}", xbits)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--indir")
+    ap.add_argument("--outdir")
+    ap.add_argument("--xbits", type=int, default=4, choices=[0, 4, 8],
+                    help="routed-expert bits: 4 (default), 8, or 0 = bf16 passthrough")
+    ap.add_argument("--watch", action="store_true",
+                    help="poll --indir while the download is still running")
+    ap.add_argument("--delete-src", action="store_true")
+    ap.add_argument("--selftest", action="store_true")
+    ap.add_argument("--selftest-e2e", nargs=2, metavar=("HFDIR", "OUTBASE"))
+    a = ap.parse_args()
+    if a.selftest:
+        selftest(); return
+    if a.selftest_e2e:
+        selftest_e2e(*a.selftest_e2e); return
+    if not a.indir or not a.outdir:
+        ap.error("--indir and --outdir required")
+    os.makedirs(a.outdir, exist_ok=True)
+    lock = open(os.path.join(a.outdir, ".convert.lock"), "w")
+    import fcntl
+    try:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        sys.exit("ERROR: another converter is already using this output directory.")
+    convert_dir(a.indir, a.outdir, a.xbits, watch=a.watch, delete_src=a.delete_src)
+
+
+if __name__ == "__main__":
+    main()

--- a/c/tools/convert_inkling_int4.py
+++ b/c/tools/convert_inkling_int4.py
@@ -250,12 +250,15 @@ def convert_dir(indir, outdir, xbits, watch=False, delete_src=False):
                   flush=True)
             if delete_src:
                 os.remove(sp)
-        # completion check: every shard named in the index is converted
+        # completion check: every model-* shard named in the index is
+        # converted. The index also references mtp.safetensors (the separate
+        # MTP-head file, skipped entirely) — only count files we convert.
         total = None
         if os.path.exists(index_path):
             wm = json.load(open(index_path))["weight_map"]
-            total = sorted(set(wm.values()))
-            if all(os.path.exists(os.path.join(outdir, shard_out_name(s))) for s in total):
+            total = sorted(s for s in set(wm.values())
+                           if re.match(r"model-\d+-of-\d+\.safetensors$", s))
+            if total and all(os.path.exists(os.path.join(outdir, shard_out_name(s))) for s in total):
                 break
         elif shards and not watch:
             break

--- a/c/tools/make_tiny_inkling.py
+++ b/c/tools/make_tiny_inkling.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Build a tiny random-weight Inkling text model + oracle fixture for inkling.c.
+
+Stage-A validation, mirroring the OLMoE ref.json flow: saves a small
+InklingForCausalLM snapshot (safetensors + config.json) and a ref_inkling.json
+with {prompt_ids, full_ids, tf_pred} from HF transformers, which the C engine
+must reproduce token-for-token (run with bits=0 for f32-exact experts).
+
+The tiny config exercises every architectural branch of the big model:
+sliding + global layers, log-length tau scaling (n_floor set below the
+sequence length), dense + sparse MLP layers, 2 shared experts, unpadded vocab.
+
+Usage: python3 make_tiny_inkling.py <outdir>
+"""
+import json
+import sys
+
+import torch
+
+try:
+    from transformers import InklingForCausalLM, InklingTextConfig
+except ImportError:
+    sys.exit("transformers has no Inkling support: pip install -U transformers")
+
+
+def main():
+    out = sys.argv[1] if len(sys.argv) > 1 else "tiny_inkling"
+    torch.manual_seed(0)
+
+    cfg = InklingTextConfig(
+        vocab_size=256,
+        unpadded_vocab_size=250,
+        hidden_size=64,
+        num_hidden_layers=8,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        swa_num_attention_heads=4,
+        swa_num_key_value_heads=4,
+        swa_head_dim=16,
+        sliding_window_size=8,
+        d_rel=8,
+        rel_extent=32,
+        log_scaling_n_floor=8,      # small, so tau != 1 is exercised
+        log_scaling_alpha=0.1,
+        local_layer_ids=[0, 1, 2, 3, 4, 6, 7],   # global layer at 5
+        dense_mlp_idx=2,
+        dense_intermediate_size=96,
+        moe_intermediate_size=32,
+        n_routed_experts=8,
+        num_experts_per_tok=2,
+        n_shared_experts=2,
+        route_scale=2.0,
+        logits_mup_width_multiplier=4.0,
+        max_position_embeddings=4096,
+        eos_token_id=None,
+    )
+
+    model = InklingForCausalLM(cfg).eval().float()
+
+    prompt = [7, 42, 199, 3, 88, 154, 21, 60, 9, 133, 77, 245]
+    ids = torch.tensor([prompt], dtype=torch.long)
+    n_new = 24
+
+    with torch.no_grad():
+        gen = model.generate(
+            ids, max_new_tokens=n_new, do_sample=False, use_cache=True
+        )
+        full = gen[0].tolist()
+        tf = model(torch.tensor([full], dtype=torch.long)).logits[0].argmax(-1).tolist()
+
+    model.save_pretrained(out, safe_serialization=True)
+    ref = {"prompt_ids": prompt, "full_ids": full, "tf_pred": tf}
+    with open(f"{out}/ref_inkling.json", "w") as f:
+        json.dump(ref, f)
+    print(f"saved tiny model + ref_inkling.json to {out}/")
+    print("continuation:", full[len(prompt):])
+
+
+if __name__ == "__main__":
+    main()

--- a/c/tools/oracle-requirements.txt
+++ b/c/tools/oracle-requirements.txt
@@ -1,0 +1,9 @@
+# Deps for the Inkling tiny-model oracle (tools/make_tiny_inkling.py) — the
+# ci.yml `inkling-oracle` job installs exactly this file, and setup-python
+# hashes it for the pip cache key. CPU torch: the oracle is a tiny random-init
+# model, no GPU wanted.
+--index-url https://download.pytorch.org/whl/cpu
+--extra-index-url https://pypi.org/simple
+torch
+transformers>=5.14   # Inkling architecture support (InklingForCausalLM)
+safetensors

--- a/docs/inkling.md
+++ b/docs/inkling.md
@@ -1,0 +1,95 @@
+# Inkling (Thinking Machines 975B MoE) on colibri
+
+`c/inkling.c` runs [Thinking Machines Inkling](https://huggingface.co/thinkingmachines/Inkling)
+(975B total / 41B active, Apache 2.0) with colibri's expert-streaming approach:
+dense weights resident (RAM or VRAM), routed experts streamed from disk with an
+LRU + pinned cache. Text-only; vision/audio encoders and the MTP head are not loaded.
+
+## Quickstart
+
+Pre-converted weights (int4 experts + bf16 residents, ~469 GiB):
+
+```sh
+hf download nbeerbower/Inkling-colibri-int4 --local-dir ~/Models/inkling_i4
+```
+
+or convert the original bf16 checkpoint yourself (shard-resumable; `--watch`
+converts while the download is still running):
+
+```sh
+python3 c/tools/convert_inkling_int4.py --indir <bf16-checkpoint> --outdir ~/Models/inkling_i4
+```
+
+Build and run:
+
+```sh
+make -C c inkling                # pure CPU (dependency-free, like glm)
+make -C c inkling CUDA=1         # + bf16 residents in VRAM (needs ~37 GB free)
+
+SNAP=~/Models/inkling_i4 ./c/inkling -p "The capital of France is" -n 64
+```
+
+Requirements: ~120 GB RAM (CPU build keeps ~86 GB of bf16 residents in RAM;
+the CUDA build moves them to VRAM and uses the freed RAM for a larger expert
+cache), NVMe storage for the snapshot.
+
+## Modes
+
+| Invocation | What it does |
+|---|---|
+| `-p "text" [-n N]` | streaming greedy generation (stops at eos or N tokens) |
+| `-f prompts.txt [-n N]` | one prompt per line (`#` comments skipped), single model load, state reset between prompts — the cache-warming workflow below |
+| `[cap] [bits] [ref.json]` | token-exact oracle harness against a `tools/make_tiny_inkling.py` fixture (CI-style validation) |
+
+## Cache warming (same idea as glm's `.coli_usage`)
+
+Expert selections are counted per `(layer, expert)` and written to
+`SNAP/.coli_usage` after each generation run. On startup the top `PIN_N`
+experts per layer are pinned (non-evictable, loaded in one parallel burst).
+Counts **accumulate across runs**, so the ranking converges toward your real
+workload — pins trained on a single prompt overfit badly (see the benchmark
+table), which is why a diverse warmup matters:
+
+```sh
+SNAP=~/Models/inkling_i4 ./c/inkling -f warmup_prompts.txt -n 32
+```
+
+| Env | Effect |
+|---|---|
+| `PIN=off` | disable warming entirely: no seeding, no pins, no history rewrite |
+| `PIN=<path>` | alternate history file |
+| `PIN_N=<n>` | pins per layer (default `cap/2`; 0 = seed ranking only) |
+| `USAGE_SAVE=0` | don't rewrite the history (benchmark runs) |
+| `NOGPU=1` / `GPU_DEV=<n>` | disable CUDA / select device |
+| `IDOT=0` | byte-exact scalar int kernels (debugging) |
+| First positional arg | expert-cache cap per layer (`0` = auto-size from free RAM) |
+
+## Performance (975B, Ryzen 9 7900 / 24t, 187 GB DDR5, RTX A6000, NVMe)
+
+24-token greedy decode, 5-token prompt, commit-tagged runs, single run each.
+"Trained" = usage history built from the same prompt; "novel" = never-seen prompt.
+
+| Configuration | Prefill | Decode | Cache hit |
+|---|---|---|---|
+| Stage A (plain LRU, serial I/O, CPU) | 150.2 s | 0.06 tok/s | ~0% |
+| + packed-int4 cache, parallel fills, pins (CPU) | 21.1 s | 0.25 tok/s | 81.5% |
+| + CUDA resident tier (A6000) | 18.4 s | 0.32 tok/s | 83.6% |
+| + deep pins, trained prompt (`PIN_N=64`) | 1.9 s | 2.51 tok/s | 100.0% |
+| deep pins, novel prompt (overfit pins) | 33.8 s | 0.17 tok/s | 79.8% |
+| **steady state: 11-prompt diverse history, default pins, novel prompt** ¹ | **35.4 s** | **0.25 tok/s** | **82.2%** |
+
+¹ 48-token generation, 13-token prompt. With only a small warmup corpus the
+ranking is barely ahead of plain LRU; hit rate (and therefore decode speed)
+grows toward the trained-prompt number as real-use history accumulates.
+
+Phase profile at high hit rates: ~90% CPU expert matmul — the next lever is
+expert compute on the GPU, not more I/O work.
+
+## Validation
+
+Every mode is token-exact against HF transformers on a tiny random-init oracle
+(`c/tools/make_tiny_inkling.py`): f32, int4-container (VNNI and `IDOT=0`
+scalar), bf16 residents on CPU, and bf16 residents through the CUDA kernel.
+The tokenizer (o200k family, auto-detected by `tok.h`) encodes 357/357 test
+strings identically to HF `tokenizers`. The converter round-trips a fabricated
+TML-layout checkpoint back through the engine exactly (`--selftest-e2e`).


### PR DESCRIPTION
## What

Support for [Thinking Machines **Inkling**](https://thinkingmachines.ai/news/introducing-inkling/) (975B total / 41B active MoE, Apache 2.0) — a second full architecture for colibri, following the `olmoe.c` standalone-engine precedent:

- **`c/inkling.c`** — Stage-A engine: GQA with interleaved sliding-window (512, 16 KV heads) / global (8 KV heads) attention at 5:1, learned relative-position bias banks (no RoPE), log-length tau scaling past 128k, four depthwise causal short-convs per layer (fp32, residual inside, cached conv state for decode), dense + MoE layers, sigmoid router with loss-free bias and jointly-normalized routed+shared weights, mup logit scaling. Routed experts stream per-expert from the fused 3D tensors (LRU cache, colibri int4/int8 container or f32). `-p "prompt"` streaming greedy mode; ref-oracle harness mode.
- **`c/tok.h`** — o200k pre-tokenizer support (case-aware Split regex), auto-detected from `tokenizer.json` so the GLM/cl100k path is byte-identical to before. New `tok_unicode_o200k.h` range tables.
- **`c/tools/convert_inkling_int4.py`** — bf16 checkpoint → colibri container (int4 experts + `.qs` per-row scales, bf16 residents, f32 norms/convs/router). Threaded quantization, shard-resumable, `--watch` converts while the download is still running. Note for reviewers: TML's fused `w13` tensors store gate/up rows **interleaved**; the converter de-interleaves exactly per `transformers`' conversion mapping.
- **`c/tools/make_tiny_inkling.py`** — tiny random-init oracle generator (HF transformers ≥ 5.14).
- Zen-4-friendly kernels in `inkling.c`: bf16 residents dotted via AVX512-BF16 `vdpbf16ps` (halves resident RAM vs f32 — required: f32 residents would be ~172 GB), int8 expert dot via AVX-512 VNNI (IDOT family; `IDOT=0` scalar path preserved). Scalar fallbacks keep the dependency-free default CPU path intact.

## Validation

- **Token-exact oracle** (the colibri standard): tiny random-init Inkling via HF transformers — **36/36 teacher-forced argmax, 24/24 greedy**, in f32, int4-container+VNNI, IDOT=0 scalar, and bf16-resident modes.
- **Tokenizer**: 357/357 strings encode identically to HF `tokenizers` (case transitions, contractions, CJK, combining marks, emoji+modifiers, 300 mixed-charset fuzz cases).
- **Converter e2e** (`--selftest-e2e`): fabricates a TML-named checkpoint from the tiny oracle (inverse mapping, re-fused, re-interleaved), converts back, engine reproduces the oracle exactly in both passthrough and int4 modes.
- **Real checkpoint** (975B, int4 experts + bf16 residents, 469 GiB snapshot):

  ```
  $ SNAP=~/Models/inkling_i4 ./inkling -p "The capital of France is" -n 24
  The capital of France is Paris.
  The capital of the UK is London.
  The capital of Russia is Moscow.
  The capital of Italy
  ```

  Converted weights published at [nbeerbower/Inkling-colibri-int4](https://huggingface.co/nbeerbower/Inkling-colibri-int4).

## Perf status (honest numbers)

Ryzen 9 7900 (24t), 187 GB RAM, NVMe snapshot, commit b60f881, `make CUDA=0`, single run, cold cache: RSS 90.5 GB, prefill 150 s (5 tok), decode 0.06 tok/s at cache 16/layer — expert streaming bound, as expected for Stage A with a plain LRU. The architecture is unusually kind to long context (55/66 layers have a fixed 512-token window; 1M-token KV ≈ 46 GB bf16, RAM-resident), so the usual roadmap applies and should pay off more than it did for GLM: hot-store/pinning + prefetch (`tier.h`), then a GQA CUDA tier — the attention here needs no MLA-style custom kernels.

`make check` passes (62 tests), `-Wall -Wextra` clean, GLM oracle path untouched (tok.h dispatch is additive).

Happy to split this into smaller PRs if you prefer (tokenizer / engine / converter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KLDCYJSyHxd39ChTr4T27