### PR TITLE
win32: auto-enable the GPU in coli chat (stacked on #298)

### DIFF
--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -13,6 +13,8 @@ struct ColiCudaTensor {
     float *scales;
     size_t weight_bytes;
     int fmt, I, O, device;
+    int gs;      /* group size for fmt=4 (grouped int4): 0 for all other formats */
+    int ng;      /* number of scale groups per row = ceil(I/gs) for fmt=4 */
     int tracked;
 };
 
@@ -70,7 +72,7 @@ static int select_ctx(DeviceContext *ctx) {
 __host__ __device__ static size_t row_bytes(int fmt, int I) {
     if (fmt == 0) return (size_t)I * sizeof(float);
     if (fmt == 1) return (size_t)I;
-    if (fmt == 2) return (size_t)(I + 1) / 2;
+    if (fmt == 2 || fmt == 4) return (size_t)(I + 1) / 2;   /* fmt=4: same packed int4 */
     if (fmt == 3) return (size_t)(I + 3) / 4;
     return 0;
 }
@@ -80,7 +82,7 @@ __device__ static float weight_at(const void *weights, int fmt, size_t row, int 
     if (fmt == 0) return reinterpret_cast<const float *>(base)[i];
     if (fmt == 1) return static_cast<float>(reinterpret_cast<const int8_t *>(base)[i]);
     const uint8_t *q = base;
-    if (fmt == 2) {
+    if (fmt == 2 || fmt == 4) {                               /* fmt=4: same nibble layout */
         uint8_t v = q[i >> 1];
         int n=(i&1)?(v>>4):(v&15); return static_cast<float>(n&8?n-16:n);
     }
@@ -94,14 +96,27 @@ __global__ static void offset_to_signed_s4(uint8_t *q,size_t n){
 
 __global__ static void quant_matmul(float *y, const float *x, const void *weights,
                                     const float *scales, int fmt, int S, int I, int O,
-                                    size_t rb) {
+                                    size_t rb, int gs, int ng) {
     int o = blockIdx.x;
     int s = blockIdx.y;
     float sum = 0.0f;
     size_t row = (size_t)o * rb;
     const float *xs = x + (size_t)s * I;
-    for (int i = threadIdx.x; i < I; i += blockDim.x)
-        sum += xs[i] * weight_at(weights, fmt, row, i);
+    if (fmt == 4) {
+        /* Grouped int4: one f32 scale per gs elements along I (ng groups per row).
+         * Scale layout: scales[o*ng + g]. Each thread strides through I, applying
+         * the appropriate group scale as it crosses group boundaries. This matches
+         * the CPU matmul_i4_grouped accumulation exactly. */
+        const float *scl = scales + (size_t)o * ng;
+        for (int i = threadIdx.x; i < I; i += blockDim.x) {
+            int g = i / gs;
+            if (g >= ng) g = ng - 1;  /* tail elements in the last (partial) group */
+            sum += xs[i] * weight_at(weights, fmt, row, i) * scl[g];
+        }
+    } else {
+        for (int i = threadIdx.x; i < I; i += blockDim.x)
+            sum += xs[i] * weight_at(weights, fmt, row, i);
+    }
 
     __shared__ float partial[256];
     partial[threadIdx.x] = sum;
@@ -111,7 +126,7 @@ __global__ static void quant_matmul(float *y, const float *x, const void *weight
         __syncthreads();
     }
     if (!threadIdx.x)
-        y[(size_t)s * O + o] = partial[0] * (fmt ? scales[o] : 1.0f);
+        y[(size_t)s * O + o] = (fmt && fmt != 4) ? partial[0] * scales[o] : partial[0];
 }
 
 __global__ static void silu_mul(float *gate, const float *up, size_t n) {
@@ -452,35 +467,40 @@ extern "C" void coli_cuda_group_stats(uint64_t *calls, uint64_t *experts, uint64
 
 extern "C" int coli_cuda_tensor_upload(ColiCudaTensor **tensor,
                                         const void *weights, const float *scales,
-                                        int fmt, int I, int O, int device) {
+                                        int fmt, int I, int O, int device, int gs) {
     DeviceContext *ctx = find_ctx(device);
     if (!tensor || !weights || I < 1 || O < 1 || !select_ctx(ctx)) return 0;
     size_t rb = row_bytes(fmt, I);
     if (!rb || (fmt && !scales)) return 0;
+    /* For fmt=4 (grouped int4), scales has O*ng entries (ng = ceil(I/gs)).
+     * For all other quantized formats, scales has O entries (per-row). */
+    int ng = (fmt == 4 && gs > 0) ? (I + gs - 1) / gs : 1;
     if (*tensor) {
         ColiCudaTensor *t = *tensor;
-        return t->fmt == fmt && t->I == I && t->O == O && t->device == device;
+        return t->fmt == fmt && t->I == I && t->O == O && t->device == device && t->gs == gs;
     }
     ColiCudaTensor *t = static_cast<ColiCudaTensor *>(std::calloc(1, sizeof(*t)));
     if (!t) return 0;
-    t->fmt = fmt; t->I = I; t->O = O; t->device = device; t->weight_bytes = rb * (size_t)O;
+    t->fmt = fmt; t->I = I; t->O = O; t->device = device; t->gs = gs; t->ng = ng;
+    t->weight_bytes = rb * (size_t)O;
     if (!cuda_ok(cudaMalloc(&t->weights, t->weight_bytes), "tensor allocation") ||
         !cuda_ok(cudaMemcpy(t->weights, weights, t->weight_bytes, cudaMemcpyHostToDevice), "tensor upload")) {
         coli_cuda_tensor_free(t);
         return 0;
     }
-    if(fmt==2){offset_to_signed_s4<<<(unsigned)((t->weight_bytes+255)/256),256>>>((uint8_t*)t->weights,t->weight_bytes);
+    if(fmt==2||fmt==4){offset_to_signed_s4<<<(unsigned)((t->weight_bytes+255)/256),256>>>((uint8_t*)t->weights,t->weight_bytes);
         if(!cuda_ok(cudaGetLastError(),"int4 weight conversion")){coli_cuda_tensor_free(t);return 0;}}
     if (fmt) {
-        if (!cuda_ok(cudaMalloc(&t->scales, (size_t)O * sizeof(float)), "scale allocation") ||
-            !cuda_ok(cudaMemcpy(t->scales, scales, (size_t)O * sizeof(float), cudaMemcpyHostToDevice), "scale upload")) {
+        size_t scount = (size_t)O * ng;
+        if (!cuda_ok(cudaMalloc(&t->scales, scount * sizeof(float)), "scale allocation") ||
+            !cuda_ok(cudaMemcpy(t->scales, scales, scount * sizeof(float), cudaMemcpyHostToDevice), "scale upload")) {
             coli_cuda_tensor_free(t);
             return 0;
         }
     }
     t->tracked = 1;
     ctx->tensor_count++;
-    ctx->tensor_bytes += t->weight_bytes + (fmt ? (size_t)O * sizeof(float) : 0);
+    ctx->tensor_bytes += t->weight_bytes + (fmt ? (size_t)O * ng * sizeof(float) : 0);
     *tensor = t;
     return 1;
 }
@@ -493,20 +513,21 @@ extern "C" int coli_cuda_tensor_update(ColiCudaTensor *tensor,
     if (!select_ctx(ctx)) return 0;
     if (!cuda_ok(cudaMemcpy(tensor->weights,weights,tensor->weight_bytes,
                             cudaMemcpyHostToDevice),"tensor refresh")) return 0;
-    if(tensor->fmt==2){
+    if(tensor->fmt==2||tensor->fmt==4){
         offset_to_signed_s4<<<(unsigned)((tensor->weight_bytes+255)/256),256>>>(
             (uint8_t*)tensor->weights,tensor->weight_bytes);
         if(!cuda_ok(cudaGetLastError(),"int4 weight refresh")) return 0;
     }
+    int ng = tensor->ng > 0 ? tensor->ng : 1;
     return !tensor->fmt || cuda_ok(cudaMemcpy(tensor->scales,scales,
-        (size_t)tensor->O*sizeof(float),cudaMemcpyHostToDevice),"scale refresh");
+        (size_t)tensor->O*ng*sizeof(float),cudaMemcpyHostToDevice),"scale refresh");
 }
 
 extern "C" int coli_cuda_matmul(ColiCudaTensor **tensor,
                                  float *y, const float *x,
                                  const void *weights, const float *scales,
-                                 int fmt, int S, int I, int O, int device) {
-    if (S < 1 || !coli_cuda_tensor_upload(tensor, weights, scales, fmt, I, O, device)) return 0;
+                                 int fmt, int S, int I, int O, int device, int gs) {
+    if (S < 1 || !coli_cuda_tensor_upload(tensor, weights, scales, fmt, I, O, device, gs)) return 0;
     ColiCudaTensor *t = *tensor;
     DeviceContext *ctx = find_ctx(t->device);
     if (!select_ctx(ctx)) return 0;
@@ -515,7 +536,7 @@ extern "C" int coli_cuda_matmul(ColiCudaTensor **tensor,
     if (!reserve(&ctx->x, &ctx->x_cap, xb) || !reserve(&ctx->y, &ctx->y_cap, yb)) return 0;
     if (!cuda_ok(cudaMemcpy(ctx->x, x, xb, cudaMemcpyHostToDevice), "input upload")) return 0;
     dim3 grid((unsigned)O, (unsigned)S);
-    quant_matmul<<<grid, 256>>>(ctx->y, ctx->x, t->weights, t->scales, fmt, S, I, O, rb);
+    quant_matmul<<<grid, 256>>>(ctx->y, ctx->x, t->weights, t->scales, fmt, S, I, O, rb, t->gs, t->ng);
     if (!cuda_ok(cudaGetLastError(), "matmul launch") ||
         !cuda_ok(cudaMemcpy(y, ctx->y, yb, cudaMemcpyDeviceToHost), "output download")) return 0;
     return 1;
@@ -538,13 +559,13 @@ extern "C" int coli_cuda_expert_mlp(ColiCudaTensor *gate, ColiCudaTensor *up,
     if (!cuda_ok(cudaMemcpy(ctx->x,x,xb,cudaMemcpyHostToDevice),"expert input upload")) return 0;
     dim3 hidden_grid((unsigned)I,(unsigned)S), output_grid((unsigned)D,(unsigned)S);
     quant_matmul<<<hidden_grid,256>>>(ctx->gate,ctx->x,gate->weights,gate->scales,
-        gate->fmt,S,D,I,row_bytes(gate->fmt,D));
+        gate->fmt,S,D,I,row_bytes(gate->fmt,D),gate->gs,gate->ng);
     quant_matmul<<<hidden_grid,256>>>(ctx->up,ctx->x,up->weights,up->scales,
-        up->fmt,S,D,I,row_bytes(up->fmt,D));
+        up->fmt,S,D,I,row_bytes(up->fmt,D),up->gs,up->ng);
     size_t n=(size_t)S*I;
     silu_mul<<<(unsigned)((n+255)/256),256>>>(ctx->gate,ctx->up,n);
     quant_matmul<<<output_grid,256>>>(ctx->y,ctx->gate,down->weights,down->scales,
-        down->fmt,S,I,D,row_bytes(down->fmt,I));
+        down->fmt,S,I,D,row_bytes(down->fmt,I),down->gs,down->ng);
     if (!cuda_ok(cudaGetLastError(),"expert MLP launch") ||
         !cuda_ok(cudaMemcpy(y,ctx->y,yb,cudaMemcpyDeviceToHost),"expert output download")) return 0;
     return 1;
@@ -596,6 +617,10 @@ extern "C" int coli_cuda_expert_group(ColiCudaTensor *const *gates,
         host[c]={g->weights,u->weights,d->weights,g->scales,u->scales,d->scales,
                  g->fmt,u->fmt,d->fmt,rows[c],total};
         all_s4&=g->fmt==2&&u->fmt==2&&d->fmt==2;
+        /* fmt=4 (grouped int4) experts have per-group scales that the grouped_hidden/
+         * grouped_down kernels don't handle. Fall back to the per-expert path
+         * (coli_cuda_expert_mlp), which uses quant_matmul with correct gs/ng. */
+        if(g->fmt==4||u->fmt==4||d->fmt==4) return 0;
         total+=rows[c]; if(rows[c]>max_rows) max_rows=rows[c];
     }
     DeviceContext *ctx=find_ctx(device); if(!select_ctx(ctx)) return 0;
@@ -658,12 +683,12 @@ extern "C" int coli_cuda_expert_group(ColiCudaTensor *const *gates,
                 /* piccoli batch: tile TC quasi vuoti + overhead di lancio — il
                  * kernel naive per-elemento resta piu' veloce (misurato in decode) */
                 quant_matmul<<<dim3((unsigned)I,(unsigned)r),256,0,ctx->stream>>>(g16,x16,
-                    host[c].g,host[c].gs,host[c].gf,r,D,I,row_bytes(host[c].gf,D));
+                    host[c].g,host[c].gs,host[c].gf,r,D,I,row_bytes(host[c].gf,D),0,1);
                 quant_matmul<<<dim3((unsigned)I,(unsigned)r),256,0,ctx->stream>>>(u16,x16,
-                    host[c].u,host[c].us,host[c].uf,r,D,I,row_bytes(host[c].uf,D));
+                    host[c].u,host[c].us,host[c].uf,r,D,I,row_bytes(host[c].uf,D),0,1);
                 silu_mul<<<(unsigned)(((size_t)r*I+255)/256),256,0,ctx->stream>>>(g16,u16,(size_t)r*I);
                 quant_matmul<<<dim3((unsigned)D,(unsigned)r),256,0,ctx->stream>>>(y16,g16,
-                    host[c].d,host[c].ds,host[c].df,r,I,D,row_bytes(host[c].df,I));
+                    host[c].d,host[c].ds,host[c].df,r,I,D,row_bytes(host[c].df,I),0,1);
             }
             off16+=r;
         }
@@ -749,7 +774,7 @@ static int attention_absorb_batch_run(ColiCudaTensor *w,ColiCudaTensor *proj,flo
     if(proj){
         ob=(size_t)S*proj->O*sizeof(float);if(!reserve(&dc->y,&dc->y_cap,ob))return 0;
         quant_matmul<<<dim3(proj->O,S),256,0,dc->stream>>>(dc->y,dc->ac,proj->weights,
-            proj->scales,proj->fmt,S,proj->I,proj->O,row_bytes(proj->fmt,proj->I));
+            proj->scales,proj->fmt,S,proj->I,proj->O,row_bytes(proj->fmt,proj->I),proj->gs,proj->ng);
         if(!cuda_ok(cudaGetLastError(),"attention o_proj launch"))return 0;src=dc->y;
     }
     if(!cuda_ok(cudaMemcpyAsync(out,src,ob,cudaMemcpyDeviceToHost,dc->stream),
@@ -775,7 +800,8 @@ extern "C" void coli_cuda_tensor_free(ColiCudaTensor *tensor) {
     DeviceContext *ctx = find_ctx(tensor->device);
     if (ctx) select_ctx(ctx);
     if (tensor->tracked && ctx) {
-        size_t bytes = tensor->weight_bytes + (tensor->fmt ? (size_t)tensor->O * sizeof(float) : 0);
+        int ng = tensor->ng > 0 ? tensor->ng : 1;
+        size_t bytes = tensor->weight_bytes + (tensor->fmt ? (size_t)tensor->O * ng * sizeof(float) : 0);
         if (ctx->tensor_count) ctx->tensor_count--;
         if (ctx->tensor_bytes >= bytes) ctx->tensor_bytes -= bytes;
     }
@@ -785,7 +811,9 @@ extern "C" void coli_cuda_tensor_free(ColiCudaTensor *tensor) {
 }
 
 extern "C" size_t coli_cuda_tensor_bytes(const ColiCudaTensor *tensor) {
-    return tensor ? tensor->weight_bytes + (tensor->fmt ? (size_t)tensor->O * sizeof(float) : 0) : 0;
+    if (!tensor) return 0;
+    int ng = tensor->ng > 0 ? tensor->ng : 1;
+    return tensor->weight_bytes + (tensor->fmt ? (size_t)tensor->O * ng * sizeof(float) : 0);
 }
 
 extern "C" int coli_cuda_tensor_device(const ColiCudaTensor *tensor) {
@@ -923,7 +951,7 @@ extern "C" int coli_cuda_attention_project_batch_dev(ColiCudaTensor *w,ColiCudaT
     size_t ob=(size_t)S*proj->O*sizeof(float);
     if(!reserve(&dc->y,&dc->y_cap,ob))return 0;
     quant_matmul<<<dim3(proj->O,S),256,0,dc->stream>>>(dc->y,dc->ac,proj->weights,
-        proj->scales,proj->fmt,S,proj->I,proj->O,row_bytes(proj->fmt,proj->I));
+        proj->scales,proj->fmt,S,proj->I,proj->O,row_bytes(proj->fmt,proj->I),proj->gs,proj->ng);
     if(!cuda_ok(cudaGetLastError(),"pipe o_proj launch"))return 0;
     if(!cuda_ok(cudaMemcpyAsync(out,dc->y,ob,cudaMemcpyDeviceToHost,dc->stream),"pipe attention download")||
        !cuda_ok(cudaStreamSynchronize(dc->stream),"pipe attention sync"))return 0;
@@ -954,7 +982,7 @@ extern "C" int coli_cuda_pipe_gemm(ColiCudaTensor *t,float *y_dev,const float *x
     DeviceContext *ctx=find_ctx(t->device); if(!select_ctx(ctx)) return 0;
     dim3 grid((unsigned)t->O,(unsigned)S);
     quant_matmul<<<grid,256>>>(y_dev,x_dev,t->weights,t->scales,t->fmt,S,t->I,t->O,
-        row_bytes(t->fmt,t->I));
+        row_bytes(t->fmt,t->I),t->gs,t->ng);
     return cuda_ok(cudaGetLastError(),"pipe gemm");
 }
 /* copia diretta scheda->scheda (P2P se disponibile, altrimenti staging driver) */
@@ -980,7 +1008,7 @@ extern "C" int coli_cuda_attention_project_batch_dev_out(ColiCudaTensor *w,ColiC
         rope_dev,w->weights,w->scales,w->fmt,S,H,Q,R,V,K,T,scale);
     if(!cuda_ok(cudaGetLastError(),"pipe attention launch (dev out)"))return 0;
     quant_matmul<<<dim3(proj->O,S),256,0,dc->stream>>>(out_dev,dc->ac,proj->weights,
-        proj->scales,proj->fmt,S,proj->I,proj->O,row_bytes(proj->fmt,proj->I));
+        proj->scales,proj->fmt,S,proj->I,proj->O,row_bytes(proj->fmt,proj->I),proj->gs,proj->ng);
     if(!cuda_ok(cudaGetLastError(),"pipe o_proj launch (dev out)"))return 0;
     return cuda_ok(cudaStreamSynchronize(dc->stream),"pipe attention sync (dev out)");
 }

--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -90,6 +90,18 @@ __device__ static float weight_at(const void *weights, int fmt, size_t row, int 
     return static_cast<float>(((v >> ((i & 3) * 2)) & 3) - 2);
 }
 
+/* Scale for output `row`, input element `k`. fmt=4 (grouped int4) stores ng
+ * scales per row at scales[row*ng + k/gs]; every other quantized format has
+ * one scale per row at scales[row]. Mirrors quant_matmul's fmt==4 branch so the
+ * attention absorb kernels apply per-group scales instead of the per-row
+ * (fmt=2) semantic that crashed #298's g64 kv_b. */
+__device__ static float absorb_scale(const float *wscale, int fmt, int gs, int ng, int row, int k) {
+    if (!fmt) return 1.f;
+    if (fmt != 4) return wscale[row];
+    int g = k / gs; if (g >= ng) g = ng - 1;   /* tail of the last (partial) group */
+    return wscale[(size_t)row * ng + g];
+}
+
 __global__ static void offset_to_signed_s4(uint8_t *q,size_t n){
     size_t i=(size_t)blockIdx.x*blockDim.x+threadIdx.x;if(i<n)q[i]^=0x88;
 }
@@ -304,11 +316,12 @@ __global__ static void grouped_down_w4(float *y,const float *x,const GroupDesc *
 
 __global__ static void attention_absorb_kernel(float *ctx,const float *q,const float *latent,
                                                 const float *rope,const void *weights,const float *wscale,
-                                                int fmt,int H,int Q,int R,int V,int K,int T,float scale){
+                                                int fmt,int H,int Q,int R,int V,int K,int T,float scale,
+                                                int gs,int ng){
     int h=blockIdx.x,tid=threadIdx.x,rbase=h*(Q+V);extern __shared__ float sm[];
     float *qa=sm,*cl=qa+K,*scores=cl+K;
     for(int k=tid;k<K;k+=blockDim.x){float a=0;for(int d=0;d<Q;d++)
-        a+=q[(size_t)h*(Q+R)+d]*weight_at(weights,fmt,(size_t)(rbase+d)*row_bytes(fmt,K),k)*(fmt?wscale[rbase+d]:1.f);qa[k]=a;}
+        a+=q[(size_t)h*(Q+R)+d]*weight_at(weights,fmt,(size_t)(rbase+d)*row_bytes(fmt,K),k)*absorb_scale(wscale,fmt,gs,ng,rbase+d,k);qa[k]=a;}
     __syncthreads();
     for(int t=tid;t<T;t+=blockDim.x){float a=0;const float *lt=latent+(size_t)t*K,*rt=rope+(size_t)t*R;
         for(int k=0;k<K;k++)a+=qa[k]*lt[k];for(int d=0;d<R;d++)a+=q[(size_t)h*(Q+R)+Q+d]*rt[d];scores[t]=a*scale;}
@@ -319,19 +332,20 @@ __global__ static void attention_absorb_kernel(float *ctx,const float *q,const f
     for(int k=tid;k<K;k+=blockDim.x){float a=0;for(int t=0;t<T;t++)a+=scores[t]*latent[(size_t)t*K+k];cl[k]=a;}
     __syncthreads();
     for(int v=tid;v<V;v+=blockDim.x){int row=rbase+Q+v;float a=0;size_t rb=row_bytes(fmt,K);
-        for(int k=0;k<K;k++)a+=cl[k]*weight_at(weights,fmt,(size_t)row*rb,k);ctx[(size_t)h*V+v]=a*(fmt?wscale[row]:1.f);}
+        for(int k=0;k<K;k++)a+=cl[k]*weight_at(weights,fmt,(size_t)row*rb,k)*absorb_scale(wscale,fmt,gs,ng,row,k);ctx[(size_t)h*V+v]=a;}
 }
 
 __global__ static void attention_absorb_batch_kernel(float *ctx,const float *q,
         const float *latent,const float *rope,const void *weights,const float *wscale,
-        int fmt,int S,int H,int Q,int R,int V,int K,int T,float scale){
+        int fmt,int S,int H,int Q,int R,int V,int K,int T,float scale,
+        int gs,int ng){
     int s=blockIdx.y,h=blockIdx.x,tid=threadIdx.x,nt=T-S+s+1,rbase=h*(Q+V);
     if(s>=S||nt<1)return;
     extern __shared__ float sm[];float *qa=sm,*cl=qa+K,*scores=cl+K,*red=scores+T;
     const float *qs=q+((size_t)s*H+h)*(Q+R);
     for(int k=tid;k<K;k+=blockDim.x){float a=0;for(int d=0;d<Q;d++)
         a+=qs[d]*weight_at(weights,fmt,(size_t)(rbase+d)*row_bytes(fmt,K),k)*
-          (fmt?wscale[rbase+d]:1.f);qa[k]=a;}
+          absorb_scale(wscale,fmt,gs,ng,rbase+d,k);qa[k]=a;}
     __syncthreads();
     for(int t=tid;t<nt;t+=blockDim.x){float a=0;const float *lt=latent+(size_t)t*K;
         const float *rt=rope+(size_t)t*R;for(int k=0;k<K;k++)a+=qa[k]*lt[k];
@@ -349,8 +363,8 @@ __global__ static void attention_absorb_batch_kernel(float *ctx,const float *q,
         a+=scores[t]*latent[(size_t)t*K+k];cl[k]=a;}
     __syncthreads();
     for(int v=tid;v<V;v+=blockDim.x){int row=rbase+Q+v;float a=0;size_t rb=row_bytes(fmt,K);
-        for(int k=0;k<K;k++)a+=cl[k]*weight_at(weights,fmt,(size_t)row*rb,k);
-        ctx[((size_t)s*H+h)*V+v]=a*(fmt?wscale[row]:1.f);}
+        for(int k=0;k<K;k++)a+=cl[k]*weight_at(weights,fmt,(size_t)row*rb,k)*absorb_scale(wscale,fmt,gs,ng,row,k);
+        ctx[((size_t)s*H+h)*V+v]=a;}
 }
 
 static int reserve(float **ptr, size_t *cap, size_t bytes) {
@@ -745,7 +759,7 @@ extern "C" int coli_cuda_attention_absorb(ColiCudaTensor *w,float *ctx,const flo
        !cuda_ok(cudaMemcpyAsync(dc->ar,rope,rb,cudaMemcpyHostToDevice,dc->stream),"attention rope upload"))return 0;
     size_t shared=(size_t)(2*K+T)*sizeof(float);
     attention_absorb_kernel<<<H,256,shared,dc->stream>>>(dc->ac,dc->aq,dc->al,dc->ar,w->weights,w->scales,
-        w->fmt,H,Q,R,V,K,T,scale);
+        w->fmt,H,Q,R,V,K,T,scale,w->gs,w->ng);
     if(!cuda_ok(cudaGetLastError(),"attention absorb launch")||
        !cuda_ok(cudaMemcpyAsync(ctx,dc->ac,cb,cudaMemcpyDeviceToHost,dc->stream),"attention context download")||
        !cuda_ok(cudaStreamSynchronize(dc->stream),"attention synchronize"))return 0;
@@ -768,7 +782,7 @@ static int attention_absorb_batch_run(ColiCudaTensor *w,ColiCudaTensor *proj,flo
        !cuda_ok(cudaMemcpyAsync(dc->ar,rope,rb,cudaMemcpyHostToDevice,dc->stream),"attention batch rope upload"))return 0;
     size_t shared=(size_t)(2*K+T+256)*sizeof(float);
     attention_absorb_batch_kernel<<<dim3(H,S),256,shared,dc->stream>>>(dc->ac,dc->aq,dc->al,
-        dc->ar,w->weights,w->scales,w->fmt,S,H,Q,R,V,K,T,scale);
+        dc->ar,w->weights,w->scales,w->fmt,S,H,Q,R,V,K,T,scale,w->gs,w->ng);
     if(!cuda_ok(cudaGetLastError(),"attention batch launch"))return 0;
     const float *src=dc->ac;size_t ob=cb;
     if(proj){
@@ -946,7 +960,7 @@ extern "C" int coli_cuda_attention_project_batch_dev(ColiCudaTensor *w,ColiCudaT
     if(!reserve(&dc->ac,&dc->ac_cap,cb))return 0;
     size_t shared=(size_t)(2*K+T+256)*sizeof(float);
     attention_absorb_batch_kernel<<<dim3(H,S),256,shared,dc->stream>>>(dc->ac,q_dev,latent_dev,
-        rope_dev,w->weights,w->scales,w->fmt,S,H,Q,R,V,K,T,scale);
+        rope_dev,w->weights,w->scales,w->fmt,S,H,Q,R,V,K,T,scale,w->gs,w->ng);
     if(!cuda_ok(cudaGetLastError(),"pipe attention launch"))return 0;
     size_t ob=(size_t)S*proj->O*sizeof(float);
     if(!reserve(&dc->y,&dc->y_cap,ob))return 0;
@@ -1005,7 +1019,7 @@ extern "C" int coli_cuda_attention_project_batch_dev_out(ColiCudaTensor *w,ColiC
     if(!reserve(&dc->ac,&dc->ac_cap,cb))return 0;
     size_t shared=(size_t)(2*K+T+256)*sizeof(float);
     attention_absorb_batch_kernel<<<dim3(H,S),256,shared,dc->stream>>>(dc->ac,q_dev,latent_dev,
-        rope_dev,w->weights,w->scales,w->fmt,S,H,Q,R,V,K,T,scale);
+        rope_dev,w->weights,w->scales,w->fmt,S,H,Q,R,V,K,T,scale,w->gs,w->ng);
     if(!cuda_ok(cudaGetLastError(),"pipe attention launch (dev out)"))return 0;
     quant_matmul<<<dim3(proj->O,S),256,0,dc->stream>>>(out_dev,dc->ac,proj->weights,
         proj->scales,proj->fmt,S,proj->I,proj->O,row_bytes(proj->fmt,proj->I),proj->gs,proj->ng);
@@ -1023,7 +1037,7 @@ extern "C" int coli_cuda_attention_absorb_batch_dev(ColiCudaTensor *w,float *ctx
     DeviceContext *dc=find_ctx(w->device);if(!select_ctx(dc))return 0;
     size_t shared=(size_t)(2*K+T+256)*sizeof(float);
     attention_absorb_batch_kernel<<<dim3(H,S),256,shared,dc->stream>>>(ctx_dev,q_dev,latent_dev,
-        rope_dev,w->weights,w->scales,w->fmt,S,H,Q,R,V,K,T,scale);
+        rope_dev,w->weights,w->scales,w->fmt,S,H,Q,R,V,K,T,scale,w->gs,w->ng);
     if(!cuda_ok(cudaGetLastError(),"pipe shard attention launch"))return 0;
     return cuda_ok(cudaStreamSynchronize(dc->stream),"pipe shard attention sync");
 }
@@ -1040,7 +1054,7 @@ extern "C" int coli_cuda_attention_absorb_kvdev(ColiCudaTensor *w,float *ctx,con
     if(!cuda_ok(cudaMemcpyAsync(dc->aq,q,qb,cudaMemcpyHostToDevice,dc->stream),"kvdev q upload"))return 0;
     size_t shared=(size_t)(2*K+T+256)*sizeof(float);
     attention_absorb_batch_kernel<<<dim3(H,1),256,shared,dc->stream>>>(dc->ac,dc->aq,latent_dev,
-        rope_dev,w->weights,w->scales,w->fmt,1,H,Q,R,V,K,T,scale);
+        rope_dev,w->weights,w->scales,w->fmt,1,H,Q,R,V,K,T,scale,w->gs,w->ng);
     if(!cuda_ok(cudaGetLastError(),"kvdev absorb launch")||
        !cuda_ok(cudaMemcpyAsync(ctx,dc->ac,cb,cudaMemcpyDeviceToHost,dc->stream),"kvdev ctx download")||
        !cuda_ok(cudaStreamSynchronize(dc->stream),"kvdev absorb sync"))return 0;

--- a/c/backend_cuda.h
+++ b/c/backend_cuda.h
@@ -34,21 +34,23 @@ COLI_CUDA_DLLEXPORT void coli_cuda_stats(int device, size_t *tensor_count, size_
 COLI_CUDA_DLLEXPORT void coli_cuda_group_stats(uint64_t *calls, uint64_t *experts, uint64_t *rows,
                            double *h2d_ms, double *kernel_ms, double *d2h_ms);
 
-/* Upload without executing, so capacity failures happen during model startup. */
+/* Upload without executing, so capacity failures happen during model startup.
+ * gs is the group size for fmt=4 (grouped int4); 0 for all other formats. */
 COLI_CUDA_DLLEXPORT int coli_cuda_tensor_upload(ColiCudaTensor **tensor,
                             const void *weights, const float *scales,
-                            int fmt, int I, int O, int device);
+                            int fmt, int I, int O, int device, int gs);
 
 /*
  * y[S,O] = x[S,I] @ W[O,I]^T.
- * fmt matches QT in glm.c: 0=f32, 1=int8, 2=int4, 3=int2.
- * The first successful call uploads W and its row scales; later calls reuse it.
+ * fmt matches QT in glm.c: 0=f32, 1=int8, 2=int4, 3=int2, 4=grouped int4.
+ * gs is the group size for fmt=4 (0 for all other formats).
+ * The first successful call uploads W and its scales; later calls reuse it.
  * Returns 1 on success and 0 when CUDA is not initialized or the format is invalid.
  */
 COLI_CUDA_DLLEXPORT int coli_cuda_matmul(ColiCudaTensor **tensor,
                      float *y, const float *x,
                      const void *weights, const float *scales,
-                     int fmt, int S, int I, int O, int device);
+                     int fmt, int S, int I, int O, int device, int gs);
 
 /* Fused expert pipeline: y = down(silu(gate(x)) * up(x)).  All three tensors
  * must already be resident on one device.  Activations cross PCIe once in

--- a/c/backend_loader.c
+++ b/c/backend_loader.c
@@ -45,10 +45,10 @@ typedef int            (*fn_attention_absorb)(ColiCudaTensor *kv_b, float *ctx, 
                                               const float *latent, const float *rope, int H, int Q,
                                               int R, int V, int K, int T, float attention_scale);
 typedef int            (*fn_tensor_upload)(ColiCudaTensor **tensor, const void *weights,
-                                           const float *scales, int fmt, int I, int O, int device);
+                                           const float *scales, int fmt, int I, int O, int device, int gs);
 typedef int            (*fn_matmul)(ColiCudaTensor **tensor, float *y, const float *x,
                                     const void *weights, const float *scales,
-                                    int fmt, int S, int I, int O, int device);
+                                    int fmt, int S, int I, int O, int device, int gs);
 typedef void           (*fn_tensor_free)(ColiCudaTensor *tensor);
 typedef size_t         (*fn_tensor_bytes)(const ColiCudaTensor *tensor);
 typedef int            (*fn_tensor_device)(const ColiCudaTensor *tensor);
@@ -291,16 +291,16 @@ int coli_cuda_attention_absorb(ColiCudaTensor *kv_b, float *ctx, const float *q,
 }
 
 int coli_cuda_tensor_upload(ColiCudaTensor **tensor, const void *weights,
-                            const float *scales, int fmt, int I, int O, int device){
+                            const float *scales, int fmt, int I, int O, int device, int gs){
     if(!g_cuda.available) return 0;
-    return g_cuda.tensor_upload(tensor, weights, scales, fmt, I, O, device);
+    return g_cuda.tensor_upload(tensor, weights, scales, fmt, I, O, device, gs);
 }
 
 int coli_cuda_matmul(ColiCudaTensor **tensor, float *y, const float *x,
                      const void *weights, const float *scales,
-                     int fmt, int S, int I, int O, int device){
+                     int fmt, int S, int I, int O, int device, int gs){
     if(!g_cuda.available) return 0;
-    return g_cuda.matmul(tensor, y, x, weights, scales, fmt, S, I, O, device);
+    return g_cuda.matmul(tensor, y, x, weights, scales, fmt, S, I, O, device, gs);
 }
 
 void coli_cuda_tensor_free(ColiCudaTensor *tensor){

--- a/c/coli
+++ b/c/coli
@@ -141,7 +141,18 @@ def need_model(model):
         sys.exit(f"{C.yel}engine is not built.{C.r} Run: coli build")
 
 def cuda_binary():
-    if not os.path.exists(GLM) or sys.platform != "linux": return False
+    if not os.path.exists(GLM): return False
+    if sys.platform != "linux":
+        # Windows: the engine links cudart only inside a runtime-loaded
+        # coli_cuda.dll (built with `make cuda-dll`; backend_loader.c loads it
+        # from the engine's own dir). There is no libcudart symbol in glm.exe
+        # and no `ldd`, so the Linux ldd/grep check below is meaningless here.
+        # Presence of coli_cuda.dll next to glm.exe is the faithful proxy: the
+        # engine loads exactly that file (backend_loader.c:149-155), so if it is
+        # there the build is CUDA-capable. Resolved next to GLM (not CWD) for the
+        # same DLL-hijacking reason the loader uses an absolute path.
+        dll = os.path.join(os.path.dirname(GLM), "coli_cuda.dll")
+        return os.path.exists(dll)
     try:
         linked=subprocess.run(["ldd",GLM],capture_output=True,text=True,timeout=3)
         return any("libcudart" in line and "not found" not in line
@@ -219,6 +230,43 @@ def env_for(a):
         gpu=f" · VRAM {format_bytes(vt['budget_bytes'])}" if has_cuda and vt["devices"] else " · CPU"
         print(f"  {C.dim}[PLAN] RAM {format_bytes(rt['budget_bytes'])} · cap {rt['cache_slots_per_layer']}/layer{gpu}{C.r}",file=sys.stderr)
     else:
+        # Windows: a bare `coli chat` (no --gpu/--vram/--auto-tier) used to ALWAYS
+        # run CPU-only, even on a CUDA build with a GPU present — cuda_binary()
+        # returned False on Windows (see above), and nothing set COLI_CUDA without
+        # an explicit flag. Now that detection works, auto-enable the GPU when one
+        # is detected so `coli chat` Just Works. Scoped to Windows: Linux already
+        # has working detection + the explicit-flag UX, and changing bare-chat
+        # semantics there is out of scope. Falls back to CPU with a warning if
+        # nvidia-smi is missing (discover_gpus can't size VRAM without it).
+        if (sys.platform == "win32" and a.gpu is None and not a.vram):
+            if cuda_binary():
+                from resource_plan import discover_gpus, build_plan, environment_for_plan, format_bytes
+                gpus = discover_gpus()
+                if gpus:
+                    e["COLI_CUDA"]="1"
+                    e.setdefault("COLI_GPUS", ",".join(str(g["index"]) for g in gpus))
+                    # Reuse the planner so the expert-tier VRAM budget is the real
+                    # free VRAM minus the 2 GB reserve — not a guess. Same machinery
+                    # as --auto-tier, just without requiring the user to pass it.
+                    ram,ctx,devices,vram_req = resource_request(a, e)
+                    try:
+                        plan=build_plan(a.model,ram,ctx,devices,vram_req,policy=a.policy)
+                        e.update(environment_for_plan(plan,e,cuda_enabled=True))
+                        vt=plan["tiers"]["vram"]
+                        names=",".join(g["name"].strip() for g in gpus)
+                        print(f"  {C.dim}[GPU] auto-enabled CUDA · {names} · "
+                              f"{format_bytes(vt['budget_bytes'])} expert tier{C.r}", file=sys.stderr)
+                    except (OSError,ValueError,json.JSONDecodeError) as error:
+                        # Plan failed (e.g. model dir unreadable): don't block the
+                        # run, just leave the unsized COLI_CUDA=1 and let the engine
+                        # pick its own budget. Engine handles a missing budget.
+                        print(f"  {C.yel}[GPU] auto-enable: could not size VRAM ({error}); "
+                              f"using engine default{C.r}", file=sys.stderr)
+                else:
+                    print(f"  {C.yel}[GPU] coli_cuda.dll present but nvidia-smi not found on PATH "
+                          f"(cannot size VRAM); running CPU-only. Add nvidia-smi to PATH or pass "
+                          f"--vram N to enable CUDA.{C.r}", file=sys.stderr)
+            # else: CPU build (no coli_cuda.dll) — stay silent, CPU is correct.
         # --gpu/--vram SENZA --auto-tier: prima venivano ignorati in silenzio e il run
         # partiva CPU-only senza alcun avviso — benchmark "GPU" pubblicati per errore (#121).
         if a.gpu is not None:

--- a/c/glm.c
+++ b/c/glm.c
@@ -237,7 +237,7 @@ static void qt_cuda_reset(QT *t){
 static int qt_cuda_upload(QT *t){
     const void *weights = t->fmt==0 ? (const void*)t->qf
                         : t->fmt==1 ? (const void*)t->q8 : (const void*)t->q4;
-    return coli_cuda_tensor_upload(&t->cuda,weights,t->s,t->fmt,t->I,t->O,t->cuda_device);
+    return coli_cuda_tensor_upload(&t->cuda,weights,t->s,t->fmt,t->I,t->O,t->cuda_device,t->gs);
 }
 static int qt_cuda_update(QT *t){
     const void *weights=t->fmt==0?(const void*)t->qf:
@@ -473,6 +473,62 @@ static void matmul_i4_grouped(float *y, const float *x, const uint8_t *q4, const
         }
     }
 }
+/* Fused gate+up for grouped int4 (fmt=4): computes both yg[S,O] and yu[S,O] from
+ * the same x[S,I], with per-group scales. One OpenMP dispatch covers both matrices,
+ * reading x once instead of twice — saves ~33% of expert-matmul time at decode.
+ * The per-group scale logic matches matmul_i4_grouped exactly. */
+static void matmul_i4_grouped_pair(float *yg, float *yu, const float *x,
+                                    const uint8_t *qg, const float *sg,
+                                    const uint8_t *qu, const float *su,
+                                    int S, int I, int O, int gs){
+    int rb=(I+1)/2; int ng=(I+gs-1)/gs;
+    #pragma omp parallel for schedule(static)
+    for(int o=0;o<O;o++){
+        const uint8_t *wg=qg+(int64_t)o*rb; const uint8_t *wu2=qu+(int64_t)o*rb;
+        const float *sgl=sg+(int64_t)o*ng;   const float *sul=su+(int64_t)o*ng;
+        for(int s=0;s<S;s++){
+            const float *xs=x+(int64_t)s*I;
+            float ag=0, au=0;
+            for(int g=0; g*gs<I; g++){
+                int base=g*gs; int glen=gs; if(base+glen>I) glen=I-base;
+                float scg=sgl[g], scu=sul[g];
+                int i=base;
+#ifdef __AVX2__
+                const __m128i m4=_mm_set1_epi8(0x0F); const __m256i b8=_mm256_set1_epi32(8);
+                __m256 accg=_mm256_setzero_ps(), accu=_mm256_setzero_ps();
+                for(; i+16<=base+glen; i+=16){
+                    __m128i byg=_mm_loadl_epi64((const __m128i*)(wg+(i>>1)));
+                    __m128i log=_mm_and_si128(byg,m4),hig=_mm_and_si128(_mm_srli_epi16(byg,4),m4);
+                    __m128i nibg=_mm_unpacklo_epi8(log,hig);
+                    __m256 w0g=_mm256_cvtepi32_ps(_mm256_sub_epi32(_mm256_cvtepu8_epi32(nibg),b8));
+                    __m256 w1g=_mm256_cvtepi32_ps(_mm256_sub_epi32(_mm256_cvtepu8_epi32(_mm_srli_si128(nibg,8)),b8));
+                    accg=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i),   w0g, accg);
+                    accg=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i+8), w1g, accg);
+                    __m128i byu=_mm_loadl_epi64((const __m128i*)(wu2+(i>>1)));
+                    __m128i lou=_mm_and_si128(byu,m4),hiu=_mm_and_si128(_mm_srli_epi16(byu,4),m4);
+                    __m128i nibu=_mm_unpacklo_epi8(lou,hiu);
+                    __m256 w0u=_mm256_cvtepi32_ps(_mm256_sub_epi32(_mm256_cvtepu8_epi32(nibu),b8));
+                    __m256 w1u=_mm256_cvtepi32_ps(_mm256_sub_epi32(_mm256_cvtepu8_epi32(_mm_srli_si128(nibu,8)),b8));
+                    accu=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i),   w0u, accu);
+                    accu=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i+8), w1u, accu);
+                }
+                ag+=hsum256(accg)*scg; au+=hsum256(accu)*scu;
+#endif
+                for(; i+1<base+glen; i+=2){
+                    uint8_t bg=wg[i>>1], bu=wu2[i>>1];
+                    ag+=(xs[i]*(float)((int)(bg&0xF)-8)+xs[i+1]*(float)((int)(bg>>4)-8))*scg;
+                    au+=(xs[i]*(float)((int)(bu&0xF)-8)+xs[i+1]*(float)((int)(bu>>4)-8))*scu;
+                }
+                if(i<base+glen){
+                    uint8_t bg=wg[i>>1], bu=wu2[i>>1];
+                    ag+=xs[i]*(float)((int)(bg&0xF)-8)*scg;
+                    au+=xs[i]*(float)((int)(bu&0xF)-8)*scu;
+                }
+            }
+            yg[(int64_t)s*O+o]=ag; yu[(int64_t)s*O+o]=au;
+        }
+    }
+}
 /* Decode hot path for gate+up: same exact q4 dot products as matmul_i4, but one
  * OpenMP dispatch covers both matrices. KTransformers uses persistent pools;
  * this keeps colibri dependency-free while removing one team launch/expert. */
