### PR TITLE
docs: add winget python one-liner to Windows install block (#310)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ GCC 16.1.0 (x86_64-ucrt-posix-seh).
 scoop install mingw-winlibs                    # portable, no shell needed
 # or: pacman -S mingw-w64-x86_64-gcc make     # via MSYS2
 
+# Python (needed by the `coli` CLI and API server). A fresh Windows resolves
+# `python` to a Microsoft Store alias stub that opens the Store instead of
+# running anything (#198) — installing the real interpreter replaces the stub:
+winget install -e --id Python.Python.3.12
+
 # Build (from c/ directory):
 make glm.exe            # GLM-5.2 engine (static, no DLL dependencies)
 make olmoe.exe          # OLMoE engine (same shims)


### PR DESCRIPTION
## Summary

Interim Windows fix discussed in #310: the `coli` CLI and `openai_server.py` need a real `python3` interpreter, but a fresh Windows resolves `python` to the Microsoft Store alias stub that opens the Store instead of running anything (the trap from #198).

This adds a documented `winget install` one-liner to the Windows toolchain install block in the README, as suggested by @ZacharyZcR:

```powershell
winget install -e --id Python.Python.3.12
```

Installing the real interpreter replaces the alias stub, so the existing `python coli chat/serve` commands in the same block work out of the box.

## Test plan

- [x] Docs-only change; verified the surrounding README block renders correctly
- [x] `winget install -e --id Python.Python.3.12` is the exact-match package ID from the winget community repo

Refs #310, #198