### PR TITLE
feat: add local-cluster MoE, dense sharding, and WebGPU workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,23 @@ large engine starts:
 For a static setup, skip discovery and provide `--cluster-workers
 HOST:PORT,...`. Cluster transport is disabled unless workers are configured,
 so existing single-machine runs retain their current execution path and output.
-The current seam is expert compute; dense-layer sharding is intentionally kept
-separate because it needs activation pipelining and tensor-parallel placement
-decisions rather than the same batch RPC.
+
+The first dense-sharding seam offloads the model's contiguous dense MLP layers.
+The coordinator keeps attention and KV state local, while the worker owns only
+the gate/up/down tensors for its assigned range:
+
+```bash
+./coli cluster dense-worker --model /nvme/glm52_i4 \
+  --port 9200 --first 0 --last 2 \
+  --coordinator http://COORDINATOR:8765 --advertise-host WORKER_IP
+
+./coli serve --model /nvme/glm52_i4 \
+  --dense-shards WORKER_IP:9200:0:2
+```
+
+This is intentionally a narrow, testable activation pipeline. Full
+attention/KV layer ownership and tensor-parallel dense sharding are subsequent
+steps; they need explicit KV ownership and cross-node pipelining semantics.
 
 The engine is a single C file (`c/glm.c`) plus small headers. No BLAS, no Python at runtime, no GPU required (an opt-in CUDA tier for pinned experts exists — see below).
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,46 @@ This is intentionally a narrow, testable activation pipeline. Full
 attention/KV layer ownership and tensor-parallel dense sharding are subsequent
 steps; they need explicit KV ownership and cross-node pipelining semantics.
 
+### Browser and mobile WebGPU workers
+
+The cluster coordinator also exposes a WebSocket worker path. Browser workers
+register their device type, precision, load, and expert ownership, while the
+coordinator's native TCP data port proxies the existing `COLIEX01` expert
+protocol to them. This keeps the C forward pass independent of browser APIs.
+
+Start the coordinator with its WebGPU data port (the default is `8766`):
+
+```bash
+./coli cluster coordinator --host 0.0.0.0 --port 8765 --data-port 8766
+```
+
+Build the web UI, open `/webgpu-worker.html` on an iPhone, iPad, Android device,
+or laptop, and connect it to:
+
+```text
+ws://COORDINATOR_IP:8765/v1/cluster/webgpu
+```
+
+Point the coordinator's inference process at the proxy:
+
+```bash
+./coli serve --model /nvme/glm52_i4 --cluster-workers COORDINATOR_IP:8766
+```
+
+The browser runtime currently uses f32 expert buffers and the model's gated
+SiLU FFN (`silu(W_gate x) * W_up x`, then `W_down`). Selected floating-point
+source experts can be exported with:
+
+```bash
+uv run python c/tools/export_webgpu_expert.py \
+  --source /path/to/source-checkpoint --output web/public \
+  --layer 0 --expert 0
+```
+
+The worker system is opt-in and intended for a trusted LAN in this first slice;
+TLS, authentication, and browser permission UX are still required before
+exposing it to the public internet.
+
 The engine is a single C file (`c/glm.c`) plus small headers. No BLAS, no Python at runtime, no GPU required (an opt-in CUDA tier for pinned experts exists — see below).
 
 ## What's implemented

--- a/README.md
+++ b/README.md
@@ -50,6 +50,43 @@ A 744B Mixture-of-Experts model activates only ~40B parameters per token — and
 - the **dense part** (attention, shared experts, embeddings — ~17B params) stays **resident in RAM at int4** (~9.9 GB);
 - the **19,456 routed experts** (75 MoE layers × 256 experts + the MTP head, ~19 MB each at int4) live **on disk** (~370 GB) and are **streamed on demand**, with a per-layer LRU cache, an optional pinned hot-store, and the OS page cache as a free L2.
 
+### Local cluster mode
+
+The C engine can act as a coordinator while other Macs serve disk-backed
+experts. The coordinator still owns token generation, routing, and KV cache;
+each routed layer is sent as one batch-union RPC, so a token does not incur one
+network round trip per expert. Workers use the same quantized expert kernels as
+the single-box engine and keep one streamed expert slot per layer.
+
+Start the optional registration/discovery process on the coordinator:
+
+```bash
+cd c
+./coli cluster coordinator --host 0.0.0.0 --port 8765
+```
+
+On each worker, with the same converted model available locally:
+
+```bash
+./coli cluster worker --model /nvme/glm52_i4 --port 9100 \
+  --coordinator http://COORDINATOR:8765 --advertise-host WORKER_IP
+```
+
+Run inference on the coordinator. It discovers live expert workers before the
+large engine starts:
+
+```bash
+./coli serve --model /nvme/glm52_i4 \
+  --cluster-coordinator http://127.0.0.1:8765
+```
+
+For a static setup, skip discovery and provide `--cluster-workers
+HOST:PORT,...`. Cluster transport is disabled unless workers are configured,
+so existing single-machine runs retain their current execution path and output.
+The current seam is expert compute; dense-layer sharding is intentionally kept
+separate because it needs activation pipelining and tensor-parallel placement
+decisions rather than the same batch RPC.
+
 The engine is a single C file (`c/glm.c`) plus small headers. No BLAS, no Python at runtime, no GPU required (an opt-in CUDA tier for pinned experts exists — see below).
 
 ## What's implemented

--- a/c/Makefile
+++ b/c/Makefile
@@ -330,7 +330,7 @@ install: glm$(EXE) olmoe$(EXE)
 	$(INSTALL) -m 755 coli $(DESTDIR)$(BINDIR)/coli
 	$(INSTALL) -m 755 glm$(EXE) $(DESTDIR)$(LIBEXECDIR)/glm$(EXE)
 	$(INSTALL) -m 755 olmoe$(EXE) $(DESTDIR)$(LIBEXECDIR)/olmoe$(EXE)