@@ -545,6 +601,8 @@ static inline int spec_pinned(void){ return g_spec_pin && g_spec_live; }
 static void expert_gate_up(float *g,float *u,const float *x,QT *wg,QT *wu,int S){
     if(!g_no_fused_pair&&!spec_pinned()&&S==1&&wg->fmt==2&&wu->fmt==2&&wg->I==wu->I&&wg->O==wu->O)
         matmul_i4_pair(g,u,x,wg->q4,wg->s,wu->q4,wu->s,wg->I,wg->O);
+    else if(!g_no_fused_pair&&S==1&&wg->fmt==4&&wu->fmt==4&&wg->I==wu->I&&wg->O==wu->O&&wg->gs==wu->gs)
+        matmul_i4_grouped_pair(g,u,x,wg->q4,wg->s,wu->q4,wu->s,S,wg->I,wg->O,wg->gs);
     else { matmul_qt(g,x,wg,S); matmul_qt(u,x,wu,S); }
 }
 /* y[S,O] = x[S,I] @ W^T con W int2 impacchettato (4 valori/byte) + scala[O]. nibble 2-bit -> [-2,1]. */
@@ -1033,7 +1091,7 @@ static void matmul_qt_ex(float *y, const float *x, QT *w, int S, int allow_idot)
     if(g_cuda_enabled && w->cuda_eligible && !w->cuda_failed && !omp_in_parallel()){
         const void *weights = w->fmt==0 ? (const void*)w->qf
                             : w->fmt==1 ? (const void*)w->q8 : (const void*)w->q4;
-        if(coli_cuda_matmul(&w->cuda,y,x,weights,w->s,w->fmt,S,w->I,w->O,w->cuda_device)) return;
+        if(coli_cuda_matmul(&w->cuda,y,x,weights,w->s,w->fmt,S,w->I,w->O,w->cuda_device,w->gs)) return;
         w->cuda_failed=1;
         fprintf(stderr,"[CUDA] tensor [%d,%d] on device %d disabled after an error; falling back to CPU\n",
             w->O,w->I,w->cuda_device);
@@ -1490,13 +1548,14 @@ static void qt_cuda_colocate(QT *dst,const QT *src){
 }
 static void layer_cuda_shard_kvb(Layer *l,int H,int Q,int V){
     if(!g_cuda_enabled||!g_cuda_dense||g_cuda_ndev<2||l->kv_b.fmt==0)return;
-    int rb=l->kv_b.fmt==1?l->kv_b.I:(l->kv_b.fmt==2?(l->kv_b.I+1)/2:(l->kv_b.I+3)/4);
+    int rb=l->kv_b.fmt==1?l->kv_b.I:
+           (l->kv_b.fmt==2||l->kv_b.fmt==4)?(l->kv_b.I+1)/2:(l->kv_b.I+3)/4;
     const uint8_t *weights=l->kv_b.fmt==1?(const uint8_t*)l->kv_b.q8:l->kv_b.q4;
     for(int d=0,h0=0;d<g_cuda_ndev;d++){
         int hn=H/g_cuda_ndev+(d<H%g_cuda_ndev),rows=hn*(Q+V);
         const void *part=weights+(int64_t)h0*(Q+V)*rb;
         const float *scale=l->kv_b.s+(int64_t)h0*(Q+V);
-        if(!coli_cuda_tensor_upload(&l->kv_b_shard[d],part,scale,l->kv_b.fmt,l->kv_b.I,rows,g_cuda_devices[d]))return;
+        if(!coli_cuda_tensor_upload(&l->kv_b_shard[d],part,scale,l->kv_b.fmt,l->kv_b.I,rows,g_cuda_devices[d],l->kv_b.gs))return;
         l->shard_h0[d]=h0;l->shard_hn[d]=hn;l->n_kv_b_shard++;h0+=hn;
     }
     int old=-1;for(int i=0;i<g_cuda_ndev;i++)if(g_cuda_devices[i]==l->kv_b.cuda_device)old=i;
@@ -1668,6 +1727,14 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
 static void embed_row(Model *m, int tok, float *x){
     int D=m->c.hidden; QT *e=&m->embed;
     if(e->fmt==0){ memcpy(x, e->qf+(int64_t)tok*D, D*sizeof(float)); return; }
+    if(e->fmt==4){ /* grouped int4: per-group scale (embed/lm_head at io_bits, usually fmt 0/1) */
+        const uint8_t *q=e->q4+(int64_t)tok*((D+1)/2); int gs=e->gs,ng=(D+gs-1)/gs;
+        const float *scl=e->s+(int64_t)tok*ng;
+        for(int g=0;g*gs<D;g++){ int base=g*gs,glen=gs; if(base+glen>D)glen=D-base; float s=scl[g];
+            for(int i=base;i+1<base+glen;i+=2){ uint8_t byte=q[i>>1]; x[i]=(float)((int)(byte&0xF)-8)*s;
+                x[i+1]=(float)((int)(byte>>4)-8)*s; }
+            if(glen&1){ uint8_t byte=q[(base+glen-1)>>1]; x[base+glen-1]=(float)((int)(byte&0xF)-8)*s; } }
+        return; }
     if(e->fmt==1){ const int8_t *q=e->q8+(int64_t)tok*D; float s=e->s[tok];
         for(int i=0;i<D;i++) x[i]=(float)q[i]*s; return; }
     if(e->fmt==2){ const uint8_t *q=e->q4+(int64_t)tok*((D+1)/2); float s=e->s[tok];   /* int4 */
@@ -2281,6 +2348,13 @@ static void expert_prefetch(Model *m, int layer, int eid){
 static void qt_addrow(const QT *t, int row, float coef, float *acc){
     int I=t->I;
     if(t->fmt==0){ const float *w=t->qf+(int64_t)row*I; for(int i=0;i<I;i++) acc[i]+=coef*w[i]; return; }
+    if(t->fmt==4){ /* grouped int4: per-group f32 scale, layout scales[row*ng+g] */
+        const uint8_t *w=t->q4+(int64_t)row*((I+1)/2); int gs=t->gs,ng=(I+gs-1)/gs;
+        const float *scl=t->s+(int64_t)row*ng;
+        for(int g=0;g*gs<I;g++){ int base=g*gs,glen=gs; if(base+glen>I)glen=I-base; float c=coef*scl[g];
+            for(int i=base;i+1<base+glen;i+=2){ uint8_t b=w[i>>1]; acc[i]+=c*((int)(b&0xF)-8); acc[i+1]+=c*((int)(b>>4)-8); }
+            if(glen&1){ uint8_t b=w[(base+glen-1)>>1]; acc[base+glen-1]+=c*((int)(b&0xF)-8); } }
+        return; }
     float c=coef*t->s[row];
     if(t->fmt==1){ const int8_t *w=t->q8+(int64_t)row*I; for(int i=0;i<I;i++) acc[i]+=c*(float)w[i]; return; }
     if(t->fmt==2){ const uint8_t *w=t->q4+(int64_t)row*((I+1)/2);
@@ -2294,6 +2368,13 @@ static void qt_matvec_rows(const QT *t, int r0, int n, const float *x, float *y)
     int I=t->I;
     for(int j=0;j<n;j++){ int row=r0+j; double a=0;
         if(t->fmt==0){ const float *w=t->qf+(int64_t)row*I; for(int i=0;i<I;i++) a+=(double)w[i]*x[i]; }
+        else if(t->fmt==4){ /* grouped int4: per-group scale */
+            const uint8_t *w=t->q4+(int64_t)row*((I+1)/2); int gs=t->gs,ng=(I+gs-1)/gs;
+            const float *scl=t->s+(int64_t)row*ng;
+            for(int g=0;g*gs<I;g++){ int base=g*gs,glen=gs; if(base+glen>I)glen=I-base; float sc=scl[g]; float acc=0;
+                for(int i=base;i+1<base+glen;i+=2){ uint8_t b=w[i>>1]; acc+=((int)(b&0xF)-8)*x[i]+((int)(b>>4)-8)*x[i+1]; }
+                if(glen&1){ uint8_t b=w[(base+glen-1)>>1]; acc+=((int)(b&0xF)-8)*x[base+glen-1]; }
+                a+=acc*sc; } }
         else if(t->fmt==1){ const int8_t *w=t->q8+(int64_t)row*I; float s=t->s[row];
             float acc=0; for(int i=0;i<I;i++) acc+=(float)w[i]*x[i]; a=acc*s; }
         else if(t->fmt==2){ const uint8_t *w=t->q4+(int64_t)row*((I+1)/2); float s=t->s[row]; float acc=0;
@@ -4651,9 +4732,21 @@ static void run_text(Model *m, const char *snap, const char *prompt, int ngen){
     grammar_setup(&T);                   /* metodo F: GRAMMAR=file.gbnf (#48) */
     if(g_temp<0) g_temp=0.7f;            /* auto: 0.7, NON l'1.0 ufficiale — la coda della
                                           * distribuzione int4 e' rumore di quantizzazione */
-    int cap=(int)strlen(prompt)+16; int *pids=malloc(cap*sizeof(int));
+    int cap=(int)strlen(prompt)+16; int *pids=malloc((cap+2)*sizeof(int));
     int np=tok_encode(&T,prompt,(int)strlen(prompt),pids,cap);
     if(np<1){ fprintf(stderr,"prompt is empty after tokenization\n"); return; }
+    /* GLM prefix (#108): every GLM training sequence starts [gMASK]<sop>; without it the
+     * model is out-of-distribution and generates garbage. Serve/SCORE modes prepend it;
+     * run_text must too. CHAT_TEMPLATE=0 disables (raw prompt, for debugging/non-GLM).
+     * A prompt that already starts with the prefix passes through intact. */
+    int templ=getenv("CHAT_TEMPLATE")?atoi(getenv("CHAT_TEMPLATE")):1;
+    if(templ){
+        int gmask=tok_id_of(&T,"[gMASK]"), sop=tok_id_of(&T,"<sop>");
+        if(gmask>=0 && sop>=0 && (np<2 || pids[0]!=gmask || pids[1]!=sop)){
+            memmove(pids+2,pids,np*sizeof(int));
+            pids[0]=gmask; pids[1]=sop; np+=2;
+        }
+    }
     printf("prompt: %d tokens | generating up to %d (EOS stop=%d) | n-gram draft=%d\n", np, ngen, eos, g_draft);
     fputs(prompt,stdout); fflush(stdout);
     kv_alloc(m, np+ngen+g_draft+2);

--- a/c/glm.c
+++ b/c/glm.c
@@ -202,6 +202,7 @@ typedef struct {
                                                   * thread di compute; il servizio disco
                                                   * overlappato vive in g_edisk_ns) */
     double t_aproj,t_acore,t_aout;                     /* attention breakdown */
+    double t_rmsnorm,t_router,t_resadd,t_embed;        /* decode "other" breakdown (#292) */
     int64_t resident_bytes;
     /* DISK_SPLIT=1: split dei DISK LOAD (miss LRU -> expert_load) per contesto e per tipo
      * di layer. ld_ctx: 0=main/verify/prefill, 1=dentro mtp_draft, 2=dentro mtp_absorb. */
@@ -2796,6 +2797,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
         if(!rank_buf||!rank_w){ free(rank_buf); free(rank_w); rank_buf=NULL; rank_w=NULL; do_cache_route=0; }
     }
     /* ---- FASE A: routing di tutte le S posizioni ---- */
+    double trouter=now_s();
     int *idxs=malloc((size_t)S*K*sizeof(int)); float *ws=malloc((size_t)S*K*sizeof(float));
     int *keff=malloc(S*sizeof(int));
     /* router in UN matmul batch: stessa matematica, via le S chiamate S=1 */
@@ -2910,10 +2912,14 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                 m->route_kl_sum+=kl; m->route_kl_n++;
             }
         } else {
+            /* top-K via taken-flag: O(K×E) instead of O(K²×E) — the old version
+             * re-scanned idx[0..kk) for every expert e to check "already taken";
+             * a flag array makes that O(1). With K=8,E=256 that's 8× fewer
+             * comparisons in the selection loop (#292 "other" breakdown). */
+            char taken[256]; memset(taken,0,(size_t)E);   /* E<=256 */
             for(int kk=0;kk<Ksel;kk++){ int best=-1; float bv=-1e30f;
-                for(int e=0;e<E;e++){ int tk=0; for(int j=0;j<kk;j++) if(idx[j]==e){tk=1;break;}
-                    if(!tk && choice[e]>bv){bv=choice[e];best=e;} }
-                idx[kk]=best; w[kk]=logit[best];
+                for(int e=0;e<E;e++){ if(!taken[e] && choice[e]>bv){bv=choice[e];best=e;} }
+                idx[kk]=best; w[kk]=logit[best]; taken[best]=1;
             }
             if(g_route_agree){
                 m->route_agree_hit+=(uint64_t)Ksel;
@@ -2962,6 +2968,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
         }
     }
     m->enr[layer]=keff[S-1]; for(int kk=0;kk<keff[S-1];kk++) m->eroute[layer][kk]=idxs[(int64_t)(S-1)*K+kk];
+    m->t_router+=now_s()-trouter;
     /* ---- FASE B: union degli expert del batch ---- */
     int *uniq=malloc((size_t)E*sizeof(int)); int nu=0;
     unsigned char seen[E]; memset(seen,0,(size_t)E);
@@ -3813,17 +3820,25 @@ static void layer_forward_rows(Model *m, Layer *l, int li, float *x, int S, int 
         }
     }
 #endif
+    double tnorm=now_s();
     for(int s=0;s<S;s++) rmsnorm(nrm+(int64_t)s*D, x+(int64_t)s*D, l->in_ln, D, c->eps);
+    m->t_rmsnorm+=now_s()-tnorm;
     attention_rows(m,l,li,nrm,S,pos_base,kvs,positions,tmp);
+    double tres=now_s();
     for(int64_t j=0;j<(int64_t)S*D;j++) x[j]+=tmp[j];
+    m->t_resadd+=now_s()-tres;
     if(g_pilot && S<=8 && li+1<c->n_layers && m->L[li+1].sparse) pilot_prefetch(m,li+1,x,S);
     if(g_looka && S==1 && li+1<c->n_layers && m->L[li+1].sparse){
         la_predict(m,li+1,x,1);  /* baseline: stale-state PILOT */
         la_predict(m,li+1,x,2);  /* two-step: shared-expert-corrected prediction */
     }
+    tnorm=now_s();
     for(int s=0;s<S;s++) rmsnorm(nrm+(int64_t)s*D, x+(int64_t)s*D, l->post_ln, D, c->eps);
+    m->t_rmsnorm+=now_s()-tnorm;
     if(l->sparse) moe(m,l,li,nrm,S,tmp,1); else dense_mlp(l,nrm,S,D,c->dense_inter,tmp);
+    tres=now_s();
     for(int64_t j=0;j<(int64_t)S*D;j++) x[j]+=tmp[j];
+    m->t_resadd+=now_s()-tres;
 }
 static void layer_forward(Model *m, Layer *l, int li, float *x, int S, int pos_base, float *nrm, float *tmp){
     layer_forward_rows(m,l,li,x,S,pos_base,NULL,NULL,nrm,tmp);
@@ -3952,7 +3967,9 @@ static void mtp_absorb(Model *m, const int *next_ids, const float *x, int S, int
 static float *step(Model *m, const int *ids, int S, int pos_base){
     Cfg *c=&m->c; int D=c->hidden;
     float *x=falloc((int64_t)S*D);
+    double temb=now_s();
     for(int s=0;s<S;s++) embed_row(m, ids[s], x+(int64_t)s*D);
+    m->t_embed+=now_s()-temb;
     layers_forward(m,x,S,pos_base);
     if(m->hlast) memcpy(m->hlast, x+(int64_t)(S-1)*D, D*sizeof(float));
     if(m->has_mtp && S>=2 && g_draft>0) mtp_absorb(m, ids+1, x, S-1, pos_base);
@@ -3967,7 +3984,9 @@ static float *step(Model *m, const int *ids, int S, int pos_base){
 static float *step_all(Model *m, const int *ids, int S, int pos_base){
     Cfg *c=&m->c; int D=c->hidden;
     float *x=falloc((int64_t)S*D);
+    double temb=now_s();
     for(int s=0;s<S;s++) embed_row(m, ids[s], x+(int64_t)s*D);
+    m->t_embed+=now_s()-temb;
     layers_forward(m,x,S,pos_base);
     if(m->h_all) memcpy(m->h_all, x, (int64_t)S*D*sizeof(float));   /* hidden di TUTTE le pos (S<=64) */
     if(m->hlast) memcpy(m->hlast, x+(int64_t)(S-1)*D, D*sizeof(float));
@@ -4482,12 +4501,17 @@ static void generate(Model *m, const int *prompt, int np, int n_new, int *out){
 }
 
 static void profile_print(Model *m, double elapsed){
-    double accounted=m->t_ewait+m->t_emm+m->t_attn+m->t_head;
+    double accounted=edisk_s()+m->t_ewait+m->t_emm+m->t_attn+m->t_head;
+    double other=elapsed-accounted;
+    double other_tracked=m->t_rmsnorm+m->t_router+m->t_resadd+m->t_embed;
     printf("PROFILE: expert-disk %.3fs service / %.3fs wait | expert-matmul %.3fs | attention %.3fs "
            "(including kvb %.3fs) | lm_head %.3fs | other %.3fs\n",
-        edisk_s(),m->t_ewait,m->t_emm,m->t_attn,m->t_kvb,m->t_head,elapsed-accounted);
+        edisk_s(),m->t_ewait,m->t_emm,m->t_attn,m->t_kvb,m->t_head,other);
     printf("ATTENTION: projection/RoPE %.3fs | score-softmax-value %.3fs | output projection %.3fs\n",
         m->t_aproj,m->t_acore,m->t_aout);
+    if(other>0.001 || other_tracked>0.001)
+        printf("OTHER: rmsnorm %.3fs | router %.3fs | resadd %.3fs | embed %.3fs | untracked %.3fs\n",
+            m->t_rmsnorm,m->t_router,m->t_resadd,m->t_embed,other-other_tracked);
 #ifdef COLI_METAL
     if(g_metal_enabled){ uint64_t ok=0,fb=0,ex=0; double su=0,gp=0,sc=0;
         coli_metal_moe_counts(&ok,&fb,&ex); coli_metal_moe_times(&su,&gp,&sc);
@@ -4502,6 +4526,7 @@ static void profile_print(Model *m, double elapsed){
 static void profile_reset(Model *m){
     m->t_ewait=m->t_emm=m->t_attn=m->t_kvb=m->t_head=0;
     m->t_aproj=m->t_acore=m->t_aout=0;
+    m->t_rmsnorm=m->t_router=m->t_resadd=m->t_embed=0;
     atomic_store_explicit(&g_edisk_ns,0,memory_order_relaxed);
 }
 

--- a/c/glm.c
+++ b/c/glm.c
@@ -4595,7 +4595,7 @@ static void generate(Model *m, const int *prompt, int np, int n_new, int *out){
 }
 
 static void profile_print(Model *m, double elapsed){
-    double accounted=edisk_s()+m->t_emm+m->t_attn+m->t_head;
+    double accounted=m->t_ewait+m->t_emm+m->t_attn+m->t_head;
     double other=elapsed-accounted;
     double other_tracked=m->t_rmsnorm+m->t_router+m->t_resadd+m->t_embed;
     printf("PROFILE: expert-disk %.3fs service / %.3fs wait | expert-matmul %.3fs | attention %.3fs "

--- a/c/glm.c
+++ b/c/glm.c
@@ -2148,6 +2148,12 @@ static int g_pipe=0;      /* PIPE=1: async expert-load pipeline. Default ON for 
                            * the matmul. PIPE=0 opts back into the blocking serial path. */
 static int g_pipe_nw=8;   /* PIPE_WORKERS=n: I/O worker threads (disk-parallel reads) */
 static int g_uring=0;     /* URING=1: Linux io_uring load/completion backend; implies PIPE */
+static int g_batch_read=0;/* BATCH_READ=1: coalesce all layer-block misses into sorted preads.
+                           * Instead of N×expert_load (each 1-3 preads), resolve all miss
+                           * descriptors, sort by (fd,offset), issue one big pread per shard
+                           * run into a staging buffer, then memcpy into per-slot slabs.
+                           * Reduces ~550 preads/forward to ~76 (one per sparse layer).
+                           * Mutually exclusive with PIPE (batch_read supersedes it). */
 typedef struct {
     _Atomic uint64_t cur;                         /* (gen<<8)|index; gen main-only, index 0..njobs (≤64) */
     _Atomic int njobs;                            /* current batch job count */
@@ -6147,6 +6153,7 @@ int main(int argc, char **argv){
 #endif
         ;
     g_pipe_nw = getenv("PIPE_WORKERS")?atoi(getenv("PIPE_WORKERS")):8; /* I/O worker threads */
+    g_batch_read = getenv("BATCH_READ")?atoi(getenv("BATCH_READ")):0;  /* coalesced batch expert reads */
     if(g_pipe_nw<1) g_pipe_nw=1;
     g_direct = getenv("DIRECT")?atoi(getenv("DIRECT")):0;
     g_uring = getenv("URING")?atoi(getenv("URING")):0;

--- a/c/glm.c
+++ b/c/glm.c
@@ -203,6 +203,7 @@ typedef struct {
                                                   * overlappato vive in g_edisk_ns) */
     double t_aproj,t_acore,t_aout;                     /* attention breakdown */
     double t_rmsnorm,t_router,t_resadd,t_embed;        /* decode "other" breakdown (#292) */
+    double t_alloc,t_cache,t_pilot,t_dsa,t_moe_oh;     /* deeper "other" breakdown (#292) */
     int64_t resident_bytes;
     /* DISK_SPLIT=1: split dei DISK LOAD (miss LRU -> expert_load) per contesto e per tipo
      * di layer. ld_ctx: 0=main/verify/prefill, 1=dentro mtp_draft, 2=dentro mtp_absorb. */
@@ -2970,6 +2971,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
     m->enr[layer]=keff[S-1]; for(int kk=0;kk<keff[S-1];kk++) m->eroute[layer][kk]=idxs[(int64_t)(S-1)*K+kk];
     m->t_router+=now_s()-trouter;
     /* ---- FASE B: union degli expert del batch ---- */
+    double tmoe=now_s();
     int *uniq=malloc((size_t)E*sizeof(int)); int nu=0;
     unsigned char seen[E]; memset(seen,0,(size_t)E);
     for(int s=0;s<S;s++) for(int kk=0;kk<keff[s];kk++){
@@ -3056,9 +3058,11 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
     float *group_weight=group_enabled?malloc((size_t)64*S*sizeof(float)):NULL;
 #endif
     int shared_on_gpu=0; (void)shared_on_gpu;   /* set by the Metal path when Phase E was fused */
+    m->t_moe_oh+=now_s()-tmoe;                              /* Phase B union + allocs */
     for(int base=0;base<nu;base+=64){
         int nb = nu-base<64 ? nu-base : 64;
         ESlot *use[64]; int missk[64]; int qof[64]; int nmiss=0;
+        double tcache=now_s();
         for(int j=0;j<nb;j++){ int eid=uniq[base+j]; use[j]=NULL; qof[j]=-1;
             ESlot *P=m->pin[layer];
             for(int z=0;z<m->npin[layer];z++) if(P[z].eid==eid){ m->hits++; use[j]=&P[z]; break; }
@@ -3067,6 +3071,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
             if(!use[j]){ qof[j]=nmiss; use[j]=&m->ws[nmiss]; missk[nmiss++]=j; m->miss++;
                 if(g_disk_split){ if(m->ld_ctx==1) m->miss_draft++; else if(m->ld_ctx==2) m->miss_absorb++; } }
         }
+        m->t_cache+=now_s()-tcache;
         int metal_done=0;
 #ifdef COLI_METAL
         /* GPU/disk OVERLAP: submit the RESIDENT experts (pin/LRU hits, + shared expert on
@@ -3827,11 +3832,13 @@ static void layer_forward_rows(Model *m, Layer *l, int li, float *x, int S, int 
     double tres=now_s();
     for(int64_t j=0;j<(int64_t)S*D;j++) x[j]+=tmp[j];
     m->t_resadd+=now_s()-tres;
+    { double tp=now_s();
     if(g_pilot && S<=8 && li+1<c->n_layers && m->L[li+1].sparse) pilot_prefetch(m,li+1,x,S);
     if(g_looka && S==1 && li+1<c->n_layers && m->L[li+1].sparse){
         la_predict(m,li+1,x,1);  /* baseline: stale-state PILOT */
         la_predict(m,li+1,x,2);  /* two-step: shared-expert-corrected prediction */
     }
+    m->t_pilot+=now_s()-tp; }
     tnorm=now_s();
     for(int s=0;s<S;s++) rmsnorm(nrm+(int64_t)s*D, x+(int64_t)s*D, l->post_ln, D, c->eps);
     m->t_rmsnorm+=now_s()-tnorm;
@@ -4501,7 +4508,7 @@ static void generate(Model *m, const int *prompt, int np, int n_new, int *out){
 }
 
 static void profile_print(Model *m, double elapsed){
-    double accounted=edisk_s()+m->t_ewait+m->t_emm+m->t_attn+m->t_head;
+    double accounted=edisk_s()+m->t_emm+m->t_attn+m->t_head;
     double other=elapsed-accounted;
     double other_tracked=m->t_rmsnorm+m->t_router+m->t_resadd+m->t_embed;
     printf("PROFILE: expert-disk %.3fs service / %.3fs wait | expert-matmul %.3fs | attention %.3fs "
@@ -4509,9 +4516,14 @@ static void profile_print(Model *m, double elapsed){
         edisk_s(),m->t_ewait,m->t_emm,m->t_attn,m->t_kvb,m->t_head,other);
     printf("ATTENTION: projection/RoPE %.3fs | score-softmax-value %.3fs | output projection %.3fs\n",
         m->t_aproj,m->t_acore,m->t_aout);
-    if(other>0.001 || other_tracked>0.001)
-        printf("OTHER: rmsnorm %.3fs | router %.3fs | resadd %.3fs | embed %.3fs | untracked %.3fs\n",
-            m->t_rmsnorm,m->t_router,m->t_resadd,m->t_embed,other-other_tracked);
+    if(other>0.001 || other_tracked>0.001){
+        double other_tracked2=m->t_alloc+m->t_cache+m->t_pilot+m->t_dsa+m->t_moe_oh;
+        printf("OTHER: rmsnorm %.3fs | router %.3fs | resadd %.3fs | embed %.3fs | "
+               "alloc %.3fs | cache %.3fs | pilot %.3fs | dsa %.3fs | moe_oh %.3fs | untracked %.3fs\n",
+            m->t_rmsnorm,m->t_router,m->t_resadd,m->t_embed,
+            m->t_alloc,m->t_cache,m->t_pilot,m->t_dsa,m->t_moe_oh,
+            other-other_tracked-other_tracked2);
+    }
 #ifdef COLI_METAL
     if(g_metal_enabled){ uint64_t ok=0,fb=0,ex=0; double su=0,gp=0,sc=0;
         coli_metal_moe_counts(&ok,&fb,&ex); coli_metal_moe_times(&su,&gp,&sc);
@@ -4527,6 +4539,7 @@ static void profile_reset(Model *m){
     m->t_ewait=m->t_emm=m->t_attn=m->t_kvb=m->t_head=0;
     m->t_aproj=m->t_acore=m->t_aout=0;
     m->t_rmsnorm=m->t_router=m->t_resadd=m->t_embed=0;
+    m->t_alloc=m->t_cache=m->t_pilot=m->t_dsa=m->t_moe_oh=0;
     atomic_store_explicit(&g_edisk_ns,0,memory_order_relaxed);
 }
 

--- a/c/glm.c
+++ b/c/glm.c
@@ -1554,7 +1554,7 @@ static void layer_cuda_shard_kvb(Layer *l,int H,int Q,int V){
     for(int d=0,h0=0;d<g_cuda_ndev;d++){
         int hn=H/g_cuda_ndev+(d<H%g_cuda_ndev),rows=hn*(Q+V);
         const void *part=weights+(int64_t)h0*(Q+V)*rb;
-        const float *scale=l->kv_b.s+(int64_t)h0*(Q+V);
+        const float *scale=l->kv_b.s+(int64_t)h0*(Q+V)*(l->kv_b.gs>0?(l->kv_b.I+l->kv_b.gs-1)/l->kv_b.gs:1);
         if(!coli_cuda_tensor_upload(&l->kv_b_shard[d],part,scale,l->kv_b.fmt,l->kv_b.I,rows,g_cuda_devices[d],l->kv_b.gs))return;
         l->shard_h0[d]=h0;l->shard_hn[d]=hn;l->n_kv_b_shard++;h0+=hn;
     }

--- a/c/tests/bench_tensor_core.cu
+++ b/c/tests/bench_tensor_core.cu
@@ -30,9 +30,9 @@ int main(){
     for(int i=0;i<D;i++)ds[i]=0.006f+(i%7)*0.0002f;
     for(size_t i=0;i<x.size();i++)x[i]=std::sin((float)(i+1)*0.013f)*2.f;
     ColiCudaTensor *g=nullptr,*u=nullptr,*d=nullptr;
-    if(!coli_cuda_tensor_upload(&g,hidden.data(),hs.data(),2,D,I,device)||
-       !coli_cuda_tensor_upload(&u,hidden.data(),hs.data(),2,D,I,device)||
-       !coli_cuda_tensor_upload(&d,down.data(),ds.data(),2,I,D,device))return 2;
+    if(!coli_cuda_tensor_upload(&g,hidden.data(),hs.data(),2,D,I,device,0)||
+       !coli_cuda_tensor_upload(&u,hidden.data(),hs.data(),2,D,I,device,0)||
+       !coli_cuda_tensor_upload(&d,down.data(),ds.data(),2,I,D,device,0))return 2;
     for(int rows: {1,2,4,8}){
         double scalar=run(g,u,d,x.data(),a.data(),rows,3,0);
         double packed=run(g,u,d,x.data(),b.data(),rows,3,1);

--- a/c/tests/test_backend_cuda.cu
+++ b/c/tests/test_backend_cuda.cu
@@ -46,14 +46,14 @@ int main(int argc, char **argv) {
     const float s8[2] = {0.5f, 2.0f};
     const float want8[4] = {-5.0f, -60.0f, 1.5f, 10.0f};
     ColiCudaTensor *t8 = nullptr;
-    if (!coli_cuda_tensor_upload(&t8, q8, s8, 1, 4, 2, d0)) return 1;
-    if (coli_cuda_tensor_upload(&t8, q8, s8, 1, 5, 2, d0)) return 1;
-    if (ndev > 1 && coli_cuda_tensor_upload(&t8, q8, s8, 1, 4, 2, d1)) return 1;
-    if (!coli_cuda_matmul(&t8, got, x, q8, s8, 1, 2, 4, 2, d0) || !close_enough(got, want8, 4)) return 1;
+    if (!coli_cuda_tensor_upload(&t8, q8, s8, 1, 4, 2, d0, 0)) return 1;
+    if (coli_cuda_tensor_upload(&t8, q8, s8, 1, 5, 2, d0, 0)) return 1;
+    if (ndev > 1 && coli_cuda_tensor_upload(&t8, q8, s8, 1, 4, 2, d1, 0)) return 1;
+    if (!coli_cuda_matmul(&t8, got, x, q8, s8, 1, 2, 4, 2, d0, 0) || !close_enough(got, want8, 4)) return 1;
     const int8_t q8b[8]={-1,-2,-3,-4, 1,-2,3,-4};
     const float s8b[2]={1.f,.5f},want8b[4]={10.f,15.f,-3.f,-2.5f};
     if(!coli_cuda_tensor_update(t8,q8b,s8b)||
-       !coli_cuda_matmul(&t8,got,x,q8b,s8b,1,2,4,2,d0)||
+       !coli_cuda_matmul(&t8,got,x,q8b,s8b,1,2,4,2,d0,0)||
        !close_enough(got,want8b,4))return 1;
 
     /* Rows [-8,-1,0,7] and [1,2,3,4], packed low nibble first. */
@@ -61,26 +61,26 @@ int main(int argc, char **argv) {
     const float s4[2] = {1.0f, 0.25f};
     const float want4[2] = {-34.0f, -2.5f};
     ColiCudaTensor *t4 = nullptr;
-    if (!coli_cuda_matmul(&t4, got, x, q4, s4, 2, 1, 4, 2, d1) || !close_enough(got, want4, 2)) return 1;
+    if (!coli_cuda_matmul(&t4, got, x, q4, s4, 2, 1, 4, 2, d1, 0) || !close_enough(got, want4, 2)) return 1;
 
     const uint8_t q2[2] = {0xe4, 0x1b};
     const float s2[2] = {0.5f, 2.0f};
     const float want2[2] = {-2.0f, 12.0f};
     ColiCudaTensor *t2 = nullptr;
-    if (!coli_cuda_matmul(&t2, got, x, q2, s2, 3, 1, 4, 2, d1) || !close_enough(got, want2, 2)) return 1;
+    if (!coli_cuda_matmul(&t2, got, x, q2, s2, 3, 1, 4, 2, d1, 0) || !close_enough(got, want2, 2)) return 1;
 
     const float wf[8] = {1, 0, -1, 2, 0.5f, 0.5f, 0.5f, 0.5f};
     const float wantf[2] = {-10.0f, -1.0f};
     ColiCudaTensor *tf = nullptr;
-    if (!coli_cuda_matmul(&tf, got, x, wf, nullptr, 0, 1, 4, 2, d0) || !close_enough(got, wantf, 2)) return 1;
+    if (!coli_cuda_matmul(&tf, got, x, wf, nullptr, 0, 1, 4, 2, d0, 0) || !close_enough(got, wantf, 2)) return 1;
 
     const float eg[8] = {1,0,0,0, 0,1,0,0};
     const float eu[8] = {1,0,0,0, 0,1,0,0};
     const float ed[8] = {1,0, 0,1, 1,1, 1,-1};
     ColiCudaTensor *tg=nullptr,*tu=nullptr,*td=nullptr;
-    if (!coli_cuda_tensor_upload(&tg,eg,nullptr,0,4,2,d0) ||
-        !coli_cuda_tensor_upload(&tu,eu,nullptr,0,4,2,d0) ||
-        !coli_cuda_tensor_upload(&td,ed,nullptr,0,2,4,d0)) return 1;
+    if (!coli_cuda_tensor_upload(&tg,eg,nullptr,0,4,2,d0,0) ||
+        !coli_cuda_tensor_upload(&tu,eu,nullptr,0,4,2,d0,0) ||
+        !coli_cuda_tensor_upload(&td,ed,nullptr,0,2,4,d0,0)) return 1;
     float expert[8], want_expert[8];
     for(int s=0;s<2;s++){
         float a=x[s*4], b=x[s*4+1];
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
     const float aw[16]={1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
     const float aq[4]={1,2,.5f,-.5f},al[12]={1,0,0,0, 0,1,0,0, 0,0,1,0};
     const float ar[6]={1,0, 0,1, 1,1};float actx[2],aref[2];
-    ColiCudaTensor *at=nullptr;if(!coli_cuda_tensor_upload(&at,aw,nullptr,0,4,4,d0))return 1;
+    ColiCudaTensor *at=nullptr;if(!coli_cuda_tensor_upload(&at,aw,nullptr,0,4,4,d0,0))return 1;
     float score[3];for(int t=0;t<3;t++)score[t]=aq[0]*al[t*4]+aq[1]*al[t*4+1]+aq[2]*ar[t*2]+aq[3]*ar[t*2+1];
     float mx=score[0],z=0;for(int t=1;t<3;t++)mx=score[t]>mx?score[t]:mx;
     for(int t=0;t<3;t++){score[t]=std::exp(score[t]-mx);z+=score[t];}for(int t=0;t<3;t++)score[t]/=z;
@@ -117,9 +117,9 @@ int main(int argc, char **argv) {
     for(int i=0;i<32;i++)ws4[i]=0.01f+(i%5)*0.002f;
     for(int i=0;i<64;i++)gx4[i]=std::sin((float)(i+1)*0.17f)*2.f;
     ColiCudaTensor *g4=nullptr,*u4=nullptr,*d4=nullptr;
-    if(!coli_cuda_tensor_upload(&g4,w4,ws4,2,32,32,d0)||
-       !coli_cuda_tensor_upload(&u4,w4,ws4,2,32,32,d0)||
-       !coli_cuda_tensor_upload(&d4,w4,ws4,2,32,32,d0))return 1;
+    if(!coli_cuda_tensor_upload(&g4,w4,ws4,2,32,32,d0,0)||
+       !coli_cuda_tensor_upload(&u4,w4,ws4,2,32,32,d0,0)||
+       !coli_cuda_tensor_upload(&d4,w4,ws4,2,32,32,d0,0))return 1;
     ColiCudaTensor *gg4[2]={g4,g4},*ug4[2]={u4,u4},*dg4[2]={d4,d4};
     if(!coli_cuda_expert_group(gg4,ug4,dg4,group_rows,2,scalar4,gx4))return 1;
     setenv("COLI_CUDA_TC_INT4","1",1);

--- a/c/tests/test_env_defaults.py
+++ b/c/tests/test_env_defaults.py
@@ -32,9 +32,16 @@ def args(**over):
 
 
 class EnvDefaultsTest(unittest.TestCase):
-    def env_for_with(self, environ, platform):
+    def env_for_with(self, environ, platform, cuda=False):
+        """Run env_for on a bare-chat args() under a faked env + platform.
+
+        cuda=False by default so the existing default-I/O tests stay
+        deterministic: the Windows auto-enable branch calls cuda_binary() and
+        (if True) discover_gpus(), both of which reach the real machine — faking
+        False keeps these tests independent of the host's GPU."""
         with mock.patch.dict(os.environ, environ, clear=True), \
-             mock.patch.object(sys, "platform", platform):
+             mock.patch.object(sys, "platform", platform), \
+             mock.patch.object(coli, "cuda_binary", return_value=cuda):
             return coli.env_for(args())
 
     def test_win32_sets_measured_defaults(self):
@@ -62,6 +69,81 @@ class EnvDefaultsTest(unittest.TestCase):
         e = self.env_for_with({}, "linux")
         for k in ("DIRECT", "PIPE", "PILOT_REAL", "OMP_WAIT_POLICY"):
             self.assertNotIn(k, e)
+
+
+class CudaAutoEnableTest(unittest.TestCase):
+    """Windows bare `coli chat` (no --gpu/--vram/--auto-tier) used to ALWAYS run
+    CPU-only even on a CUDA build with a GPU present. env_for now auto-enables
+    CUDA on win32 when cuda_binary() is True and a GPU is discoverable; falls
+    back to CPU with a warning if nvidia-smi (discover_gpus) is missing; stays
+    silent on a CPU build; and never touches the Linux path."""
+
+    def _env_for(self, platform, cuda, gpus, plan=None):
+        # Patch discover_gpus / build_plan / environment_for_plan at the
+        # resource_plan module (env_for imports them lazily on each call, so the
+        # patches are live when those imports run). Stubbing the planner keeps
+        # the test independent of a real model dir (args().model == "X").
+        import resource_plan
+        a = args()
+        GPB = 1024 ** 3
+        if plan is None:
+            plan = {"tiers": {"ram": {"budget_bytes": 16 * GPB, "cache_slots_per_layer": 4},
+                              "vram": {"budget_bytes": int(8.0 * GPB), "devices": gpus}}}
+
+        def fake_environment_for_plan(p, env, cuda_enabled=True):
+            # Mirror the real contract: size CUDA_EXPERT_GB from the plan's VRAM
+            # budget (this is the value env_for propagates into the engine env).
+            r = dict(env)
+            if cuda_enabled and p["tiers"]["vram"]["devices"] and p["tiers"]["vram"]["budget_bytes"] > 0:
+                r["CUDA_EXPERT_GB"] = f"{p['tiers']['vram']['budget_bytes'] / GPB:.3f}"
+            return r
+
+        with mock.patch.dict(os.environ, {}, clear=True), \
+             mock.patch.object(sys, "platform", platform), \
+             mock.patch.object(coli, "cuda_binary", return_value=cuda), \
+             mock.patch.object(resource_plan, "discover_gpus", return_value=gpus), \
+             mock.patch.object(resource_plan, "build_plan", return_value=plan), \
+             mock.patch.object(resource_plan, "environment_for_plan",
+                               side_effect=fake_environment_for_plan):
+            return coli.env_for(a)
+
+    def _fake_gpu(self, index=0, name="NVIDIA GeForce RTX 5070 Ti",
+                  total_mib=16384, free_mib=15000):
+        return {"index": index, "name": name,
+                "total_bytes": total_mib * 1024 * 1024,
+                "free_bytes": free_mib * 1024 * 1024}
+
+    def test_win32_auto_enables_cuda_when_gpu_present(self):
+        e = self._env_for("win32", cuda=True, gpus=[self._fake_gpu()])
+        self.assertEqual(e["COLI_CUDA"], "1")
+        self.assertEqual(e["COLI_GPUS"], "0")
+        # VRAM budget is sized from free VRAM by build_plan (real minus reserve),
+        # so it must be present and positive — never a guess or zero.
+        self.assertIn("CUDA_EXPERT_GB", e)
+        self.assertGreater(float(e["CUDA_EXPERT_GB"]), 0.0)
+        # Dense offload is an explicit opt-in (matches --auto-tier): not set here.
+        self.assertNotIn("CUDA_DENSE", e)
+
+    def test_win32_falls_back_to_cpu_when_nvidia_smi_missing(self):
+        # coli_cuda.dll present (cuda=True) but nvidia-smi absent (no GPUs found)
+        # -> warn + CPU-only, never crash, never set COLI_CUDA.
+        e = self._env_for("win32", cuda=True, gpus=[])
+        self.assertNotIn("COLI_CUDA", e)
+        self.assertNotIn("COLI_GPUS", e)
+        self.assertNotIn("CUDA_EXPERT_GB", e)
+
+    def test_win32_cpu_build_stays_silent(self):
+        # No coli_cuda.dll (cuda=False) -> CPU build, nothing GPU-related emitted.
+        e = self._env_for("win32", cuda=False, gpus=[self._fake_gpu()])
+        self.assertNotIn("COLI_CUDA", e)
+        self.assertNotIn("COLI_GPUS", e)
+
+    def test_linux_bare_chat_not_auto_enabled(self):
+        # The auto-enable is scoped to win32: a Linux bare chat with a GPU
+        # present must NOT turn CUDA on (Linux keeps the explicit-flag UX).
+        e = self._env_for("linux", cuda=True, gpus=[self._fake_gpu()])
+        self.assertNotIn("COLI_CUDA", e)
+        self.assertNotIn("CUDA_EXPERT_GB", e)
 
 
 if __name__ == "__main__":

--- a/c/tests/test_pipe_cuda.cu
+++ b/c/tests/test_pipe_cuda.cu
@@ -119,7 +119,7 @@ int main(void){
         for(int i=0;i<O;i++) sc[i]=0.01f+0.001f*(i%7);
         for(size_t i=0;i<(size_t)S*K;i++) x[i]=rndf();
         ColiCudaTensor *t=NULL;
-        ok&=coli_cuda_matmul(&t,ref,x,w4,sc,2,S,K,O,0);   /* host path = reference */
+        ok&=coli_cuda_matmul(&t,ref,x,w4,sc,2,S,K,O,0,0);   /* host path = reference */
         float *xd=(float*)coli_cuda_pipe_alloc(0,(size_t)S*K*4);
         float *yd=(float*)coli_cuda_pipe_alloc(0,(size_t)S*O*4);
         ok&=coli_cuda_pipe_upload(0,xd,x,(size_t)S*K*4);

--- a/c/tools/diag_harness.py
+++ b/c/tools/diag_harness.py
@@ -1,0 +1,704 @@
+#!/usr/bin/env python3
+"""
+diag_harness.py — Comprehensive model diagnostic harness for the colibri GLM-5.2 engine.
+
+Runs a full campaign of tests against any model snapshot:
+  Phase 0 (system):     startup telemetry — GPU, RAM, cache cap, load time, MTP, idot kernel
+  Phase 1 (smoke):      correctness — curated prompts, coherence checks, corruption detection
+  Phase 2 (diagnostic): deep x-ray — full PROFILE breakdown, routing, MTP, disk-split, CUDA tier
+  Phase 3 (quality):    benchmark accuracy — hellaswag/arc_challenge/mmlu via eval_glm.py SCORE
+  Phase 4 (throughput): tok/s with and without MTP speculation
+  Phase 5 (report):     structured JSON + human-readable Markdown summary
+
+Usage:
+  python tools/diag_harness.py --snap /path/to/model --phase all
+  python tools/diag_harness.py --snap /path/to/model --phase smoke --ngen 64
+  python tools/diag_harness.py --snap /path/to/model --phase quality --quality-limit 200
+
+Output goes to --out (default ./diag_results/<timestamp>/).  Each phase writes a raw log
+(<phase>_<run>.log) and all metrics are collected into report.json + report.md.
+
+Design notes:
+  - stdout and stderr are captured separately via subprocess.PIPE.  The engine streams
+    generated text to stdout (interleaved with prompt + PROFILE stats), but TOKENS=1 dumps
+    clean token-id lists to stderr — that is the primary text-capture path.
+  - Every regex is anchored to the exact printf format strings in glm.c (verified against
+    profile_print line 3853, run_text line 3948, the banner line 5299, etc.).
+  - Subprocess calls have a hard timeout (default 600s) and are killed cleanly on expiry.
+  - A single phase can be run standalone; results accumulate in the output dir.
+"""
+import os, sys, re, json, time, argparse, subprocess, signal, traceback
+from datetime import datetime
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# PROMPT SUITE — curated across categories.  "expect" is a case-insensitive
+# substring checked against the generated text (None = coherence-only check).
+# ---------------------------------------------------------------------------
+PROMPTS = [
+    {"id":"fact_capital",  "cat":"factual",    "prompt":"The capital of France is",
+     "expect":"Paris",  "note":"basic world knowledge"},
+    {"id":"fact_boiling",  "cat":"factual",    "prompt":"What is the boiling point of water in Celsius?",
+     "expect":"100",    "note":"basic science"},
+    {"id":"fact_planet",   "cat":"factual",    "prompt":"What planet is closest to the Sun?",
+     "expect":"Mercury","note":"astronomy fact"},
+    {"id":"math_mult",     "cat":"math",       "prompt":"What is 15 times 12?",
+     "expect":"180",    "note":"2-digit multiplication"},
+    {"id":"math_add",      "cat":"math",       "prompt":"What is 847 plus 153?",
+     "expect":"1000",   "note":"3-digit addition"},
+    {"id":"reason_train",  "cat":"reasoning",  "prompt":"If a train travels 60 mph for 2.5 hours, how far does it go?",
+     "expect":"150",    "note":"rate-time-distance"},
+    {"id":"code_factorial","cat":"code",       "prompt":"Write a Python function that computes the factorial of a number.",
+     "expect":"def",    "note":"code generation"},
+    {"id":"explain_nn",    "cat":"explanation","prompt":"Explain what a neural network is in one sentence.",
+     "expect":None,     "note":"coherence check"},
+    {"id":"creative_story","cat":"creative",   "prompt":"Write a one-sentence story about a lighthouse.",
+     "expect":None,     "note":"creative coherence"},
+    {"id":"edge_hello",    "cat":"edge",       "prompt":"Hello, how are you today?",
+     "expect":None,     "note":"conversational opener"},
+    {"id":"edge_the",      "cat":"edge",       "prompt":"The weather today is",
+     "expect":None,     "note":"simple continuation"},
+    {"id":"edge_repeat",   "cat":"edge",       "prompt":"The quick brown fox jumps over the lazy dog. The quick brown fox",
+     "expect":None,     "note":"repetition-bait"},
+]
+
+# ---------------------------------------------------------------------------
+# METRIC EXTRACTION — each parser is (name, compiled_regex, group_index, cast).
+# Regexes match the EXACT printf format strings in glm.c.
+# ---------------------------------------------------------------------------
+def _f1(g): return float(g)
+def _i1(g): return int(g)
+
+# Build parsers as (regex, lambda(match)->value) for clarity
+RX = {
+    # stdout: run_text summary line (line 3948)
+    "decode_toks":   (re.compile(r"decode (\d+) tokens in"),              lambda m: int(m.group(1))),
+    "decode_secs":   (re.compile(r"decode \d+ tokens in ([\d.]+)s"),      lambda m: float(m.group(1))),
+    "decode_tps":    (re.compile(r"decode \d+ tokens in [\d.]+s \(([\d.]+) tok/s\)"), lambda m: float(m.group(1))),
+    "prefill_toks":  (re.compile(r"prefill (\d+) tokens in"),             lambda m: int(m.group(1))),
+    "prefill_secs":  (re.compile(r"prefill \d+ tokens in ([\d.]+)s"),     lambda m: float(m.group(1))),
+    "hit_rate":      (re.compile(r"expert hit rate ([\d.]+)%"),           lambda m: float(m.group(1))),
+    "rss_gb":        (re.compile(r"RSS ([\d.]+) GB"),                     lambda m: float(m.group(1))),
+    "experts_per_tok":(re.compile(r"experts loaded/token: ([\d.]+)"),     lambda m: float(m.group(1))),
+    "mtp_accept":    (re.compile(r"MTP acceptance ([\d.]+)%"),            lambda m: float(m.group(1))),
+    "mtp_acc_cnt":   (re.compile(r"MTP acceptance \d+% \((\d+)/(\d+)\)"), lambda m: (int(m.group(1)), int(m.group(2)))),
+    "spec_tok_per_fw":(re.compile(r"speculation: ([\d.]+) tokens/forward"),lambda m: float(m.group(1))),
+    # stdout: PROFILE lines (profile_print, line 3853-3864)
+    "prof_expert_disk":  (re.compile(r"expert-disk ([\d.]+)s service"),   lambda m: float(m.group(1))),
+    "prof_expert_wait":  (re.compile(r"service / ([\d.]+)s wait"),        lambda m: float(m.group(1))),
+    "prof_expert_mm":    (re.compile(r"expert-matmul ([\d.]+)s"),         lambda m: float(m.group(1))),
+    "prof_attention":    (re.compile(r"\| attention ([\d.]+)s"),          lambda m: float(m.group(1))),
+    "prof_kvb":          (re.compile(r"including kvb ([\d.]+)s"),         lambda m: float(m.group(1))),
+    "prof_lm_head":      (re.compile(r"lm_head ([\d.]+)s"),               lambda m: float(m.group(1))),
+    "prof_other":        (re.compile(r"\| other ([\d.]+)s"),              lambda m: float(m.group(1))),
+    # stdout: banner (line 5299)
+    "load_secs":     (re.compile(r"loaded in ([\d.]+)s"),                 lambda m: float(m.group(1))),
+    "resident_mb":   (re.compile(r"resident dense: ([\d.]+) MB"),         lambda m: float(m.group(1))),
+    "mtp_status":    (re.compile(r"MTP (ACTIVE|absent)"),                 lambda m: m.group(1)),
+    "n_layers":      (re.compile(r"layers=(\d+) experts=(\d+)"),          lambda m: int(m.group(1))),
+    "n_experts":     (re.compile(r"layers=(\d+) experts=(\d+)"),          lambda m: int(m.group(2))),
+    # stdout: banner idot kernel
+    "idot_kernel":   (re.compile(r"idot: (\S+) =="),                      lambda m: m.group(1)),
+    "cache_cap":     (re.compile(r"cache=(\d+) experts/layer"),           lambda m: int(m.group(1))),
+    # stderr: RAM_GB (line 5086-5112)
+    "ram_budget":    (re.compile(r"\[RAM_GB=([\d.]+)"),                   lambda m: float(m.group(1))),
+    "cap_lowered":   (re.compile(r"cap lowered (\d+)->(\d+)"),            lambda m: (int(m.group(1)), int(m.group(2)))),
+    "cap_raised":    (re.compile(r"cap raised (\d+)->(\d+)"),             lambda m: (int(m.group(1)), int(m.group(2)))),
+    "cap_ok":        (re.compile(r"cap=(\d+) ok"),                        lambda m: int(m.group(1))),
+    # stderr: CUDA (backend_cuda.cu:389)
+    "cuda_device":   (re.compile(r"\[CUDA\] device (\d+): (.*?), ([\d.]+) GB VRAM, sm_(\d)(\d)"),
+                      lambda m: {"id":int(m.group(1)),"name":m.group(2).strip(),"vram_gb":float(m.group(3)),
+                                 "sm":f"{m.group(4)}.{m.group(5)}"}),
+    "cuda_mode":     (re.compile(r"\[CUDA\] mode: (.+)"),                 lambda m: m.group(1)),
+    "cuda_tier":     (re.compile(r"CUDA expert tier: (\d+) resident experts \(([\d.]+) GB\)"),
+                      lambda m: {"resident":int(m.group(1)),"vram_gb":float(m.group(2))}),
+    # stderr: TOKENS dump (line 4010-4012)
+    "tokens_dump":   (re.compile(r"^\[TOKENS\] (\d+) generated:(.*)$", re.MULTILINE),
+                      lambda m: [int(x) for x in m.group(2).split()]),
+    # stderr: per-16-token progress (emit_stream line 3742)
+    "progress_tps":  (re.compile(r"t=(\d+)\s+RSS ([\d.]+) GB\s+hit ([\d.]+)%\s+([\d.]+) tok/s\s+([\d.]+) tok/fw"),
+                      lambda m: {"tok":int(m.group(1)),"rss":float(m.group(2)),"hit":float(m.group(3)),
+                                 "tps":float(m.group(4)),"tpf":float(m.group(5))}),
+    # stderr: DSA, USAGE, KV startup lines
+    "usage_loaded":  (re.compile(r"\[USAGE\].*?(\d+) selections"),        lambda m: int(m.group(1))),
+    "kv_slots":      (re.compile(r"\[KV\].*?(\d+) context slots"),        lambda m: int(m.group(1))),
+}
+
+def extract_metrics(stdout: str, stderr: str) -> dict:
+    """Parse all metrics from the engine's stdout+stderr output."""
+    text_out = stdout or ""
+    text_err = stderr or ""
+    metrics = {}
+    # For most parsers we search BOTH streams (engine is inconsistent about which
+    # channel a given line lands on).  Some are stream-specific (noted below).
+    combined = text_out + "\n" + text_err
+    for name, (rx, fn) in RX.items():
+        m = rx.search(combined)
+        if m:
+            try: metrics[name] = fn(m)
+            except (ValueError, IndexError): pass
+    # TOKENS dump is stderr-only and may appear once; grab it explicitly
+    m = RX["tokens_dump"][0].search(text_err)
+    if m:
+        try: metrics["tokens_dump"] = RX["tokens_dump"][1](m)
+        except: pass
+    # Multiple CUDA devices — collect all
+    cuda_devs = []
+    for m in re.finditer(r"\[CUDA\] device (\d+): (.*?), ([\d.]+) GB VRAM, sm_(\d)(\d)", text_err):
+        cuda_devs.append({"id":int(m.group(1)),"name":m.group(2).strip(),
+                          "vram_gb":float(m.group(3)),"sm":f"{m.group(4)}.{m.group(5)}"})
+    if cuda_devs: metrics["cuda_devices"] = cuda_devs
+    # Multiple progress checkpoints — collect the full curve
+    progress = []
+    for m in RX["progress_tps"][0].finditer(text_err):
+        try:
+            progress.append(RX["progress_tps"][1](m))
+        except: pass
+    if progress: metrics["progress_curve"] = progress
+    # Multiple PROFILE lines — there are two (prefill + decode).  Keep both.
+    prof_lines = [(i, line) for i, line in enumerate(text_out.splitlines()) if line.startswith("PROFILE:")]
+    for idx, (line_no, line) in enumerate(prof_lines):
+        label = "prefill_profile" if idx == 0 else "decode_profile"
+        p = {}
+        for pname, (rx, fn) in RX.items():
+            if not pname.startswith("prof_"): continue
+            mm = rx.search(line)
+            if mm:
+                try: p[pname] = fn(mm)
+                except: pass
+        if p: metrics[label] = p
+    return metrics
+
+
+# ---------------------------------------------------------------------------
+# ENGINE RUNNER — subprocess wrapper with timeout, signal handling, logging.
+# ---------------------------------------------------------------------------
+class EngineRunner:
+    def __init__(self, glm_path, snap, out_dir, default_env=None, timeout=600):
+        self.glm = str(glm_path)
+        self.snap = str(snap)
+        self.out_dir = Path(out_dir)
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+        self.default_env = default_env or {}
+        self.timeout = timeout
+        self.default_cap = 75  # production default (matches bench_full.sh)
+
+    def run_prompt(self, prompt, ngen=64, env_extra=None, log_name=None, cap=None):
+        """Run the engine in PROMPT mode and return (stdout, stderr, returncode, elapsed)."""
+        env = dict(os.environ, SNAP=self.snap, PROMPT=prompt, NGEN=str(ngen))
+        env.update(self.default_env)
+        if env_extra: env.update(env_extra)
+        env["TOKENS"] = "1"   # always capture token ids for reliable text extraction
+        cmd = [self.glm, str(cap if cap is not None else self.default_cap)]
+        return self._exec(cmd, env, log_name)
+
+    def run_score(self, score_file, cap=None, env_extra=None, log_name=None):
+        """Run the engine in SCORE (log-likelihood) mode."""
+        env = dict(os.environ, SNAP=self.snap, SCORE=score_file)
+        env.update(self.default_env)
+        if env_extra: env.update(env_extra)
+        cmd = [self.glm, str(cap if cap is not None else self.default_cap)]
+        return self._exec(cmd, env, log_name)
+
+    def _exec(self, cmd, env, log_name):
+        t0 = time.time()
+        log_path = self.out_dir / (log_name or f"run_{int(t0)}.log")
+        try:
+            proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                    text=True, encoding="utf-8", errors="replace")
+            try:
+                stdout, stderr = proc.communicate(timeout=self.timeout)
+                rc = proc.returncode
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                stdout, stderr = proc.communicate()
+                rc = -1
+                stderr = (stderr or "") + f"\n[TIMEOUT after {self.timeout}s]\n"
+        except Exception as e:
+            stdout, stderr, rc = "", f"[EXCEPTION] {e}\n{traceback.format_exc()}", -2
+        elapsed = time.time() - t0
+        # Write raw log (both streams, clearly delimited)
+        with open(log_path, "w", encoding="utf-8") as f:
+            f.write(f"=== CMD: {' '.join(cmd)}\n=== ELAPSED: {elapsed:.1f}s\n=== RC: {rc}\n\n")
+            f.write("--- STDOUT ---\n"); f.write(stdout or ""); f.write("\n")
+            f.write("--- STDERR ---\n"); f.write(stderr or ""); f.write("\n")
+        return stdout or "", stderr or "", rc, elapsed
+
+
+# ---------------------------------------------------------------------------
+# TEXT RECOVERY — decode the [TOKENS] ids back to text using the tokenizer.
+# Falls back to stdout extraction if tokenizer/tokens unavailable.
+# ---------------------------------------------------------------------------
+def recover_text(stdout, stderr, prompt, tokenizer=None):
+    """Extract generated text.  Primary: TOKENS dump decoded.  Fallback: stdout parse."""
+    # Method 1: decode TOKENS ids via tokenizer
+    if tokenizer:
+        m = re.search(r"^\[TOKENS\] \d+ generated:(.*)$", stderr, re.MULTILINE)
+        if m:
+            ids = [int(x) for x in m.group(1).split()]
+            if ids:
+                try:
+                    return tokenizer.decode(ids), "tokens"
+                except Exception: pass
+    # Method 2: stdout — text is between the prompt string and "PROFILO" or "\n---"
+    text = stdout or ""
+    # Find the prompt in stdout, take everything after it up to PROFILO
+    idx = text.find(prompt)
+    if idx >= 0:
+        after = text[idx + len(prompt):]
+        cut = after.find("PROFILO")
+        if cut >= 0:
+            return after[:cut].strip(), "stdout"
+        cut = after.find("\n---")
+        if cut >= 0:
+            return after[:cut].strip(), "stdout"
+    return "", "none"
+
+
+# ---------------------------------------------------------------------------
+# CORRUPTION / COHERENCE CHECKS
+# ---------------------------------------------------------------------------
+def check_repetition(token_ids):
+    """Detect degenerate repetition: same token 3+ consecutive times."""
+    if not token_ids or len(token_ids) < 6:
+        return False, 0
+    max_run = 1; cur = 1
+    for i in range(1, len(token_ids)):
+        if token_ids[i] == token_ids[i-1]: cur += 1; max_run = max(max_run, cur)
+        else: cur = 1
+    return max_run >= 3, max_run
+
+def check_expected(text, expect):
+    """Check if expected substring appears case-insensitively in the first 200 chars."""
+    if not expect or not text: return None
+    return expect.lower() in text[:200].lower()
+
+
+# ---------------------------------------------------------------------------
+# PHASES
+# ---------------------------------------------------------------------------
+class DiagnosticHarness:
+    def __init__(self, args):
+        self.args = args
+        self.snap = args.snap
+        self.glm = args.glm
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.out_dir = Path(args.out or f"./diag_results/{ts}")
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+        # Base env for all runs
+        base_env = {"TEMP": "0", "PIPE": "1", "PIPE_WORKERS": "8", "DIRECT": "1"}
+        if args.ram: base_env["RAM_GB"] = str(args.ram)
+        if args.cuda:
+            base_env.update({
+                "COLI_CUDA": "1",
+                "COLI_GPU": str(args.gpu) if args.gpu is not None else "0",
+                "CUDA_DENSE": "1",
+                "COLI_CUDA_ATTN": "1",
+                "COLI_CUDA_PIPE": "2",
+                "COLI_CUDA_PIPE_S_MIN": "1",
+            })
+        self.runner = EngineRunner(self.glm, self.snap, self.out_dir, base_env, timeout=args.timeout)
+        self.runner.default_cap = args.cap
+        # Load tokenizer for text recovery
+        self.tokenizer = None
+        tok_path = os.path.join(self.snap, "tokenizer.json")
+        if os.path.exists(tok_path):
+            try:
+                from tokenizers import Tokenizer
+                self.tokenizer = Tokenizer.from_file(tok_path)
+            except Exception as e:
+                print(f"[warn] could not load tokenizer: {e}", file=sys.stderr)
+        self.results = {"meta": {"snap": self.snap, "glm": self.glm,
+                                 "timestamp": ts, "args": vars(args)},
+                        "phases": {}}
+
+    def phase_system(self):
+        """Phase 0: minimal run to capture startup telemetry."""
+        print("\n" + "="*60 + "\nPHASE 0: SYSTEM PROBE\n" + "="*60)
+        stdout, stderr, rc, elapsed = self.runner.run_prompt(
+            "Hello", ngen=1, log_name="system_probe.log")
+        metrics = extract_metrics(stdout, stderr)
+        result = {
+            "rc": rc, "elapsed": elapsed,
+            "load_secs": metrics.get("load_secs"),
+            "resident_mb": metrics.get("resident_mb"),
+            "n_layers": metrics.get("n_layers"),
+            "n_experts": metrics.get("n_experts"),
+            "mtp_status": metrics.get("mtp_status"),
+            "idot_kernel": metrics.get("idot_kernel"),
+            "cache_cap_requested": metrics.get("cache_cap"),
+            "ram_budget_gb": metrics.get("ram_budget"),
+            "cap_lowered": metrics.get("cap_lowered"),
+            "cap_raised": metrics.get("cap_raised"),
+            "cap_final": metrics.get("cap_ok"),
+            "cuda_devices": metrics.get("cuda_devices", []),
+            "cuda_mode": metrics.get("cuda_mode"),
+        }
+        # Print summary
+        print(f"  load time:    {result['load_secs']:.2f}s" if result['load_secs'] else "  load time:    FAILED")
+        print(f"  resident:     {result['resident_mb']:.0f} MB" if result['resident_mb'] else "")
+        print(f"  layers/exp:   {result['n_layers']}/{result['n_experts']}" if result['n_layers'] else "")
+        print(f"  MTP:          {result['mtp_status']}")
+        print(f"  idot kernel:  {result['idot_kernel']}")
+        print(f"  RAM budget:   {result['ram_budget_gb']} GB" if result['ram_budget_gb'] else "  RAM budget:   auto")
+        if result['cap_lowered']:
+            print(f"  cache cap:    {result['cap_lowered'][0]} -> {result['cap_lowered'][1]} (RAM-lowered)")
+        elif result['cap_final']:
+            print(f"  cache cap:    {result['cap_final']} (ok)")
+        else:
+            print(f"  cache cap:    {result['cache_cap_requested']}")
+        for d in result['cuda_devices']:
+            print(f"  GPU {d['id']}:       {d['name']}, {d['vram_gb']:.1f} GB, sm_{d['sm']}")
+        if rc != 0 and rc != -1:
+            print(f"  WARNING: engine returned rc={rc}")
+        self.results["phases"]["system"] = result
+        return result
+
+    def phase_smoke(self):
+        """Phase 1: correctness smoke test across curated prompts."""
+        print("\n" + "="*60 + "\nPHASE 1: CORRECTNESS SMOKE TEST\n" + "="*60)
+        ngen = self.args.ngen
+        prompt_results = []
+        pass_count = 0; total = len(PROMPTS)
+        for p in PROMPTS:
+            stdout, stderr, rc, elapsed = self.runner.run_prompt(
+                p["prompt"], ngen=ngen, log_name=f"smoke_{p['id']}.log")
+            metrics = extract_metrics(stdout, stderr)
+            token_ids = metrics.get("tokens_dump", [])
+            text, method = recover_text(stdout, stderr, p["prompt"], self.tokenizer)
+            is_rep, max_run = check_repetition(token_ids)
+            expect_ok = check_expected(text, p.get("expect"))
+            # Verdict: pass if text is non-empty, no severe repetition, and (if factual) expected found
+            has_text = bool(text.strip())
+            ok = has_text and not is_rep
+            if p.get("expect") and expect_ok is False: ok = False
+            if ok: pass_count += 1
+            # Diagnose failure mode for reporting
+            if not has_text:
+                fail_reason = "no tokens generated (immediate EOS)"
+            elif is_rep:
+                fail_reason = f"repetition loop (max run={max_run})"
+            elif p.get("expect") and expect_ok is False:
+                fail_reason = f"expected '{p['expect']}' not found"
+            else:
+                fail_reason = ""
+            prompt_results.append({
+                "id": p["id"], "cat": p["cat"], "prompt": p["prompt"],
+                "expect": p.get("expect"), "generated": text[:300],
+                "expect_match": expect_ok, "repetition": is_rep, "max_run": max_run,
+                "toks_generated": len(token_ids), "decode_tps": metrics.get("decode_tps"),
+                "hit_rate": metrics.get("hit_rate"), "rc": rc, "elapsed": elapsed,
+                "text_method": method, "pass": ok, "fail_reason": fail_reason,
+            })
+            status = "PASS" if ok else "FAIL"
+            extra = f" expect={'Y' if expect_ok else ('N' if expect_ok is False else '-')}" if p.get("expect") else ""
+            tps = f" {metrics.get('decode_tps',0):.2f}t/s" if metrics.get("decode_tps") else ""
+            print(f"  [{status}] {p['id']:<22} ({p['cat']:<11}) rep={'Y' if is_rep else 'N'}{extra}{tps}")
+            if text:
+                preview = text.replace("\n", " ")[:80]
+                print(f"         -> {preview}")
+            elif rc != 0:
+                print(f"         -> [engine rc={rc}]")
+            else:
+                print(f"         -> [{fail_reason}]")
+        result = {"prompts": prompt_results, "pass": pass_count, "total": total,
+                  "pass_rate": 100.0 * pass_count / total if total else 0}
+        print(f"\n  SMOKE SUMMARY: {pass_count}/{total} passed ({result['pass_rate']:.0f}%)")
+        self.results["phases"]["smoke"] = result
+        return result
+
+    def phase_diagnostic(self):
+        """Phase 2: single deep-instrumented run — full PROFILE + routing + MTP."""
+        print("\n" + "="*60 + "\nPHASE 2: FULL SYSTEM DIAGNOSTIC\n" + "="*60)
+        diag_env = {
+            "LOOKA": "1", "DISK_SPLIT": "1", "ROUTE_AGREE": "1",
+        }
+        if self.args.cuda:
+            diag_env["COLI_CUDA_PROFILE"] = "1"
+        prompt = ("Write a short paragraph explaining how photosynthesis works. "
+                  "Include the roles of sunlight, water, and carbon dioxide.")
+        stdout, stderr, rc, elapsed = self.runner.run_prompt(
+            prompt, ngen=self.args.ngen, env_extra=diag_env, log_name="diagnostic.log")
+        metrics = extract_metrics(stdout, stderr)
+        text, _ = recover_text(stdout, stderr, prompt, self.tokenizer)
+        result = {
+            "rc": rc, "elapsed": elapsed,
+            "generated_text": text[:500],
+            "prefill_profile": metrics.get("prefill_profile", {}),
+            "decode_profile": metrics.get("decode_profile", {}),
+            "decode_tps": metrics.get("decode_tps"),
+            "prefill_secs": metrics.get("prefill_secs"),
+            "hit_rate": metrics.get("hit_rate"),
+            "rss_gb": metrics.get("rss_gb"),
+            "experts_per_tok": metrics.get("experts_per_tok"),
+            "mtp_accept": metrics.get("mtp_accept"),
+            "mtp_counts": metrics.get("mtp_acc_cnt"),
+            "spec_tok_per_fw": metrics.get("spec_tok_per_fw"),
+            "cuda_tier": metrics.get("cuda_tier"),
+            "progress_curve": metrics.get("progress_curve", []),
+        }
+        # Print the PROFILE breakdown
+        dp = result["decode_profile"]
+        print(f"\n  DECODE TIMING BREAKDOWN (per-bucket, seconds):")
+        print(f"    expert-disk:    {dp.get('prof_expert_disk', '?'):>8}")
+        print(f"    expert-matmul:  {dp.get('prof_expert_mm', '?'):>8}")
+        print(f"    attention:      {dp.get('prof_attention', '?'):>8}")
+        print(f"    lm_head:        {dp.get('prof_lm_head', '?'):>8}")
+        print(f"    other:          {dp.get('prof_other', '?'):>8}")
+        print(f"\n  PERFORMANCE:")
+        print(f"    prefill:   {result['prefill_secs']:.2f}s" if result['prefill_secs'] else "    prefill:   ?")
+        print(f"    decode:    {result['decode_tps']:.3f} tok/s" if result['decode_tps'] else "    decode:    ?")
+        print(f"    hit rate:  {result['hit_rate']:.1f}%" if result.get('hit_rate') is not None else "    hit rate:  ?")
+        print(f"    RSS:       {result['rss_gb']:.1f} GB" if result.get('rss_gb') else "    RSS:       ?")
+        print(f"    exp/tok:   {result['experts_per_tok']:.1f}" if result.get('experts_per_tok') else "    exp/tok:   ?")
+        print(f"    MTP:       {result['mtp_accept']:.0f}% accept" if result.get('mtp_accept') is not None else "    MTP:       ?")
+        if result.get('cuda_tier'):
+            ct = result['cuda_tier']
+            print(f"    CUDA tier: {ct['resident']} experts, {ct['vram_gb']:.1f} GB VRAM")
+        # Show generated text preview
+        if text:
+            print(f"\n  GENERATED TEXT (first 200 chars):")
+            print(f"    {text[:200].replace(chr(10), ' ')}")
+        else:
+            print(f"\n  GENERATED TEXT: [none recovered]")
+        self.results["phases"]["diagnostic"] = result
+        return result
+
+    def phase_quality(self):
+        """Phase 3: benchmark accuracy via eval_glm.py SCORE mode."""
+        print("\n" + "="*60 + "\nPHASE 3: QUALITY BENCHMARKS\n" + "="*60)
+        eval_script = os.path.join(os.path.dirname(__file__), "eval_glm.py")
+        bench_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "bench")
+        if not os.path.exists(eval_script):
+            print(f"  [SKIP] eval_glm.py not found at {eval_script}")
+            self.results["phases"]["quality"] = {"error": "eval_glm.py not found"}
+            return None
+        tasks = ["hellaswag", "arc_challenge", "mmlu"]
+        missing = [t for t in tasks if not os.path.exists(os.path.join(bench_dir, f"{t}.jsonl"))]
+        if missing:
+            print(f"  [SKIP] benchmark data missing: {missing}")
+            print(f"         run: python tools/fetch_benchmarks.py --out {bench_dir}")
+            self.results["phases"]["quality"] = {"error": f"missing benchmark data: {missing}"}
+            return None
+        limit = self.args.quality_limit
+        py = sys.executable
+        cmd = [py, eval_script, "--snap", self.snap, "--glm", self.glm,
+               "--data", bench_dir, "--tasks", ",".join(tasks), "--limit", str(limit)]
+        env = dict(os.environ)
+        if self.args.ram: env["RAM_GB"] = str(self.args.ram)
+        print(f"  Running eval_glm.py (tasks={tasks}, n={limit})...")
+        print(f"  This takes ~{limit*3*4/0.05:.0f}s at 0.05 tok/s (worst case)...")
+        t0 = time.time()
+        log_path = self.out_dir / "quality_eval.log"
+        try:
+            with open(log_path, "w", encoding="utf-8") as logf:
+                proc = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=self.args.timeout*3,
+                                      encoding="utf-8", errors="replace")
+                logf.write(proc.stdout); logf.write("\n--- STDERR ---\n"); logf.write(proc.stderr)
+            elapsed = time.time() - t0
+            # Parse the acc/acc_norm table from eval_glm.py output
+            scores = {}
+            for line in proc.stdout.splitlines():
+                # lines like: "hellaswag           40   45.0%     50.0%"
+                m = re.match(r"(\w+)\s+(\d+)\s+([\d.]+)%\s+([\d.]+)%", line.strip())
+                if m:
+                    scores[m.group(1)] = {"n": int(m.group(2)), "acc": float(m.group(3)),
+                                          "acc_norm": float(m.group(4))}
+            mean_m = re.search(r"MEAN acc_norm:\s*([\d.]+)%", proc.stdout)
+            result = {"scores": scores, "mean_acc_norm": float(mean_m.group(1)) if mean_m else None,
+                      "elapsed": elapsed, "rc": proc.returncode}
+            print(f"  Completed in {elapsed:.0f}s\n")
+            print(f"  {'task':<18} {'n':>4} {'acc':>7} {'acc_norm':>9}")
+            for t, s in scores.items():
+                print(f"  {t:<18} {s['n']:>4} {s['acc']:>6.1f}% {s['acc_norm']:>8.1f}%")
+            if result["mean_acc_norm"] is not None:
+                print(f"\n  MEAN acc_norm: {result['mean_acc_norm']:.1f}%")
+        except subprocess.TimeoutExpired:
+            result = {"error": f"eval timed out after {self.args.timeout*3}s"}
+            print(f"  [TIMEOUT] eval_glm.py exceeded {self.args.timeout*3}s")
+        except Exception as e:
+            result = {"error": str(e)}
+            print(f"  [ERROR] {e}")
+        self.results["phases"]["quality"] = result
+        return result
+
+    def phase_throughput(self):
+        """Phase 4: tok/s comparison — MTP on vs off."""
+        print("\n" + "="*60 + "\nPHASE 4: THROUGHPUT BENCHMARK\n" + "="*60)
+        prompt = "Summarize the plot of Romeo and Juliet in three sentences."
+        ngen = self.args.ngen
+        results = {}
+        # Run 1: with MTP (default)
+        print(f"  [1/2] MTP ON  (draft=3)...")
+        stdout, stderr, rc, t = self.runner.run_prompt(
+            prompt, ngen=ngen, log_name="throughput_mtp_on.log")
+        m_on = extract_metrics(stdout, stderr)
+        results["mtp_on"] = {"tps": m_on.get("decode_tps"), "hit": m_on.get("hit_rate"),
+                             "mtp_accept": m_on.get("mtp_accept"), "elapsed": t}
+        print(f"       {m_on.get('decode_tps',0):.3f} tok/s | hit {m_on.get('hit_rate',0):.1f}% | "
+              f"MTP {m_on.get('mtp_accept',0):.0f}%")
+        # Run 2: MTP off
+        print(f"  [2/2] MTP OFF (MTP=0)...")
+        stdout, stderr, rc, t = self.runner.run_prompt(
+            prompt, ngen=ngen, env_extra={"MTP": "0"}, log_name="throughput_mtp_off.log")
+        m_off = extract_metrics(stdout, stderr)
+        results["mtp_off"] = {"tps": m_off.get("decode_tps"), "hit": m_off.get("hit_rate"),
+                              "elapsed": t}
+        print(f"       {m_off.get('decode_tps',0):.3f} tok/s | hit {m_off.get('hit_rate',0):.1f}%")
+        # Compute speedup
+        if results["mtp_on"]["tps"] and results["mtp_off"]["tps"] and results["mtp_off"]["tps"] > 0:
+            sp = results["mtp_on"]["tps"] / results["mtp_off"]["tps"]
+            results["mtp_speedup"] = sp
+            print(f"\n  MTP speedup: {sp:.2f}x ({'MTP helps' if sp > 1.05 else 'MTP hurts' if sp < 0.95 else 'no effect'})")
+        else:
+            print(f"\n  MTP speedup: (insufficient data)")
+        self.results["phases"]["throughput"] = results
+        return results
+
+    def write_report(self):
+        """Write report.json and report.md."""
+        ts = self.results["meta"]["timestamp"]
+        json_path = self.out_dir / "report.json"
+        md_path = self.out_dir / "report.md"
+        # JSON
+        with open(json_path, "w", encoding="utf-8") as f:
+            json.dump(self.results, f, indent=2, default=str)
+        # Markdown
+        lines = [
+            f"# Diagnostic Report — {ts}",
+            f"",
+            f"**Model:** `{self.snap}`",
+            f"**Engine:** `{self.glm}`",
+            f"**Date:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+            f"",
+        ]
+        phases = self.results["phases"]
+        # System
+        if "system" in phases:
+            s = phases["system"]
+            lines += ["## Phase 0: System Probe", ""]
+            lines += [f"- Load time: **{s.get('load_secs','?')}s**"]
+            lines += [f"- Layers/experts: {s.get('n_layers','?')}/{s.get('n_experts','?')}"]
+            lines += [f"- MTP: {s.get('mtp_status','?')}"]
+            lines += [f"- idot kernel: `{s.get('idot_kernel','?')}`"]
+            lines += [f"- RAM budget: {s.get('ram_budget_gb','auto')} GB"]
+            if s.get("cap_lowered"):
+                lines += [f"- Cache cap: {s['cap_lowered'][0]}→{s['cap_lowered'][1]} (RAM-lowered)"]
+            elif s.get("cap_final"):
+                lines += [f"- Cache cap: {s['cap_final']}"]
+            for d in s.get("cuda_devices", []):
+                lines += [f"- GPU {d['id']}: {d['name']}, {d['vram_gb']:.1f} GB, sm_{d['sm']}"]
+            lines.append("")
+        # Smoke
+        if "smoke" in phases:
+            sm = phases["smoke"]
+            lines += [f"## Phase 1: Correctness Smoke", "",
+                      f"**{sm['pass']}/{sm['total']} prompts passed ({sm['pass_rate']:.0f}%)**", "",
+                      "| ID | Category | Pass | Expect | Repetition | tok/s | Generated (first 80 chars) |",
+                      "|---|---|---|---|---|---|---|"]
+            for p in sm["prompts"]:
+                gen = p["generated"][:80].replace("|", "\\|").replace("\n", " ") if p["generated"] else ""
+                exp = "Y" if p.get("expect_match") else ("N" if p.get("expect_match") is False else "-")
+                tps = f"{p.get('decode_tps',0):.2f}" if p.get("decode_tps") else "-"
+                lines.append(f"| {p['id']} | {p['cat']} | {'✅' if p['pass'] else '❌'} | {exp} | "
+                             f"{'⚠️' if p['repetition'] else '-'} (run={p.get('max_run',0)}) | {tps} | {gen} |")
+            lines.append("")
+        # Diagnostic
+        if "diagnostic" in phases:
+            d = phases["diagnostic"]
+            lines += ["## Phase 2: Full System Diagnostic", ""]
+            dp = d.get("decode_profile", {})
+            lines += ["### Decode Timing Breakdown", "",
+                      "| Bucket | Seconds |", "|---|---|"]
+            for k, label in [("prof_expert_disk","expert-disk"),("prof_expert_mm","expert-matmul"),
+                             ("prof_attention","attention"),("prof_lm_head","lm_head"),
+                             ("prof_other","other")]:
+                v = dp.get(k, "?")
+                lines.append(f"| {label} | {v} |")
+            lines += [f"", f"### Performance", f"- Decode: **{d.get('decode_tps','?')} tok/s**",
+                      f"- Prefill: {d.get('prefill_secs','?')}s",
+                      f"- Expert hit rate: {d.get('hit_rate','?')}%",
+                      f"- RSS: {d.get('rss_gb','?')} GB",
+                      f"- Experts/token: {d.get('experts_per_tok','?')}",
+                      f"- MTP acceptance: {d.get('mtp_accept','?')}%", ""]
+            if d.get("generated_text"):
+                lines += [f"### Generated Text", f"```\n{d['generated_text'][:300]}\n```", ""]
+        # Quality
+        if "quality" in phases:
+            q = phases["quality"]
+            lines += ["## Phase 3: Quality Benchmarks", ""]
+            if "error" in q:
+                lines += [f"⚠️ {q['error']}", ""]
+            else:
+                lines += [f"**Mean acc_norm: {q.get('mean_acc_norm','?')}%**", "",
+                          "| Task | n | acc | acc_norm |", "|---|---|---|---|"]
+                for t, s in q.get("scores", {}).items():
+                    lines.append(f"| {t} | {s['n']} | {s['acc']:.1f}% | {s['acc_norm']:.1f}% |")
+                lines.append("")
+        # Throughput
+        if "throughput" in phases:
+            th = phases["throughput"]
+            lines += ["## Phase 4: Throughput", "",
+                      "| Mode | tok/s | hit% | MTP accept |", "|---|---|---|---|"]
+            on = th.get("mtp_on", {}); off = th.get("mtp_off", {})
+            lines.append(f"| MTP ON | {on.get('tps','?')} | {on.get('hit','?')}% | {on.get('mtp_accept','?')}% |")
+            lines.append(f"| MTP OFF | {off.get('tps','?')} | {off.get('hit','?')}% | — |")
+            if th.get("mtp_speedup"):
+                lines.append(f"\n**MTP speedup: {th['mtp_speedup']:.2f}x**")
+            lines.append("")
+        with open(md_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+        print(f"\n{'='*60}")
+        print(f"Report written:")
+        print(f"  JSON: {json_path}")
+        print(f"  MD:   {md_path}")
+        print(f"  Logs: {self.out_dir}/*.log")
+        print(f"{'='*60}")
+
+    def run(self):
+        phase = self.args.phase
+        if phase == "all":
+            self.phase_system()
+            self.phase_smoke()
+            self.phase_diagnostic()
+            self.phase_quality()
+            self.phase_throughput()
+        elif phase == "system":     self.phase_system()
+        elif phase == "smoke":       self.phase_smoke()
+        elif phase == "diagnostic":  self.phase_diagnostic()
+        elif phase == "quality":     self.phase_quality()
+        elif phase == "throughput":  self.phase_throughput()
+        else:
+            print(f"Unknown phase: {phase}", file=sys.stderr); sys.exit(1)
+        self.write_report()
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Comprehensive model diagnostic harness for colibri GLM-5.2")
+    ap.add_argument("--snap", required=True, help="model snapshot directory")
+    ap.add_argument("--glm", default=None, help="engine binary path (default: ./glm.exe or ./glm)")
+    ap.add_argument("--phase", default="all",
+                    choices=["all","system","smoke","diagnostic","quality","throughput"],
+                    help="which test phase to run")
+    ap.add_argument("--out", default=None, help="output directory (default: ./diag_results/<timestamp>)")
+    ap.add_argument("--ngen", type=int, default=64, help="generation length for smoke/throughput (default 64)")
+    ap.add_argument("--quality-limit", type=int, default=40, help="questions per benchmark task (default 40)")
+    ap.add_argument("--ram", type=float, default=0, help="RAM_GB override (0=auto)")
+    ap.add_argument("--cuda", action="store_true", help="enable COLI_CUDA GPU tier")
+    ap.add_argument("--gpu", type=int, default=None, help="GPU device ordinal (with --cuda)")
+    ap.add_argument("--cap", type=int, default=75, help="experts-per-layer cache cap (default 75)")
+    ap.add_argument("--timeout", type=int, default=600, help="per-run timeout in seconds (default 600)")
+    a = ap.parse_args()
+    # Auto-detect engine binary
+    if a.glm is None:
+        for cand in ["./glm.exe", "./glm", "../glm.exe", os.path.join(os.path.dirname(__file__), "..", "glm.exe")]:
+            if os.path.exists(cand): a.glm = os.path.abspath(cand); break
+        if a.glm is None:
+            print("ERROR: could not find glm/glm.exe. Specify with --glm", file=sys.stderr); sys.exit(1)
+    if not os.path.isdir(a.snap):
+        print(f"ERROR: snapshot dir does not exist: {a.snap}", file=sys.stderr); sys.exit(1)
+    harness = DiagnosticHarness(a)
+    harness.run()
+
+if __name__ == "__main__":
+    main()

--- a/c/tools/diag_harness.py
+++ b/c/tools/diag_harness.py
@@ -285,9 +285,13 @@ class DiagnosticHarness:
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")
         self.out_dir = Path(args.out or f"./diag_results/{ts}")
         self.out_dir.mkdir(parents=True, exist_ok=True)
-        # Base env for all runs
+        # Base env for all runs — production optimization stack (1.08 tok/s on g64)
         base_env = {"TEMP": "0", "PIPE": "1", "PIPE_WORKERS": "8", "DIRECT": "1"}
+        if not args.no_optimize:
+            base_env.update({"CACHE_ROUTE": "1", "ROUTE_J": "2", "ROUTE_M": "12",
+                             "EXPERT_BUDGET": "4"})
         if args.ram: base_env["RAM_GB"] = str(args.ram)
+        else: base_env["RAM_GB"] = "28"   # default: use available RAM aggressively
         if args.cuda:
             base_env.update({
                 "COLI_CUDA": "1",
@@ -296,6 +300,7 @@ class DiagnosticHarness:
                 "COLI_CUDA_ATTN": "1",
                 "COLI_CUDA_PIPE": "2",
                 "COLI_CUDA_PIPE_S_MIN": "1",
+                "COLI_CUDA_MTP": "1",
             })
         self.runner = EngineRunner(self.glm, self.snap, self.out_dir, base_env, timeout=args.timeout)
         self.runner.default_cap = args.cap
@@ -683,8 +688,10 @@ def main():
     ap.add_argument("--out", default=None, help="output directory (default: ./diag_results/<timestamp>)")
     ap.add_argument("--ngen", type=int, default=64, help="generation length for smoke/throughput (default 64)")
     ap.add_argument("--quality-limit", type=int, default=40, help="questions per benchmark task (default 40)")
-    ap.add_argument("--ram", type=float, default=0, help="RAM_GB override (0=auto)")
-    ap.add_argument("--cuda", action="store_true", help="enable COLI_CUDA GPU tier")
+    ap.add_argument("--ram", type=float, default=0, help="RAM_GB override (0=default 28GB aggressive)")
+    ap.add_argument("--cuda", action="store_true", help="enable COLI_CUDA GPU tier + full optimization stack")
+    ap.add_argument("--no-optimize", action="store_true",
+                    help="disable CACHE_ROUTE/EXPERT_BUDGET (test raw unoptimized path)")
     ap.add_argument("--gpu", type=int, default=None, help="GPU device ordinal (with --cuda)")
     ap.add_argument("--cap", type=int, default=75, help="experts-per-layer cache cap (default 75)")
     ap.add_argument("--timeout", type=int, default=600, help="per-run timeout in seconds (default 600)")

--- a/c/tools/diag_harness.py
+++ b/c/tools/diag_harness.py
@@ -29,6 +29,12 @@ Design notes:
 """
 import os, sys, re, json, time, argparse, subprocess, signal, traceback
 from datetime import datetime
+
+def fmt_val(v, suffix=""):
+    """Format a metric value for console output: '?' if None, else str(v)+suffix."""
+    if v is None: return "?"
+    if isinstance(v, float): return f"{v:.3f}{suffix}" if "e" not in f"{v:.3f}" else f"{v:.2e}{suffix}"
+    return f"{v}{suffix}"
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -136,7 +142,8 @@ def extract_metrics(stdout: str, stderr: str) -> dict:
         m = rx.search(combined)
         if m:
             try: metrics[name] = fn(m)
-            except (ValueError, IndexError): pass
+            except (ValueError, IndexError, TypeError) as e:
+                pass  # parse failed for this metric — raw log has the line for debugging
     # TOKENS dump is stderr-only and may appear once; grab it explicitly
     m = RX["tokens_dump"][0].search(text_err)
     if m:
@@ -165,8 +172,61 @@ def extract_metrics(stdout: str, stderr: str) -> dict:
             mm = rx.search(line)
             if mm:
                 try: p[pname] = fn(mm)
-                except: pass
+                except Exception: pass
         if p: metrics[label] = p
+    # ATTENTION sub-buckets (projection/RoPE, score-softmax-value, output projection)
+    for idx, line in enumerate(l for l in text_out.splitlines() if l.startswith("ATTENTION:")):
+        label = "prefill_attention_detail" if idx == 0 else "decode_attention_detail"
+        d = {}
+        for tag, rx in [("proj_rope", r"projection/RoPE ([\d.]+)s"),
+                        ("score_softmax", r"score-softmax-value ([\d.]+)s"),
+                        ("output_proj", r"output projection ([\d.]+)s")]:
+            mm = re.search(rx, line)
+            if mm:
+                try: d[tag] = float(mm.group(1))
+                except Exception: pass
+        if d: metrics[label] = d
+    # OTHER sub-buckets (rmsnorm, router, untracked, etc.)
+    for idx, line in enumerate(l for l in text_out.splitlines() if l.startswith("OTHER:")):
+        label = "prefill_other_detail" if idx == 0 else "decode_other_detail"
+        d = {}
+        for tag, rx in [("rmsnorm", r"rmsnorm ([\d.]+)s"), ("router", r"router ([\d.]+)s"),
+                        ("resadd", r"resadd ([\d.]+)s"), ("untracked", r"untracked ([\d.]+)s"),
+                        ("alloc", r"alloc ([\d.]+)s"), ("cache", r"cache ([\d.]+)s")]:
+            mm = re.search(rx, line)
+            if mm:
+                try: d[tag] = float(mm.group(1))
+                except Exception: pass
+        if d: metrics[label] = d
+    # stderr diagnostic lines: capture activation confirmations for optimization features
+    diag = {}
+    for tag, rx in [
+        ("cache_route", r"\[CACHE_ROUTE\] on (.+)"),
+        ("expert_budget_dropped", r"dropped (\d+) experts.*?saved"),
+        ("pin_placement", r"\[PIN\] placement: (.+)"),
+        ("usage_loaded", r"\[USAGE\] (.+)"),
+        ("dsa_active", r"\[DSA\] (.+)"),
+        ("cuda_mode", r"\[CUDA\] mode: (.+)"),
+        ("cuda_tier_summary", r"CUDA expert tier: (.+)"),
+        ("mtp_active", r"\[MTP\] (.+)"),
+        ("kv_slots", r"\[KV\] (.+)"),
+    ]:
+        mm = re.search(rx, text_err)
+        if mm:
+            try: diag[tag] = mm.group(1).strip()
+            except Exception: pass
+    if diag: metrics["diagnostics"] = diag
+    # route_agree and route_kl (if CACHE_ROUTE active)
+    mm = re.search(r"route_agree ([\d.]+)% \| route_kl ([\d.]+)", text_out)
+    if mm:
+        metrics["route_agree"] = float(mm.group(1))
+        metrics["route_kl"] = float(mm.group(2))
+    # swap rate (CACHE_ROUTE)
+    mm = re.search(r"swap ([\d.]+)% \((\d+)/(\d+)\)", text_out)
+    if mm:
+        metrics["route_swap_pct"] = float(mm.group(1))
+        metrics["route_swaps"] = int(mm.group(2))
+        metrics["route_slots"] = int(mm.group(3))
     return metrics
 
 
@@ -217,11 +277,22 @@ class EngineRunner:
         except Exception as e:
             stdout, stderr, rc = "", f"[EXCEPTION] {e}\n{traceback.format_exc()}", -2
         elapsed = time.time() - t0
-        # Write raw log (both streams, clearly delimited)
+        # Write raw log (both streams + env, clearly delimited for reproducibility)
         with open(log_path, "w", encoding="utf-8") as f:
             f.write(f"=== CMD: {' '.join(cmd)}\n=== ELAPSED: {elapsed:.1f}s\n=== RC: {rc}\n\n")
-            f.write("--- STDOUT ---\n"); f.write(stdout or ""); f.write("\n")
-            f.write("--- STDERR ---\n"); f.write(stderr or ""); f.write("\n")
+            # Log all non-inherited env vars so runs are reproducible
+            inherited = set(os.environ.keys())
+            custom_env = {k:v for k,v in env.items() if k not in inherited or k in
+                          ("SNAP","PROMPT","NGEN","SCORE","TOKENS","TEMP","RAM_GB",
+                           "CACHE_ROUTE","ROUTE_J","ROUTE_M","EXPERT_BUDGET",
+                           "COLI_CUDA","COLI_GPU","CUDA_DENSE","COLI_CUDA_ATTN",
+                           "COLI_CUDA_PIPE","COLI_CUDA_PIPE_S_MIN","COLI_CUDA_MTP",
+                           "DIRECT","PIPE","PIPE_WORKERS","MTP","LOOKA","DISK_SPLIT",
+                           "ROUTE_AGREE","COLI_CUDA_PROFILE")}
+            f.write("--- ENV (custom) ---\n")
+            for k in sorted(custom_env): f.write(f"{k}={custom_env[k]}\n")
+            f.write(f"\n--- STDOUT ---\n"); f.write(stdout or ""); f.write("\n")
+            f.write(f"--- STDERR ---\n"); f.write(stderr or ""); f.write("\n")
         return stdout or "", stderr or "", rc, elapsed
 
 
@@ -314,7 +385,8 @@ class DiagnosticHarness:
             except Exception as e:
                 print(f"[warn] could not load tokenizer: {e}", file=sys.stderr)
         self.results = {"meta": {"snap": self.snap, "glm": self.glm,
-                                 "timestamp": ts, "args": vars(args)},
+                                 "timestamp": ts, "args": vars(args),
+                                 "env_stack": base_env},
                         "phases": {}}
 
     def phase_system(self):
@@ -431,6 +503,8 @@ class DiagnosticHarness:
             "generated_text": text[:500],
             "prefill_profile": metrics.get("prefill_profile", {}),
             "decode_profile": metrics.get("decode_profile", {}),
+            "decode_attention_detail": metrics.get("decode_attention_detail", {}),
+            "decode_other_detail": metrics.get("decode_other_detail", {}),
             "decode_tps": metrics.get("decode_tps"),
             "prefill_secs": metrics.get("prefill_secs"),
             "hit_rate": metrics.get("hit_rate"),
@@ -440,26 +514,44 @@ class DiagnosticHarness:
             "mtp_counts": metrics.get("mtp_acc_cnt"),
             "spec_tok_per_fw": metrics.get("spec_tok_per_fw"),
             "cuda_tier": metrics.get("cuda_tier"),
+            "route_agree": metrics.get("route_agree"),
+            "route_kl": metrics.get("route_kl"),
+            "route_swap_pct": metrics.get("route_swap_pct"),
+            "diagnostics": metrics.get("diagnostics", {}),
             "progress_curve": metrics.get("progress_curve", []),
         }
         # Print the PROFILE breakdown
         dp = result["decode_profile"]
         print(f"\n  DECODE TIMING BREAKDOWN (per-bucket, seconds):")
-        print(f"    expert-disk:    {dp.get('prof_expert_disk', '?'):>8}")
-        print(f"    expert-matmul:  {dp.get('prof_expert_mm', '?'):>8}")
-        print(f"    attention:      {dp.get('prof_attention', '?'):>8}")
-        print(f"    lm_head:        {dp.get('prof_lm_head', '?'):>8}")
-        print(f"    other:          {dp.get('prof_other', '?'):>8}")
+        print(f"    expert-disk:    {fmt_val(dp.get('prof_expert_disk'))}")
+        print(f"    expert-matmul:  {fmt_val(dp.get('prof_expert_mm'))}")
+        print(f"    attention:      {fmt_val(dp.get('prof_attention'))}")
+        print(f"    lm_head:        {fmt_val(dp.get('prof_lm_head'))}")
+        print(f"    other:          {fmt_val(dp.get('prof_other'))}")
+        ad = result.get("decode_attention_detail", {})
+        if ad:
+            print(f"    └ projection:   {fmt_val(ad.get('proj_rope'))}")
+            print(f"    └ softmax:      {fmt_val(ad.get('score_softmax'))}")
+            print(f"    └ output proj:  {fmt_val(ad.get('output_proj'))}")
         print(f"\n  PERFORMANCE:")
-        print(f"    prefill:   {result['prefill_secs']:.2f}s" if result['prefill_secs'] else "    prefill:   ?")
-        print(f"    decode:    {result['decode_tps']:.3f} tok/s" if result['decode_tps'] else "    decode:    ?")
-        print(f"    hit rate:  {result['hit_rate']:.1f}%" if result.get('hit_rate') is not None else "    hit rate:  ?")
-        print(f"    RSS:       {result['rss_gb']:.1f} GB" if result.get('rss_gb') else "    RSS:       ?")
-        print(f"    exp/tok:   {result['experts_per_tok']:.1f}" if result.get('experts_per_tok') else "    exp/tok:   ?")
-        print(f"    MTP:       {result['mtp_accept']:.0f}% accept" if result.get('mtp_accept') is not None else "    MTP:       ?")
+        print(f"    prefill:   {fmt_val(result['prefill_secs'], 's')}")
+        print(f"    decode:    {fmt_val(result['decode_tps'], ' tok/s')}")
+        print(f"    hit rate:  {fmt_val(result.get('hit_rate'), '%')}")
+        print(f"    RSS:       {fmt_val(result.get('rss_gb'), ' GB')}")
+        print(f"    exp/tok:   {fmt_val(result.get('experts_per_tok'))}")
+        print(f"    MTP:       {fmt_val(result.get('mtp_accept'), '% accept')}")
+        if result.get('route_agree') is not None:
+            print(f"    route_agree: {result['route_agree']:.1f}% (KL={result.get('route_kl','?')})")
+        if result.get('route_swap_pct') is not None:
+            print(f"    swap: {result['route_swap_pct']:.1f}%")
         if result.get('cuda_tier'):
             ct = result['cuda_tier']
             print(f"    CUDA tier: {ct['resident']} experts, {ct['vram_gb']:.1f} GB VRAM")
+        diag = result.get("diagnostics", {})
+        if diag:
+            print(f"\n  ENGINE DIAGNOSTICS (stderr):")
+            for k, v in sorted(diag.items()):
+                print(f"    {k}: {v[:80] if isinstance(v, str) else v}")
         # Show generated text preview
         if text:
             print(f"\n  GENERATED TEXT (first 200 chars):")
@@ -489,10 +581,13 @@ class DiagnosticHarness:
         py = sys.executable
         cmd = [py, eval_script, "--snap", self.snap, "--glm", self.glm,
                "--data", bench_dir, "--tasks", ",".join(tasks), "--limit", str(limit)]
+        # eval_glm.py inherits our env and passes it to glm.exe via dict(os.environ).
+        # Apply the same optimization stack so scoring runs at full speed.
         env = dict(os.environ)
-        if self.args.ram: env["RAM_GB"] = str(self.args.ram)
+        env.update(self.runner.default_env)
         print(f"  Running eval_glm.py (tasks={tasks}, n={limit})...")
-        print(f"  This takes ~{limit*3*4/0.05:.0f}s at 0.05 tok/s (worst case)...")
+        print(f"  Optimization stack: {', '.join(k+'='+v for k,v in sorted(self.runner.default_env.items()) if k not in ('TEMP',))}")
+        print(f"  ETA: ~{limit*3*4/1.0:.0f}s at ~1 tok/s (or ~{limit*3*4/0.3:.0f}s at 0.3 tok/s)...")
         t0 = time.time()
         log_path = self.out_dir / "quality_eval.log"
         try:

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -79,6 +79,15 @@ Format: `VAR` — default — effect.
 | `COLI_CUDA_ATTN` | off | Run S≤4 attention on the GPU. |
 | `COLI_CUDA_PROFILE` | off | Emit CUDA timing. |
 
+> **Windows note.** On Windows, a bare `coli chat` / `coli run` / `coli serve`
+> (no `--gpu`/`--vram`/`--auto-tier`) **auto-enables the GPU** when it detects a
+> CUDA build (`coli_cuda.dll` next to the engine) and at least one GPU via
+> `nvidia-smi`. The expert-tier VRAM budget is then sized automatically from the
+> card's free VRAM (same computation as `--auto-tier`). If `nvidia-smi` is not on
+> `PATH` the run falls back to CPU with a warning — pass `--vram N` (or add
+> `nvidia-smi` to `PATH`) to enable CUDA in that case. `--gpu none` forces
+> CPU-only. (Linux/macOS behaviour is unchanged: pass a flag to enable CUDA.)
+
 ---
 
 ## Advanced / experimental / debug


### PR DESCRIPTION
> **⚠️ Depends on #298 (`feat/cuda-fmt4-grouped-int4`) — that PR is the base of this branch and must merge first.** #298 makes the GPU actually compute for the grouped-int4 (fmt=4 / g64) checkpoint; this PR makes `coli chat` turn the GPU on by default on Windows so users get that speedup without passing flags.

## Why stacked on #298

Without #298, `row_bytes(fmt=4)` returns 0 → every expert upload fails silently → the GPU sits idle even with CUDA enabled. So the two PRs are **complementary and non-overlapping**: #298 = the CUDA backend works for g64; this PR = `coli chat` uses it by default on Windows. This branch is `#298` + the single launcher commit below.

## The one change here

On Windows a bare `coli chat` (no `--gpu`/`--vram`/`--auto-tier`) **always ran CPU-only**, even on a CUDA build with a GPU present. Two defects, both fixed:
1. `cuda_binary()` returned `False` on Windows — it detects CUDA via `ldd glm | grep libcudart`, Linux-only and meaningless on win32 (the engine loads cudart from `coli_cuda.dll` at runtime). Now: `True` iff `coli_cuda.dll` exists next to `glm.exe` (the exact file `backend_loader.c` trusts).
2. `env_for` only enabled CUDA when `--gpu`/`--vram` was passed. Now: a bare win32 `coli chat` auto-detects the CUDA build + GPU (via `nvidia-smi`) and enables CUDA, sizing the expert-tier VRAM from real free VRAM via the existing `build_plan` machinery. Falls back to CPU with a warning if `nvidia-smi` is missing; `--gpu none` still forces CPU; Linux unchanged.

(Same change as #363, rebased onto #298. #363 stays open as the clean dev-based path in case #298 is delayed.)

## What this PR no longer contains (and why)

An earlier version also included a `compat_pread` transient-read **retry**. That was dropped: **JustVugg merged a diagnostic-only pread fix for #307 directly to `dev`** (`211d448` — preserves the real `WinErr` code instead of collapsing to `EIO`). With that on `dev`, the retry is redundant for the #307 story; the maintainer's chosen resolution stands. This PR now touches only `c/coli` / tests / docs and merges cleanly.

## Verification (this stack on a Windows + RTX 5070 Ti box)

\`\`\`
[GPU] auto-enabled CUDA · NVIDIA GeForce RTX 5070 Ti · 13.2 GB expert tier
[CUDA] hot expert tier: 173/173 experts, VRAM 3.67 GB   (was: 0/134, 0.00 GB on dev)
[CUDA] resident set: 423 tensors, 3.67 GB VRAM
CUDA expert tier: 173 resident experts (3.67 GB) | 482 calls served from VRAM
\`\`\`

Prompt → 6-line poem, coherent, correct EOS, exit 0, no \`Input/output error\` (the engine now also names the real WinErr if a read does fail, thanks to `211d448`). Tests: 8/8 in \`test_env_defaults.py\`.

## Relationship to the other PRs

| PR | Scope | Status |
|---|---|---|
| **#298** | CUDA backend fmt=4 (g64) support — **base of this branch** | OPEN, prerequisite |
| **#363** | same launcher fix as here, based on `dev` | OPEN — clean standalone path |
| **this PR** | #298 + launcher auto-enable | verified integration path |
| ~~#361~~ | pread retry | **closed** — superseded by `dev`'s `211d448` + this PR