### PR TITLE
Fix CUDA detection on Windows (coli/doctor.py always report CPU-only)

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -141,12 +141,24 @@ def need_model(model):
         sys.exit(f"{C.yel}engine is not built.{C.r} Run: coli build")
 
 def cuda_binary():
-    if not os.path.exists(GLM) or sys.platform != "linux": return False
-    try:
-        linked=subprocess.run(["ldd",GLM],capture_output=True,text=True,timeout=3)
-        return any("libcudart" in line and "not found" not in line
-                   for line in linked.stdout.splitlines())
-    except (OSError,subprocess.SubprocessError): return False
+    if not os.path.exists(GLM): return False
+    if sys.platform == "linux":
+        try:
+            linked=subprocess.run(["ldd",GLM],capture_output=True,text=True,timeout=3)
+            return any("libcudart" in line and "not found" not in line
+                       for line in linked.stdout.splitlines())
+        except (OSError,subprocess.SubprocessError): return False
+    if sys.platform == "win32":
+        # Windows CUDA_DLL=1 builds never link libcudart directly: glm.exe loads
+        # coli_cuda.dll at runtime via LoadLibrary (backend_loader.c), so there's no
+        # import-table entry for ldd/dumpbin to see. Detect the COLI_CUDA build via a
+        # marker string baked into glm.c's #ifdef COLI_CUDA block instead, and require
+        # coli_cuda.dll to actually sit next to glm.exe (else CUDA init fails at startup).
+        try:
+            with open(GLM,"rb") as f: built=b"[CUDA] mode: routed experts" in f.read()
+        except OSError: return False
+        return built and os.path.exists(os.path.join(os.path.dirname(GLM),"coli_cuda.dll"))
+    return False
 
 def resource_request(a, env):
     ctx=a.ctx or int(env.get("CTX",4096))

--- a/c/doctor.py
+++ b/c/doctor.py
@@ -19,16 +19,33 @@ def _check(identifier, status, summary, **details):
 
 def cuda_linkage(engine_path):
     """Return CUDA linkage state without loading the executable or CUDA runtime."""
-    if not Path(engine_path).is_file() or os.name != "posix":
+    engine = Path(engine_path)
+    if not engine.is_file():
         return {"linked": False, "missing": False}
-    try:
-        result = subprocess.run(["ldd", str(engine_path)], capture_output=True, text=True,
-                                timeout=3, check=False)
-    except (OSError, subprocess.SubprocessError):
-        return {"linked": False, "missing": False}
-    lines = [line for line in result.stdout.splitlines() if "libcudart" in line]
-    return {"linked": any("not found" not in line for line in lines),
-            "missing": any("not found" in line for line in lines)}
+    if os.name == "posix":
+        try:
+            result = subprocess.run(["ldd", str(engine)], capture_output=True, text=True,
+                                    timeout=3, check=False)
+        except (OSError, subprocess.SubprocessError):
+            return {"linked": False, "missing": False}
+        lines = [line for line in result.stdout.splitlines() if "libcudart" in line]
+        return {"linked": any("not found" not in line for line in lines),
+                "missing": any("not found" in line for line in lines)}
+    if sys.platform == "win32":
+        # Windows CUDA_DLL=1 builds never link libcudart directly: glm.exe loads
+        # coli_cuda.dll at runtime via LoadLibrary (backend_loader.c), so there's no
+        # import-table entry for ldd/dumpbin to see. Detect the COLI_CUDA build via a
+        # marker string baked into glm.c's #ifdef COLI_CUDA block instead, and require
+        # coli_cuda.dll to actually sit next to glm.exe (else CUDA init fails at startup).
+        try:
+            built = b"[CUDA] mode: routed experts" in engine.read_bytes()
+        except OSError:
+            return {"linked": False, "missing": False}
+        if not built:
+            return {"linked": False, "missing": False}
+        dll_present = (engine.parent / "coli_cuda.dll").is_file()
+        return {"linked": dll_present, "missing": not dll_present}
+    return {"linked": False, "missing": False}
 
 
 def run_doctor(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0, *,


### PR DESCRIPTION
## The bug

`cuda_binary()` in `c/coli` and `cuda_linkage()` in `c/doctor.py` both detect CUDA support by shelling out to `ldd` and checking for a linked `libcudart`. Both are hard-gated to Linux/POSIX:

```python
# c/coli
def cuda_binary():
    if not os.path.exists(GLM) or sys.platform != "linux": return False
    ...

# c/doctor.py
def cuda_linkage(engine_path):
    if not Path(engine_path).is_file() or os.name != "posix":
        return {"linked": False, "missing": False}
    ...
```

On Windows, `CUDA_DLL=1` builds never link `libcudart` at all — `glm.exe` loads `coli_cuda.dll` dynamically via `LoadLibrary`/`GetProcAddress` at startup (`backend_loader.c`), so there's no import-table entry for `ldd`/`dumpbin` to find even in principle.

Practical effect on a correctly built `CUDA_DLL=1` binary with `coli_cuda.dll` sitting right next to `glm.exe`:
- `coli doctor` always reports `[warn] accelerator.cuda   NVIDIA GPU detected but the engine is CPU-only`
- `coli run/chat/serve --gpu ...` always hard-exits with `--gpu needs the CUDA build: make glm CUDA=1 (this binary is CPU-only)`

The only workaround is bypassing the wrapper and setting `COLI_CUDA=1`/`COLI_GPU`/`CUDA_EXPERT_GB` directly as env vars for `glm.exe`, which actually works fine — the detection layer is just wrong.

## The fix

On `win32`, detect a `COLI_CUDA` build by scanning `glm.exe`'s bytes for the marker string `"[CUDA] mode: routed experts"`, which only exists in code compiled under `#ifdef COLI_CUDA` (the CUDA init block in `glm.c`). Then confirm `coli_cuda.dll` actually sits next to the binary, mirroring the existing Linux "linked but missing" distinction (`{"linked": ..., "missing": ...}`).

Linux/macOS detection paths are untouched.

## Testing

Verified on Windows 11, mingw-w64 GCC 16.1.0, CUDA 13.2, RTX 5080 (`make CUDA_DLL=1 cuda-dll` + `make CUDA_DLL=1 glm.exe`):

Before:
```
[warn] accelerator.cuda   NVIDIA GPU detected but the engine is CPU-only
...
--gpu needs the CUDA build: make glm CUDA=1 (this binary is CPU-only)
```

After:
```
[  ok] accelerator.cuda   CUDA engine and devices are available
...
$ coli run "..." --gpu 0 --vram 8
...
Hello! How can I help you today?[CUDA] resident set: 625 tensors, 9.16 GB VRAM
```

`coli run/chat/serve --gpu ...` now works end-to-end through the normal CLI instead of requiring the manual env-var workaround.