-	$(INSTALL) -m 644 resource_plan.py doctor.py openai_server.py $(DESTDIR)$(LIBEXECDIR)/
+	$(INSTALL) -m 644 resource_plan.py doctor.py openai_server.py cluster.py $(DESTDIR)$(LIBEXECDIR)/
 	$(INSTALL) -m 644 tools/*.py $(DESTDIR)$(LIBEXECDIR)/tools/
 
 uninstall:

--- a/c/cluster.py
+++ b/c/cluster.py
@@ -9,7 +9,11 @@ expert activations use the binary TCP data plane implemented by ``glm``.
 from __future__ import annotations
 
 import argparse
+import base64
+import hashlib
 import json
+import socketserver
+import struct
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -18,12 +22,151 @@ from urllib.request import Request, urlopen
 
 
 PROTOCOL_VERSION = 1
+EXPERT_MAGIC = b"COLIEX01"
+WEBSOCKET_PATH = "/v1/cluster/webgpu"
+
+
+def parse_expert_batch(payload):
+    """Decode the native expert batch protocol without touching activation bytes."""
+    header = struct.Struct("!4I")
+    if len(payload) < 8 + header.size or payload[:8] != EXPERT_MAGIC:
+        raise ValueError("invalid expert batch magic")
+    version, layer, hidden, count = header.unpack_from(payload, 8)
+    if version != PROTOCOL_VERSION or count > 64 or not 1 <= hidden <= 65536:
+        raise ValueError("invalid expert batch header")
+    offset = 8 + header.size
+    items = []
+    for _ in range(count):
+        if offset + 8 > len(payload):
+            raise ValueError("truncated expert item")
+        expert_id, rows = struct.unpack_from("!2I", payload, offset)
+        offset += 8
+        size = rows * hidden * 4
+        if rows < 1 or rows > 65536 or offset + size > len(payload):
+            raise ValueError("invalid expert activation payload")
+        items.append({"expert_id": expert_id, "rows": rows,
+                      "activations": payload[offset:offset + size]})
+        offset += size
+    if offset != len(payload):
+        raise ValueError("trailing expert batch bytes")
+    return {"version": version, "layer": layer, "hidden": hidden, "items": items}
+
+
+def pack_expert_batch(batch):
+    parts = [EXPERT_MAGIC, struct.pack("!4I", PROTOCOL_VERSION, batch["layer"],
+                                       batch["hidden"], len(batch["items"]))]
+    for item in batch["items"]:
+        activations = item["activations"]
+        expected = item["rows"] * batch["hidden"] * 4
+        if len(activations) != expected:
+            raise ValueError("activation byte count does not match item shape")
+        parts.append(struct.pack("!2I", item["expert_id"], item["rows"]))
+        parts.append(activations)
+    return b"".join(parts)
+
+
+def pack_expert_response(batch, outputs, status=0):
+    parts = [EXPERT_MAGIC, struct.pack("!3I", PROTOCOL_VERSION, status, len(outputs))]
+    for item, output in zip(batch["items"], outputs):
+        if len(output) != item["rows"] * batch["hidden"] * 4:
+            raise ValueError("expert output byte count does not match item shape")
+        parts.append(struct.pack("!2I", item["expert_id"], item["rows"]))
+        parts.append(output)
+    return b"".join(parts)
+
+
+def parse_expert_response(payload):
+    if len(payload) < 8 + 12 or payload[:8] != EXPERT_MAGIC:
+        raise ValueError("invalid expert response magic")
+    version, status, count = struct.unpack_from("!3I", payload, 8)
+    if version != PROTOCOL_VERSION or count > 64:
+        raise ValueError("invalid expert response header")
+    return {"version": version, "status": status, "count": count, "payload": payload[20:]}
+
+
+def _ws_read_frame(sock):
+    header = _recv_exact(sock, 2)
+    first, second = header
+    opcode = first & 0x0F
+    masked = second & 0x80
+    length = second & 0x7F
+    if length == 126:
+        length = struct.unpack("!H", _recv_exact(sock, 2))[0]
+    elif length == 127:
+        length = struct.unpack("!Q", _recv_exact(sock, 8))[0]
+    if length > 64 << 20:
+        raise ValueError("websocket frame too large")
+    mask = _recv_exact(sock, 4) if masked else b""
+    data = bytearray(_recv_exact(sock, length))
+    if mask:
+        for index in range(length):
+            data[index] ^= mask[index % 4]
+    return opcode, bytes(data)
+
+
+def _recv_exact(sock, size):
+    chunks = []
+    while size:
+        chunk = sock.recv(size)
+        if not chunk:
+            raise ConnectionError("socket closed")
+        chunks.append(chunk)
+        size -= len(chunk)
+    return b"".join(chunks)
+
+
+def _ws_frame(opcode, payload):
+    length = len(payload)
+    if length < 126:
+        header = bytes((0x80 | opcode, length))
+    elif length <= 0xFFFF:
+        header = bytes((0x80 | opcode, 126)) + struct.pack("!H", length)
+    else:
+        header = bytes((0x80 | opcode, 127)) + struct.pack("!Q", length)
+    return header + payload
+
+
+class WebGPUConnection:
+    def __init__(self, sock, node):
+        self.sock = sock
+        self.node = node
+        self.lock = threading.Lock()
+        self.closed = False
+
+    def request(self, payload):
+        with self.lock:
+            if self.closed:
+                raise ConnectionError("WebGPU worker is closed")
+            self.sock.sendall(_ws_frame(2, payload))
+            while True:
+                opcode, data = _ws_read_frame(self.sock)
+                if opcode == 2:
+                    self.node["load"] = max(0, self.node.get("load", 1) - 1)
+                    return data
+                if opcode == 8:
+                    raise ConnectionError("WebGPU worker closed")
+                if opcode == 9:
+                    self.sock.sendall(_ws_frame(10, data))
+
+    def close(self):
+        with self.lock:
+            if not self.closed:
+                self.closed = True
+                try:
+                    self.sock.sendall(_ws_frame(8, b""))
+                except OSError:
+                    pass
+                try:
+                    self.sock.close()
+                except OSError:
+                    pass
 
 
 class ClusterRegistry:
     def __init__(self, stale_after=30.0):
         self.stale_after = float(stale_after)
         self._nodes = {}
+        self._webgpu = {}
         self._lock = threading.Lock()
 
     def register(self, node):
@@ -31,12 +174,12 @@ class ClusterRegistry:
         missing = sorted(required - set(node))
         if missing:
             raise ValueError("missing node fields: " + ", ".join(missing))
-        port = int(node["port"])
-        if not 1 <= port <= 65535:
-            raise ValueError("port must be between 1 and 65535")
         role = str(node["role"])
-        if role not in ("expert", "dense", "coordinator"):
-            raise ValueError("role must be expert, dense, or coordinator")
+        port = int(node["port"])
+        if role != "webgpu" and not 1 <= port <= 65535:
+            raise ValueError("port must be between 1 and 65535")
+        if role not in ("expert", "dense", "webgpu", "coordinator"):
+            raise ValueError("role must be expert, dense, webgpu, or coordinator")
         record = dict(node)
         record["protocol_version"] = PROTOCOL_VERSION
         record["port"] = port
@@ -44,6 +187,69 @@ class ClusterRegistry:
         with self._lock:
             self._nodes[str(node["node_id"])] = record
         return record
+
+    def register_webgpu_connection(self, sock, hello):
+        node = dict(hello)
+        node.setdefault("role", "webgpu")
+        node.setdefault("host", "browser")
+        node.setdefault("port", 0)
+        node.setdefault("device_type", "unknown")
+        node.setdefault("precision", "f32")
+        node.setdefault("expert_ids", ["*"])
+        node["node_id"] = str(node.get("node_id") or f"webgpu-{id(sock)}")
+        record = self.register(node)
+        record["load"] = 0
+        connection = WebGPUConnection(sock, record)
+        with self._lock:
+            self._webgpu[record["node_id"]] = connection
+        return connection
+
+    def unregister_webgpu(self, connection):
+        with self._lock:
+            node_id = connection.node["node_id"]
+            if self._webgpu.get(node_id) is connection:
+                del self._webgpu[node_id]
+                self._nodes.pop(node_id, None)
+        connection.close()
+
+    def touch(self, node_id):
+        with self._lock:
+            node = self._nodes.get(str(node_id))
+            if node:
+                node["last_seen"] = time.time()
+
+    def _webgpu_owner(self, layer, expert_id):
+        key = f"{layer}:{expert_id}"
+        with self._lock:
+            candidates = []
+            for connection in self._webgpu.values():
+                node = connection.node
+                experts = node.get("expert_ids", ["*"])
+                if "*" in experts or key in experts or str(expert_id) in experts:
+                    candidates.append(connection)
+            if not candidates:
+                return None
+            return min(candidates, key=lambda item: item.node.get("load", 0))
+
+    def dispatch_webgpu(self, payload):
+        batch = parse_expert_batch(payload)
+        groups = {}
+        for item in batch["items"]:
+            owner = self._webgpu_owner(batch["layer"], item["expert_id"])
+            if owner is None:
+                return pack_expert_response(batch, [], status=1)
+            groups.setdefault(owner, []).append(item)
+        results = {}
+        for owner, items in groups.items():
+            sub_batch = dict(batch, items=items)
+            owner.node["load"] = owner.node.get("load", 0) + 1
+            self.touch(owner.node["node_id"])
+            response = parse_expert_response(owner.request(pack_expert_batch(sub_batch)))
+            if response["status"] or response["count"] != len(items):
+                return pack_expert_response(batch, [], status=1)
+            results.update(_response_items(response["payload"], items, batch["hidden"]))
+        outputs = [results[item["expert_id"]] for item in batch["items"]]
+        return pack_expert_response(batch, outputs)
 
     def heartbeat(self, node_id):
         with self._lock:
@@ -59,11 +265,30 @@ class ClusterRegistry:
             nodes = [dict(node) for node in self._nodes.values()
                      if now - node["last_seen"] <= self.stale_after]
         nodes.sort(key=lambda node: (node["role"], node["node_id"]))
-        return {"protocol_version": PROTOCOL_VERSION, "nodes": nodes}
+        return {"protocol_version": PROTOCOL_VERSION, "nodes": nodes,
+                "webgpu_workers": len(self._webgpu)}
 
     def expert_endpoints(self):
         return [f"{node['host']}:{node['port']}"
                 for node in self.snapshot()["nodes"] if node["role"] == "expert"]
+
+
+def _response_items(payload, items, hidden):
+    offset = 0
+    outputs = {}
+    for item in items:
+        if offset + 8 > len(payload):
+            raise ValueError("truncated WebGPU response")
+        expert_id, rows = struct.unpack_from("!2I", payload, offset)
+        offset += 8
+        size = rows * hidden * 4
+        if expert_id != item["expert_id"] or rows != item["rows"] or offset + size > len(payload):
+            raise ValueError("invalid WebGPU response item")
+        outputs[expert_id] = payload[offset:offset + size]
+        offset += size
+    if offset != len(payload):
+        raise ValueError("trailing WebGPU response bytes")
+    return outputs
 
 
 class _Handler(BaseHTTPRequestHandler):
@@ -87,10 +312,45 @@ class _Handler(BaseHTTPRequestHandler):
         return json.loads(self.rfile.read(length) or b"{}")
 
     def do_GET(self):  # noqa: N802 - stdlib handler API
+        if self.path == WEBSOCKET_PATH and self.headers.get("Upgrade", "").lower() == "websocket":
+            self._webgpu_websocket()
+            return
         if self.path in ("/health", "/v1/cluster/topology"):
             self._json(200, self.server.registry.snapshot())
             return
         self._json(404, {"error": "not found"})
+
+    def _webgpu_websocket(self):
+        key = self.headers.get("Sec-WebSocket-Key")
+        if not key:
+            self._json(400, {"error": "missing Sec-WebSocket-Key"})
+            return
+        accept = base64.b64encode(hashlib.sha1(
+            (key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode()).digest()).decode()
+        self.send_response(101, "Switching Protocols")
+        self.send_header("Upgrade", "websocket")
+        self.send_header("Connection", "Upgrade")
+        self.send_header("Sec-WebSocket-Accept", accept)
+        self.end_headers()
+        self.wfile.flush()
+        connection = None
+        try:
+            opcode, payload = _ws_read_frame(self.connection)
+            if opcode != 1:
+                raise ValueError("WebGPU worker must begin with a JSON hello")
+            hello = json.loads(payload.decode("utf-8"))
+            if hello.get("role", "webgpu") != "webgpu":
+                raise ValueError("worker role must be webgpu")
+            connection = self.server.registry.register_webgpu_connection(self.connection, hello)
+            self.server.registry.touch(connection.node["node_id"])
+            while not connection.closed:
+                self.server.registry.touch(connection.node["node_id"])
+                time.sleep(1)
+        except (ConnectionError, OSError, ValueError, json.JSONDecodeError):
+            pass
+        finally:
+            if connection is not None:
+                self.server.registry.unregister_webgpu(connection)
 
     def do_POST(self):  # noqa: N802 - stdlib handler API
         try:
@@ -105,6 +365,34 @@ class _Handler(BaseHTTPRequestHandler):
             self._json(400, {"error": str(error)})
 
 
+class _WebGPUProxyHandler(socketserver.BaseRequestHandler):
+    def handle(self):
+        while True:
+            try:
+                header = _recv_exact(self.request, 24)
+                if header[:8] != EXPERT_MAGIC:
+                    return
+                version, layer, hidden, count = struct.unpack("!4I", header[8:])
+                if version != PROTOCOL_VERSION or count > 64 or not 1 <= hidden <= 65536:
+                    return
+                parts = [header]
+                for _ in range(count):
+                    item_header = _recv_exact(self.request, 8)
+                    expert_id, rows = struct.unpack("!2I", item_header)
+                    if rows < 1 or rows > 65536:
+                        return
+                    parts.extend((item_header, _recv_exact(self.request, rows * hidden * 4)))
+                response = self.server.registry.dispatch_webgpu(b"".join(parts))
+                self.request.sendall(response)
+            except (ConnectionError, OSError, ValueError, KeyError):
+                return
+
+
+class _ThreadingTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
 class ClusterServer(ThreadingHTTPServer):
     daemon_threads = True
 
@@ -113,14 +401,19 @@ class ClusterServer(ThreadingHTTPServer):
         self.registry = registry
 
 
-def serve(host="127.0.0.1", port=8765, stale_after=30.0):
+def serve(host="127.0.0.1", port=8765, stale_after=30.0, data_port=8766):
     registry = ClusterRegistry(stale_after)
     server = ClusterServer((host, port), registry)
-    print(f"colibri cluster coordinator listening on http://{host}:{port}", flush=True)
+    proxy = _ThreadingTCPServer((host, data_port), _WebGPUProxyHandler)
+    proxy.registry = registry
+    threading.Thread(target=proxy.serve_forever, name="colibri-webgpu-proxy", daemon=True).start()
+    print(f"colibri cluster coordinator listening on http://{host}:{port} · WebGPU data port {data_port}", flush=True)
     try:
         server.serve_forever()
     finally:
         server.server_close()
+        proxy.shutdown()
+        proxy.server_close()
 
 
 def register(coordinator, node):
@@ -152,8 +445,9 @@ def main():
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8765)
     parser.add_argument("--stale-after", type=float, default=30.0)
+    parser.add_argument("--data-port", type=int, default=8766)
     args = parser.parse_args()
-    serve(args.host, args.port, args.stale_after)
+    serve(args.host, args.port, args.stale_after, args.data_port)
 
 
 if __name__ == "__main__":

--- a/c/cluster.py
+++ b/c/cluster.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Small, dependency-free control plane for a local colibrì cluster.
+
+The inference coordinator remains the C engine: it owns the token loop, KV
+cache, and router.  This module only handles node registration and discovery;
+expert activations use the binary TCP data plane implemented by ``glm``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlsplit
+from urllib.request import Request, urlopen
+
+
+PROTOCOL_VERSION = 1
+
+
+class ClusterRegistry:
+    def __init__(self, stale_after=30.0):
+        self.stale_after = float(stale_after)
+        self._nodes = {}
+        self._lock = threading.Lock()
+
+    def register(self, node):
+        required = {"node_id", "host", "port", "role"}
+        missing = sorted(required - set(node))
+        if missing:
+            raise ValueError("missing node fields: " + ", ".join(missing))
+        port = int(node["port"])
+        if not 1 <= port <= 65535:
+            raise ValueError("port must be between 1 and 65535")
+        role = str(node["role"])
+        if role not in ("expert", "dense", "coordinator"):
+            raise ValueError("role must be expert, dense, or coordinator")
+        record = dict(node)
+        record["protocol_version"] = PROTOCOL_VERSION
+        record["port"] = port
+        record["last_seen"] = time.time()
+        with self._lock:
+            self._nodes[str(node["node_id"])] = record
+        return record
+
+    def heartbeat(self, node_id):
+        with self._lock:
+            node = self._nodes.get(str(node_id))
+            if node is None:
+                raise KeyError(node_id)
+            node["last_seen"] = time.time()
+            return dict(node)
+
+    def snapshot(self):
+        now = time.time()
+        with self._lock:
+            nodes = [dict(node) for node in self._nodes.values()
+                     if now - node["last_seen"] <= self.stale_after]
+        nodes.sort(key=lambda node: (node["role"], node["node_id"]))
+        return {"protocol_version": PROTOCOL_VERSION, "nodes": nodes}
+
+    def expert_endpoints(self):
+        return [f"{node['host']}:{node['port']}"
+                for node in self.snapshot()["nodes"] if node["role"] == "expert"]
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server_version = "colibri-cluster/1"
+
+    def log_message(self, *_args):
+        return
+
+    def _json(self, status, value):
+        payload = json.dumps(value, separators=(",", ":")).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _body(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        if length > 1 << 20:
+            raise ValueError("request body is too large")
+        return json.loads(self.rfile.read(length) or b"{}")
+
+    def do_GET(self):  # noqa: N802 - stdlib handler API
+        if self.path in ("/health", "/v1/cluster/topology"):
+            self._json(200, self.server.registry.snapshot())
+            return
+        self._json(404, {"error": "not found"})
+
+    def do_POST(self):  # noqa: N802 - stdlib handler API
+        try:
+            body = self._body()
+            if self.path == "/v1/cluster/register":
+                self._json(200, self.server.registry.register(body))
+            elif self.path == "/v1/cluster/heartbeat":
+                self._json(200, self.server.registry.heartbeat(body["node_id"]))
+            else:
+                self._json(404, {"error": "not found"})
+        except (KeyError, ValueError, TypeError, json.JSONDecodeError) as error:
+            self._json(400, {"error": str(error)})
+
+
+class ClusterServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, address, registry):
+        super().__init__(address, _Handler)
+        self.registry = registry
+
+
+def serve(host="127.0.0.1", port=8765, stale_after=30.0):
+    registry = ClusterRegistry(stale_after)
+    server = ClusterServer((host, port), registry)
+    print(f"colibri cluster coordinator listening on http://{host}:{port}", flush=True)
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()
+
+
+def register(coordinator, node):
+    url = coordinator.rstrip("/") + "/v1/cluster/register"
+    request = Request(url, data=json.dumps(node).encode(),
+                     headers={"Content-Type": "application/json"}, method="POST")
+    with urlopen(request, timeout=5) as response:
+        return json.load(response)
+
+
+def heartbeat(coordinator, node_id):
+    url = coordinator.rstrip("/") + "/v1/cluster/heartbeat"
+    request = Request(url, data=json.dumps({"node_id": node_id}).encode(),
+                     headers={"Content-Type": "application/json"}, method="POST")
+    with urlopen(request, timeout=5) as response:
+        return json.load(response)
+
+
+def discover_workers(coordinator):
+    url = coordinator.rstrip("/") + "/v1/cluster/topology"
+    with urlopen(url, timeout=5) as response:
+        topology = json.load(response)
+    return [f"{node['host']}:{int(node['port'])}"
+            for node in topology.get("nodes", []) if node.get("role") == "expert"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--stale-after", type=float, default=30.0)
+    args = parser.parse_args()
+    serve(args.host, args.port, args.stale_after)
+
+
+if __name__ == "__main__":
+    main()

--- a/c/coli
+++ b/c/coli
@@ -651,7 +651,7 @@ def cmd_serve(a):
 
 def cmd_cluster_coordinator(a):
     from cluster import serve
-    serve(a.host, a.port, a.stale_after)
+    serve(a.host, a.port, a.stale_after, a.data_port)
 
 def cmd_cluster_worker(a):
     need_worker_model(a.model)
@@ -844,7 +844,7 @@ def main():
     cluster_sub=pcluster.add_subparsers(dest="cluster_cmd")
     pcoord=cluster_sub.add_parser("coordinator", help="serve worker registration and discovery")
     pcoord.add_argument("--host",default="127.0.0.1"); pcoord.add_argument("--port",type=int,default=8765)
-    pcoord.add_argument("--stale-after",type=float,default=30.0)
+    pcoord.add_argument("--stale-after",type=float,default=30.0); pcoord.add_argument("--data-port",type=int,default=8766)
     pworker=cluster_sub.add_parser("worker", parents=[common], help="serve disk-backed expert compute")
     pworker.add_argument("--port",type=int,default=int(os.environ.get("CLUSTER_WORKER_PORT","9100")))
     pworker.add_argument("--coordinator",default=os.environ.get("CLUSTER_COORDINATOR"))

--- a/c/coli
+++ b/c/coli
@@ -137,6 +137,12 @@ def need_model(model):
         sys.exit(f"{C.yel}model not found:{C.r} {model}\n  set COLI_MODEL or use --model")
     if not os.path.exists(os.path.join(model,"tokenizer.json")):
         sys.exit(f"{C.yel}tokenizer.json is missing from {model}{C.r}")
+
+def need_worker_model(model):
+    if not os.path.isdir(model):
+        sys.exit(f"{C.yel}model not found:{C.r} {model}\n  set COLI_MODEL or use --model")
+    if not os.path.exists(os.path.join(model, "config.json")):
+        sys.exit(f"{C.yel}config.json is missing from {model}{C.r}")
     if not os.path.exists(GLM):
         sys.exit(f"{C.yel}engine is not built.{C.r} Run: coli build")
 
@@ -190,6 +196,10 @@ def env_for(a):
         e.setdefault("PIPE", "1")
         e.setdefault("PILOT_REAL", "1")
     e["COLI_POLICY"]=a.policy
+    if getattr(a, "cluster_workers", None):
+        e["CLUSTER_WORKERS"] = a.cluster_workers
+    if getattr(a, "cluster_coordinator", None):
+        e["CLUSTER_COORDINATOR"] = a.cluster_coordinator
     if a.ram:  e["RAM_GB"]=str(a.ram)
     if a.ngen: e["NGEN"]=str(a.ngen)
     if a.topp: e["TOPP"]=str(a.topp)
@@ -622,9 +632,53 @@ def cmd_chat(a):
 def cmd_serve(a):
     need_model(a.model)
     from openai_server import serve
+    e=env_for(a)
+    if a.cluster_coordinator and not a.cluster_workers:
+        from cluster import discover_workers
+        try:
+            workers=discover_workers(a.cluster_coordinator)
+        except OSError as error:
+            sys.exit(f"{C.yel}cannot discover cluster workers:{C.r} {error}")
+        if not workers:
+            sys.exit(f"{C.yel}cluster coordinator has no live expert workers{C.r}")
+        e["CLUSTER_WORKERS"]=",".join(workers)
+        print(f"  {C.dim}[CLUSTER] discovered {len(workers)} expert worker(s){C.r}",file=sys.stderr)
     serve(a.model, a.host, a.port, a.model_id, a.api_key,
-          a.cap,a.ngen,GLM,env_for(a),a.cors_origin,
+          a.cap,a.ngen,GLM,e,a.cors_origin,
           a.max_queue,a.queue_timeout,a.kv_slots)
+
+def cmd_cluster_coordinator(a):
+    from cluster import serve
+    serve(a.host, a.port, a.stale_after)
+
+def cmd_cluster_worker(a):
+    need_worker_model(a.model)
+    coordinator=a.coordinator or os.environ.get("CLUSTER_COORDINATOR")
+    host=a.advertise_host or os.environ.get("CLUSTER_ADVERTISE_HOST", "127.0.0.1")
+    node_id=a.node_id or f"{host}:{a.port}"
+    stop_heartbeat=threading.Event()
+    if coordinator:
+        from cluster import heartbeat, register
+        try:
+            register(coordinator, {"node_id":node_id, "host":host, "port":a.port,
+                                   "role":"expert", "layers":a.layers})
+        except OSError as error:
+            sys.exit(f"{C.yel}cannot register expert worker:{C.r} {error}")
+        def keep_registered():
+            while not stop_heartbeat.wait(10):
+                try:
+                    heartbeat(coordinator, node_id)
+                except OSError:
+                    pass
+        threading.Thread(target=keep_registered, name="colibri-cluster-heartbeat", daemon=True).start()
+    e=env_for(a)
+    e.update({"EXPERT_WORKER":"1", "CLUSTER_WORKER_PORT":str(a.port),
+              "COLI_MMAP":os.environ.get("COLI_MMAP", "1")})
+    print(f"  {C.dim}[CLUSTER] expert worker {node_id} · port {a.port} · disk-backed{C.r}")
+    try:
+        return subprocess.call([GLM,str(a.cap),str(a.ebits),str(a.dbits)],env=e)
+    finally:
+        stop_heartbeat.set()
 
 def cmd_web(a):
     """serve + open the dashboard in the browser once the API answers."""
@@ -711,6 +765,10 @@ def main():
     common.add_argument("--cap", type=int, default=8); common.add_argument("--ngen", type=int, default=1024)  # rete di sicurezza: la fine vera la decidono gli stop token
     common.add_argument("--topp", type=float, default=0); common.add_argument("--topk", type=int, default=0)
     common.add_argument("--temp", type=float, default=None)  # temperatura token (0=greedy, default 1.0+nucleus .95)
+    common.add_argument("--cluster-workers", default=os.environ.get("CLUSTER_WORKERS"),
+                        help="comma-separated expert workers, host:port,...")
+    common.add_argument("--cluster-coordinator", default=os.environ.get("CLUSTER_COORDINATOR"),
+                        help="control-plane URL used to discover expert workers")
     ap=argparse.ArgumentParser(prog="coli", parents=[common], description="colibrì — run GLM-5.2 locally")
     sub=ap.add_subparsers(dest="cmd")
     sub.add_parser("build", parents=[common]); sub.add_parser("info", parents=[common])
@@ -749,10 +807,24 @@ def main():
     pc=sub.add_parser("convert", parents=[common]); pc.add_argument("--repo",default="zai-org/GLM-5.2-FP8")
     pc.add_argument("--ebits",type=int,default=4); pc.add_argument("--io-bits",type=int,default=8); pc.add_argument("--xbits",type=int,default=0)
     pc.add_argument("--no-mtp",action="store_true",help="skip the MTP head (no speculative drafts)")
+    pcluster=sub.add_parser("cluster", help="run the local-cluster control plane or an expert worker")
+    cluster_sub=pcluster.add_subparsers(dest="cluster_cmd")
+    pcoord=cluster_sub.add_parser("coordinator", help="serve worker registration and discovery")
+    pcoord.add_argument("--host",default="127.0.0.1"); pcoord.add_argument("--port",type=int,default=8765)
+    pcoord.add_argument("--stale-after",type=float,default=30.0)
+    pworker=cluster_sub.add_parser("worker", parents=[common], help="serve disk-backed expert compute")
+    pworker.add_argument("--port",type=int,default=int(os.environ.get("CLUSTER_WORKER_PORT","9100")))
+    pworker.add_argument("--coordinator",default=os.environ.get("CLUSTER_COORDINATOR"))
+    pworker.add_argument("--node-id",default=None); pworker.add_argument("--advertise-host",default=None)
+    pworker.add_argument("--layers",default="all",help="topology label, e.g. 0-37")
+    pworker.add_argument("--ebits",type=int,default=8); pworker.add_argument("--dbits",type=int,default=8)
     a=ap.parse_args()
     handler={"build":cmd_build,"info":cmd_info,"plan":cmd_plan,"doctor":cmd_doctor,
              "run":cmd_run,"chat":cmd_chat,"serve":cmd_serve,"bench":cmd_bench,
              "convert":cmd_convert,"web":cmd_web}.get(a.cmd)
+    if a.cmd=="cluster":
+        if a.cluster_cmd=="coordinator": handler=cmd_cluster_coordinator
+        elif a.cluster_cmd=="worker": handler=cmd_cluster_worker
     if handler: sys.exit(handler(a) or 0)
     banner(); print(__doc__)
 

--- a/c/coli
+++ b/c/coli
@@ -200,6 +200,8 @@ def env_for(a):
         e["CLUSTER_WORKERS"] = a.cluster_workers
     if getattr(a, "cluster_coordinator", None):
         e["CLUSTER_COORDINATOR"] = a.cluster_coordinator
+    if getattr(a, "dense_shards", None):
+        e["DENSE_SHARDS"] = a.dense_shards
     if a.ram:  e["RAM_GB"]=str(a.ram)
     if a.ngen: e["NGEN"]=str(a.ngen)
     if a.topp: e["TOPP"]=str(a.topp)
@@ -680,6 +682,35 @@ def cmd_cluster_worker(a):
     finally:
         stop_heartbeat.set()
 
+def cmd_cluster_dense_worker(a):
+    need_worker_model(a.model)
+    if a.first < 0 or a.last < a.first:
+        sys.exit(f"{C.yel}dense worker range must satisfy 0 <= --first <= --last{C.r}")
+    coordinator=a.coordinator or os.environ.get("CLUSTER_COORDINATOR")
+    host=a.advertise_host or os.environ.get("CLUSTER_ADVERTISE_HOST", "127.0.0.1")
+    node_id=a.node_id or f"dense-{host}:{a.port}-{a.first}-{a.last}"
+    stop_heartbeat=threading.Event()
+    if coordinator:
+        from cluster import heartbeat, register
+        try:
+            register(coordinator, {"node_id":node_id, "host":host, "port":a.port,
+                                   "role":"dense", "layers":f"{a.first}-{a.last}"})
+        except OSError as error:
+            sys.exit(f"{C.yel}cannot register dense worker:{C.r} {error}")
+        def keep_registered():
+            while not stop_heartbeat.wait(10):
+                try: heartbeat(coordinator, node_id)
+                except OSError: pass
+        threading.Thread(target=keep_registered, name="colibri-dense-heartbeat", daemon=True).start()
+    e=env_for(a)
+    e.update({"DENSE_WORKER":"1", "DENSE_WORKER_PORT":str(a.port),
+              "DENSE_WORKER_FIRST":str(a.first), "DENSE_WORKER_LAST":str(a.last)})
+    print(f"  {C.dim}[DENSE] worker {node_id} · layers {a.first}-{a.last} · MLP activation pipeline{C.r}")
+    try:
+        return subprocess.call([GLM,str(a.cap),str(a.ebits),str(a.dbits)],env=e)
+    finally:
+        stop_heartbeat.set()
+
 def cmd_web(a):
     """serve + open the dashboard in the browser once the API answers."""
     need_model(a.model)
@@ -769,6 +800,8 @@ def main():
                         help="comma-separated expert workers, host:port,...")
     common.add_argument("--cluster-coordinator", default=os.environ.get("CLUSTER_COORDINATOR"),
                         help="control-plane URL used to discover expert workers")
+    common.add_argument("--dense-shards", default=os.environ.get("DENSE_SHARDS"),
+                        help="static dense MLP shards: host:port:first:last,...")
     ap=argparse.ArgumentParser(prog="coli", parents=[common], description="colibrì — run GLM-5.2 locally")
     sub=ap.add_subparsers(dest="cmd")
     sub.add_parser("build", parents=[common]); sub.add_parser("info", parents=[common])
@@ -818,6 +851,11 @@ def main():
     pworker.add_argument("--node-id",default=None); pworker.add_argument("--advertise-host",default=None)
     pworker.add_argument("--layers",default="all",help="topology label, e.g. 0-37")
     pworker.add_argument("--ebits",type=int,default=8); pworker.add_argument("--dbits",type=int,default=8)
+    pdense=cluster_sub.add_parser("dense-worker", parents=[common], help="serve sharded dense MLP layers")
+    pdense.add_argument("--port",type=int,default=9200); pdense.add_argument("--first",type=int,required=True)
+    pdense.add_argument("--last",type=int,required=True); pdense.add_argument("--coordinator",default=os.environ.get("CLUSTER_COORDINATOR"))
+    pdense.add_argument("--node-id",default=None); pdense.add_argument("--advertise-host",default=None)
+    pdense.add_argument("--ebits",type=int,default=8); pdense.add_argument("--dbits",type=int,default=8)
     a=ap.parse_args()
     handler={"build":cmd_build,"info":cmd_info,"plan":cmd_plan,"doctor":cmd_doctor,
              "run":cmd_run,"chat":cmd_chat,"serve":cmd_serve,"bench":cmd_bench,
@@ -825,6 +863,7 @@ def main():
     if a.cmd=="cluster":
         if a.cluster_cmd=="coordinator": handler=cmd_cluster_coordinator
         elif a.cluster_cmd=="worker": handler=cmd_cluster_worker
+        elif a.cluster_cmd=="dense-worker": handler=cmd_cluster_dense_worker
     if handler: sys.exit(handler(a) or 0)
     banner(); print(__doc__)
 

--- a/c/glm.c
+++ b/c/glm.c
@@ -24,10 +24,18 @@
 #include <math.h>
 #include <time.h>
 #include <limits.h>
+#include <stdint.h>
 #include <pthread.h>                              /* thread I/O del PILOTA */
 #include <stdatomic.h>                            /* PIPE ready-flags/job queue + PILOT_REAL cross-layer handshake */
 #include <sched.h>                                /* sched_yield: PIPE spin / PILOT barrier */
 #include <unistd.h>
