### PR TITLE
coli: honor THINK=1 in run mode

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -480,8 +480,11 @@ def cmd_run(a):
     need_model(a.model)
     prompt=" ".join(a.prompt) if a.prompt else sys.exit('usage: coli run "your prompt"')
     banner("run")
-    # template ufficiale GLM-5.2: niente \n dopo i ruoli; <think></think> = risposta diretta (nothink)
-    e=env_for(a); e["PROMPT"]=f"[gMASK]<sop><|user|>{prompt}<|assistant|><think></think>"
+    # template ufficiale GLM-5.2: niente \n dopo i ruoli; <think></think> = risposta diretta (nothink).
+    # THINK=1 lascia <think> aperto, stessa convenzione del serve mode (glm.c). EN: THINK=1 leaves
+    # <think> open so the engine emits its reasoning block; the default stays nothink.
+    tk="<think>" if os.environ.get("THINK","0")=="1" else "<think></think>"
+    e=env_for(a); e["PROMPT"]=f"[gMASK]<sop><|user|>{prompt}<|assistant|>{tk}"
     sys.exit(subprocess.call([GLM, str(a.cap)], env=e))
 
 def server_probe(base, api_key=None, timeout=1.5):


### PR DESCRIPTION
## Summary

`coli run` hardcodes the nothink template — `<|assistant|><think></think>` — so `THINK=1` silently has no effect in one-shot runs: the reasoning block is pre-closed before the engine sees a token. Serve mode already picks the template from the env in `glm.c` (`getenv("THINK") && atoi(...) ? "<think>" : "<think></think>"`). This PR makes `cmd_run` pick it the same way: two lines, default unchanged (nothink), and ENVIRONMENT.md's "`THINK=1` turns on visible reasoning" now holds for `run` the way it does for serve.

Noticed on a DGX Spark GB10 while batch-running long planning prompts through `coli run`: outputs consistently opened with an empty `<think></think>` despite `THINK=1` in the environment. With the patch the model emits its reasoning block; we've been running exactly this change locally for multi-hour THINK batches on the 744B model today.

`coli chat` needs no change — it hands the raw text to the engine, whose template already honors `THINK`.

## Validation

- [x] `make -C c check` — clean build, C unit tests, and the Python suite (73 tests) green on this branch (aarch64, gcc 13.3)
- [ ] CUDA — n/a (launcher-only change)
- [x] No performance claims

## Compatibility

- [x] The default CPU build remains dependency-free (stdlib `os.environ` only)
- [x] No model files, generated binaries, or benchmark artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
