### PR TITLE
oracle: hard-fail on transformers < 5.11.0 (interleaved-RoPE floor, #281)

### DIFF
--- a/c/tools/make_glm_oracle.py
+++ b/c/tools/make_glm_oracle.py
@@ -17,6 +17,45 @@ EN: computed AFTER the FP8 round-trip, so the reference matches exactly what the
 EN: ingests. Default: bf16 (original oracle unchanged)."""
 import json, sys, argparse
 from pathlib import Path
+
+# --- Version gate (must run BEFORE the heavy `from transformers import ...`,
+# which triggers transformers' lazy-loading and can in turn reset the in-memory
+# __version__ attribute; importlib.metadata reads the installed package version
+# directly and is immune to that). ---
+#
+# GLM-5.2's MLA attention uses interleaved (DeepSeek-style) RoPE, which is what
+# the C engine implements. transformers < 5.11.0 applied split-half (Llama-style)
+# RoPE in GlmMoeDsa* instead; an oracle built on those versions drifts and the
+# engine then scores 25/32 instead of the documented 32/32 (issue #281). Weights
+# come out identical across versions — only the forward pass differs — so there
+# is no safe "partial" run: a too-old transformers silently produces an invalid
+# ref_glm.json. Hard-fail rather than warn. EN: same.
+import transformers
+from importlib.metadata import version as _pkg_version, PackageNotFoundError
+
+_MIN_TRANSFORMERS = (5, 11)
+def _tf_version_tuple():
+    try:
+        v = _pkg_version("transformers")          # authoritative: installed dist metadata
+    except PackageNotFoundError:
+        v = getattr(transformers, "__version__", "0")   # fallback (editable/src installs)
+    out = []
+    for part in v.split(".")[:2]:                 # major.minor only
+        out.append(int("".join(c for c in part if c.isdigit()) or "0"))
+    while len(out) < 2:
+        out.append(0)
+    return tuple(out[:2])
+
+_tf_ver = _tf_version_tuple()
+if _tf_ver < _MIN_TRANSFORMERS:
+    sys.exit(
+        f"\nERROR: make_glm_oracle.py requires transformers >= "
+        f"{'.'.join(map(str, _MIN_TRANSFORMERS))}.0 (found {_tf_ver[0]}.{_tf_ver[1]}). "
+        f"GLM-5.2 MLA uses interleaved RoPE; older versions apply split-half RoPE "
+        f"and silently produce an oracle the engine scores 25/32 against (issue #281). "
+        f"Upgrade: pip install -U 'transformers>=5.11'\n"
+    )
+
 import torch
 from transformers import GlmMoeDsaConfig, GlmMoeDsaForCausalLM
 


### PR DESCRIPTION
## Summary

`make_glm_oracle.py` silently produces an **invalid oracle** (engine scores 25/32 instead of the documented 32/32) on transformers < 5.11.0. This adds a hard version gate that refuses to run, with an actionable message. Closes the open half of #281 (the part #318 does *not* cover).

### Root cause (bisected in #281 by @KingIcyCreamProjects)

GLM-5.2's MLA attention uses **interleaved (DeepSeek-style) RoPE** — which is what the C engine implements. transformers ≤ 5.10.4 applied the wrong variant (split-half, Llama-style) in `GlmMoeDsa*`; **5.11.0 switched to interleaved**. Weights come out hash-identical across versions — only the forward pass differs — so a too-old transformers produces a `ref_glm.json` that drifts, with no error. The mismatch is invisible until `SNAP=./glm_tiny TF=1 ./glm 64 16 16` prints `25/32`.

### The fix

`sys.exit` at the top of `make_glm_oracle.py` if transformers < 5.11.0:

```
ERROR: make_glm_oracle.py requires transformers >= 5.11.0 (found 5.5).
GLM-5.2 MLA uses interleaved RoPE; older versions apply split-half RoPE
and silently produce an oracle the engine scores 25/32 against (issue #281).
Upgrade: pip install -U 'transformers>=5.11'
```

**Two design choices, both deliberate:**

1. **Hard-fail, not warn.** The issue thread's original maintainer ask was \"warns,\" but that predates the definitive bisect showing it's a hard incompatibility (weights identical, forward pass wrong). A warn-then-continue would still write a corrupt `ref_glm.json` that then fails `setup.sh`'s 32/32 gate — the exact confusion that caused the report. There is no useful \"partial\" output.
2. **Read `importlib.metadata.version()`, not `transformers.__version__`.** The mutable `__version__` attribute is reset by transformers' lazy-loading machinery when `from transformers import GlmMoeDsaForCausalLM` runs — so reading it *after* that import is unreliable (I hit this during testing: the gate read a reverted value). `importlib.metadata` reads the authoritative installed-dist version and is immune to this. The gate runs *before* the heavy import, with a fallback to the attribute for editable/src installs.

## A/B testing requested

I can only validate against the transformers version installed locally (5.13.1, in the known-good 5.11–5.14 range). To confirm the gate behaves correctly across the boundary, it would help to have it exercised on both sides:

| run | transformers | expected |
|---|---|---|
| **A (below floor)** | 5.5.0 – 5.10.4 (the drifting versions from #281) | gate blocks with the message above; **no** `ref_glm.json` written |
| **B (at/above floor)** | ≥ 5.11.0 | gate passes; oracle generated; engine scores **32/32** |

If someone has an env pinned to a < 5.11 transformers, please try `python tools/make_glm_oracle.py` and confirm it hard-fails rather than writing a drifted 25/32 oracle. That's the regression this prevents.

## Validation

Local env: Windows 11, Python 3.11, torch 2.13.0+cpu, **transformers 5.13.1**, built `glm.exe`.

- [x] `python tools/make_glm_oracle.py` → exit 0, writes weights + config + ref
- [x] `SNAP=./glm_tiny TF=1 ./glm 64 16 16` → **`PREFILL (teacher-forcing) C vs oracle: 32/32 positions`**
- [x] Regenerated `ref_glm.json` and `model.safetensors` are **byte-identical** to the shipped versions (gate is inert on a known-good transformers — zero behavioral change)
- [x] Negative path: with the floor temporarily raised to `(5,14)`, the installed 5.13.1 is correctly blocked — message cites #281, includes the `pip install` hint, exits non-zero
- [x] `importlib.metadata` immunity confirmed: spoofing `transformers.__version__ = "5.5.0"` does not trick the gate (it reads the real installed metadata)
- [x] `--fp8` variant (shares the gate) still runs end-to-end
- [x] Boundary parity with the #281 bisect: 5.11 passes, 5.10 blocks (tested across 13 version strings incl. `5.10.4+cpu`, `v5.11.0`, `05.11.0`, garbage)

## Compatibility

- [x] The default CPU build remains dependency-free (gate is Python-only, `importlib.metadata` is stdlib since 3.8)
- [x] No model files, generated binaries, or benchmark artifacts included
- [x] Disjoint from #318 (the `glm_tiny/` mkdir fix) — that touches ~line 118, this touches the imports header; both can merge independently

🤖 Generated with [ZCode](https://z.ai)