+#if !defined(_WIN32)
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#endif
 #if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
 #include <sys/select.h>                             /* select() serve-loop polling (#68); not on native MinGW */
 #endif
@@ -205,6 +213,17 @@ typedef struct {
     uint64_t ld_mtp, ld_main;                    /* expert_load per tipo layer (MTP int8 vs main int4) */
     uint64_t bytes_mtp, bytes_main;              /* byte letti da disco per tipo layer */
 } Model;
+
+/* LOCAL CLUSTER: the coordinator stays in this process (token loop, KV cache,
+ * router).  Routed expert blocks are optionally sent to persistent workers over
+ * a small binary protocol.  Keeping this state outside Model makes cluster mode
+ * orthogonal to model placement and preserves the single-box path byte-for-byte. */
+#if !defined(_WIN32)
+typedef struct { int fd; char host[128]; int port; } ClusterWorker;
+static ClusterWorker g_cluster_workers[16];
+static int g_cluster_n;
+static uint64_t g_cluster_calls, g_cluster_experts, g_cluster_rows;
+#endif
 
 static void usage_save(Model *m);        /* cache che impara: definita accanto a stats_dump */
 static void tiers_emit(Model *m);
@@ -1814,6 +1833,174 @@ static int expert_load(Model *m, int layer, int eid, ESlot *s, int fatal){
     s->eid=eid; return 0;
 }
 
