### PR TITLE
packaging: pyproject.toml (pip install) + .editorconfig + .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,10 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 120
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
+AllowShortLoopsOnASingleLine: true
+BreakBeforeBraces: Attach
+PointerAlignment: Right
+SpaceAfterCStyleCast: false
+SortIncludes: false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{c,h,cu}]
+indent_size = 4
+
+[*.{ts,tsx,js,json,css}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.yml]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/colibri/__init__.py
+++ b/colibri/__init__.py
@@ -1,0 +1,5 @@
+"""colibrì — tiny engine, immense model."""
+
+from colibri._version import __version__
+
+__all__ = ["__version__"]

--- a/colibri/_version.py
+++ b/colibri/_version.py
@@ -1,0 +1,3 @@
+"""Single source of truth for the colibrì version number."""
+
+__version__ = "1.0.0"

--- a/colibri/cli.py
+++ b/colibri/cli.py
@@ -1,0 +1,30 @@
+"""Entry point for `coli` when installed via pip.
+
+Delegates to the original c/coli script which handles all subcommands.
+This wrapper exists so `pip install colibri-engine` creates a `coli` console
+script that works without the user having to add c/ to PATH manually.
+"""
+
+import os
+import sys
+import runpy
+
+
+def main():
+    here = os.path.dirname(os.path.abspath(__file__))
+    engine_dir = os.path.join(os.path.dirname(here), "c")
+    coli_script = os.path.join(engine_dir, "coli")
+
+    if not os.path.exists(coli_script):
+        sys.exit(
+            "colibri engine directory not found.\n"
+            "Install from source: git clone + pip install -e ."
+        )
+
+    sys.path.insert(0, engine_dir)
+    sys.argv[0] = coli_script
+    runpy.run_path(coli_script, run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "colibri-engine"
+dynamic = ["version"]
+description = "Tiny engine, immense model — run GLM-5.2 (744B MoE) locally"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.10"
+authors = [
+    {name = "JustVugg"},
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Science/Research",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+
+[project.optional-dependencies]
+convert = [
+    "numpy",
+    "huggingface_hub",
+]
+oracle = [
+    "torch>=2.0",
+    "transformers>=4.40",
+    "safetensors",
+]
+bench = [
+    "tokenizers",
+    "datasets",
+]
+
+[project.scripts]
+coli = "colibri.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/JustVugg/colibri"
+Issues = "https://github.com/JustVugg/colibri/issues"
+
+[tool.setuptools.dynamic]
+version = {attr = "colibri._version.__version__"}
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["colibri*"]


### PR DESCRIPTION
## Summary

Two quality-of-life additions for a 16k-star project:

### 1. Python packaging (`pip install colibri-engine`)

```bash
pip install -e .              # CLI + serve (stdlib only, no heavy deps)
pip install -e .[convert]     # adds numpy + huggingface_hub
pip install -e .[oracle]      # adds torch + transformers + safetensors
pip install -e .[bench]       # adds tokenizers + datasets
```

- `pyproject.toml` with setuptools backend, version from `colibri/_version.py`
- `colibri/` package: thin wrapper delegating to the existing `c/coli` script
- Console script entry point: `coli` command works after `pip install`
- Engine binary is still native C (not pip-distributed) — the CLI auto-detects it

### 2. Code style definitions

- `.editorconfig`: consistent indent/charset/EOL for all editors
- `.clang-format`: LLVM-based, 120 columns, single-line short functions — matches the existing engine style without reformatting everything

These are *definitions* only — no pre-commit hook or CI enforcement yet (that can be a follow-up once the team agrees on whether to enforce).

## Test plan

- [x] `pip install -e .` → `Successfully installed colibri-engine-1.0.0`
- [x] `python3 -c "import colibri; print(colibri.__version__)"` → `1.0.0`
- [x] `python3 -m colibri.cli` → banner prints
- [x] Existing tests unaffected

🐦 Generated with [Claude Code](https://claude.ai/code)