### PR TITLE
fix(test): make test_stops build on Windows (mkdtemp compat shim)

### DIFF
--- a/c/compat.h
+++ b/c/compat.h
@@ -80,6 +80,7 @@ static inline int compat_open_direct(const char *path){
 #endif
 #include <windows.h>
 #include <io.h>
+#include <direct.h>   /* _mkdir (for the mkdtemp shim below) */
 #include <process.h>
 #include <malloc.h>
 #include <fcntl.h>
@@ -303,6 +304,19 @@ static inline int compat_setenv(const char *name, const char *value, int overwri
     return SetEnvironmentVariableA(name, value) ? 0 : -1;
 }
 #define setenv(name,value,overwrite) compat_setenv(name,value,overwrite)
+
+/* --- mkdtemp -> _mktemp + _mkdir (POSIX mkdtemp assente su Windows) ---
+ * Test binaries (test_stops.c) create a scratch dir in the CWD via a
+ * "name_XXXXXX" template; POSIX mkdtemp fills the X's and mkdirs 0700. The
+ * Windows CRT has _mktemp (in-place, same XXXXXX contract) so we compose it.
+ * Returns the template pointer on success, NULL on failure — matching POSIX. */
+static inline char *compat_mkdtemp(char *tmpl){
+    if(!tmpl) return NULL;
+    if(!_mktemp(tmpl)) return NULL;       /* fills the trailing X's in place */
+    if(_mkdir(tmpl) != 0) return NULL;    /* EEXIST is impossible post-_mktemp */
+    return tmpl;
+}
+#define mkdtemp(tmpl) compat_mkdtemp(tmpl)
 
 #endif /* _WIN32 */
 


### PR DESCRIPTION
## What

`make test` halted on the Windows job: `tests/test_stops.c` uses POSIX `mkdtemp()`, which MinGW-w64 doesn't declare, so the test **failed to compile** on Windows (and only there).

```
tests/test_stops.c:73:9: error: implicit declaration of function 'mkdtemp';
   did you mean 'mktemp'? [-Wimplicit-function-declaration]
make: *** [Makefile:318: tests/test_stops.exe] Error 1
```

This blocked the entire C-test phase on Windows. (`test_uring` is correctly gated to Linux via `ifneq (,$(LINUX))`, so `test_stops` was the only Windows blocker.)

## Fix

Added a `compat_mkdtemp` shim to `c/compat.h`, following the file's stated convention — *"every platform difference lives here; the `.c` files stay clean."* POSIX `mkdtemp` takes a `char[]` template ending in `XXXXXX`, replaces the X's randomly, mkdirs `0700`, and returns the pointer (or NULL). On Windows:

```c
static inline char *compat_mkdtemp(char *tmpl){
    if(!tmpl) return NULL;
    if(!_mktemp(tmpl)) return NULL;       /* fills the trailing X's in place */
    if(_mkdir(tmpl) != 0) return NULL;    /* EEXIST is impossible post-_mktemp */
    return tmpl;
}
#define mkdtemp(tmpl) compat_mkdtemp(tmpl)
```

`_mktemp` (CRT, `<io.h>`) has the same `XXXXXX` contract; `_mkdir` needed `<direct.h>`, added. On Linux `compat.h` is a complete no-op — POSIX `mkdtemp` is untouched.

## Why a shim and not a test-local fix

The earlier fix in `test_stops.c` (commit on this file) already moved off `/tmp/...` to a CWD-relative path to fix the Windows job, but `mkdtemp` itself was still POSIX-only. A `compat.h` shim is the project's established pattern for exactly this (see `getline`, `setenv`, `posix_fadvise`, `pread`, `rename`...) and keeps the test portable without `#ifdef _WIN32` inside the test source.

## Verification

On MinGW:
```
make tests/test_stops.exe   # builds clean (the mkdtemp error is gone)
./tests/test_stops.exe      # all 5 sub-cases pass
```

The two unrelated `-Wall` warnings that still show in this branch's build (`compat.h:241` pragma, `glm.c:1210` g_numa_nodes) are addressed by **#350** — this PR is based on `origin/dev` and is independent of it.

