### PR TITLE
CI: GitHub Actions for make check + the zero-warnings review gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+# CI: the checks CONTRIBUTING.md asks reviewers to run by hand.
+#  - `make check`: one portable CPU build + C unit tests + Python stdlib tests
+#    (no model download, no CUDA — same contract as the local target)
+#  - zero-warnings gate: the review bar is "clean build (0 warnings)", so the
+#    glm build fails CI if gcc emits any warning
+# CUDA and model-oracle validation stay manual: runners have no GPU and the
+# tiny oracle snapshots are not in the repo.
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+
+jobs:
+  check:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      # Apple clang has no bundled OpenMP runtime; the Makefile falls back to a
+      # single-threaded build without it, so install libomp to test the real path.
+      - name: Install libomp (macOS)
+        if: runner.os == 'macOS'
+        run: brew install libomp
+      - name: make check
+        run: make check
+
+  warnings:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build glm with a clean log
+        run: |
+          make -C c glm ARCH=x86-64-v3 2>&1 | tee build.log
+          if grep -E "warning:" build.log; then
+            echo "::error::build emitted warnings — the review bar is 0 warnings"
+            exit 1
+          fi
+      - name: Build olmoe with a clean log
+        run: |
+          make -C c olmoe ARCH=x86-64-v3 2>&1 | tee build2.log
+          if grep -E "warning:" build2.log; then
+            echo "::error::build emitted warnings — the review bar is 0 warnings"
+            exit 1
+          fi


### PR DESCRIPTION
Automates the two review checks from CONTRIBUTING.md so every PR gets them before a human looks:

- **`make check`** on `ubuntu-latest` **and** `macos-latest` — the documented no-model, no-CUDA suite (portable CPU build + C unit tests + Python stdlib tests). The macOS job installs `libomp` so CI exercises the real OpenMP build rather than the single-thread fallback.
- **Zero-warnings gate** — `glm` and `olmoe` built at `ARCH=x86-64-v3`; any compiler warning fails the job, matching the "clean build (0 warnings)" review bar.

Deliberately out of scope (stays manual, as today): CUDA builds (no GPU on hosted runners) and the token-exact model oracles (tiny snapshots aren't in the repo — happy to add an oracle job in a follow-up if you'd like the fixtures checked in or fetched).

Validated locally on `dev`: `make check` 68/68 on Linux, both builds warning-free at x86-64-v3. Triggers: `pull_request` + pushes to `main`/`dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KLDCYJSyHxd39ChTr4T27