+#if !defined(_WIN32)
+/* Expert data-plane protocol.  All consumers are little-endian Macs/Linux
+ * machines, so activations remain raw IEEE-754 floats; integer headers are
+ * network order.  A request is one layer's batch-union, which amortizes the
+ * socket round trip across every expert selected by the current forward. */
+#define COLI_CLUSTER_MAGIC "COLIEX01"
+#define COLI_CLUSTER_VERSION 1u
+static int cluster_io(int fd, void *buf, size_t n, int write_mode){
+    char *p=(char*)buf;
+    while(n){
+        ssize_t r=write_mode?send(fd,p,n,0):recv(fd,p,n,MSG_WAITALL);
+        if(r<=0){ if(r<0&&errno==EINTR) continue; return -1; }
+        p+=r; n-=(size_t)r;
+    }
+    return 0;
+}
+static int cluster_u32(int fd, uint32_t *v, int write_mode){
+    uint32_t x=write_mode?htonl(*v):0;
+    if(cluster_io(fd,write_mode?(void*)&x:(void*)v,sizeof(x),write_mode)) return -1;
+    if(!write_mode) *v=ntohl(*v);
+    return 0;
+}
+static int cluster_connect_one(const char *spec, ClusterWorker *out){
+    char copy[256]; strncpy(copy,spec,sizeof(copy)-1); copy[sizeof(copy)-1]=0;
+    char *colon=strrchr(copy,':'); if(!colon||colon==copy||!colon[1]) return -1;
+    *colon=0; int port=atoi(colon+1); if(port<1||port>65535) return -1;
+    char portbuf[16]; snprintf(portbuf,sizeof(portbuf),"%d",port);
+    struct addrinfo hint={0},*ai=NULL; hint.ai_socktype=SOCK_STREAM;
+    if(getaddrinfo(copy,portbuf,&hint,&ai)!=0) return -1;
+    int fd=-1;
+    for(struct addrinfo *p=ai;p;p=p->ai_next){
+        fd=socket(p->ai_family,p->ai_socktype,p->ai_protocol);
+        if(fd<0) continue;
+        if(connect(fd,p->ai_addr,p->ai_addrlen)==0) break;
+        close(fd); fd=-1;
+    }
+    freeaddrinfo(ai); if(fd<0) return -1;
+    out->fd=fd; strncpy(out->host,copy,sizeof(out->host)-1); out->host[sizeof(out->host)-1]=0;
+    out->port=port; return 0;
+}
+static void cluster_close_all(void){
+    for(int i=0;i<g_cluster_n;i++) if(g_cluster_workers[i].fd>=0) close(g_cluster_workers[i].fd);
+    g_cluster_n=0;
+}
+static void cluster_init(void){
+    const char *list=getenv("CLUSTER_WORKERS");
+    if(!list||!*list) return;
+    char *copy=strdup(list),*save=NULL;
+    for(char *tok=strtok_r(copy,",",&save);tok&&g_cluster_n<16;tok=strtok_r(NULL,",",&save)){
+        while(*tok==' '||*tok=='\t') tok++;
+        if(cluster_connect_one(tok,&g_cluster_workers[g_cluster_n])) g_cluster_n++;
+        else fprintf(stderr,"[CLUSTER] cannot connect to expert worker %s\n",tok);
+    }
+    free(copy);
+    if(g_cluster_n<1){ fprintf(stderr,"[CLUSTER] no expert workers reachable\n"); exit(1); }
+    fprintf(stderr,"[CLUSTER] coordinator connected to %d expert worker(s)\n",g_cluster_n);
+}
+typedef struct { int eid,nr; int *rows; float *weights,*inputs; } ClusterItem;
+static int cluster_item(const int *idxs,const float *ws,const int *keff,int K,int S,
+                        int eid,ClusterItem *it,int D,const float *x){
+    it->eid=eid; it->nr=0;
+    for(int s=0;s<S;s++) for(int k=0;k<keff[s];k++)
+        if(idxs[(int64_t)s*K+k]==eid){ it->nr++; break; }
+    if(!it->nr) return 0;
+    it->rows=malloc((size_t)it->nr*sizeof(int)); it->weights=malloc((size_t)it->nr*sizeof(float));
+    it->inputs=falloc((int64_t)it->nr*D); int r=0;
+    for(int s=0;s<S;s++) for(int k=0;k<keff[s];k++) if(idxs[(int64_t)s*K+k]==eid){
+        it->rows[r]=s; it->weights[r]=ws[(int64_t)s*K+k];
+        memcpy(it->inputs+(int64_t)r*D,x+(int64_t)s*D,(size_t)D*sizeof(float)); r++; break;
+    }
+    return 1;
+}
+static void cluster_item_free(ClusterItem *it){ free(it->rows); free(it->weights); free(it->inputs); memset(it,0,sizeof(*it)); }
+static void cluster_moe_batch(Model *m,int layer,float *x,int S,float *out,
+                              const int *idxs,const float *ws,const int *keff,int K,
+                              const int *uniq,int base,int nb){
+    int D=m->c.hidden;
+    for(int wi=0;wi<g_cluster_n;wi++){
+        ClusterItem items[64]; memset(items,0,sizeof(items)); int n=0;
+        for(int j=0;j<nb;j++){
+            int eid=uniq[base+j];
+            if((eid+layer)%g_cluster_n!=wi) continue;
+            if(n<64 && cluster_item(idxs,ws,keff,K,S,eid,&items[n],D,x)) n++;
+        }
+        if(!n) continue;
+        ClusterWorker *w=&g_cluster_workers[wi]; char magic[8]; uint32_t v;
+        if(cluster_io(w->fd,(void*)COLI_CLUSTER_MAGIC,8,1)) goto fail;
+        v=COLI_CLUSTER_VERSION; if(cluster_u32(w->fd,&v,1)) goto fail;
+        v=(uint32_t)layer; if(cluster_u32(w->fd,&v,1)) goto fail;
+        v=(uint32_t)D; if(cluster_u32(w->fd,&v,1)) goto fail;
+        v=(uint32_t)m->c.moe_inter; if(cluster_u32(w->fd,&v,1)) goto fail;
+        v=(uint32_t)n; if(cluster_u32(w->fd,&v,1)) goto fail;
+        for(int j=0;j<n;j++){
+            v=(uint32_t)items[j].eid; if(cluster_u32(w->fd,&v,1)) goto fail;
+            v=(uint32_t)items[j].nr; if(cluster_u32(w->fd,&v,1)) goto fail;
+            if(cluster_io(w->fd,items[j].inputs,(size_t)items[j].nr*D*sizeof(float),1)) goto fail;
+        }
+        if(cluster_io(w->fd,magic,8,0)) goto fail;
+        if(memcmp(magic,COLI_CLUSTER_MAGIC,8)) goto fail;
+        if(cluster_u32(w->fd,&v,0)||v!=COLI_CLUSTER_VERSION) goto fail;
+        if(cluster_u32(w->fd,&v,0)||v!=0) goto fail;
+        if(cluster_u32(w->fd,&v,0)||v!=(uint32_t)n) goto fail;
+        for(int j=0;j<n;j++){
+            uint32_t eid,nr; if(cluster_u32(w->fd,&eid,0)||cluster_u32(w->fd,&nr,0)) goto fail;
+            if(eid!= (uint32_t)items[j].eid || nr!=(uint32_t)items[j].nr) goto fail;
+            float *y=falloc((int64_t)nr*D);
+            if(cluster_io(w->fd,y,(size_t)nr*D*sizeof(float),0)){ free(y); goto fail; }
+            for(uint32_t r=0;r<nr;r++){ float *dst=out+(int64_t)items[j].rows[r]*D;
+                float wt=items[j].weights[r]; for(int d=0;d<D;d++) dst[d]+=wt*y[(int64_t)r*D+d]; }
+            free(y); g_cluster_rows+=(uint64_t)nr; g_cluster_experts++;
+        }
+        g_cluster_calls++;
+        for(int j=0;j<n;j++) cluster_item_free(&items[j]);
+        continue;
+fail:
+        for(int j=0;j<n;j++) cluster_item_free(&items[j]);
+        fprintf(stderr,"[CLUSTER] expert worker %s:%d failed during layer %d batch\n",w->host,w->port,layer);
+        exit(1);
+    }
+}
+
+typedef struct { int eid,nr; float *inputs; } ClusterRequestItem;
+static int cluster_worker_run(const char *snap,int port,int ebits,int dbits){
+    Model m; memset(&m,0,sizeof(m)); m.ebits=ebits; m.dbits=dbits; load_cfg(&m.c,snap); st_init(&m.S,snap);
+    int nr_layers=m.c.n_layers+1; ESlot *cache=calloc((size_t)nr_layers,sizeof(ESlot));
+    for(int i=0;i<nr_layers;i++) cache[i].eid=-1;
+    int fd=socket(AF_INET,SOCK_STREAM,0); if(fd<0){perror("cluster worker socket");return 1;}
+    int yes=1; setsockopt(fd,SOL_SOCKET,SO_REUSEADDR,&yes,sizeof(yes));
+    struct sockaddr_in addr={0}; addr.sin_family=AF_INET; addr.sin_addr.s_addr=htonl(INADDR_ANY); addr.sin_port=htons((uint16_t)port);
+    if(bind(fd,(struct sockaddr*)&addr,sizeof(addr))||listen(fd,4)){perror("cluster worker bind/listen");return 1;}
+    fprintf(stderr,"[CLUSTER] expert worker listening on 0.0.0.0:%d (disk-backed, cache=%d/layer)\n",port,nr_layers);
+    for(;;){
+        int cfd=accept(fd,NULL,NULL); if(cfd<0){if(errno==EINTR)continue;break;}
+        for(;;){
+            char magic[8]; uint32_t v,layer,D,I,n;
+            if(cluster_io(cfd,magic,8,0)) break;
+            if(memcmp(magic,COLI_CLUSTER_MAGIC,8)||cluster_u32(cfd,&v,0)||v!=COLI_CLUSTER_VERSION||
+               cluster_u32(cfd,&layer,0)||cluster_u32(cfd,&D,0)||cluster_u32(cfd,&I,0)||cluster_u32(cfd,&n,0)||
+               D!=(uint32_t)m.c.hidden||I!=(uint32_t)m.c.moe_inter||layer>=(uint32_t)nr_layers||n>64){ close(cfd); cfd=-1; break; }
+            ClusterRequestItem *items=calloc(n,sizeof(*items)); int bad=0;
+            for(uint32_t j=0;j<n;j++){
+                uint32_t eid,nr; if(cluster_u32(cfd,&eid,0)||cluster_u32(cfd,&nr,0)||eid>=(uint32_t)m.c.n_experts||nr>65536){bad=1;break;}
+                items[j].eid=(int)eid; items[j].nr=(int)nr; items[j].inputs=falloc((int64_t)nr*D);
+                if(cluster_io(cfd,items[j].inputs,(size_t)nr*D*sizeof(float),0)){bad=1;break;}
+            }
+            if(bad){ for(uint32_t j=0;j<n;j++)free(items[j].inputs);free(items);close(cfd);cfd=-1;break; }
+            v=COLI_CLUSTER_VERSION; if(cluster_io(cfd,(void*)COLI_CLUSTER_MAGIC,8,1)||cluster_u32(cfd,&v,1)) break;
+            v=0; if(cluster_u32(cfd,&v,1)) break; v=n; if(cluster_u32(cfd,&v,1)) break;
+            ESlot *slot=&cache[layer];
+            for(uint32_t j=0;j<n;j++){
+                if(slot->eid!=items[j].eid && expert_load(&m,(int)layer,items[j].eid,slot,1)){bad=1;break;}
+                int rows=items[j].nr; float *g=falloc((int64_t)rows*I),*u=falloc((int64_t)rows*I),*y=falloc((int64_t)rows*D);
+                expert_gate_up(g,u,items[j].inputs,&slot->g,&slot->u,rows);
+                for(int64_t z=0;z<(int64_t)rows*I;z++)g[z]=siluf(g[z])*u[z];
+                matmul_qt(y,g,&slot->d,rows);
+                v=(uint32_t)items[j].eid; if(cluster_u32(cfd,&v,1)){bad=1;free(g);free(u);free(y);break;}
+                v=(uint32_t)rows; if(cluster_u32(cfd,&v,1)||cluster_io(cfd,y,(size_t)rows*D*sizeof(float),1)){bad=1;free(g);free(u);free(y);break;}
+                free(g);free(u);free(y);
+            }
+            for(uint32_t j=0;j<n;j++)free(items[j].inputs);free(items);
+            if(bad)break;
+        }
+        if(cfd>=0)close(cfd);
+    }
+    close(fd); return 0;
+}
+#endif
+
 #ifdef __linux__
 /* io_uring expert batches.  One owner prepares all reads for a block, submits
  * them in one syscall, and reaps CQEs on demand.  The kernel, rather than a set
@@ -2935,6 +3122,14 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
     int shared_on_gpu=0; (void)shared_on_gpu;   /* set by the Metal path when Phase E was fused */
     for(int base=0;base<nu;base+=64){
         int nb = nu-base<64 ? nu-base : 64;
+#if !defined(_WIN32)
+        if(g_cluster_n){
+            /* The coordinator already did routing and built `uniq`; the worker
+             * receives only activation rows, never router state or model history. */
+            cluster_moe_batch(m,layer,x,S,out,idxs,ws,keff,K,uniq,base,nb);
+            continue;
+        }
+#endif
         ESlot *use[64]; int missk[64]; int qof[64]; int nmiss=0;
         for(int j=0;j<nb;j++){ int eid=uniq[base+j]; use[j]=NULL; qof[j]=-1;
             ESlot *P=m->pin[layer];
@@ -5884,6 +6079,15 @@ int main(int argc, char **argv){
     int cap  = argc>1?atoi(argv[1]):64;
     int ebits= argc>2?atoi(argv[2]):8;
     int dbits= argc>3?atoi(argv[3]):ebits;
+#if !defined(_WIN32)
+    if(getenv("EXPERT_WORKER")){
+        int port=getenv("CLUSTER_WORKER_PORT")?atoi(getenv("CLUSTER_WORKER_PORT")):9100;
+        if(port<1||port>65535){fprintf(stderr,"CLUSTER_WORKER_PORT must be 1..65535\n");return 2;}
+        return cluster_worker_run(snap,port,ebits,dbits);
+    }
+#else
+    if(getenv("EXPERT_WORKER")){ fprintf(stderr,"[CLUSTER] expert workers are not supported on Windows yet\n"); return 2; }
+#endif
     if(getenv("SERVE") && (kv_slot_count()<1 || kv_slot_count()>16)){
         fprintf(stderr,"KV_SLOTS must be between 1 and 16\n"); return 2;
     }
@@ -5939,6 +6143,10 @@ int main(int argc, char **argv){
     printf("== GLM C engine (glm_moe_dsa), cache=%d experts/layer | experts@%d-bit dense@%d-bit | idot: " IDOT_KERNEL " ==\n", cap, ebits, dbits);
     g_mem_avail_boot = mem_available_gb();
     Model m; double t0=now_s(); model_init(&m,snap,cap,ebits,dbits);
+#if !defined(_WIN32)
+    cluster_init();
+    atexit(cluster_close_all);
+#endif
     if(g_draft<0){
 #ifdef COLI_CUDA
         /* MTP is disabled under CUDA by default: cold (streaming) experts still

--- a/c/glm.c
+++ b/c/glm.c
@@ -219,10 +219,16 @@ typedef struct {
  * a small binary protocol.  Keeping this state outside Model makes cluster mode
  * orthogonal to model placement and preserves the single-box path byte-for-byte. */
 #if !defined(_WIN32)
-typedef struct { int fd; char host[128]; int port; } ClusterWorker;
+typedef struct { int fd; char host[128]; int port, first, last; } ClusterWorker;
 static ClusterWorker g_cluster_workers[16];
 static int g_cluster_n;
 static uint64_t g_cluster_calls, g_cluster_experts, g_cluster_rows;
+static ClusterWorker g_dense_workers[16];
+static int g_dense_n;
+static int g_dense_mlp_worker;
+static int g_dense_worker_first, g_dense_worker_last;
+static int cluster_dense_owner(int layer);
+static int dense_worker_run(const char *snap,int port,int first,int last,int cap,int ebits,int dbits);
 #endif
 
 static void usage_save(Model *m);        /* cache che impara: definita accanto a stats_dump */
@@ -1427,9 +1433,11 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
     /* embed e lm_head sono il confine I/O: tenerli ad alta precisione (come i quant dynamic
      * reali). A bf16 ~1.9GB su GLM reale: trascurabile. dbits>=8 -> qui f32; piu' basso -> dbits. */
     int io_bits = dbits>=8 ? 16 : dbits;
-    m->embed   = qt_load(m,"model.embed_tokens.weight", c->vocab, D, io_bits);
-    m->lm_head = qt_load(m,"lm_head.weight", c->vocab, D, io_bits);
-    m->final_norm = ld(m,"model.norm.weight");
+    if(!g_dense_mlp_worker){
+        m->embed   = qt_load(m,"model.embed_tokens.weight", c->vocab, D, io_bits);
+        m->lm_head = qt_load(m,"lm_head.weight", c->vocab, D, io_bits);
+        m->final_norm = ld(m,"model.norm.weight");
+    }
     m->L=calloc(c->n_layers,sizeof(Layer));
     int NR=c->n_layers+1;                        /* +1: riga del layer MTP */
     m->ecap=cap; m->ecache=calloc(NR,sizeof(ESlot*)); m->ecn=calloc(NR,sizeof(int));
@@ -1443,6 +1451,16 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
     m->kv_start=m->kv->kv_start=calloc(NR,sizeof(int));
     for(int i=0;i<c->n_layers;i++){
         Layer *l=&m->L[i];
+        if(g_dense_mlp_worker){
+            if(i<g_dense_worker_first||i>g_dense_worker_last||i>=c->first_dense) continue;
+            l->sparse=0;
+            #define PW(s) (snprintf(nm,sizeof(nm),"model.layers.%d." s,i),nm)
+            l->gate_proj=qt_load(m,PW("mlp.gate_proj.weight"),c->dense_inter,D,dbits);
+            l->up_proj=qt_load(m,PW("mlp.up_proj.weight"),c->dense_inter,D,dbits);
+            l->down_proj=qt_load(m,PW("mlp.down_proj.weight"),D,c->dense_inter,dbits);
+            #undef PW
+            continue;
+        }
         #define P(s) (snprintf(nm,sizeof(nm),"model.layers.%d." s,i),nm)
         l->in_ln=ld(m,P("input_layernorm.weight"));
         l->post_ln=ld(m,P("post_attention_layernorm.weight"));
@@ -1462,11 +1480,11 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
             layer_cuda_shard_kvb(l,H,c->qk_nope,c->v_head);
 #endif
         l->sparse = (i >= c->first_dense);
-        if(!l->sparse){
+        if(!l->sparse && (i>=c->first_dense || cluster_dense_owner(i)<0)){
             l->gate_proj = qt_load(m,P("mlp.gate_proj.weight"), c->dense_inter, D, dbits);
             l->up_proj   = qt_load(m,P("mlp.up_proj.weight"),   c->dense_inter, D, dbits);
             l->down_proj = qt_load(m,P("mlp.down_proj.weight"), D, c->dense_inter, dbits);
-        } else {
+        } else if(l->sparse) {
             l->router=ld(m,P("mlp.gate.weight"));
             l->router_bias=ld(m,P("mlp.gate.e_score_correction_bias"));
             int sI=c->moe_inter*c->n_shared;
@@ -1496,7 +1514,7 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
             "self_attn.kv_b_proj.weight","self_attn.o_proj.weight","mlp.gate.weight",
             "mlp.shared_experts.gate_proj.weight","mlp.shared_experts.down_proj.weight",
             "mlp.experts.0.gate_proj.weight","mlp.experts.255.down_proj.weight"};
-        char mn[256]; m->has_mtp=1;
+        char mn[256]; m->has_mtp=g_dense_mlp_worker?0:1;
         for(unsigned q=0;q<sizeof(req)/sizeof(req[0]);q++){
             snprintf(mn,sizeof(mn),"model.layers.%d.%s",c->n_layers,req[q]);
             if(!st_has(&m->S,mn)){ m->has_mtp=0; break; }
@@ -1536,7 +1554,7 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
     /* DSA lightning indexer: attivo SOLO se i pesi (conversione --indexer) ci sono per
      * TUTTI i layer full. Auto-rilevamento come per MTP: niente flag, niente passi extra. */
     {
-        m->has_dsa = (c->index_topk>0 && c->index_nh>0 && c->index_hd>0 && c->index_hd<=256);
+        m->has_dsa = (!g_dense_mlp_worker && c->index_topk>0 && c->index_nh>0 && c->index_hd>0 && c->index_hd<=256);
         char inm[300];
         for(int i=0;i<c->n_layers && m->has_dsa;i++){
             if(!c->idx_type[i]) continue;
@@ -1889,6 +1907,52 @@ static void cluster_init(void){
     free(copy);
     if(g_cluster_n<1){ fprintf(stderr,"[CLUSTER] no expert workers reachable\n"); exit(1); }
     fprintf(stderr,"[CLUSTER] coordinator connected to %d expert worker(s)\n",g_cluster_n);
+}
+static int cluster_dense_owner(int layer){
+    for(int i=0;i<g_dense_n;i++) if(layer>=g_dense_workers[i].first&&layer<=g_dense_workers[i].last) return i;
+    return -1;
+}
+/* DENSE_SHARDS=host:port:first:last,... is deliberately static in this first
+ * pipeline. A worker owns a contiguous range of dense MLP layers; attention
+ * and its KV state remain on the coordinator until the activation seam is
+ * proven. This removes the largest easy-to-isolate resident tensors without
+ * inventing distributed KV semantics prematurely. */
+static void cluster_dense_init(void){
+    const char *list=getenv("DENSE_SHARDS"); if(!list||!*list) return;
+    char *copy=strdup(list),*save=NULL;
+    for(char *tok=strtok_r(copy,",",&save);tok&&g_dense_n<16;tok=strtok_r(NULL,",",&save)){
+        char spec[256]; strncpy(spec,tok,sizeof(spec)-1); spec[sizeof(spec)-1]=0;
+        char *last=strrchr(spec,':'); if(!last) continue; int end=atoi(last+1); *last=0;
+        char *firstp=strrchr(spec,':'); if(!firstp) continue; int first=atoi(firstp+1); *firstp=0;
+        char *portp=strrchr(spec,':'); if(!portp) continue; int eport=atoi(portp+1); *portp=0;
+        char joined[256]; snprintf(joined,sizeof(joined),"%s:%d",spec,eport);
+        if(first<0||end<first||eport<1||eport>65535||cluster_connect_one(joined,&g_dense_workers[g_dense_n])) continue;
+        g_dense_workers[g_dense_n].first=first; g_dense_workers[g_dense_n].last=end; g_dense_n++;
+    }
+    free(copy);
+    if(!g_dense_n){ fprintf(stderr,"[DENSE] no dense shard workers reachable\n"); exit(1); }
+    fprintf(stderr,"[DENSE] activation pipeline connected to %d shard(s)\n",g_dense_n);
+}
+static void cluster_dense_close(void){
+    for(int i=0;i<g_dense_n;i++) if(g_dense_workers[i].fd>=0) close(g_dense_workers[i].fd);
+    g_dense_n=0;
+}
+static void cluster_dense_mlp(Model *m,int layer,const float *input,int S,float *output){
+    int wi=cluster_dense_owner(layer); if(wi<0){ fprintf(stderr,"[DENSE] no owner for layer %d\n",layer); exit(1); }
+    ClusterWorker *w=&g_dense_workers[wi]; uint32_t v; char magic[8]; int D=m->c.hidden,I=m->c.dense_inter;
+    if(cluster_io(w->fd,(void*)"COLIDN01",8,1)) goto fail;
+    v=1; if(cluster_u32(w->fd,&v,1)) goto fail; v=(uint32_t)layer; if(cluster_u32(w->fd,&v,1)) goto fail;
+    v=(uint32_t)D; if(cluster_u32(w->fd,&v,1)) goto fail; v=(uint32_t)I; if(cluster_u32(w->fd,&v,1)) goto fail;
+    v=(uint32_t)S; if(cluster_u32(w->fd,&v,1)) goto fail;
+    if(cluster_io(w->fd,(void*)input,(size_t)S*D*sizeof(float),1)) goto fail;
+    if(cluster_io(w->fd,magic,8,0)||memcmp(magic,"COLIDN01",8)) goto fail;
+    if(cluster_u32(w->fd,&v,0)||v!=1) goto fail;
+    if(cluster_u32(w->fd,&v,0)||v!=0) goto fail;
+    if(cluster_u32(w->fd,&v,0)||v!=(uint32_t)S) goto fail;
+    if(cluster_io(w->fd,output,(size_t)S*D*sizeof(float),0)) goto fail;
+    return;
+fail:
+    fprintf(stderr,"[DENSE] shard %s:%d failed for layer %d\n",w->host,w->port,layer); exit(1);
 }
 typedef struct { int eid,nr; int *rows; float *weights,*inputs; } ClusterItem;
 static int cluster_item(const int *idxs,const float *ws,const int *keff,int K,int S,
@@ -3407,6 +3471,41 @@ static void dense_mlp(Layer *l, float *x, int S, int D, int I, float *out){
     free(g); free(u);
 }
 
+#if !defined(_WIN32)
+static int dense_worker_run(const char *snap,int port,int first,int last,int cap,int ebits,int dbits){
+    g_dense_mlp_worker=1; g_dense_worker_first=first; g_dense_worker_last=last;
+    Model m; double t0=now_s(); model_init(&m,snap,cap,ebits,dbits);
+    int fd=socket(AF_INET,SOCK_STREAM,0); if(fd<0){perror("dense worker socket");return 1;}
+    int yes=1; setsockopt(fd,SOL_SOCKET,SO_REUSEADDR,&yes,sizeof(yes));
+    struct sockaddr_in addr={0}; addr.sin_family=AF_INET; addr.sin_addr.s_addr=htonl(INADDR_ANY); addr.sin_port=htons((uint16_t)port);
+    if(bind(fd,(struct sockaddr*)&addr,sizeof(addr))||listen(fd,4)){perror("dense worker bind/listen");return 1;}
+    fprintf(stderr,"[DENSE] worker listening on 0.0.0.0:%d · layers %d-%d · loaded %.2f MB in %.2fs\n",
+            port,first,last,m.resident_bytes/(1024.0*1024.0),now_s()-t0);
+    for(;;){
+        int cfd=accept(fd,NULL,NULL); if(cfd<0){if(errno==EINTR)continue;break;}
+        for(;;){
+            char magic[8]; uint32_t v,layer,D,I,S;
+            if(cluster_io(cfd,magic,8,0)) break;
+            if(memcmp(magic,"COLIDN01",8)||cluster_u32(cfd,&v,0)||v!=1||
+               cluster_u32(cfd,&layer,0)||cluster_u32(cfd,&D,0)||cluster_u32(cfd,&I,0)||cluster_u32(cfd,&S,0)||
+               layer>=(uint32_t)m.c.n_layers||layer<(uint32_t)first||layer>(uint32_t)last||layer>=(uint32_t)m.c.first_dense||
+               D!=(uint32_t)m.c.hidden||I!=(uint32_t)m.c.dense_inter||S<1||S>4096){
+                close(cfd); cfd=-1; break;
+            }
+            float *input=falloc((int64_t)S*D),*output=falloc((int64_t)S*D);
+            if(cluster_io(cfd,input,(size_t)S*D*sizeof(float),0)){free(input);free(output);break;}
+            dense_mlp(&m.L[layer],input,S,D,I,output);
+            v=1; if(cluster_io(cfd,(void*)"COLIDN01",8,1)||cluster_u32(cfd,&v,1)){free(input);free(output);break;}
+            v=0; if(cluster_u32(cfd,&v,1)){free(input);free(output);break;}
+            v=S; if(cluster_u32(cfd,&v,1)||cluster_io(cfd,output,(size_t)S*D*sizeof(float),1)){free(input);free(output);break;}
+            free(input);free(output);
+        }
+        if(cfd>=0)close(cfd);
+    }
+    close(fd); return 0;
+}
+#endif
+
 /* LOOKA: predice il top-K del router del layer `target` dallo stato h (residual stream),
  * usando la STESSA pipeline del routing vero (post_ln -> router -> sigmoid+bias, top-K).
  * kind 0 = stesso layer saltando l'attention
@@ -3900,7 +3999,11 @@ static void layer_forward_rows(Model *m, Layer *l, int li, float *x, int S, int 
         la_predict(m,li+1,x,2);  /* two-step: shared-expert-corrected prediction */
     }
     for(int s=0;s<S;s++) rmsnorm(nrm+(int64_t)s*D, x+(int64_t)s*D, l->post_ln, D, c->eps);
-    if(l->sparse) moe(m,l,li,nrm,S,tmp,1); else dense_mlp(l,nrm,S,D,c->dense_inter,tmp);
+    if(l->sparse) moe(m,l,li,nrm,S,tmp,1);
+#if !defined(_WIN32)
+    else if(cluster_dense_owner(li)>=0) cluster_dense_mlp(m,li,nrm,S,tmp);
+#endif
+    else dense_mlp(l,nrm,S,D,c->dense_inter,tmp);
     for(int64_t j=0;j<(int64_t)S*D;j++) x[j]+=tmp[j];
 }
 static void layer_forward(Model *m, Layer *l, int li, float *x, int S, int pos_base, float *nrm, float *tmp){
@@ -6085,6 +6188,13 @@ int main(int argc, char **argv){
         if(port<1||port>65535){fprintf(stderr,"CLUSTER_WORKER_PORT must be 1..65535\n");return 2;}
         return cluster_worker_run(snap,port,ebits,dbits);
     }
+    if(getenv("DENSE_WORKER")){
+        int port=getenv("DENSE_WORKER_PORT")?atoi(getenv("DENSE_WORKER_PORT")):9200;
+        int first=getenv("DENSE_WORKER_FIRST")?atoi(getenv("DENSE_WORKER_FIRST")):-1;
+        int last=getenv("DENSE_WORKER_LAST")?atoi(getenv("DENSE_WORKER_LAST")):-1;
+        if(port<1||port>65535||first<0||last<first){fprintf(stderr,"invalid dense worker port/range\n");return 2;}
+        return dense_worker_run(snap,port,first,last,cap,ebits,dbits);
+    }
 #else
     if(getenv("EXPERT_WORKER")){ fprintf(stderr,"[CLUSTER] expert workers are not supported on Windows yet\n"); return 2; }
 #endif
@@ -6142,10 +6252,14 @@ int main(int argc, char **argv){
 #endif
     printf("== GLM C engine (glm_moe_dsa), cache=%d experts/layer | experts@%d-bit dense@%d-bit | idot: " IDOT_KERNEL " ==\n", cap, ebits, dbits);
     g_mem_avail_boot = mem_available_gb();
+    #if !defined(_WIN32)
+    cluster_dense_init();
+    #endif
     Model m; double t0=now_s(); model_init(&m,snap,cap,ebits,dbits);
 #if !defined(_WIN32)
     cluster_init();
     atexit(cluster_close_all);
+    atexit(cluster_dense_close);
 #endif
     if(g_draft<0){
 #ifdef COLI_CUDA

--- a/c/tests/test_cluster.py
+++ b/c/tests/test_cluster.py
@@ -1,0 +1,48 @@
+import json
+import threading
+import unittest
+from http.client import HTTPConnection
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from cluster import ClusterRegistry, ClusterServer, PROTOCOL_VERSION
+
+
+class ClusterRegistryTests(unittest.TestCase):
+    def test_registers_and_discovers_expert_nodes(self):
+        registry = ClusterRegistry()
+        registry.register({"node_id": "mac-a", "host": "10.0.0.2", "port": 9100,
+                           "role": "expert", "layers": "0-37"})
+        registry.register({"node_id": "mac-b", "host": "10.0.0.3", "port": 9101,
+                           "role": "dense", "layers": "38-75"})
+        self.assertEqual(registry.expert_endpoints(), ["10.0.0.2:9100"])
+        self.assertEqual(registry.snapshot()["protocol_version"], PROTOCOL_VERSION)
+
+    def test_http_topology_and_registration(self):
+        server = ClusterServer(("127.0.0.1", 0), ClusterRegistry())
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            conn = HTTPConnection(*server.server_address)
+            body = json.dumps({"node_id": "mac-a", "host": "127.0.0.1",
+                               "port": 9100, "role": "expert"})
+            conn.request("POST", "/v1/cluster/register", body,
+                         {"Content-Type": "application/json"})
+            self.assertEqual(conn.getresponse().status, 200)
+            conn.request("POST", "/v1/cluster/heartbeat", json.dumps({"node_id": "mac-a"}),
+                         {"Content-Type": "application/json"})
+            self.assertEqual(conn.getresponse().status, 200)
+            conn.request("GET", "/v1/cluster/topology")
+            response = conn.getresponse()
+            self.assertEqual(response.status, 200)
+            self.assertEqual(len(json.loads(response.read())["nodes"]), 1)
+            conn.close()
+        finally:
+            server.shutdown()
+            server.server_close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tests/test_cluster.py
+++ b/c/tests/test_cluster.py
@@ -1,4 +1,5 @@
 import json
+import socket
 import threading
 import unittest
 from http.client import HTTPConnection
@@ -7,10 +8,23 @@ import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from cluster import ClusterRegistry, ClusterServer, PROTOCOL_VERSION
+from cluster import (ClusterRegistry, ClusterServer, PROTOCOL_VERSION,
+                     pack_expert_batch, pack_expert_response,
+                     parse_expert_batch, parse_expert_response,
+                     _ws_frame, _ws_read_frame)
 
 
 class ClusterRegistryTests(unittest.TestCase):
+    def test_expert_wire_round_trip_preserves_activation_bytes(self):
+        batch = {"layer": 4, "hidden": 2, "items": [
+            {"expert_id": 7, "rows": 1, "activations": b"abcdefgh"},
+        ]}
+        decoded = parse_expert_batch(pack_expert_batch(batch))
+        self.assertEqual(decoded["layer"], 4)
+        self.assertEqual(decoded["items"][0]["activations"], b"abcdefgh")
+        response = parse_expert_response(pack_expert_response(decoded, [b"12345678"]))
+        self.assertEqual((response["status"], response["count"]), (0, 1))
+
     def test_registers_and_discovers_expert_nodes(self):
         registry = ClusterRegistry()
         registry.register({"node_id": "mac-a", "host": "10.0.0.2", "port": 9100,
@@ -19,6 +33,45 @@ class ClusterRegistryTests(unittest.TestCase):
                            "role": "dense", "layers": "38-75"})
         self.assertEqual(registry.expert_endpoints(), ["10.0.0.2:9100"])
         self.assertEqual(registry.snapshot()["protocol_version"], PROTOCOL_VERSION)
+
+    def test_accepts_browser_webgpu_capability_record(self):
+        registry = ClusterRegistry()
+        registry.register({"node_id": "iphone-a", "host": "browser", "port": 0,
+                           "role": "webgpu", "device_type": "iPhone", "precision": "f32",
+                           "expert_ids": ["4:7"]})
+        self.assertEqual(registry.snapshot()["nodes"][0]["role"], "webgpu")
+
+    def test_dispatches_native_batch_over_websocket_connection(self):
+        coordinator, browser = socket.socketpair()
+        connection = None
+        try:
+            registry = ClusterRegistry()
+            connection = registry.register_webgpu_connection(
+                coordinator,
+                {"node_id": "browser-a", "expert_ids": ["4:7"]},
+            )
+
+            def browser_worker():
+                opcode, payload = _ws_read_frame(browser)
+                self.assertEqual(opcode, 2)
+                batch = parse_expert_batch(payload)
+                response = pack_expert_response(batch, [b"12345678"])
+                browser.sendall(_ws_frame(2, response))
+
+            worker = threading.Thread(target=browser_worker)
+            worker.start()
+            batch = {"layer": 4, "hidden": 2, "items": [
+                {"expert_id": 7, "rows": 1, "activations": b"abcdefgh"},
+            ]}
+            response = parse_expert_response(registry.dispatch_webgpu(pack_expert_batch(batch)))
+            self.assertEqual(response["status"], 0)
+            self.assertEqual(response["count"], 1)
+            worker.join(timeout=1)
+            self.assertFalse(worker.is_alive())
+        finally:
+            if connection is not None:
+                registry.unregister_webgpu(connection)
+            browser.close()
 
     def test_http_topology_and_registration(self):
         server = ClusterServer(("127.0.0.1", 0), ClusterRegistry())

--- a/c/tools/export_webgpu_expert.py
+++ b/c/tools/export_webgpu_expert.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Export selected dense MoE experts to browser-uploadable f32 buffers.
+
+This first exporter intentionally targets readable floating-point source
+checkpoints. Colibrì's packed int4 container needs a later dequantizing path;
+keeping that conversion explicit avoids silently changing model quality.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_indices(values):
+    result = []
+    for value in values:
+        for part in value.split(","):
+            if "-" in part:
+                start, end = (int(x) for x in part.split("-", 1))
+                result.extend(range(start, end + 1))
+            elif part.strip():
+                result.append(int(part))
+    return sorted(set(result))
+
+
+def export(source, output, layers, experts):
+    try:
+        import numpy as np
+        from safetensors import safe_open
+    except ImportError as error:
+        raise SystemExit("install exporter dependencies with: uv pip install numpy safetensors") from error
+
+    source = Path(source)
+    output = Path(output)
+    shards = sorted(source.glob("*.safetensors"))
+    if not shards:
+        raise SystemExit(f"no safetensors files found in {source}")
+    index = {}
+    for shard in shards:
+        with safe_open(str(shard), framework="pt", device="cpu") as handle:
+            for name in handle.keys():
+                index.setdefault(name, shard)
+
+    manifest = {"schema_version": 1, "dtype": "f32", "experts": {}}
+    for layer in layers:
+        for expert in experts:
+            prefix = f"model.layers.{layer}.mlp.experts.{expert}"
+            names = {key: f"{prefix}.{key}_proj.weight" for key in ("gate", "up", "down")}
+            missing = [name for name in names.values() if name not in index]
+            if missing:
+                raise SystemExit(f"missing tensors for {layer}:{expert}: {', '.join(missing)}")
+            arrays = {}
+            for key, name in names.items():
+                with safe_open(str(index[name]), framework="pt", device="cpu") as handle:
+                    arrays[key] = np.asarray(handle.get_tensor(name).detach().cpu().numpy(), dtype="<f4")
+            gate, up, down = arrays["gate"], arrays["up"], arrays["down"]
+            if gate.ndim != 2 or up.shape != gate.shape or down.shape != (gate.shape[1], gate.shape[0]):
+                raise SystemExit(f"unexpected shapes for {layer}:{expert}: {gate.shape}, {up.shape}, {down.shape}")
+            manifest.setdefault("hidden", int(gate.shape[1]))
+            manifest.setdefault("intermediate", int(gate.shape[0]))
+            if (manifest["hidden"], manifest["intermediate"]) != (gate.shape[1], gate.shape[0]):
+                raise SystemExit("all exported experts must have the same dimensions")
+            directory = output / "experts" / f"layer-{layer:04d}" / f"expert-{expert:04d}"
+            directory.mkdir(parents=True, exist_ok=True)
+            paths = {}
+            for key, array in arrays.items():
+                path = directory / f"{key}.f32"
+                array.tofile(path)
+                paths[key] = str(path.relative_to(output))
+            manifest["experts"][f"{layer}:{expert}"] = paths
+    (output / "webgpu-manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    print(json.dumps({"manifest": str(output / "webgpu-manifest.json"),
+                      "experts": len(manifest["experts"]),
+                      "hidden": manifest["hidden"],
+                      "intermediate": manifest["intermediate"]}, indent=2))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", required=True, help="source checkpoint directory")
+    parser.add_argument("--output", required=True, help="directory served to the browser")
+    parser.add_argument("--layer", action="append", required=True, help="layer id/range, repeatable")
+    parser.add_argument("--expert", action="append", required=True, help="expert id/list, repeatable")
+    args = parser.parse_args()
+    export(args.source, args.output, parse_indices(args.layer), parse_indices(args.expert))
+
+
+if __name__ == "__main__":
+    main()

--- a/web/public/webgpu-worker.html
+++ b/web/public/webgpu-worker.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>colibrì WebGPU expert worker</title>
+<style>
+  body { font: 15px system-ui, sans-serif; max-width: 720px; margin: 3rem auto; padding: 0 1rem; }
+  label { display: block; margin: .8rem 0 .25rem; } input { width: 100%; padding: .55rem; box-sizing: border-box; }
+  button { margin-top: 1rem; padding: .6rem 1rem; } pre { background: #111; color: #9f9; padding: 1rem; min-height: 4rem; }
+</style>
+<h1>colibrì WebGPU expert worker</h1>
+<p>This browser tab contributes expert FFN compute to a trusted local coordinator.</p>
+<label>Coordinator WebSocket URL</label><input id="url" value="ws://127.0.0.1:8765/v1/cluster/webgpu">
+<label>Worker ID</label><input id="worker" value="browser-worker-1">
+<label>Manifest URL</label><input id="manifest" value="/webgpu-manifest.json">
+<label>Expert ownership (comma-separated <code>layer:expert</code>, or <code>*</code>)</label>
+<input id="experts" value="*">
+<button id="start">Start worker</button><pre id="status">idle</pre>
+<script type="module">
+  import { WebGPUExpertWorker } from "/webgpu-worker.js";
+  const status = document.querySelector("#status");
+  document.querySelector("#start").onclick = async () => {
+    try {
+      status.textContent = "loading manifest and requesting WebGPU…";
+      const manifest = await fetch(document.querySelector("#manifest").value).then(r => r.json());
+      const experts = document.querySelector("#experts").value.split(",").map(x => x.trim()).filter(Boolean);
+      await new WebGPUExpertWorker({ manifest, experts, workerId: document.querySelector("#worker").value })
+        .connect(document.querySelector("#url").value);
+      status.textContent = `connected · ${manifest.hidden} hidden · ${manifest.intermediate} intermediate · WebGPU active`;
+    } catch (error) { status.textContent = error.stack || String(error); }
+  };
+</script>

--- a/web/public/webgpu-worker.js
+++ b/web/public/webgpu-worker.js
@@ -1,0 +1,200 @@
+/* Standalone browser-side WebGPU expert worker.
+ * The coordinator sends the same COLIEX01 batch used by native expert workers.
+ * Weights are intentionally plain little-endian f32 in this first slice: this
+ * is easy to validate across browsers, and a later exporter can add f16/int8
+ * variants without changing the dispatch contract. */
+
+const MAGIC = "COLIEX01";
+const VERSION = 1;
+
+function textMagic(bytes) {
+  return new TextDecoder().decode(bytes);
+}
+
+function putU32(view, offset, value) {
+  view.setUint32(offset, value >>> 0, false);
+}
+
+function getU32(view, offset) {
+  return view.getUint32(offset, false);
+}
+
+function concat(parts) {
+  const size = parts.reduce((total, part) => total + part.byteLength, 0);
+  const out = new Uint8Array(size);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(new Uint8Array(part.buffer || part, part.byteOffset || 0, part.byteLength), offset);
+    offset += part.byteLength;
+  }
+  return out;
+}
+
+export class WebGPUExpertWorker {
+  constructor({ manifest, workerId, experts = ["*"], deviceType = "browser" }) {
+    this.manifest = manifest;
+    this.workerId = workerId;
+    this.experts = experts;
+    this.deviceType = deviceType;
+    this.socket = null;
+    this.device = null;
+    this.cache = new Map();
+    this.gatePipeline = null;
+    this.downPipeline = null;
+  }
+
+  async connect(url) {
+    if (!navigator.gpu) throw new Error("WebGPU is unavailable in this browser");
+    const adapter = await navigator.gpu.requestAdapter();
+    if (!adapter) throw new Error("no WebGPU adapter found");
+    this.device = await adapter.requestDevice();
+    this._createPipelines();
+    this.socket = new WebSocket(url);
+    this.socket.binaryType = "arraybuffer";
+    await new Promise((resolve, reject) => {
+      this.socket.addEventListener("open", resolve, { once: true });
+      this.socket.addEventListener("error", () => reject(new Error("WebGPU worker socket failed")), { once: true });
+    });
+    this.socket.send(JSON.stringify({
+      role: "webgpu", node_id: this.workerId, host: "browser", port: 0,
+      device_type: this.deviceType, precision: "f32", expert_ids: this.experts,
+    }));
+    this.socket.addEventListener("message", event => this._onMessage(event.data));
+    return this;
+  }
+
+  _createPipelines() {
+    const dims = `struct Dims { rows: u32, hidden: u32, intermediate: u32, pad: u32 };
+      @group(0) @binding(0) var<storage, read> input: array<f32>;
+      @group(0) @binding(1) var<storage, read> gate: array<f32>;
+      @group(0) @binding(2) var<storage, read> up: array<f32>;
+      @group(0) @binding(3) var<storage, read_write> hidden: array<f32>;
+      @group(0) @binding(4) var<uniform> dims: Dims;
+      @compute @workgroup_size(64) fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+        let index = id.x; let total = dims.rows * dims.intermediate;
+        if (index >= total) { return; }
+        let row = index / dims.intermediate; let unit = index % dims.intermediate;
+        var g = 0.0; var u = 0.0;
+        for (var d = 0u; d < dims.hidden; d++) {
+          let value = input[row * dims.hidden + d];
+          g += gate[unit * dims.hidden + d] * value;
+          u += up[unit * dims.hidden + d] * value;
+        }
+        let silu = g / (1.0 + exp(-g)); hidden[index] = silu * u;
+      }`;
+    this.gatePipeline = this.device.createComputePipeline({ layout: "auto", compute: {
+      module: this.device.createShaderModule({ code: dims }), entryPoint: "main",
+    }});
+    const down = `struct Dims { rows: u32, hidden: u32, intermediate: u32, pad: u32 };
+      @group(0) @binding(0) var<storage, read> hidden: array<f32>;
+      @group(0) @binding(1) var<storage, read> down: array<f32>;
+      @group(0) @binding(2) var<storage, read_write> output: array<f32>;
+      @group(0) @binding(3) var<uniform> dims: Dims;
+      @compute @workgroup_size(64) fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+        let index = id.x; let total = dims.rows * dims.hidden;
+        if (index >= total) { return; }
+        let row = index / dims.hidden; let dim = index % dims.hidden;
+        var sum = 0.0;
+        for (var unit = 0u; unit < dims.intermediate; unit++) {
+          sum += down[dim * dims.intermediate + unit] * hidden[row * dims.intermediate + unit];
+        }
+        output[index] = sum;
+      }`;
+    this.downPipeline = this.device.createComputePipeline({ layout: "auto", compute: {
+      module: this.device.createShaderModule({ code: down }), entryPoint: "main",
+    }});
+  }
+
+  async _loadExpert(layer, expertId) {
+    const key = `${layer}:${expertId}`;
+    if (this.cache.has(key)) return this.cache.get(key);
+    const spec = this.manifest.experts[key];
+    if (!spec) throw new Error(`manifest has no expert ${key}`);
+    const [gate, up, down] = await Promise.all([spec.gate, spec.up, spec.down]
+      .map(path => fetch(new URL(path, this.manifest.base_url || location.href))
+        .then(response => { if (!response.ok) throw new Error(`cannot load ${path}`); return response.arrayBuffer(); })
+        .then(buffer => new Float32Array(buffer))));
+    const expert = { gate: this._weightBuffer(gate), up: this._weightBuffer(up), down: this._weightBuffer(down) };
+    this.cache.set(key, expert);
+    return expert;
+  }
+
+  _weightBuffer(values) {
+    const buffer = this.device.createBuffer({ size: values.byteLength,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST });
+    this.device.queue.writeBuffer(buffer, 0, values);
+    return buffer;
+  }
+
+  _buffer(bytes, usage) {
+    const buffer = this.device.createBuffer({ size: Math.max(4, bytes.byteLength),
+      usage: usage | GPUBufferUsage.COPY_SRC });
+    this.device.queue.writeBuffer(buffer, 0, bytes);
+    return buffer;
+  }
+
+  async _forward(layer, expertId, rows, hidden, inputBytes) {
+    const intermediate = this.manifest.intermediate;
+    const expert = await this._loadExpert(layer, expertId);
+    const input = this._buffer(inputBytes, GPUBufferUsage.STORAGE);
+    const hiddenBuffer = this.device.createBuffer({ size: rows * intermediate * 4,
+      usage: GPUBufferUsage.STORAGE });
+    const output = this.device.createBuffer({ size: rows * hidden * 4,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC });
+    const readback = this.device.createBuffer({ size: rows * hidden * 4,
+      usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST });
+    const uniform = this.device.createBuffer({ size: 16,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    this.device.queue.writeBuffer(uniform, 0, new Uint32Array([rows, hidden, intermediate, 0]));
+    const gateGroup = this.device.createBindGroup({ layout: this.gatePipeline.getBindGroupLayout(0), entries: [
+      { binding: 0, resource: { buffer: input } }, { binding: 1, resource: { buffer: expert.gate } },
+      { binding: 2, resource: { buffer: expert.up } }, { binding: 3, resource: { buffer: hiddenBuffer } },
+      { binding: 4, resource: { buffer: uniform } },
+    ]});
+    const downGroup = this.device.createBindGroup({ layout: this.downPipeline.getBindGroupLayout(0), entries: [
+      { binding: 0, resource: { buffer: hiddenBuffer } }, { binding: 1, resource: { buffer: expert.down } },
+      { binding: 2, resource: { buffer: output } }, { binding: 3, resource: { buffer: uniform } },
+    ]});
+    const encoder = this.device.createCommandEncoder();
+    const first = encoder.beginComputePass(); first.setPipeline(this.gatePipeline); first.setBindGroup(0, gateGroup);
+    first.dispatchWorkgroups(Math.ceil(rows * intermediate / 64)); first.end();
+    const second = encoder.beginComputePass(); second.setPipeline(this.downPipeline); second.setBindGroup(0, downGroup);
+    second.dispatchWorkgroups(Math.ceil(rows * hidden / 64)); second.end();
+    encoder.copyBufferToBuffer(output, 0, readback, 0, rows * hidden * 4);
+    this.device.queue.submit([encoder.finish()]);
+    await readback.mapAsync(GPUMapMode.READ);
+    const result = readback.getMappedRange().slice(0);
+    readback.unmap();
+    for (const buffer of [input, hiddenBuffer, output, readback, uniform]) buffer.destroy();
+    return result;
+  }
+
+  async _onMessage(data) {
+    try {
+      const bytes = new Uint8Array(data);
+      const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+      if (textMagic(bytes.subarray(0, 8)) !== MAGIC || getU32(view, 8) !== VERSION) throw new Error("bad request");
+      const layer = getU32(view, 12), hidden = getU32(view, 16), count = getU32(view, 20);
+      if (hidden !== this.manifest.hidden || count > 64) throw new Error("unsupported request shape");
+      let offset = 24, outputs = [];
+      for (let i = 0; i < count; i++) {
+        const expertId = getU32(view, offset), rows = getU32(view, offset + 4); offset += 8;
+        const size = rows * hidden * 4;
+        const input = bytes.slice(offset, offset + size); offset += size;
+        outputs.push({ expertId, rows, bytes: await this._forward(layer, expertId, rows, hidden, input) });
+      }
+      const parts = [new Uint8Array(20)]; const response = new DataView(parts[0].buffer);
+      for (let i = 0; i < 8; i++) parts[0][i] = MAGIC.charCodeAt(i);
+      putU32(response, 8, VERSION); putU32(response, 12, 0); putU32(response, 16, outputs.length);
+      for (const output of outputs) { const header = new Uint8Array(8); const hv = new DataView(header.buffer);
+        putU32(hv, 0, output.expertId); putU32(hv, 4, output.rows); parts.push(header, new Uint8Array(output.bytes)); }
+      this.socket.send(concat(parts));
+    } catch (error) {
+      console.error("WebGPU expert request failed", error);
+      const response = new Uint8Array(20); const view = new DataView(response.buffer);
+      for (let i = 0; i < 8; i++) response[i] = MAGIC.charCodeAt(i);
+      putU32(view, 8, VERSION); putU32(view, 12, 1); putU32(view, 16, 0);
+      this.socket.send(response);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a progressive local-cluster execution path for consumer Macs and browser/WebGPU devices:

- coordinator/worker registration and distributed MoE expert routing
- native batch-union expert RPC for disk-backed workers
- contiguous dense MLP activation sharding across local nodes
- browser/mobile WebGPU expert workers over WebSocket
- native TCP-to-WebSocket activation proxy
- WebGPU expert weight exporter for readable floating-point checkpoints
- browser worker UI and protocol/dispatch tests

The coordinator keeps token generation, routing, attention, and KV state local. Remote workers execute assigned expert FFNs or dense MLP ranges.

## Validation

- native `make test`
- 73 Python tests
- 17 web tests
- TypeScript/Vite production build
- Python and JavaScript syntax checks

## Scope and follow-ups

The WebGPU path currently uses f32 buffers and is intended for a trusted LAN. TLS/authentication, WebRTC transport, quantized WebGPU weight formats, and broader dense/tensor-parallel sharding can follow as separate changes.

## Not yet tested (sorry for being gpu poor) :
Real C coordinator → dense worker COLIDN01 end-to-end
Dense shard output equivalence against local computation
Real C → WebGPU browser integration
WebGPU FFN numerical correctness against a CPU reference
Exporter tests
Actual iPhone/Android/WebGPU hardware smoke test
