### PR TITLE
fix(flake): package engine, support modules, and python for Nix builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,9 @@
           version = "1.0";
           src = ./.;
 
-          nativeBuildInputs = [ pkgs.makeWrapper ];
+          # python3 is needed by checkPhase: `make test-c` shells out to
+          # `python3 tools/run_tests.py` (see c/Makefile, PYTHON ?= python3).
+          nativeBuildInputs = [ pkgs.makeWrapper pkgs.python3 ];
 
           buildInputs = [
             pkgs.gcc
@@ -44,18 +46,29 @@
 
           installPhase = ''
             runHook preInstall
-            mkdir -p $out/bin
-            cp c/glm $out/bin/glm
 
-            # Wrap coli (the Python CLI) so it finds the right python and the engine
-            mkdir -p $out/share/colibri
-            cp c/coli $out/share/colibri/coli
-            chmod +x $out/share/colibri/coli
-            cp -r c/tools $out/share/colibri/tools
+            # Self-contained layout under $out/lib/colibri that mirrors the
+            # source tree `coli` runs in (see the path-resolution logic at the
+            # top of c/coli): the engine, the coli CLI script, the support
+            # modules it imports (openai_server.py, resource_plan.py,
+            # doctor.py), and tools/ all sit next to each other.
+            mkdir -p $out/lib/colibri/tools $out/bin
+            cp c/glm             $out/lib/colibri/glm
+            cp c/coli            $out/lib/colibri/coli
+            chmod +x $out/lib/colibri/coli
+            cp c/openai_server.py c/resource_plan.py c/doctor.py $out/lib/colibri/
+            cp -r c/tools/*      $out/lib/colibri/tools/
 
+            # $out/bin holds the user-facing entry points.
+            ln -s ../lib/colibri/glm $out/bin/glm
+
+            # Wrap coli: point it at the bundled engine (COLI_ENGINE) so it is
+            # found by default, and at the module dir (PYTHONPATH) so
+            # `import openai_server` / `resource_plan` / `doctor` resolve.
             makeWrapper ${pythonEnv}/bin/python $out/bin/coli \
-              --add-flags "$out/share/colibri/coli" \
-              --set PYTHONPATH "${pythonEnv}/${pkgs.python3.sitePackages}"
+              --add-flags "$out/lib/colibri/coli" \
+              --set COLI_ENGINE "$out/lib/colibri/glm" \
+              --set PYTHONPATH "$out/lib/colibri:${pythonEnv}/${pkgs.python3.sitePackages}"
             runHook postInstall
           '';
 


### PR DESCRIPTION
## Fixes #345

Reported by @LordMZTE — the Nix flake didn't produce a working colibri installation. Four bugs, all addressed here.

### Root causes & fixes

| # | Symptom | Cause | Fix |
|---|---------|-------|-----|
| 1 | `nix build` → *"cannot write modified lock file"* | No `flake.lock` committed | ⚠️ See note below — not generated in this PR |
| 2 | `make: python3: No such file or directory` during `checkPhase` | `make test-c` runs `python3 tools/run_tests.py` (`c/Makefile`, `PYTHON ?= python3`) but `python3` wasn't in `nativeBuildInputs` | Added `pkgs.python3` to `nativeBuildInputs` |
| 3 | `coli serve` → *"engine is not built"* despite glm being packaged | The engine was installed to `$out/bin/glm`, but `coli` resolves it via `COLI_ENGINE`, beside-the-script, or `libexec/colibri` (`c/coli:57-66`) — none matched | Wrapper now sets `COLI_ENGINE` to the bundled engine |
| 4 | `coli serve` → `ModuleNotFoundError: No module named 'openai_server'` | `openai_server.py` (and `resource_plan.py`, `doctor.py`) were never installed | Installed into the package and added to `PYTHONPATH` |

For #3 and #4 together, the `installPhase` now produces a **self-contained layout** under `$out/lib/colibri/` that mirrors the source tree `coli` is designed to run in (the run-in-place layout documented at the top of `c/coli`): `glm`, `coli`, the support modules, and `tools/` all sit side-by-side. `$out/bin/` holds the two user-facing entry points — `glm` (symlink) and `coli` (wrapped python). With `COLI_ENGINE` set and the module dir on `PYTHONPATH`, both `coli chat` and `coli serve` resolve the engine and imports correctly.

### ⚠️ `flake.lock` is intentionally not included

A valid `flake.lock` carries `narHash` values for every pinned input, and those can **only** be computed by the `nix` tooling itself (`nix flake lock`). I don't have `nix` available, so I can't generate a correct lock file in this PR — and a hand-written one would corrupt the build.

**To close the loop on bug #1**, someone on a Nix host needs to run, against this branch:

```sh
git checkout fix/nix-flake-packaging-345
nix flake lock          # generates flake.lock
git add flake.lock
git commit -m "flake: add flake.lock"
git push
```

`flake.lock` is **not** gitignored in this repo, so committing it will work. Once that lands, `nix build github:JustVugg/colibri` will succeed without `--no-write-lock-file`.

### Verification done

- Static review of the flake against `c/coli` path-resolution logic (`c/coli:42-66`) and `c/Makefile` (`test-c`, `PYTHON`, `install` targets).
- Confirmed the four referenced files exist and are tracked: `c/openai_server.py`, `c/resource_plan.py`, `c/doctor.py`, `c/tools/`.
- `nix build` not reproducible in my environment (no `nix`); the reporter's repro steps in #345 are the end-to-end validation path.

### Notes

- Branch is based off `dev` (where the flake currently lives and diverges). `flake.nix` is byte-identical between `dev` and the `72d3d37` commit referenced in the issue, so the fix applies cleanly to both.
- `meta.mainProgram = \"glm\"` still resolves correctly (`$out/bin/glm` exists via the symlink).

Closes #345 (pending the `flake.lock` follow-up noted above).