### PR TITLE
glm: fmt=4 support in qt_addrow/qt_matvec_rows — CPU absorbed-attention path decoded grouped int4 as int2

### DIFF
--- a/c/glm.c
+++ b/c/glm.c
@@ -2284,6 +2284,18 @@ static void expert_prefetch(Model *m, int layer, int eid){
 static void qt_addrow(const QT *t, int row, float coef, float *acc){
     int I=t->I;
     if(t->fmt==0){ const float *w=t->qf+(int64_t)row*I; for(int i=0;i<I;i++) acc[i]+=coef*w[i]; return; }
+    /* fmt=4 PRIMA del calcolo di c: s[] e' [O,ng] per-gruppo, s[row] sarebbe la scala
+     * sbagliata. Senza questo ramo il fall-through int2 decodificava i nibble int4 come
+     * coppie di valori a 2 bit — lo stesso bug di #298 sui kernel absorb CUDA, lato CPU.
+     * EN: fmt=4 BEFORE computing c: s[] is [O,ng] per-group, s[row] would be the wrong
+     * scale. Without this branch the int2 fall-through decoded int4 nibbles as pairs of
+     * 2-bit values — the same bug #298 fixed in the CUDA absorb kernels, CPU side. */
+    if(t->fmt==4){ const uint8_t *w=t->q4+(int64_t)row*((I+1)/2);
+        int gs=t->gs, ng=(I+gs-1)/gs; const float *scl=t->s+(int64_t)row*ng;
+        for(int i=0;i+1<I;i+=2){ uint8_t b=w[i>>1];
+            acc[i]  +=coef*scl[i/gs]    *((int)(b&0xF)-8);
+            acc[i+1]+=coef*scl[(i+1)/gs]*((int)(b>>4)-8); }
+        if(I&1){ uint8_t b=w[I>>1]; acc[I-1]+=coef*scl[(I-1)/gs]*((int)(b&0xF)-8); } return; }
     float c=coef*t->s[row];
     if(t->fmt==1){ const int8_t *w=t->q8+(int64_t)row*I; for(int i=0;i<I;i++) acc[i]+=c*(float)w[i]; return; }
     if(t->fmt==2){ const uint8_t *w=t->q4+(int64_t)row*((I+1)/2);
@@ -2302,6 +2314,13 @@ static void qt_matvec_rows(const QT *t, int r0, int n, const float *x, float *y)
         else if(t->fmt==2){ const uint8_t *w=t->q4+(int64_t)row*((I+1)/2); float s=t->s[row]; float acc=0;
             for(int i=0;i+1<I;i+=2){ uint8_t b=w[i>>1]; acc+=((int)(b&0xF)-8)*x[i]+((int)(b>>4)-8)*x[i+1]; }
             if(I&1){ uint8_t b=w[I>>1]; acc+=((int)(b&0xF)-8)*x[I-1]; } a=acc*s; }
+        else if(t->fmt==4){ /* per-gruppo, come matmul_i4_grouped / per-group, as matmul_i4_grouped */
+            const uint8_t *w=t->q4+(int64_t)row*((I+1)/2);
+            int gs=t->gs, ng=(I+gs-1)/gs; const float *scl=t->s+(int64_t)row*ng;
+            for(int g=0; g*gs<I; g++){ int base=g*gs, end=base+gs>I?I:base+gs; float acc=0;
+                for(int i=base;i<end;i++){ uint8_t b=w[i>>1];
+                    acc+=(float)((i&1)?((int)(b>>4)-8):((int)(b&0xF)-8))*x[i]; }
+                a+=(double)acc*scl[g]; } }
         else { const uint8_t *w=t->q4+(int64_t)row*((I+3)/4); float s=t->s[row]; float acc=0;
             for(int i=0;i<I;i++){ uint8_t b=w[i>>2]; acc+=((int)((b>>((i&3)*2))&3)-2)*x[i]; } a=acc*s; }
         y[j]=(float)a;


### PR DESCRIPTION
## Symptom

An all-grouped container (`kv_b_proj` at fmt=4) emits exactly one correct token, then EOS. Greedy-deterministic. Bisect:

| run | config | output |
|---|---|---|
| 1 | defaults, `DRAFT=3` | `When` → EOS |
| 2 | `DRAFT=0 MTP=0 --temp 0` | `When` → EOS (not speculation) |
| 3 | run 2 + `TOPP=0` | `When` → EOS (not routing pruning) |
| 4 | run 3 + **`ABSORB=0`** | fully coherent — so the S≤4 absorbed-attention path |

Prefill is computed correctly in all runs (the one emitted token is the right continuation, and it comes from prefill logits) — reconstruction at S>4 never touches the broken helpers, which is why this looked like an EOS bug rather than an attention bug.

## Root cause

`qt_addrow` and `qt_matvec_rows` — the CPU absorbed-attention helpers — handle fmt 0/1/2 and then fall through to the **int2 decoder**. A fmt=4 tensor gets its int4 nibbles unpacked as 2-bit pairs, under a per-row scale `s[row]` that does not exist in fmt=4's `[O, ng]` grouped layout. Garbage K/V at decode, EOS argmax.

Same class as #298 (the two CUDA absorb kernels missing fmt=4) — this is the CPU side of that audit. Existing grouped containers escape it because the recommended mixed-precision recipe (#237) keeps `kv_b_proj` at int8, so these helpers only ever saw fmt=1.

## Fix

Per-group fmt=4 branches in both helpers, mirroring `matmul_i4_grouped` semantics (`scl = s + row*ng`, group scale per `gs` elements). The fmt=4 branch in `qt_addrow` sits before the shared `coef*s[row]` line, which is itself wrong for grouped layout. fmt 0/1/2/3 paths are byte-identical to before.

## Validation

All-fmt=4 g128 GLM-5.2 744B container (converted from the FP8 checkpoint with `--ebits 4 --group-size 128`), 9955HX Zen 5, Linux, CPU path:

- Before: `When` → EOS, every run, every config except `ABSORB=0`.
- After, **default `ABSORB`**: "When you type a URL into a browser and hit Enter, a complex series of events happens in seconds to fetch and display the website. Here is a brief breakdown…" — 32/32 tokens, deterministic.
- `make test`: 68/68 on Linux and macOS.

Converter-side, a guard may still be worth it for users on older engine builds: `convert_fp8_to_int4.py` could warn (or imply `--kvb-bits 8`) when emitting fmt=4 kv_b, since every released engine before this PR mis-decodes it on CPU decode. Happy to add that here or as a follow-up, maintainer's preference.
