### PR TITLE
fix(warnings): silence two -Wall/-Wextra warnings on the MinGW build

### DIFF
--- a/c/compat.h
+++ b/c/compat.h
@@ -237,7 +237,9 @@ static inline int compat_rename(const char *old, const char *new){
 /* --- rss_gb: getrusage -> GetProcessMemoryInfo ---
  * ru_maxrss in KB (come Linux): rss_gb() divide per 1e6 → GB corretti. */
 #include <psapi.h>
-#pragma comment(lib, "psapi.lib")
+#ifdef _MSC_VER
+#pragma comment(lib, "psapi.lib")   /* MSVC: link psapi; MinGW/GCC uses -lpsapi */
+#endif
 struct rusage { long ru_maxrss; };
 #define RUSAGE_SELF 0
 static inline int getrusage(int who, struct rusage *r){

--- a/c/glm.c
+++ b/c/glm.c
@@ -1207,7 +1207,9 @@ static int g_disk_split=0; /* DISK_SPLIT=1: contatori che spezzano i DISK LOAD (
  * 10x (#82) — hence per-region mbind here and nothing else. Raw syscall, no libnuma
  * dependency; MPOL_MF_MOVE migrates pages of reused heap chunks too. Linux-only,
  * silent no-op elsewhere or on single-node hosts. */
-static int g_numa_nodes=0;
+#ifdef __linux__
+static int g_numa_nodes=0;      /* only touched under __linux__; off-Linux NUMA is a no-op */
+#endif
 static void numa_slab_bind(void *p, size_t n){
 #ifdef __linux__
     if(g_numa_nodes<2 || !p || !n) return;


### PR DESCRIPTION
## What

A clean `make glm` on MinGW emitted exactly two `-Wall -Wextra` warnings. Both are real; this silences them.

## The two warnings

**1. `compat.h:240` — `ignoring '#pragma comment ' [-Wunknown-pragmas]`**

```c
#pragma comment(lib, "psapi.lib")
```
This is an MSVC linker directive. MinGW/GCC doesn't understand it and warns. Guarded with `#ifdef _MSC_VER` — MinGW already links psapi via `-lpsapi` (in the Makefile / `.build-config`), and MSVC keeps the pragma.

**2. `glm.c:1210` — `'g_numa_nodes' defined but not used [-Wunused-variable]`**

`g_numa_nodes` is only read/written inside `#ifdef __linux__` blocks (`numa_slab_bind`, `numa_init`). On every non-Linux build it's a file-scope static that nothing references → unused-variable warning. Moved the definition under the same `__linux__` guard:

```c
#ifdef __linux__
static int g_numa_nodes=0;      /* only touched under __linux__; off-Linux NUMA is a no-op */
#endif
```

Off-Linux `numa_slab_bind` / `numa_init` are already full no-ops (they `(void)` their args and return), so nothing references the variable there.

## Verification

```
rm -f *.o glm.exe && make glm   # 0 warnings, 0 errors, binary builds
```

Behavior is unchanged on Linux (the variable is identical there) and on MSVC (the pragma is unchanged there).

