### PR TITLE
win32: retry transient ReadFile errors in compat_pread (#307)

### DIFF
--- a/c/compat.h
+++ b/c/compat.h
@@ -142,7 +142,34 @@ static inline int compat_fadvise(int fd, off_t off, off_t len, int advice){
 /* --- pread -> ReadFile + OVERLAPPED su raw OS handle ---
  * Thread-safe (no shared seek position). Gestisce offset >4 GB e chunking
  * per letture >2 GB (anche se i tensori individuali sono nell'ordine dei
- * MB-centinaia di MB, il wrapper e' robusto per ogni taglia). */
+ * MB-centinaia di MB, il wrapper e' robusto per ogni taglia).
+ *
+ * RETRY ON TRANSIENT ERRORS (#307): gli shard handle NON sono aperti con
+ * FILE_FLAG_OVERLAPPED (st.h:85 li apre buffered), quindi il kernel serializza
+ * le ReadFile concorrenti allo stesso handle. Sotto il carico del motore su
+ * Windows (default: DIRECT=1, PIPE=1, PIPE_WORKERS=8, PILOT_REAL=1 -> 8 worker
+ * + pilot + main, tutti compat_pread sugli stessi shard handle; piu' un'altra
+ * ReadFile sincrona per ogni hint WILLNEED in compat_fadvise) errori transitori
+ * come ERROR_LOCK_VIOLATION / ERROR_SHARING_VIOLATION / ERROR_NOT_READY sono
+ * normali e recuperabili: conflitto momentaneo sul handle, AV che scansiona il
+ * VHDX, un detach/timeout del disco virtuale. Mapparli a EIO e ritornare -1 al
+ * primo tentativo (il comportamento precedente) uccideva il load con un singolo
+ * ReadFile flaky -> "[engine terminated: exit code 1]" + "pread qs: Input/output
+ * error (off X, 0/N bytes)" nel bel mezzo di una generazione, dopo che il motore
+ * aveva girato bene finche' il working set era caldo. Ora questi tre errori si
+ * ritentano fino a 3 volte con backoff 1/2/4 ms, poi si arrendono a EIO: un
+ * disco morente fallira' comunque (dopo i tentativi), ma un transient vero
+ * sopravvive. EOF, EBADF e gli altri errori reali restano immediati. */
+static inline int compat_pread_retryable(DWORD err){
+    /* Letture concorrenti su un handle non-overlapped, AV/VHDX, disco che si
+     * rimette in linea: transienti documentati, ognuno risolvibile ritentando. */
+    return err == ERROR_LOCK_VIOLATION   /* 33: un altro handle trattiene la regione */
+        || err == ERROR_SHARING_VIOLATION/* 32: conflitto di condivisione momentaneo */
+        || err == ERROR_NOT_READY;       /* 21: dispositivo non pronto (riprova) */
+}
+static inline void compat_sleep_ms(DWORD ms){
+    SleepEx(ms, FALSE);
+}
 static inline ssize_t compat_pread(int fd, void *buf, size_t n, off_t off){
     intptr_t osfh = _get_osfhandle(fd);
     if(osfh == -1 || osfh == -2){ errno = EBADF; return -1; }
@@ -151,13 +178,20 @@ static inline ssize_t compat_pread(int fd, void *buf, size_t n, off_t off){
     while(total < n){
         size_t chunk = n - total;
         DWORD chunk32 = (chunk > 0x7FFFFFFF) ? 0x7FFFFFFF : (DWORD)chunk;
-        OVERLAPPED ov = {0};
-        ov.Offset     = (DWORD)( (off + (off_t)total)        & 0xFFFFFFFFULL);
-        ov.OffsetHigh = (DWORD)(((off + (off_t)total) >> 32) & 0xFFFFFFFFULL);
-        DWORD rd = 0;
-        if(!ReadFile(h, (char*)buf + total, chunk32, &rd, &ov)){
-            DWORD err = GetLastError();
-            if(err == ERROR_HANDLE_EOF) break;  /* past EOF → return bytes read (0 if none, matching POSIX pread) */
+        DWORD rd = 0; DWORD err = 0; int attempt = 0; int ok = 0;
+        for(;;){                             /* retry loop: solo errori transienti */
+            OVERLAPPED ov = {0};
+            ov.Offset     = (DWORD)( (off + (off_t)total)        & 0xFFFFFFFFULL);
+            ov.OffsetHigh = (DWORD)(((off + (off_t)total) >> 32) & 0xFFFFFFFFULL);
+            rd = 0;
+            ok = ReadFile(h, (char*)buf + total, chunk32, &rd, &ov);
+            if(ok) break;                    /* successo (EOF/partial gestiti sotto via rd) */
+            err = GetLastError();            /* significativo solo quando ok==0 */
+            if(!compat_pread_retryable(err) || ++attempt > 3) break;
+            compat_sleep_ms(attempt == 1 ? 1 : (attempt == 2 ? 2 : 4));
+        }
+        if(!ok){                             /* ReadFile fallito: err e' onesto */
+            if(err == ERROR_HANDLE_EOF) break;/* past EOF → bytes letti (0 = POSIX pread) */
             if(err == ERROR_INVALID_HANDLE || err == ERROR_INVALID_FUNCTION) errno = EBADF;
             else errno = EIO;
             return -1;


### PR DESCRIPTION
## Summary

On Windows, `compat_pread` mapped **every** non-EOF / non-`EBADF` `ReadFile` failure to `EIO` and returned `-1` on the **first** attempt. Under the engine's default Windows load — `DIRECT=1`, `PIPE=1`, `PIPE_WORKERS=8`, `PILOT_REAL=1` (8 pipe workers + pilot + main, all issuing `compat_pread` on the same shard handles) plus a synchronous `ReadFile` per `WILLNEED` hint — transient errors are normal and recoverable:

- `ERROR_LOCK_VIOLATION` (33) — momentary handle conflict
- `ERROR_SHARING_VIOLATION` (32) — momentary sharing conflict
- `ERROR_NOT_READY` (21) — device momentarily not ready (AV scanning the VHDX, virtual-disk detach/timeout)

A single flaky `ReadFile` killed the load:

```
[engine terminated: exit code 1]
pread qs: Input/output error (off 3728808, 0/8192 bytes)
```

…mid-generation, after the engine had run fine while the working set was warm. This is the new symptom reported on #307 after the stale-`.coli_kv` fix landed.

## Root cause — what it is *not*

Two investigations ruled out the obvious suspects:

- **Not the OMP fix (`d5327e2`).** That `KMP_BLOCKTIME` code is behind `#ifdef __linux__` (`glm.c:6009`) and never runs on Windows; the `coli` launcher's `env_for` (`c/coli:176-180`) does not even set `KMP_BLOCKTIME`. Idle-spin tuning has no path to a `ReadFile` returning failure.
- **Not a slab/ESlot concurrency race.** The three slot pools (`pin[]`, `ecache[]`, `ws[]`) are disjoint. The pilot writes only `ecache[L > g_cur_moe_layer]` while the main thread reads `ecache[current]`, gated by `g_pilot_inflight[layer]==0`. `expert_load_impl` sets `s->eid` last. No half-loaded slab can be matmul'd, and a slab-realloc race would corrupt weights (wrong tokens), not produce `EIO`-exit.

The defect is in the I/O wrapper's error classification — not tensor geometry or alignment.

## The fix

`compat_pread` now retries the three genuinely transient codes up to **3×** with **1/2/4 ms** backoff before giving up to `EIO`. `ERROR_HANDLE_EOF`, `EBADF`-class, and real errors remain immediate. A dying drive still fails (after the retries); a genuine transient survives.

`err` is gated on an explicit success flag (`ok`), so a stale error from an earlier retried attempt can never be misreported (e.g. transient-fail-then-successful-EOF reads as EOF, not `EIO`).

## What this does *not* change

- **Linux / macOS:** untouched. `compat_pread` is Windows-only (`#ifdef _WIN32`).
- **Throughput:** unchanged on a healthy system — retries only fire on actual transient errors.
- **Honest failure:** a persistent fault still surfaces as `EIO` after the retries are exhausted.

## Verification

Compiles clean against real MinGW-w64 `windows.h` with `-Wall -Wextra` (zero warnings in the changed code). Logic traced through all cases: success-first, transient-then-success, transient-exhausted, hard-error, EOF (success with `rd=0`), EOF (`ERROR_HANDLE_EOF`), partial read.

## Open question for @galmok

This fix makes the contention **survivable**. Whether it is **sufficient** for your case depends on whether your failures are transient-recoverable (this should let you run to completion) vs. genuine storage faults (the retries delay but won't prevent the eventual `EIO`). To tell them apart, please also grab:

- **Windows Event Viewer → Windows Logs → System** during a failing run — look for `disk`, `Ntfs`, `diskpart` / `storahci` errors at the crash timestamp.
- **`chkdsk`** on the model volume.
- Which physical drive + filesystem the model lives on (local NVMe? a VHDX? an external/USB drive?).

Refs #307.