### PR TITLE
packaging: pyproject + editorconfig + clang-format (#396) with a single version source

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,10 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 120
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
+AllowShortLoopsOnASingleLine: true
+BreakBeforeBraces: Attach
+PointerAlignment: Right
+SpaceAfterCStyleCast: false
+SortIncludes: false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{c,h,cu}]
+indent_size = 4
+
+[*.{ts,tsx,js,json,css}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.yml]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ COLI_MODEL=/nvme/glm52_i4 ./coli doctor   # read-only readiness check
 The engine at runtime is pure C — python is only used by the one-time converter
 and the optional API gateway.
 
+Prefer a `coli` command on your PATH? From a checkout, `pip install -e .`
+registers it (the engine itself still lives in `c/` — this is an editable
+install from the clone, not a standalone wheel).
+
 ### 3. Go deeper
 
 | topic | doc |

--- a/colibri/__init__.py
+++ b/colibri/__init__.py
@@ -1,0 +1,5 @@
+"""colibrì — tiny engine, immense model."""
+
+from colibri._version import __version__
+
+__all__ = ["__version__"]

--- a/colibri/_version.py
+++ b/colibri/_version.py
@@ -1,0 +1,3 @@
+"""Single source of truth for the colibrì version number."""
+
+__version__ = "1.0.0"

--- a/colibri/_version.py
+++ b/colibri/_version.py
@@ -1,3 +1,23 @@
-"""Single source of truth for the colibrì version number."""
+"""Version accessor for the pip package.
 
-__version__ = "1.0.0"
+The single source of truth is c/version.py (#394): coli --version and the
+GitHub Release workflow read it, so the pip metadata must read the SAME file
+instead of carrying a second literal that would drift on the first bump.
+
+From a checkout (the supported install: `pip install -e .`) the file is read
+directly. From an installed wheel c/ is not on disk, so fall back to the
+package metadata that setuptools baked at build time from that same file.
+"""
+from pathlib import Path
+
+try:
+    _ns = {}
+    exec((Path(__file__).resolve().parent.parent / "c" / "version.py").read_text(), _ns)
+    __version__ = _ns["__version__"]
+except OSError:
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        __version__ = version("colibri-engine")
+    except PackageNotFoundError:
+        __version__ = "0.0.0+unknown"

--- a/colibri/cli.py
+++ b/colibri/cli.py
@@ -1,0 +1,30 @@
+"""Entry point for `coli` when installed via pip.
+
+Delegates to the original c/coli script which handles all subcommands.
+This wrapper exists so `pip install colibri-engine` creates a `coli` console
+script that works without the user having to add c/ to PATH manually.
+"""
+
+import os
+import sys
+import runpy
+
+
+def main():
+    here = os.path.dirname(os.path.abspath(__file__))
+    engine_dir = os.path.join(os.path.dirname(here), "c")
+    coli_script = os.path.join(engine_dir, "coli")
+
+    if not os.path.exists(coli_script):
+        sys.exit(
+            "colibri engine directory not found.\n"
+            "Install from source: git clone + pip install -e ."
+        )
+
+    sys.path.insert(0, engine_dir)
+    sys.argv[0] = coli_script
+    runpy.run_path(coli_script, run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "colibri-engine"
+dynamic = ["version"]
+description = "Tiny engine, immense model — run GLM-5.2 (744B MoE) locally"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.10"
+authors = [
+    {name = "JustVugg"},
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Science/Research",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+
+[project.optional-dependencies]
+convert = [
+    "numpy",
+    "huggingface_hub",
+]
+oracle = [
+    "torch>=2.0",
+    "transformers>=4.40",
+    "safetensors",
+]
+bench = [
+    "tokenizers",
+    "datasets",
+]
+
+[project.scripts]
+coli = "colibri.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/JustVugg/colibri"
+Issues = "https://github.com/JustVugg/colibri/issues"
+
+[tool.setuptools.dynamic]
+version = {attr = "colibri._version.__version__"}
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["colibri*"]


### PR DESCRIPTION
Porta dentro la #396 di @ZacharyZcR con le due sistemazioni discusse in review:

1. **Fonte versione unica**: `colibri/_version.py` ora legge `c/version.py` (la fonte della #394 usata da `coli --version` e dal workflow release) invece di duplicare il literal — al primo bump non possono più divergere. Fallback a `importlib.metadata` per il caso wheel installata (dove `c/` non esiste su disco).
2. **Semantica d'installazione onesta**: il README documenta che la forma supportata è `pip install -e .` dal clone — il motore vive in `c/` e non viene impacchettato in una wheel standalone (una wheel pura darebbe un `coli` che muore con "engine directory not found").

Verificato in un venv pulito: `pip install -e .` → `colibri.__version__ == 1.0.0` letto da `c/version.py`, entrypoint `coli` sul PATH e funzionante.

Include invariati `.editorconfig` e `.clang-format` della PR originale.

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)