### PR TITLE
convert: resolve --mtp/--indexer shards from the local index instead of scanning all of them (#383)

### DIFF
--- a/c/tools/convert_fp8_to_int4.py
+++ b/c/tools/convert_fp8_to_int4.py
@@ -389,6 +389,25 @@ def main():
     if a.indir:    # conversione locale (test)
         shards = sorted(glob.glob(os.path.join(a.indir, "*.safetensors")))
         from safetensors.numpy import save_file
+        # #383: se l'indice c'e', i passaggi --mtp/--indexer convertono SOLO gli shard
+        # che contengono i tensori richiesti (3 invece di scandire tutti i 141 — ogni
+        # scansione a vuoto apre comunque uno shard da 5 GB). Senza indice: scansione
+        # completa come prima.
+        # EN: #383: when the index is present, the --mtp/--indexer passes convert ONLY
+        # the shards that hold the requested tensors (3 instead of scanning all 141 —
+        # every empty scan still opens a 5 GB shard). Without the index: full scan as
+        # before.
+        if a.mtp or a.indexer:
+            idxp = os.path.join(a.indir, "model.safetensors.index.json")
+            if os.path.exists(idxp):
+                wmap = json.load(open(idxp))["weight_map"]
+                if a.mtp:
+                    want = {v for k, v in wmap.items() if k.startswith(f"model.layers.{a.n_layers}.")}
+                else:
+                    want = {v for k, v in wmap.items() if "indexer" in k and 0 <= layer_idx(k) < a.n_layers}
+                keep = [sp for sp in shards if os.path.basename(sp) in want]
+                print(f"[PLAN] index: {len(keep)}/{len(shards)} local shard(s) hold the requested tensors")
+                shards = keep
         # BUG #355: questo ramo ignorava --mtp/--indexer. Con --mtp scriveva
         # out-NNNNN (gli STESSI nomi di una conversione normale) in ebits=8 e
         # keep_mtp=False -> il "secondo passaggio MTP" nella stessa outdir


### PR DESCRIPTION
The follow-up invited in #383. When `--indir` contains `model.safetensors.index.json`, the `--mtp`/`--indexer` passes convert only the shards that actually hold the requested tensors — for the GLM-5.2 head pass that's **3 shards instead of scanning 141**, where every empty scan still opens a 5 GB file. The selection is announced in the `[PLAN]` block:

```
[PLAN] mode: MTP head only | source: local /data/fp8_head | …
[PLAN] index: 3/4 local shard(s) hold the requested tensors
```

Without the index the full scan is unchanged (silent fallback). The `--indexer` filter mirrors the download path's (`"indexer" in name`, layer < n_layers).

**Tested** (5950X, `f8e4dc9` base, GLM-5.2 FP8 head shards + index fetched from ModelScope):
- index present + a planted decoy shard → `3/4` selected, decoy excluded, 3 `out-mtp` files
- index absent → full scan, decoy scanned-and-skipped as empty, same 3 files
- **sha256 byte-identical outputs across both paths** — and identical to both the pre-fix manual `convert_shard(keep_mtp=True)` workaround and the post-fix unfiltered branch, so four routes now provably produce one artifact.
