### PR TITLE
fix: make_glm_oracle.py creates glm_tiny/ before saving (fresh-checkout failure)

### DIFF
--- a/c/tools/make_glm_oracle.py
+++ b/c/tools/make_glm_oracle.py
@@ -115,6 +115,7 @@ print("tf_pred:", tf_pred)
 sd = model.state_dict()
 unfuse_experts(sd)
 
+Path("glm_tiny").mkdir(parents=True, exist_ok=True)   # safetensors/json won't create the dir themselves
 if args.fp8:
     n_fp8, n_tot = save_fp8_safetensors(sd, "glm_tiny/model.safetensors")
     print(f"\nsaved FP8: {n_fp8} e4m3 tensors (+{n_tot - n_fp8} scale_inv sidecars / f32) "


### PR DESCRIPTION
## Summary

On a clean checkout, `python tools/make_glm_oracle.py` — the tiny-model step in
the README's "Verify" flow — fails before writing anything:

    SafetensorError: Error while serializing: I/O error:
    The system cannot find the path specified. (os error 3)
    at path ".../glm_tiny/.tmpXXXXXX"

The script saves into `glm_tiny/` but never creates it. `safetensors.save_file`
stages a temp file inside the target directory before renaming, so a missing
`glm_tiny/` aborts the write. It only worked previously when the directory was
left over from an earlier run — so the very first run fails for every new user.

Fix: one line before the save branch —

    Path("glm_tiny").mkdir(parents=True, exist_ok=True)

`Path` is already imported. This covers all three writes (fp8, bf16, and
`config.json`). No new dependency, no change to the engine or the CPU build.

Reproduced and fixed on Windows 11 (native MinGW-w64, gcc 16.1.0, Python 3.12):
- Before: `rm -rf c/glm_tiny && python tools/make_glm_oracle.py` → os error 3
- After:  same command → creates `glm_tiny/` and writes weights + config + ref, exit 0
- `SNAP=./glm_tiny TF=1 ./glm 64 16 16` → `32/32 positions`

## Validation

- [x] `make -C c check` → exit 0 (portable CPU build + C unit tests + 68 Python tests,
      OK with 3 environmental skips). Verified on Windows 11 / MinGW-w64 gcc 16.1.0.
      The two build warnings (psapi `#pragma`, `glm.c:1662` snprintf) are pre-existing
      upstream and unrelated — this PR changes only Python tooling.
- [x] Tooling-only change; oracle regenerates cleanly from an empty dir and
      still validates 32/32 TF
- [x] CUDA changes were tested with `make -C c cuda-test` (N/A — no CUDA code touched)
- [x] Performance claims: none

## Compatibility

- [x] The default CPU build remains dependency-free (Python tooling only, no engine change)
- [x] No model files, generated binaries, or benchmark artifacts are included
