### PR TITLE
Vulkan backend: expert tier + dense + MLA attention on any Vulkan 1.2 GPU (successor to #84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,10 @@ layer's experts — routing is measurably **71.6% predictable one layer ahead**.
 On GPUs, the resident pipeline (`COLI_CUDA_PIPE=2`) keeps the residual stream
 on-device across layers so the CPU expert loop runs uninterrupted; on Apple
 Silicon an experimental [Metal backend](docs/metal.md) does the batched expert
-math on the unified-memory GPU.
+math on the unified-memory GPU; and a [Vulkan backend](docs/vulkan.md) brings
+the expert tier, dense projections, and the MLA attention core to any GPU with
+a Vulkan 1.2 driver — including AMD cards via Mesa/RADV (measured faster than
+ROCm on RDNA4) and cards the vendor stacks no longer support.
 
 > **On real NVMe, measure `DIRECT=1`.** O_DIRECT bypasses the page cache and is
 > often a large win on drives with DRAM cache and bandwidth headroom (+34%
@@ -369,6 +372,7 @@ and the optional API gateway.
 | Tuning knobs, policies, the learning cache, prefetch | [docs/tuning.md](docs/tuning.md) |
 | Windows 11 native build (+ CUDA DLL) | [docs/windows.md](docs/windows.md) |
 | CUDA backend, VRAM expert tier, full residency | [docs/cuda.md](docs/cuda.md) |
+| Vulkan backend (any GPU: AMD via RADV, incl. cards ROCm dropped) | [docs/vulkan.md](docs/vulkan.md) |
 | Apple Silicon Metal backend | [docs/metal.md](docs/metal.md) |
 | OpenAI-compatible API, KV slots, web dashboard | [docs/api.md](docs/api.md) |
 | Grammar-forced drafts (structured output) | [docs/grammar-draft.md](docs/grammar-draft.md) |

--- a/README.md
+++ b/README.md
@@ -215,8 +215,9 @@ on-device across layers so the CPU expert loop runs uninterrupted; on Apple
 Silicon an experimental [Metal backend](docs/metal.md) does the batched expert
 math on the unified-memory GPU; and a [Vulkan backend](docs/vulkan.md) brings
 the expert tier, dense projections, and the MLA attention core to any GPU with
-a Vulkan 1.2 driver — including AMD cards via Mesa/RADV (measured faster than
-ROCm on RDNA4) and cards the vendor stacks no longer support.
+a Vulkan 1.2 driver — including AMD cards via Mesa/RADV (the only backend for
+cards the vendor stacks no longer support, like the RX 580, and competitive
+with ROCm on RDNA4 — see [the benchmarking notes](docs/vulkan.md)).
 
 > **On real NVMe, measure `DIRECT=1`.** O_DIRECT bypasses the page cache and is
 > often a large win on drives with DRAM cache and bandwidth headroom (+34%

--- a/c/.gitignore
+++ b/c/.gitignore
@@ -13,3 +13,16 @@ tools/librans_c.dylib
 tools/rans_c.dll
 tests/fuzz_rans
 tests/*.dSYM/
+tests/test_dsa_select
+tests/test_i4_grouped
+tests/test_kv_alloc
+tests/test_kv_disk
+tests/test_kv_fp8
+tests/test_logit_nan
+tests/test_sample_nan
+tests/test_stops
+tests/test_topp
+tests/test_int3
+tests/test_int3_load
+tests/test_tok_o200k
+tests/test_pipe_block

--- a/c/Makefile
+++ b/c/Makefile
@@ -214,7 +214,7 @@ else
 PYTHON    ?= python3
 endif
 CUDA_OBJ  =
-TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_st_mirror$(EXE) tests/test_st_pread$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_grouped$(EXE) tests/test_stops$(EXE) tests/test_topp$(EXE) tests/test_sample_nan$(EXE) tests/test_temp_env$(EXE) tests/test_tok_o200k$(EXE) tests/test_kv_alloc$(EXE) tests/test_int3$(EXE) tests/test_int3_load$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE) tests/test_dsa_select$(EXE) tests/test_logit_nan$(EXE) tests/test_router_nan$(EXE) tests/test_pipe_block$(EXE) tests/test_e8_kernel$(EXE) tests/test_rans$(EXE) tests/test_corpus_draft$(EXE)
+TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_st_mirror$(EXE) tests/test_st_pread$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_grouped$(EXE) tests/test_stops$(EXE) tests/test_topp$(EXE) tests/test_sample_nan$(EXE) tests/test_temp_env$(EXE) tests/test_tok_o200k$(EXE) tests/test_kv_alloc$(EXE) tests/test_int3$(EXE) tests/test_int3_load$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE) tests/test_dsa_select$(EXE) tests/test_logit_nan$(EXE) tests/test_router_nan$(EXE) tests/test_pipe_block$(EXE) tests/test_e8_kernel$(EXE) tests/test_rans$(EXE) tests/test_corpus_draft$(EXE) tests/test_pilot_ring$(EXE)
 ifneq (,$(LINUX))
 TEST_BINS += tests/test_uring$(EXE)
 endif
@@ -577,6 +577,9 @@ tests/test_uring$(EXE): tests/test_uring.c colibri.c st.h uring.h json.h tok.h t
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_pipe_block$(EXE): tests/test_pipe_block.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+tests/test_pilot_ring$(EXE): tests/test_pilot_ring.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 test-c: $(TEST_BINS)

--- a/c/Makefile
+++ b/c/Makefile
@@ -290,7 +290,9 @@ endif
 
 # VK=1 adds an opt-in Vulkan compute backend (any Vulkan 1.2 driver, e.g. Mesa/RADV)
 # for resident expert tensors. Independent of CUDA/HIP: works on GPUs ROCm doesn't
-# support (Polaris/RX 580) and measured ~35% faster than ROCm on RDNA4 for int4 experts.
+# support (Polaris/RX 580); the VRAM-resident int4 expert-group PRIMITIVE measured ~35%
+# faster than the ROCm/HIP one on an RX 9070 (per-call incl. readback — end-to-end tok/s
+# depends on what else bounds the box; see docs/vulkan.md, benchmarking notes included).
 # Needs libvulkan + glslc (shaderc). Default build unchanged (all colibri.c hooks under
 # #ifdef COLI_VULKAN). The .comp shaders compile to .spv, loaded at runtime from
 # COLI_VK_SHADERS (default: alongside the binary / ./shaders).

--- a/c/Makefile
+++ b/c/Makefile
@@ -302,7 +302,7 @@ ifeq ($(VK),1)
 CFLAGS   += -DCOLI_VULKAN
 LDFLAGS  += -lvulkan
 VK_OBJ    = backend_vulkan.o
-VK_SPV    = shaders/qmatmul.spv shaders/qmatmul_gate_up.spv shaders/attention_absorb.spv
+VK_SPV    = shaders/qmatmul.spv shaders/qmatmul_gate_up.spv shaders/attention_absorb.spv shaders/rmsnorm.spv
 endif
 
 all: colibri$(EXE)

--- a/c/Makefile
+++ b/c/Makefile
@@ -288,6 +288,23 @@ LDFLAGS  += -framework Metal -framework Foundation -lc++
 METAL_OBJ = backend_metal.o
 endif
 
+# VK=1 adds an opt-in Vulkan compute backend (any Vulkan 1.2 driver, e.g. Mesa/RADV)
+# for resident expert tensors. Independent of CUDA/HIP: works on GPUs ROCm doesn't
+# support (Polaris/RX 580) and measured ~35% faster than ROCm on RDNA4 for int4 experts.
+# Needs libvulkan + glslc (shaderc). Default build unchanged (all colibri.c hooks under
+# #ifdef COLI_VULKAN). The .comp shaders compile to .spv, loaded at runtime from
+# COLI_VK_SHADERS (default: alongside the binary / ./shaders).
+VK        ?= 0
+VK_OBJ     =
+VK_SPV     =
+GLSLC     ?= glslc
+ifeq ($(VK),1)
+CFLAGS   += -DCOLI_VULKAN
+LDFLAGS  += -lvulkan
+VK_OBJ    = backend_vulkan.o
+VK_SPV    = shaders/qmatmul.spv shaders/qmatmul_gate_up.spv
+endif
+
 all: colibri$(EXE)
 
 # phony targets — 'glm' kept for backward compatibility
@@ -301,7 +318,7 @@ glm: colibri$(EXE)
 # rewrite it ONLY when they change (evaluated here at parse time, so the file's
 # timestamp moves exactly when the config moves). The binary and CUDA/loader objects depend
 # on it, so they relink on a config change and stay put otherwise. (#306)
-BUILD_CONFIG     := $(CC)|$(CFLAGS)|$(LDFLAGS)|CUDA=$(CUDA)|CUDA_DLL=$(CUDA_DLL)|ARCH=$(ARCH)|CUDA_ARCH=$(CUDA_ARCH)|METAL=$(METAL)|HIP=$(HIP)|HIP_ARCH=$(HIP_ARCH)
+BUILD_CONFIG     := $(CC)|$(CFLAGS)|$(LDFLAGS)|CUDA=$(CUDA)|CUDA_DLL=$(CUDA_DLL)|ARCH=$(ARCH)|CUDA_ARCH=$(CUDA_ARCH)|METAL=$(METAL)|HIP=$(HIP)|HIP_ARCH=$(HIP_ARCH)|VK=$(VK)
 BUILD_CONFIG_OLD := $(shell cat .build-config 2>/dev/null)
 ifneq "$(BUILD_CONFIG)" "$(BUILD_CONFIG_OLD)"
 # $(file ...) writes via make's own primitive (GNU Make >= 4.0, 2013), NOT by
@@ -314,8 +331,15 @@ $(file >.build-config,$(BUILD_CONFIG))
 endif
 .build-config: ;
 
-colibri$(EXE): colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h quant.h sample.h kv_persist.h telemetry.h $(CUDA_OBJ) $(METAL_OBJ) .build-config
-	$(CC) $(CFLAGS) colibri.c $(CUDA_OBJ) $(METAL_OBJ) -o colibri$(EXE) $(LDFLAGS)
+colibri$(EXE): colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h quant.h sample.h kv_persist.h telemetry.h $(CUDA_OBJ) $(METAL_OBJ) $(VK_OBJ) $(VK_SPV) .build-config
+	$(CC) $(CFLAGS) colibri.c $(CUDA_OBJ) $(METAL_OBJ) $(VK_OBJ) -o colibri$(EXE) $(LDFLAGS)
+
+# Vulkan backend object (plain C + vulkan headers) and its SPIR-V shaders.
+backend_vulkan.o: backend_vulkan.c backend_vulkan.h .build-config
+	$(CC) $(CFLAGS) -c backend_vulkan.c -o $@
+shaders/%.spv: shaders/%.comp
+	@command -v $(GLSLC) >/dev/null 2>&1 || { echo "glslc not found: install shaderc (for VK=1)" >&2; exit 1; }
+	$(GLSLC) --target-env=vulkan1.2 $< -o $@
 
 # Windows runtime loader object: resolves coli_cuda_* from coli_cuda.dll.
 backend_loader.o: backend_loader.c backend_cuda.h compat.h .build-config

--- a/c/Makefile
+++ b/c/Makefile
@@ -302,7 +302,7 @@ ifeq ($(VK),1)
 CFLAGS   += -DCOLI_VULKAN
 LDFLAGS  += -lvulkan
 VK_OBJ    = backend_vulkan.o
-VK_SPV    = shaders/qmatmul.spv shaders/qmatmul_gate_up.spv
+VK_SPV    = shaders/qmatmul.spv shaders/qmatmul_gate_up.spv shaders/attention_absorb.spv
 endif
 
 all: colibri$(EXE)

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -1,0 +1,400 @@
+// Vulkan compute backend for colibri's quantized matmul, targeting the
+// Strix Halo iGPU (RADV gfx1151). Mirrors backend_cuda.c's contract but
+// exploits unified memory: weight "uploads" write into HOST_VISIBLE|
+// DEVICE_LOCAL memory — the same physical RAM the iGPU reads — so there is
+// no PCIe copy. That is what makes offloading *streamed experts* profitable
+// here, which the discrete-CUDA path deliberately avoids.
+//
+// M2 scope: correctness + a standalone GPU-vs-CPU test harness. Synchronous
+// submit/wait per call; async queues and zero-copy import come in M4.
+#include "backend_vulkan.h"
+#include <vulkan/vulkan.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define VKCHECK(x, what) do { VkResult _r = (x); if (_r != VK_SUCCESS) { \
+    fprintf(stderr, "[VK] %s failed: %d\n", what, _r); return 0; } } while (0)
+
+struct ColiVkTensor {
+    VkBuffer wbuf, sbuf;
+    VkDeviceMemory wmem, smem;
+    size_t wbytes;
+    int fmt, I, O, rowWords;
+};
+
+typedef struct {
+    VkBuffer buf; VkDeviceMemory mem; void *ptr; size_t cap;
+} Scratch;
+
+static struct {
+    int ready;
+    VkInstance inst;
+    VkPhysicalDevice phys;
+    VkDevice dev;
+    VkQueue queue;
+    uint32_t qfam;
+    uint32_t memtype;            // HOST_VISIBLE|HOST_COHERENT (prefer DEVICE_LOCAL)
+    VkDescriptorSetLayout dsl;
+    VkPipelineLayout plyt;
+    VkPipeline pipe;
+    VkShaderModule shader;
+    VkDescriptorPool dpool;
+    VkDescriptorSet dset;
+    VkCommandPool cpool;
+    VkCommandBuffer cmd;
+    VkFence fence;
+    Scratch x, y;
+    size_t used_bytes, tensor_count;
+} G;
+
+struct PC { int fmt, S, I, O, rowWords; };
+
+static int pick_memtype(void) {
+    VkPhysicalDeviceMemoryProperties m;
+    vkGetPhysicalDeviceMemoryProperties(G.phys, &m);
+    int best = -1;
+    for (uint32_t i = 0; i < m.memoryTypeCount; i++) {
+        VkMemoryPropertyFlags f = m.memoryTypes[i].propertyFlags;
+        if ((f & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) &&
+            (f & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) {
+            if (f & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) return (int)i; // ideal on APU
+            if (best < 0) best = (int)i;
+        }
+    }
+    return best;
+}
+
+static int alloc_hostvis(size_t bytes, VkBuffer *buf, VkDeviceMemory *mem, void **ptr) {
+    VkBufferCreateInfo bi = {.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .size = bytes, .usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE};
+    VKCHECK(vkCreateBuffer(G.dev, &bi, NULL, buf), "vkCreateBuffer");
+    VkMemoryRequirements req;
+    vkGetBufferMemoryRequirements(G.dev, *buf, &req);
+    VkMemoryAllocateInfo ai = {.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .allocationSize = req.size, .memoryTypeIndex = G.memtype};
+    VKCHECK(vkAllocateMemory(G.dev, &ai, NULL, mem), "vkAllocateMemory");
+    VKCHECK(vkBindBufferMemory(G.dev, *buf, *mem, 0), "vkBindBufferMemory");
+    if (ptr) VKCHECK(vkMapMemory(G.dev, *mem, 0, bytes, 0, ptr), "vkMapMemory");
+    return 1;
+}
+
+static int scratch_reserve(Scratch *s, size_t bytes) {
+    if (s->cap >= bytes) return 1;
+    if (s->buf) { vkDestroyBuffer(G.dev, s->buf, NULL); vkFreeMemory(G.dev, s->mem, NULL); }
+    s->buf = VK_NULL_HANDLE; s->cap = 0; s->ptr = NULL;
+    if (!alloc_hostvis(bytes, &s->buf, &s->mem, &s->ptr)) return 0;
+    s->cap = bytes;
+    return 1;
+}
+
+static int rowwords(int fmt, int I) {
+    size_t rb = fmt == 1 ? (size_t)I : (size_t)(I + 1) / 2; // bytes/row on CPU side
+    return (int)((rb + 3) / 4);                              // padded to uint32
+}
+
+static VkShaderModule load_spv(const char *path) {
+    FILE *f = fopen(path, "rb");
+    if (!f) { fprintf(stderr, "[VK] cannot open %s\n", path); return VK_NULL_HANDLE; }
+    fseek(f, 0, SEEK_END); long n = ftell(f); fseek(f, 0, SEEK_SET);
+    if (n <= 0 || n % 4 != 0) {   // SPIR-V is a stream of uint32; empty/non-seekable/odd size is invalid
+        fprintf(stderr, "[VK] bad SPIR-V size %ld in %s\n", n, path); fclose(f); return VK_NULL_HANDLE; }
+    uint32_t *code = malloc((size_t)n);
+    if (!code) { fclose(f); return VK_NULL_HANDLE; }
+    if (fread(code, 1, n, f) != (size_t)n) { fclose(f); free(code); return VK_NULL_HANDLE; }
+    fclose(f);
+    VkShaderModuleCreateInfo si = {.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
+        .codeSize = n, .pCode = code};
+    VkShaderModule m;
+    VkResult r = vkCreateShaderModule(G.dev, &si, NULL, &m);
+    free(code);
+    return r == VK_SUCCESS ? m : VK_NULL_HANDLE;
+}
+
+int coli_vk_init(const char *spv_path) {
+    if (G.ready) return 1;
+    VkApplicationInfo app = {.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+        .apiVersion = VK_API_VERSION_1_2};
+    VkInstanceCreateInfo ici = {.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+        .pApplicationInfo = &app};
+    VKCHECK(vkCreateInstance(&ici, NULL, &G.inst), "vkCreateInstance");
+
+    uint32_t nd = 0;
+    vkEnumeratePhysicalDevices(G.inst, &nd, NULL);
+    if (!nd) { fprintf(stderr, "[VK] no devices\n"); return 0; }
+    VkPhysicalDevice devs[8]; if (nd > 8) nd = 8;
+    vkEnumeratePhysicalDevices(G.inst, &nd, devs);
+    // Prefer a real GPU over a CPU/software device (llvmpipe) on multi-adapter hosts:
+    // discrete > integrated > virtual > other/cpu. Falls back to devs[0] if all equal.
+    G.phys = devs[0];
+    int bestrank = -1;
+    for (uint32_t i = 0; i < nd; i++) {
+        VkPhysicalDeviceProperties p; vkGetPhysicalDeviceProperties(devs[i], &p);
+        int rank = p.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU   ? 4 :
+                   p.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU ? 3 :
+                   p.deviceType == VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU    ? 2 :
+                   p.deviceType == VK_PHYSICAL_DEVICE_TYPE_OTHER          ? 1 : 0; // CPU last
+        if (rank > bestrank) { bestrank = rank; G.phys = devs[i]; }
+    }
+
+    uint32_t nq = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(G.phys, &nq, NULL);
+    VkQueueFamilyProperties qf[16]; if (nq > 16) nq = 16;
+    vkGetPhysicalDeviceQueueFamilyProperties(G.phys, &nq, qf);
+    G.qfam = UINT32_MAX;
+    for (uint32_t i = 0; i < nq; i++)
+        if (qf[i].queueFlags & VK_QUEUE_COMPUTE_BIT) { G.qfam = i; break; }
+    if (G.qfam == UINT32_MAX) { fprintf(stderr, "[VK] no compute queue\n"); return 0; }
+
+    float prio = 1.0f;
+    VkDeviceQueueCreateInfo qi = {.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+        .queueFamilyIndex = G.qfam, .queueCount = 1, .pQueuePriorities = &prio};
+    VkDeviceCreateInfo di = {.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+        .queueCreateInfoCount = 1, .pQueueCreateInfos = &qi};
+    VKCHECK(vkCreateDevice(G.phys, &di, NULL, &G.dev), "vkCreateDevice");
+    vkGetDeviceQueue(G.dev, G.qfam, 0, &G.queue);
+
+    int mt = pick_memtype();
+    if (mt < 0) { fprintf(stderr, "[VK] no host-visible memory\n"); return 0; }
+    G.memtype = (uint32_t)mt;
+
+    G.shader = load_spv(spv_path);
+    if (!G.shader) return 0;
+
+    VkDescriptorSetLayoutBinding b[4];
+    for (int i = 0; i < 4; i++) b[i] = (VkDescriptorSetLayoutBinding){
+        .binding = i, .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+        .descriptorCount = 1, .stageFlags = VK_SHADER_STAGE_COMPUTE_BIT};
+    VkDescriptorSetLayoutCreateInfo dsli = {
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+        .bindingCount = 4, .pBindings = b};
+    VKCHECK(vkCreateDescriptorSetLayout(G.dev, &dsli, NULL, &G.dsl), "descSetLayout");
+
+    VkPushConstantRange pcr = {.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT,
+        .offset = 0, .size = sizeof(struct PC)};
+    VkPipelineLayoutCreateInfo pli = {.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+        .setLayoutCount = 1, .pSetLayouts = &G.dsl,
+        .pushConstantRangeCount = 1, .pPushConstantRanges = &pcr};
+    VKCHECK(vkCreatePipelineLayout(G.dev, &pli, NULL, &G.plyt), "pipelineLayout");
+
+    VkComputePipelineCreateInfo cpi = {.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
+        .stage = {.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+                  .stage = VK_SHADER_STAGE_COMPUTE_BIT, .module = G.shader, .pName = "main"},
+        .layout = G.plyt};
+    VKCHECK(vkCreateComputePipelines(G.dev, VK_NULL_HANDLE, 1, &cpi, NULL, &G.pipe), "pipeline");
+
+    VkDescriptorPoolSize ps = {.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = 4};
+    VkDescriptorPoolCreateInfo dpi = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+        .maxSets = 1, .poolSizeCount = 1, .pPoolSizes = &ps};
+    VKCHECK(vkCreateDescriptorPool(G.dev, &dpi, NULL, &G.dpool), "descPool");
+    VkDescriptorSetAllocateInfo dsa = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+        .descriptorPool = G.dpool, .descriptorSetCount = 1, .pSetLayouts = &G.dsl};
+    VKCHECK(vkAllocateDescriptorSets(G.dev, &dsa, &G.dset), "allocDescSet");
+
+    VkCommandPoolCreateInfo cpci = {.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+        .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT, .queueFamilyIndex = G.qfam};
+    VKCHECK(vkCreateCommandPool(G.dev, &cpci, NULL, &G.cpool), "cmdPool");
+    VkCommandBufferAllocateInfo cbi = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+        .commandPool = G.cpool, .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY, .commandBufferCount = 1};
+    VKCHECK(vkAllocateCommandBuffers(G.dev, &cbi, &G.cmd), "cmdBuf");
+    VkFenceCreateInfo fi = {.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
+    VKCHECK(vkCreateFence(G.dev, &fi, NULL, &G.fence), "fence");
+
+    G.ready = 1;
+    VkPhysicalDeviceProperties p; vkGetPhysicalDeviceProperties(G.phys, &p);
+    fprintf(stderr, "[VK] ready: %s, compute qfam %u, memtype %u\n", p.deviceName, G.qfam, G.memtype);
+    return 1;
+}
+
+int coli_vk_available(void) { return G.ready; }
+
+void coli_vk_mem_info(size_t *used, size_t *count) {
+    if (used) *used = G.used_bytes;
+    if (count) *count = G.tensor_count;
+}
+
+static int upload_tensor(ColiVkTensor **out, const void *weights, const float *scales,
+                         int fmt, int I, int O) {
+    if (*out) return (*out)->fmt == fmt && (*out)->I == I && (*out)->O == O;
+    if (fmt != 1 && fmt != 2) return 0;
+    ColiVkTensor *t = calloc(1, sizeof(*t));
+    if (!t) return 0;
+    t->fmt = fmt; t->I = I; t->O = O; t->rowWords = rowwords(fmt, I);
+    size_t stride = (size_t)t->rowWords * 4;         // padded row bytes
+    size_t cpu_rb = fmt == 1 ? (size_t)I : (size_t)(I + 1) / 2;
+    t->wbytes = stride * (size_t)O;
+    void *wptr;
+    if (!alloc_hostvis(t->wbytes, &t->wbuf, &t->wmem, &wptr)) { free(t); return 0; }
+    memset(wptr, 0, t->wbytes);
+    for (int o = 0; o < O; o++)                        // copy row-by-row into padded layout
+        memcpy((uint8_t *)wptr + (size_t)o * stride,
+               (const uint8_t *)weights + (size_t)o * cpu_rb, cpu_rb);
+    void *sptr;
+    if (!alloc_hostvis((size_t)O * sizeof(float), &t->sbuf, &t->smem, &sptr)) {
+        vkDestroyBuffer(G.dev, t->wbuf, NULL); vkFreeMemory(G.dev, t->wmem, NULL); free(t); return 0;
+    }
+    memcpy(sptr, scales, (size_t)O * sizeof(float));
+    // Counters are touched concurrently: frees run from expert_load under
+    // `#pragma omp parallel`, so RMW them atomically (torn counts otherwise).
+    __atomic_add_fetch(&G.used_bytes, t->wbytes + (size_t)O * sizeof(float), __ATOMIC_RELAXED);
+    __atomic_add_fetch(&G.tensor_count, 1, __ATOMIC_RELAXED);
+    *out = t;
+    return 1;
+}
+
+int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
+                   const void *weights, const float *scales,
+                   int fmt, int S, int I, int O) {
+    if (!G.ready || S < 1 || !upload_tensor(tensor, weights, scales, fmt, I, O)) return 0;
+    ColiVkTensor *t = *tensor;
+    size_t xb = (size_t)S * I * sizeof(float), yb = (size_t)S * O * sizeof(float);
+    if (!scratch_reserve(&G.x, xb) || !scratch_reserve(&G.y, yb)) return 0;
+    memcpy(G.x.ptr, x, xb);
+
+    VkDescriptorBufferInfo bi[4] = {
+        {.buffer = G.x.buf, .range = VK_WHOLE_SIZE},
+        {.buffer = t->wbuf, .range = VK_WHOLE_SIZE},
+        {.buffer = t->sbuf, .range = VK_WHOLE_SIZE},
+        {.buffer = G.y.buf, .range = VK_WHOLE_SIZE}};
+    VkWriteDescriptorSet w[4];
+    for (int i = 0; i < 4; i++) w[i] = (VkWriteDescriptorSet){
+        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, .dstSet = G.dset,
+        .dstBinding = i, .descriptorCount = 1,
+        .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .pBufferInfo = &bi[i]};
+    vkUpdateDescriptorSets(G.dev, 4, w, 0, NULL);
+
+    VKCHECK(vkResetCommandBuffer(G.cmd, 0), "resetCmd");
+    VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+        .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT};
+    VKCHECK(vkBeginCommandBuffer(G.cmd, &begin), "beginCmd");
+    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
+    vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.dset, 0, NULL);
+    struct PC pc = {fmt, S, I, O, t->rowWords};
+    vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
+    vkCmdDispatch(G.cmd, (uint32_t)O, (uint32_t)S, 1);
+    VKCHECK(vkEndCommandBuffer(G.cmd), "endCmd");
+
+    VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+        .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
+    VKCHECK(vkResetFences(G.dev, 1, &G.fence), "resetFence");
+    VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
+    // Bounded wait: a GPU hang/TDR must never wedge the process. 10s is orders of
+    // magnitude over a single-GEMV dispatch; on timeout/device-loss disable VK for
+    // the rest of the run and fall back to CPU (the caller degrades on our 0 return).
+    VkResult wr = vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL);
+    if (wr != VK_SUCCESS) {
+        fprintf(stderr, "[VK] fence wait failed: %d — disabling GPU offload, staying on CPU\n", wr);
+        G.ready = 0;
+        return 0;
+    }
+    memcpy(y, G.y.ptr, yb);
+    return 1;
+}
+
+void coli_vk_tensor_free(ColiVkTensor *t) {
+    if (!t) return;
+    // If the device was lost/disabled (the fence-timeout path sets G.ready=0), a submission
+    // may still reference these buffers — do NOT vkDestroy into a dead device (GPU-side UAF).
+    // Leak the GPU handles (we're degrading to CPU for the rest of the run) and reclaim the
+    // host struct + counters only.
+    if (G.ready) {
+        if (t->wbuf) { vkDestroyBuffer(G.dev, t->wbuf, NULL); vkFreeMemory(G.dev, t->wmem, NULL); }
+        if (t->sbuf) { vkDestroyBuffer(G.dev, t->sbuf, NULL); vkFreeMemory(G.dev, t->smem, NULL); }
+    }
+    // Mirror upload_tensor exactly (weights + scales), atomically — otherwise
+    // used_bytes leaks the O*float scales buffer on every free and drifts upward.
+    __atomic_sub_fetch(&G.tensor_count, 1, __ATOMIC_RELAXED);
+    __atomic_sub_fetch(&G.used_bytes, t->wbytes + (size_t)t->O * sizeof(float), __ATOMIC_RELAXED);
+    free(t);
+}
+
+size_t coli_vk_tensor_bytes(const ColiVkTensor *t) { return t ? t->wbytes : 0; }
+
+void coli_vk_shutdown(void) {
+    if (!G.ready) return;
+    vkDeviceWaitIdle(G.dev);
+    if (G.x.buf) { vkDestroyBuffer(G.dev, G.x.buf, NULL); vkFreeMemory(G.dev, G.x.mem, NULL); }
+    if (G.y.buf) { vkDestroyBuffer(G.dev, G.y.buf, NULL); vkFreeMemory(G.dev, G.y.mem, NULL); }
+    vkDestroyFence(G.dev, G.fence, NULL);
+    vkDestroyCommandPool(G.dev, G.cpool, NULL);
+    vkDestroyDescriptorPool(G.dev, G.dpool, NULL);
+    vkDestroyPipeline(G.dev, G.pipe, NULL);
+    vkDestroyPipelineLayout(G.dev, G.plyt, NULL);
+    vkDestroyDescriptorSetLayout(G.dev, G.dsl, NULL);
+    vkDestroyShaderModule(G.dev, G.shader, NULL);
+    vkDestroyDevice(G.dev, NULL);
+    vkDestroyInstance(G.inst, NULL);
+    memset(&G, 0, sizeof(G));
+}
+
+#ifdef VK_TEST
+// ---- standalone GPU-vs-CPU validation + microbench --------------------------
+#include <math.h>
+#include <time.h>
+
+static double now(void) { struct timespec ts; clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec + ts.tv_nsec / 1e9; }
+
+static float deq(const uint8_t *row, int fmt, int i) {
+    if (fmt == 1) { int b = ((const int8_t *)row)[i]; return (float)b; }
+    uint8_t v = row[i >> 1]; int nib = (i & 1) ? (v >> 4) : (v & 15); return (float)(nib - 8);
+}
+
+static void cpu_ref(float *y, const float *x, const uint8_t *w, const float *sc,
+                    int fmt, int S, int I, int O) {
+    size_t rb = fmt == 1 ? (size_t)I : (size_t)(I + 1) / 2;
+    for (int s = 0; s < S; s++) for (int o = 0; o < O; o++) {
+        double sum = 0; const uint8_t *row = w + (size_t)o * rb;
+        for (int i = 0; i < I; i++) sum += x[s * I + i] * deq(row, fmt, i);
+        y[s * O + o] = (float)(sum * sc[o]);
+    }
+}
+
+static int run_case(int fmt, int S, int I, int O, int iters) {
+    size_t rb = fmt == 1 ? (size_t)I : (size_t)(I + 1) / 2;
+    float *x = malloc((size_t)S * I * sizeof(float));
+    uint8_t *w = malloc(rb * O);
+    float *sc = malloc((size_t)O * sizeof(float));
+    float *yg = malloc((size_t)S * O * sizeof(float));
+    float *yc = malloc((size_t)S * O * sizeof(float));
+    for (int i = 0; i < S * I; i++) x[i] = (float)((rand() % 200 - 100) / 100.0);
+    for (size_t i = 0; i < rb * O; i++) w[i] = rand() & 0xff;
+    for (int o = 0; o < O; o++) sc[o] = 0.01f + (rand() % 100) / 10000.0f;
+
+    ColiVkTensor *t = NULL;
+    if (!coli_vk_matmul(&t, yg, x, w, sc, fmt, S, I, O)) { printf("matmul failed\n"); return 1; }
+    cpu_ref(yc, x, w, sc, fmt, S, I, O);
+    double maxerr = 0, maxrel = 0;
+    for (int i = 0; i < S * O; i++) {
+        double e = fabs(yg[i] - yc[i]); if (e > maxerr) maxerr = e;
+        if (fabs(yc[i]) > 1e-2) { double r = e / fabs(yc[i]); if (r > maxrel) maxrel = r; }
+    }
+    // microbench (GPU)
+    double t0 = now();
+    for (int k = 0; k < iters; k++) coli_vk_matmul(&t, yg, x, w, sc, fmt, S, I, O);
+    double gpu_ms = (now() - t0) * 1000 / iters;
+    // microbench (CPU ref, 1 iter — it's slow)
+    double c0 = now(); cpu_ref(yc, x, w, sc, fmt, S, I, O); double cpu_ms = (now() - c0) * 1000;
+    printf("fmt=%d S=%d I=%d O=%d | maxerr=%.4g maxrel=%.4g | gpu=%.3f ms  cpu_ref=%.3f ms\n",
+           fmt, S, I, O, maxerr, maxrel, gpu_ms, cpu_ms);
+    coli_vk_tensor_free(t);
+    free(x); free(w); free(sc); free(yg); free(yc);
+    return maxrel > 1e-3 ? 1 : 0;
+}
+
+int main(int argc, char **argv) {
+    const char *spv = argc > 1 ? argv[1] : "shaders/qmatmul.spv";
+    if (!coli_vk_init(spv)) { printf("vk init failed\n"); return 1; }
+    srand(1234);
+    int bad = 0;
+    bad |= run_case(1, 1, 6144, 1536, 50);   // int8 expert gate/up shape (S=1 decode)
+    bad |= run_case(2, 1, 6144, 1536, 50);   // int4 expert
+    bad |= run_case(1, 1, 1536, 6144, 50);   // down proj shape
+    bad |= run_case(2, 8, 6144, 1536, 20);   // prefill/MTP batch
+    bad |= run_case(1, 1, 512, 512, 100);    // small
+    printf(bad ? "FAIL\n" : "PASS\n");
+    coli_vk_shutdown();
+    return bad;
+}
+#endif

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -1050,9 +1050,15 @@ static int eg2_prepare_submit(ColiVkTensor *const *gates, ColiVkTensor *const *u
             downs[c]->I != I || downs[c]->O != D || downs[c]->fmt != dfmt) return 0;
     }
     size_t xb = (size_t)total*D*4, hb = (size_t)total*I*4, yb = (size_t)total*D*4;
+    /* VK_PROF=1: phase split of the dev2 issue cost (same scheme as the dense path) —
+     * localizes the per-block tax between our copy, descriptors, recording and the
+     * driver's submit on the chipset-x4 Polaris path. */
+    static double q_x, q_desc, q_rec, q_sub; static long q_n;
+    double t0 = G.eg_prof ? vk_now() : 0, tA;
     if (!scratch_reserve_d2(&G2.x, xb, G2.memtype) || !scratch_reserve_d2(&G2.h, hb, G2.memtype) ||
         !scratch_reserve_d2(&G2.y, yb, G2.memtype_cached)) return 0;
     memcpy(G2.x.ptr, x, xb);
+    if (G.eg_prof) { tA = vk_now(); q_x += tA - t0; t0 = tA; }
     if (!G2.pool) {
         VkDescriptorPoolSize ps = {.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = 64*6 + 64*4};
         VkDescriptorPoolCreateInfo dpi = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO, .maxSets = 128, .poolSizeCount = 1, .pPoolSizes = &ps};
@@ -1077,6 +1083,7 @@ static int eg2_prepare_submit(ColiVkTensor *const *gates, ColiVkTensor *const *u
             {downs[c]->sbuf, 0, VK_WHOLE_SIZE}, {G2.y.buf, yo, (VkDeviceSize)rows[c]*D*4}};
         wr_desc_dev(G2.dev, G2.dn[c], 4, di);
     }
+    if (G.eg_prof) { tA = vk_now(); q_desc += tA - t0; t0 = tA; }
     VKCHECK(vkResetCommandBuffer(G2.cmd, 0), "d2 eg resetCmd");
     VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
     VKCHECK(vkBeginCommandBuffer(G2.cmd, &begin), "d2 eg beginCmd");
@@ -1097,9 +1104,15 @@ static int eg2_prepare_submit(ColiVkTensor *const *gates, ColiVkTensor *const *u
         vkCmdDispatch(G2.cmd, (uint32_t)((D + 7) / 8), (uint32_t)rows[c], 1);
     }
     VKCHECK(vkEndCommandBuffer(G2.cmd), "d2 eg endCmd");
+    if (G.eg_prof) { tA = vk_now(); q_rec += tA - t0; t0 = tA; }
     VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G2.cmd};
     VKCHECK(vkResetFences(G2.dev, 1, &G2.fence), "d2 eg resetFence");
     VKCHECK(vkQueueSubmit(G2.queue, 1, &si, G2.fence), "d2 eg queueSubmit");
+    if (G.eg_prof) { tA = vk_now(); q_sub += tA - t0;
+        if ((++q_n & 2047) == 0)
+            fprintf(stderr, "[VK_PROF d2iss] n=%ld | memcpy_x %.0f | desc %.0f | record %.0f | submit %.0f ms\n",
+                    q_n, q_x, q_desc, q_rec, q_sub);
+    }
     G2.pending_yb = yb; G2.inflight = 1;
     return 1;
 }

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -71,6 +71,8 @@ static struct {
     VkDescriptorPool eg_pool; VkDescriptorSet eg_gu[64], eg_dn[64]; int eg_nsets;
     Scratch att_sc;              /* attention score scratch (GPU-only) */
     Scratch att_ctx;             /* fused absorb+o: ctx stays on device (GPU-only) */
+    Scratch y2;                  /* second output of the fused matmul pair (readback) */
+    VkDescriptorPool pair_pool; VkDescriptorSet dset_pair;   /* 4-binding set for the pair's 2nd matmul */
     VkKvLayer kv[VK_KV_LAYERS];  /* per-layer resident KV latent/rope cache */
     /* resubmit cache: skip vkUpdateDescriptorSets + command re-record when the bound
      * tensor / shape / scratch buffers are unchanged from the previous call (the hot-
@@ -635,6 +637,63 @@ int coli_vk_attention_absorb(ColiVkTensor **kvb, const void *w, const float *sc,
     return 1;
 }
 
+/* Two resident matmuls sharing the SAME input x in ONE submit (q_a + kv_a in the
+ * attention prologue): one x staging, two dispatches, one fence — replaces two
+ * full submit+wait roundtrips. Outputs y1 [S,O1] and y2 [S,O2] read back from
+ * cached memory. Returns 0 -> caller falls back to the single-matmul path. */
+int coli_vk_matmul_pair(ColiVkTensor **t1p, float *y1, const void *w1, const float *s1, int O1,
+                        ColiVkTensor **t2p, float *y2, const void *w2, const float *s2, int O2,
+                        int fmt, const float *x, int S, int I) {
+    if (!G.ready || S < 1) return 0;
+    if (!upload_tensor(t1p, w1, s1, fmt, I, O1) || !upload_tensor(t2p, w2, s2, fmt, I, O2)) return 0;
+    ColiVkTensor *t1 = *t1p, *t2 = *t2p;
+    size_t xb = (size_t)S * I * 4, yb1 = (size_t)S * O1 * 4, yb2 = (size_t)S * O2 * 4;
+    if (!scratch_reserve(&G.x, xb) || !scratch_reserve_mt(&G.y, yb1, G.memtype_cached) ||
+        !scratch_reserve_mt(&G.y2, yb2, G.memtype_cached)) return 0;
+    memcpy(G.x.ptr, x, xb);
+
+    if (!G.pair_pool) {   /* one-time: a second 4-binding set (G.dset serves the first) */
+        VkDescriptorPoolSize ps = {.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = 4};
+        VkDescriptorPoolCreateInfo dpi = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+            .maxSets = 1, .poolSizeCount = 1, .pPoolSizes = &ps};
+        VKCHECK(vkCreateDescriptorPool(G.dev, &dpi, NULL, &G.pair_pool), "pair descPool");
+        VkDescriptorSetAllocateInfo dsa = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+            .descriptorPool = G.pair_pool, .descriptorSetCount = 1, .pSetLayouts = &G.dsl};
+        VKCHECK(vkAllocateDescriptorSets(G.dev, &dsa, &G.dset_pair), "pair descSet");
+    }
+    VkDescriptorBufferInfo b1[4] = {
+        {.buffer = G.x.buf, .range = VK_WHOLE_SIZE}, {.buffer = t1->wbuf, .range = VK_WHOLE_SIZE},
+        {.buffer = t1->sbuf, .range = VK_WHOLE_SIZE}, {.buffer = G.y.buf, .range = VK_WHOLE_SIZE}};
+    VkDescriptorBufferInfo b2[4] = {
+        {.buffer = G.x.buf, .range = VK_WHOLE_SIZE}, {.buffer = t2->wbuf, .range = VK_WHOLE_SIZE},
+        {.buffer = t2->sbuf, .range = VK_WHOLE_SIZE}, {.buffer = G.y2.buf, .range = VK_WHOLE_SIZE}};
+    wr_desc(G.dset, 4, b1);
+    wr_desc(G.dset_pair, 4, b2);
+
+    VKCHECK(vkResetCommandBuffer(G.cmd, 0), "resetCmd");
+    VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+    VKCHECK(vkBeginCommandBuffer(G.cmd, &begin), "beginCmd");
+    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
+    struct PC pc1 = {fmt, S, I, O1, t1->rowWords};
+    vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.dset, 0, NULL);
+    vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc1), &pc1);
+    vkCmdDispatch(G.cmd, (uint32_t)((O1 + 7) / 8), (uint32_t)S, 1);
+    struct PC pc2 = {fmt, S, I, O2, t2->rowWords};
+    vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.dset_pair, 0, NULL);
+    vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc2), &pc2);
+    vkCmdDispatch(G.cmd, (uint32_t)((O2 + 7) / 8), (uint32_t)S, 1);
+    VKCHECK(vkEndCommandBuffer(G.cmd), "endCmd");
+
+    VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
+    VKCHECK(vkResetFences(G.dev, 1, &G.fence), "resetFence");
+    VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
+    if (vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) { G.ready = 0; return 0; }
+    memcpy(y1, G.y.ptr, yb1);
+    memcpy(y2, G.y2.ptr, yb2);
+    G.cmd_ready = 0; G.bound_tensor = NULL;   /* the shared command buffer/binding was clobbered */
+    return 1;
+}
+
 /* Fused absorb attention + o-projection in ONE submit: the absorb kernel writes ctx
  * [S,H*V] to a device-only scratch, a barrier, then the resident o_proj ([Dout, H*V])
  * runs on it via the plain matmul pipeline — only out [S,Dout] returns to the host.
@@ -734,6 +793,8 @@ void coli_vk_shutdown(void) {
     if (G.eg_y.buf) { vkDestroyBuffer(G.dev, G.eg_y.buf, NULL); vkFreeMemory(G.dev, G.eg_y.mem, NULL); }
     if (G.att_sc.buf) { vkDestroyBuffer(G.dev, G.att_sc.buf, NULL); vkFreeMemory(G.dev, G.att_sc.mem, NULL); }
     if (G.att_ctx.buf) { vkDestroyBuffer(G.dev, G.att_ctx.buf, NULL); vkFreeMemory(G.dev, G.att_ctx.mem, NULL); }
+    if (G.y2.buf) { vkDestroyBuffer(G.dev, G.y2.buf, NULL); vkFreeMemory(G.dev, G.y2.mem, NULL); }
+    if (G.pair_pool) vkDestroyDescriptorPool(G.dev, G.pair_pool, NULL);
     coli_vk_kv_reset();
     if (G.eg_pool) vkDestroyDescriptorPool(G.dev, G.eg_pool, NULL);
     vkDestroyFence(G.dev, G.fence, NULL);
@@ -1013,10 +1074,11 @@ static int run_expert_group(int fmt, int D, int I, int K) {
         coli_vk_tensor_free(tg[c]); coli_vk_tensor_free(tu[c]); coli_vk_tensor_free(td[c]);
         free(hgw[c]); free(huw[c]); free(hdw[c]); free(hgs[c]); free(hus[c]); free(hds[c]);
     }
-    /* K>=32 accumulates fp32 rounding across the double 6144-length reduction chain
-     * (gate_up -> down); ~2e-3 observed and fine for greedy argmax. 3e-3 keeps the
+    /* The gate_up -> down chain accumulates fp32 rounding across two long reductions
+     * (D=6144 then I) vs the double-precision CPU ref; 1-2e-3 shows up at any K
+     * depending on the random draw, and is fine for greedy argmax. 3e-3 keeps the
      * gate honest without flagging the known fp behavior as a failure. */
-    return maxrel > (K >= 32 ? 3e-3 : 1e-3) ? 1 : 0;
+    return maxrel > 3e-3 ? 1 : 0;
 }
 
 /* MLA absorb attention vs a CPU ref that mirrors glm.c's absorb loop exactly:
@@ -1153,6 +1215,35 @@ int main(int argc, char **argv) {
     bad |= run_expert_group(2, 6144, 2048, 1);
     bad |= run_expert_group(2, 6144, 2048, 8);
     bad |= run_expert_group(2, 6144, 2048, 32);
+    /* Fused same-input matmul pair (the q_a + kv_a prologue pattern). */
+    {
+        int I = 6144, O1 = 2048, O2 = 576, S = 1;
+        size_t rb = (size_t)(I + 1) / 2;
+        uint8_t *w1 = malloc(rb * O1), *w2 = malloc(rb * O2);
+        float *s1 = malloc((size_t)O1 * 4), *s2 = malloc((size_t)O2 * 4), *x = malloc((size_t)I * 4);
+        float *y1 = malloc((size_t)O1 * 4), *y2 = malloc((size_t)O2 * 4);
+        float *c1 = malloc((size_t)O1 * 4), *c2 = malloc((size_t)O2 * 4);
+        for (size_t i = 0; i < rb * (size_t)O1; i++) w1[i] = rand() & 0xff;
+        for (size_t i = 0; i < rb * (size_t)O2; i++) w2[i] = rand() & 0xff;
+        for (int o = 0; o < O1; o++) s1[o] = 0.01f + (rand() % 100) / 10000.0f;
+        for (int o = 0; o < O2; o++) s2[o] = 0.01f + (rand() % 100) / 10000.0f;
+        for (int i = 0; i < I; i++) x[i] = (rand() % 200 - 100) / 100.0f;
+        ColiVkTensor *t1 = NULL, *t2 = NULL;
+        if (!coli_vk_matmul_pair(&t1, y1, w1, s1, O1, &t2, y2, w2, s2, O2, 2, x, S, I)) {
+            printf("matmul_pair failed\n"); bad = 1;
+        } else {
+            cpu_ref(c1, x, w1, s1, 2, S, I, O1); cpu_ref(c2, x, w2, s2, 2, S, I, O2);
+            double mr = 0;
+            for (int i = 0; i < O1; i++) { double e = fabs(y1[i]-c1[i]); if (fabs(c1[i])>1e-2) { double r=e/fabs(c1[i]); if (r>mr) mr=r; } }
+            for (int i = 0; i < O2; i++) { double e = fabs(y2[i]-c2[i]); if (fabs(c2[i])>1e-2) { double r=e/fabs(c2[i]); if (r>mr) mr=r; } }
+            double t0 = now();
+            for (int k = 0; k < 30; k++) coli_vk_matmul_pair(&t1, y1, w1, s1, O1, &t2, y2, w2, s2, O2, 2, x, S, I);
+            printf("matmul_pair 6144->(2048,576)          | maxrel=%.4g | %.3f ms/pair-call\n", mr, (now()-t0)*1000/30);
+            bad |= mr > 1e-3;
+        }
+        coli_vk_tensor_free(t1); coli_vk_tensor_free(t2);
+        free(w1); free(w2); free(s1); free(s2); free(x); free(y1); free(y2); free(c1); free(c2);
+    }
     /* MLA absorb attention core (GLM decode shape + window/causal/int8 variants). */
     if (G.pipe_att) {
         bad |= run_absorb(2, 1, 64, 192, 64, 256, 512, 0, 300, 0);    // GLM-5.2 decode

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -364,6 +364,33 @@ int coli_vk_init(const char *spv_path) {
     G.memtype = (uint32_t)mt;
     G.memtype_cached = (uint32_t)pick_memtype_cached(G.phys);
 
+    /* Resizable-BAR sanity (#523): on discrete cards the weight tiers want
+     * HOST_VISIBLE|DEVICE_LOCAL. With ReBAR disabled that combination exists only in a
+     * ~256 MB BAR window (or not at all), so tier allocations silently land in system
+     * RAM and every access crosses PCIe — measurably SLOWER than the CPU path, while
+     * the resident-experts log still reports an apparently healthy VRAM tier. Compare
+     * the chosen type's heap against the largest DEVICE_LOCAL heap and say so up front. */
+    {
+        VkPhysicalDeviceMemoryProperties mp;
+        vkGetPhysicalDeviceMemoryProperties(G.phys, &mp);
+        VkDeviceSize dl_max = 0;
+        for (uint32_t i = 0; i < mp.memoryHeapCount; i++)
+            if ((mp.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) &&
+                mp.memoryHeaps[i].size > dl_max) dl_max = mp.memoryHeaps[i].size;
+        VkMemoryPropertyFlags cf = mp.memoryTypes[G.memtype].propertyFlags;
+        VkDeviceSize hv_dl = mp.memoryHeaps[mp.memoryTypes[G.memtype].heapIndex].size;
+        if (dl_max && !(cf & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT))
+            fprintf(stderr, "[VK] warning: no host-visible+device-local memory type — weight tiers "
+                    "will live in system RAM and every access crosses PCIe (expect slower than "
+                    "CPU-only). On a discrete card, enable Resizable BAR in the BIOS.\n");
+        else if (dl_max && hv_dl * 4 < dl_max)
+            fprintf(stderr, "[VK] warning: only %llu of %llu MB VRAM is host-visible (Resizable BAR "
+                    "appears disabled) — allocations beyond the %llu MB window fall back to system "
+                    "RAM and will be slow. Enable Resizable BAR / Smart Access Memory in the BIOS.\n",
+                    (unsigned long long)(hv_dl >> 20), (unsigned long long)(dl_max >> 20),
+                    (unsigned long long)(hv_dl >> 20));
+    }
+
     G.shader = load_spv(G.dev, spv_path);
     if (!G.shader) return 0;
     if (!build_pipeline(G.dev, 4, sizeof(struct PC), G.shader, &G.dsl, &G.plyt, &G.pipe, &G.dpool, &G.dset)) return 0;

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -22,7 +22,7 @@ struct ColiVkTensor {
     VkBuffer wbuf, sbuf;
     VkDeviceMemory wmem, smem;
     size_t wbytes;
-    int fmt, I, O, rowWords;
+    int fmt, I, O, rowWords, gs;
 };
 
 typedef struct {
@@ -96,9 +96,9 @@ static struct {
     float prio;                  /* priority applied to the NEXT allocations (class knob) */
 } G;
 
-struct PC { int fmt, S, I, O, rowWords; };
+struct PC { int fmt, S, I, O, rowWords, gs; };
 /* Push constants of the absorb attention kernel (must match attention_absorb.comp). */
-struct PCAttn { int fmt, S, H, Q, R, V, K, st0, T, rowWords, cap; float scale; };
+struct PCAttn { int fmt, S, H, Q, R, V, K, st0, T, rowWords, cap; float scale; int gs; };
 
 static int pick_memtype(void) {
     VkPhysicalDeviceMemoryProperties m;
@@ -200,8 +200,10 @@ static int rowwords(int fmt, int I) {
 }
 /* Scale floats per tensor: per-row formats carry O, int3-g64 carries O*ceil(I/64)
  * (one f32 per 64-input group). upload_tensor and tensor_free must agree on this. */
-static size_t scale_floats(int fmt, int I, int O) {
-    return fmt == 5 ? (size_t)O * (((size_t)I + 63) / 64) : (size_t)O;
+static size_t scale_floats(int fmt, int I, int O, int gs) {
+    if (fmt == 5) return (size_t)O * (((size_t)I + 63) / 64);
+    if (fmt == 4) return (size_t)O * (((size_t)I + gs - 1) / gs);   // per-group [O,ng]
+    return (size_t)O;
 }
 
 static VkShaderModule load_spv(const char *path) {
@@ -448,16 +450,17 @@ static int arena_suballoc(size_t bytes, VkBuffer *buf, void **ptr) {
 }
 
 static int upload_tensor(ColiVkTensor **out, const void *weights, const float *scales,
-                         int fmt, int I, int O) {
+                         int fmt, int I, int O, int gs) {
     if (*out) return (*out)->fmt == fmt && (*out)->I == I && (*out)->O == O;
-    if (fmt != 1 && fmt != 2 && fmt != 5) return 0;
+    if (fmt != 1 && fmt != 2 && fmt != 5 &&
+        !(fmt == 4 && gs >= 8 && gs % 8 == 0)) return 0;   /* fmt=4: word-aligned groups only */
     ColiVkTensor *t = calloc(1, sizeof(*t));
     if (!t) return 0;
-    t->fmt = fmt; t->I = I; t->O = O; t->rowWords = rowwords(fmt, I);
+    t->fmt = fmt; t->I = I; t->O = O; t->rowWords = rowwords(fmt, I); t->gs = fmt == 4 ? gs : 0;
     size_t stride = (size_t)t->rowWords * 4;         // padded row bytes
     size_t cpu_rb = fmt == 1 ? (size_t)I
                   : fmt == 5 ? ((size_t)I + 63) / 64 * 24 : (size_t)(I + 1) / 2;
-    size_t sfl = scale_floats(fmt, I, O);            // fmt=5: O*ceil(I/64) group scales
+    size_t sfl = scale_floats(fmt, I, O, gs);            // fmt=5: O*ceil(I/64) group scales
     t->wbytes = stride * (size_t)O;
     void *wptr;
     if (!arena_suballoc(t->wbytes, &t->wbuf, &wptr)) { free(t); return 0; }
@@ -480,9 +483,9 @@ static int upload_tensor(ColiVkTensor **out, const void *weights, const float *s
 
 /* Upload a resident tensor without computing (for the expert tier: gate/up/down are
  * uploaded once, then driven by coli_vk_expert_group). Returns 0 on failure. */
-int coli_vk_tensor_ensure(ColiVkTensor **tensor, const void *weights, const float *scales, int fmt, int I, int O) {
+int coli_vk_tensor_ensure(ColiVkTensor **tensor, const void *weights, const float *scales, int fmt, int I, int O, int grp) {
     if (!G.ready) return 0;
-    return upload_tensor(tensor, weights, scales, fmt, I, O);
+    return upload_tensor(tensor, weights, scales, fmt, I, O, grp);
 }
 
 /* Global submit/wait totals across EVERY synchronous GPU path (VK_PROF=1) — the
@@ -496,8 +499,8 @@ static void vkprof_tick(void) {
 
 int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
                    const void *weights, const float *scales,
-                   int fmt, int S, int I, int O) {
-    if (!G.ready || S < 1 || !upload_tensor(tensor, weights, scales, fmt, I, O)) return 0;
+                   int fmt, int S, int I, int O, int gs) {
+    if (!G.ready || S < 1 || !upload_tensor(tensor, weights, scales, fmt, I, O, gs)) return 0;
     ColiVkTensor *t = *tensor;
     /* VK_PROF=1: phase split of the dense per-call cost, printed every 8192 calls —
      * separates our code (memcpy/desc/record) from the driver (submit) and the GPU
@@ -539,7 +542,7 @@ int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
         VKCHECK(vkBeginCommandBuffer(G.cmd, &begin), "beginCmd");
         vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
         vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.dset, 0, NULL);
-        struct PC pc = {fmt, S, I, O, t->rowWords};
+        struct PC pc = {fmt, S, I, O, t->rowWords, t->gs};
         vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
         /* Grid-stride shader: one subgroup per output row (~8 rows/workgroup at wave32).
          * Launch ~O/8 workgroups for occupancy; the shader loops to cover any O / wave width. */
@@ -579,9 +582,9 @@ int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
  * first call). D = input (hidden) dim, I = moe_inter. Returns 0 -> caller falls back. */
 int coli_vk_gate_up(ColiVkTensor **gate, ColiVkTensor **up, float *hidden, const float *x,
                     const void *gw, const float *gs, const void *uw, const float *us,
-                    int fmt, int S, int D, int I) {
+                    int fmt, int S, int D, int I, int grp) {
     if (!G.ready || !G.shader_gu || S < 1 || D > 6144) return 0;   /* shader stages x in xsh[6144] */
-    if (!upload_tensor(gate, gw, gs, fmt, D, I) || !upload_tensor(up, uw, us, fmt, D, I)) return 0;
+    if (!upload_tensor(gate, gw, gs, fmt, D, I, grp) || !upload_tensor(up, uw, us, fmt, D, I, grp)) return 0;
     ColiVkTensor *tg = *gate, *tu = *up;
     size_t xb = (size_t)S * D * sizeof(float), hb = (size_t)S * I * sizeof(float);
     if (!scratch_reserve(&G.x, xb) || !scratch_reserve_mt(&G.h, hb, G.memtype_cached)) return 0;  /* hidden read back */
@@ -603,7 +606,7 @@ int coli_vk_gate_up(ColiVkTensor **gate, ColiVkTensor **up, float *hidden, const
     VKCHECK(vkBeginCommandBuffer(G.cmd, &begin), "beginCmd");
     vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe_gu);
     vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt_gu, 0, 1, &G.dset_gu, 0, NULL);
-    struct PC pc = {fmt, S, D, I, tg->rowWords};   // PC.I = input D, PC.O = moe_inter I
+    struct PC pc = {fmt, S, D, I, tg->rowWords, tg->gs};   // PC.I = input D, PC.O = moe_inter I
     vkCmdPushConstants(G.cmd, G.plyt_gu, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
     vkCmdDispatch(G.cmd, (uint32_t)((I + 7) / 8), (uint32_t)S, 1);
     VKCHECK(vkEndCommandBuffer(G.cmd), "endCmd");
@@ -692,7 +695,7 @@ static int eg_prepare_submit(ColiVkTensor *const *gates, ColiVkTensor *const *up
     /* phase 1: fused gate+up+silu -> hidden (per expert, bound to its x/hidden slices) */
     vkCmdBindPipeline(G.eg_cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe_gu);
     for (int c = 0; c < count; c++) {
-        struct PC pc = {fmt, rows[c], D, I, gates[c]->rowWords};
+        struct PC pc = {fmt, rows[c], D, I, gates[c]->rowWords, gates[c]->gs};
         vkCmdBindDescriptorSets(G.eg_cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt_gu, 0, 1, &G.eg_gu[c], 0, NULL);
         vkCmdPushConstants(G.eg_cmd, G.plyt_gu, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
         vkCmdDispatch(G.eg_cmd, (uint32_t)((I + 7) / 8), (uint32_t)rows[c], 1);
@@ -701,7 +704,7 @@ static int eg_prepare_submit(ColiVkTensor *const *gates, ColiVkTensor *const *up
     /* phase 2: down projection hidden -> y */
     vkCmdBindPipeline(G.eg_cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
     for (int c = 0; c < count; c++) {
-        struct PC pc = {dfmt, rows[c], I, D, downs[c]->rowWords};
+        struct PC pc = {dfmt, rows[c], I, D, downs[c]->rowWords, downs[c]->gs};
         vkCmdBindDescriptorSets(G.eg_cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.eg_dn[c], 0, NULL);
         vkCmdPushConstants(G.eg_cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
         vkCmdDispatch(G.eg_cmd, (uint32_t)((D + 7) / 8), (uint32_t)rows[c], 1);
@@ -805,14 +808,14 @@ void coli_vk_kv_reset(void) {
  * projected through the value rows of kv_b. kv_b ([H*(Q+V), K]) uploads on first
  * call and stays resident; L/R rows [st0, T) must already be mirrored via
  * coli_vk_kv_row. Returns 0 -> caller falls back to CPU. */
-int coli_vk_attention_absorb(ColiVkTensor **kvb, const void *w, const float *sc, int fmt,
+int coli_vk_attention_absorb(ColiVkTensor **kvb, const void *w, const float *sc, int fmt, int grp,
                              float *ctx, const float *q, int layer, int S, int H,
                              int Q, int R, int V, int K, int st0, int T, float scale) {
     if (!G.ready || !G.pipe_att || S < 1 || H < 1 || layer < 0 || layer >= VK_KV_LAYERS) return 0;
     if (Q > 256 || R > 64 || K > 512 || st0 < 0 || T - S - st0 < 0) return 0;  /* shared-array limits */
     VkKvLayer *kv = &G.kv[layer];
     if (!kv->bl || kv->rows < T || kv->K != K || kv->R != R) return 0;
-    if (!upload_tensor(kvb, w, sc, fmt, K, H * (Q + V))) return 0;
+    if (!upload_tensor(kvb, w, sc, fmt, K, H * (Q + V), grp)) return 0;
     ColiVkTensor *t = *kvb;
     int cap = T - st0;
     size_t qb = (size_t)S * H * (Q + R) * 4, cb = (size_t)S * H * V * 4;
@@ -838,7 +841,7 @@ int coli_vk_attention_absorb(ColiVkTensor **kvb, const void *w, const float *sc,
     VKCHECK(vkBeginCommandBuffer(G.cmd, &begin), "beginCmd");
     vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe_att);
     vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt_att, 0, 1, &G.dset_att, 0, NULL);
-    struct PCAttn pc = {fmt, S, H, Q, R, V, K, st0, T, t->rowWords, cap, scale};
+    struct PCAttn pc = {fmt, S, H, Q, R, V, K, st0, T, t->rowWords, cap, scale, t->gs};
     vkCmdPushConstants(G.cmd, G.plyt_att, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
     vkCmdDispatch(G.cmd, (uint32_t)H, (uint32_t)S, 1);     /* one workgroup per (head, row) */
     VKCHECK(vkEndCommandBuffer(G.cmd), "endCmd");
@@ -861,9 +864,9 @@ int coli_vk_attention_absorb(ColiVkTensor **kvb, const void *w, const float *sc,
  * cached memory. Returns 0 -> caller falls back to the single-matmul path. */
 int coli_vk_matmul_pair(ColiVkTensor **t1p, float *y1, const void *w1, const float *s1, int O1,
                         ColiVkTensor **t2p, float *y2, const void *w2, const float *s2, int O2,
-                        int fmt, const float *x, int S, int I) {
+                        int fmt, const float *x, int S, int I, int grp) {
     if (!G.ready || S < 1) return 0;
-    if (!upload_tensor(t1p, w1, s1, fmt, I, O1) || !upload_tensor(t2p, w2, s2, fmt, I, O2)) return 0;
+    if (!upload_tensor(t1p, w1, s1, fmt, I, O1, grp) || !upload_tensor(t2p, w2, s2, fmt, I, O2, grp)) return 0;
     ColiVkTensor *t1 = *t1p, *t2 = *t2p;
     size_t xb = (size_t)S * I * 4, yb1 = (size_t)S * O1 * 4, yb2 = (size_t)S * O2 * 4;
     if (!scratch_reserve(&G.x, xb) || !scratch_reserve_mt(&G.y, yb1, G.memtype_cached) ||
@@ -892,11 +895,11 @@ int coli_vk_matmul_pair(ColiVkTensor **t1p, float *y1, const void *w1, const flo
     VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
     VKCHECK(vkBeginCommandBuffer(G.cmd, &begin), "beginCmd");
     vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
-    struct PC pc1 = {fmt, S, I, O1, t1->rowWords};
+    struct PC pc1 = {fmt, S, I, O1, t1->rowWords, t1->gs};
     vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.dset, 0, NULL);
     vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc1), &pc1);
     vkCmdDispatch(G.cmd, (uint32_t)((O1 + 7) / 8), (uint32_t)S, 1);
-    struct PC pc2 = {fmt, S, I, O2, t2->rowWords};
+    struct PC pc2 = {fmt, S, I, O2, t2->rowWords, t2->gs};
     vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.dset_pair, 0, NULL);
     vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc2), &pc2);
     vkCmdDispatch(G.cmd, (uint32_t)((O2 + 7) / 8), (uint32_t)S, 1);
@@ -920,8 +923,8 @@ int coli_vk_matmul_pair(ColiVkTensor **t1p, float *y1, const void *w1, const flo
  * runs on it via the plain matmul pipeline — only out [S,Dout] returns to the host.
  * Kills the per-layer ctx readback + re-upload + second submit of the unfused path.
  * Returns 0 -> caller falls back (plain absorb or CPU). */
-int coli_vk_attention_absorb_project(ColiVkTensor **kvb, const void *w, const float *sc, int fmt,
-                                     ColiVkTensor **ot, const void *ow, const float *osc, int ofmt,
+int coli_vk_attention_absorb_project(ColiVkTensor **kvb, const void *w, const float *sc, int fmt, int grp,
+                                     ColiVkTensor **ot, const void *ow, const float *osc, int ofmt, int ogrp,
                                      float *out, const float *q, int layer, int S, int H,
                                      int Q, int R, int V, int K, int st0, int T, float scale,
                                      int Dout) {
@@ -929,8 +932,8 @@ int coli_vk_attention_absorb_project(ColiVkTensor **kvb, const void *w, const fl
     if (Q > 256 || R > 64 || K > 512 || st0 < 0 || T - S - st0 < 0 || Dout < 1) return 0;
     VkKvLayer *kv = &G.kv[layer];
     if (!kv->bl || kv->rows < T || kv->K != K || kv->R != R) return 0;
-    if (!upload_tensor(kvb, w, sc, fmt, K, H * (Q + V))) return 0;
-    if (!upload_tensor(ot, ow, osc, ofmt, H * V, Dout)) return 0;
+    if (!upload_tensor(kvb, w, sc, fmt, K, H * (Q + V), grp)) return 0;
+    if (!upload_tensor(ot, ow, osc, ofmt, H * V, Dout, ogrp)) return 0;
     ColiVkTensor *t = *kvb, *to = *ot;
     int cap = T - st0;
     size_t qb = (size_t)S * H * (Q + R) * 4, cb = (size_t)S * H * V * 4;
@@ -960,7 +963,7 @@ int coli_vk_attention_absorb_project(ColiVkTensor **kvb, const void *w, const fl
     VKCHECK(vkBeginCommandBuffer(G.cmd, &begin), "beginCmd");
     vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe_att);
     vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt_att, 0, 1, &G.dset_att, 0, NULL);
-    struct PCAttn pc = {fmt, S, H, Q, R, V, K, st0, T, t->rowWords, cap, scale};
+    struct PCAttn pc = {fmt, S, H, Q, R, V, K, st0, T, t->rowWords, cap, scale, t->gs};
     vkCmdPushConstants(G.cmd, G.plyt_att, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
     vkCmdDispatch(G.cmd, (uint32_t)H, (uint32_t)S, 1);
     VkMemoryBarrier mb = {.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
@@ -969,7 +972,7 @@ int coli_vk_attention_absorb_project(ColiVkTensor **kvb, const void *w, const fl
         VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1, &mb, 0, NULL, 0, NULL);
     vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
     vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.dset, 0, NULL);
-    struct PC opc = {ofmt, S, H * V, Dout, to->rowWords};
+    struct PC opc = {ofmt, S, H * V, Dout, to->rowWords, to->gs};
     vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(opc), &opc);
     vkCmdDispatch(G.cmd, (uint32_t)((Dout + 7) / 8), (uint32_t)S, 1);
     VKCHECK(vkEndCommandBuffer(G.cmd), "endCmd");
@@ -1000,7 +1003,7 @@ void coli_vk_tensor_free(ColiVkTensor *t) {
     // Mirror upload_tensor exactly (weights + scales), atomically — otherwise
     // used_bytes leaks the scales buffer on every free and drifts upward.
     __atomic_sub_fetch(&G.tensor_count, 1, __ATOMIC_RELAXED);
-    __atomic_sub_fetch(&G.used_bytes, t->wbytes + scale_floats(t->fmt, t->I, t->O) * sizeof(float), __ATOMIC_RELAXED);
+    __atomic_sub_fetch(&G.used_bytes, t->wbytes + scale_floats(t->fmt, t->I, t->O, t->gs) * sizeof(float), __ATOMIC_RELAXED);
     free(t);
 }
 
@@ -1062,11 +1065,14 @@ void coli_vk_shutdown(void) {
 static double now(void) { struct timespec ts; clock_gettime(CLOCK_MONOTONIC, &ts);
     return ts.tv_sec + ts.tv_nsec / 1e9; }
 
+static int g_ref_gs = 64;   /* fmt=4 group size the harness cases use */
 static size_t ref_rowbytes(int fmt, int I) {
     return fmt == 1 ? (size_t)I : fmt == 5 ? (size_t)((I + 63) / 64) * 24 : (size_t)(I + 1) / 2;
 }
-static size_t ref_scales(int fmt, int I, int O) {   // scale COUNT (fmt=5: per 64-group)
-    return fmt == 5 ? (size_t)O * (size_t)((I + 63) / 64) : (size_t)O;
+static size_t ref_scales(int fmt, int I, int O) {   // scale COUNT (per-group for fmt 4/5)
+    if (fmt == 5) return (size_t)O * (size_t)((I + 63) / 64);
+    if (fmt == 4) return (size_t)O * (size_t)((I + g_ref_gs - 1) / g_ref_gs);
+    return (size_t)O;
 }
 static float deq(const uint8_t *row, int fmt, int i) {
     if (fmt == 1) { int b = ((const int8_t *)row)[i]; return (float)b; }
@@ -1080,13 +1086,13 @@ static float deq(const uint8_t *row, int fmt, int i) {
 static void cpu_ref(float *y, const float *x, const uint8_t *w, const float *sc,
                     int fmt, int S, int I, int O) {
     size_t rb = ref_rowbytes(fmt, I);
-    int ng = (I + 63) / 64;
+    int gw2 = fmt == 4 ? g_ref_gs : 64, ng = (I + gw2 - 1) / gw2;
     for (int s = 0; s < S; s++) for (int o = 0; o < O; o++) {
         double sum = 0; const uint8_t *row = w + (size_t)o * rb;
-        if (fmt == 5) {   // per-group scales fold inside the sum
+        if (fmt == 5 || fmt == 4) {   // per-group scales fold inside the sum
             for (int g = 0; g < ng; g++) {
-                double a = 0; int end = (g + 1) * 64 < I ? (g + 1) * 64 : I;
-                for (int i = g * 64; i < end; i++) a += x[s * I + i] * deq(row, fmt, i);
+                double a = 0; int end = (g + 1) * gw2 < I ? (g + 1) * gw2 : I;
+                for (int i = g * gw2; i < end; i++) a += x[s * I + i] * deq(row, fmt, i);
                 sum += a * sc[(size_t)o * ng + g];
             }
             y[s * O + o] = (float)sum;
@@ -1100,11 +1106,12 @@ static void cpu_ref(float *y, const float *x, const uint8_t *w, const float *sc,
 /* dequant dot of one weight row against x with that row's scales applied —
  * per-row for fmt 1/2, per 64-group for fmt=5. scb = tensor scale array, o = row. */
 static double ref_dot(const float *x, const uint8_t *row, const float *scb, int o, int fmt, int I) {
-    if (fmt == 5) {
-        int ng = (I + 63) / 64; double sum = 0;
+    if (fmt == 5 || fmt == 4) {
+        int gw2 = fmt == 4 ? g_ref_gs : 64;
+        int ng = (I + gw2 - 1) / gw2; double sum = 0;
         for (int g = 0; g < ng; g++) {
-            double a = 0; int end = (g + 1) * 64 < I ? (g + 1) * 64 : I;
-            for (int i = g * 64; i < end; i++) a += x[i] * deq(row, fmt, i);
+            double a = 0; int end = (g + 1) * gw2 < I ? (g + 1) * gw2 : I;
+            for (int i = g * gw2; i < end; i++) a += x[i] * deq(row, fmt, i);
             sum += a * scb[(size_t)o * ng + g];
         }
         return sum;
@@ -1126,7 +1133,7 @@ static int run_case(int fmt, int S, int I, int O, int iters) {
     for (size_t o = 0; o < nsc; o++) sc[o] = 0.01f + (rand() % 100) / 10000.0f;
 
     ColiVkTensor *t = NULL;
-    if (!coli_vk_matmul(&t, yg, x, w, sc, fmt, S, I, O)) { printf("matmul failed\n"); return 1; }
+    if (!coli_vk_matmul(&t, yg, x, w, sc, fmt, S, I, O, g_ref_gs)) { printf("matmul failed\n"); return 1; }
     cpu_ref(yc, x, w, sc, fmt, S, I, O);
     double maxerr = 0, maxrel = 0;
     for (int i = 0; i < S * O; i++) {
@@ -1135,7 +1142,7 @@ static int run_case(int fmt, int S, int I, int O, int iters) {
     }
     // microbench (GPU)
     double t0 = now();
-    for (int k = 0; k < iters; k++) coli_vk_matmul(&t, yg, x, w, sc, fmt, S, I, O);
+    for (int k = 0; k < iters; k++) coli_vk_matmul(&t, yg, x, w, sc, fmt, S, I, O, g_ref_gs);
     double gpu_ms = (now() - t0) * 1000 / iters;
     // microbench (CPU ref, 1 iter — it's slow)
     double c0 = now(); cpu_ref(yc, x, w, sc, fmt, S, I, O); double cpu_ms = (now() - c0) * 1000;
@@ -1158,7 +1165,7 @@ static double bench_batched(ColiVkTensor *t, const float *x, int fmt, int S, int
     vkBeginCommandBuffer(G.cmd, &begin);
     vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
     vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.dset, 0, NULL);
-    struct PC pc = {fmt, S, I, O, t->rowWords};
+    struct PC pc = {fmt, S, I, O, t->rowWords, t->gs};
     vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
     VkMemoryBarrier mb = {.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
         .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT, .dstAccessMask = VK_ACCESS_SHADER_READ_BIT};
@@ -1192,7 +1199,7 @@ static int run_gate_up(int fmt, int S, int D, int I) {
     for (size_t i = 0; i < rb*I; i++) { gw[i] = rand()&0xff; uw[i] = rand()&0xff; }
     for (size_t o = 0; o < nsc; o++) { gs[o] = 0.01f+(rand()%100)/10000.0f; us[o] = 0.01f+(rand()%100)/10000.0f; }
     ColiVkTensor *tg = NULL, *tu = NULL;
-    if (!coli_vk_gate_up(&tg, &tu, hg, x, gw, gs, uw, us, fmt, S, D, I)) { printf("gate_up failed\n"); return 1; }
+    if (!coli_vk_gate_up(&tg, &tu, hg, x, gw, gs, uw, us, fmt, S, D, I, g_ref_gs)) { printf("gate_up failed\n"); return 1; }
     for (int s = 0; s < S; s++) for (int o = 0; o < I; o++) {
         float gt = (float)ref_dot(x+(size_t)s*D, gw+(size_t)o*rb, gs, o, fmt, D);
         float ut = (float)ref_dot(x+(size_t)s*D, uw+(size_t)o*rb, us, o, fmt, D);
@@ -1214,7 +1221,7 @@ static double bench_gu_batched(ColiVkTensor *tg, const float *x, int fmt, int S,
     vkBeginCommandBuffer(G.cmd, &begin);
     vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe_gu);
     vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt_gu, 0, 1, &G.dset_gu, 0, NULL);
-    struct PC pc = {fmt, S, D, I, tg->rowWords};
+    struct PC pc = {fmt, S, D, I, tg->rowWords, tg->gs};
     vkCmdPushConstants(G.cmd, G.plyt_gu, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
     VkMemoryBarrier mb = {.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
         .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT, .dstAccessMask = VK_ACCESS_SHADER_READ_BIT};
@@ -1243,7 +1250,7 @@ static double bench_experts_fair(int fmt, int D, int I, int K, int Npass) {
         uint8_t *gw = malloc(rb*I), *uw = malloc(rb*I); float *gs = malloc(nsc*4), *us = malloc(nsc*4);
         for (size_t i = 0; i < rb*I; i++) { gw[i] = rand()&0xff; uw[i] = rand()&0xff; }
         for (size_t o = 0; o < nsc; o++) { gs[o] = 0.01f; us[o] = 0.01f; }
-        coli_vk_gate_up(&tg[c], &tu[c], h, x, gw, gs, uw, us, fmt, 1, D, I);   /* uploads distinct experts */
+        coli_vk_gate_up(&tg[c], &tu[c], h, x, gw, gs, uw, us, fmt, 1, D, I, g_ref_gs);   /* uploads distinct experts */
         free(gw); free(uw); free(gs); free(us);
     }
     VkDescriptorPoolSize ps = {.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = (uint32_t)(6*K)};
@@ -1262,7 +1269,7 @@ static double bench_experts_fair(int fmt, int D, int I, int K, int Npass) {
     VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
     vkBeginCommandBuffer(G.cmd, &begin);
     vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe_gu);
-    struct PC pc = {fmt, 1, D, I, tg[0]->rowWords};
+    struct PC pc = {fmt, 1, D, I, tg[0]->rowWords, tg[0]->gs};
     vkCmdPushConstants(G.cmd, G.plyt_gu, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
     VkMemoryBarrier mb = {.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER, .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT, .dstAccessMask = VK_ACCESS_SHADER_READ_BIT};
     for (int pass = 0; pass < Npass; pass++) for (int c = 0; c < K; c++) {
@@ -1300,9 +1307,9 @@ static int run_expert_group(int fmt, int D, int I, int K) {
         hgs[c] = malloc(gu_sc*4); hus[c] = malloc(gu_sc*4); hds[c] = malloc(d_sc*4);
         for (size_t o = 0; o < gu_sc; o++) { hgs[c][o] = 0.01f+(rand()%100)/10000.0f; hus[c][o] = 0.01f+(rand()%100)/10000.0f; }
         for (size_t o = 0; o < d_sc; o++) hds[c][o] = 0.01f+(rand()%100)/10000.0f;
-        coli_vk_matmul(&tg[c], tmp, x, hgw[c], hgs[c], fmt, 1, D, I);   /* upload gate  (D->I) */
-        coli_vk_matmul(&tu[c], tmp, x, huw[c], hus[c], fmt, 1, D, I);   /* upload up    (D->I) */
-        coli_vk_matmul(&td[c], tmp, x, hdw[c], hds[c], fmt, 1, I, D);   /* upload down  (I->D) */
+        coli_vk_matmul(&tg[c], tmp, x, hgw[c], hgs[c], fmt, 1, D, I, g_ref_gs);   /* upload gate  (D->I) */
+        coli_vk_matmul(&tu[c], tmp, x, huw[c], hus[c], fmt, 1, D, I, g_ref_gs);   /* upload up    (D->I) */
+        coli_vk_matmul(&td[c], tmp, x, hdw[c], hds[c], fmt, 1, I, D, g_ref_gs);   /* upload down  (I->D) */
     }
     int rows[64]; for (int c = 0; c < K; c++) rows[c] = 1;
     if (!coli_vk_expert_group(tg, tu, td, rows, K, yg, x)) { printf("expert_group failed\n"); return 1; }
@@ -1377,7 +1384,7 @@ static int run_absorb(int fmt, int S, int H, int Q, int R, int V, int K, int st0
     for (int t = 0; t < T; t++)
         if (!coli_vk_kv_row(layer, t, L + (size_t)t * K, Rr + (size_t)t * R)) { printf("kv_row failed\n"); return 1; }
     ColiVkTensor *kvb = NULL;
-    if (!coli_vk_attention_absorb(&kvb, w, ws, fmt, cg, q, layer, S, H, Q, R, V, K, st0, T, scale)) {
+    if (!coli_vk_attention_absorb(&kvb, w, ws, fmt, g_ref_gs, cg, q, layer, S, H, Q, R, V, K, st0, T, scale)) {
         printf("absorb failed\n"); return 1; }
     float *qabs = malloc((size_t)K * 4), *clat = malloc((size_t)K * 4), *sc = malloc((size_t)(T - st0) * 4);
     for (int s = 0; s < S; s++) for (int h = 0; h < H; h++) {
@@ -1386,7 +1393,9 @@ static int run_absorb(int fmt, int S, int H, int Q, int R, int V, int K, int st0
         for (int i = 0; i < K; i++) qabs[i] = 0;
         for (int d = 0; d < Q; d++) { const uint8_t *row = w + (size_t)(rbase + d) * rb;
             for (int i = 0; i < K; i++) {
-                float sw = fmt == 5 ? ws[(size_t)(rbase + d) * ngK + (i >> 6)] : ws[rbase + d];
+                float sw = fmt == 5 ? ws[(size_t)(rbase + d) * ngK + (i >> 6)]
+                         : fmt == 4 ? ws[(size_t)(rbase + d) * ((K + g_ref_gs - 1) / g_ref_gs) + i / g_ref_gs]
+                         : ws[rbase + d];
                 qabs[i] += qp[d] * deq(row, fmt, i) * sw; } }
         for (int j = 0; j < nt; j++) { int t = st0 + j;
             double a = 0;
@@ -1407,7 +1416,7 @@ static int run_absorb(int fmt, int S, int H, int Q, int R, int V, int K, int st0
         if (fabs(cc[i]) > 1e-2) { double r = e / fabs(cc[i]); if (r > maxrel) maxrel = r; } }
     double t0 = now(); int iters = 20;   /* per-call cost, the engine pattern (one submit/layer) */
     for (int k = 0; k < iters; k++)
-        coli_vk_attention_absorb(&kvb, w, ws, fmt, cg, q, layer, S, H, Q, R, V, K, st0, T, scale);
+        coli_vk_attention_absorb(&kvb, w, ws, fmt, g_ref_gs, cg, q, layer, S, H, Q, R, V, K, st0, T, scale);
     double ms = (now() - t0) * 1000 / iters;
     printf("absorb fmt=%d S=%d H=%d Q=%d R=%d V=%d K=%d st0=%d T=%d | maxerr=%.4g maxrel=%.4g | %.3f ms/call\n",
            fmt, S, H, Q, R, V, K, st0, T, maxerr, maxrel, ms);
@@ -1418,7 +1427,7 @@ static int run_absorb(int fmt, int S, int H, int Q, int R, int V, int K, int st0
     for (size_t i = 0; i < orb * (size_t)Dout; i++) owt[i] = rand() & 0xff;
     for (size_t o = 0; o < onsc; o++) osc[o] = 0.01f + (rand() % 100) / 10000.0f;
     ColiVkTensor *ot = NULL;
-    if (!coli_vk_attention_absorb_project(&kvb, w, ws, fmt, &ot, owt, osc, fmt,
+    if (!coli_vk_attention_absorb_project(&kvb, w, ws, fmt, g_ref_gs, &ot, owt, osc, fmt, g_ref_gs,
             og, q, layer, S, H, Q, R, V, K, st0, T, scale, Dout)) { printf("absorb_project failed\n"); return 1; }
     cpu_ref(oc, cc, owt, osc, fmt, S, H * V, Dout);
     double pmaxrel = 0;
@@ -1426,7 +1435,7 @@ static int run_absorb(int fmt, int S, int H, int Q, int R, int V, int K, int st0
         if (fabs(oc[i]) > 1e-2) { double r = e / fabs(oc[i]); if (r > pmaxrel) pmaxrel = r; } }
     t0 = now();
     for (int k = 0; k < iters; k++)
-        coli_vk_attention_absorb_project(&kvb, w, ws, fmt, &ot, owt, osc, fmt,
+        coli_vk_attention_absorb_project(&kvb, w, ws, fmt, g_ref_gs, &ot, owt, osc, fmt, g_ref_gs,
             og, q, layer, S, H, Q, R, V, K, st0, T, scale, Dout);
     printf("absorb+project fused                  | maxrel=%.4g | %.3f ms/call (unfused absorb was %.3f)\n",
            pmaxrel, (now() - t0) * 1000 / iters, ms);
@@ -1474,7 +1483,7 @@ int main(int argc, char **argv) {
         for (size_t i = 0; i < (size_t)(I + 1) / 2 * O; i++) w[i] = rand() & 0xff;
         for (int o = 0; o < O; o++) sc[o] = 0.01f + (rand() % 100) / 10000.0f;
         float *y = malloc((size_t)O * 4);
-        ColiVkTensor *t = NULL; coli_vk_matmul(&t, y, x, w, sc, 2, 1, I, O);   /* bind */
+        ColiVkTensor *t = NULL; coli_vk_matmul(&t, y, x, w, sc, 2, 1, I, O, 0);   /* bind */
         printf("BATCHED int4 S=1 6144->2048 (our gate/up): %.4f ms/matmul (N=64, one submit)\n",
                bench_batched(t, x, 2, 1, I, O, 64));
         coli_vk_tensor_free(t); free(x); free(w); free(sc); free(y);
@@ -1484,7 +1493,7 @@ int main(int argc, char **argv) {
         for (size_t i = 0; i < (size_t)(I + 1) / 2 * O; i++) w[i] = rand() & 0xff;
         for (int o = 0; o < O; o++) sc[o] = 0.01f + (rand() % 100) / 10000.0f;
         y = malloc((size_t)O * 4);
-        t = NULL; coli_vk_matmul(&t, y, x, w, sc, 2, 1, I, O);
+        t = NULL; coli_vk_matmul(&t, y, x, w, sc, 2, 1, I, O, 0);
         printf("BATCHED int4 S=1 2048->6144 (our down):    %.4f ms/matmul (N=64, one submit)\n",
                bench_batched(t, x, 2, 1, I, O, 64));
         coli_vk_tensor_free(t); free(x); free(w); free(sc); free(y);
@@ -1500,7 +1509,7 @@ int main(int argc, char **argv) {
         for (int i = 0; i < D; i++) x[i] = (rand()%200-100)/100.0f;
         for (size_t i = 0; i < rb*I; i++) { gw[i] = rand()&0xff; uw[i] = rand()&0xff; }
         for (int o = 0; o < I; o++) { gs[o] = 0.01f; us[o] = 0.01f; }
-        ColiVkTensor *tg = NULL, *tu = NULL; coli_vk_gate_up(&tg, &tu, h, x, gw, gs, uw, us, 2, 1, D, I);
+        ColiVkTensor *tg = NULL, *tu = NULL; coli_vk_gate_up(&tg, &tu, h, x, gw, gs, uw, us, 2, 1, D, I, 0);
         printf("BATCHED fused gate_up int4 6144->2048:     %.4f ms (N=64, SAME expert = L2-cached)\n",
                bench_gu_batched(tg, x, 2, 1, D, I, 64));
         coli_vk_tensor_free(tg); coli_vk_tensor_free(tu); free(x); free(gw); free(uw); free(gs); free(us); free(h);
@@ -1517,12 +1526,22 @@ int main(int argc, char **argv) {
     bad |= run_expert_group(2, 6144, 2048, 32);
     /* int3-g64 expert group: correctness + the 0.86x-bytes throughput question.
      * count=1 included — it is the SHARED-expert path shape in the engine. */
+    /* fmt=4 grouped int4 (#298 semantics), gs=64 across real shapes + gs=32 sanity */
+    g_ref_gs = 64;
+    bad |= run_case(4, 1, 6144, 2048, 50);
+    bad |= run_case(4, 1, 2048, 6144, 50);
+    bad |= run_case(4, 8, 6144, 1536, 20);
+    bad |= run_case(4, 1, 16384, 6144, 10);
+    g_ref_gs = 32;
+    bad |= run_case(4, 1, 6144, 2048, 20);
+    g_ref_gs = 64;
+    bad |= run_expert_group(4, 6144, 2048, 8);
     bad |= run_expert_group(5, 6144, 2048, 1);
     bad |= run_expert_group(5, 6144, 2048, 8);
     bad |= run_expert_group(5, 6144, 2048, 32);
     /* Fused same-input matmul pair (the q_a + kv_a prologue pattern), int4 AND int3. */
-    for (int pi = 0; pi < 2; pi++) {
-        int pf = pi == 0 ? 2 : 5;
+    for (int pi = 0; pi < 3; pi++) {
+        int pf = pi == 0 ? 2 : pi == 1 ? 5 : 4;
         int I = 6144, O1 = 2048, O2 = 576, S = 1;
         size_t rb = ref_rowbytes(pf, I);
         size_t n1 = ref_scales(pf, I, O1), n2 = ref_scales(pf, I, O2);
@@ -1536,7 +1555,7 @@ int main(int argc, char **argv) {
         for (size_t o = 0; o < n2; o++) s2[o] = 0.01f + (rand() % 100) / 10000.0f;
         for (int i = 0; i < I; i++) x[i] = (rand() % 200 - 100) / 100.0f;
         ColiVkTensor *t1 = NULL, *t2 = NULL;
-        if (!coli_vk_matmul_pair(&t1, y1, w1, s1, O1, &t2, y2, w2, s2, O2, pf, x, S, I)) {
+        if (!coli_vk_matmul_pair(&t1, y1, w1, s1, O1, &t2, y2, w2, s2, O2, pf, x, S, I, g_ref_gs)) {
             printf("matmul_pair fmt=%d failed\n", pf); bad = 1;
         } else {
             cpu_ref(c1, x, w1, s1, pf, S, I, O1); cpu_ref(c2, x, w2, s2, pf, S, I, O2);
@@ -1544,7 +1563,7 @@ int main(int argc, char **argv) {
             for (int i = 0; i < O1; i++) { double e = fabs(y1[i]-c1[i]); if (fabs(c1[i])>1e-2) { double r=e/fabs(c1[i]); if (r>mr) mr=r; } }
             for (int i = 0; i < O2; i++) { double e = fabs(y2[i]-c2[i]); if (fabs(c2[i])>1e-2) { double r=e/fabs(c2[i]); if (r>mr) mr=r; } }
             double t0 = now();
-            for (int k = 0; k < 30; k++) coli_vk_matmul_pair(&t1, y1, w1, s1, O1, &t2, y2, w2, s2, O2, pf, x, S, I);
+            for (int k = 0; k < 30; k++) coli_vk_matmul_pair(&t1, y1, w1, s1, O1, &t2, y2, w2, s2, O2, pf, x, S, I, g_ref_gs);
             printf("matmul_pair fmt=%d 6144->(2048,576)   | maxrel=%.4g | %.3f ms/pair-call\n", pf, mr, (now()-t0)*1000/30);
             bad |= mr > 1e-3;
         }
@@ -1560,6 +1579,8 @@ int main(int argc, char **argv) {
         bad |= run_absorb(2, 1, 64, 192, 64, 256, 512, 0, 2000, 4);   // long context
         bad |= run_absorb(5, 1, 64, 192, 64, 256, 512, 0, 300, 5);    // int3-g64 kv_b + o
         bad |= run_absorb(5, 2, 64, 192, 64, 256, 512, 17, 300, 6);   // int3 S=2 causal + window
+        bad |= run_absorb(4, 1, 64, 192, 64, 256, 512, 0, 300, 7);    // grouped-int4 kv_b + o
+        bad |= run_absorb(4, 2, 64, 192, 64, 256, 512, 17, 300, 8);   // fmt=4 S=2 causal + window
     }
     printf(bad ? "FAIL\n" : "PASS\n");
     coli_vk_shutdown();

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -151,8 +151,15 @@ static int scratch_reserve_mt(Scratch *s, size_t bytes, uint32_t memtype) {
 static int scratch_reserve(Scratch *s, size_t bytes) { return scratch_reserve_mt(s, bytes, G.memtype); }
 
 static int rowwords(int fmt, int I) {
-    size_t rb = fmt == 1 ? (size_t)I : (size_t)(I + 1) / 2; // bytes/row on CPU side
-    return (int)((rb + 3) / 4);                              // padded to uint32
+    size_t rb = fmt == 1 ? (size_t)I                         // bytes/row on CPU side
+              : fmt == 5 ? ((size_t)I + 63) / 64 * 24        // int3-g64: 24B per 64-group
+              : (size_t)(I + 1) / 2;
+    return (int)((rb + 3) / 4);                              // padded to uint32 (24|4: exact)
+}
+/* Scale floats per tensor: per-row formats carry O, int3-g64 carries O*ceil(I/64)
+ * (one f32 per 64-input group). upload_tensor and tensor_free must agree on this. */
+static size_t scale_floats(int fmt, int I, int O) {
+    return fmt == 5 ? (size_t)O * (((size_t)I + 63) / 64) : (size_t)O;
 }
 
 static VkShaderModule load_spv(const char *path) {
@@ -314,12 +321,14 @@ void coli_vk_mem_info(size_t *used, size_t *count) {
 static int upload_tensor(ColiVkTensor **out, const void *weights, const float *scales,
                          int fmt, int I, int O) {
     if (*out) return (*out)->fmt == fmt && (*out)->I == I && (*out)->O == O;
-    if (fmt != 1 && fmt != 2) return 0;
+    if (fmt != 1 && fmt != 2 && fmt != 5) return 0;
     ColiVkTensor *t = calloc(1, sizeof(*t));
     if (!t) return 0;
     t->fmt = fmt; t->I = I; t->O = O; t->rowWords = rowwords(fmt, I);
     size_t stride = (size_t)t->rowWords * 4;         // padded row bytes
-    size_t cpu_rb = fmt == 1 ? (size_t)I : (size_t)(I + 1) / 2;
+    size_t cpu_rb = fmt == 1 ? (size_t)I
+                  : fmt == 5 ? ((size_t)I + 63) / 64 * 24 : (size_t)(I + 1) / 2;
+    size_t sfl = scale_floats(fmt, I, O);            // fmt=5: O*ceil(I/64) group scales
     t->wbytes = stride * (size_t)O;
     void *wptr;
     if (!alloc_hostvis(t->wbytes, &t->wbuf, &t->wmem, &wptr)) { free(t); return 0; }
@@ -328,13 +337,13 @@ static int upload_tensor(ColiVkTensor **out, const void *weights, const float *s
         memcpy((uint8_t *)wptr + (size_t)o * stride,
                (const uint8_t *)weights + (size_t)o * cpu_rb, cpu_rb);
     void *sptr;
-    if (!alloc_hostvis((size_t)O * sizeof(float), &t->sbuf, &t->smem, &sptr)) {
+    if (!alloc_hostvis(sfl * sizeof(float), &t->sbuf, &t->smem, &sptr)) {
         vkDestroyBuffer(G.dev, t->wbuf, NULL); vkFreeMemory(G.dev, t->wmem, NULL); free(t); return 0;
     }
-    memcpy(sptr, scales, (size_t)O * sizeof(float));
+    memcpy(sptr, scales, sfl * sizeof(float));
     // Counters are touched concurrently: frees run from expert_load under
     // `#pragma omp parallel`, so RMW them atomically (torn counts otherwise).
-    __atomic_add_fetch(&G.used_bytes, t->wbytes + (size_t)O * sizeof(float), __ATOMIC_RELAXED);
+    __atomic_add_fetch(&G.used_bytes, t->wbytes + sfl * sizeof(float), __ATOMIC_RELAXED);
     __atomic_add_fetch(&G.tensor_count, 1, __ATOMIC_RELAXED);
     *out = t;
     return 1;
@@ -476,10 +485,14 @@ static int eg_prepare_submit(ColiVkTensor *const *gates, ColiVkTensor *const *up
     ColiVkTensor *g0 = gates[0]; if (!g0) return 0;
     int D = g0->I, I = g0->O, fmt = g0->fmt, total = 0, off[64];
     if (D > 6144) return 0;   /* gate_up shader stages x in xsh[6144] */
+    int dfmt = downs[0]->fmt;   /* down may be a different quant than gate/up (per-projection
+                                 * containers, e.g. --up-bits 3); gate/up must MATCH — the
+                                 * fused gate_up shader decodes both with one fmt. */
     for (int c = 0; c < count; c++) {
         off[c] = total; total += rows[c];
         if (rows[c] < 1 || gates[c]->I != D || gates[c]->O != I || gates[c]->fmt != fmt ||
-            ups[c]->I != D || ups[c]->O != I || downs[c]->I != I || downs[c]->O != D) return 0;
+            ups[c]->I != D || ups[c]->O != I || ups[c]->fmt != fmt ||
+            downs[c]->I != I || downs[c]->O != D || downs[c]->fmt != dfmt) return 0;
     }
     size_t xb = (size_t)total*D*4, hb = (size_t)total*I*4, yb = (size_t)total*D*4;
     if (!scratch_reserve(&G.eg_x, xb) || !scratch_reserve(&G.eg_h, hb) ||
@@ -531,7 +544,7 @@ static int eg_prepare_submit(ColiVkTensor *const *gates, ColiVkTensor *const *up
     /* phase 2: down projection hidden -> y */
     vkCmdBindPipeline(G.eg_cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
     for (int c = 0; c < count; c++) {
-        struct PC pc = {fmt, rows[c], I, D, downs[c]->rowWords};
+        struct PC pc = {dfmt, rows[c], I, D, downs[c]->rowWords};
         vkCmdBindDescriptorSets(G.eg_cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.eg_dn[c], 0, NULL);
         vkCmdPushConstants(G.eg_cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
         vkCmdDispatch(G.eg_cmd, (uint32_t)((D + 7) / 8), (uint32_t)rows[c], 1);
@@ -814,9 +827,9 @@ void coli_vk_tensor_free(ColiVkTensor *t) {
         if (t->sbuf) { vkDestroyBuffer(G.dev, t->sbuf, NULL); vkFreeMemory(G.dev, t->smem, NULL); }
     }
     // Mirror upload_tensor exactly (weights + scales), atomically — otherwise
-    // used_bytes leaks the O*float scales buffer on every free and drifts upward.
+    // used_bytes leaks the scales buffer on every free and drifts upward.
     __atomic_sub_fetch(&G.tensor_count, 1, __ATOMIC_RELAXED);
-    __atomic_sub_fetch(&G.used_bytes, t->wbytes + (size_t)t->O * sizeof(float), __ATOMIC_RELAXED);
+    __atomic_sub_fetch(&G.used_bytes, t->wbytes + scale_floats(t->fmt, t->I, t->O) * sizeof(float), __ATOMIC_RELAXED);
     free(t);
 }
 
@@ -872,31 +885,68 @@ void coli_vk_shutdown(void) {
 static double now(void) { struct timespec ts; clock_gettime(CLOCK_MONOTONIC, &ts);
     return ts.tv_sec + ts.tv_nsec / 1e9; }
 
+static size_t ref_rowbytes(int fmt, int I) {
+    return fmt == 1 ? (size_t)I : fmt == 5 ? (size_t)((I + 63) / 64) * 24 : (size_t)(I + 1) / 2;
+}
+static size_t ref_scales(int fmt, int I, int O) {   // scale COUNT (fmt=5: per 64-group)
+    return fmt == 5 ? (size_t)O * (size_t)((I + 63) / 64) : (size_t)O;
+}
 static float deq(const uint8_t *row, int fmt, int i) {
     if (fmt == 1) { int b = ((const int8_t *)row)[i]; return (float)b; }
+    if (fmt == 5) {   // int3-g64: 16B low plane (2 bits) + 8B high plane (1 bit), v+4
+        const uint8_t *lo = row + (size_t)(i >> 6) * 24, *hi = lo + 16; int j = i & 63;
+        unsigned u = ((lo[j >> 2] >> ((j & 3) * 2)) & 3u) | (((hi[j >> 3] >> (j & 7)) & 1u) << 2);
+        return (float)((int)u - 4); }
     uint8_t v = row[i >> 1]; int nib = (i & 1) ? (v >> 4) : (v & 15); return (float)(nib - 8);
 }
 
 static void cpu_ref(float *y, const float *x, const uint8_t *w, const float *sc,
                     int fmt, int S, int I, int O) {
-    size_t rb = fmt == 1 ? (size_t)I : (size_t)(I + 1) / 2;
+    size_t rb = ref_rowbytes(fmt, I);
+    int ng = (I + 63) / 64;
     for (int s = 0; s < S; s++) for (int o = 0; o < O; o++) {
         double sum = 0; const uint8_t *row = w + (size_t)o * rb;
-        for (int i = 0; i < I; i++) sum += x[s * I + i] * deq(row, fmt, i);
-        y[s * O + o] = (float)(sum * sc[o]);
+        if (fmt == 5) {   // per-group scales fold inside the sum
+            for (int g = 0; g < ng; g++) {
+                double a = 0; int end = (g + 1) * 64 < I ? (g + 1) * 64 : I;
+                for (int i = g * 64; i < end; i++) a += x[s * I + i] * deq(row, fmt, i);
+                sum += a * sc[(size_t)o * ng + g];
+            }
+            y[s * O + o] = (float)sum;
+        } else {
+            for (int i = 0; i < I; i++) sum += x[s * I + i] * deq(row, fmt, i);
+            y[s * O + o] = (float)(sum * sc[o]);
+        }
     }
 }
 
+/* dequant dot of one weight row against x with that row's scales applied —
+ * per-row for fmt 1/2, per 64-group for fmt=5. scb = tensor scale array, o = row. */
+static double ref_dot(const float *x, const uint8_t *row, const float *scb, int o, int fmt, int I) {
+    if (fmt == 5) {
+        int ng = (I + 63) / 64; double sum = 0;
+        for (int g = 0; g < ng; g++) {
+            double a = 0; int end = (g + 1) * 64 < I ? (g + 1) * 64 : I;
+            for (int i = g * 64; i < end; i++) a += x[i] * deq(row, fmt, i);
+            sum += a * scb[(size_t)o * ng + g];
+        }
+        return sum;
+    }
+    double sum = 0;
+    for (int i = 0; i < I; i++) sum += x[i] * deq(row, fmt, i);
+    return sum * scb[o];
+}
+
 static int run_case(int fmt, int S, int I, int O, int iters) {
-    size_t rb = fmt == 1 ? (size_t)I : (size_t)(I + 1) / 2;
+    size_t rb = ref_rowbytes(fmt, I), nsc = ref_scales(fmt, I, O);
     float *x = malloc((size_t)S * I * sizeof(float));
     uint8_t *w = malloc(rb * O);
-    float *sc = malloc((size_t)O * sizeof(float));
+    float *sc = malloc(nsc * sizeof(float));
     float *yg = malloc((size_t)S * O * sizeof(float));
     float *yc = malloc((size_t)S * O * sizeof(float));
     for (int i = 0; i < S * I; i++) x[i] = (float)((rand() % 200 - 100) / 100.0);
     for (size_t i = 0; i < rb * O; i++) w[i] = rand() & 0xff;
-    for (int o = 0; o < O; o++) sc[o] = 0.01f + (rand() % 100) / 10000.0f;
+    for (size_t o = 0; o < nsc; o++) sc[o] = 0.01f + (rand() % 100) / 10000.0f;
 
     ColiVkTensor *t = NULL;
     if (!coli_vk_matmul(&t, yg, x, w, sc, fmt, S, I, O)) { printf("matmul failed\n"); return 1; }
@@ -957,19 +1007,18 @@ static double bench_batched(ColiVkTensor *t, const float *x, int fmt, int S, int
 
 /* Fused gate+up correctness vs CPU ref: hidden = silu(gate*x)*(up*x). */
 static int run_gate_up(int fmt, int S, int D, int I) {
-    size_t rb = fmt == 1 ? (size_t)D : (size_t)(D + 1) / 2;
+    size_t rb = ref_rowbytes(fmt, D), nsc = ref_scales(fmt, D, I);
     float *x = malloc((size_t)S*D*4); uint8_t *gw = malloc(rb*I), *uw = malloc(rb*I);
-    float *gs = malloc((size_t)I*4), *us = malloc((size_t)I*4);
+    float *gs = malloc(nsc*4), *us = malloc(nsc*4);
     float *hg = malloc((size_t)S*I*4), *hc = malloc((size_t)S*I*4);
     for (int i = 0; i < S*D; i++) x[i] = (rand()%200-100)/100.0f;
     for (size_t i = 0; i < rb*I; i++) { gw[i] = rand()&0xff; uw[i] = rand()&0xff; }
-    for (int o = 0; o < I; o++) { gs[o] = 0.01f+(rand()%100)/10000.0f; us[o] = 0.01f+(rand()%100)/10000.0f; }
+    for (size_t o = 0; o < nsc; o++) { gs[o] = 0.01f+(rand()%100)/10000.0f; us[o] = 0.01f+(rand()%100)/10000.0f; }
     ColiVkTensor *tg = NULL, *tu = NULL;
     if (!coli_vk_gate_up(&tg, &tu, hg, x, gw, gs, uw, us, fmt, S, D, I)) { printf("gate_up failed\n"); return 1; }
     for (int s = 0; s < S; s++) for (int o = 0; o < I; o++) {
-        double g = 0, u = 0; const uint8_t *gr = gw+(size_t)o*rb, *ur = uw+(size_t)o*rb;
-        for (int i = 0; i < D; i++) { g += x[s*D+i]*deq(gr,fmt,i); u += x[s*D+i]*deq(ur,fmt,i); }
-        float gt = (float)(g*gs[o]), ut = (float)(u*us[o]);
+        float gt = (float)ref_dot(x+(size_t)s*D, gw+(size_t)o*rb, gs, o, fmt, D);
+        float ut = (float)ref_dot(x+(size_t)s*D, uw+(size_t)o*rb, us, o, fmt, D);
         hc[s*I+o] = (gt/(1.0f+expf(-gt)))*ut;
     }
     double maxrel = 0;
@@ -1009,14 +1058,14 @@ static double bench_gu_batched(ColiVkTensor *tg, const float *x, int fmt, int S,
  * Returns ms per gate_up (one expert). */
 static double bench_experts_fair(int fmt, int D, int I, int K, int Npass) {
     if (K > 32) K = 32;
-    size_t rb = fmt == 1 ? (size_t)D : (size_t)(D + 1) / 2;
+    size_t rb = ref_rowbytes(fmt, D), nsc = ref_scales(fmt, D, I);
     ColiVkTensor *tg[32] = {0}, *tu[32] = {0};
     float *h = malloc((size_t)I*4), *x = malloc((size_t)D*4);
     for (int i = 0; i < D; i++) x[i] = (rand()%200-100)/100.0f;
     for (int c = 0; c < K; c++) {
-        uint8_t *gw = malloc(rb*I), *uw = malloc(rb*I); float *gs = malloc((size_t)I*4), *us = malloc((size_t)I*4);
+        uint8_t *gw = malloc(rb*I), *uw = malloc(rb*I); float *gs = malloc(nsc*4), *us = malloc(nsc*4);
         for (size_t i = 0; i < rb*I; i++) { gw[i] = rand()&0xff; uw[i] = rand()&0xff; }
-        for (int o = 0; o < I; o++) { gs[o] = 0.01f; us[o] = 0.01f; }
+        for (size_t o = 0; o < nsc; o++) { gs[o] = 0.01f; us[o] = 0.01f; }
         coli_vk_gate_up(&tg[c], &tu[c], h, x, gw, gs, uw, us, fmt, 1, D, I);   /* uploads distinct experts */
         free(gw); free(uw); free(gs); free(us);
     }
@@ -1060,8 +1109,8 @@ static double bench_experts_fair(int fmt, int D, int I, int K, int Npass) {
  * one submit, hidden on-device. The real comparison to ROCm's coli_cuda_expert_group. */
 static int run_expert_group(int fmt, int D, int I, int K) {
     if (K > 64) K = 64;
-    size_t gu_rb = fmt == 1 ? (size_t)D : (size_t)(D + 1) / 2;
-    size_t d_rb  = fmt == 1 ? (size_t)I : (size_t)(I + 1) / 2;
+    size_t gu_rb = ref_rowbytes(fmt, D), gu_sc = ref_scales(fmt, D, I);
+    size_t d_rb  = ref_rowbytes(fmt, I), d_sc  = ref_scales(fmt, I, D);
     ColiVkTensor *tg[64] = {0}, *tu[64] = {0}, *td[64] = {0};
     uint8_t *hgw[64], *huw[64], *hdw[64]; float *hgs[64], *hus[64], *hds[64];
     float *x = malloc((size_t)K*D*4), *yg = malloc((size_t)K*D*4), *yc = malloc((size_t)K*D*4);
@@ -1071,9 +1120,9 @@ static int run_expert_group(int fmt, int D, int I, int K) {
         hgw[c] = malloc(gu_rb*I); huw[c] = malloc(gu_rb*I); hdw[c] = malloc(d_rb*D);
         for (size_t i = 0; i < gu_rb*I; i++) { hgw[c][i] = rand()&0xff; huw[c][i] = rand()&0xff; }
         for (size_t i = 0; i < d_rb*D; i++) hdw[c][i] = rand()&0xff;
-        hgs[c] = malloc((size_t)I*4); hus[c] = malloc((size_t)I*4); hds[c] = malloc((size_t)D*4);
-        for (int o = 0; o < I; o++) { hgs[c][o] = 0.01f+(rand()%100)/10000.0f; hus[c][o] = 0.01f+(rand()%100)/10000.0f; }
-        for (int o = 0; o < D; o++) hds[c][o] = 0.01f+(rand()%100)/10000.0f;
+        hgs[c] = malloc(gu_sc*4); hus[c] = malloc(gu_sc*4); hds[c] = malloc(d_sc*4);
+        for (size_t o = 0; o < gu_sc; o++) { hgs[c][o] = 0.01f+(rand()%100)/10000.0f; hus[c][o] = 0.01f+(rand()%100)/10000.0f; }
+        for (size_t o = 0; o < d_sc; o++) hds[c][o] = 0.01f+(rand()%100)/10000.0f;
         coli_vk_matmul(&tg[c], tmp, x, hgw[c], hgs[c], fmt, 1, D, I);   /* upload gate  (D->I) */
         coli_vk_matmul(&tu[c], tmp, x, huw[c], hus[c], fmt, 1, D, I);   /* upload up    (D->I) */
         coli_vk_matmul(&td[c], tmp, x, hdw[c], hds[c], fmt, 1, I, D);   /* upload down  (I->D) */
@@ -1084,16 +1133,12 @@ static int run_expert_group(int fmt, int D, int I, int K) {
     for (int c = 0; c < K; c++) {
         float *xc = x + (size_t)c*D;
         for (int o = 0; o < I; o++) {
-            double g = 0, u = 0; const uint8_t *gr = hgw[c]+(size_t)o*gu_rb, *ur = huw[c]+(size_t)o*gu_rb;
-            for (int i = 0; i < D; i++) { g += xc[i]*deq(gr,fmt,i); u += xc[i]*deq(ur,fmt,i); }
-            float gt = (float)(g*hgs[c][o]), ut = (float)(u*hus[c][o]);
+            float gt = (float)ref_dot(xc, hgw[c]+(size_t)o*gu_rb, hgs[c], o, fmt, D);
+            float ut = (float)ref_dot(xc, huw[c]+(size_t)o*gu_rb, hus[c], o, fmt, D);
             hid[o] = (gt/(1.0f+expf(-gt)))*ut;
         }
-        for (int d = 0; d < D; d++) {
-            double sdot = 0; const uint8_t *dr = hdw[c]+(size_t)d*d_rb;
-            for (int o = 0; o < I; o++) sdot += hid[o]*deq(dr,fmt,o);
-            yc[c*D+d] = (float)(sdot*hds[c][d]);
-        }
+        for (int d = 0; d < D; d++)
+            yc[c*D+d] = (float)ref_dot(hid, hdw[c]+(size_t)d*d_rb, hds[c], d, fmt, I);
     }
     double maxrel = 0;
     for (int i = 0; i < K*D; i++) { double e = fabs(yg[i]-yc[i]); if (fabs(yc[i])>1e-2) { double r = e/fabs(yc[i]); if (r>maxrel) maxrel = r; } }
@@ -1138,14 +1183,15 @@ static int run_expert_group(int fmt, int D, int I, int K) {
  * qabs = sum_d q[d]*deq(row rbase+d)*ws, scores over cache rows [st0, T-S+s],
  * softmax, weighted latent, value-row projection. */
 static int run_absorb(int fmt, int S, int H, int Q, int R, int V, int K, int st0, int T, int layer) {
-    size_t rb = fmt == 1 ? (size_t)K : (size_t)(K + 1) / 2;
-    int O = H * (Q + V);
-    uint8_t *w = malloc(rb * O); float *ws = malloc((size_t)O * 4);
+    size_t rb = ref_rowbytes(fmt, K);
+    int O = H * (Q + V), ngK = (K + 63) / 64;
+    size_t nws = ref_scales(fmt, K, O);
+    uint8_t *w = malloc(rb * O); float *ws = malloc(nws * 4);
     float *q = malloc((size_t)S * H * (Q + R) * 4);
     float *L = malloc((size_t)T * K * 4), *Rr = malloc((size_t)T * R * 4);
     float *cg = malloc((size_t)S * H * V * 4), *cc = malloc((size_t)S * H * V * 4);
     for (size_t i = 0; i < rb * (size_t)O; i++) w[i] = rand() & 0xff;
-    for (int o = 0; o < O; o++) ws[o] = 0.01f + (rand() % 100) / 10000.0f;
+    for (size_t o = 0; o < nws; o++) ws[o] = 0.01f + (rand() % 100) / 10000.0f;
     for (int i = 0; i < S * H * (Q + R); i++) q[i] = (rand() % 200 - 100) / 100.0f;
     for (int i = 0; i < T * K; i++) L[i] = (rand() % 200 - 100) / 100.0f;
     for (int i = 0; i < T * R; i++) Rr[i] = (rand() % 200 - 100) / 100.0f;
@@ -1162,7 +1208,9 @@ static int run_absorb(int fmt, int S, int H, int Q, int R, int V, int K, int st0
         int rbase = h * (Q + V), nt = (T - S + s + 1) - st0;
         for (int i = 0; i < K; i++) qabs[i] = 0;
         for (int d = 0; d < Q; d++) { const uint8_t *row = w + (size_t)(rbase + d) * rb;
-            for (int i = 0; i < K; i++) qabs[i] += qp[d] * deq(row, fmt, i) * ws[rbase + d]; }
+            for (int i = 0; i < K; i++) {
+                float sw = fmt == 5 ? ws[(size_t)(rbase + d) * ngK + (i >> 6)] : ws[rbase + d];
+                qabs[i] += qp[d] * deq(row, fmt, i) * sw; } }
         for (int j = 0; j < nt; j++) { int t = st0 + j;
             double a = 0;
             for (int i = 0; i < K; i++) a += qabs[i] * L[(size_t)t * K + i];
@@ -1173,9 +1221,9 @@ static int run_absorb(int fmt, int S, int H, int Q, int R, int V, int K, int st0
         for (int i = 0; i < K; i++) clat[i] = 0;
         for (int j = 0; j < nt; j++) { float a = (float)(sc[j] / sum);
             for (int i = 0; i < K; i++) clat[i] += a * L[(size_t)(st0 + j) * K + i]; }
-        for (int v = 0; v < V; v++) { const uint8_t *row = w + (size_t)(rbase + Q + v) * rb;
-            double a = 0; for (int i = 0; i < K; i++) a += clat[i] * deq(row, fmt, i);
-            cc[((size_t)s * H + h) * V + v] = (float)(a * ws[rbase + Q + v]); }
+        for (int v = 0; v < V; v++)
+            cc[((size_t)s * H + h) * V + v] =
+                (float)ref_dot(clat, w + (size_t)(rbase + Q + v) * rb, ws, rbase + Q + v, fmt, K);
     }
     double maxrel = 0, maxerr = 0;
     for (int i = 0; i < S * H * V; i++) { double e = fabs(cg[i] - cc[i]); if (e > maxerr) maxerr = e;
@@ -1187,11 +1235,11 @@ static int run_absorb(int fmt, int S, int H, int Q, int R, int V, int K, int st0
     printf("absorb fmt=%d S=%d H=%d Q=%d R=%d V=%d K=%d st0=%d T=%d | maxerr=%.4g maxrel=%.4g | %.3f ms/call\n",
            fmt, S, H, Q, R, V, K, st0, T, maxerr, maxrel, ms);
     /* fused absorb+project vs (CPU ctx ref) @ (CPU o ref) */
-    int Dout = 512; size_t orb = fmt == 1 ? (size_t)H * V : (size_t)(H * V + 1) / 2;
-    uint8_t *owt = malloc(orb * Dout); float *osc = malloc((size_t)Dout * 4);
+    int Dout = 512; size_t orb = ref_rowbytes(fmt, H * V), onsc = ref_scales(fmt, H * V, Dout);
+    uint8_t *owt = malloc(orb * Dout); float *osc = malloc(onsc * 4);
     float *og = malloc((size_t)S * Dout * 4), *oc = malloc((size_t)S * Dout * 4);
     for (size_t i = 0; i < orb * (size_t)Dout; i++) owt[i] = rand() & 0xff;
-    for (int o = 0; o < Dout; o++) osc[o] = 0.01f + (rand() % 100) / 10000.0f;
+    for (size_t o = 0; o < onsc; o++) osc[o] = 0.01f + (rand() % 100) / 10000.0f;
     ColiVkTensor *ot = NULL;
     if (!coli_vk_attention_absorb_project(&kvb, w, ws, fmt, &ot, owt, osc, fmt,
             og, q, layer, S, H, Q, R, V, K, st0, T, scale, Dout)) { printf("absorb_project failed\n"); return 1; }
@@ -1222,6 +1270,12 @@ int main(int argc, char **argv) {
     bad |= run_case(2, 8, 6144, 1536, 20);   // prefill/MTP batch
     bad |= run_case(1, 1, 512, 512, 100);    // small
     bad |= run_case(2, 1, 16384, 6144, 20);  // o_proj shape: I > xsh capacity (unstaged path)
+    /* int3-g64 (fmt=5): per-group scales through every dense shape incl. tail groups */
+    bad |= run_case(5, 1, 6144, 2048, 50);   // int3 expert gate/up shape
+    bad |= run_case(5, 1, 2048, 6144, 50);   // int3 down proj shape
+    bad |= run_case(5, 8, 6144, 2048, 20);   // int3 batch
+    bad |= run_case(5, 1, 100, 64, 20);      // partial tail group (I%64 != 0)
+    bad |= run_case(5, 1, 16384, 6144, 20);  // int3 o_proj shape (unstaged path)
     /* Batched (amortized) throughput on the int4 expert shapes — the real expert-tier pattern. */
     {
         int I = 6144, O = 2048;   /* our gate/up dims */
@@ -1249,6 +1303,7 @@ int main(int argc, char **argv) {
     {
         int D = 6144, I = 2048;
         bad |= run_gate_up(2, 1, D, I);
+        bad |= run_gate_up(5, 1, D, I);   // int3-g64 fused pair (per-group scales)
         size_t rb = (size_t)(D + 1) / 2;
         float *x = malloc((size_t)D*4); uint8_t *gw = malloc(rb*I), *uw = malloc(rb*I);
         float *gs = malloc((size_t)I*4), *us = malloc((size_t)I*4), *h = malloc((size_t)I*4);
@@ -1263,11 +1318,16 @@ int main(int argc, char **argv) {
     /* FAIR: cycle 8 distinct experts (VRAM reads, not L2) — matches ROCm expert_group. */
     printf("FAIR fused gate_up int4 6144->2048 (8 distinct experts): %.4f ms/expert\n",
            bench_experts_fair(2, 6144, 2048, 8, 8));
+    printf("FAIR fused gate_up int3 6144->2048 (8 distinct experts): %.4f ms/expert\n",
+           bench_experts_fair(5, 6144, 2048, 8, 8));
     /* FULL expert_group: the real primitive. Sweep K to see if per-expert cost is fixed
      * per-call overhead (drops with K) or per-dispatch (constant). */
     bad |= run_expert_group(2, 6144, 2048, 1);
     bad |= run_expert_group(2, 6144, 2048, 8);
     bad |= run_expert_group(2, 6144, 2048, 32);
+    /* int3-g64 expert group: correctness + the 0.86x-bytes throughput question */
+    bad |= run_expert_group(5, 6144, 2048, 8);
+    bad |= run_expert_group(5, 6144, 2048, 32);
     /* Fused same-input matmul pair (the q_a + kv_a prologue pattern). */
     {
         int I = 6144, O1 = 2048, O2 = 576, S = 1;
@@ -1304,6 +1364,8 @@ int main(int argc, char **argv) {
         bad |= run_absorb(2, 2, 64, 192, 64, 256, 512, 0, 300, 2);    // S=2 causal (MTP verify)
         bad |= run_absorb(1, 1, 8, 128, 32, 64, 256, 0, 64, 3);       // int8, odd dims
         bad |= run_absorb(2, 1, 64, 192, 64, 256, 512, 0, 2000, 4);   // long context
+        bad |= run_absorb(5, 1, 64, 192, 64, 256, 512, 0, 300, 5);    // int3-g64 kv_b + o
+        bad |= run_absorb(5, 2, 64, 192, 64, 256, 512, 17, 300, 6);   // int3 S=2 causal + window
     }
     printf(bad ? "FAIL\n" : "PASS\n");
     coli_vk_shutdown();

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -48,6 +48,11 @@ static struct {
     VkCommandBuffer cmd;
     VkFence fence;
     Scratch x, y, h;   /* h = fused gate+up hidden output */
+    /* full expert-group scratch: activations/hidden/output for K experts + per-expert
+     * descriptor sets (gate_up: dsl_gu, down: dsl), so gate_up->down runs on-device in
+     * one submit with hidden never leaving the GPU. */
+    Scratch eg_x, eg_h, eg_y;
+    VkDescriptorPool eg_pool; VkDescriptorSet eg_gu[64], eg_dn[64]; int eg_nsets;
     /* resubmit cache: skip vkUpdateDescriptorSets + command re-record when the bound
      * tensor / shape / scratch buffers are unchanged from the previous call (the hot-
      * expert-called-repeatedly pattern). The synchronous fence wait each call means no
@@ -379,6 +384,90 @@ int coli_vk_gate_up(ColiVkTensor **gate, ColiVkTensor **up, float *hidden, const
     return 1;
 }
 
+static void wr_desc(VkDescriptorSet set, int n, const VkDescriptorBufferInfo *bi) {
+    VkWriteDescriptorSet w[6];
+    for (int i = 0; i < n; i++) w[i] = (VkWriteDescriptorSet){
+        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, .dstSet = set, .dstBinding = (uint32_t)i,
+        .descriptorCount = 1, .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .pBufferInfo = &bi[i]};
+    vkUpdateDescriptorSets(G.dev, (uint32_t)n, w, 0, NULL);
+}
+
+/* Full batched expert MLP for `count` experts in ONE submit, hidden staying on-device:
+ * for each c, hidden_c = silu(gate_c(x_c))*up_c(x_c) (fused), then y_c = down_c(hidden_c).
+ * x/y are packed [sum(rows)*D]; experts are resident VkTensors (gate/up: D->I, down: I->D).
+ * Mirrors coli_cuda_expert_group. Returns 0 -> caller falls back to CPU. */
+int coli_vk_expert_group(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
+                         ColiVkTensor *const *downs, const int *rows, int count,
+                         float *y, const float *x) {
+    if (!G.ready || !G.shader_gu || count < 1 || count > 64) return 0;
+    ColiVkTensor *g0 = gates[0]; if (!g0) return 0;
+    int D = g0->I, I = g0->O, fmt = g0->fmt, total = 0, off[64];
+    for (int c = 0; c < count; c++) {
+        off[c] = total; total += rows[c];
+        if (rows[c] < 1 || gates[c]->I != D || gates[c]->O != I || gates[c]->fmt != fmt ||
+            ups[c]->I != D || ups[c]->O != I || downs[c]->I != I || downs[c]->O != D) return 0;
+    }
+    size_t xb = (size_t)total*D*4, hb = (size_t)total*I*4, yb = (size_t)total*D*4;
+    if (!scratch_reserve(&G.eg_x, xb) || !scratch_reserve(&G.eg_h, hb) || !scratch_reserve(&G.eg_y, yb)) return 0;
+    memcpy(G.eg_x.ptr, x, xb);
+
+    if (!G.eg_pool) {   /* one-time: 64 gate_up (6-binding) + 64 down (4-binding) sets */
+        VkDescriptorPoolSize ps = {.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = 64*6 + 64*4};
+        VkDescriptorPoolCreateInfo dpi = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO, .maxSets = 128, .poolSizeCount = 1, .pPoolSizes = &ps};
+        VKCHECK(vkCreateDescriptorPool(G.dev, &dpi, NULL, &G.eg_pool), "eg descPool");
+        VkDescriptorSetLayout lg[64], ld[64];
+        for (int c = 0; c < 64; c++) { lg[c] = G.dsl_gu; ld[c] = G.dsl; }
+        VkDescriptorSetAllocateInfo ag = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO, .descriptorPool = G.eg_pool, .descriptorSetCount = 64, .pSetLayouts = lg};
+        VkDescriptorSetAllocateInfo ad = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO, .descriptorPool = G.eg_pool, .descriptorSetCount = 64, .pSetLayouts = ld};
+        VKCHECK(vkAllocateDescriptorSets(G.dev, &ag, G.eg_gu), "eg gu sets");
+        VKCHECK(vkAllocateDescriptorSets(G.dev, &ad, G.eg_dn), "eg dn sets");
+        G.eg_nsets = 64;
+    }
+    for (int c = 0; c < count; c++) {
+        VkDeviceSize xo = (VkDeviceSize)off[c]*D*4, ho = (VkDeviceSize)off[c]*I*4, yo = (VkDeviceSize)off[c]*D*4;
+        VkDescriptorBufferInfo gi[6] = {
+            {G.eg_x.buf, xo, (VkDeviceSize)rows[c]*D*4}, {gates[c]->wbuf, 0, VK_WHOLE_SIZE},
+            {gates[c]->sbuf, 0, VK_WHOLE_SIZE}, {ups[c]->wbuf, 0, VK_WHOLE_SIZE},
+            {ups[c]->sbuf, 0, VK_WHOLE_SIZE}, {G.eg_h.buf, ho, (VkDeviceSize)rows[c]*I*4}};
+        wr_desc(G.eg_gu[c], 6, gi);
+        VkDescriptorBufferInfo di[4] = {
+            {G.eg_h.buf, ho, (VkDeviceSize)rows[c]*I*4}, {downs[c]->wbuf, 0, VK_WHOLE_SIZE},
+            {downs[c]->sbuf, 0, VK_WHOLE_SIZE}, {G.eg_y.buf, yo, (VkDeviceSize)rows[c]*D*4}};
+        wr_desc(G.eg_dn[c], 4, di);
+    }
+
+    VKCHECK(vkResetCommandBuffer(G.cmd, 0), "resetCmd");
+    VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+    VKCHECK(vkBeginCommandBuffer(G.cmd, &begin), "beginCmd");
+    VkMemoryBarrier mb = {.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER, .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT, .dstAccessMask = VK_ACCESS_SHADER_READ_BIT};
+    /* phase 1: fused gate+up+silu -> hidden (per expert, bound to its x/hidden slices) */
+    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe_gu);
+    for (int c = 0; c < count; c++) {
+        struct PC pc = {fmt, rows[c], D, I, gates[c]->rowWords};
+        vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt_gu, 0, 1, &G.eg_gu[c], 0, NULL);
+        vkCmdPushConstants(G.cmd, G.plyt_gu, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
+        vkCmdDispatch(G.cmd, (uint32_t)((I + 7) / 8), (uint32_t)rows[c], 1);
+    }
+    vkCmdPipelineBarrier(G.cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1, &mb, 0, NULL, 0, NULL);
+    /* phase 2: down projection hidden -> y */
+    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
+    for (int c = 0; c < count; c++) {
+        struct PC pc = {fmt, rows[c], I, D, downs[c]->rowWords};
+        vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.eg_dn[c], 0, NULL);
+        vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
+        vkCmdDispatch(G.cmd, (uint32_t)((D + 7) / 8), (uint32_t)rows[c], 1);
+    }
+    VKCHECK(vkEndCommandBuffer(G.cmd), "endCmd");
+
+    VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
+    VKCHECK(vkResetFences(G.dev, 1, &G.fence), "resetFence");
+    VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
+    if (vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) { G.ready = 0; return 0; }
+    memcpy(y, G.eg_y.ptr, yb);
+    G.cmd_ready = 0; G.bound_tensor = NULL;
+    return 1;
+}
+
 void coli_vk_tensor_free(ColiVkTensor *t) {
     if (!t) return;
     if (G.bound_tensor == t) { G.bound_tensor = NULL; G.cmd_ready = 0; }  /* drop stale cache */
@@ -405,6 +494,10 @@ void coli_vk_shutdown(void) {
     if (G.x.buf) { vkDestroyBuffer(G.dev, G.x.buf, NULL); vkFreeMemory(G.dev, G.x.mem, NULL); }
     if (G.y.buf) { vkDestroyBuffer(G.dev, G.y.buf, NULL); vkFreeMemory(G.dev, G.y.mem, NULL); }
     if (G.h.buf) { vkDestroyBuffer(G.dev, G.h.buf, NULL); vkFreeMemory(G.dev, G.h.mem, NULL); }
+    if (G.eg_x.buf) { vkDestroyBuffer(G.dev, G.eg_x.buf, NULL); vkFreeMemory(G.dev, G.eg_x.mem, NULL); }
+    if (G.eg_h.buf) { vkDestroyBuffer(G.dev, G.eg_h.buf, NULL); vkFreeMemory(G.dev, G.eg_h.mem, NULL); }
+    if (G.eg_y.buf) { vkDestroyBuffer(G.dev, G.eg_y.buf, NULL); vkFreeMemory(G.dev, G.eg_y.mem, NULL); }
+    if (G.eg_pool) vkDestroyDescriptorPool(G.dev, G.eg_pool, NULL);
     vkDestroyFence(G.dev, G.fence, NULL);
     vkDestroyCommandPool(G.dev, G.cpool, NULL);
     vkDestroyDescriptorPool(G.dev, G.dpool, NULL);
@@ -616,6 +709,68 @@ static double bench_experts_fair(int fmt, int D, int I, int K, int Npass) {
     return ms;
 }
 
+/* Full expert-group correctness (vs CPU ref) + fair throughput: K distinct experts,
+ * one submit, hidden on-device. The real comparison to ROCm's coli_cuda_expert_group. */
+static int run_expert_group(int fmt, int D, int I, int K) {
+    if (K > 64) K = 64;
+    size_t gu_rb = fmt == 1 ? (size_t)D : (size_t)(D + 1) / 2;
+    size_t d_rb  = fmt == 1 ? (size_t)I : (size_t)(I + 1) / 2;
+    ColiVkTensor *tg[64] = {0}, *tu[64] = {0}, *td[64] = {0};
+    uint8_t *hgw[64], *huw[64], *hdw[64]; float *hgs[64], *hus[64], *hds[64];
+    float *x = malloc((size_t)K*D*4), *yg = malloc((size_t)K*D*4), *yc = malloc((size_t)K*D*4);
+    float *tmp = malloc((size_t)(D > I ? D : I) * 4);
+    for (int i = 0; i < K*D; i++) x[i] = (rand()%200-100)/100.0f;
+    for (int c = 0; c < K; c++) {
+        hgw[c] = malloc(gu_rb*I); huw[c] = malloc(gu_rb*I); hdw[c] = malloc(d_rb*D);
+        for (size_t i = 0; i < gu_rb*I; i++) { hgw[c][i] = rand()&0xff; huw[c][i] = rand()&0xff; }
+        for (size_t i = 0; i < d_rb*D; i++) hdw[c][i] = rand()&0xff;
+        hgs[c] = malloc((size_t)I*4); hus[c] = malloc((size_t)I*4); hds[c] = malloc((size_t)D*4);
+        for (int o = 0; o < I; o++) { hgs[c][o] = 0.01f+(rand()%100)/10000.0f; hus[c][o] = 0.01f+(rand()%100)/10000.0f; }
+        for (int o = 0; o < D; o++) hds[c][o] = 0.01f+(rand()%100)/10000.0f;
+        coli_vk_matmul(&tg[c], tmp, x, hgw[c], hgs[c], fmt, 1, D, I);   /* upload gate  (D->I) */
+        coli_vk_matmul(&tu[c], tmp, x, huw[c], hus[c], fmt, 1, D, I);   /* upload up    (D->I) */
+        coli_vk_matmul(&td[c], tmp, x, hdw[c], hds[c], fmt, 1, I, D);   /* upload down  (I->D) */
+    }
+    int rows[64]; for (int c = 0; c < K; c++) rows[c] = 1;
+    if (!coli_vk_expert_group(tg, tu, td, rows, K, yg, x)) { printf("expert_group failed\n"); return 1; }
+    float *hid = malloc((size_t)I*4);
+    for (int c = 0; c < K; c++) {
+        float *xc = x + (size_t)c*D;
+        for (int o = 0; o < I; o++) {
+            double g = 0, u = 0; const uint8_t *gr = hgw[c]+(size_t)o*gu_rb, *ur = huw[c]+(size_t)o*gu_rb;
+            for (int i = 0; i < D; i++) { g += xc[i]*deq(gr,fmt,i); u += xc[i]*deq(ur,fmt,i); }
+            float gt = (float)(g*hgs[c][o]), ut = (float)(u*hus[c][o]);
+            hid[o] = (gt/(1.0f+expf(-gt)))*ut;
+        }
+        for (int d = 0; d < D; d++) {
+            double sdot = 0; const uint8_t *dr = hdw[c]+(size_t)d*d_rb;
+            for (int o = 0; o < I; o++) sdot += hid[o]*deq(dr,fmt,o);
+            yc[c*D+d] = (float)(sdot*hds[c][d]);
+        }
+    }
+    double maxrel = 0;
+    for (int i = 0; i < K*D; i++) { double e = fabs(yg[i]-yc[i]); if (fabs(yc[i])>1e-2) { double r = e/fabs(yc[i]); if (r>maxrel) maxrel = r; } }
+    coli_vk_expert_group(tg, tu, td, rows, K, yg, x);   /* warm + leaves G.cmd recorded */
+    int iters = 20; double t0 = now();
+    for (int k = 0; k < iters; k++) coli_vk_expert_group(tg, tu, td, rows, K, yg, x);
+    double ms = (now()-t0)*1000.0/iters/K;
+    /* GPU-only: re-submit the already-recorded command buffer (skips per-call host setup:
+     * descriptor updates + recording), isolating raw GPU throughput. */
+    VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
+    for (int w = 0; w < 2; w++) { vkResetFences(G.dev,1,&G.fence); vkQueueSubmit(G.queue,1,&si,G.fence); vkWaitForFences(G.dev,1,&G.fence,VK_TRUE,10000000000ULL); }
+    double g0 = now();
+    for (int k = 0; k < iters; k++) { vkResetFences(G.dev,1,&G.fence); vkQueueSubmit(G.queue,1,&si,G.fence); vkWaitForFences(G.dev,1,&G.fence,VK_TRUE,10000000000ULL); }
+    double gpums = (now()-g0)*1000.0/iters/K;
+    printf("FULL VK expert_group fmt=%d %2d experts | maxrel=%.4g | per-call %.4f  GPU-only %.4f ms/expert (ROCm 0.179)\n",
+           fmt, K, maxrel, ms, gpums);
+    free(hid); free(x); free(yg); free(yc); free(tmp);
+    for (int c = 0; c < K; c++) {
+        coli_vk_tensor_free(tg[c]); coli_vk_tensor_free(tu[c]); coli_vk_tensor_free(td[c]);
+        free(hgw[c]); free(huw[c]); free(hdw[c]); free(hgs[c]); free(hus[c]); free(hds[c]);
+    }
+    return maxrel > 1e-3 ? 1 : 0;
+}
+
 int main(int argc, char **argv) {
     const char *spv = argc > 1 ? argv[1] : "shaders/qmatmul.spv";
     if (!coli_vk_init(spv)) { printf("vk init failed\n"); return 1; }
@@ -667,6 +822,11 @@ int main(int argc, char **argv) {
     /* FAIR: cycle 8 distinct experts (VRAM reads, not L2) — matches ROCm expert_group. */
     printf("FAIR fused gate_up int4 6144->2048 (8 distinct experts): %.4f ms/expert\n",
            bench_experts_fair(2, 6144, 2048, 8, 8));
+    /* FULL expert_group: the real primitive. Sweep K to see if per-expert cost is fixed
+     * per-call overhead (drops with K) or per-dispatch (constant). */
+    bad |= run_expert_group(2, 6144, 2048, 1);
+    bad |= run_expert_group(2, 6144, 2048, 8);
+    bad |= run_expert_group(2, 6144, 2048, 32);
     printf(bad ? "FAIL\n" : "PASS\n");
     coli_vk_shutdown();
     return bad;

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -29,6 +29,16 @@ typedef struct {
     VkBuffer buf; VkDeviceMemory mem; void *ptr; size_t cap;
 } Scratch;
 
+/* Persistent device-side KV latent/rope cache for one layer (MLA attention).
+ * Host appends rows as tokens decode (absolute-position indexing); the absorb
+ * kernel reads them in place. Allocated once at max_t rows, like the CUDA
+ * kv_dev shadow. */
+#define VK_KV_LAYERS 160
+typedef struct {
+    VkBuffer bl, br; VkDeviceMemory ml, mr; void *pl, *pr;
+    int rows, K, R;
+} VkKvLayer;
+
 static struct {
     int ready;
     VkInstance inst;
@@ -47,6 +57,9 @@ static struct {
     /* fused dual gate+up+silu pipeline (6 bindings): x, Wg, gscale, Wu, uscale, hidden */
     VkShaderModule shader_gu; VkDescriptorSetLayout dsl_gu; VkPipelineLayout plyt_gu;
     VkPipeline pipe_gu; VkDescriptorPool dpool_gu; VkDescriptorSet dset_gu;
+    /* MLA absorb attention core (7 bindings): q, W, scales, Lcache, Rcache, scores, ctx */
+    VkShaderModule shader_att; VkDescriptorSetLayout dsl_att; VkPipelineLayout plyt_att;
+    VkPipeline pipe_att; VkDescriptorPool dpool_att; VkDescriptorSet dset_att;
     VkCommandPool cpool;
     VkCommandBuffer cmd;
     VkFence fence;
@@ -56,6 +69,8 @@ static struct {
      * one submit with hidden never leaving the GPU. */
     Scratch eg_x, eg_h, eg_y;
     VkDescriptorPool eg_pool; VkDescriptorSet eg_gu[64], eg_dn[64]; int eg_nsets;
+    Scratch att_sc;              /* attention score scratch (GPU-only) */
+    VkKvLayer kv[VK_KV_LAYERS];  /* per-layer resident KV latent/rope cache */
     /* resubmit cache: skip vkUpdateDescriptorSets + command re-record when the bound
      * tensor / shape / scratch buffers are unchanged from the previous call (the hot-
      * expert-called-repeatedly pattern). The synchronous fence wait each call means no
@@ -67,6 +82,8 @@ static struct {
 } G;
 
 struct PC { int fmt, S, I, O, rowWords; };
+/* Push constants of the absorb attention kernel (must match attention_absorb.comp). */
+struct PCAttn { int fmt, S, H, Q, R, V, K, st0, T, rowWords, cap; float scale; };
 
 static int pick_memtype(void) {
     VkPhysicalDeviceMemoryProperties m;
@@ -148,11 +165,12 @@ static VkShaderModule load_spv(const char *path) {
     return r == VK_SUCCESS ? m : VK_NULL_HANDLE;
 }
 
-/* Build a compute pipeline + descriptor pool/set for nbind storage buffers sharing the
- * struct PC push constant. Used for both the 4-binding matmul and 6-binding gate_up. */
-static int build_pipeline(int nbind, VkShaderModule shader, VkDescriptorSetLayout *dsl,
-                          VkPipelineLayout *plyt, VkPipeline *pipe, VkDescriptorPool *dpool,
-                          VkDescriptorSet *dset) {
+/* Build a compute pipeline + descriptor pool/set for nbind storage buffers with a
+ * pc_size-byte push constant. Used by the 4-binding matmul, 6-binding gate_up and
+ * 7-binding absorb attention pipelines. */
+static int build_pipeline(int nbind, size_t pc_size, VkShaderModule shader,
+                          VkDescriptorSetLayout *dsl, VkPipelineLayout *plyt, VkPipeline *pipe,
+                          VkDescriptorPool *dpool, VkDescriptorSet *dset) {
     VkDescriptorSetLayoutBinding b[8];
     for (int i = 0; i < nbind; i++) b[i] = (VkDescriptorSetLayoutBinding){
         .binding = (uint32_t)i, .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
@@ -160,7 +178,7 @@ static int build_pipeline(int nbind, VkShaderModule shader, VkDescriptorSetLayou
     VkDescriptorSetLayoutCreateInfo dsli = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
         .bindingCount = (uint32_t)nbind, .pBindings = b};
     VKCHECK(vkCreateDescriptorSetLayout(G.dev, &dsli, NULL, dsl), "descSetLayout");
-    VkPushConstantRange pcr = {.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT, .offset = 0, .size = sizeof(struct PC)};
+    VkPushConstantRange pcr = {.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT, .offset = 0, .size = (uint32_t)pc_size};
     VkPipelineLayoutCreateInfo pli = {.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
         .setLayoutCount = 1, .pSetLayouts = dsl, .pushConstantRangeCount = 1, .pPushConstantRanges = &pcr};
     VKCHECK(vkCreatePipelineLayout(G.dev, &pli, NULL, plyt), "pipelineLayout");
@@ -179,13 +197,20 @@ static int build_pipeline(int nbind, VkShaderModule shader, VkDescriptorSetLayou
     return 1;
 }
 
-/* "…/qmatmul.spv" -> "…/qmatmul_gate_up.spv" (sibling of the main shader). */
-static void derive_gu_path(const char *spv, char *out, size_t n) {
+/* "…/qmatmul.spv" -> "…/qmatmul<suffix>" (sibling of the main shader). */
+static void derive_sibling(const char *spv, const char *suffix, char *out, size_t n) {
     const char *dot = strstr(spv, ".spv");
-    if (dot && (size_t)(dot - spv) + 13 < n) {
+    if (dot && (size_t)(dot - spv) + strlen(suffix) + 1 < n) {
         size_t pre = (size_t)(dot - spv);
-        memcpy(out, spv, pre); strcpy(out + pre, "_gate_up.spv");
+        memcpy(out, spv, pre); strcpy(out + pre, suffix);
     } else snprintf(out, n, "%s", spv);
+}
+/* "…/qmatmul.spv" -> "…/attention_absorb.spv" (same directory). */
+static void derive_dir_file(const char *spv, const char *fname, char *out, size_t n) {
+    const char *sl = strrchr(spv, '/');
+    size_t pre = sl ? (size_t)(sl - spv) + 1 : 0;
+    if (pre + strlen(fname) + 1 < n) { memcpy(out, spv, pre); strcpy(out + pre, fname); }
+    else snprintf(out, n, "%s", fname);
 }
 
 int coli_vk_init(const char *spv_path) {
@@ -238,13 +263,19 @@ int coli_vk_init(const char *spv_path) {
 
     G.shader = load_spv(spv_path);
     if (!G.shader) return 0;
-    if (!build_pipeline(4, G.shader, &G.dsl, &G.plyt, &G.pipe, &G.dpool, &G.dset)) return 0;
+    if (!build_pipeline(4, sizeof(struct PC), G.shader, &G.dsl, &G.plyt, &G.pipe, &G.dpool, &G.dset)) return 0;
 
     /* Optional fused gate+up pipeline: skip gracefully if its shader isn't present
      * (single-matmul path keeps working). */
-    char gu_path[512]; derive_gu_path(spv_path, gu_path, sizeof(gu_path));
+    char gu_path[512]; derive_sibling(spv_path, "_gate_up.spv", gu_path, sizeof(gu_path));
     G.shader_gu = load_spv(gu_path);
-    if (G.shader_gu && !build_pipeline(6, G.shader_gu, &G.dsl_gu, &G.plyt_gu, &G.pipe_gu, &G.dpool_gu, &G.dset_gu))
+    if (G.shader_gu && !build_pipeline(6, sizeof(struct PC), G.shader_gu, &G.dsl_gu, &G.plyt_gu, &G.pipe_gu, &G.dpool_gu, &G.dset_gu))
+        return 0;
+
+    /* Optional MLA absorb attention pipeline (same directory as the main shader). */
+    char att_path[512]; derive_dir_file(spv_path, "attention_absorb.spv", att_path, sizeof(att_path));
+    G.shader_att = load_spv(att_path);
+    if (G.shader_att && !build_pipeline(7, sizeof(struct PCAttn), G.shader_att, &G.dsl_att, &G.plyt_att, &G.pipe_att, &G.dpool_att, &G.dset_att))
         return 0;
 
     VkCommandPoolCreateInfo cpci = {.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
@@ -258,8 +289,8 @@ int coli_vk_init(const char *spv_path) {
 
     G.ready = 1;
     VkPhysicalDeviceProperties p; vkGetPhysicalDeviceProperties(G.phys, &p);
-    fprintf(stderr, "[VK] ready: %s, compute qfam %u, memtype %u%s\n", p.deviceName, G.qfam, G.memtype,
-            G.shader_gu ? ", fused gate+up" : "");
+    fprintf(stderr, "[VK] ready: %s, compute qfam %u, memtype %u%s%s\n", p.deviceName, G.qfam, G.memtype,
+            G.shader_gu ? ", fused gate+up" : "", G.shader_att ? ", absorb attention" : "");
     return 1;
 }
 
@@ -507,6 +538,101 @@ int coli_vk_expert_group(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
     return 1;
 }
 
+/* ---- MLA absorb attention core -------------------------------------------------
+ * The KV latent (L, [rows,K]) and rope (R, [rows,Rd]) caches live in persistent
+ * per-layer device buffers, appended row-by-row as tokens decode (the host stays
+ * canonical; glm.c tracks a valid-watermark and re-appends after invalidation).
+ * Rows are indexed by ABSOLUTE position, so kv_start windows just skip rows. */
+
+int coli_vk_kv_ensure(int layer, int max_rows, int K, int Rd) {
+    if (!G.ready || layer < 0 || layer >= VK_KV_LAYERS || max_rows < 1 || K < 1 || Rd < 1) return 0;
+    VkKvLayer *v = &G.kv[layer];
+    if (v->bl) return v->rows >= max_rows && v->K == K && v->R == Rd;  /* resize goes through coli_vk_kv_reset */
+    if (!alloc_hostvis((size_t)max_rows * K * 4, &v->bl, &v->ml, &v->pl)) return 0;
+    if (!alloc_hostvis((size_t)max_rows * Rd * 4, &v->br, &v->mr, &v->pr)) {
+        vkDestroyBuffer(G.dev, v->bl, NULL); vkFreeMemory(G.dev, v->ml, NULL);
+        memset(v, 0, sizeof(*v)); return 0;
+    }
+    v->rows = max_rows; v->K = K; v->R = Rd;
+    return 1;
+}
+
+/* Mirror one host cache row into the device copy (write-combined memory: the CPU
+ * only ever WRITES these buffers, the GPU reads them). */
+int coli_vk_kv_row(int layer, int pos, const float *L, const float *R) {
+    if (layer < 0 || layer >= VK_KV_LAYERS) return 0;
+    VkKvLayer *v = &G.kv[layer];
+    if (!v->pl || pos < 0 || pos >= v->rows) return 0;
+    memcpy((float *)v->pl + (size_t)pos * v->K, L, (size_t)v->K * 4);
+    memcpy((float *)v->pr + (size_t)pos * v->R, R, (size_t)v->R * 4);
+    return 1;
+}
+
+/* Drop all per-layer KV device caches (cache resize in kv_alloc). */
+void coli_vk_kv_reset(void) {
+    for (int i = 0; i < VK_KV_LAYERS; i++) {
+        VkKvLayer *v = &G.kv[i];
+        if (!v->bl) continue;
+        if (G.ready) {   /* dead device: leak GPU handles like coli_vk_tensor_free */
+            vkDestroyBuffer(G.dev, v->bl, NULL); vkFreeMemory(G.dev, v->ml, NULL);
+            vkDestroyBuffer(G.dev, v->br, NULL); vkFreeMemory(G.dev, v->mr, NULL);
+        }
+        memset(v, 0, sizeof(*v));
+    }
+}
+
+/* Decode MLA absorption core for S causal query rows of one sequence, one submit:
+ * ctx[s,h,:] = softmax((Wnope_h^T q_nope).L_t + q_rope.R_t) weighted latent context
+ * projected through the value rows of kv_b. kv_b ([H*(Q+V), K]) uploads on first
+ * call and stays resident; L/R rows [st0, T) must already be mirrored via
+ * coli_vk_kv_row. Returns 0 -> caller falls back to CPU. */
+int coli_vk_attention_absorb(ColiVkTensor **kvb, const void *w, const float *sc, int fmt,
+                             float *ctx, const float *q, int layer, int S, int H,
+                             int Q, int R, int V, int K, int st0, int T, float scale) {
+    if (!G.ready || !G.pipe_att || S < 1 || H < 1 || layer < 0 || layer >= VK_KV_LAYERS) return 0;
+    if (Q > 256 || R > 64 || K > 512 || st0 < 0 || T - S - st0 < 0) return 0;  /* shared-array limits */
+    VkKvLayer *kv = &G.kv[layer];
+    if (!kv->bl || kv->rows < T || kv->K != K || kv->R != R) return 0;
+    if (!upload_tensor(kvb, w, sc, fmt, K, H * (Q + V))) return 0;
+    ColiVkTensor *t = *kvb;
+    int cap = T - st0;
+    size_t qb = (size_t)S * H * (Q + R) * 4, cb = (size_t)S * H * V * 4;
+    size_t sb = (size_t)S * H * cap * 4;
+    if (!scratch_reserve(&G.x, qb) || !scratch_reserve_mt(&G.y, cb, G.memtype_cached) ||
+        !scratch_reserve(&G.att_sc, sb)) return 0;    /* y (ctx) is read back -> cached */
+    memcpy(G.x.ptr, q, qb);
+
+    VkDescriptorBufferInfo bi[7] = {
+        {.buffer = G.x.buf, .range = VK_WHOLE_SIZE}, {.buffer = t->wbuf, .range = VK_WHOLE_SIZE},
+        {.buffer = t->sbuf, .range = VK_WHOLE_SIZE}, {.buffer = kv->bl, .range = VK_WHOLE_SIZE},
+        {.buffer = kv->br, .range = VK_WHOLE_SIZE}, {.buffer = G.att_sc.buf, .range = VK_WHOLE_SIZE},
+        {.buffer = G.y.buf, .range = VK_WHOLE_SIZE}};
+    VkWriteDescriptorSet wd[7];
+    for (int i = 0; i < 7; i++) wd[i] = (VkWriteDescriptorSet){
+        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, .dstSet = G.dset_att,
+        .dstBinding = (uint32_t)i, .descriptorCount = 1,
+        .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .pBufferInfo = &bi[i]};
+    vkUpdateDescriptorSets(G.dev, 7, wd, 0, NULL);
+
+    VKCHECK(vkResetCommandBuffer(G.cmd, 0), "resetCmd");
+    VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+    VKCHECK(vkBeginCommandBuffer(G.cmd, &begin), "beginCmd");
+    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe_att);
+    vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt_att, 0, 1, &G.dset_att, 0, NULL);
+    struct PCAttn pc = {fmt, S, H, Q, R, V, K, st0, T, t->rowWords, cap, scale};
+    vkCmdPushConstants(G.cmd, G.plyt_att, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
+    vkCmdDispatch(G.cmd, (uint32_t)H, (uint32_t)S, 1);     /* one workgroup per (head, row) */
+    VKCHECK(vkEndCommandBuffer(G.cmd), "endCmd");
+
+    VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
+    VKCHECK(vkResetFences(G.dev, 1, &G.fence), "resetFence");
+    VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
+    if (vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) { G.ready = 0; return 0; }
+    memcpy(ctx, G.y.ptr, cb);
+    G.cmd_ready = 0; G.bound_tensor = NULL;   /* the shared command buffer/binding was clobbered */
+    return 1;
+}
+
 void coli_vk_tensor_free(ColiVkTensor *t) {
     if (!t) return;
     if (G.bound_tensor == t) { G.bound_tensor = NULL; G.cmd_ready = 0; }  /* drop stale cache */
@@ -536,6 +662,8 @@ void coli_vk_shutdown(void) {
     if (G.eg_x.buf) { vkDestroyBuffer(G.dev, G.eg_x.buf, NULL); vkFreeMemory(G.dev, G.eg_x.mem, NULL); }
     if (G.eg_h.buf) { vkDestroyBuffer(G.dev, G.eg_h.buf, NULL); vkFreeMemory(G.dev, G.eg_h.mem, NULL); }
     if (G.eg_y.buf) { vkDestroyBuffer(G.dev, G.eg_y.buf, NULL); vkFreeMemory(G.dev, G.eg_y.mem, NULL); }
+    if (G.att_sc.buf) { vkDestroyBuffer(G.dev, G.att_sc.buf, NULL); vkFreeMemory(G.dev, G.att_sc.mem, NULL); }
+    coli_vk_kv_reset();
     if (G.eg_pool) vkDestroyDescriptorPool(G.dev, G.eg_pool, NULL);
     vkDestroyFence(G.dev, G.fence, NULL);
     vkDestroyCommandPool(G.dev, G.cpool, NULL);
@@ -550,6 +678,13 @@ void coli_vk_shutdown(void) {
         vkDestroyPipelineLayout(G.dev, G.plyt_gu, NULL);
         vkDestroyDescriptorSetLayout(G.dev, G.dsl_gu, NULL);
         vkDestroyShaderModule(G.dev, G.shader_gu, NULL);
+    }
+    if (G.shader_att) {
+        vkDestroyDescriptorPool(G.dev, G.dpool_att, NULL);
+        vkDestroyPipeline(G.dev, G.pipe_att, NULL);
+        vkDestroyPipelineLayout(G.dev, G.plyt_att, NULL);
+        vkDestroyDescriptorSetLayout(G.dev, G.dsl_att, NULL);
+        vkDestroyShaderModule(G.dev, G.shader_att, NULL);
     }
     vkDestroyDevice(G.dev, NULL);
     vkDestroyInstance(G.inst, NULL);
@@ -810,6 +945,63 @@ static int run_expert_group(int fmt, int D, int I, int K) {
     return maxrel > 1e-3 ? 1 : 0;
 }
 
+/* MLA absorb attention vs a CPU ref that mirrors glm.c's absorb loop exactly:
+ * qabs = sum_d q[d]*deq(row rbase+d)*ws, scores over cache rows [st0, T-S+s],
+ * softmax, weighted latent, value-row projection. */
+static int run_absorb(int fmt, int S, int H, int Q, int R, int V, int K, int st0, int T, int layer) {
+    size_t rb = fmt == 1 ? (size_t)K : (size_t)(K + 1) / 2;
+    int O = H * (Q + V);
+    uint8_t *w = malloc(rb * O); float *ws = malloc((size_t)O * 4);
+    float *q = malloc((size_t)S * H * (Q + R) * 4);
+    float *L = malloc((size_t)T * K * 4), *Rr = malloc((size_t)T * R * 4);
+    float *cg = malloc((size_t)S * H * V * 4), *cc = malloc((size_t)S * H * V * 4);
+    for (size_t i = 0; i < rb * (size_t)O; i++) w[i] = rand() & 0xff;
+    for (int o = 0; o < O; o++) ws[o] = 0.01f + (rand() % 100) / 10000.0f;
+    for (int i = 0; i < S * H * (Q + R); i++) q[i] = (rand() % 200 - 100) / 100.0f;
+    for (int i = 0; i < T * K; i++) L[i] = (rand() % 200 - 100) / 100.0f;
+    for (int i = 0; i < T * R; i++) Rr[i] = (rand() % 200 - 100) / 100.0f;
+    float scale = 0.13f;
+    if (!coli_vk_kv_ensure(layer, T, K, R)) { printf("kv_ensure failed\n"); return 1; }
+    for (int t = 0; t < T; t++)
+        if (!coli_vk_kv_row(layer, t, L + (size_t)t * K, Rr + (size_t)t * R)) { printf("kv_row failed\n"); return 1; }
+    ColiVkTensor *kvb = NULL;
+    if (!coli_vk_attention_absorb(&kvb, w, ws, fmt, cg, q, layer, S, H, Q, R, V, K, st0, T, scale)) {
+        printf("absorb failed\n"); return 1; }
+    float *qabs = malloc((size_t)K * 4), *clat = malloc((size_t)K * 4), *sc = malloc((size_t)(T - st0) * 4);
+    for (int s = 0; s < S; s++) for (int h = 0; h < H; h++) {
+        const float *qp = q + ((size_t)s * H + h) * (Q + R), *qr = qp + Q;
+        int rbase = h * (Q + V), nt = (T - S + s + 1) - st0;
+        for (int i = 0; i < K; i++) qabs[i] = 0;
+        for (int d = 0; d < Q; d++) { const uint8_t *row = w + (size_t)(rbase + d) * rb;
+            for (int i = 0; i < K; i++) qabs[i] += qp[d] * deq(row, fmt, i) * ws[rbase + d]; }
+        for (int j = 0; j < nt; j++) { int t = st0 + j;
+            double a = 0;
+            for (int i = 0; i < K; i++) a += qabs[i] * L[(size_t)t * K + i];
+            for (int d = 0; d < R; d++) a += qr[d] * Rr[(size_t)t * R + d];
+            sc[j] = (float)(a * scale); }
+        float mx = sc[0]; for (int j = 1; j < nt; j++) if (sc[j] > mx) mx = sc[j];
+        double sum = 0; for (int j = 0; j < nt; j++) { sc[j] = expf(sc[j] - mx); sum += sc[j]; }
+        for (int i = 0; i < K; i++) clat[i] = 0;
+        for (int j = 0; j < nt; j++) { float a = (float)(sc[j] / sum);
+            for (int i = 0; i < K; i++) clat[i] += a * L[(size_t)(st0 + j) * K + i]; }
+        for (int v = 0; v < V; v++) { const uint8_t *row = w + (size_t)(rbase + Q + v) * rb;
+            double a = 0; for (int i = 0; i < K; i++) a += clat[i] * deq(row, fmt, i);
+            cc[((size_t)s * H + h) * V + v] = (float)(a * ws[rbase + Q + v]); }
+    }
+    double maxrel = 0, maxerr = 0;
+    for (int i = 0; i < S * H * V; i++) { double e = fabs(cg[i] - cc[i]); if (e > maxerr) maxerr = e;
+        if (fabs(cc[i]) > 1e-2) { double r = e / fabs(cc[i]); if (r > maxrel) maxrel = r; } }
+    double t0 = now(); int iters = 20;   /* per-call cost, the engine pattern (one submit/layer) */
+    for (int k = 0; k < iters; k++)
+        coli_vk_attention_absorb(&kvb, w, ws, fmt, cg, q, layer, S, H, Q, R, V, K, st0, T, scale);
+    double ms = (now() - t0) * 1000 / iters;
+    printf("absorb fmt=%d S=%d H=%d Q=%d R=%d V=%d K=%d st0=%d T=%d | maxerr=%.4g maxrel=%.4g | %.3f ms/call\n",
+           fmt, S, H, Q, R, V, K, st0, T, maxerr, maxrel, ms);
+    coli_vk_tensor_free(kvb);
+    free(w); free(ws); free(q); free(L); free(Rr); free(cg); free(cc); free(qabs); free(clat); free(sc);
+    return maxrel > 2e-3 ? 1 : 0;
+}
+
 int main(int argc, char **argv) {
     const char *spv = argc > 1 ? argv[1] : "shaders/qmatmul.spv";
     if (!coli_vk_init(spv)) { printf("vk init failed\n"); return 1; }
@@ -866,6 +1058,14 @@ int main(int argc, char **argv) {
     bad |= run_expert_group(2, 6144, 2048, 1);
     bad |= run_expert_group(2, 6144, 2048, 8);
     bad |= run_expert_group(2, 6144, 2048, 32);
+    /* MLA absorb attention core (GLM decode shape + window/causal/int8 variants). */
+    if (G.pipe_att) {
+        bad |= run_absorb(2, 1, 64, 192, 64, 256, 512, 0, 300, 0);    // GLM-5.2 decode
+        bad |= run_absorb(2, 1, 64, 192, 64, 256, 512, 17, 300, 1);   // kv_start window
+        bad |= run_absorb(2, 2, 64, 192, 64, 256, 512, 0, 300, 2);    // S=2 causal (MTP verify)
+        bad |= run_absorb(1, 1, 8, 128, 32, 64, 256, 0, 64, 3);       // int8, odd dims
+        bad |= run_absorb(2, 1, 64, 192, 64, 256, 512, 0, 2000, 4);   // long context
+    }
     printf(bad ? "FAIL\n" : "PASS\n");
     coli_vk_shutdown();
     return bad;

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -485,6 +485,15 @@ int coli_vk_tensor_ensure(ColiVkTensor **tensor, const void *weights, const floa
     return upload_tensor(tensor, weights, scales, fmt, I, O);
 }
 
+/* Global submit/wait totals across EVERY synchronous GPU path (VK_PROF=1) — the
+ * per-path counters miss traffic that flows through the fused pair/absorb/group
+ * entries, so the tier-size-linear per-submit tax is localized here instead. */
+static double g_vsub_ms, g_vwait_ms; static long g_vsub_n;
+static void vkprof_tick(void) {
+    if ((++g_vsub_n & 2047) == 0)
+        fprintf(stderr, "[VK_PROF sub] n=%ld | submit %.0f | wait %.0f ms\n", g_vsub_n, g_vsub_ms, g_vwait_ms);
+}
+
 int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
                    const void *weights, const float *scales,
                    int fmt, int S, int I, int O) {
@@ -544,7 +553,7 @@ int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
         .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
     VKCHECK(vkResetFences(G.dev, 1, &G.fence), "resetFence");
     VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
-    if (G.eg_prof) { tA = vk_now(); p_sub += tA - t0; t0 = tA; }
+    if (G.eg_prof) { tA = vk_now(); p_sub += tA - t0; g_vsub_ms += tA - t0; t0 = tA; }
     // Bounded wait: a GPU hang/TDR must never wedge the process. 10s is orders of
     // magnitude over a single-GEMV dispatch; on timeout/device-loss disable VK for
     // the rest of the run and fall back to CPU (the caller degrades on our 0 return).
@@ -554,7 +563,7 @@ int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
         G.ready = 0;
         return 0;
     }
-    if (G.eg_prof) { tA = vk_now(); p_wait += tA - t0; t0 = tA; }
+    if (G.eg_prof) { tA = vk_now(); p_wait += tA - t0; g_vwait_ms += tA - t0; t0 = tA; vkprof_tick(); }
     memcpy(y, G.y.ptr, yb);
     if (G.eg_prof) {
         p_y += vk_now() - t0;
@@ -601,8 +610,11 @@ int coli_vk_gate_up(ColiVkTensor **gate, ColiVkTensor **up, float *hidden, const
 
     VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
     VKCHECK(vkResetFences(G.dev, 1, &G.fence), "resetFence");
+    double vp0 = G.eg_prof ? vk_now() : 0;
     VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
+    if (G.eg_prof) { double vp1 = vk_now(); g_vsub_ms += vp1 - vp0; vp0 = vp1; }
     if (vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) { G.ready = 0; return 0; }
+    if (G.eg_prof) { g_vwait_ms += vk_now() - vp0; vkprof_tick(); }
     memcpy(hidden, G.h.ptr, hb);
     G.cmd_ready = 0; G.bound_tensor = NULL;   /* the shared command buffer/binding was clobbered */
     return 1;
@@ -699,7 +711,9 @@ static int eg_prepare_submit(ColiVkTensor *const *gates, ColiVkTensor *const *up
 
     VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.eg_cmd};
     VKCHECK(vkResetFences(G.dev, 1, &G.eg_fence), "eg resetFence");
-    VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.eg_fence), "eg queueSubmit");
+    { double vp0 = G.eg_prof ? vk_now() : 0;
+      VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.eg_fence), "eg queueSubmit");
+      if (G.eg_prof) g_vsub_ms += vk_now() - vp0; }
     G.eg_pending_yb = yb; G.eg_inflight = 1;
     return 1;
 }
@@ -831,8 +845,11 @@ int coli_vk_attention_absorb(ColiVkTensor **kvb, const void *w, const float *sc,
 
     VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
     VKCHECK(vkResetFences(G.dev, 1, &G.fence), "resetFence");
+    double vp0 = G.eg_prof ? vk_now() : 0;
     VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
+    if (G.eg_prof) { double vp1 = vk_now(); g_vsub_ms += vp1 - vp0; vp0 = vp1; }
     if (vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) { G.ready = 0; return 0; }
+    if (G.eg_prof) { g_vwait_ms += vk_now() - vp0; vkprof_tick(); }
     memcpy(ctx, G.y.ptr, cb);
     G.cmd_ready = 0; G.bound_tensor = NULL;   /* the shared command buffer/binding was clobbered */
     return 1;
@@ -887,8 +904,11 @@ int coli_vk_matmul_pair(ColiVkTensor **t1p, float *y1, const void *w1, const flo
 
     VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
     VKCHECK(vkResetFences(G.dev, 1, &G.fence), "resetFence");
+    double vp0 = G.eg_prof ? vk_now() : 0;
     VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
+    if (G.eg_prof) { double vp1 = vk_now(); g_vsub_ms += vp1 - vp0; vp0 = vp1; }
     if (vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) { G.ready = 0; return 0; }
+    if (G.eg_prof) { g_vwait_ms += vk_now() - vp0; vkprof_tick(); }
     memcpy(y1, G.y.ptr, yb1);
     memcpy(y2, G.y2.ptr, yb2);
     G.cmd_ready = 0; G.bound_tensor = NULL;   /* the shared command buffer/binding was clobbered */
@@ -956,8 +976,11 @@ int coli_vk_attention_absorb_project(ColiVkTensor **kvb, const void *w, const fl
 
     VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
     VKCHECK(vkResetFences(G.dev, 1, &G.fence), "resetFence");
+    double vp0 = G.eg_prof ? vk_now() : 0;
     VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
+    if (G.eg_prof) { double vp1 = vk_now(); g_vsub_ms += vp1 - vp0; vp0 = vp1; }
     if (vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) { G.ready = 0; return 0; }
+    if (G.eg_prof) { g_vwait_ms += vk_now() - vp0; vkprof_tick(); }
     memcpy(out, G.y.ptr, ob);
     G.cmd_ready = 0; G.bound_tensor = NULL;   /* the shared command buffer/binding was clobbered */
     return 1;

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -299,6 +299,13 @@ static int upload_tensor(ColiVkTensor **out, const void *weights, const float *s
     return 1;
 }
 
+/* Upload a resident tensor without computing (for the expert tier: gate/up/down are
+ * uploaded once, then driven by coli_vk_expert_group). Returns 0 on failure. */
+int coli_vk_tensor_ensure(ColiVkTensor **tensor, const void *weights, const float *scales, int fmt, int I, int O) {
+    if (!G.ready) return 0;
+    return upload_tensor(tensor, weights, scales, fmt, I, O);
+}
+
 int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
                    const void *weights, const float *scales,
                    int fmt, int S, int I, int O) {

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -514,6 +514,29 @@ int coli_vk_tensor_ensure(ColiVkTensor **tensor, const void *weights, const floa
     return upload_tensor(tensor, weights, scales, fmt, I, O, grp);
 }
 
+/* Sync-path fence wait. A blocked vkWaitForFences pays a scheduler wake on
+ * signal (~50-150 us) — and the engine fences ~2 sync submits per layer per
+ * token, so the wakes alone cost seconds per run. Spin on vkGetFenceStatus for
+ * a short budget first (the common decode dispatch completes in 0.5-2 ms),
+ * then fall back to the blocking wait. The spinning thread is stalled on the
+ * GPU result anyway. COLI_VK_SPIN_US=0 restores the pure blocking wait. */
+static long g_vk_spin_us = -1;
+static VkResult vk_fence_wait(VkFence f) {
+    if (g_vk_spin_us < 0) {
+        const char *e = getenv("COLI_VK_SPIN_US");
+        g_vk_spin_us = e ? atol(e) : 300;
+        if (g_vk_spin_us < 0) g_vk_spin_us = 0;
+    }
+    if (g_vk_spin_us > 0) {
+        double t0 = vk_now();
+        do {
+            VkResult r = vkGetFenceStatus(G.dev, f);
+            if (r != VK_NOT_READY) return r;   /* VK_SUCCESS or a real error */
+        } while ((vk_now() - t0) * 1000.0 < (double)g_vk_spin_us);
+    }
+    return vkWaitForFences(G.dev, 1, &f, VK_TRUE, 10000000000ULL);
+}
+
 /* Global submit/wait totals across EVERY synchronous GPU path (VK_PROF=1) — the
  * per-path counters miss traffic that flows through the fused pair/absorb/group
  * entries, so the tier-size-linear per-submit tax is localized here instead. */
@@ -586,7 +609,7 @@ int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
     // Bounded wait: a GPU hang/TDR must never wedge the process. 10s is orders of
     // magnitude over a single-GEMV dispatch; on timeout/device-loss disable VK for
     // the rest of the run and fall back to CPU (the caller degrades on our 0 return).
-    VkResult wr = vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL);
+    VkResult wr = vk_fence_wait(G.fence);
     if (wr != VK_SUCCESS) {
         fprintf(stderr, "[VK] fence wait failed: %d — disabling GPU offload, staying on CPU\n", wr);
         G.ready = 0;
@@ -642,7 +665,7 @@ int coli_vk_gate_up(ColiVkTensor **gate, ColiVkTensor **up, float *hidden, const
     double vp0 = G.eg_prof ? vk_now() : 0;
     VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
     if (G.eg_prof) { double vp1 = vk_now(); g_vsub_ms += vp1 - vp0; vp0 = vp1; }
-    if (vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) { G.ready = 0; return 0; }
+    if (vk_fence_wait(G.fence) != VK_SUCCESS) { G.ready = 0; return 0; }
     if (G.eg_prof) { g_vwait_ms += vk_now() - vp0; vkprof_tick(); }
     memcpy(hidden, G.h.ptr, hb);
     G.cmd_ready = 0; G.bound_tensor = NULL;   /* the shared command buffer/binding was clobbered */
@@ -760,7 +783,7 @@ int coli_vk_expert_group_issue(ColiVkTensor *const *gates, ColiVkTensor *const *
 int coli_vk_expert_group_take(float *y) {
     if (!G.eg_inflight) return 0;
     G.eg_inflight = 0;
-    if (vkWaitForFences(G.dev, 1, &G.eg_fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) {
+    if (vk_fence_wait(G.eg_fence) != VK_SUCCESS) {
         fprintf(stderr, "[VK] expert-group fence wait failed — disabling GPU offload\n");
         G.ready = 0; return 0;
     }
@@ -877,7 +900,7 @@ int coli_vk_attention_absorb(ColiVkTensor **kvb, const void *w, const float *sc,
     double vp0 = G.eg_prof ? vk_now() : 0;
     VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
     if (G.eg_prof) { double vp1 = vk_now(); g_vsub_ms += vp1 - vp0; vp0 = vp1; }
-    if (vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) { G.ready = 0; return 0; }
+    if (vk_fence_wait(G.fence) != VK_SUCCESS) { G.ready = 0; return 0; }
     if (G.eg_prof) { g_vwait_ms += vk_now() - vp0; vkprof_tick(); }
     memcpy(ctx, G.y.ptr, cb);
     G.cmd_ready = 0; G.bound_tensor = NULL;   /* the shared command buffer/binding was clobbered */
@@ -936,7 +959,7 @@ int coli_vk_matmul_pair(ColiVkTensor **t1p, float *y1, const void *w1, const flo
     double vp0 = G.eg_prof ? vk_now() : 0;
     VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
     if (G.eg_prof) { double vp1 = vk_now(); g_vsub_ms += vp1 - vp0; vp0 = vp1; }
-    if (vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) { G.ready = 0; return 0; }
+    if (vk_fence_wait(G.fence) != VK_SUCCESS) { G.ready = 0; return 0; }
     if (G.eg_prof) { g_vwait_ms += vk_now() - vp0; vkprof_tick(); }
     memcpy(y1, G.y.ptr, yb1);
     memcpy(y2, G.y2.ptr, yb2);
@@ -1037,7 +1060,7 @@ int coli_vk_attn_qprep(int layer,
     double vp0 = G.eg_prof ? vk_now() : 0;
     VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
     if (G.eg_prof) { double vp1 = vk_now(); g_vsub_ms += vp1 - vp0; vp0 = vp1; }
-    if (vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) { G.ready = 0; return 0; }
+    if (vk_fence_wait(G.fence) != VK_SUCCESS) { G.ready = 0; return 0; }
     if (G.eg_prof) { g_vwait_ms += vk_now() - vp0; vkprof_tick(); }
     memcpy(q_out, G.y.ptr, qb_b);
     memcpy(kv_out, G.y2.ptr, kvb_b);
@@ -1110,7 +1133,7 @@ int coli_vk_attention_absorb_project(ColiVkTensor **kvb, const void *w, const fl
     double vp0 = G.eg_prof ? vk_now() : 0;
     VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
     if (G.eg_prof) { double vp1 = vk_now(); g_vsub_ms += vp1 - vp0; vp0 = vp1; }
-    if (vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) { G.ready = 0; return 0; }
+    if (vk_fence_wait(G.fence) != VK_SUCCESS) { G.ready = 0; return 0; }
     if (G.eg_prof) { g_vwait_ms += vk_now() - vp0; vkprof_tick(); }
     memcpy(out, G.y.ptr, ob);
     G.cmd_ready = 0; G.bound_tensor = NULL;   /* the shared command buffer/binding was clobbered */

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -23,6 +23,7 @@ struct ColiVkTensor {
     VkDeviceMemory wmem, smem;
     size_t wbytes;
     int fmt, I, O, rowWords, gs;
+    int dev;               /* 0 = primary device, 1 = the COLI_VK_DEV2 expert-tier device */
 };
 
 typedef struct {
@@ -108,9 +109,9 @@ struct PCN { int S, D; float eps; };
 /* Push constants of the absorb attention kernel (must match attention_absorb.comp). */
 struct PCAttn { int fmt, S, H, Q, R, V, K, st0, T, rowWords, cap; float scale; int gs; };
 
-static int pick_memtype(void) {
+static int pick_memtype(VkPhysicalDevice phys) {
     VkPhysicalDeviceMemoryProperties m;
-    vkGetPhysicalDeviceMemoryProperties(G.phys, &m);
+    vkGetPhysicalDeviceMemoryProperties(phys, &m);
     int best = -1;
     for (uint32_t i = 0; i < m.memoryTypeCount; i++) {
         VkMemoryPropertyFlags f = m.memoryTypes[i].propertyFlags;
@@ -126,15 +127,15 @@ static int pick_memtype(void) {
 /* Cached+coherent host-visible type for buffers the CPU READS BACK. pick_memtype prefers
  * DEVICE_LOCAL host-visible = write-combined VRAM over ReBAR, which the CPU writes fast but
  * reads catastrophically slowly (~40 MB/s). Outputs must be HOST_CACHED for cheap readback. */
-static int pick_memtype_cached(void) {
+static int pick_memtype_cached(VkPhysicalDevice phys) {
     VkPhysicalDeviceMemoryProperties m;
-    vkGetPhysicalDeviceMemoryProperties(G.phys, &m);
+    vkGetPhysicalDeviceMemoryProperties(phys, &m);
     for (uint32_t i = 0; i < m.memoryTypeCount; i++) {
         VkMemoryPropertyFlags f = m.memoryTypes[i].propertyFlags;
         if ((f & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) && (f & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) &&
             (f & VK_MEMORY_PROPERTY_HOST_CACHED_BIT)) return (int)i;
     }
-    return pick_memtype();   /* no cached type -> fall back (no worse than before) */
+    return pick_memtype(phys);   /* no cached type -> fall back (no worse than before) */
 }
 
 static int alloc_hostvis_mt(size_t bytes, VkBuffer *buf, VkDeviceMemory *mem, void **ptr, uint32_t memtype) {
@@ -214,7 +215,7 @@ static size_t scale_floats(int fmt, int I, int O, int gs) {
     return (size_t)O;
 }
 
-static VkShaderModule load_spv(const char *path) {
+static VkShaderModule load_spv(VkDevice dev, const char *path) {
     FILE *f = fopen(path, "rb");
     if (!f) { fprintf(stderr, "[VK] cannot open %s\n", path); return VK_NULL_HANDLE; }
     fseek(f, 0, SEEK_END); long n = ftell(f); fseek(f, 0, SEEK_SET);
@@ -227,7 +228,7 @@ static VkShaderModule load_spv(const char *path) {
     VkShaderModuleCreateInfo si = {.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
         .codeSize = n, .pCode = code};
     VkShaderModule m;
-    VkResult r = vkCreateShaderModule(G.dev, &si, NULL, &m);
+    VkResult r = vkCreateShaderModule(dev, &si, NULL, &m);
     free(code);
     return r == VK_SUCCESS ? m : VK_NULL_HANDLE;
 }
@@ -235,7 +236,7 @@ static VkShaderModule load_spv(const char *path) {
 /* Build a compute pipeline + descriptor pool/set for nbind storage buffers with a
  * pc_size-byte push constant. Used by the 4-binding matmul, 6-binding gate_up and
  * 7-binding absorb attention pipelines. */
-static int build_pipeline(int nbind, size_t pc_size, VkShaderModule shader,
+static int build_pipeline(VkDevice dev, int nbind, size_t pc_size, VkShaderModule shader,
                           VkDescriptorSetLayout *dsl, VkPipelineLayout *plyt, VkPipeline *pipe,
                           VkDescriptorPool *dpool, VkDescriptorSet *dset) {
     VkDescriptorSetLayoutBinding b[8];
@@ -244,23 +245,23 @@ static int build_pipeline(int nbind, size_t pc_size, VkShaderModule shader,
         .descriptorCount = 1, .stageFlags = VK_SHADER_STAGE_COMPUTE_BIT};
     VkDescriptorSetLayoutCreateInfo dsli = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
         .bindingCount = (uint32_t)nbind, .pBindings = b};
-    VKCHECK(vkCreateDescriptorSetLayout(G.dev, &dsli, NULL, dsl), "descSetLayout");
+    VKCHECK(vkCreateDescriptorSetLayout(dev, &dsli, NULL, dsl), "descSetLayout");
     VkPushConstantRange pcr = {.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT, .offset = 0, .size = (uint32_t)pc_size};
     VkPipelineLayoutCreateInfo pli = {.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
         .setLayoutCount = 1, .pSetLayouts = dsl, .pushConstantRangeCount = 1, .pPushConstantRanges = &pcr};
-    VKCHECK(vkCreatePipelineLayout(G.dev, &pli, NULL, plyt), "pipelineLayout");
+    VKCHECK(vkCreatePipelineLayout(dev, &pli, NULL, plyt), "pipelineLayout");
     VkComputePipelineCreateInfo cpi = {.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
         .stage = {.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
                   .stage = VK_SHADER_STAGE_COMPUTE_BIT, .module = shader, .pName = "main"},
         .layout = *plyt};
-    VKCHECK(vkCreateComputePipelines(G.dev, VK_NULL_HANDLE, 1, &cpi, NULL, pipe), "pipeline");
+    VKCHECK(vkCreateComputePipelines(dev, VK_NULL_HANDLE, 1, &cpi, NULL, pipe), "pipeline");
     VkDescriptorPoolSize ps = {.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = (uint32_t)nbind};
     VkDescriptorPoolCreateInfo dpi = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
         .maxSets = 1, .poolSizeCount = 1, .pPoolSizes = &ps};
-    VKCHECK(vkCreateDescriptorPool(G.dev, &dpi, NULL, dpool), "descPool");
+    VKCHECK(vkCreateDescriptorPool(dev, &dpi, NULL, dpool), "descPool");
     VkDescriptorSetAllocateInfo dsa = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
         .descriptorPool = *dpool, .descriptorSetCount = 1, .pSetLayouts = dsl};
-    VKCHECK(vkAllocateDescriptorSets(G.dev, &dsa, dset), "allocDescSet");
+    VKCHECK(vkAllocateDescriptorSets(dev, &dsa, dset), "allocDescSet");
     return 1;
 }
 
@@ -358,30 +359,30 @@ int coli_vk_init(const char *spv_path) {
         fprintf(stderr, "[VK] VRAM pressure-proofing: memory_priority %s, memory_budget %s\n",
                 G.has_prio ? "on" : "absent", G.has_budget ? "on" : "absent");
 
-    int mt = pick_memtype();
+    int mt = pick_memtype(G.phys);
     if (mt < 0) { fprintf(stderr, "[VK] no host-visible memory\n"); return 0; }
     G.memtype = (uint32_t)mt;
-    G.memtype_cached = (uint32_t)pick_memtype_cached();
+    G.memtype_cached = (uint32_t)pick_memtype_cached(G.phys);
 
-    G.shader = load_spv(spv_path);
+    G.shader = load_spv(G.dev, spv_path);
     if (!G.shader) return 0;
-    if (!build_pipeline(4, sizeof(struct PC), G.shader, &G.dsl, &G.plyt, &G.pipe, &G.dpool, &G.dset)) return 0;
+    if (!build_pipeline(G.dev, 4, sizeof(struct PC), G.shader, &G.dsl, &G.plyt, &G.pipe, &G.dpool, &G.dset)) return 0;
 
     /* Optional fused gate+up pipeline: skip gracefully if its shader isn't present
      * (single-matmul path keeps working). */
     char gu_path[512]; derive_sibling(spv_path, "_gate_up.spv", gu_path, sizeof(gu_path));
-    G.shader_gu = load_spv(gu_path);
-    if (G.shader_gu && !build_pipeline(6, sizeof(struct PC), G.shader_gu, &G.dsl_gu, &G.plyt_gu, &G.pipe_gu, &G.dpool_gu, &G.dset_gu))
+    G.shader_gu = load_spv(G.dev, gu_path);
+    if (G.shader_gu && !build_pipeline(G.dev, 6, sizeof(struct PC), G.shader_gu, &G.dsl_gu, &G.plyt_gu, &G.pipe_gu, &G.dpool_gu, &G.dset_gu))
         return 0;
 
     /* Optional MLA absorb attention pipeline (same directory as the main shader). */
     /* Optional rmsnorm pipeline: enables the pair->norm->q_b single-submit chain
      * (coli_vk_attn_qprep); absent -> callers keep the 3-submit path. */
     char nrm_path[512]; derive_dir_file(spv_path, "rmsnorm.spv", nrm_path, sizeof(nrm_path));
-    G.shader_nrm = load_spv(nrm_path);
+    G.shader_nrm = load_spv(G.dev, nrm_path);
     if (G.shader_nrm) {
         VkDescriptorPool np; VkDescriptorSet ns;
-        if (!build_pipeline(3, sizeof(struct PCN), G.shader_nrm, &G.dsl_nrm, &G.plyt_nrm, &G.pipe_nrm, &np, &ns))
+        if (!build_pipeline(G.dev, 3, sizeof(struct PCN), G.shader_nrm, &G.dsl_nrm, &G.plyt_nrm, &G.pipe_nrm, &np, &ns))
             return 0;
         G.dset_nrm = ns;
         /* one extra 4-binding matmul set for the chain's 3rd matmul (dset+dset_pair serve 1+2) */
@@ -394,8 +395,8 @@ int coli_vk_init(const char *spv_path) {
         VKCHECK(vkAllocateDescriptorSets(G.dev, &dsa3, &G.dset_qp3), "qprep descSet");
     }
     char att_path[512]; derive_dir_file(spv_path, "attention_absorb.spv", att_path, sizeof(att_path));
-    G.shader_att = load_spv(att_path);
-    if (G.shader_att && !build_pipeline(7, sizeof(struct PCAttn), G.shader_att, &G.dsl_att, &G.plyt_att, &G.pipe_att, &G.dpool_att, &G.dset_att))
+    G.shader_att = load_spv(G.dev, att_path);
+    if (G.shader_att && !build_pipeline(G.dev, 7, sizeof(struct PCAttn), G.shader_att, &G.dsl_att, &G.plyt_att, &G.pipe_att, &G.dpool_att, &G.dset_att))
         return 0;
 
     VkCommandPoolCreateInfo cpci = {.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
@@ -521,7 +522,7 @@ int coli_vk_tensor_ensure(ColiVkTensor **tensor, const void *weights, const floa
  * then fall back to the blocking wait. The spinning thread is stalled on the
  * GPU result anyway. COLI_VK_SPIN_US=0 restores the pure blocking wait. */
 static long g_vk_spin_us = -1;
-static VkResult vk_fence_wait(VkFence f) {
+static VkResult vk_fence_wait(VkDevice dev, VkFence f) {
     if (g_vk_spin_us < 0) {
         const char *e = getenv("COLI_VK_SPIN_US");
         g_vk_spin_us = e ? atol(e) : 300;
@@ -530,11 +531,11 @@ static VkResult vk_fence_wait(VkFence f) {
     if (g_vk_spin_us > 0) {
         double t0 = vk_now();
         do {
-            VkResult r = vkGetFenceStatus(G.dev, f);
+            VkResult r = vkGetFenceStatus(dev, f);
             if (r != VK_NOT_READY) return r;   /* VK_SUCCESS or a real error */
         } while ((vk_now() - t0) * 1000.0 < (double)g_vk_spin_us);
     }
-    return vkWaitForFences(G.dev, 1, &f, VK_TRUE, 10000000000ULL);
+    return vkWaitForFences(dev, 1, &f, VK_TRUE, 10000000000ULL);
 }
 
 /* Global submit/wait totals across EVERY synchronous GPU path (VK_PROF=1) — the
@@ -609,7 +610,7 @@ int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
     // Bounded wait: a GPU hang/TDR must never wedge the process. 10s is orders of
     // magnitude over a single-GEMV dispatch; on timeout/device-loss disable VK for
     // the rest of the run and fall back to CPU (the caller degrades on our 0 return).
-    VkResult wr = vk_fence_wait(G.fence);
+    VkResult wr = vk_fence_wait(G.dev, G.fence);
     if (wr != VK_SUCCESS) {
         fprintf(stderr, "[VK] fence wait failed: %d — disabling GPU offload, staying on CPU\n", wr);
         G.ready = 0;
@@ -665,19 +666,22 @@ int coli_vk_gate_up(ColiVkTensor **gate, ColiVkTensor **up, float *hidden, const
     double vp0 = G.eg_prof ? vk_now() : 0;
     VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
     if (G.eg_prof) { double vp1 = vk_now(); g_vsub_ms += vp1 - vp0; vp0 = vp1; }
-    if (vk_fence_wait(G.fence) != VK_SUCCESS) { G.ready = 0; return 0; }
+    if (vk_fence_wait(G.dev, G.fence) != VK_SUCCESS) { G.ready = 0; return 0; }
     if (G.eg_prof) { g_vwait_ms += vk_now() - vp0; vkprof_tick(); }
     memcpy(hidden, G.h.ptr, hb);
     G.cmd_ready = 0; G.bound_tensor = NULL;   /* the shared command buffer/binding was clobbered */
     return 1;
 }
 
-static void wr_desc(VkDescriptorSet set, int n, const VkDescriptorBufferInfo *bi) {
+static void wr_desc_dev(VkDevice dev, VkDescriptorSet set, int n, const VkDescriptorBufferInfo *bi) {
     VkWriteDescriptorSet w[6];
     for (int i = 0; i < n; i++) w[i] = (VkWriteDescriptorSet){
         .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, .dstSet = set, .dstBinding = (uint32_t)i,
         .descriptorCount = 1, .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .pBufferInfo = &bi[i]};
-    vkUpdateDescriptorSets(G.dev, (uint32_t)n, w, 0, NULL);
+    vkUpdateDescriptorSets(dev, (uint32_t)n, w, 0, NULL);
+}
+static void wr_desc(VkDescriptorSet set, int n, const VkDescriptorBufferInfo *bi) {
+    wr_desc_dev(G.dev, set, n, bi);
 }
 
 /* Full batched expert MLP for `count` experts, hidden staying on-device:
@@ -783,7 +787,7 @@ int coli_vk_expert_group_issue(ColiVkTensor *const *gates, ColiVkTensor *const *
 int coli_vk_expert_group_take(float *y) {
     if (!G.eg_inflight) return 0;
     G.eg_inflight = 0;
-    if (vk_fence_wait(G.eg_fence) != VK_SUCCESS) {
+    if (vk_fence_wait(G.dev, G.eg_fence) != VK_SUCCESS) {
         fprintf(stderr, "[VK] expert-group fence wait failed — disabling GPU offload\n");
         G.ready = 0; return 0;
     }
@@ -804,6 +808,324 @@ int coli_vk_expert_group(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
     if (G.eg_inflight) return 0;
     if (!eg_prepare_submit(gates, ups, downs, rows, count, x)) return 0;
     return coli_vk_expert_group_take(y);
+}
+
+/* ==================== SECOND DEVICE: expert tier only (COLI_VK_DEV2) ============
+ * A self-contained context for a second Vulkan GPU (e.g. an RX 580 beside the
+ * RX 9070) that hosts ONLY resident tier experts and runs ONLY the async
+ * expert-group path (fused gate_up -> down). Attention, dense, q-prep and the
+ * KV mirror stay on device 0. Deliberately separate from G so the device-0 hot
+ * path is untouched and both groups can be in flight simultaneously. The same
+ * physical device as dev0 is allowed when forced by index (a second logical
+ * device — the pre-hardware test mode); `auto` requires a distinct real GPU. */
+static struct {
+    int ready;
+    VkPhysicalDevice phys; VkDevice dev; VkQueue queue; uint32_t qfam;
+    uint32_t memtype, memtype_cached;
+    VkShaderModule sh_qmm, sh_gu;
+    VkDescriptorSetLayout dsl, dsl_gu; VkPipelineLayout plyt, plyt_gu;
+    VkPipeline pipe, pipe_gu;
+    VkCommandPool cpool; VkCommandBuffer cmd; VkFence fence;
+    VkDescriptorPool pool; VkDescriptorSet gu[64], dn[64]; int nsets;
+    Scratch x, h, y;
+    int inflight; size_t pending_yb;
+    VkWArena *arena;
+    size_t used_bytes, tensor_count;
+    int has_budget;
+} G2;
+
+static int alloc_hostvis_d2(size_t bytes, VkBuffer *buf, VkDeviceMemory *mem, void **ptr, uint32_t memtype) {
+    VkBufferCreateInfo bi = {.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .size = bytes, .usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE};
+    VKCHECK(vkCreateBuffer(G2.dev, &bi, NULL, buf), "d2 vkCreateBuffer");
+    VkMemoryRequirements req;
+    vkGetBufferMemoryRequirements(G2.dev, *buf, &req);
+    VkMemoryAllocateInfo ai = {.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .allocationSize = req.size, .memoryTypeIndex = memtype};
+    VKCHECK(vkAllocateMemory(G2.dev, &ai, NULL, mem), "d2 vkAllocateMemory");
+    VKCHECK(vkBindBufferMemory(G2.dev, *buf, *mem, 0), "d2 vkBindBufferMemory");
+    if (ptr) VKCHECK(vkMapMemory(G2.dev, *mem, 0, bytes, 0, ptr), "d2 vkMapMemory");
+    return 1;
+}
+static int scratch_reserve_d2(Scratch *s, size_t bytes, uint32_t memtype) {
+    if (s->cap >= bytes) return 1;
+    if (s->buf) { vkDestroyBuffer(G2.dev, s->buf, NULL); vkFreeMemory(G2.dev, s->mem, NULL); }
+    s->buf = VK_NULL_HANDLE; s->cap = 0; s->ptr = NULL;
+    if (!alloc_hostvis_d2(bytes, &s->buf, &s->mem, &s->ptr, memtype)) return 0;
+    s->cap = bytes;
+    return 1;
+}
+static int arena_suballoc_d2(size_t bytes, VkBuffer *buf, void **ptr) {
+    VkBufferCreateInfo bi = {.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .size = bytes, .usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE};
+    VKCHECK(vkCreateBuffer(G2.dev, &bi, NULL, buf), "d2 vkCreateBuffer");
+    VkMemoryRequirements req;
+    vkGetBufferMemoryRequirements(G2.dev, *buf, &req);
+    if (!(req.memoryTypeBits & (1u << G2.memtype))) { vkDestroyBuffer(G2.dev, *buf, NULL); *buf = VK_NULL_HANDLE; return 0; }
+    size_t align = req.alignment ? req.alignment : 256, off = 0;
+    VkWArena *a = G2.arena;
+    for (; a; a = a->next) {
+        off = (a->off + align - 1) & ~(align - 1);
+        if (off + req.size <= a->cap) break;
+    }
+    if (!a) {
+        size_t cap = req.size > VK_WARENA_BLOCK ? (req.size + 4095) & ~(size_t)4095 : VK_WARENA_BLOCK;
+        a = calloc(1, sizeof(*a));
+        if (!a) { vkDestroyBuffer(G2.dev, *buf, NULL); *buf = VK_NULL_HANDLE; return 0; }
+        VkMemoryAllocateInfo ai = {.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+            .allocationSize = cap, .memoryTypeIndex = G2.memtype};
+        if (vkAllocateMemory(G2.dev, &ai, NULL, &a->mem) != VK_SUCCESS ||
+            vkMapMemory(G2.dev, a->mem, 0, cap, 0, (void **)&a->base) != VK_SUCCESS) {
+            if (a->mem) vkFreeMemory(G2.dev, a->mem, NULL);
+            free(a); vkDestroyBuffer(G2.dev, *buf, NULL); *buf = VK_NULL_HANDLE; return 0;
+        }
+        a->cap = cap; a->next = G2.arena; G2.arena = a;
+        off = 0;
+    }
+    VKCHECK(vkBindBufferMemory(G2.dev, *buf, a->mem, off), "d2 vkBindBufferMemory");
+    if (ptr) *ptr = a->base + off;
+    a->off = off + req.size;
+    return 1;
+}
+static int upload_tensor_d2(ColiVkTensor **out, const void *weights, const float *scales,
+                            int fmt, int I, int O, int gs) {
+    if (*out) return (*out)->fmt == fmt && (*out)->I == I && (*out)->O == O;
+    if (fmt != 1 && fmt != 2 && fmt != 5 &&
+        !(fmt == 4 && gs >= 8 && gs % 8 == 0)) return 0;
+    ColiVkTensor *t = calloc(1, sizeof(*t));
+    if (!t) return 0;
+    t->fmt = fmt; t->I = I; t->O = O; t->rowWords = rowwords(fmt, I); t->gs = fmt == 4 ? gs : 0;
+    t->dev = 1;
+    size_t stride = (size_t)t->rowWords * 4;
+    size_t cpu_rb = fmt == 1 ? (size_t)I
+                  : fmt == 5 ? ((size_t)I + 63) / 64 * 24 : (size_t)(I + 1) / 2;
+    size_t sfl = scale_floats(fmt, I, O, gs);
+    t->wbytes = stride * (size_t)O;
+    void *wptr;
+    if (!arena_suballoc_d2(t->wbytes, &t->wbuf, &wptr)) { free(t); return 0; }
+    memset(wptr, 0, t->wbytes);
+    for (int o = 0; o < O; o++)
+        memcpy((uint8_t *)wptr + (size_t)o * stride,
+               (const uint8_t *)weights + (size_t)o * cpu_rb, cpu_rb);
+    void *sptr;
+    if (!arena_suballoc_d2(sfl * sizeof(float), &t->sbuf, &sptr)) {
+        vkDestroyBuffer(G2.dev, t->wbuf, NULL); free(t); return 0;
+    }
+    memcpy(sptr, scales, sfl * sizeof(float));
+    __atomic_add_fetch(&G2.used_bytes, t->wbytes + sfl * sizeof(float), __ATOMIC_RELAXED);
+    __atomic_add_fetch(&G2.tensor_count, 1, __ATOMIC_RELAXED);
+    *out = t;
+    return 1;
+}
+
+/* Bring up the second device. devidx: -1 = auto (best-ranked real GPU that is NOT
+ * device 0; fails if none), >=0 = that enumeration index (same-physical-device
+ * allowed with a warning — the pre-hardware test mode). Requires coli_vk_init. */
+int coli_vk_init_dev2(const char *spv_path, int devidx) {
+    if (G2.ready) return 1;
+    if (!G.ready) return 0;
+    uint32_t nd = 0;
+    vkEnumeratePhysicalDevices(G.inst, &nd, NULL);
+    VkPhysicalDevice devs[8]; if (nd > 8) nd = 8;
+    if (!nd) return 0;
+    vkEnumeratePhysicalDevices(G.inst, &nd, devs);
+    if (devidx >= 0) {
+        if ((uint32_t)devidx >= nd) { fprintf(stderr, "[VK] dev2: index %d out of range (%u devices)\n", devidx, nd); return 0; }
+        G2.phys = devs[devidx];
+        if (G2.phys == G.phys)
+            fprintf(stderr, "[VK] dev2: SAME physical device as dev0 — second logical device (test mode)\n");
+    } else {
+        int bestrank = -1;
+        for (uint32_t i = 0; i < nd; i++) {
+            if (devs[i] == G.phys) continue;
+            VkPhysicalDeviceProperties p; vkGetPhysicalDeviceProperties(devs[i], &p);
+            int rank = p.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU   ? 4 :
+                       p.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU ? 3 : -1;
+            if (rank > bestrank) { bestrank = rank; G2.phys = devs[i]; }
+        }
+        if (bestrank < 0) { fprintf(stderr, "[VK] dev2=auto: no second real GPU found\n"); return 0; }
+    }
+    uint32_t nq = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(G2.phys, &nq, NULL);
+    VkQueueFamilyProperties qf[16]; if (nq > 16) nq = 16;
+    vkGetPhysicalDeviceQueueFamilyProperties(G2.phys, &nq, qf);
+    G2.qfam = UINT32_MAX;
+    for (uint32_t i = 0; i < nq; i++)
+        if (qf[i].queueFlags & VK_QUEUE_COMPUTE_BIT) { G2.qfam = i; break; }
+    if (G2.qfam == UINT32_MAX) { fprintf(stderr, "[VK] dev2: no compute queue\n"); return 0; }
+    float qprio = 1.0f;
+    VkDeviceQueueCreateInfo qi = {.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+        .queueFamilyIndex = G2.qfam, .queueCount = 1, .pQueuePriorities = &qprio};
+    const char *dext[1]; uint32_t ndext = 0;
+#ifdef VK_EXT_memory_budget
+    {
+        uint32_t ne = 0;
+        vkEnumerateDeviceExtensionProperties(G2.phys, NULL, &ne, NULL);
+        VkExtensionProperties *ep = ne ? malloc(ne * sizeof(*ep)) : NULL;
+        if (ep) {
+            vkEnumerateDeviceExtensionProperties(G2.phys, NULL, &ne, ep);
+            for (uint32_t i = 0; i < ne; i++)
+                if (!strcmp(ep[i].extensionName, VK_EXT_MEMORY_BUDGET_EXTENSION_NAME)) G2.has_budget = 1;
+            free(ep);
+        }
+        if (G2.has_budget) dext[ndext++] = VK_EXT_MEMORY_BUDGET_EXTENSION_NAME;
+    }
+#endif
+    VkDeviceCreateInfo di = {.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+        .queueCreateInfoCount = 1, .pQueueCreateInfos = &qi,
+        .enabledExtensionCount = ndext, .ppEnabledExtensionNames = ndext ? dext : NULL};
+    VKCHECK(vkCreateDevice(G2.phys, &di, NULL, &G2.dev), "d2 vkCreateDevice");
+    vkGetDeviceQueue(G2.dev, G2.qfam, 0, &G2.queue);
+    int mt = pick_memtype(G2.phys);
+    if (mt < 0) { fprintf(stderr, "[VK] dev2: no host-visible memory\n"); return 0; }
+    G2.memtype = (uint32_t)mt;
+    G2.memtype_cached = (uint32_t)pick_memtype_cached(G2.phys);
+    G2.sh_qmm = load_spv(G2.dev, spv_path);
+    if (!G2.sh_qmm) return 0;
+    char gu_path[512]; derive_sibling(spv_path, "_gate_up.spv", gu_path, sizeof(gu_path));
+    G2.sh_gu = load_spv(G2.dev, gu_path);
+    if (!G2.sh_gu) { fprintf(stderr, "[VK] dev2: gate_up shader required for the tier\n"); return 0; }
+    VkDescriptorPool dp; VkDescriptorSet ds;   /* build_pipeline's singleton set: unused here */
+    if (!build_pipeline(G2.dev, 4, sizeof(struct PC), G2.sh_qmm, &G2.dsl, &G2.plyt, &G2.pipe, &dp, &ds)) return 0;
+    if (!build_pipeline(G2.dev, 6, sizeof(struct PC), G2.sh_gu, &G2.dsl_gu, &G2.plyt_gu, &G2.pipe_gu, &dp, &ds)) return 0;
+    VkCommandPoolCreateInfo cpci = {.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+        .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT, .queueFamilyIndex = G2.qfam};
+    VKCHECK(vkCreateCommandPool(G2.dev, &cpci, NULL, &G2.cpool), "d2 cmdPool");
+    VkCommandBufferAllocateInfo cbi = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+        .commandPool = G2.cpool, .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY, .commandBufferCount = 1};
+    VKCHECK(vkAllocateCommandBuffers(G2.dev, &cbi, &G2.cmd), "d2 cmdBuf");
+    VkFenceCreateInfo fi = {.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
+    VKCHECK(vkCreateFence(G2.dev, &fi, NULL, &G2.fence), "d2 fence");
+    G2.ready = 1;
+    VkPhysicalDeviceProperties p; vkGetPhysicalDeviceProperties(G2.phys, &p);
+    fprintf(stderr, "[VK] dev2 ready: %s (expert tier only), compute qfam %u, memtype %u\n",
+            p.deviceName, G2.qfam, G2.memtype);
+    return 1;
+}
+
+int coli_vk_dev2_available(void) { return G2.ready; }
+int coli_vk_tensor_dev(const ColiVkTensor *t) { return t ? t->dev : 0; }
+
+int coli_vk_mem_budget2(double *used_gb, double *budget_gb) {
+#ifdef VK_EXT_memory_budget
+    if (!G2.has_budget || !G2.phys) return 0;
+    VkPhysicalDeviceMemoryBudgetPropertiesEXT bud = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT};
+    VkPhysicalDeviceMemoryProperties2 mp2 = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2, .pNext = &bud};
+    vkGetPhysicalDeviceMemoryProperties2(G2.phys, &mp2);
+    double u = 0, b = 0;
+    for (uint32_t i = 0; i < mp2.memoryProperties.memoryHeapCount; i++)
+        if (mp2.memoryProperties.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) {
+            u += (double)bud.heapUsage[i]; b += (double)bud.heapBudget[i];
+        }
+    if (used_gb) *used_gb = u / 1e9;
+    if (budget_gb) *budget_gb = b / 1e9;
+    return b > 0;
+#else
+    (void)used_gb; (void)budget_gb; return 0;
+#endif
+}
+
+int coli_vk_tensor_ensure2(ColiVkTensor **tensor, const void *weights, const float *scales, int fmt, int I, int O, int grp) {
+    if (!G2.ready) return 0;
+    return upload_tensor_d2(tensor, weights, scales, fmt, I, O, grp);
+}
+
+/* dev2 mirror of eg_prepare_submit: identical structure on G2's pipelines/scratches. */
+static int eg2_prepare_submit(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
+                              ColiVkTensor *const *downs, const int *rows, int count,
+                              const float *x) {
+    if (!G2.ready || count < 1 || count > 64) return 0;
+    ColiVkTensor *g0 = gates[0]; if (!g0) return 0;
+    int D = g0->I, I = g0->O, fmt = g0->fmt, total = 0, off[64];
+    if (D > 6144) return 0;
+    int dfmt = downs[0]->fmt;
+    for (int c = 0; c < count; c++) {
+        off[c] = total; total += rows[c];
+        if (rows[c] < 1 || gates[c]->I != D || gates[c]->O != I || gates[c]->fmt != fmt ||
+            ups[c]->I != D || ups[c]->O != I || ups[c]->fmt != fmt ||
+            downs[c]->I != I || downs[c]->O != D || downs[c]->fmt != dfmt) return 0;
+    }
+    size_t xb = (size_t)total*D*4, hb = (size_t)total*I*4, yb = (size_t)total*D*4;
+    if (!scratch_reserve_d2(&G2.x, xb, G2.memtype) || !scratch_reserve_d2(&G2.h, hb, G2.memtype) ||
+        !scratch_reserve_d2(&G2.y, yb, G2.memtype_cached)) return 0;
+    memcpy(G2.x.ptr, x, xb);
+    if (!G2.pool) {
+        VkDescriptorPoolSize ps = {.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = 64*6 + 64*4};
+        VkDescriptorPoolCreateInfo dpi = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO, .maxSets = 128, .poolSizeCount = 1, .pPoolSizes = &ps};
+        VKCHECK(vkCreateDescriptorPool(G2.dev, &dpi, NULL, &G2.pool), "d2 eg descPool");
+        VkDescriptorSetLayout lg[64], ld[64];
+        for (int c = 0; c < 64; c++) { lg[c] = G2.dsl_gu; ld[c] = G2.dsl; }
+        VkDescriptorSetAllocateInfo ag = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO, .descriptorPool = G2.pool, .descriptorSetCount = 64, .pSetLayouts = lg};
+        VkDescriptorSetAllocateInfo ad = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO, .descriptorPool = G2.pool, .descriptorSetCount = 64, .pSetLayouts = ld};
+        VKCHECK(vkAllocateDescriptorSets(G2.dev, &ag, G2.gu), "d2 eg gu sets");
+        VKCHECK(vkAllocateDescriptorSets(G2.dev, &ad, G2.dn), "d2 eg dn sets");
+        G2.nsets = 64;
+    }
+    for (int c = 0; c < count; c++) {
+        VkDeviceSize xo = (VkDeviceSize)off[c]*D*4, ho = (VkDeviceSize)off[c]*I*4, yo = (VkDeviceSize)off[c]*D*4;
+        VkDescriptorBufferInfo gi[6] = {
+            {G2.x.buf, xo, (VkDeviceSize)rows[c]*D*4}, {gates[c]->wbuf, 0, VK_WHOLE_SIZE},
+            {gates[c]->sbuf, 0, VK_WHOLE_SIZE}, {ups[c]->wbuf, 0, VK_WHOLE_SIZE},
+            {ups[c]->sbuf, 0, VK_WHOLE_SIZE}, {G2.h.buf, ho, (VkDeviceSize)rows[c]*I*4}};
+        wr_desc_dev(G2.dev, G2.gu[c], 6, gi);
+        VkDescriptorBufferInfo di[4] = {
+            {G2.h.buf, ho, (VkDeviceSize)rows[c]*I*4}, {downs[c]->wbuf, 0, VK_WHOLE_SIZE},
+            {downs[c]->sbuf, 0, VK_WHOLE_SIZE}, {G2.y.buf, yo, (VkDeviceSize)rows[c]*D*4}};
+        wr_desc_dev(G2.dev, G2.dn[c], 4, di);
+    }
+    VKCHECK(vkResetCommandBuffer(G2.cmd, 0), "d2 eg resetCmd");
+    VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+    VKCHECK(vkBeginCommandBuffer(G2.cmd, &begin), "d2 eg beginCmd");
+    VkMemoryBarrier mb = {.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER, .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT, .dstAccessMask = VK_ACCESS_SHADER_READ_BIT};
+    vkCmdBindPipeline(G2.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G2.pipe_gu);
+    for (int c = 0; c < count; c++) {
+        struct PC pc = {fmt, rows[c], D, I, gates[c]->rowWords, gates[c]->gs};
+        vkCmdBindDescriptorSets(G2.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G2.plyt_gu, 0, 1, &G2.gu[c], 0, NULL);
+        vkCmdPushConstants(G2.cmd, G2.plyt_gu, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
+        vkCmdDispatch(G2.cmd, (uint32_t)((I + 7) / 8), (uint32_t)rows[c], 1);
+    }
+    vkCmdPipelineBarrier(G2.cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1, &mb, 0, NULL, 0, NULL);
+    vkCmdBindPipeline(G2.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G2.pipe);
+    for (int c = 0; c < count; c++) {
+        struct PC pc = {dfmt, rows[c], I, D, downs[c]->rowWords, downs[c]->gs};
+        vkCmdBindDescriptorSets(G2.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G2.plyt, 0, 1, &G2.dn[c], 0, NULL);
+        vkCmdPushConstants(G2.cmd, G2.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
+        vkCmdDispatch(G2.cmd, (uint32_t)((D + 7) / 8), (uint32_t)rows[c], 1);
+    }
+    VKCHECK(vkEndCommandBuffer(G2.cmd), "d2 eg endCmd");
+    VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G2.cmd};
+    VKCHECK(vkResetFences(G2.dev, 1, &G2.fence), "d2 eg resetFence");
+    VKCHECK(vkQueueSubmit(G2.queue, 1, &si, G2.fence), "d2 eg queueSubmit");
+    G2.pending_yb = yb; G2.inflight = 1;
+    return 1;
+}
+
+int coli_vk_expert_group_issue2(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
+                                ColiVkTensor *const *downs, const int *rows, int count,
+                                const float *x) {
+    if (G2.inflight) return 0;
+    return eg2_prepare_submit(gates, ups, downs, rows, count, x);
+}
+int coli_vk_expert_group_take2(float *y) {
+    if (!G2.inflight) return 0;
+    G2.inflight = 0;
+    if (vk_fence_wait(G2.dev, G2.fence) != VK_SUCCESS) {
+        fprintf(stderr, "[VK] dev2 expert-group fence wait failed — disabling dev2 offload\n");
+        G2.ready = 0; return 0;
+    }
+    memcpy(y, G2.y.ptr, G2.pending_yb);
+    return 1;
+}
+int coli_vk_expert_group2(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
+                          ColiVkTensor *const *downs, const int *rows, int count,
+                          float *y, const float *x) {
+    if (G2.inflight) return 0;
+    if (!eg2_prepare_submit(gates, ups, downs, rows, count, x)) return 0;
+    return coli_vk_expert_group_take2(y);
 }
 
 /* ---- MLA absorb attention core -------------------------------------------------
@@ -900,7 +1222,7 @@ int coli_vk_attention_absorb(ColiVkTensor **kvb, const void *w, const float *sc,
     double vp0 = G.eg_prof ? vk_now() : 0;
     VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
     if (G.eg_prof) { double vp1 = vk_now(); g_vsub_ms += vp1 - vp0; vp0 = vp1; }
-    if (vk_fence_wait(G.fence) != VK_SUCCESS) { G.ready = 0; return 0; }
+    if (vk_fence_wait(G.dev, G.fence) != VK_SUCCESS) { G.ready = 0; return 0; }
     if (G.eg_prof) { g_vwait_ms += vk_now() - vp0; vkprof_tick(); }
     memcpy(ctx, G.y.ptr, cb);
     G.cmd_ready = 0; G.bound_tensor = NULL;   /* the shared command buffer/binding was clobbered */
@@ -959,7 +1281,7 @@ int coli_vk_matmul_pair(ColiVkTensor **t1p, float *y1, const void *w1, const flo
     double vp0 = G.eg_prof ? vk_now() : 0;
     VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
     if (G.eg_prof) { double vp1 = vk_now(); g_vsub_ms += vp1 - vp0; vp0 = vp1; }
-    if (vk_fence_wait(G.fence) != VK_SUCCESS) { G.ready = 0; return 0; }
+    if (vk_fence_wait(G.dev, G.fence) != VK_SUCCESS) { G.ready = 0; return 0; }
     if (G.eg_prof) { g_vwait_ms += vk_now() - vp0; vkprof_tick(); }
     memcpy(y1, G.y.ptr, yb1);
     memcpy(y2, G.y2.ptr, yb2);
@@ -1060,7 +1382,7 @@ int coli_vk_attn_qprep(int layer,
     double vp0 = G.eg_prof ? vk_now() : 0;
     VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
     if (G.eg_prof) { double vp1 = vk_now(); g_vsub_ms += vp1 - vp0; vp0 = vp1; }
-    if (vk_fence_wait(G.fence) != VK_SUCCESS) { G.ready = 0; return 0; }
+    if (vk_fence_wait(G.dev, G.fence) != VK_SUCCESS) { G.ready = 0; return 0; }
     if (G.eg_prof) { g_vwait_ms += vk_now() - vp0; vkprof_tick(); }
     memcpy(q_out, G.y.ptr, qb_b);
     memcpy(kv_out, G.y2.ptr, kvb_b);
@@ -1133,7 +1455,7 @@ int coli_vk_attention_absorb_project(ColiVkTensor **kvb, const void *w, const fl
     double vp0 = G.eg_prof ? vk_now() : 0;
     VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
     if (G.eg_prof) { double vp1 = vk_now(); g_vsub_ms += vp1 - vp0; vp0 = vp1; }
-    if (vk_fence_wait(G.fence) != VK_SUCCESS) { G.ready = 0; return 0; }
+    if (vk_fence_wait(G.dev, G.fence) != VK_SUCCESS) { G.ready = 0; return 0; }
     if (G.eg_prof) { g_vwait_ms += vk_now() - vp0; vkprof_tick(); }
     memcpy(out, G.y.ptr, ob);
     G.cmd_ready = 0; G.bound_tensor = NULL;   /* the shared command buffer/binding was clobbered */
@@ -1142,6 +1464,16 @@ int coli_vk_attention_absorb_project(ColiVkTensor **kvb, const void *w, const fl
 
 void coli_vk_tensor_free(ColiVkTensor *t) {
     if (!t) return;
+    if (t->dev == 1) {   /* dev2 tensor: destroy on ITS device, count in ITS counters */
+        if (G2.ready) {
+            if (t->wbuf) { vkDestroyBuffer(G2.dev, t->wbuf, NULL); vkFreeMemory(G2.dev, t->wmem, NULL); }
+            if (t->sbuf) { vkDestroyBuffer(G2.dev, t->sbuf, NULL); vkFreeMemory(G2.dev, t->smem, NULL); }
+        }
+        __atomic_sub_fetch(&G2.tensor_count, 1, __ATOMIC_RELAXED);
+        __atomic_sub_fetch(&G2.used_bytes, t->wbytes + scale_floats(t->fmt, t->I, t->O, t->gs) * sizeof(float), __ATOMIC_RELAXED);
+        free(t);
+        return;
+    }
     if (G.bound_tensor == t) { G.bound_tensor = NULL; G.cmd_ready = 0; }  /* drop stale cache */
     // If the device was lost/disabled (the fence-timeout path sets G.ready=0), a submission
     // may still reference these buffers — do NOT vkDestroy into a dead device (GPU-side UAF).

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -74,6 +74,13 @@ static struct {
      * immediately, the CPU computes its share, take() joins. */
     VkCommandBuffer eg_cmd; VkFence eg_fence; int eg_inflight; size_t eg_pending_yb;
     double eg_t0, eg_t1, eg_t2, eg_t3; int eg_prof;
+    /* q-prep chain (pair -> rmsnorm -> q_b in ONE submit): norm pipeline (3 bindings),
+     * a 3rd matmul set + norm set, GPU-only latent intermediates, per-layer resident
+     * norm-weight buffers (tiny, uploaded once like the KV mirror). */
+    VkShaderModule shader_nrm; VkDescriptorSetLayout dsl_nrm; VkPipelineLayout plyt_nrm;
+    VkPipeline pipe_nrm; VkDescriptorPool qprep_pool; VkDescriptorSet dset_qp3, dset_nrm;
+    Scratch qp1, qp2;
+    VkBuffer lnbuf[VK_KV_LAYERS]; VkDeviceMemory lnmem[VK_KV_LAYERS]; int lnlen[VK_KV_LAYERS];
     Scratch att_sc;              /* attention score scratch (GPU-only) */
     Scratch att_ctx;             /* fused absorb+o: ctx stays on device (GPU-only) */
     Scratch y2;                  /* second output of the fused matmul pair (readback) */
@@ -97,6 +104,7 @@ static struct {
 } G;
 
 struct PC { int fmt, S, I, O, rowWords, gs; };
+struct PCN { int S, D; float eps; };
 /* Push constants of the absorb attention kernel (must match attention_absorb.comp). */
 struct PCAttn { int fmt, S, H, Q, R, V, K, st0, T, rowWords, cap; float scale; int gs; };
 
@@ -367,6 +375,24 @@ int coli_vk_init(const char *spv_path) {
         return 0;
 
     /* Optional MLA absorb attention pipeline (same directory as the main shader). */
+    /* Optional rmsnorm pipeline: enables the pair->norm->q_b single-submit chain
+     * (coli_vk_attn_qprep); absent -> callers keep the 3-submit path. */
+    char nrm_path[512]; derive_dir_file(spv_path, "rmsnorm.spv", nrm_path, sizeof(nrm_path));
+    G.shader_nrm = load_spv(nrm_path);
+    if (G.shader_nrm) {
+        VkDescriptorPool np; VkDescriptorSet ns;
+        if (!build_pipeline(3, sizeof(struct PCN), G.shader_nrm, &G.dsl_nrm, &G.plyt_nrm, &G.pipe_nrm, &np, &ns))
+            return 0;
+        G.dset_nrm = ns;
+        /* one extra 4-binding matmul set for the chain's 3rd matmul (dset+dset_pair serve 1+2) */
+        VkDescriptorPoolSize ps3 = {.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = 4};
+        VkDescriptorPoolCreateInfo dpi3 = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+            .maxSets = 1, .poolSizeCount = 1, .pPoolSizes = &ps3};
+        VKCHECK(vkCreateDescriptorPool(G.dev, &dpi3, NULL, &G.qprep_pool), "qprep descPool");
+        VkDescriptorSetAllocateInfo dsa3 = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+            .descriptorPool = G.qprep_pool, .descriptorSetCount = 1, .pSetLayouts = &G.dsl};
+        VKCHECK(vkAllocateDescriptorSets(G.dev, &dsa3, &G.dset_qp3), "qprep descSet");
+    }
     char att_path[512]; derive_dir_file(spv_path, "attention_absorb.spv", att_path, sizeof(att_path));
     G.shader_att = load_spv(att_path);
     if (G.shader_att && !build_pipeline(7, sizeof(struct PCAttn), G.shader_att, &G.dsl_att, &G.plyt_att, &G.pipe_att, &G.dpool_att, &G.dset_att))
@@ -918,6 +944,108 @@ int coli_vk_matmul_pair(ColiVkTensor **t1p, float *y1, const void *w1, const flo
     return 1;
 }
 
+
+/* q-prep chain: [q_a + kv_a pair] -> rmsnorm(q_latent) -> [q_b], recorded in ONE
+ * command buffer with compute barriers — one submit+fence where the engine paid
+ * three (the middle CPU norm forced two roundtrips). Only q [S,Oqb] and the kv
+ * latent [S,Okva] return to the host (RoPE + canonical KV append stay CPU-side).
+ * The per-layer norm weights upload once into a tiny resident buffer (KV-mirror
+ * pattern). All three tensors must share fmt (dense io is int8 in practice).
+ * Returns 0 -> caller runs the 3-submit path (also when rmsnorm.spv is absent). */
+int coli_vk_attn_qprep(int layer,
+                       ColiVkTensor **qa,  const void *wqa,  const float *sqa,  int Oqa,
+                       ColiVkTensor **kva, const void *wkva, const float *skva, int Okva,
+                       ColiVkTensor **qb,  const void *wqb,  const float *sqb,  int Oqb,
+                       int fmt, int grp, const float *lnw, float eps,
+                       const float *x, int S, int I, float *q_out, float *kv_out, float *lat_out) {
+    if (!G.ready || !G.shader_nrm || S < 1 || layer < 0 || layer >= VK_KV_LAYERS) return 0;
+    if (!upload_tensor(qa, wqa, sqa, fmt, I, Oqa, grp) || !upload_tensor(kva, wkva, skva, fmt, I, Okva, grp) ||
+        !upload_tensor(qb, wqb, sqb, fmt, Oqa, Oqb, grp)) return 0;
+    ColiVkTensor *tqa = *qa, *tkv = *kva, *tqb = *qb;
+    if (!G.lnbuf[layer]) {                       /* resident norm weights, uploaded once */
+        void *lp; float p0 = G.prio; G.prio = 1.0f;
+        int ok = alloc_hostvis((size_t)Oqa * 4, &G.lnbuf[layer], &G.lnmem[layer], &lp);
+        G.prio = p0;
+        if (!ok) { G.lnbuf[layer] = VK_NULL_HANDLE; return 0; }
+        memcpy(lp, lnw, (size_t)Oqa * 4); G.lnlen[layer] = Oqa;
+    }
+    if (G.lnlen[layer] != Oqa) return 0;
+    size_t xb = (size_t)S * I * 4, qb_b = (size_t)S * Oqb * 4, kvb_b = (size_t)S * Okva * 4;
+    size_t lat = (size_t)S * Oqa * 4;
+    if (!scratch_reserve(&G.x, xb) || !scratch_reserve_mt(&G.y, qb_b, G.memtype_cached) ||
+        !scratch_reserve_mt(&G.y2, kvb_b, G.memtype_cached) ||
+        !scratch_reserve(&G.qp1, lat) ||
+        !scratch_reserve_mt(&G.qp2, lat, G.memtype_cached)) return 0;   /* normed latent reads back (DSA indexer) */
+    memcpy(G.x.ptr, x, xb);
+
+    VkDescriptorBufferInfo b1[4] = {
+        {.buffer = G.x.buf, .range = VK_WHOLE_SIZE}, {.buffer = tqa->wbuf, .range = VK_WHOLE_SIZE},
+        {.buffer = tqa->sbuf, .range = VK_WHOLE_SIZE}, {.buffer = G.qp1.buf, .range = VK_WHOLE_SIZE}};
+    VkDescriptorBufferInfo b2[4] = {
+        {.buffer = G.x.buf, .range = VK_WHOLE_SIZE}, {.buffer = tkv->wbuf, .range = VK_WHOLE_SIZE},
+        {.buffer = tkv->sbuf, .range = VK_WHOLE_SIZE}, {.buffer = G.y2.buf, .range = VK_WHOLE_SIZE}};
+    VkDescriptorBufferInfo bn[3] = {
+        {.buffer = G.qp1.buf, .range = VK_WHOLE_SIZE}, {.buffer = G.lnbuf[layer], .range = VK_WHOLE_SIZE},
+        {.buffer = G.qp2.buf, .range = VK_WHOLE_SIZE}};
+    VkDescriptorBufferInfo b3[4] = {
+        {.buffer = G.qp2.buf, .range = VK_WHOLE_SIZE}, {.buffer = tqb->wbuf, .range = VK_WHOLE_SIZE},
+        {.buffer = tqb->sbuf, .range = VK_WHOLE_SIZE}, {.buffer = G.y.buf, .range = VK_WHOLE_SIZE}};
+    if (!G.pair_pool) {   /* the chain reuses the pair's 2nd matmul set */
+        VkDescriptorPoolSize ps = {.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = 4};
+        VkDescriptorPoolCreateInfo dpi = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+            .maxSets = 1, .poolSizeCount = 1, .pPoolSizes = &ps};
+        VKCHECK(vkCreateDescriptorPool(G.dev, &dpi, NULL, &G.pair_pool), "pair descPool");
+        VkDescriptorSetAllocateInfo dsa = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+            .descriptorPool = G.pair_pool, .descriptorSetCount = 1, .pSetLayouts = &G.dsl};
+        VKCHECK(vkAllocateDescriptorSets(G.dev, &dsa, &G.dset_pair), "pair descSet");
+    }
+    wr_desc(G.dset, 4, b1); wr_desc(G.dset_pair, 4, b2); wr_desc(G.dset_qp3, 4, b3);
+    wr_desc(G.dset_nrm, 3, bn);
+
+    VKCHECK(vkResetCommandBuffer(G.cmd, 0), "resetCmd");
+    VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+    VKCHECK(vkBeginCommandBuffer(G.cmd, &begin), "beginCmd");
+    VkMemoryBarrier mb = {.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+        .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT, .dstAccessMask = VK_ACCESS_SHADER_READ_BIT};
+    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
+    struct PC pc1 = {fmt, S, I, Oqa, tqa->rowWords, tqa->gs};
+    vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.dset, 0, NULL);
+    vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc1), &pc1);
+    vkCmdDispatch(G.cmd, (uint32_t)((Oqa + 7) / 8), (uint32_t)S, 1);
+    struct PC pc2 = {fmt, S, I, Okva, tkv->rowWords, tkv->gs};
+    vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.dset_pair, 0, NULL);
+    vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc2), &pc2);
+    vkCmdDispatch(G.cmd, (uint32_t)((Okva + 7) / 8), (uint32_t)S, 1);
+    vkCmdPipelineBarrier(G.cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                         0, 1, &mb, 0, NULL, 0, NULL);
+    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe_nrm);
+    struct PCN pcn = {S, Oqa, eps};
+    vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt_nrm, 0, 1, &G.dset_nrm, 0, NULL);
+    vkCmdPushConstants(G.cmd, G.plyt_nrm, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pcn), &pcn);
+    vkCmdDispatch(G.cmd, (uint32_t)S, 1, 1);
+    vkCmdPipelineBarrier(G.cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                         0, 1, &mb, 0, NULL, 0, NULL);
+    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
+    struct PC pc3 = {fmt, S, Oqa, Oqb, tqb->rowWords, tqb->gs};
+    vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.dset_qp3, 0, NULL);
+    vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc3), &pc3);
+    vkCmdDispatch(G.cmd, (uint32_t)((Oqb + 7) / 8), (uint32_t)S, 1);
+    VKCHECK(vkEndCommandBuffer(G.cmd), "endCmd");
+
+    VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
+    VKCHECK(vkResetFences(G.dev, 1, &G.fence), "resetFence");
+    double vp0 = G.eg_prof ? vk_now() : 0;
+    VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
+    if (G.eg_prof) { double vp1 = vk_now(); g_vsub_ms += vp1 - vp0; vp0 = vp1; }
+    if (vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) { G.ready = 0; return 0; }
+    if (G.eg_prof) { g_vwait_ms += vk_now() - vp0; vkprof_tick(); }
+    memcpy(q_out, G.y.ptr, qb_b);
+    memcpy(kv_out, G.y2.ptr, kvb_b);
+    if (lat_out) memcpy(lat_out, G.qp2.ptr, lat);
+    G.cmd_ready = 0; G.bound_tensor = NULL;   /* the shared command buffer/binding was clobbered */
+    return 1;
+}
+
 /* Fused absorb attention + o-projection in ONE submit: the absorb kernel writes ctx
  * [S,H*V] to a device-only scratch, a barrier, then the resident o_proj ([Dout, H*V])
  * runs on it via the plain matmul pipeline — only out [S,Dout] returns to the host.
@@ -1445,6 +1573,55 @@ static int run_absorb(int fmt, int S, int H, int Q, int R, int V, int K, int st0
     return (maxrel > 2e-3 || pmaxrel > 5e-3) ? 1 : 0;
 }
 
+
+/* q-prep chain vs CPU ref: matmul(qa) -> rmsnorm -> matmul(qb), kv_a alongside. */
+static int run_qprep(int fmt, int S, int I, int Oqa, int Okva, int Oqb) {
+    size_t rba = ref_rowbytes(fmt, I), rbb = ref_rowbytes(fmt, Oqa);
+    size_t nsa = ref_scales(fmt, I, Oqa), nsk = ref_scales(fmt, I, Okva), nsb = ref_scales(fmt, Oqa, Oqb);
+    uint8_t *wa = malloc(rba * Oqa), *wk = malloc(rba * Okva), *wb = malloc(rbb * Oqb);
+    float *sa = malloc(nsa * 4), *sk = malloc(nsk * 4), *sb = malloc(nsb * 4);
+    float *ln = malloc((size_t)Oqa * 4), *x = malloc((size_t)S * I * 4);
+    float *qg = malloc((size_t)S * Oqb * 4), *kvg = malloc((size_t)S * Okva * 4);
+    float *lat = malloc((size_t)S * Oqa * 4), *qc = malloc((size_t)S * Oqb * 4), *kvc = malloc((size_t)S * Okva * 4);
+    for (size_t i = 0; i < rba * (size_t)Oqa; i++) wa[i] = rand() & 0xff;
+    for (size_t i = 0; i < rba * (size_t)Okva; i++) wk[i] = rand() & 0xff;
+    for (size_t i = 0; i < rbb * (size_t)Oqb; i++) wb[i] = rand() & 0xff;
+    for (size_t o = 0; o < nsa; o++) sa[o] = 0.01f + (rand() % 100) / 10000.0f;
+    for (size_t o = 0; o < nsk; o++) sk[o] = 0.01f + (rand() % 100) / 10000.0f;
+    for (size_t o = 0; o < nsb; o++) sb[o] = 0.01f + (rand() % 100) / 10000.0f;
+    for (int i = 0; i < Oqa; i++) ln[i] = 0.5f + (rand() % 100) / 100.0f;
+    for (int i = 0; i < S * I; i++) x[i] = (rand() % 2000 - 1000) / 500.0f;
+    ColiVkTensor *ta = NULL, *tk = NULL, *tb = NULL;
+    static int qp_layer = 140;         /* distinct high slot per case: the per-layer ln
+                                        * cache is upload-once by design (engine weights
+                                        * are immutable); reuse here would mix cases */
+    int layer = qp_layer++;
+    if (!coli_vk_attn_qprep(layer, &ta, wa, sa, Oqa, &tk, wk, sk, Okva, &tb, wb, sb, Oqb,
+                            fmt, g_ref_gs, ln, 1e-6f, x, S, I, qg, kvg, NULL)) {
+        printf("qprep unavailable (rmsnorm.spv missing?)\n"); return 1; }
+    cpu_ref(lat, x, wa, sa, fmt, S, I, Oqa);
+    cpu_ref(kvc, x, wk, sk, fmt, S, I, Okva);
+    for (int s = 0; s < S; s++) {                       /* rmsnorm rows like colibri.c */
+        double ms = 0; float *r = lat + (size_t)s * Oqa;
+        for (int i = 0; i < Oqa; i++) ms += (double)r[i] * r[i];
+        float rr = 1.0f / sqrtf((float)(ms / Oqa) + 1e-6f);
+        for (int i = 0; i < Oqa; i++) r[i] = r[i] * rr * ln[i];
+    }
+    cpu_ref(qc, lat, wb, sb, fmt, S, Oqa, Oqb);
+    float mq = 0, mk = 0;
+    for (int i = 0; i < S * Oqb; i++) { float d = fabsf(qg[i] - qc[i]) / (fabsf(qc[i]) + 1e-3f); if (d > mq) mq = d; }
+    for (int i = 0; i < S * Okva; i++) { float d = fabsf(kvg[i] - kvc[i]) / (fabsf(kvc[i]) + 1e-3f); if (d > mk) mk = d; }
+    printf("qprep fmt=%d S=%d I=%d (%d->%d, kv %d) | maxrel q %.4g kv %.4g\n", fmt, S, I, Oqa, Oqb, Okva, mq, mk);
+    coli_vk_tensor_free(ta); coli_vk_tensor_free(tk); coli_vk_tensor_free(tb);
+    free(wa); free(wk); free(wb); free(sa); free(sk); free(sb); free(ln); free(x);
+    free(qg); free(kvg); free(lat); free(qc); free(kvc);
+    /* q crosses TWO quantized reductions + the norm; random +-8-nibble rows are
+     * cancellation-heavy, so fp32-vs-f64 divergence amplifies ~10x vs one GEMV
+     * (same reasoning as the expert_group 3e-3 threshold). Engine-level logit
+     * comparison on real weights is the tight check. */
+    return mq > 1e-2f || mk > 1e-3f;
+}
+
 int main(int argc, char **argv) {
     const char *spv = argc > 1 ? argv[1] : "shaders/qmatmul.spv";
     if (!coli_vk_init(spv)) { printf("vk init failed\n"); return 1; }
@@ -1526,6 +1703,10 @@ int main(int argc, char **argv) {
     bad |= run_expert_group(2, 6144, 2048, 32);
     /* int3-g64 expert group: correctness + the 0.86x-bytes throughput question.
      * count=1 included — it is the SHARED-expert path shape in the engine. */
+    bad |= run_qprep(1, 1, 6144, 1536, 576, 16384);   /* GLM q_a/kv_a/q_b decode shapes */
+    bad |= run_qprep(1, 11, 6144, 1536, 576, 16384);  /* prefill batch */
+    bad |= run_qprep(1, 2, 6144, 1536, 576, 16384);   /* S=2 (MTP verify) */
+    bad |= run_qprep(2, 1, 6144, 1536, 576, 16384);   /* int4 dense variant */
     /* fmt=4 grouped int4 (#298 semantics), gs=64 across real shapes + gs=32 sanity */
     g_ref_gs = 64;
     bad |= run_case(4, 1, 6144, 2048, 50);

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -395,6 +395,58 @@ void coli_vk_mem_info(size_t *used, size_t *count) {
     if (count) *count = G.tensor_count;
 }
 
+/* Weight-tensor suballocator: many tensors share a few big VkDeviceMemory blocks.
+ * WHY: per-submit driver cost measures LINEAR in the number of distinct device-memory
+ * objects the queue actively references (~0.35 ms/submit extra at a 950-expert tier's
+ * ~5.7k allocations: decode attention 7.9s @420 -> 17.6s @950, flat once the GPU paths
+ * moved to CPU; IDLE allocations cost nothing until first referenced — harness ballast
+ * probe). Packing tier+dense uploads into 256 MB arenas keeps the referenced-BO count
+ * in the dozens. Arena slices are never reclaimed per-tensor (registry/dense uploads
+ * live for the process; the rare fill-failure free leaks its slice, bounded) — a
+ * tensor's mem handle stays VK_NULL_HANDLE, which coli_vk_tensor_free's vkFreeMemory
+ * treats as the documented no-op. */
+typedef struct VkWArena { VkDeviceMemory mem; uint8_t *base; size_t cap, off; struct VkWArena *next; } VkWArena;
+static VkWArena *g_warena;
+#define VK_WARENA_BLOCK ((size_t)256 << 20)
+static int arena_suballoc(size_t bytes, VkBuffer *buf, void **ptr) {
+    VkBufferCreateInfo bi = {.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .size = bytes, .usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE};
+    VKCHECK(vkCreateBuffer(G.dev, &bi, NULL, buf), "vkCreateBuffer");
+    VkMemoryRequirements req;
+    vkGetBufferMemoryRequirements(G.dev, *buf, &req);
+    if (!(req.memoryTypeBits & (1u << G.memtype))) { vkDestroyBuffer(G.dev, *buf, NULL); *buf = VK_NULL_HANDLE; return 0; }
+    size_t align = req.alignment ? req.alignment : 256, off = 0;
+    VkWArena *a = g_warena;
+    for (; a; a = a->next) {
+        off = (a->off + align - 1) & ~(align - 1);
+        if (off + req.size <= a->cap) break;
+    }
+    if (!a) {
+        size_t cap = req.size > VK_WARENA_BLOCK ? (req.size + 4095) & ~(size_t)4095 : VK_WARENA_BLOCK;
+        a = calloc(1, sizeof(*a));
+        if (!a) { vkDestroyBuffer(G.dev, *buf, NULL); *buf = VK_NULL_HANDLE; return 0; }
+        VkMemoryAllocateInfo ai = {.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+            .allocationSize = cap, .memoryTypeIndex = G.memtype};
+#ifdef VK_EXT_memory_priority
+        VkMemoryPriorityAllocateInfoEXT pri = {.sType = VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT,
+            .priority = G.prio};
+        if (G.has_prio) ai.pNext = &pri;
+#endif
+        if (vkAllocateMemory(G.dev, &ai, NULL, &a->mem) != VK_SUCCESS ||
+            vkMapMemory(G.dev, a->mem, 0, cap, 0, (void **)&a->base) != VK_SUCCESS) {
+            if (a->mem) vkFreeMemory(G.dev, a->mem, NULL);
+            free(a); vkDestroyBuffer(G.dev, *buf, NULL); *buf = VK_NULL_HANDLE; return 0;
+        }
+        a->cap = cap; a->next = g_warena; g_warena = a;
+        off = 0;
+    }
+    VKCHECK(vkBindBufferMemory(G.dev, *buf, a->mem, off), "vkBindBufferMemory");
+    if (ptr) *ptr = a->base + off;
+    a->off = off + req.size;
+    return 1;
+}
+
 static int upload_tensor(ColiVkTensor **out, const void *weights, const float *scales,
                          int fmt, int I, int O) {
     if (*out) return (*out)->fmt == fmt && (*out)->I == I && (*out)->O == O;
@@ -408,14 +460,14 @@ static int upload_tensor(ColiVkTensor **out, const void *weights, const float *s
     size_t sfl = scale_floats(fmt, I, O);            // fmt=5: O*ceil(I/64) group scales
     t->wbytes = stride * (size_t)O;
     void *wptr;
-    if (!alloc_hostvis(t->wbytes, &t->wbuf, &t->wmem, &wptr)) { free(t); return 0; }
+    if (!arena_suballoc(t->wbytes, &t->wbuf, &wptr)) { free(t); return 0; }
     memset(wptr, 0, t->wbytes);
     for (int o = 0; o < O; o++)                        // copy row-by-row into padded layout
         memcpy((uint8_t *)wptr + (size_t)o * stride,
                (const uint8_t *)weights + (size_t)o * cpu_rb, cpu_rb);
     void *sptr;
-    if (!alloc_hostvis(sfl * sizeof(float), &t->sbuf, &t->smem, &sptr)) {
-        vkDestroyBuffer(G.dev, t->wbuf, NULL); vkFreeMemory(G.dev, t->wmem, NULL); free(t); return 0;
+    if (!arena_suballoc(sfl * sizeof(float), &t->sbuf, &sptr)) {
+        vkDestroyBuffer(G.dev, t->wbuf, NULL); free(t); return 0;
     }
     memcpy(sptr, scales, sfl * sizeof(float));
     // Counters are touched concurrently: frees run from expert_load under
@@ -952,6 +1004,12 @@ void coli_vk_shutdown(void) {
         vkDestroyDescriptorSetLayout(G.dev, G.dsl_att, NULL);
         vkDestroyShaderModule(G.dev, G.shader_att, NULL);
     }
+    for (VkWArena *a = g_warena; a;) {   /* weight arenas: unmapped/freed with the device */
+        VkWArena *nx = a->next;
+        vkUnmapMemory(G.dev, a->mem); vkFreeMemory(G.dev, a->mem, NULL);
+        free(a); a = nx;
+    }
+    g_warena = NULL;
     vkDestroyDevice(G.dev, NULL);
     vkDestroyInstance(G.inst, NULL);
     memset(&G, 0, sizeof(G));
@@ -1344,6 +1402,19 @@ int main(int argc, char **argv) {
     if (!coli_vk_init(spv)) { printf("vk init failed\n"); return 1; }
     srand(1234);
     int bad = 0;
+    /* COLI_VK_TEST_BALLAST=N: allocate N idle 4 MB device buffers before benching.
+     * Probes whether per-submit cost scales with the process's ALLOCATION COUNT
+     * (RADV/amdgpu CS buffer-list accounting) independent of bytes — the suspected
+     * mechanism behind decode attention degrading with expert-tier size even with
+     * VRAM to spare (7.9s @2.6k BOs -> 15.6s @4.3k with 2.9 GB free). */
+    {
+        int nb = getenv("COLI_VK_TEST_BALLAST") ? atoi(getenv("COLI_VK_TEST_BALLAST")) : 0;
+        for (int i = 0; i < nb; i++) {
+            VkBuffer b; VkDeviceMemory m;
+            if (!alloc_hostvis_mt(4u << 20, &b, &m, NULL, G.memtype)) { printf("ballast stop at %d\n", i); break; }
+        }
+        if (nb) printf("ballast: %d x 4 MB idle allocations\n", nb);
+    }
     bad |= run_case(1, 1, 6144, 1536, 50);   // int8 expert gate/up shape (S=1 decode)
     bad |= run_case(2, 1, 6144, 1536, 50);   // int4 expert
     bad |= run_case(1, 1, 1536, 6144, 50);   // down proj shape

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -45,6 +45,13 @@ static struct {
     VkCommandBuffer cmd;
     VkFence fence;
     Scratch x, y;
+    /* resubmit cache: skip vkUpdateDescriptorSets + command re-record when the bound
+     * tensor / shape / scratch buffers are unchanged from the previous call (the hot-
+     * expert-called-repeatedly pattern). The synchronous fence wait each call means no
+     * submission is ever in flight, so rebinding/re-recording only when something
+     * actually changed is safe. */
+    ColiVkTensor *bound_tensor; int bound_S, bound_I, bound_O, cmd_ready;
+    VkBuffer bound_xbuf, bound_ybuf;
     size_t used_bytes, tensor_count;
 } G;
 
@@ -249,31 +256,46 @@ int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
     if (!G.ready || S < 1 || !upload_tensor(tensor, weights, scales, fmt, I, O)) return 0;
     ColiVkTensor *t = *tensor;
     size_t xb = (size_t)S * I * sizeof(float), yb = (size_t)S * O * sizeof(float);
+    VkBuffer old_x = G.x.buf, old_y = G.y.buf;
     if (!scratch_reserve(&G.x, xb) || !scratch_reserve(&G.y, yb)) return 0;
     memcpy(G.x.ptr, x, xb);
 
-    VkDescriptorBufferInfo bi[4] = {
-        {.buffer = G.x.buf, .range = VK_WHOLE_SIZE},
-        {.buffer = t->wbuf, .range = VK_WHOLE_SIZE},
-        {.buffer = t->sbuf, .range = VK_WHOLE_SIZE},
-        {.buffer = G.y.buf, .range = VK_WHOLE_SIZE}};
-    VkWriteDescriptorSet w[4];
-    for (int i = 0; i < 4; i++) w[i] = (VkWriteDescriptorSet){
-        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, .dstSet = G.dset,
-        .dstBinding = i, .descriptorCount = 1,
-        .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .pBufferInfo = &bi[i]};
-    vkUpdateDescriptorSets(G.dev, 4, w, 0, NULL);
+    /* Rebind descriptors only when the tensor or a scratch buffer changed (a realloc
+     * makes the old VkBuffer handle stale); otherwise the previous binding is still valid. */
+    int rebind = G.bound_tensor != t || G.x.buf != old_x || G.y.buf != old_y
+              || G.bound_xbuf != G.x.buf || G.bound_ybuf != G.y.buf;
+    if (rebind) {
+        VkDescriptorBufferInfo bi[4] = {
+            {.buffer = G.x.buf, .range = VK_WHOLE_SIZE},
+            {.buffer = t->wbuf, .range = VK_WHOLE_SIZE},
+            {.buffer = t->sbuf, .range = VK_WHOLE_SIZE},
+            {.buffer = G.y.buf, .range = VK_WHOLE_SIZE}};
+        VkWriteDescriptorSet w[4];
+        for (int i = 0; i < 4; i++) w[i] = (VkWriteDescriptorSet){
+            .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, .dstSet = G.dset,
+            .dstBinding = i, .descriptorCount = 1,
+            .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .pBufferInfo = &bi[i]};
+        vkUpdateDescriptorSets(G.dev, 4, w, 0, NULL);
+        G.bound_tensor = t; G.bound_xbuf = G.x.buf; G.bound_ybuf = G.y.buf;
+    }
 
-    VKCHECK(vkResetCommandBuffer(G.cmd, 0), "resetCmd");
-    VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
-        .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT};
-    VKCHECK(vkBeginCommandBuffer(G.cmd, &begin), "beginCmd");
-    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
-    vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.dset, 0, NULL);
-    struct PC pc = {fmt, S, I, O, t->rowWords};
-    vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
-    vkCmdDispatch(G.cmd, (uint32_t)O, (uint32_t)S, 1);
-    VKCHECK(vkEndCommandBuffer(G.cmd), "endCmd");
+    /* Re-record the command buffer only when the binding or the dispatch shape changed.
+     * Recorded WITHOUT one-time-submit so the same buffer can be resubmitted verbatim —
+     * for repeated calls to the same expert this drops setup to a bare submit+wait. */
+    if (rebind || !G.cmd_ready || G.bound_S != S || G.bound_I != I || G.bound_O != O) {
+        VKCHECK(vkResetCommandBuffer(G.cmd, 0), "resetCmd");
+        VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+        VKCHECK(vkBeginCommandBuffer(G.cmd, &begin), "beginCmd");
+        vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
+        vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.dset, 0, NULL);
+        struct PC pc = {fmt, S, I, O, t->rowWords};
+        vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
+        /* Grid-stride shader: one subgroup per output row (~8 rows/workgroup at wave32).
+         * Launch ~O/8 workgroups for occupancy; the shader loops to cover any O / wave width. */
+        vkCmdDispatch(G.cmd, (uint32_t)((O + 7) / 8), (uint32_t)S, 1);
+        VKCHECK(vkEndCommandBuffer(G.cmd), "endCmd");
+        G.cmd_ready = 1; G.bound_S = S; G.bound_I = I; G.bound_O = O;
+    }
 
     VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
         .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
@@ -294,6 +316,7 @@ int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
 
 void coli_vk_tensor_free(ColiVkTensor *t) {
     if (!t) return;
+    if (G.bound_tensor == t) { G.bound_tensor = NULL; G.cmd_ready = 0; }  /* drop stale cache */
     // If the device was lost/disabled (the fence-timeout path sets G.ready=0), a submission
     // may still reference these buffers — do NOT vkDestroy into a dead device (GPU-side UAF).
     // Leak the GPU handles (we're degrading to CPU for the rest of the run) and reclaim the
@@ -383,6 +406,42 @@ static int run_case(int fmt, int S, int I, int O, int iters) {
     return maxrel > 1e-3 ? 1 : 0;
 }
 
+/* Batched throughput: record N dispatches in ONE command buffer, one submit + one
+ * fence wait — the amortized per-matmul cost with the submit roundtrip spread across
+ * the batch (how the real expert tier would drive it). Reuses the descriptor binding
+ * left by a prior coli_vk_matmul call for this tensor/shape. */
+static double bench_batched(ColiVkTensor *t, const float *x, int fmt, int S, int I, int O, int N) {
+    size_t xb = (size_t)S * I * sizeof(float);
+    memcpy(G.x.ptr, x, xb);
+    vkResetCommandBuffer(G.cmd, 0);
+    VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+    vkBeginCommandBuffer(G.cmd, &begin);
+    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
+    vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.dset, 0, NULL);
+    struct PC pc = {fmt, S, I, O, t->rowWords};
+    vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
+    VkMemoryBarrier mb = {.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+        .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT, .dstAccessMask = VK_ACCESS_SHADER_READ_BIT};
+    for (int i = 0; i < N; i++) {
+        vkCmdDispatch(G.cmd, (uint32_t)((O + 7) / 8), (uint32_t)S, 1);
+        vkCmdPipelineBarrier(G.cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+            VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1, &mb, 0, NULL, 0, NULL);
+    }
+    vkEndCommandBuffer(G.cmd);
+    VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
+    for (int warm = 0; warm < 2; warm++) {
+        vkResetFences(G.dev, 1, &G.fence); vkQueueSubmit(G.queue, 1, &si, G.fence);
+        vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL);
+    }
+    int iters = 10; double t0 = now();
+    for (int k = 0; k < iters; k++) {
+        vkResetFences(G.dev, 1, &G.fence); vkQueueSubmit(G.queue, 1, &si, G.fence);
+        vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL);
+    }
+    G.cmd_ready = 0;   /* we clobbered the cached command buffer */
+    return (now() - t0) * 1000.0 / iters / N;   /* ms per matmul, roundtrip amortized */
+}
+
 int main(int argc, char **argv) {
     const char *spv = argc > 1 ? argv[1] : "shaders/qmatmul.spv";
     if (!coli_vk_init(spv)) { printf("vk init failed\n"); return 1; }
@@ -393,6 +452,29 @@ int main(int argc, char **argv) {
     bad |= run_case(1, 1, 1536, 6144, 50);   // down proj shape
     bad |= run_case(2, 8, 6144, 1536, 20);   // prefill/MTP batch
     bad |= run_case(1, 1, 512, 512, 100);    // small
+    /* Batched (amortized) throughput on the int4 expert shapes — the real expert-tier pattern. */
+    {
+        int I = 6144, O = 2048;   /* our gate/up dims */
+        float *x = malloc((size_t)I * 4); uint8_t *w = malloc((size_t)(I + 1) / 2 * O); float *sc = malloc((size_t)O * 4);
+        for (int i = 0; i < I; i++) x[i] = (rand() % 200 - 100) / 100.0f;
+        for (size_t i = 0; i < (size_t)(I + 1) / 2 * O; i++) w[i] = rand() & 0xff;
+        for (int o = 0; o < O; o++) sc[o] = 0.01f + (rand() % 100) / 10000.0f;
+        float *y = malloc((size_t)O * 4);
+        ColiVkTensor *t = NULL; coli_vk_matmul(&t, y, x, w, sc, 2, 1, I, O);   /* bind */
+        printf("BATCHED int4 S=1 6144->2048 (our gate/up): %.4f ms/matmul (N=64, one submit)\n",
+               bench_batched(t, x, 2, 1, I, O, 64));
+        coli_vk_tensor_free(t); free(x); free(w); free(sc); free(y);
+        I = 2048; O = 6144;   /* our down dims */
+        x = malloc((size_t)I * 4); w = malloc((size_t)(I + 1) / 2 * O); sc = malloc((size_t)O * 4);
+        for (int i = 0; i < I; i++) x[i] = (rand() % 200 - 100) / 100.0f;
+        for (size_t i = 0; i < (size_t)(I + 1) / 2 * O; i++) w[i] = rand() & 0xff;
+        for (int o = 0; o < O; o++) sc[o] = 0.01f + (rand() % 100) / 10000.0f;
+        y = malloc((size_t)O * 4);
+        t = NULL; coli_vk_matmul(&t, y, x, w, sc, 2, 1, I, O);
+        printf("BATCHED int4 S=1 2048->6144 (our down):    %.4f ms/matmul (N=64, one submit)\n",
+               bench_batched(t, x, 2, 1, I, O, 64));
+        coli_vk_tensor_free(t); free(x); free(w); free(sc); free(y);
+    }
     printf(bad ? "FAIL\n" : "PASS\n");
     coli_vk_shutdown();
     return bad;

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -70,6 +70,7 @@ static struct {
     Scratch eg_x, eg_h, eg_y;
     VkDescriptorPool eg_pool; VkDescriptorSet eg_gu[64], eg_dn[64]; int eg_nsets;
     Scratch att_sc;              /* attention score scratch (GPU-only) */
+    Scratch att_ctx;             /* fused absorb+o: ctx stays on device (GPU-only) */
     VkKvLayer kv[VK_KV_LAYERS];  /* per-layer resident KV latent/rope cache */
     /* resubmit cache: skip vkUpdateDescriptorSets + command re-record when the bound
      * tensor / shape / scratch buffers are unchanged from the previous call (the hot-
@@ -407,7 +408,7 @@ int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
 int coli_vk_gate_up(ColiVkTensor **gate, ColiVkTensor **up, float *hidden, const float *x,
                     const void *gw, const float *gs, const void *uw, const float *us,
                     int fmt, int S, int D, int I) {
-    if (!G.ready || !G.shader_gu || S < 1) return 0;
+    if (!G.ready || !G.shader_gu || S < 1 || D > 6144) return 0;   /* shader stages x in xsh[6144] */
     if (!upload_tensor(gate, gw, gs, fmt, D, I) || !upload_tensor(up, uw, us, fmt, D, I)) return 0;
     ColiVkTensor *tg = *gate, *tu = *up;
     size_t xb = (size_t)S * D * sizeof(float), hb = (size_t)S * I * sizeof(float);
@@ -462,6 +463,7 @@ int coli_vk_expert_group(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
     if (!G.ready || !G.shader_gu || count < 1 || count > 64) return 0;
     ColiVkTensor *g0 = gates[0]; if (!g0) return 0;
     int D = g0->I, I = g0->O, fmt = g0->fmt, total = 0, off[64];
+    if (D > 6144) return 0;   /* gate_up shader stages x in xsh[6144] */
     for (int c = 0; c < count; c++) {
         off[c] = total; total += rows[c];
         if (rows[c] < 1 || gates[c]->I != D || gates[c]->O != I || gates[c]->fmt != fmt ||
@@ -633,6 +635,74 @@ int coli_vk_attention_absorb(ColiVkTensor **kvb, const void *w, const float *sc,
     return 1;
 }
 
+/* Fused absorb attention + o-projection in ONE submit: the absorb kernel writes ctx
+ * [S,H*V] to a device-only scratch, a barrier, then the resident o_proj ([Dout, H*V])
+ * runs on it via the plain matmul pipeline — only out [S,Dout] returns to the host.
+ * Kills the per-layer ctx readback + re-upload + second submit of the unfused path.
+ * Returns 0 -> caller falls back (plain absorb or CPU). */
+int coli_vk_attention_absorb_project(ColiVkTensor **kvb, const void *w, const float *sc, int fmt,
+                                     ColiVkTensor **ot, const void *ow, const float *osc, int ofmt,
+                                     float *out, const float *q, int layer, int S, int H,
+                                     int Q, int R, int V, int K, int st0, int T, float scale,
+                                     int Dout) {
+    if (!G.ready || !G.pipe_att || S < 1 || H < 1 || layer < 0 || layer >= VK_KV_LAYERS) return 0;
+    if (Q > 256 || R > 64 || K > 512 || st0 < 0 || T - S - st0 < 0 || Dout < 1) return 0;
+    VkKvLayer *kv = &G.kv[layer];
+    if (!kv->bl || kv->rows < T || kv->K != K || kv->R != R) return 0;
+    if (!upload_tensor(kvb, w, sc, fmt, K, H * (Q + V))) return 0;
+    if (!upload_tensor(ot, ow, osc, ofmt, H * V, Dout)) return 0;
+    ColiVkTensor *t = *kvb, *to = *ot;
+    int cap = T - st0;
+    size_t qb = (size_t)S * H * (Q + R) * 4, cb = (size_t)S * H * V * 4;
+    size_t sb = (size_t)S * H * cap * 4, ob = (size_t)S * Dout * 4;
+    if (!scratch_reserve(&G.x, qb) || !scratch_reserve(&G.att_ctx, cb) ||
+        !scratch_reserve(&G.att_sc, sb) || !scratch_reserve_mt(&G.y, ob, G.memtype_cached)) return 0;
+    memcpy(G.x.ptr, q, qb);
+
+    VkDescriptorBufferInfo bi[7] = {
+        {.buffer = G.x.buf, .range = VK_WHOLE_SIZE}, {.buffer = t->wbuf, .range = VK_WHOLE_SIZE},
+        {.buffer = t->sbuf, .range = VK_WHOLE_SIZE}, {.buffer = kv->bl, .range = VK_WHOLE_SIZE},
+        {.buffer = kv->br, .range = VK_WHOLE_SIZE}, {.buffer = G.att_sc.buf, .range = VK_WHOLE_SIZE},
+        {.buffer = G.att_ctx.buf, .range = VK_WHOLE_SIZE}};
+    VkWriteDescriptorSet wd[7];
+    for (int i = 0; i < 7; i++) wd[i] = (VkWriteDescriptorSet){
+        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, .dstSet = G.dset_att,
+        .dstBinding = (uint32_t)i, .descriptorCount = 1,
+        .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .pBufferInfo = &bi[i]};
+    vkUpdateDescriptorSets(G.dev, 7, wd, 0, NULL);
+    VkDescriptorBufferInfo oi[4] = {
+        {.buffer = G.att_ctx.buf, .range = VK_WHOLE_SIZE}, {.buffer = to->wbuf, .range = VK_WHOLE_SIZE},
+        {.buffer = to->sbuf, .range = VK_WHOLE_SIZE}, {.buffer = G.y.buf, .range = VK_WHOLE_SIZE}};
+    wr_desc(G.dset, 4, oi);
+
+    VKCHECK(vkResetCommandBuffer(G.cmd, 0), "resetCmd");
+    VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+    VKCHECK(vkBeginCommandBuffer(G.cmd, &begin), "beginCmd");
+    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe_att);
+    vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt_att, 0, 1, &G.dset_att, 0, NULL);
+    struct PCAttn pc = {fmt, S, H, Q, R, V, K, st0, T, t->rowWords, cap, scale};
+    vkCmdPushConstants(G.cmd, G.plyt_att, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
+    vkCmdDispatch(G.cmd, (uint32_t)H, (uint32_t)S, 1);
+    VkMemoryBarrier mb = {.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+        .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT, .dstAccessMask = VK_ACCESS_SHADER_READ_BIT};
+    vkCmdPipelineBarrier(G.cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1, &mb, 0, NULL, 0, NULL);
+    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
+    vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.dset, 0, NULL);
+    struct PC opc = {ofmt, S, H * V, Dout, to->rowWords};
+    vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(opc), &opc);
+    vkCmdDispatch(G.cmd, (uint32_t)((Dout + 7) / 8), (uint32_t)S, 1);
+    VKCHECK(vkEndCommandBuffer(G.cmd), "endCmd");
+
+    VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
+    VKCHECK(vkResetFences(G.dev, 1, &G.fence), "resetFence");
+    VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
+    if (vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) { G.ready = 0; return 0; }
+    memcpy(out, G.y.ptr, ob);
+    G.cmd_ready = 0; G.bound_tensor = NULL;   /* the shared command buffer/binding was clobbered */
+    return 1;
+}
+
 void coli_vk_tensor_free(ColiVkTensor *t) {
     if (!t) return;
     if (G.bound_tensor == t) { G.bound_tensor = NULL; G.cmd_ready = 0; }  /* drop stale cache */
@@ -663,6 +733,7 @@ void coli_vk_shutdown(void) {
     if (G.eg_h.buf) { vkDestroyBuffer(G.dev, G.eg_h.buf, NULL); vkFreeMemory(G.dev, G.eg_h.mem, NULL); }
     if (G.eg_y.buf) { vkDestroyBuffer(G.dev, G.eg_y.buf, NULL); vkFreeMemory(G.dev, G.eg_y.mem, NULL); }
     if (G.att_sc.buf) { vkDestroyBuffer(G.dev, G.att_sc.buf, NULL); vkFreeMemory(G.dev, G.att_sc.mem, NULL); }
+    if (G.att_ctx.buf) { vkDestroyBuffer(G.dev, G.att_ctx.buf, NULL); vkFreeMemory(G.dev, G.att_ctx.mem, NULL); }
     coli_vk_kv_reset();
     if (G.eg_pool) vkDestroyDescriptorPool(G.dev, G.eg_pool, NULL);
     vkDestroyFence(G.dev, G.fence, NULL);
@@ -942,7 +1013,10 @@ static int run_expert_group(int fmt, int D, int I, int K) {
         coli_vk_tensor_free(tg[c]); coli_vk_tensor_free(tu[c]); coli_vk_tensor_free(td[c]);
         free(hgw[c]); free(huw[c]); free(hdw[c]); free(hgs[c]); free(hus[c]); free(hds[c]);
     }
-    return maxrel > 1e-3 ? 1 : 0;
+    /* K>=32 accumulates fp32 rounding across the double 6144-length reduction chain
+     * (gate_up -> down); ~2e-3 observed and fine for greedy argmax. 3e-3 keeps the
+     * gate honest without flagging the known fp behavior as a failure. */
+    return maxrel > (K >= 32 ? 3e-3 : 1e-3) ? 1 : 0;
 }
 
 /* MLA absorb attention vs a CPU ref that mirrors glm.c's absorb loop exactly:
@@ -997,9 +1071,29 @@ static int run_absorb(int fmt, int S, int H, int Q, int R, int V, int K, int st0
     double ms = (now() - t0) * 1000 / iters;
     printf("absorb fmt=%d S=%d H=%d Q=%d R=%d V=%d K=%d st0=%d T=%d | maxerr=%.4g maxrel=%.4g | %.3f ms/call\n",
            fmt, S, H, Q, R, V, K, st0, T, maxerr, maxrel, ms);
+    /* fused absorb+project vs (CPU ctx ref) @ (CPU o ref) */
+    int Dout = 512; size_t orb = fmt == 1 ? (size_t)H * V : (size_t)(H * V + 1) / 2;
+    uint8_t *owt = malloc(orb * Dout); float *osc = malloc((size_t)Dout * 4);
+    float *og = malloc((size_t)S * Dout * 4), *oc = malloc((size_t)S * Dout * 4);
+    for (size_t i = 0; i < orb * (size_t)Dout; i++) owt[i] = rand() & 0xff;
+    for (int o = 0; o < Dout; o++) osc[o] = 0.01f + (rand() % 100) / 10000.0f;
+    ColiVkTensor *ot = NULL;
+    if (!coli_vk_attention_absorb_project(&kvb, w, ws, fmt, &ot, owt, osc, fmt,
+            og, q, layer, S, H, Q, R, V, K, st0, T, scale, Dout)) { printf("absorb_project failed\n"); return 1; }
+    cpu_ref(oc, cc, owt, osc, fmt, S, H * V, Dout);
+    double pmaxrel = 0;
+    for (int i = 0; i < S * Dout; i++) { double e = fabs(og[i] - oc[i]);
+        if (fabs(oc[i]) > 1e-2) { double r = e / fabs(oc[i]); if (r > pmaxrel) pmaxrel = r; } }
+    t0 = now();
+    for (int k = 0; k < iters; k++)
+        coli_vk_attention_absorb_project(&kvb, w, ws, fmt, &ot, owt, osc, fmt,
+            og, q, layer, S, H, Q, R, V, K, st0, T, scale, Dout);
+    printf("absorb+project fused                  | maxrel=%.4g | %.3f ms/call (unfused absorb was %.3f)\n",
+           pmaxrel, (now() - t0) * 1000 / iters, ms);
+    coli_vk_tensor_free(ot); free(owt); free(osc); free(og); free(oc);
     coli_vk_tensor_free(kvb);
     free(w); free(ws); free(q); free(L); free(Rr); free(cg); free(cc); free(qabs); free(clat); free(sc);
-    return maxrel > 2e-3 ? 1 : 0;
+    return (maxrel > 2e-3 || pmaxrel > 5e-3) ? 1 : 0;
 }
 
 int main(int argc, char **argv) {
@@ -1012,6 +1106,7 @@ int main(int argc, char **argv) {
     bad |= run_case(1, 1, 1536, 6144, 50);   // down proj shape
     bad |= run_case(2, 8, 6144, 1536, 20);   // prefill/MTP batch
     bad |= run_case(1, 1, 512, 512, 100);    // small
+    bad |= run_case(2, 1, 16384, 6144, 20);  // o_proj shape: I > xsh capacity (unstaged path)
     /* Batched (amortized) throughput on the int4 expert shapes — the real expert-tier pattern. */
     {
         int I = 6144, O = 2048;   /* our gate/up dims */

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -41,10 +41,13 @@ static struct {
     VkShaderModule shader;
     VkDescriptorPool dpool;
     VkDescriptorSet dset;
+    /* fused dual gate+up+silu pipeline (6 bindings): x, Wg, gscale, Wu, uscale, hidden */
+    VkShaderModule shader_gu; VkDescriptorSetLayout dsl_gu; VkPipelineLayout plyt_gu;
+    VkPipeline pipe_gu; VkDescriptorPool dpool_gu; VkDescriptorSet dset_gu;
     VkCommandPool cpool;
     VkCommandBuffer cmd;
     VkFence fence;
-    Scratch x, y;
+    Scratch x, y, h;   /* h = fused gate+up hidden output */
     /* resubmit cache: skip vkUpdateDescriptorSets + command re-record when the bound
      * tensor / shape / scratch buffers are unchanged from the previous call (the hot-
      * expert-called-repeatedly pattern). The synchronous fence wait each call means no
@@ -119,6 +122,46 @@ static VkShaderModule load_spv(const char *path) {
     return r == VK_SUCCESS ? m : VK_NULL_HANDLE;
 }
 
+/* Build a compute pipeline + descriptor pool/set for nbind storage buffers sharing the
+ * struct PC push constant. Used for both the 4-binding matmul and 6-binding gate_up. */
+static int build_pipeline(int nbind, VkShaderModule shader, VkDescriptorSetLayout *dsl,
+                          VkPipelineLayout *plyt, VkPipeline *pipe, VkDescriptorPool *dpool,
+                          VkDescriptorSet *dset) {
+    VkDescriptorSetLayoutBinding b[8];
+    for (int i = 0; i < nbind; i++) b[i] = (VkDescriptorSetLayoutBinding){
+        .binding = (uint32_t)i, .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+        .descriptorCount = 1, .stageFlags = VK_SHADER_STAGE_COMPUTE_BIT};
+    VkDescriptorSetLayoutCreateInfo dsli = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+        .bindingCount = (uint32_t)nbind, .pBindings = b};
+    VKCHECK(vkCreateDescriptorSetLayout(G.dev, &dsli, NULL, dsl), "descSetLayout");
+    VkPushConstantRange pcr = {.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT, .offset = 0, .size = sizeof(struct PC)};
+    VkPipelineLayoutCreateInfo pli = {.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+        .setLayoutCount = 1, .pSetLayouts = dsl, .pushConstantRangeCount = 1, .pPushConstantRanges = &pcr};
+    VKCHECK(vkCreatePipelineLayout(G.dev, &pli, NULL, plyt), "pipelineLayout");
+    VkComputePipelineCreateInfo cpi = {.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
+        .stage = {.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+                  .stage = VK_SHADER_STAGE_COMPUTE_BIT, .module = shader, .pName = "main"},
+        .layout = *plyt};
+    VKCHECK(vkCreateComputePipelines(G.dev, VK_NULL_HANDLE, 1, &cpi, NULL, pipe), "pipeline");
+    VkDescriptorPoolSize ps = {.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = (uint32_t)nbind};
+    VkDescriptorPoolCreateInfo dpi = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+        .maxSets = 1, .poolSizeCount = 1, .pPoolSizes = &ps};
+    VKCHECK(vkCreateDescriptorPool(G.dev, &dpi, NULL, dpool), "descPool");
+    VkDescriptorSetAllocateInfo dsa = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+        .descriptorPool = *dpool, .descriptorSetCount = 1, .pSetLayouts = dsl};
+    VKCHECK(vkAllocateDescriptorSets(G.dev, &dsa, dset), "allocDescSet");
+    return 1;
+}
+
+/* "…/qmatmul.spv" -> "…/qmatmul_gate_up.spv" (sibling of the main shader). */
+static void derive_gu_path(const char *spv, char *out, size_t n) {
+    const char *dot = strstr(spv, ".spv");
+    if (dot && (size_t)(dot - spv) + 13 < n) {
+        size_t pre = (size_t)(dot - spv);
+        memcpy(out, spv, pre); strcpy(out + pre, "_gate_up.spv");
+    } else snprintf(out, n, "%s", spv);
+}
+
 int coli_vk_init(const char *spv_path) {
     if (G.ready) return 1;
     VkApplicationInfo app = {.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
@@ -168,36 +211,14 @@ int coli_vk_init(const char *spv_path) {
 
     G.shader = load_spv(spv_path);
     if (!G.shader) return 0;
+    if (!build_pipeline(4, G.shader, &G.dsl, &G.plyt, &G.pipe, &G.dpool, &G.dset)) return 0;
 
-    VkDescriptorSetLayoutBinding b[4];
-    for (int i = 0; i < 4; i++) b[i] = (VkDescriptorSetLayoutBinding){
-        .binding = i, .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-        .descriptorCount = 1, .stageFlags = VK_SHADER_STAGE_COMPUTE_BIT};
-    VkDescriptorSetLayoutCreateInfo dsli = {
-        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
-        .bindingCount = 4, .pBindings = b};
-    VKCHECK(vkCreateDescriptorSetLayout(G.dev, &dsli, NULL, &G.dsl), "descSetLayout");
-
-    VkPushConstantRange pcr = {.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT,
-        .offset = 0, .size = sizeof(struct PC)};
-    VkPipelineLayoutCreateInfo pli = {.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
-        .setLayoutCount = 1, .pSetLayouts = &G.dsl,
-        .pushConstantRangeCount = 1, .pPushConstantRanges = &pcr};
-    VKCHECK(vkCreatePipelineLayout(G.dev, &pli, NULL, &G.plyt), "pipelineLayout");
-
-    VkComputePipelineCreateInfo cpi = {.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
-        .stage = {.sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
-                  .stage = VK_SHADER_STAGE_COMPUTE_BIT, .module = G.shader, .pName = "main"},
-        .layout = G.plyt};
-    VKCHECK(vkCreateComputePipelines(G.dev, VK_NULL_HANDLE, 1, &cpi, NULL, &G.pipe), "pipeline");
-
-    VkDescriptorPoolSize ps = {.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = 4};
-    VkDescriptorPoolCreateInfo dpi = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
-        .maxSets = 1, .poolSizeCount = 1, .pPoolSizes = &ps};
-    VKCHECK(vkCreateDescriptorPool(G.dev, &dpi, NULL, &G.dpool), "descPool");
-    VkDescriptorSetAllocateInfo dsa = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
-        .descriptorPool = G.dpool, .descriptorSetCount = 1, .pSetLayouts = &G.dsl};
-    VKCHECK(vkAllocateDescriptorSets(G.dev, &dsa, &G.dset), "allocDescSet");
+    /* Optional fused gate+up pipeline: skip gracefully if its shader isn't present
+     * (single-matmul path keeps working). */
+    char gu_path[512]; derive_gu_path(spv_path, gu_path, sizeof(gu_path));
+    G.shader_gu = load_spv(gu_path);
+    if (G.shader_gu && !build_pipeline(6, G.shader_gu, &G.dsl_gu, &G.plyt_gu, &G.pipe_gu, &G.dpool_gu, &G.dset_gu))
+        return 0;
 
     VkCommandPoolCreateInfo cpci = {.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
         .flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT, .queueFamilyIndex = G.qfam};
@@ -210,7 +231,8 @@ int coli_vk_init(const char *spv_path) {
 
     G.ready = 1;
     VkPhysicalDeviceProperties p; vkGetPhysicalDeviceProperties(G.phys, &p);
-    fprintf(stderr, "[VK] ready: %s, compute qfam %u, memtype %u\n", p.deviceName, G.qfam, G.memtype);
+    fprintf(stderr, "[VK] ready: %s, compute qfam %u, memtype %u%s\n", p.deviceName, G.qfam, G.memtype,
+            G.shader_gu ? ", fused gate+up" : "");
     return 1;
 }
 
@@ -314,6 +336,49 @@ int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
     return 1;
 }
 
+/* Fused first half of the expert MLP: hidden = silu(gate(x)) * up(x), computed in ONE
+ * dispatch that reads x once for both projections. gate/up are resident (uploaded on
+ * first call). D = input (hidden) dim, I = moe_inter. Returns 0 -> caller falls back. */
+int coli_vk_gate_up(ColiVkTensor **gate, ColiVkTensor **up, float *hidden, const float *x,
+                    const void *gw, const float *gs, const void *uw, const float *us,
+                    int fmt, int S, int D, int I) {
+    if (!G.ready || !G.shader_gu || S < 1) return 0;
+    if (!upload_tensor(gate, gw, gs, fmt, D, I) || !upload_tensor(up, uw, us, fmt, D, I)) return 0;
+    ColiVkTensor *tg = *gate, *tu = *up;
+    size_t xb = (size_t)S * D * sizeof(float), hb = (size_t)S * I * sizeof(float);
+    if (!scratch_reserve(&G.x, xb) || !scratch_reserve(&G.h, hb)) return 0;
+    memcpy(G.x.ptr, x, xb);
+
+    VkDescriptorBufferInfo bi[6] = {
+        {.buffer = G.x.buf, .range = VK_WHOLE_SIZE}, {.buffer = tg->wbuf, .range = VK_WHOLE_SIZE},
+        {.buffer = tg->sbuf, .range = VK_WHOLE_SIZE}, {.buffer = tu->wbuf, .range = VK_WHOLE_SIZE},
+        {.buffer = tu->sbuf, .range = VK_WHOLE_SIZE}, {.buffer = G.h.buf, .range = VK_WHOLE_SIZE}};
+    VkWriteDescriptorSet w[6];
+    for (int i = 0; i < 6; i++) w[i] = (VkWriteDescriptorSet){
+        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, .dstSet = G.dset_gu,
+        .dstBinding = (uint32_t)i, .descriptorCount = 1,
+        .descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .pBufferInfo = &bi[i]};
+    vkUpdateDescriptorSets(G.dev, 6, w, 0, NULL);
+
+    VKCHECK(vkResetCommandBuffer(G.cmd, 0), "resetCmd");
+    VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+    VKCHECK(vkBeginCommandBuffer(G.cmd, &begin), "beginCmd");
+    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe_gu);
+    vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt_gu, 0, 1, &G.dset_gu, 0, NULL);
+    struct PC pc = {fmt, S, D, I, tg->rowWords};   // PC.I = input D, PC.O = moe_inter I
+    vkCmdPushConstants(G.cmd, G.plyt_gu, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
+    vkCmdDispatch(G.cmd, (uint32_t)((I + 7) / 8), (uint32_t)S, 1);
+    VKCHECK(vkEndCommandBuffer(G.cmd), "endCmd");
+
+    VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
+    VKCHECK(vkResetFences(G.dev, 1, &G.fence), "resetFence");
+    VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
+    if (vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) { G.ready = 0; return 0; }
+    memcpy(hidden, G.h.ptr, hb);
+    G.cmd_ready = 0; G.bound_tensor = NULL;   /* the shared command buffer/binding was clobbered */
+    return 1;
+}
+
 void coli_vk_tensor_free(ColiVkTensor *t) {
     if (!t) return;
     if (G.bound_tensor == t) { G.bound_tensor = NULL; G.cmd_ready = 0; }  /* drop stale cache */
@@ -339,6 +404,7 @@ void coli_vk_shutdown(void) {
     vkDeviceWaitIdle(G.dev);
     if (G.x.buf) { vkDestroyBuffer(G.dev, G.x.buf, NULL); vkFreeMemory(G.dev, G.x.mem, NULL); }
     if (G.y.buf) { vkDestroyBuffer(G.dev, G.y.buf, NULL); vkFreeMemory(G.dev, G.y.mem, NULL); }
+    if (G.h.buf) { vkDestroyBuffer(G.dev, G.h.buf, NULL); vkFreeMemory(G.dev, G.h.mem, NULL); }
     vkDestroyFence(G.dev, G.fence, NULL);
     vkDestroyCommandPool(G.dev, G.cpool, NULL);
     vkDestroyDescriptorPool(G.dev, G.dpool, NULL);
@@ -346,6 +412,13 @@ void coli_vk_shutdown(void) {
     vkDestroyPipelineLayout(G.dev, G.plyt, NULL);
     vkDestroyDescriptorSetLayout(G.dev, G.dsl, NULL);
     vkDestroyShaderModule(G.dev, G.shader, NULL);
+    if (G.shader_gu) {
+        vkDestroyDescriptorPool(G.dev, G.dpool_gu, NULL);
+        vkDestroyPipeline(G.dev, G.pipe_gu, NULL);
+        vkDestroyPipelineLayout(G.dev, G.plyt_gu, NULL);
+        vkDestroyDescriptorSetLayout(G.dev, G.dsl_gu, NULL);
+        vkDestroyShaderModule(G.dev, G.shader_gu, NULL);
+    }
     vkDestroyDevice(G.dev, NULL);
     vkDestroyInstance(G.inst, NULL);
     memset(&G, 0, sizeof(G));
@@ -442,6 +515,107 @@ static double bench_batched(ColiVkTensor *t, const float *x, int fmt, int S, int
     return (now() - t0) * 1000.0 / iters / N;   /* ms per matmul, roundtrip amortized */
 }
 
+/* Fused gate+up correctness vs CPU ref: hidden = silu(gate*x)*(up*x). */
+static int run_gate_up(int fmt, int S, int D, int I) {
+    size_t rb = fmt == 1 ? (size_t)D : (size_t)(D + 1) / 2;
+    float *x = malloc((size_t)S*D*4); uint8_t *gw = malloc(rb*I), *uw = malloc(rb*I);
+    float *gs = malloc((size_t)I*4), *us = malloc((size_t)I*4);
+    float *hg = malloc((size_t)S*I*4), *hc = malloc((size_t)S*I*4);
+    for (int i = 0; i < S*D; i++) x[i] = (rand()%200-100)/100.0f;
+    for (size_t i = 0; i < rb*I; i++) { gw[i] = rand()&0xff; uw[i] = rand()&0xff; }
+    for (int o = 0; o < I; o++) { gs[o] = 0.01f+(rand()%100)/10000.0f; us[o] = 0.01f+(rand()%100)/10000.0f; }
+    ColiVkTensor *tg = NULL, *tu = NULL;
+    if (!coli_vk_gate_up(&tg, &tu, hg, x, gw, gs, uw, us, fmt, S, D, I)) { printf("gate_up failed\n"); return 1; }
+    for (int s = 0; s < S; s++) for (int o = 0; o < I; o++) {
+        double g = 0, u = 0; const uint8_t *gr = gw+(size_t)o*rb, *ur = uw+(size_t)o*rb;
+        for (int i = 0; i < D; i++) { g += x[s*D+i]*deq(gr,fmt,i); u += x[s*D+i]*deq(ur,fmt,i); }
+        float gt = (float)(g*gs[o]), ut = (float)(u*us[o]);
+        hc[s*I+o] = (gt/(1.0f+expf(-gt)))*ut;
+    }
+    double maxrel = 0;
+    for (int i = 0; i < S*I; i++) { double e = fabs(hg[i]-hc[i]); if (fabs(hc[i])>1e-2) { double r = e/fabs(hc[i]); if (r>maxrel) maxrel = r; } }
+    printf("gate_up(fused) fmt=%d S=%d D=%d I=%d | maxrel=%.4g\n", fmt, S, D, I, maxrel);
+    coli_vk_tensor_free(tg); coli_vk_tensor_free(tu);
+    free(x); free(gw); free(uw); free(gs); free(us); free(hg); free(hc);
+    return maxrel > 1e-3 ? 1 : 0;
+}
+
+/* Batched throughput of the fused gate_up (N dispatches / one submit). */
+static double bench_gu_batched(ColiVkTensor *tg, const float *x, int fmt, int S, int D, int I, int N) {
+    memcpy(G.x.ptr, x, (size_t)S*D*sizeof(float));
+    vkResetCommandBuffer(G.cmd, 0);
+    VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+    vkBeginCommandBuffer(G.cmd, &begin);
+    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe_gu);
+    vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt_gu, 0, 1, &G.dset_gu, 0, NULL);
+    struct PC pc = {fmt, S, D, I, tg->rowWords};
+    vkCmdPushConstants(G.cmd, G.plyt_gu, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
+    VkMemoryBarrier mb = {.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
+        .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT, .dstAccessMask = VK_ACCESS_SHADER_READ_BIT};
+    for (int i = 0; i < N; i++) {
+        vkCmdDispatch(G.cmd, (uint32_t)((I+7)/8), (uint32_t)S, 1);
+        vkCmdPipelineBarrier(G.cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1, &mb, 0, NULL, 0, NULL);
+    }
+    vkEndCommandBuffer(G.cmd);
+    VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
+    for (int w = 0; w < 2; w++) { vkResetFences(G.dev,1,&G.fence); vkQueueSubmit(G.queue,1,&si,G.fence); vkWaitForFences(G.dev,1,&G.fence,VK_TRUE,10000000000ULL); }
+    int iters = 10; double t0 = now();
+    for (int k = 0; k < iters; k++) { vkResetFences(G.dev,1,&G.fence); vkQueueSubmit(G.queue,1,&si,G.fence); vkWaitForFences(G.dev,1,&G.fence,VK_TRUE,10000000000ULL); }
+    return (now()-t0)*1000.0/iters/N;
+}
+
+/* FAIR fused-gate_up throughput: cycle K DISTINCT experts (own descriptor set each) so
+ * weights come from VRAM, not L2 — matching ROCm's expert_group reading distinct experts.
+ * Returns ms per gate_up (one expert). */
+static double bench_experts_fair(int fmt, int D, int I, int K, int Npass) {
+    if (K > 32) K = 32;
+    size_t rb = fmt == 1 ? (size_t)D : (size_t)(D + 1) / 2;
+    ColiVkTensor *tg[32] = {0}, *tu[32] = {0};
+    float *h = malloc((size_t)I*4), *x = malloc((size_t)D*4);
+    for (int i = 0; i < D; i++) x[i] = (rand()%200-100)/100.0f;
+    for (int c = 0; c < K; c++) {
+        uint8_t *gw = malloc(rb*I), *uw = malloc(rb*I); float *gs = malloc((size_t)I*4), *us = malloc((size_t)I*4);
+        for (size_t i = 0; i < rb*I; i++) { gw[i] = rand()&0xff; uw[i] = rand()&0xff; }
+        for (int o = 0; o < I; o++) { gs[o] = 0.01f; us[o] = 0.01f; }
+        coli_vk_gate_up(&tg[c], &tu[c], h, x, gw, gs, uw, us, fmt, 1, D, I);   /* uploads distinct experts */
+        free(gw); free(uw); free(gs); free(us);
+    }
+    VkDescriptorPoolSize ps = {.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = (uint32_t)(6*K)};
+    VkDescriptorPoolCreateInfo dpi = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO, .maxSets = (uint32_t)K, .poolSizeCount = 1, .pPoolSizes = &ps};
+    VkDescriptorPool pool; vkCreateDescriptorPool(G.dev, &dpi, NULL, &pool);
+    VkDescriptorSetLayout lays[32]; VkDescriptorSet sets[32]; for (int c = 0; c < K; c++) lays[c] = G.dsl_gu;
+    VkDescriptorSetAllocateInfo dsa = {.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO, .descriptorPool = pool, .descriptorSetCount = (uint32_t)K, .pSetLayouts = lays};
+    vkAllocateDescriptorSets(G.dev, &dsa, sets);
+    memcpy(G.x.ptr, x, (size_t)D*4);
+    for (int c = 0; c < K; c++) {
+        VkDescriptorBufferInfo bi[6] = {{.buffer=G.x.buf,.range=VK_WHOLE_SIZE},{.buffer=tg[c]->wbuf,.range=VK_WHOLE_SIZE},{.buffer=tg[c]->sbuf,.range=VK_WHOLE_SIZE},{.buffer=tu[c]->wbuf,.range=VK_WHOLE_SIZE},{.buffer=tu[c]->sbuf,.range=VK_WHOLE_SIZE},{.buffer=G.h.buf,.range=VK_WHOLE_SIZE}};
+        VkWriteDescriptorSet w[6]; for (int i = 0; i < 6; i++) w[i] = (VkWriteDescriptorSet){.sType=VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,.dstSet=sets[c],.dstBinding=(uint32_t)i,.descriptorCount=1,.descriptorType=VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,.pBufferInfo=&bi[i]};
+        vkUpdateDescriptorSets(G.dev, 6, w, 0, NULL);
+    }
+    vkResetCommandBuffer(G.cmd, 0);
+    VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+    vkBeginCommandBuffer(G.cmd, &begin);
+    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe_gu);
+    struct PC pc = {fmt, 1, D, I, tg[0]->rowWords};
+    vkCmdPushConstants(G.cmd, G.plyt_gu, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
+    VkMemoryBarrier mb = {.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER, .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT, .dstAccessMask = VK_ACCESS_SHADER_READ_BIT};
+    for (int pass = 0; pass < Npass; pass++) for (int c = 0; c < K; c++) {
+        vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt_gu, 0, 1, &sets[c], 0, NULL);
+        vkCmdDispatch(G.cmd, (uint32_t)((I+7)/8), 1, 1);
+        vkCmdPipelineBarrier(G.cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1, &mb, 0, NULL, 0, NULL);
+    }
+    vkEndCommandBuffer(G.cmd);
+    VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
+    for (int w = 0; w < 2; w++) { vkResetFences(G.dev,1,&G.fence); vkQueueSubmit(G.queue,1,&si,G.fence); vkWaitForFences(G.dev,1,&G.fence,VK_TRUE,10000000000ULL); }
+    int iters = 10; double t0 = now();
+    for (int k = 0; k < iters; k++) { vkResetFences(G.dev,1,&G.fence); vkQueueSubmit(G.queue,1,&si,G.fence); vkWaitForFences(G.dev,1,&G.fence,VK_TRUE,10000000000ULL); }
+    double ms = (now()-t0)*1000.0/iters/((double)Npass*K);
+    vkDestroyDescriptorPool(G.dev, pool, NULL);
+    for (int c = 0; c < K; c++) { coli_vk_tensor_free(tg[c]); coli_vk_tensor_free(tu[c]); }
+    free(h); free(x); G.cmd_ready = 0; G.bound_tensor = NULL;
+    return ms;
+}
+
 int main(int argc, char **argv) {
     const char *spv = argc > 1 ? argv[1] : "shaders/qmatmul.spv";
     if (!coli_vk_init(spv)) { printf("vk init failed\n"); return 1; }
@@ -475,6 +649,24 @@ int main(int argc, char **argv) {
                bench_batched(t, x, 2, 1, I, O, 64));
         coli_vk_tensor_free(t); free(x); free(w); free(sc); free(y);
     }
+    /* FUSED gate+up: correctness + batched throughput (vs 2x separate gate/up). */
+    {
+        int D = 6144, I = 2048;
+        bad |= run_gate_up(2, 1, D, I);
+        size_t rb = (size_t)(D + 1) / 2;
+        float *x = malloc((size_t)D*4); uint8_t *gw = malloc(rb*I), *uw = malloc(rb*I);
+        float *gs = malloc((size_t)I*4), *us = malloc((size_t)I*4), *h = malloc((size_t)I*4);
+        for (int i = 0; i < D; i++) x[i] = (rand()%200-100)/100.0f;
+        for (size_t i = 0; i < rb*I; i++) { gw[i] = rand()&0xff; uw[i] = rand()&0xff; }
+        for (int o = 0; o < I; o++) { gs[o] = 0.01f; us[o] = 0.01f; }
+        ColiVkTensor *tg = NULL, *tu = NULL; coli_vk_gate_up(&tg, &tu, h, x, gw, gs, uw, us, 2, 1, D, I);
+        printf("BATCHED fused gate_up int4 6144->2048:     %.4f ms (N=64, SAME expert = L2-cached)\n",
+               bench_gu_batched(tg, x, 2, 1, D, I, 64));
+        coli_vk_tensor_free(tg); coli_vk_tensor_free(tu); free(x); free(gw); free(uw); free(gs); free(us); free(h);
+    }
+    /* FAIR: cycle 8 distinct experts (VRAM reads, not L2) — matches ROCm expert_group. */
+    printf("FAIR fused gate_up int4 6144->2048 (8 distinct experts): %.4f ms/expert\n",
+           bench_experts_fair(2, 6144, 2048, 8, 8));
     printf(bad ? "FAIL\n" : "PASS\n");
     coli_vk_shutdown();
     return bad;

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -12,6 +12,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
+static double vk_now(void) { struct timespec t; clock_gettime(CLOCK_MONOTONIC, &t); return t.tv_sec*1000.0 + t.tv_nsec/1e6; }
 
 #define VKCHECK(x, what) do { VkResult _r = (x); if (_r != VK_SUCCESS) { \
     fprintf(stderr, "[VK] %s failed: %d\n", what, _r); return 0; } } while (0)
@@ -34,7 +36,8 @@ static struct {
     VkDevice dev;
     VkQueue queue;
     uint32_t qfam;
-    uint32_t memtype;            // HOST_VISIBLE|HOST_COHERENT (prefer DEVICE_LOCAL)
+    uint32_t memtype;            // HOST_VISIBLE|HOST_COHERENT (prefer DEVICE_LOCAL) — for inputs/weights
+    uint32_t memtype_cached;     // HOST_CACHED — for buffers the CPU reads back (outputs)
     VkDescriptorSetLayout dsl;
     VkPipelineLayout plyt;
     VkPipeline pipe;
@@ -80,7 +83,21 @@ static int pick_memtype(void) {
     return best;
 }
 
-static int alloc_hostvis(size_t bytes, VkBuffer *buf, VkDeviceMemory *mem, void **ptr) {
+/* Cached+coherent host-visible type for buffers the CPU READS BACK. pick_memtype prefers
+ * DEVICE_LOCAL host-visible = write-combined VRAM over ReBAR, which the CPU writes fast but
+ * reads catastrophically slowly (~40 MB/s). Outputs must be HOST_CACHED for cheap readback. */
+static int pick_memtype_cached(void) {
+    VkPhysicalDeviceMemoryProperties m;
+    vkGetPhysicalDeviceMemoryProperties(G.phys, &m);
+    for (uint32_t i = 0; i < m.memoryTypeCount; i++) {
+        VkMemoryPropertyFlags f = m.memoryTypes[i].propertyFlags;
+        if ((f & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) && (f & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) &&
+            (f & VK_MEMORY_PROPERTY_HOST_CACHED_BIT)) return (int)i;
+    }
+    return pick_memtype();   /* no cached type -> fall back (no worse than before) */
+}
+
+static int alloc_hostvis_mt(size_t bytes, VkBuffer *buf, VkDeviceMemory *mem, void **ptr, uint32_t memtype) {
     VkBufferCreateInfo bi = {.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
         .size = bytes, .usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
         .sharingMode = VK_SHARING_MODE_EXCLUSIVE};
@@ -88,21 +105,25 @@ static int alloc_hostvis(size_t bytes, VkBuffer *buf, VkDeviceMemory *mem, void 
     VkMemoryRequirements req;
     vkGetBufferMemoryRequirements(G.dev, *buf, &req);
     VkMemoryAllocateInfo ai = {.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
-        .allocationSize = req.size, .memoryTypeIndex = G.memtype};
+        .allocationSize = req.size, .memoryTypeIndex = memtype};
     VKCHECK(vkAllocateMemory(G.dev, &ai, NULL, mem), "vkAllocateMemory");
     VKCHECK(vkBindBufferMemory(G.dev, *buf, *mem, 0), "vkBindBufferMemory");
     if (ptr) VKCHECK(vkMapMemory(G.dev, *mem, 0, bytes, 0, ptr), "vkMapMemory");
     return 1;
 }
+static int alloc_hostvis(size_t bytes, VkBuffer *buf, VkDeviceMemory *mem, void **ptr) {
+    return alloc_hostvis_mt(bytes, buf, mem, ptr, G.memtype);
+}
 
-static int scratch_reserve(Scratch *s, size_t bytes) {
+static int scratch_reserve_mt(Scratch *s, size_t bytes, uint32_t memtype) {
     if (s->cap >= bytes) return 1;
     if (s->buf) { vkDestroyBuffer(G.dev, s->buf, NULL); vkFreeMemory(G.dev, s->mem, NULL); }
     s->buf = VK_NULL_HANDLE; s->cap = 0; s->ptr = NULL;
-    if (!alloc_hostvis(bytes, &s->buf, &s->mem, &s->ptr)) return 0;
+    if (!alloc_hostvis_mt(bytes, &s->buf, &s->mem, &s->ptr, memtype)) return 0;
     s->cap = bytes;
     return 1;
 }
+static int scratch_reserve(Scratch *s, size_t bytes) { return scratch_reserve_mt(s, bytes, G.memtype); }
 
 static int rowwords(int fmt, int I) {
     size_t rb = fmt == 1 ? (size_t)I : (size_t)(I + 1) / 2; // bytes/row on CPU side
@@ -213,6 +234,7 @@ int coli_vk_init(const char *spv_path) {
     int mt = pick_memtype();
     if (mt < 0) { fprintf(stderr, "[VK] no host-visible memory\n"); return 0; }
     G.memtype = (uint32_t)mt;
+    G.memtype_cached = (uint32_t)pick_memtype_cached();
 
     G.shader = load_spv(spv_path);
     if (!G.shader) return 0;
@@ -284,7 +306,7 @@ int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
     ColiVkTensor *t = *tensor;
     size_t xb = (size_t)S * I * sizeof(float), yb = (size_t)S * O * sizeof(float);
     VkBuffer old_x = G.x.buf, old_y = G.y.buf;
-    if (!scratch_reserve(&G.x, xb) || !scratch_reserve(&G.y, yb)) return 0;
+    if (!scratch_reserve(&G.x, xb) || !scratch_reserve_mt(&G.y, yb, G.memtype_cached)) return 0;  /* y read back */
     memcpy(G.x.ptr, x, xb);
 
     /* Rebind descriptors only when the tensor or a scratch buffer changed (a realloc
@@ -351,7 +373,7 @@ int coli_vk_gate_up(ColiVkTensor **gate, ColiVkTensor **up, float *hidden, const
     if (!upload_tensor(gate, gw, gs, fmt, D, I) || !upload_tensor(up, uw, us, fmt, D, I)) return 0;
     ColiVkTensor *tg = *gate, *tu = *up;
     size_t xb = (size_t)S * D * sizeof(float), hb = (size_t)S * I * sizeof(float);
-    if (!scratch_reserve(&G.x, xb) || !scratch_reserve(&G.h, hb)) return 0;
+    if (!scratch_reserve(&G.x, xb) || !scratch_reserve_mt(&G.h, hb, G.memtype_cached)) return 0;  /* hidden read back */
     memcpy(G.x.ptr, x, xb);
 
     VkDescriptorBufferInfo bi[6] = {
@@ -408,8 +430,12 @@ int coli_vk_expert_group(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
             ups[c]->I != D || ups[c]->O != I || downs[c]->I != I || downs[c]->O != D) return 0;
     }
     size_t xb = (size_t)total*D*4, hb = (size_t)total*I*4, yb = (size_t)total*D*4;
-    if (!scratch_reserve(&G.eg_x, xb) || !scratch_reserve(&G.eg_h, hb) || !scratch_reserve(&G.eg_y, yb)) return 0;
+    if (!scratch_reserve(&G.eg_x, xb) || !scratch_reserve(&G.eg_h, hb) ||
+        !scratch_reserve_mt(&G.eg_y, yb, G.memtype_cached)) return 0;   /* eg_y is read back -> cached */
+    int prof = getenv("VK_PROF") != NULL; double t0=0,t1=0,t2=0,t3=0,t4=0,t5=0;
+    if (prof) t0 = vk_now();
     memcpy(G.eg_x.ptr, x, xb);
+    if (prof) t1 = vk_now();
 
     if (!G.eg_pool) {   /* one-time: 64 gate_up (6-binding) + 64 down (4-binding) sets */
         VkDescriptorPoolSize ps = {.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = 64*6 + 64*4};
@@ -435,6 +461,7 @@ int coli_vk_expert_group(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
             {downs[c]->sbuf, 0, VK_WHOLE_SIZE}, {G.eg_y.buf, yo, (VkDeviceSize)rows[c]*D*4}};
         wr_desc(G.eg_dn[c], 4, di);
     }
+    if (prof) t2 = vk_now();
 
     VKCHECK(vkResetCommandBuffer(G.cmd, 0), "resetCmd");
     VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
@@ -458,12 +485,17 @@ int coli_vk_expert_group(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
         vkCmdDispatch(G.cmd, (uint32_t)((D + 7) / 8), (uint32_t)rows[c], 1);
     }
     VKCHECK(vkEndCommandBuffer(G.cmd), "endCmd");
+    if (prof) t3 = vk_now();
 
     VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
     VKCHECK(vkResetFences(G.dev, 1, &G.fence), "resetFence");
     VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
     if (vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) { G.ready = 0; return 0; }
+    if (prof) t4 = vk_now();
     memcpy(y, G.eg_y.ptr, yb);
+    if (prof) { t5 = vk_now();
+        fprintf(stderr, "[VK_PROF] K=%d memcpy_x %.3f | desc %.3f | record %.3f | gpu %.3f | memcpy_y %.3f ms\n",
+                count, t1-t0, t2-t1, t3-t2, t4-t3, t5-t4); }
     G.cmd_ready = 0; G.bound_tensor = NULL;
     return 1;
 }

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -87,6 +87,13 @@ static struct {
     ColiVkTensor *bound_tensor; int bound_S, bound_I, bound_O, cmd_ready;
     VkBuffer bound_xbuf, bound_ybuf;
     size_t used_bytes, tensor_count;
+    /* VRAM pressure-proofing: with VK_EXT_memory_priority the attention working set
+     * (KV mirror, scratches) outranks bulk expert weights, so an oversubscribed heap
+     * evicts cold tier experts instead of thrashing the per-token attention submits
+     * (measured: decode attention 7.8s at 7.6 GB resident -> 17.8s at 15.2 GB).
+     * VK_EXT_memory_budget lets the tier fill stop at a reserve instead of guessing. */
+    int has_prio, has_budget;
+    float prio;                  /* priority applied to the NEXT allocations (class knob) */
 } G;
 
 struct PC { int fmt, S, I, O, rowWords; };
@@ -131,10 +138,42 @@ static int alloc_hostvis_mt(size_t bytes, VkBuffer *buf, VkDeviceMemory *mem, vo
     vkGetBufferMemoryRequirements(G.dev, *buf, &req);
     VkMemoryAllocateInfo ai = {.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
         .allocationSize = req.size, .memoryTypeIndex = memtype};
+#ifdef VK_EXT_memory_priority
+    VkMemoryPriorityAllocateInfoEXT pri = {.sType = VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT,
+        .priority = G.prio};
+    if (G.has_prio) ai.pNext = &pri;
+#endif
     VKCHECK(vkAllocateMemory(G.dev, &ai, NULL, mem), "vkAllocateMemory");
     VKCHECK(vkBindBufferMemory(G.dev, *buf, *mem, 0), "vkBindBufferMemory");
     if (ptr) VKCHECK(vkMapMemory(G.dev, *mem, 0, bytes, 0, ptr), "vkMapMemory");
     return 1;
+}
+/* Priority class of subsequent allocations (VK_EXT_memory_priority; no-op without it).
+ * Scratches/KV force 1.0 internally; weight uploads take whatever is current — the
+ * engine sets 0.4 around the bulk expert-tier fill, dense stays at the 0.75 default. */
+void coli_vk_alloc_priority(float p) { G.prio = p < 0 ? 0 : p > 1 ? 1 : p; }
+
+/* Device-local heap usage/budget in GB (VK_EXT_memory_budget). Returns 0 when the
+ * extension is absent — callers then keep their count-based caps unchanged. */
+int coli_vk_mem_budget(double *used_gb, double *budget_gb) {
+#ifdef VK_EXT_memory_budget
+    if (!G.has_budget || !G.phys) return 0;
+    VkPhysicalDeviceMemoryBudgetPropertiesEXT bud = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT};
+    VkPhysicalDeviceMemoryProperties2 mp2 = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2, .pNext = &bud};
+    vkGetPhysicalDeviceMemoryProperties2(G.phys, &mp2);
+    double u = 0, b = 0;
+    for (uint32_t i = 0; i < mp2.memoryProperties.memoryHeapCount; i++)
+        if (mp2.memoryProperties.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) {
+            u += (double)bud.heapUsage[i]; b += (double)bud.heapBudget[i];
+        }
+    if (used_gb) *used_gb = u / 1e9;
+    if (budget_gb) *budget_gb = b / 1e9;
+    return b > 0;
+#else
+    (void)used_gb; (void)budget_gb; return 0;
+#endif
 }
 static int alloc_hostvis(size_t bytes, VkBuffer *buf, VkDeviceMemory *mem, void **ptr) {
     return alloc_hostvis_mt(bytes, buf, mem, ptr, G.memtype);
@@ -144,7 +183,10 @@ static int scratch_reserve_mt(Scratch *s, size_t bytes, uint32_t memtype) {
     if (s->cap >= bytes) return 1;
     if (s->buf) { vkDestroyBuffer(G.dev, s->buf, NULL); vkFreeMemory(G.dev, s->mem, NULL); }
     s->buf = VK_NULL_HANDLE; s->cap = 0; s->ptr = NULL;
-    if (!alloc_hostvis_mt(bytes, &s->buf, &s->mem, &s->ptr, memtype)) return 0;
+    float p0 = G.prio; G.prio = 1.0f;            /* scratches ride every submit: never evict */
+    int ok = alloc_hostvis_mt(bytes, &s->buf, &s->mem, &s->ptr, memtype);
+    G.prio = p0;
+    if (!ok) return 0;
     s->cap = bytes;
     return 1;
 }
@@ -266,10 +308,45 @@ int coli_vk_init(const char *spv_path) {
     float prio = 1.0f;
     VkDeviceQueueCreateInfo qi = {.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
         .queueFamilyIndex = G.qfam, .queueCount = 1, .pQueuePriorities = &prio};
+    /* Pressure-proofing extensions (both optional, detected at runtime):
+     * memory_priority ranks allocations for the kernel's eviction order,
+     * memory_budget exposes how much VRAM a new allocation can still take. */
+    const char *dext[2]; uint32_t ndext = 0;
+    {
+        uint32_t ne = 0;
+        vkEnumerateDeviceExtensionProperties(G.phys, NULL, &ne, NULL);
+        VkExtensionProperties *ep = ne ? malloc(ne * sizeof(*ep)) : NULL;
+        if (ep) {
+            vkEnumerateDeviceExtensionProperties(G.phys, NULL, &ne, ep);
+            for (uint32_t i = 0; i < ne; i++) {
+#ifdef VK_EXT_memory_priority
+                if (!strcmp(ep[i].extensionName, VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME)) G.has_prio = 1;
+#endif
+#ifdef VK_EXT_memory_budget
+                if (!strcmp(ep[i].extensionName, VK_EXT_MEMORY_BUDGET_EXTENSION_NAME)) G.has_budget = 1;
+#endif
+            }
+            free(ep);
+        }
+    }
     VkDeviceCreateInfo di = {.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
         .queueCreateInfoCount = 1, .pQueueCreateInfos = &qi};
+#ifdef VK_EXT_memory_priority
+    VkPhysicalDeviceMemoryPriorityFeaturesEXT prif = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT,
+        .memoryPriority = VK_TRUE};
+    if (G.has_prio) { dext[ndext++] = VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME; prif.pNext = (void *)di.pNext; di.pNext = &prif; }
+#endif
+#ifdef VK_EXT_memory_budget
+    if (G.has_budget) dext[ndext++] = VK_EXT_MEMORY_BUDGET_EXTENSION_NAME;
+#endif
+    di.enabledExtensionCount = ndext; di.ppEnabledExtensionNames = ndext ? dext : NULL;
+    G.prio = 0.75f;                              /* default class: dense/resident weights */
     VKCHECK(vkCreateDevice(G.phys, &di, NULL, &G.dev), "vkCreateDevice");
     vkGetDeviceQueue(G.dev, G.qfam, 0, &G.queue);
+    if (G.has_prio || G.has_budget)
+        fprintf(stderr, "[VK] VRAM pressure-proofing: memory_priority %s, memory_budget %s\n",
+                G.has_prio ? "on" : "absent", G.has_budget ? "on" : "absent");
 
     int mt = pick_memtype();
     if (mt < 0) { fprintf(stderr, "[VK] no host-visible memory\n"); return 0; }
@@ -605,9 +682,12 @@ int coli_vk_kv_ensure(int layer, int max_rows, int K, int Rd) {
     if (!G.ready || layer < 0 || layer >= VK_KV_LAYERS || max_rows < 1 || K < 1 || Rd < 1) return 0;
     VkKvLayer *v = &G.kv[layer];
     if (v->bl) return v->rows >= max_rows && v->K == K && v->R == Rd;  /* resize goes through coli_vk_kv_reset */
-    if (!alloc_hostvis((size_t)max_rows * K * 4, &v->bl, &v->ml, &v->pl)) return 0;
-    if (!alloc_hostvis((size_t)max_rows * Rd * 4, &v->br, &v->mr, &v->pr)) {
-        vkDestroyBuffer(G.dev, v->bl, NULL); vkFreeMemory(G.dev, v->ml, NULL);
+    float p0 = G.prio; G.prio = 1.0f;            /* KV mirror rides every attention submit */
+    int ok1 = alloc_hostvis((size_t)max_rows * K * 4, &v->bl, &v->ml, &v->pl);
+    int ok = ok1 && alloc_hostvis((size_t)max_rows * Rd * 4, &v->br, &v->mr, &v->pr);
+    G.prio = p0;
+    if (!ok) {
+        if (ok1) { vkDestroyBuffer(G.dev, v->bl, NULL); vkFreeMemory(G.dev, v->ml, NULL); }
         memset(v, 0, sizeof(*v)); return 0;
     }
     v->rows = max_rows; v->K = K; v->R = Rd;

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -490,10 +490,16 @@ int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
                    int fmt, int S, int I, int O) {
     if (!G.ready || S < 1 || !upload_tensor(tensor, weights, scales, fmt, I, O)) return 0;
     ColiVkTensor *t = *tensor;
+    /* VK_PROF=1: phase split of the dense per-call cost, printed every 8192 calls —
+     * separates our code (memcpy/desc/record) from the driver (submit) and the GPU
+     * (fence wait) to localize the tier-size-linear tax. */
+    static double p_x, p_desc, p_rec, p_sub, p_wait, p_y; static long p_n;
+    double t0 = G.eg_prof ? vk_now() : 0, tA;
     size_t xb = (size_t)S * I * sizeof(float), yb = (size_t)S * O * sizeof(float);
     VkBuffer old_x = G.x.buf, old_y = G.y.buf;
     if (!scratch_reserve(&G.x, xb) || !scratch_reserve_mt(&G.y, yb, G.memtype_cached)) return 0;  /* y read back */
     memcpy(G.x.ptr, x, xb);
+    if (G.eg_prof) { tA = vk_now(); p_x += tA - t0; t0 = tA; }
 
     /* Rebind descriptors only when the tensor or a scratch buffer changed (a realloc
      * makes the old VkBuffer handle stale); otherwise the previous binding is still valid. */
@@ -513,6 +519,7 @@ int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
         vkUpdateDescriptorSets(G.dev, 4, w, 0, NULL);
         G.bound_tensor = t; G.bound_xbuf = G.x.buf; G.bound_ybuf = G.y.buf;
     }
+    if (G.eg_prof) { tA = vk_now(); p_desc += tA - t0; t0 = tA; }
 
     /* Re-record the command buffer only when the binding or the dispatch shape changed.
      * Recorded WITHOUT one-time-submit so the same buffer can be resubmitted verbatim —
@@ -531,11 +538,13 @@ int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
         VKCHECK(vkEndCommandBuffer(G.cmd), "endCmd");
         G.cmd_ready = 1; G.bound_S = S; G.bound_I = I; G.bound_O = O;
     }
+    if (G.eg_prof) { tA = vk_now(); p_rec += tA - t0; t0 = tA; }
 
     VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
         .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
     VKCHECK(vkResetFences(G.dev, 1, &G.fence), "resetFence");
     VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
+    if (G.eg_prof) { tA = vk_now(); p_sub += tA - t0; t0 = tA; }
     // Bounded wait: a GPU hang/TDR must never wedge the process. 10s is orders of
     // magnitude over a single-GEMV dispatch; on timeout/device-loss disable VK for
     // the rest of the run and fall back to CPU (the caller degrades on our 0 return).
@@ -545,7 +554,14 @@ int coli_vk_matmul(ColiVkTensor **tensor, float *y, const float *x,
         G.ready = 0;
         return 0;
     }
+    if (G.eg_prof) { tA = vk_now(); p_wait += tA - t0; t0 = tA; }
     memcpy(y, G.y.ptr, yb);
+    if (G.eg_prof) {
+        p_y += vk_now() - t0;
+        if ((++p_n & 8191) == 0)
+            fprintf(stderr, "[VK_PROF dense] n=%ld | memcpy_x %.0f | desc %.0f | record %.0f | submit %.0f | wait %.0f | memcpy_y %.0f ms\n",
+                    p_n, p_x, p_desc, p_rec, p_sub, p_wait, p_y);
+    }
     return 1;
 }
 

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -69,6 +69,11 @@ static struct {
      * one submit with hidden never leaving the GPU. */
     Scratch eg_x, eg_h, eg_y;
     VkDescriptorPool eg_pool; VkDescriptorSet eg_gu[64], eg_dn[64]; int eg_nsets;
+    /* expert-group ASYNC state: its own command buffer + fence so an in-flight group
+     * never collides with the main cmd/fence (dense matmuls, absorb) — issue() returns
+     * immediately, the CPU computes its share, take() joins. */
+    VkCommandBuffer eg_cmd; VkFence eg_fence; int eg_inflight; size_t eg_pending_yb;
+    double eg_t0, eg_t1, eg_t2, eg_t3; int eg_prof;
     Scratch att_sc;              /* attention score scratch (GPU-only) */
     Scratch att_ctx;             /* fused absorb+o: ctx stays on device (GPU-only) */
     Scratch y2;                  /* second output of the fused matmul pair (readback) */
@@ -287,8 +292,10 @@ int coli_vk_init(const char *spv_path) {
     VkCommandBufferAllocateInfo cbi = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
         .commandPool = G.cpool, .level = VK_COMMAND_BUFFER_LEVEL_PRIMARY, .commandBufferCount = 1};
     VKCHECK(vkAllocateCommandBuffers(G.dev, &cbi, &G.cmd), "cmdBuf");
+    VKCHECK(vkAllocateCommandBuffers(G.dev, &cbi, &G.eg_cmd), "eg cmdBuf");
     VkFenceCreateInfo fi = {.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
     VKCHECK(vkCreateFence(G.dev, &fi, NULL, &G.fence), "fence");
+    VKCHECK(vkCreateFence(G.dev, &fi, NULL, &G.eg_fence), "eg fence");
 
     G.ready = 1;
     VkPhysicalDeviceProperties p; vkGetPhysicalDeviceProperties(G.phys, &p);
@@ -455,13 +462,16 @@ static void wr_desc(VkDescriptorSet set, int n, const VkDescriptorBufferInfo *bi
     vkUpdateDescriptorSets(G.dev, (uint32_t)n, w, 0, NULL);
 }
 
-/* Full batched expert MLP for `count` experts in ONE submit, hidden staying on-device:
+/* Full batched expert MLP for `count` experts, hidden staying on-device:
  * for each c, hidden_c = silu(gate_c(x_c))*up_c(x_c) (fused), then y_c = down_c(hidden_c).
  * x/y are packed [sum(rows)*D]; experts are resident VkTensors (gate/up: D->I, down: I->D).
- * Mirrors coli_cuda_expert_group. Returns 0 -> caller falls back to CPU. */
-int coli_vk_expert_group(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
-                         ColiVkTensor *const *downs, const int *rows, int count,
-                         float *y, const float *x) {
+ * Mirrors coli_cuda_expert_group. Split into prepare+submit / take so the caller can
+ * overlap the GPU batch with its own CPU share (issue -> CPU rows -> take); the group
+ * runs on its OWN command buffer + fence, so in-flight work never collides with the
+ * main pipeline (dense matmuls, absorb attention). Returns 0 -> caller falls back. */
+static int eg_prepare_submit(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
+                             ColiVkTensor *const *downs, const int *rows, int count,
+                             const float *x) {
     if (!G.ready || !G.shader_gu || count < 1 || count > 64) return 0;
     ColiVkTensor *g0 = gates[0]; if (!g0) return 0;
     int D = g0->I, I = g0->O, fmt = g0->fmt, total = 0, off[64];
@@ -474,10 +484,10 @@ int coli_vk_expert_group(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
     size_t xb = (size_t)total*D*4, hb = (size_t)total*I*4, yb = (size_t)total*D*4;
     if (!scratch_reserve(&G.eg_x, xb) || !scratch_reserve(&G.eg_h, hb) ||
         !scratch_reserve_mt(&G.eg_y, yb, G.memtype_cached)) return 0;   /* eg_y is read back -> cached */
-    int prof = getenv("VK_PROF") != NULL; double t0=0,t1=0,t2=0,t3=0,t4=0,t5=0;
-    if (prof) t0 = vk_now();
+    G.eg_prof = getenv("VK_PROF") != NULL;
+    if (G.eg_prof) G.eg_t0 = vk_now();
     memcpy(G.eg_x.ptr, x, xb);
-    if (prof) t1 = vk_now();
+    if (G.eg_prof) G.eg_t1 = vk_now();
 
     if (!G.eg_pool) {   /* one-time: 64 gate_up (6-binding) + 64 down (4-binding) sets */
         VkDescriptorPoolSize ps = {.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = 64*6 + 64*4};
@@ -503,43 +513,73 @@ int coli_vk_expert_group(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
             {downs[c]->sbuf, 0, VK_WHOLE_SIZE}, {G.eg_y.buf, yo, (VkDeviceSize)rows[c]*D*4}};
         wr_desc(G.eg_dn[c], 4, di);
     }
-    if (prof) t2 = vk_now();
+    if (G.eg_prof) G.eg_t2 = vk_now();
 
-    VKCHECK(vkResetCommandBuffer(G.cmd, 0), "resetCmd");
+    VKCHECK(vkResetCommandBuffer(G.eg_cmd, 0), "eg resetCmd");
     VkCommandBufferBeginInfo begin = {.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
-    VKCHECK(vkBeginCommandBuffer(G.cmd, &begin), "beginCmd");
+    VKCHECK(vkBeginCommandBuffer(G.eg_cmd, &begin), "eg beginCmd");
     VkMemoryBarrier mb = {.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER, .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT, .dstAccessMask = VK_ACCESS_SHADER_READ_BIT};
     /* phase 1: fused gate+up+silu -> hidden (per expert, bound to its x/hidden slices) */
-    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe_gu);
+    vkCmdBindPipeline(G.eg_cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe_gu);
     for (int c = 0; c < count; c++) {
         struct PC pc = {fmt, rows[c], D, I, gates[c]->rowWords};
-        vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt_gu, 0, 1, &G.eg_gu[c], 0, NULL);
-        vkCmdPushConstants(G.cmd, G.plyt_gu, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
-        vkCmdDispatch(G.cmd, (uint32_t)((I + 7) / 8), (uint32_t)rows[c], 1);
+        vkCmdBindDescriptorSets(G.eg_cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt_gu, 0, 1, &G.eg_gu[c], 0, NULL);
+        vkCmdPushConstants(G.eg_cmd, G.plyt_gu, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
+        vkCmdDispatch(G.eg_cmd, (uint32_t)((I + 7) / 8), (uint32_t)rows[c], 1);
     }
-    vkCmdPipelineBarrier(G.cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1, &mb, 0, NULL, 0, NULL);
+    vkCmdPipelineBarrier(G.eg_cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1, &mb, 0, NULL, 0, NULL);
     /* phase 2: down projection hidden -> y */
-    vkCmdBindPipeline(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
+    vkCmdBindPipeline(G.eg_cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.pipe);
     for (int c = 0; c < count; c++) {
         struct PC pc = {fmt, rows[c], I, D, downs[c]->rowWords};
-        vkCmdBindDescriptorSets(G.cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.eg_dn[c], 0, NULL);
-        vkCmdPushConstants(G.cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
-        vkCmdDispatch(G.cmd, (uint32_t)((D + 7) / 8), (uint32_t)rows[c], 1);
+        vkCmdBindDescriptorSets(G.eg_cmd, VK_PIPELINE_BIND_POINT_COMPUTE, G.plyt, 0, 1, &G.eg_dn[c], 0, NULL);
+        vkCmdPushConstants(G.eg_cmd, G.plyt, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(pc), &pc);
+        vkCmdDispatch(G.eg_cmd, (uint32_t)((D + 7) / 8), (uint32_t)rows[c], 1);
     }
-    VKCHECK(vkEndCommandBuffer(G.cmd), "endCmd");
-    if (prof) t3 = vk_now();
+    VKCHECK(vkEndCommandBuffer(G.eg_cmd), "eg endCmd");
+    if (G.eg_prof) G.eg_t3 = vk_now();
 
-    VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
-    VKCHECK(vkResetFences(G.dev, 1, &G.fence), "resetFence");
-    VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.fence), "queueSubmit");
-    if (vkWaitForFences(G.dev, 1, &G.fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) { G.ready = 0; return 0; }
-    if (prof) t4 = vk_now();
-    memcpy(y, G.eg_y.ptr, yb);
-    if (prof) { t5 = vk_now();
-        fprintf(stderr, "[VK_PROF] K=%d memcpy_x %.3f | desc %.3f | record %.3f | gpu %.3f | memcpy_y %.3f ms\n",
-                count, t1-t0, t2-t1, t3-t2, t4-t3, t5-t4); }
-    G.cmd_ready = 0; G.bound_tensor = NULL;
+    VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.eg_cmd};
+    VKCHECK(vkResetFences(G.dev, 1, &G.eg_fence), "eg resetFence");
+    VKCHECK(vkQueueSubmit(G.queue, 1, &si, G.eg_fence), "eg queueSubmit");
+    G.eg_pending_yb = yb; G.eg_inflight = 1;
     return 1;
+}
+
+/* Issue a group asynchronously: submit and return WITHOUT waiting, so the caller
+ * computes its CPU share concurrently. Exactly one group may be in flight. */
+int coli_vk_expert_group_issue(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
+                               ColiVkTensor *const *downs, const int *rows, int count,
+                               const float *x) {
+    if (G.eg_inflight) return 0;
+    return eg_prepare_submit(gates, ups, downs, rows, count, x);
+}
+
+/* Join the in-flight group and read back the packed outputs. */
+int coli_vk_expert_group_take(float *y) {
+    if (!G.eg_inflight) return 0;
+    G.eg_inflight = 0;
+    if (vkWaitForFences(G.dev, 1, &G.eg_fence, VK_TRUE, 10000000000ULL) != VK_SUCCESS) {
+        fprintf(stderr, "[VK] expert-group fence wait failed — disabling GPU offload\n");
+        G.ready = 0; return 0;
+    }
+    double t4 = G.eg_prof ? vk_now() : 0;
+    memcpy(y, G.eg_y.ptr, G.eg_pending_yb);
+    if (G.eg_prof) {
+        double t5 = vk_now();
+        fprintf(stderr, "[VK_PROF] memcpy_x %.3f | desc %.3f | record %.3f | issue->take %.3f | memcpy_y %.3f ms\n",
+                G.eg_t1-G.eg_t0, G.eg_t2-G.eg_t1, G.eg_t3-G.eg_t2, t4-G.eg_t3, t5-t4);
+    }
+    return 1;
+}
+
+/* Synchronous form (shared expert, harness): issue + take in one call. */
+int coli_vk_expert_group(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
+                         ColiVkTensor *const *downs, const int *rows, int count,
+                         float *y, const float *x) {
+    if (G.eg_inflight) return 0;
+    if (!eg_prepare_submit(gates, ups, downs, rows, count, x)) return 0;
+    return coli_vk_expert_group_take(y);
 }
 
 /* ---- MLA absorb attention core -------------------------------------------------
@@ -798,6 +838,7 @@ void coli_vk_shutdown(void) {
     coli_vk_kv_reset();
     if (G.eg_pool) vkDestroyDescriptorPool(G.dev, G.eg_pool, NULL);
     vkDestroyFence(G.dev, G.fence, NULL);
+    vkDestroyFence(G.dev, G.eg_fence, NULL);
     vkDestroyCommandPool(G.dev, G.cpool, NULL);
     vkDestroyDescriptorPool(G.dev, G.dpool, NULL);
     vkDestroyPipeline(G.dev, G.pipe, NULL);
@@ -1056,16 +1097,28 @@ static int run_expert_group(int fmt, int D, int I, int K) {
     }
     double maxrel = 0;
     for (int i = 0; i < K*D; i++) { double e = fabs(yg[i]-yc[i]); if (fabs(yc[i])>1e-2) { double r = e/fabs(yc[i]); if (r>maxrel) maxrel = r; } }
-    coli_vk_expert_group(tg, tu, td, rows, K, yg, x);   /* warm + leaves G.cmd recorded */
+    coli_vk_expert_group(tg, tu, td, rows, K, yg, x);   /* warm + leaves G.eg_cmd recorded */
+    /* async issue/take must reproduce the sync result exactly (same buffers/records) */
+    {
+        float *ya = malloc((size_t)K*D*4);
+        if (!coli_vk_expert_group_issue(tg, tu, td, rows, K, x) || !coli_vk_expert_group_take(ya)) {
+            printf("expert_group issue/take failed\n"); maxrel = 1;
+        } else {
+            double amr = 0;
+            for (int i = 0; i < K*D; i++) { double e = fabs(ya[i]-yg[i]); if (fabs(yg[i])>1e-2) { double r = e/fabs(yg[i]); if (r>amr) amr = r; } }
+            if (amr > 1e-6) { printf("issue/take deviates from sync: %.4g\n", amr); maxrel = 1; }
+        }
+        free(ya);
+    }
     int iters = 20; double t0 = now();
     for (int k = 0; k < iters; k++) coli_vk_expert_group(tg, tu, td, rows, K, yg, x);
     double ms = (now()-t0)*1000.0/iters/K;
     /* GPU-only: re-submit the already-recorded command buffer (skips per-call host setup:
      * descriptor updates + recording), isolating raw GPU throughput. */
-    VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.cmd};
-    for (int w = 0; w < 2; w++) { vkResetFences(G.dev,1,&G.fence); vkQueueSubmit(G.queue,1,&si,G.fence); vkWaitForFences(G.dev,1,&G.fence,VK_TRUE,10000000000ULL); }
+    VkSubmitInfo si = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO, .commandBufferCount = 1, .pCommandBuffers = &G.eg_cmd};
+    for (int w = 0; w < 2; w++) { vkResetFences(G.dev,1,&G.eg_fence); vkQueueSubmit(G.queue,1,&si,G.eg_fence); vkWaitForFences(G.dev,1,&G.eg_fence,VK_TRUE,10000000000ULL); }
     double g0 = now();
-    for (int k = 0; k < iters; k++) { vkResetFences(G.dev,1,&G.fence); vkQueueSubmit(G.queue,1,&si,G.fence); vkWaitForFences(G.dev,1,&G.fence,VK_TRUE,10000000000ULL); }
+    for (int k = 0; k < iters; k++) { vkResetFences(G.dev,1,&G.eg_fence); vkQueueSubmit(G.queue,1,&si,G.eg_fence); vkWaitForFences(G.dev,1,&G.eg_fence,VK_TRUE,10000000000ULL); }
     double gpums = (now()-g0)*1000.0/iters/K;
     printf("FULL VK expert_group fmt=%d %2d experts | maxrel=%.4g | per-call %.4f  GPU-only %.4f ms/expert (ROCm 0.179)\n",
            fmt, K, maxrel, ms, gpums);

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -1325,33 +1325,37 @@ int main(int argc, char **argv) {
     bad |= run_expert_group(2, 6144, 2048, 1);
     bad |= run_expert_group(2, 6144, 2048, 8);
     bad |= run_expert_group(2, 6144, 2048, 32);
-    /* int3-g64 expert group: correctness + the 0.86x-bytes throughput question */
+    /* int3-g64 expert group: correctness + the 0.86x-bytes throughput question.
+     * count=1 included — it is the SHARED-expert path shape in the engine. */
+    bad |= run_expert_group(5, 6144, 2048, 1);
     bad |= run_expert_group(5, 6144, 2048, 8);
     bad |= run_expert_group(5, 6144, 2048, 32);
-    /* Fused same-input matmul pair (the q_a + kv_a prologue pattern). */
-    {
+    /* Fused same-input matmul pair (the q_a + kv_a prologue pattern), int4 AND int3. */
+    for (int pi = 0; pi < 2; pi++) {
+        int pf = pi == 0 ? 2 : 5;
         int I = 6144, O1 = 2048, O2 = 576, S = 1;
-        size_t rb = (size_t)(I + 1) / 2;
+        size_t rb = ref_rowbytes(pf, I);
+        size_t n1 = ref_scales(pf, I, O1), n2 = ref_scales(pf, I, O2);
         uint8_t *w1 = malloc(rb * O1), *w2 = malloc(rb * O2);
-        float *s1 = malloc((size_t)O1 * 4), *s2 = malloc((size_t)O2 * 4), *x = malloc((size_t)I * 4);
+        float *s1 = malloc(n1 * 4), *s2 = malloc(n2 * 4), *x = malloc((size_t)I * 4);
         float *y1 = malloc((size_t)O1 * 4), *y2 = malloc((size_t)O2 * 4);
         float *c1 = malloc((size_t)O1 * 4), *c2 = malloc((size_t)O2 * 4);
         for (size_t i = 0; i < rb * (size_t)O1; i++) w1[i] = rand() & 0xff;
         for (size_t i = 0; i < rb * (size_t)O2; i++) w2[i] = rand() & 0xff;
-        for (int o = 0; o < O1; o++) s1[o] = 0.01f + (rand() % 100) / 10000.0f;
-        for (int o = 0; o < O2; o++) s2[o] = 0.01f + (rand() % 100) / 10000.0f;
+        for (size_t o = 0; o < n1; o++) s1[o] = 0.01f + (rand() % 100) / 10000.0f;
+        for (size_t o = 0; o < n2; o++) s2[o] = 0.01f + (rand() % 100) / 10000.0f;
         for (int i = 0; i < I; i++) x[i] = (rand() % 200 - 100) / 100.0f;
         ColiVkTensor *t1 = NULL, *t2 = NULL;
-        if (!coli_vk_matmul_pair(&t1, y1, w1, s1, O1, &t2, y2, w2, s2, O2, 2, x, S, I)) {
-            printf("matmul_pair failed\n"); bad = 1;
+        if (!coli_vk_matmul_pair(&t1, y1, w1, s1, O1, &t2, y2, w2, s2, O2, pf, x, S, I)) {
+            printf("matmul_pair fmt=%d failed\n", pf); bad = 1;
         } else {
-            cpu_ref(c1, x, w1, s1, 2, S, I, O1); cpu_ref(c2, x, w2, s2, 2, S, I, O2);
+            cpu_ref(c1, x, w1, s1, pf, S, I, O1); cpu_ref(c2, x, w2, s2, pf, S, I, O2);
             double mr = 0;
             for (int i = 0; i < O1; i++) { double e = fabs(y1[i]-c1[i]); if (fabs(c1[i])>1e-2) { double r=e/fabs(c1[i]); if (r>mr) mr=r; } }
             for (int i = 0; i < O2; i++) { double e = fabs(y2[i]-c2[i]); if (fabs(c2[i])>1e-2) { double r=e/fabs(c2[i]); if (r>mr) mr=r; } }
             double t0 = now();
-            for (int k = 0; k < 30; k++) coli_vk_matmul_pair(&t1, y1, w1, s1, O1, &t2, y2, w2, s2, O2, 2, x, S, I);
-            printf("matmul_pair 6144->(2048,576)          | maxrel=%.4g | %.3f ms/pair-call\n", mr, (now()-t0)*1000/30);
+            for (int k = 0; k < 30; k++) coli_vk_matmul_pair(&t1, y1, w1, s1, O1, &t2, y2, w2, s2, O2, pf, x, S, I);
+            printf("matmul_pair fmt=%d 6144->(2048,576)   | maxrel=%.4g | %.3f ms/pair-call\n", pf, mr, (now()-t0)*1000/30);
             bad |= mr > 1e-3;
         }
         coli_vk_tensor_free(t1); coli_vk_tensor_free(t2);

--- a/c/backend_vulkan.h
+++ b/c/backend_vulkan.h
@@ -1,0 +1,40 @@
+#ifndef COLIBRI_BACKEND_VULKAN_H
+#define COLIBRI_BACKEND_VULKAN_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque persistent device copy of one resident quantized tensor,
+ * mirroring backend_cuda.h. On Strix Halo the "upload" writes into
+ * HOST_VISIBLE|DEVICE_LOCAL memory — same physical RAM the iGPU reads,
+ * so there is no PCIe copy, unlike the discrete-CUDA path. */
+typedef struct ColiVkTensor ColiVkTensor;
+
+/* Bring up instance/device/queue/pipeline. Returns 1 on success.
+ * spv_path points at the compiled qmatmul.spv. */
+int  coli_vk_init(const char *spv_path);
+void coli_vk_shutdown(void);
+int  coli_vk_available(void);
+void coli_vk_mem_info(size_t *used_bytes, size_t *tensor_count);
+
+/* y[S,O] = (x[S,I] @ dequant(W[O,I])^T) * scale[O].
+ * fmt matches QT in glm.c: 1=int8, 2=int4. (0=f32,3=int2 fall back to CPU.)
+ * First call uploads W+scales; later calls reuse the resident copy.
+ * Returns 1 on success, 0 if unavailable / unsupported fmt. */
+int  coli_vk_matmul(ColiVkTensor **tensor,
+                    float *y, const float *x,
+                    const void *weights, const float *scales,
+                    int fmt, int S, int I, int O);
+
+void   coli_vk_tensor_free(ColiVkTensor *t);
+size_t coli_vk_tensor_bytes(const ColiVkTensor *t);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/c/backend_vulkan.h
+++ b/c/backend_vulkan.h
@@ -65,6 +65,12 @@ void coli_vk_kv_reset(void);
 int  coli_vk_attention_absorb(ColiVkTensor **kvb, const void *w, const float *sc, int fmt,
                               float *ctx, const float *q, int layer, int S, int H,
                               int Q, int R, int V, int K, int st0, int T, float scale);
+/* Two resident matmuls sharing one input x in ONE submit (q_a + kv_a prologue pair).
+ * Returns 0 -> caller falls back to single-matmul calls. */
+int  coli_vk_matmul_pair(ColiVkTensor **t1p, float *y1, const void *w1, const float *s1, int O1,
+                         ColiVkTensor **t2p, float *y2, const void *w2, const float *s2, int O2,
+                         int fmt, const float *x, int S, int I);
+
 /* Fused variant: absorb + resident o-projection ([Dout, H*V]) in one submit; ctx stays
  * on-device, only out [S,Dout] is read back. Falls back like absorb (returns 0). */
 int  coli_vk_attention_absorb_project(ColiVkTensor **kvb, const void *w, const float *sc, int fmt,

--- a/c/backend_vulkan.h
+++ b/c/backend_vulkan.h
@@ -30,6 +30,16 @@ int  coli_vk_matmul(ColiVkTensor **tensor,
                     const void *weights, const float *scales,
                     int fmt, int S, int I, int O);
 
+/* Fused first half of the expert MLP in ONE dispatch (VK equivalent of
+ * grouped_hidden_w4_dual): hidden[s,o] = silu(gate(x)) * up(x), reading x once for both
+ * projections. D = input (hidden) dim, I = moe_inter. gate/up upload on first call.
+ * Returns 0 if unavailable (no gate_up shader) / unsupported fmt so the caller falls back. */
+int  coli_vk_gate_up(ColiVkTensor **gate, ColiVkTensor **up,
+                     float *hidden, const float *x,
+                     const void *gw, const float *gs,
+                     const void *uw, const float *us,
+                     int fmt, int S, int D, int I);
+
 void   coli_vk_tensor_free(ColiVkTensor *t);
 size_t coli_vk_tensor_bytes(const ColiVkTensor *t);
 

--- a/c/backend_vulkan.h
+++ b/c/backend_vulkan.h
@@ -48,6 +48,10 @@ int  coli_vk_expert_group(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
                           ColiVkTensor *const *downs, const int *rows, int count,
                           float *y, const float *x);
 
+/* Upload a resident tensor without computing (expert tier: gate/up/down uploaded once,
+ * then driven by coli_vk_expert_group). Returns 0 on failure/unsupported fmt. */
+int  coli_vk_tensor_ensure(ColiVkTensor **tensor, const void *weights, const float *scales, int fmt, int I, int O);
+
 void   coli_vk_tensor_free(ColiVkTensor *t);
 size_t coli_vk_tensor_bytes(const ColiVkTensor *t);
 

--- a/c/backend_vulkan.h
+++ b/c/backend_vulkan.h
@@ -47,6 +47,13 @@ int  coli_vk_gate_up(ColiVkTensor **gate, ColiVkTensor **up,
 int  coli_vk_expert_group(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
                           ColiVkTensor *const *downs, const int *rows, int count,
                           float *y, const float *x);
+/* Async form: _issue submits the group and returns immediately (one in flight max);
+ * the caller computes its CPU share, then _take joins and reads back the packed y.
+ * Both return 0 on failure (caller computes those experts on the CPU instead). */
+int  coli_vk_expert_group_issue(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
+                                ColiVkTensor *const *downs, const int *rows, int count,
+                                const float *x);
+int  coli_vk_expert_group_take(float *y);
 
 /* Upload a resident tensor without computing (expert tier: gate/up/down uploaded once,
  * then driven by coli_vk_expert_group). Returns 0 on failure/unsupported fmt. */

--- a/c/backend_vulkan.h
+++ b/c/backend_vulkan.h
@@ -40,6 +40,14 @@ int  coli_vk_gate_up(ColiVkTensor **gate, ColiVkTensor **up,
                      const void *uw, const float *us,
                      int fmt, int S, int D, int I);
 
+/* Full batched expert MLP for `count` experts in ONE submit, hidden staying on-device:
+ * for each c, y_c = down_c(silu(gate_c(x_c)) * up_c(x_c)). x/y packed [sum(rows)*D];
+ * experts are resident (gate/up: D->I, down: I->D). Mirrors coli_cuda_expert_group.
+ * Returns 0 -> caller falls back to CPU. */
+int  coli_vk_expert_group(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
+                          ColiVkTensor *const *downs, const int *rows, int count,
+                          float *y, const float *x);
+
 void   coli_vk_tensor_free(ColiVkTensor *t);
 size_t coli_vk_tensor_bytes(const ColiVkTensor *t);
 

--- a/c/backend_vulkan.h
+++ b/c/backend_vulkan.h
@@ -21,6 +21,16 @@ void coli_vk_shutdown(void);
 int  coli_vk_available(void);
 void coli_vk_mem_info(size_t *used_bytes, size_t *tensor_count);
 
+/* VRAM pressure-proofing (both no-ops when the extension is absent):
+ * alloc_priority sets the eviction-priority class of SUBSEQUENT weight uploads
+ * (VK_EXT_memory_priority; scratches and the KV mirror pin themselves at 1.0) —
+ * the engine brackets the bulk expert-tier fill at 0.4 so an oversubscribed heap
+ * evicts cold experts, never the per-token attention working set.
+ * mem_budget reports device-local usage/budget in GB (VK_EXT_memory_budget);
+ * returns 0 if unavailable. */
+void coli_vk_alloc_priority(float p);
+int  coli_vk_mem_budget(double *used_gb, double *budget_gb);
+
 /* y[S,O] = (x[S,I] @ dequant(W[O,I])^T) * scale[O].
  * fmt matches QT in glm.c: 1=int8, 2=int4. (0=f32,3=int2 fall back to CPU.)
  * First call uploads W+scales; later calls reuse the resident copy.

--- a/c/backend_vulkan.h
+++ b/c/backend_vulkan.h
@@ -65,6 +65,12 @@ void coli_vk_kv_reset(void);
 int  coli_vk_attention_absorb(ColiVkTensor **kvb, const void *w, const float *sc, int fmt,
                               float *ctx, const float *q, int layer, int S, int H,
                               int Q, int R, int V, int K, int st0, int T, float scale);
+/* Fused variant: absorb + resident o-projection ([Dout, H*V]) in one submit; ctx stays
+ * on-device, only out [S,Dout] is read back. Falls back like absorb (returns 0). */
+int  coli_vk_attention_absorb_project(ColiVkTensor **kvb, const void *w, const float *sc, int fmt,
+                              ColiVkTensor **ot, const void *ow, const float *osc, int ofmt,
+                              float *out, const float *q, int layer, int S, int H,
+                              int Q, int R, int V, int K, int st0, int T, float scale, int Dout);
 
 void   coli_vk_tensor_free(ColiVkTensor *t);
 size_t coli_vk_tensor_bytes(const ColiVkTensor *t);

--- a/c/backend_vulkan.h
+++ b/c/backend_vulkan.h
@@ -52,6 +52,20 @@ int  coli_vk_expert_group(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
  * then driven by coli_vk_expert_group). Returns 0 on failure/unsupported fmt. */
 int  coli_vk_tensor_ensure(ColiVkTensor **tensor, const void *weights, const float *scales, int fmt, int I, int O);
 
+/* MLA absorb attention core (decode). The KV latent/rope caches live in persistent
+ * per-layer device buffers: _ensure allocates a layer's cache at max_rows (once; resize
+ * via _reset), _row mirrors one host row (absolute position), _reset drops all layers.
+ * The caller keeps a valid-watermark and re-mirrors rows after any invalidation.
+ * absorb runs S causal query rows over cache rows [st0, T) in one submit:
+ * q [S,H*(Q+R)] roped, kv_b [H*(Q+V), K] uploads once (fmt 1=int8/2=int4),
+ * ctx out [S,H*V]. Returns 0 -> caller falls back to CPU. */
+int  coli_vk_kv_ensure(int layer, int max_rows, int K, int Rd);
+int  coli_vk_kv_row(int layer, int pos, const float *L, const float *R);
+void coli_vk_kv_reset(void);
+int  coli_vk_attention_absorb(ColiVkTensor **kvb, const void *w, const float *sc, int fmt,
+                              float *ctx, const float *q, int layer, int S, int H,
+                              int Q, int R, int V, int K, int st0, int T, float scale);
+
 void   coli_vk_tensor_free(ColiVkTensor *t);
 size_t coli_vk_tensor_bytes(const ColiVkTensor *t);
 

--- a/c/backend_vulkan.h
+++ b/c/backend_vulkan.h
@@ -84,6 +84,16 @@ int  coli_vk_attention_absorb(ColiVkTensor **kvb, const void *w, const float *sc
                               int Q, int R, int V, int K, int st0, int T, float scale);
 /* Two resident matmuls sharing one input x in ONE submit (q_a + kv_a prologue pair).
  * Returns 0 -> caller falls back to single-matmul calls. */
+/* q-prep chain: [q_a+kv_a pair] -> rmsnorm(q latent) -> q_b in ONE submit (needs
+ * rmsnorm.spv next to the main shader; returns 0 without it -> 3-submit path).
+ * lnw = the q-latent RMS-norm weights [Oqa], resident per layer after first call. */
+int  coli_vk_attn_qprep(int layer,
+                        ColiVkTensor **qa,  const void *wqa,  const float *sqa,  int Oqa,
+                        ColiVkTensor **kva, const void *wkva, const float *skva, int Okva,
+                        ColiVkTensor **qb,  const void *wqb,  const float *sqb,  int Oqb,
+                        int fmt, int grp, const float *lnw, float eps,
+                        const float *x, int S, int I, float *q_out, float *kv_out,
+                        float *lat_out /* normed q latent [S,Oqa], NULLable — DSA indexer input */);
 int  coli_vk_matmul_pair(ColiVkTensor **t1p, float *y1, const void *w1, const float *s1, int O1,
                          ColiVkTensor **t2p, float *y2, const void *w2, const float *s2, int O2,
                          int fmt, const float *x, int S, int I, int grp);

--- a/c/backend_vulkan.h
+++ b/c/backend_vulkan.h
@@ -38,7 +38,7 @@ int  coli_vk_mem_budget(double *used_gb, double *budget_gb);
 int  coli_vk_matmul(ColiVkTensor **tensor,
                     float *y, const float *x,
                     const void *weights, const float *scales,
-                    int fmt, int S, int I, int O);
+                    int fmt, int S, int I, int O, int gs);
 
 /* Fused first half of the expert MLP in ONE dispatch (VK equivalent of
  * grouped_hidden_w4_dual): hidden[s,o] = silu(gate(x)) * up(x), reading x once for both
@@ -48,7 +48,7 @@ int  coli_vk_gate_up(ColiVkTensor **gate, ColiVkTensor **up,
                      float *hidden, const float *x,
                      const void *gw, const float *gs,
                      const void *uw, const float *us,
-                     int fmt, int S, int D, int I);
+                     int fmt, int S, int D, int I, int grp);
 
 /* Full batched expert MLP for `count` experts in ONE submit, hidden staying on-device:
  * for each c, y_c = down_c(silu(gate_c(x_c)) * up_c(x_c)). x/y packed [sum(rows)*D];
@@ -67,7 +67,7 @@ int  coli_vk_expert_group_take(float *y);
 
 /* Upload a resident tensor without computing (expert tier: gate/up/down uploaded once,
  * then driven by coli_vk_expert_group). Returns 0 on failure/unsupported fmt. */
-int  coli_vk_tensor_ensure(ColiVkTensor **tensor, const void *weights, const float *scales, int fmt, int I, int O);
+int  coli_vk_tensor_ensure(ColiVkTensor **tensor, const void *weights, const float *scales, int fmt, int I, int O, int grp);
 
 /* MLA absorb attention core (decode). The KV latent/rope caches live in persistent
  * per-layer device buffers: _ensure allocates a layer's cache at max_rows (once; resize
@@ -79,19 +79,19 @@ int  coli_vk_tensor_ensure(ColiVkTensor **tensor, const void *weights, const flo
 int  coli_vk_kv_ensure(int layer, int max_rows, int K, int Rd);
 int  coli_vk_kv_row(int layer, int pos, const float *L, const float *R);
 void coli_vk_kv_reset(void);
-int  coli_vk_attention_absorb(ColiVkTensor **kvb, const void *w, const float *sc, int fmt,
+int  coli_vk_attention_absorb(ColiVkTensor **kvb, const void *w, const float *sc, int fmt, int grp,
                               float *ctx, const float *q, int layer, int S, int H,
                               int Q, int R, int V, int K, int st0, int T, float scale);
 /* Two resident matmuls sharing one input x in ONE submit (q_a + kv_a prologue pair).
  * Returns 0 -> caller falls back to single-matmul calls. */
 int  coli_vk_matmul_pair(ColiVkTensor **t1p, float *y1, const void *w1, const float *s1, int O1,
                          ColiVkTensor **t2p, float *y2, const void *w2, const float *s2, int O2,
-                         int fmt, const float *x, int S, int I);
+                         int fmt, const float *x, int S, int I, int grp);
 
 /* Fused variant: absorb + resident o-projection ([Dout, H*V]) in one submit; ctx stays
  * on-device, only out [S,Dout] is read back. Falls back like absorb (returns 0). */
-int  coli_vk_attention_absorb_project(ColiVkTensor **kvb, const void *w, const float *sc, int fmt,
-                              ColiVkTensor **ot, const void *ow, const float *osc, int ofmt,
+int  coli_vk_attention_absorb_project(ColiVkTensor **kvb, const void *w, const float *sc, int fmt, int grp,
+                              ColiVkTensor **ot, const void *ow, const float *osc, int ofmt, int ogrp,
                               float *out, const float *q, int layer, int S, int H,
                               int Q, int R, int V, int K, int st0, int T, float scale, int Dout);
 

--- a/c/backend_vulkan.h
+++ b/c/backend_vulkan.h
@@ -69,6 +69,25 @@ int  coli_vk_expert_group_take(float *y);
  * then driven by coli_vk_expert_group). Returns 0 on failure/unsupported fmt. */
 int  coli_vk_tensor_ensure(ColiVkTensor **tensor, const void *weights, const float *scales, int fmt, int I, int O, int grp);
 
+/* SECOND DEVICE (COLI_VK_DEV2): a self-contained context on another Vulkan GPU that
+ * hosts ONLY tier experts and runs ONLY the async expert-group path. devidx: -1 =
+ * auto (best real GPU that is not device 0), >=0 = enumeration index (the same
+ * physical device is allowed with a warning — pre-hardware test mode). Its group
+ * may be in flight simultaneously with device 0's. Tensors remember their device
+ * (coli_vk_tensor_dev); free/bytes work on either. */
+int  coli_vk_init_dev2(const char *spv_path, int devidx);
+int  coli_vk_dev2_available(void);
+int  coli_vk_tensor_dev(const ColiVkTensor *t);
+int  coli_vk_mem_budget2(double *used_gb, double *budget_gb);
+int  coli_vk_tensor_ensure2(ColiVkTensor **tensor, const void *weights, const float *scales, int fmt, int I, int O, int grp);
+int  coli_vk_expert_group_issue2(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
+                                 ColiVkTensor *const *downs, const int *rows, int count,
+                                 const float *x);
+int  coli_vk_expert_group_take2(float *y);
+int  coli_vk_expert_group2(ColiVkTensor *const *gates, ColiVkTensor *const *ups,
+                           ColiVkTensor *const *downs, const int *rows, int count,
+                           float *y, const float *x);
+
 /* MLA absorb attention core (decode). The KV latent/rope caches live in persistent
  * per-layer device buffers: _ensure allocates a layer's cache at max_rows (once; resize
  * via _reset), _row mirrors one host row (absolute position), _reset drops all layers.

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -2130,6 +2130,16 @@ static void pipe_dispatch(Model *m,int layer,const int *eids,int njobs){
     atomic_store_explicit(&g_pp.cur,(g<<8),memory_order_release);                          /* PUBLISH */
     pthread_mutex_lock(&g_pp.mx); pthread_cond_broadcast(&g_pp.cv); pthread_mutex_unlock(&g_pp.mx);
 }
+/* Non-blocking probe of a pipe slot's load-done flag — an ORDERING hint only (the
+ * VK block computes ready experts first): callers still pipe_wait() before touching
+ * the slab. Under URING completion happens inside finalize, there is no flag to
+ * peek — report not-ready and let the wait do the work. */
+static inline int pipe_ready(int q){
+#ifdef __linux__
+    if(g_uring) return 0;
+#endif
+    return atomic_load_explicit(&g_pp.ready[q],memory_order_acquire)!=0;
+}
 static inline void pipe_wait(int q){
 #ifdef __linux__
     if(g_uring){
@@ -3664,20 +3674,40 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                 }
             }
             int vk_issued = nvk>0 && coli_vk_expert_group_issue(vg,vu,vd,vrows,nvk,vk_xh);
-            double t_cpu0=now_s();
-            for(int c2=0;c2<ncpu;c2++){ ESlot *e=ce[c2]; int nr=cnr[c2];
-                if(g_pipe && cqof[c2]>=0){ double tw=now_s(); pipe_wait(cqof[c2]); m->t_ewait += now_s()-tw; }
-                if(!e->slab) expert_load(m,layer,e->eid,e,1,1);   /* demand=1: moe miss path (FASE A snapshot valid) */
-                for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)crmap[c2*S+r]*D, D*sizeof(float));
-                expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
-                for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
-                matmul_qt(hh, gg, &e->d, nr);
-                for(int r=0;r<nr;r++){ float *os=out+(int64_t)crmap[c2*S+r]*D, wgt=cwmap[c2*S+r], *hr=hh+(int64_t)r*D;
-                    for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
-                if(g_prof){ m->cpu_expert_bytes+=qt_bytes(&e->g)+qt_bytes(&e->u)+qt_bytes(&e->d);
-                    m->cpu_expert_rows+=(uint64_t)nr; }
+            /* CPU share stays SERIAL over experts with row-parallel kernels: a decode
+             * block leaves only ~5-6 CPU experts (the tier absorbs the hot head), fewer
+             * than the OMP pool, so one-task-per-expert ran each expert single-threaded
+             * at ~2.5 GB/s while cores idled — measured -23% vs this structure (A/B
+             * 2026-07-20); the kernels' internal parallel-for already uses every core.
+             * What IS reordered: pipe-ready and cache-resident experts run FIRST, so a
+             * still-loading expert gets its I/O hidden behind their matmuls instead of
+             * head-of-line blocking the block. The class is an ordering HINT only —
+             * the body still pipe_waits/loads every entry, so a stale probe costs
+             * nothing but order. t_ecpu counts kernel time only (the default path's
+             * meaning); the waits land in t_ewait. */
+            {
+                uint8_t vcls[64];
+                for(int c2=0;c2<ncpu;c2++){
+                    if(g_pipe && cqof[c2]>=0) vcls[c2] = pipe_ready(cqof[c2]) ? 0 : 2;   /* loaded : in flight */
+                    else                      vcls[c2] = ce[c2]->slab       ? 0 : 1;   /* resident : sync miss */
+                }
+                int vord[64], no=0;
+                for(uint8_t k2=0;k2<3;k2++) for(int c2=0;c2<ncpu;c2++) if(vcls[c2]==k2) vord[no++]=c2;
+                for(int oi=0;oi<no;oi++){ int c2=vord[oi]; ESlot *e=ce[c2]; int nr=cnr[c2];
+                    if(g_pipe && cqof[c2]>=0){ double tw=now_s(); pipe_wait(cqof[c2]); m->t_ewait += now_s()-tw; }
+                    if(!e->slab) expert_load(m,layer,e->eid,e,1,1);   /* demand=1: moe miss path (FASE A snapshot valid) */
+                    for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)crmap[c2*S+r]*D, D*sizeof(float));
+                    double te0=now_s();
+                    expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
+                    for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
+                    matmul_qt(hh, gg, &e->d, nr);
+                    for(int r=0;r<nr;r++){ float *os=out+(int64_t)crmap[c2*S+r]*D, wgt=cwmap[c2*S+r], *hr=hh+(int64_t)r*D;
+                        for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
+                    if(g_prof){ m->t_ecpu+=now_s()-te0;
+                        m->cpu_expert_bytes+=qt_bytes(&e->g)+qt_bytes(&e->u)+qt_bytes(&e->d);
+                        m->cpu_expert_rows+=(uint64_t)nr; }
+                }
             }
-            if(g_prof) m->t_ecpu+=now_s()-t_cpu0;
             double t_take0=now_s();
             int vk_ok = vk_issued && coli_vk_expert_group_take(vk_yh);
             if(g_prof) m->t_egpu+=now_s()-t_take0;

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -315,6 +315,30 @@ static int g_vk_dense;        /* COLI_VK_DENSE=1: run the resident dense matmuls
                                * projections + shared expert) on Vulkan too */
 static int g_vk_budget2;      /* COLI_VK_EXPERTS2: dev2 expert-tier cap (with COLI_VK_DEV2) */
 static int g_vk_reg_n2;       /* experts resident on the dev2 tier */
+/* Resolve the main shader path (#523): COLI_VK_SHADERS may be the qmatmul.spv file itself
+ * OR a directory containing it; unset, look alongside the binary (<exedir>/shaders/, the
+ * build layout) before the historical CWD-relative fallback, so launching from outside c/
+ * works. The other shaders load as siblings of the returned path (backend derive_*). */
+static const char *vk_resolve_spv(char *buf, size_t n){
+    const char *env = getenv("COLI_VK_SHADERS");
+    struct stat st;
+    if(env && *env){
+        if(!stat(env,&st) && S_ISDIR(st.st_mode)){ snprintf(buf,n,"%s/qmatmul.spv",env); return buf; }
+        return env;
+    }
+#ifdef __linux__
+    ssize_t k = readlink("/proc/self/exe", buf, n-1);
+    if(k > 0){
+        buf[k] = 0;
+        char *sl = strrchr(buf, '/');
+        if(sl && (size_t)(sl+1-buf) + sizeof("shaders/qmatmul.spv") <= n){
+            strcpy(sl+1, "shaders/qmatmul.spv");
+            if(!stat(buf,&st)) return buf;
+        }
+    }
+#endif
+    return "shaders/qmatmul.spv";
+}
 /* PROF anatomy of the VK expert block (master-thread accumulated in moe(), printed by
  * profile_print): where a decode block's wall goes besides t_ecpu/t_ewait/t_egpu. */
 static double g_vkb_cls, g_vkb_issue, g_vkb_acc, g_vkb_wrk, g_vkb_join;
@@ -7777,9 +7801,11 @@ int main(int argc, char **argv){
 #endif
 #ifdef COLI_VULKAN
     if(getenv("COLI_VULKAN") && atoi(getenv("COLI_VULKAN"))){
-        const char *spv = getenv("COLI_VK_SHADERS"); if(!spv) spv = "shaders/qmatmul.spv";
+        char spvbuf[512]; const char *spv = vk_resolve_spv(spvbuf, sizeof(spvbuf));
         g_vulkan = coli_vk_init(spv);
-        if(!g_vulkan){ fprintf(stderr,"[VK] Vulkan backend unavailable (need libvulkan + shaders/qmatmul{,_gate_up}.spv)\n"); return 2; }
+        if(!g_vulkan){ fprintf(stderr,"[VK] Vulkan backend unavailable (tried %s; need libvulkan + "
+                               "the compiled shaders — point COLI_VK_SHADERS at the shader directory "
+                               "or the qmatmul.spv file, or run `make VK=1` to build them)\n", spv); return 2; }
         /* 320 = sweep optimum on a 16 GB card (256-384 measured flat, 320 best median;
          * ~6 GB tier + ~8 GB dense leaves headroom for the long-context KV mirror). */
         g_vk_budget = getenv("COLI_VK_EXPERTS") ? atoi(getenv("COLI_VK_EXPERTS")) : 320;

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -6575,7 +6575,18 @@ static void vk_registry_fill(Model *m){
     if(!g_vk_reg){ free(cand); return; }
     ESlot tmp; memset(&tmp,0,sizeof(tmp)); tmp.eid=-1;
     double t0=now_s(); int64_t bytes=0; int tried=0, loadfail=0;
+    /* Pressure-proofing: tier weights are the EVICTABLE class (0.4 vs scratch/KV 1.0,
+     * dense 0.75) so an oversubscribed heap sheds cold experts instead of thrashing
+     * the per-token attention submits; and the fill STOPS while the device-local
+     * budget still holds COLI_VK_RESERVE_GB (default 3) for the lazily-allocated
+     * dense weights + KV mirror + staging (measured ~1.7 GB at 4k ctx, growing with
+     * max_t). Without the budget extension the count cap alone applies, as before. */
+    double vkr_reserve = getenv("COLI_VK_RESERVE_GB")?atof(getenv("COLI_VK_RESERVE_GB")):3.0;
+    int vkr_stopped=0; double vkr_used=0, vkr_budget=0;
+    coli_vk_alloc_priority(0.4f);
     for(int64_t i2=0;i2<n && g_vk_reg_n<g_vk_budget;i2++){
+        if(vkr_reserve>0 && (g_vk_reg_n&7)==0 && coli_vk_mem_budget(&vkr_used,&vkr_budget)
+           && vkr_budget-vkr_used < vkr_reserve){ vkr_stopped=1; break; }
         int layer=cand[i2].layer, eid=cand[i2].eid; tried++;
         ESlot *src=NULL, *P=m->pin[layer];
         for(int z=0;z<m->npin[layer];z++) if(P[z].eid==eid && P[z].slab){ src=&P[z]; break; }
@@ -6601,10 +6612,14 @@ static void vk_registry_fill(Model *m){
         bytes+=coli_vk_tensor_bytes(slot[0])+coli_vk_tensor_bytes(slot[1])+coli_vk_tensor_bytes(slot[2]);
         g_vk_reg_n++;
     }
+    coli_vk_alloc_priority(0.75f);               /* back to the dense/default class */
     if(tmp.slab){ compat_aligned_free(tmp.slab); free(tmp.fslab); }
     free(cand);
     fprintf(stderr,"[VK] expert tier: %d hot experts resident (%.2f GB VRAM, %.1fs, top-%d of history)\n",
             g_vk_reg_n,bytes/1e9,now_s()-t0,tried);
+    if(vkr_stopped)
+        fprintf(stderr,"[VK] expert tier: budget stop at %d experts — %.1f of %.1f GB device-local used, %.1f GB reserved (COLI_VK_RESERVE_GB)\n",
+                g_vk_reg_n,vkr_used,vkr_budget,vkr_reserve);
 }
 #endif
 

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -3631,7 +3631,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
             }
         }
 #ifdef COLI_VULKAN
-        /* Vulkan expert tier (COLI_VULKAN=1): upload routed int4 experts to the GPU once
+        /* Vulkan expert tier (COLI_VULKAN=1): upload routed int4/int3-g64 experts to the GPU once
          * (capped by COLI_VK_EXPERTS), then compute the resident ones as one batched
          * coli_vk_expert_group (fused gate+up+silu -> down, on-device); the rest + misses
          * fall back to the CPU below. Decode-only (S<=4). Measured ~35% faster than ROCm. */
@@ -7398,7 +7398,7 @@ int main(int argc, char **argv){
         g_vk_budget = getenv("COLI_VK_EXPERTS") ? atoi(getenv("COLI_VK_EXPERTS")) : 320;
         g_vk_dense = getenv("COLI_VK_DENSE") ? atoi(getenv("COLI_VK_DENSE")) : 0;
         g_vk_attn = getenv("COLI_VK_ATTN") ? atoi(getenv("COLI_VK_ATTN")) : 0;
-        fprintf(stderr,"[VK] expert tier active: routed int4 experts on the GPU (budget %d)%s%s\n",
+        fprintf(stderr,"[VK] expert tier active: routed quantized experts on the GPU (budget %d)%s%s\n",
                 g_vk_budget, g_vk_dense ? " + dense projections + shared expert" : "",
                 g_vk_attn ? " + absorb attention core" : "");
     }

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -293,6 +293,8 @@ static uint64_t g_last_repin;
 static int g_vulkan;          /* COLI_VULKAN=1: compute routed experts on the Vulkan tier */
 static int g_vk_budget;       /* COLI_VK_EXPERTS: max experts uploaded to VK VRAM (default 1024) */
 static int g_vk_resident;     /* how many experts currently VK-resident */
+static int g_vk_dense;        /* COLI_VK_DENSE=1: run the resident dense matmuls (attention
+                               * projections + shared expert) on Vulkan too */
 #endif
 #ifdef COLI_CUDA
 static int g_cuda_enabled;
@@ -332,6 +334,14 @@ static int g_cuda_e8_ready;   /* codebook published to the devices (see cuda_boo
 static void qt_vk_reset(QT *t){
     if(t->vk){ coli_vk_tensor_free(t->vk); t->vk=NULL; }
     t->vk_eligible=0;
+}
+/* Dense matmul on the Vulkan tier: y[S,O] = x[S,I] @ dequant(t)^T. Uploads the resident
+ * int4/int8 weight once (t->vk), then reuses it. Returns 0 (caller runs the CPU matmul)
+ * when VK-dense is off, the format is unsupported, or upload/compute fails. */
+static int vk_matmul_qt(QT *t, float *y, const float *x, int S){
+    if(!g_vk_dense || (t->fmt!=1 && t->fmt!=2)) return 0;
+    const void *w = t->fmt==1 ? (const void*)t->q8 : (const void*)t->q4;
+    return coli_vk_matmul(&t->vk, y, x, w, t->s, t->fmt, S, t->I, t->O);
 }
 #endif
 #ifdef COLI_CUDA
@@ -2496,10 +2506,19 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
         pipe_done=attn_pipe_prefill(m,l,layer,x,0,S,pos_base,out,NULL);
 #endif
     if(!pipe_done){
+#ifdef COLI_VULKAN
+        if(!vk_matmul_qt(&l->q_a, QR, x, S))
+#endif
         matmul_qt_ex(QR, x, &l->q_a, S, 0);
         for(int s=0;s<S;s++){ float *qr=QR+(int64_t)s*c->q_lora;
             rmsnorm(qr, qr, l->q_a_ln, c->q_lora, c->eps); }         /* q_b legge il residuo NORMATO */
+#ifdef COLI_VULKAN
+        if(!vk_matmul_qt(&l->q_b, Q, QR, S))
+#endif
         matmul_qt_ex(Q, QR, &l->q_b, S, 0);
+#ifdef COLI_VULKAN
+        if(!vk_matmul_qt(&l->kv_a, comp, x, S))
+#endif
         matmul_qt_ex(comp, x, &l->kv_a, S, 0);
     }
     if(!pipe_done) for(int s=0;s<S;s++){
@@ -2783,7 +2802,12 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
         }
         }
         m->t_acore+=now_s()-tac; double tao=now_s();
-        if(!cuda_projected){matmul_qt(out, ctx, &l->o, S);} m->t_aout+=now_s()-tao;
+        if(!cuda_projected){
+#ifdef COLI_VULKAN
+            if(!vk_matmul_qt(&l->o, out, ctx, S))
+#endif
+            matmul_qt(out, ctx, &l->o, S);
+        } m->t_aout+=now_s()-tao;
         free(ctx); free(Q); free(QR); free(comp); free(sc_all);
         m->t_attn += now_s()-ta0;
         return;
@@ -3800,9 +3824,18 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
 #endif
     if(!shared_cuda){
         sg=falloc((int64_t)S*sI);su=falloc((int64_t)S*sI);
+#ifdef COLI_VULKAN
+        if(!vk_matmul_qt(&l->sh_gate, sg, x, S))
+#endif
         matmul_qt(sg, x, &l->sh_gate, S);
+#ifdef COLI_VULKAN
+        if(!vk_matmul_qt(&l->sh_up, su, x, S))
+#endif
         matmul_qt(su, x, &l->sh_up,   S);
         for(int64_t z=0;z<(int64_t)S*sI;z++) sg[z]=siluf(sg[z])*su[z];
+#ifdef COLI_VULKAN
+        if(!vk_matmul_qt(&l->sh_down, hh, sg, S))
+#endif
         matmul_qt(hh, sg, &l->sh_down, S);
     }
     if(shared_cuda!=2) for(int64_t z=0;z<(int64_t)S*D;z++) out[z]+=hh[z];
@@ -7155,7 +7188,9 @@ int main(int argc, char **argv){
         g_vulkan = coli_vk_init(spv);
         if(!g_vulkan){ fprintf(stderr,"[VK] Vulkan backend unavailable (need libvulkan + shaders/qmatmul{,_gate_up}.spv)\n"); return 2; }
         g_vk_budget = getenv("COLI_VK_EXPERTS") ? atoi(getenv("COLI_VK_EXPERTS")) : 1024;
-        fprintf(stderr,"[VK] expert tier active: routed int4 experts on the GPU (budget %d)\n", g_vk_budget);
+        g_vk_dense = getenv("COLI_VK_DENSE") ? atoi(getenv("COLI_VK_DENSE")) : 0;
+        fprintf(stderr,"[VK] expert tier active: routed int4 experts on the GPU (budget %d)%s\n",
+                g_vk_budget, g_vk_dense ? " + dense projections + shared expert" : "");
     }
 #endif
 #ifdef COLI_CUDA

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -7388,7 +7388,9 @@ int main(int argc, char **argv){
         const char *spv = getenv("COLI_VK_SHADERS"); if(!spv) spv = "shaders/qmatmul.spv";
         g_vulkan = coli_vk_init(spv);
         if(!g_vulkan){ fprintf(stderr,"[VK] Vulkan backend unavailable (need libvulkan + shaders/qmatmul{,_gate_up}.spv)\n"); return 2; }
-        g_vk_budget = getenv("COLI_VK_EXPERTS") ? atoi(getenv("COLI_VK_EXPERTS")) : 1024;
+        /* 320 = sweep optimum on a 16 GB card (256-384 measured flat, 320 best median;
+         * ~6 GB tier + ~8 GB dense leaves headroom for the long-context KV mirror). */
+        g_vk_budget = getenv("COLI_VK_EXPERTS") ? atoi(getenv("COLI_VK_EXPERTS")) : 320;
         g_vk_dense = getenv("COLI_VK_DENSE") ? atoi(getenv("COLI_VK_DENSE")) : 0;
         g_vk_attn = getenv("COLI_VK_ATTN") ? atoi(getenv("COLI_VK_ATTN")) : 0;
         fprintf(stderr,"[VK] expert tier active: routed int4 experts on the GPU (budget %d)%s%s\n",

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -313,10 +313,12 @@ static inline int vk_reg_served(int layer,int eid){
 }
 static int g_vk_dense;        /* COLI_VK_DENSE=1: run the resident dense matmuls (attention
                                * projections + shared expert) on Vulkan too */
+static int g_vk_budget2;      /* COLI_VK_EXPERTS2: dev2 expert-tier cap (with COLI_VK_DEV2) */
+static int g_vk_reg_n2;       /* experts resident on the dev2 tier */
 /* PROF anatomy of the VK expert block (master-thread accumulated in moe(), printed by
  * profile_print): where a decode block's wall goes besides t_ecpu/t_ewait/t_egpu. */
 static double g_vkb_cls, g_vkb_issue, g_vkb_acc;
-static int64_t g_vkb_blocks, g_vkb_nvk, g_vkb_ncpu;
+static int64_t g_vkb_blocks, g_vkb_nvk, g_vkb_nvk2, g_vkb_ncpu;
 static int g_vk_attn;         /* COLI_VK_ATTN=1: run the MLA absorb attention core on Vulkan
                                * (mirrors COLI_CUDA_ATTN; KV latent cache mirrored on-device) */
 #endif
@@ -3443,10 +3445,13 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
 #endif
     int vk_active = 0; (void)vk_active;
 #ifdef COLI_VULKAN
-    vk_active = g_vulkan && g_vk_reg_n>0 && !omp_in_parallel() && S<=4;   /* empty registry (tier
-                                                * off / no usage history) = normal CPU expert loop */
+    vk_active = g_vulkan && (g_vk_reg_n+g_vk_reg_n2)>0 && !omp_in_parallel() && S<=4;   /* empty
+                                                * registry (tier off / no usage history) = normal CPU expert loop */
     float *vk_xh = vk_active?falloc((int64_t)S*K*D):NULL;
     float *vk_yh = vk_active?falloc((int64_t)S*K*D):NULL;
+    int vk2_on = vk_active && g_vk_reg_n2>0;    /* dev2 tier live: second async group */
+    float *vk_xh2 = vk2_on?falloc((int64_t)S*K*D):NULL;
+    float *vk_yh2 = vk2_on?falloc((int64_t)S*K*D):NULL;
 #endif
     int shared_on_gpu=0; (void)shared_on_gpu;   /* set by the Metal path when Phase E was fused */
     for(int base=0;base<nu;base+=64){
@@ -3749,8 +3754,9 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
              * waited, every use[] slot loaded before the end-of-block LRU swap); pass 4
              * takes the GPU results (fallback: recompute those rows on the CPU). */
             ColiVkTensor *vg[64],*vu[64],*vd[64]; int veid[64]; int vrows[64], voff[64], vrmap[64*4]; float vwmap[64*4];
+            ColiVkTensor *vg2[64],*vu2[64],*vd2[64]; int veid2[64]; int vrows2[64], voff2[64], vrmap2[64*4]; float vwmap2[64*4];
             ESlot *ce[64]; int cnr[64], crmap[64*4]; float cwmap[64*4]; int cqof[64];
-            int nvk=0, vtot=0, ncpu=0;
+            int nvk=0, vtot=0, nvk2=0, vtot2=0, ncpu=0;
             double t0=now_s();
             for(int j=0;j<nb;j++){ int eid=uniq[base+j];
                 int nr=0;
@@ -3759,18 +3765,27 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                 if(!nr){ if(g_pipe && qof[j]>=0){ double tw=now_s(); pipe_wait(qof[j]); m->t_ewait += now_s()-tw; } continue; }
                 if(vk_hit[j]){          /* registry-served: no RAM slot, no disk load */
                     ColiVkTensor **reg=vk_reg_at(layer,eid);
-                    voff[nvk]=vtot;
-                    for(int r=0;r<nr;r++){ memcpy(vk_xh+(int64_t)(vtot+r)*D, x+(int64_t)rows[r]*D, D*sizeof(float));
-                        vrmap[nvk*S+r]=rows[r]; vwmap[nvk*S+r]=rw[r]; }
-                    vg[nvk]=reg[0]; vu[nvk]=reg[1]; vd[nvk]=reg[2]; veid[nvk]=eid; vrows[nvk]=nr; vtot+=nr; nvk++;
+                    if(vk2_on && coli_vk_tensor_dev(reg[0])==1){   /* dev2 tier expert */
+                        voff2[nvk2]=vtot2;
+                        for(int r=0;r<nr;r++){ memcpy(vk_xh2+(int64_t)(vtot2+r)*D, x+(int64_t)rows[r]*D, D*sizeof(float));
+                            vrmap2[nvk2*S+r]=rows[r]; vwmap2[nvk2*S+r]=rw[r]; }
+                        vg2[nvk2]=reg[0]; vu2[nvk2]=reg[1]; vd2[nvk2]=reg[2]; veid2[nvk2]=eid; vrows2[nvk2]=nr; vtot2+=nr; nvk2++;
+                    } else {
+                        voff[nvk]=vtot;
+                        for(int r=0;r<nr;r++){ memcpy(vk_xh+(int64_t)(vtot+r)*D, x+(int64_t)rows[r]*D, D*sizeof(float));
+                            vrmap[nvk*S+r]=rows[r]; vwmap[nvk*S+r]=rw[r]; }
+                        vg[nvk]=reg[0]; vu[nvk]=reg[1]; vd[nvk]=reg[2]; veid[nvk]=eid; vrows[nvk]=nr; vtot+=nr; nvk++;
+                    }
                 } else {
                     ce[ncpu]=use[j]; cnr[ncpu]=nr; cqof[ncpu]=qof[j];
                     for(int r=0;r<nr;r++){ crmap[ncpu*S+r]=rows[r]; cwmap[ncpu*S+r]=rw[r]; }
                     ncpu++;
                 }
             }
-            if(g_prof){ g_vkb_cls+=now_s()-t0; g_vkb_blocks++; g_vkb_nvk+=nvk; g_vkb_ncpu+=ncpu; }
+            if(g_prof){ g_vkb_cls+=now_s()-t0; g_vkb_blocks++; g_vkb_nvk+=nvk+nvk2; g_vkb_nvk2+=nvk2; g_vkb_ncpu+=ncpu; }
             double t_iss0=now_s();
+            /* issue the SLOWER device first so it gets the longest overlap window */
+            int vk2_issued = nvk2>0 && coli_vk_expert_group_issue2(vg2,vu2,vd2,vrows2,nvk2,vk_xh2);
             int vk_issued = nvk>0 && coli_vk_expert_group_issue(vg,vu,vd,vrows,nvk,vk_xh);
             if(g_prof) g_vkb_issue+=now_s()-t_iss0;
             /* CPU share stays SERIAL over experts with row-parallel kernels: a decode
@@ -3822,6 +3837,24 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                     for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
                     matmul_qt(hh, gg, &e->d, nr);
                     for(int r=0;r<nr;r++){ float *os=out+(int64_t)vrmap[c2*S+r]*D, wgt=vwmap[c2*S+r], *hr=hh+(int64_t)r*D;
+                        for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
+                }
+            }
+            /* dev2 group: taken AFTER dev0's accumulate so the slower card gets the
+             * extra overlap; same per-expert CPU recompute fallback on failure. */
+            int vk2_ok = vk2_issued && coli_vk_expert_group_take2(vk_yh2);
+            for(int c2=0;c2<nvk2;c2++){ int nr=vrows2[c2];
+                if(vk2_ok){ int o=voff2[c2];
+                    for(int r=0;r<nr;r++){ float *os=out+(int64_t)vrmap2[c2*S+r]*D, wgt=vwmap2[c2*S+r], *src=vk_yh2+(int64_t)(o+r)*D;
+                        for(int d=0;d<D;d++) os[d]+=wgt*src[d]; }
+                } else {
+                    ESlot *e=&m->ws[nmiss<63?nmiss:63];
+                    if(e->eid!=veid2[c2] || !e->slab) expert_load(m,layer,veid2[c2],e,1,0);
+                    for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)vrmap2[c2*S+r]*D, D*sizeof(float));
+                    expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
+                    for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
+                    matmul_qt(hh, gg, &e->d, nr);
+                    for(int r=0;r<nr;r++){ float *os=out+(int64_t)vrmap2[c2*S+r]*D, wgt=vwmap2[c2*S+r], *hr=hh+(int64_t)r*D;
                         for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
                 }
             }
@@ -5527,8 +5560,8 @@ static void profile_print(Model *m, double elapsed){
         elapsed-m->t_ewait-m->t_emm-m->t_attn-m->t_head-m->t_route-m->t_p2p:0);
 #ifdef COLI_VULKAN
     if(g_prof && g_vkb_blocks)
-        printf("VK-BLOCK: %lld blocks | avg nvk %.2f / ncpu %.2f | classify %.3fs | issue %.3fs | take+acc %.3fs (take-wait %.3fs) | cpu exec %.3fs wait %.3fs\n",
-            (long long)g_vkb_blocks,(double)g_vkb_nvk/g_vkb_blocks,(double)g_vkb_ncpu/g_vkb_blocks,
+        printf("VK-BLOCK: %lld blocks | avg nvk %.2f (dev2 %.2f) / ncpu %.2f | classify %.3fs | issue %.3fs | take+acc %.3fs (take-wait %.3fs) | cpu exec %.3fs wait %.3fs\n",
+            (long long)g_vkb_blocks,(double)g_vkb_nvk/g_vkb_blocks,(double)g_vkb_nvk2/g_vkb_blocks,(double)g_vkb_ncpu/g_vkb_blocks,
             g_vkb_cls,g_vkb_issue,g_vkb_acc,m->t_egpu,m->t_ecpu,m->t_ewait);
 #endif
     if(g_mirror){
@@ -5559,7 +5592,7 @@ static void profile_reset(Model *m){
     m->t_ecpu=m->t_egpu=m->t_route=m->t_p2p=0;m->n_p2p=0;
     m->cpu_expert_bytes=0;m->cpu_expert_rows=0;
 #ifdef COLI_VULKAN
-    g_vkb_cls=g_vkb_issue=g_vkb_acc=0; g_vkb_blocks=g_vkb_nvk=g_vkb_ncpu=0;
+    g_vkb_cls=g_vkb_issue=g_vkb_acc=0; g_vkb_blocks=g_vkb_nvk=g_vkb_nvk2=g_vkb_ncpu=0;
 #endif
     m->t_aproj=m->t_acore=m->t_aout=0;
     atomic_store_explicit(&g_edisk_ns,0,memory_order_relaxed);
@@ -6758,8 +6791,9 @@ static void vk_registry_fill(Model *m){
      * max_t). Without the budget extension the count cap alone applies, as before. */
     double vkr_reserve = getenv("COLI_VK_RESERVE_GB")?atof(getenv("COLI_VK_RESERVE_GB")):3.0;
     int vkr_stopped=0; double vkr_used=0, vkr_budget=0;
+    int64_t i2=0;
     coli_vk_alloc_priority(0.4f);
-    for(int64_t i2=0;i2<n && g_vk_reg_n<g_vk_budget;i2++){
+    for(;i2<n && g_vk_reg_n<g_vk_budget;i2++){
         if(vkr_reserve>0 && (g_vk_reg_n&7)==0 && coli_vk_mem_budget(&vkr_used,&vkr_budget)
            && vkr_budget-vkr_used < vkr_reserve){ vkr_stopped=1; break; }
         int layer=cand[i2].layer, eid=cand[i2].eid; tried++;
@@ -6790,13 +6824,51 @@ static void vk_registry_fill(Model *m){
         g_vk_reg_n++;
     }
     coli_vk_alloc_priority(0.75f);               /* back to the dense/default class */
-    if(tmp.slab){ compat_aligned_free(tmp.slab); free(tmp.fslab); }
-    free(cand);
     fprintf(stderr,"[VK] expert tier: %d hot experts resident (%.2f GB VRAM, %.1fs, top-%d of history)\n",
             g_vk_reg_n,bytes/1e9,now_s()-t0,tried);
     if(vkr_stopped)
         fprintf(stderr,"[VK] expert tier: budget stop at %d experts — %.1f of %.1f GB device-local used, %.1f GB reserved (COLI_VK_RESERVE_GB)\n",
                 g_vk_reg_n,vkr_used,vkr_budget,vkr_reserve);
+    /* DEV2 tier: continue down the heat ranking onto the second GPU (COLI_VK_DEV2),
+     * starting at the candidate dev0 stopped on. Same fmt gates, its own budget. */
+    if(g_vk_budget2>0 && coli_vk_dev2_available()){
+        double t20=now_s(); int64_t bytes2=0; int tried2=0;
+        double vkr2_reserve = getenv("COLI_VK_RESERVE2_GB")?atof(getenv("COLI_VK_RESERVE2_GB")):0.5;
+        int vkr2_stopped=0; double u2=0,b2=0;
+        for(;i2<n && g_vk_reg_n2<g_vk_budget2;i2++){
+            if(vkr2_reserve>0 && (g_vk_reg_n2&7)==0 && coli_vk_mem_budget2(&u2,&b2)
+               && b2-u2 < vkr2_reserve){ vkr2_stopped=1; break; }
+            int layer=cand[i2].layer, eid=cand[i2].eid; tried2++;
+            ESlot *src=NULL, *P=m->pin[layer];
+            for(int z=0;z<m->npin[layer];z++) if(P[z].eid==eid && P[z].slab){ src=&P[z]; break; }
+            if(!src){ if(expert_load(m,layer,eid,&tmp,0,0)!=0){
+                    if(++loadfail>=64) break;
+                    continue; } src=&tmp; }
+            int xf=src->g.fmt;
+            if((xf!=2&&xf!=4&&xf!=5)||src->u.fmt!=xf||src->u.gs!=src->g.gs
+               ||(src->d.fmt!=2&&src->d.fmt!=4&&src->d.fmt!=5)
+               ||(xf==4&&(src->g.gs<8||src->g.gs%8))||(src->d.fmt==4&&(src->d.gs<8||src->d.gs%8)))
+                continue;
+            ColiVkTensor **slot=vk_reg_at(layer,eid);
+            if(!coli_vk_tensor_ensure2(&slot[0],src->g.q4,src->g.s,xf,c->hidden,c->moe_inter,src->g.gs)||
+               !coli_vk_tensor_ensure2(&slot[1],src->u.q4,src->u.s,xf,c->hidden,c->moe_inter,src->u.gs)||
+               !coli_vk_tensor_ensure2(&slot[2],src->d.q4,src->d.s,src->d.fmt,c->moe_inter,c->hidden,src->d.gs)){
+                if(slot[0]){coli_vk_tensor_free(slot[0]);slot[0]=NULL;}
+                if(slot[1]){coli_vk_tensor_free(slot[1]);slot[1]=NULL;}
+                fprintf(stderr,"[VK] dev2 tier: VRAM full after %d experts\n",g_vk_reg_n2);
+                break;
+            }
+            bytes2+=coli_vk_tensor_bytes(slot[0])+coli_vk_tensor_bytes(slot[1])+coli_vk_tensor_bytes(slot[2]);
+            g_vk_reg_n2++;
+        }
+        fprintf(stderr,"[VK] dev2 tier: %d experts resident (%.2f GB VRAM, %.1fs, next-%d of history)\n",
+                g_vk_reg_n2,bytes2/1e9,now_s()-t20,tried2);
+        if(vkr2_stopped)
+            fprintf(stderr,"[VK] dev2 tier: budget stop at %d experts — %.1f of %.1f GB device-local used, %.1f GB reserved (COLI_VK_RESERVE2_GB)\n",
+                    g_vk_reg_n2,u2,b2,vkr2_reserve);
+    }
+    if(tmp.slab){ compat_aligned_free(tmp.slab); free(tmp.fslab); }
+    free(cand);
 }
 #endif
 
@@ -7691,6 +7763,16 @@ int main(int argc, char **argv){
         fprintf(stderr,"[VK] expert tier active: routed quantized experts on the GPU (budget %d)%s%s\n",
                 g_vk_budget, g_vk_dense ? " + dense projections + shared expert" : "",
                 g_vk_attn ? " + absorb attention core" : "");
+        /* COLI_VK_DEV2=auto|<index>: bring up a SECOND GPU for tier experts only
+         * (e.g. an RX 580 beside the primary card). The dev2 tier fills with the
+         * next heat-ranked experts after dev0's budget stop, capped by
+         * COLI_VK_EXPERTS2 and its own VRAM budget (COLI_VK_RESERVE2_GB). */
+        { const char *d2 = getenv("COLI_VK_DEV2");
+          if(d2 && *d2){
+              int idx = strcmp(d2,"auto") ? atoi(d2) : -1;
+              if(coli_vk_init_dev2(spv, idx))
+                  g_vk_budget2 = getenv("COLI_VK_EXPERTS2") ? atoi(getenv("COLI_VK_EXPERTS2")) : 512;
+          } }
     }
 #endif
 #ifdef COLI_CUDA

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -313,6 +313,10 @@ static inline int vk_reg_served(int layer,int eid){
 }
 static int g_vk_dense;        /* COLI_VK_DENSE=1: run the resident dense matmuls (attention
                                * projections + shared expert) on Vulkan too */
+/* PROF anatomy of the VK expert block (master-thread accumulated in moe(), printed by
+ * profile_print): where a decode block's wall goes besides t_ecpu/t_ewait/t_egpu. */
+static double g_vkb_cls, g_vkb_issue, g_vkb_acc;
+static int64_t g_vkb_blocks, g_vkb_nvk, g_vkb_ncpu;
 static int g_vk_attn;         /* COLI_VK_ATTN=1: run the MLA absorb attention core on Vulkan
                                * (mirrors COLI_CUDA_ATTN; KV latent cache mirrored on-device) */
 #endif
@@ -3673,7 +3677,10 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                     ncpu++;
                 }
             }
+            if(g_prof){ g_vkb_cls+=now_s()-t0; g_vkb_blocks++; g_vkb_nvk+=nvk; g_vkb_ncpu+=ncpu; }
+            double t_iss0=now_s();
             int vk_issued = nvk>0 && coli_vk_expert_group_issue(vg,vu,vd,vrows,nvk,vk_xh);
+            if(g_prof) g_vkb_issue+=now_s()-t_iss0;
             /* CPU share stays SERIAL over experts with row-parallel kernels: a decode
              * block leaves only ~5-6 CPU experts (the tier absorbs the hot head), fewer
              * than the OMP pool, so one-task-per-expert ran each expert single-threaded
@@ -3727,6 +3734,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                 }
             }
             double dt=now_s()-t0; m->t_emm+=dt;
+            if(g_prof) g_vkb_acc+=now_s()-t_take0;   /* take-wait (t_egpu) + result accumulate */
         }
 #endif
         if(!metal_done && !xexp_done && !vk_active)
@@ -5374,6 +5382,12 @@ static void profile_print(Model *m, double elapsed){
         (unsigned long long)m->cpu_expert_rows,m->t_egpu,m->t_route,m->t_p2p,(unsigned long long)m->n_p2p,
         elapsed-m->t_ewait-m->t_emm-m->t_attn-m->t_head-m->t_route-m->t_p2p>0?
         elapsed-m->t_ewait-m->t_emm-m->t_attn-m->t_head-m->t_route-m->t_p2p:0);
+#ifdef COLI_VULKAN
+    if(g_prof && g_vkb_blocks)
+        printf("VK-BLOCK: %lld blocks | avg nvk %.2f / ncpu %.2f | classify %.3fs | issue %.3fs | take+acc %.3fs (take-wait %.3fs) | cpu exec %.3fs wait %.3fs\n",
+            (long long)g_vkb_blocks,(double)g_vkb_nvk/g_vkb_blocks,(double)g_vkb_ncpu/g_vkb_blocks,
+            g_vkb_cls,g_vkb_issue,g_vkb_acc,m->t_egpu,m->t_ecpu,m->t_ewait);
+#endif
     if(g_mirror){
         double b0=atomic_load_explicit(&g_mir_bytes[0],memory_order_relaxed)/1e9;
         double b1=atomic_load_explicit(&g_mir_bytes[1],memory_order_relaxed)/1e9;
@@ -5399,6 +5413,9 @@ static void profile_reset(Model *m){
     m->t_ewait=m->t_emm=m->t_attn=m->t_kvb=m->t_head=0;
     m->t_ecpu=m->t_egpu=m->t_route=m->t_p2p=0;m->n_p2p=0;
     m->cpu_expert_bytes=0;m->cpu_expert_rows=0;
+#ifdef COLI_VULKAN
+    g_vkb_cls=g_vkb_issue=g_vkb_acc=0; g_vkb_blocks=g_vkb_nvk=g_vkb_ncpu=0;
+#endif
     m->t_aproj=m->t_acore=m->t_aout=0;
     atomic_store_explicit(&g_edisk_ns,0,memory_order_relaxed);
 }

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -1494,6 +1494,54 @@ static inline int rep_bfd(shards *S,int fd,int rep){
     int r=st_fd_rep(S,fd,rep); return r<0?fd:r;
 }
 
+/* MULTI-SSD striped demand read (COLI_MIR_STRIPE=0 disables): split the one
+ * coalesced O_DIRECT expert pread into disjoint 4K-aligned chunks, one per
+ * replica that holds the shard, read in parallel. A cold ~19 MB expert read is
+ * single-thread latency-bound (~4 GB/s on one NVMe) and it is the felt wait of
+ * every demand miss; N drives reading stripes of the SAME expert cut it ~N-fold.
+ * O_DIRECT only: no page cache involved, so striping cannot double-cache an
+ * expert across drives (the buffered path keeps whole-expert replica routing).
+ * Chunk 0 starts on the ROUTED replica so the hash still spreads first-chunk
+ * load evenly. Any short stripe fails the whole attempt (caller falls back to
+ * the single-replica read). */
+static int g_mir_stripe=1;
+typedef struct { int fd; char *buf; int64_t len, off; ssize_t r; } MirStripe;
+static void *mir_stripe_worker(void *a){
+    MirStripe *st=(MirStripe*)a;
+    st->r = pread(st->fd, st->buf, (size_t)st->len, st->off);
+    return NULL;
+}
+/* Returns total bytes read (== len) on success, -1 to make the caller fall back. */
+static int64_t mir_pread_striped(shards *S,int fd,int rep,char *buf,int64_t len,int64_t base){
+    if(!g_mir_stripe || g_mir_nrep<2 || len < (4<<20)) return -1;
+    int sfd[MIR_REPS], srep[MIR_REPS], nsf=0;
+    for(int r=0;r<g_mir_nrep && r<MIR_REPS;r++){
+        int f=st_direct_fd_rep(S,fd,r);
+        if(f>=0){ sfd[nsf]=f; srep[nsf]=r; nsf++; }
+    }
+    if(nsf<2) return -1;
+    int64_t chunk=((len+nsf-1)/nsf + 4095) & ~4095LL;
+    MirStripe st[MIR_REPS]; pthread_t th[MIR_REPS]; int nth=0, ns=0;
+    for(int i=0;i<nsf;i++){
+        int64_t o=(int64_t)i*chunk; if(o>=len) break;
+        int k=(rep+i)%nsf;                    /* chunk 0 on the routed replica */
+        st[ns]=(MirStripe){sfd[k], buf+o, len-o<chunk?len-o:chunk, base+o, -1};
+        ns++;
+    }
+    for(int i=1;i<ns;i++)
+        if(pthread_create(&th[nth],NULL,mir_stripe_worker,&st[i])==0) nth++;
+        else st[i].r=pread(st[i].fd,st[i].buf,(size_t)st[i].len,st[i].off);
+    st[0].r = pread(st[0].fd, st[0].buf, (size_t)st[0].len, st[0].off);
+    for(int i=0;i<nth;i++) pthread_join(th[i],NULL);
+    for(int i=0;i<ns;i++) if(st[i].r!=st[i].len) return -1;
+    for(int i=0;i<ns;i++){
+        int k=(rep+i)%nsf;
+        atomic_fetch_add_explicit(&g_mir_bytes[srep[k]],st[i].len,memory_order_relaxed);
+        atomic_fetch_add_explicit(&g_mir_nread[srep[k]],1,memory_order_relaxed);
+    }
+    return len;
+}
+
 static int pread_full(int fd, void *buf, int64_t n, int64_t off, const char *tag);
 
 /* pread on the chosen replica with fallback to the primary on error/short-read:
@@ -1752,12 +1800,19 @@ static int expert_load_impl(Model *m, int layer, int eid, ESlot *s, int fatal, i
         if(dfd>=0){                              /* O_DIRECT: offset/len allineati a 4K */
             int64_t base=off0 & ~4095LL, need=(off0-base)+wtot;
             int64_t len=(need+4095)&~4095LL;
-            ssize_t r=pread(dfd, s->slab, len, base);
+            /* multi-SSD: stripe the read across the replicas (accounts internally);
+             * any failure falls back to the whole read on the routed replica */
+            ssize_t r=(ssize_t)mir_pread_striped(&m->S,tw[ord[0]]->fd,rep,(char*)s->slab,len,base);
+            if(r<need){
+                r=pread(dfd, s->slab, len, base);
+                if(r>=need){
+                    atomic_fetch_add_explicit(&g_mir_bytes[rep],(int64_t)r,memory_order_relaxed);
+                    atomic_fetch_add_explicit(&g_mir_nread[rep],1,memory_order_relaxed);
+                }
+            }
             if(r>=need){
                 pos[ord[0]]=off0-base; pos[ord[1]]=pos[ord[0]]+tw[ord[0]]->nbytes;
                 pos[ord[2]]=pos[ord[1]]+tw[ord[1]]->nbytes; done=1; dc_direct=1;
-                atomic_fetch_add_explicit(&g_mir_bytes[rep],(int64_t)r,memory_order_relaxed);
-                atomic_fetch_add_explicit(&g_mir_nread[rep],1,memory_order_relaxed);
             }
         }
         if(!done){                               /* fallback bufferizzato */
@@ -7516,7 +7571,8 @@ int main(int argc, char **argv){
         fprintf(stderr,"URING=1 is supported only on Linux\n"); return 2;
 #endif
     }
-    g_mirror_dir = getenv("COLI_MODEL_MIRROR");            /* DUAL-SSD: second model copy */
+    if(getenv("COLI_MIR_STRIPE")) g_mir_stripe=atoi(getenv("COLI_MIR_STRIPE"));
+    g_mirror_dir = getenv("COLI_MODEL_MIRROR");            /* MULTI-SSD: replica model copies */
     if(!g_mirror_dir||!*g_mirror_dir) g_mirror_dir = getenv("SNAP_MIRROR");
     if(g_mirror_dir&&!*g_mirror_dir) g_mirror_dir = NULL;
     g_idot = getenv("IDOT")?atoi(getenv("IDOT")):1;        /* 0 = kernel f32 esatti (A/B) */

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -3667,7 +3667,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
             double t_cpu0=now_s();
             for(int c2=0;c2<ncpu;c2++){ ESlot *e=ce[c2]; int nr=cnr[c2];
                 if(g_pipe && cqof[c2]>=0){ double tw=now_s(); pipe_wait(cqof[c2]); m->t_ewait += now_s()-tw; }
-                if(!e->slab) expert_load(m,layer,e->eid,e,1);
+                if(!e->slab) expert_load(m,layer,e->eid,e,1,1);   /* demand=1: moe miss path (FASE A snapshot valid) */
                 for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)crmap[c2*S+r]*D, D*sizeof(float));
                 expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
                 for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
@@ -3687,7 +3687,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                         for(int d=0;d<D;d++) os[d]+=wgt*src[d]; }
                 } else {   /* issue/take failed (device lost): load + recompute on the CPU */
                     ESlot *e=&m->ws[nmiss<63?nmiss:63];
-                    if(e->eid!=veid[c2] || !e->slab) expert_load(m,layer,veid[c2],e,1);
+                    if(e->eid!=veid[c2] || !e->slab) expert_load(m,layer,veid[c2],e,1,0);   /* device-lost recovery: DISK-CLASS leaves it unclassified */
                     for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)vrmap[c2*S+r]*D, D*sizeof(float));
                     expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
                     for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
@@ -6532,7 +6532,7 @@ static void vk_registry_fill(Model *m){
         int layer=cand[i2].layer, eid=cand[i2].eid; tried++;
         ESlot *src=NULL, *P=m->pin[layer];
         for(int z=0;z<m->npin[layer];z++) if(P[z].eid==eid && P[z].slab){ src=&P[z]; break; }
-        if(!src){ if(expert_load(m,layer,eid,&tmp,0)!=0){   /* 0 = success (impl convention) */
+        if(!src){ if(expert_load(m,layer,eid,&tmp,0,0)!=0){   /* 0 = success (impl convention); demand=0: startup tier fill */
                 if(++loadfail<4) fprintf(stderr,"[VK] tier fill: expert_load(%d,%d) failed\n",layer,eid);
                 if(loadfail>=64) break;                     /* disk trouble: stop burning time */
                 continue; } src=&tmp; }

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -3297,7 +3297,8 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
 #endif
     int vk_active = 0; (void)vk_active;
 #ifdef COLI_VULKAN
-    vk_active = g_vulkan && !omp_in_parallel() && S<=4;
+    vk_active = g_vulkan && g_vk_budget>0 && !omp_in_parallel() && S<=4;   /* budget 0 = tier off,
+                                                * experts stay on the normal (parallel) CPU loop */
     float *vk_xh = vk_active?falloc((int64_t)S*K*D):NULL;
     float *vk_yh = vk_active?falloc((int64_t)S*K*D):NULL;
 #endif

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -246,6 +246,7 @@ typedef struct {
     int **eroute; int *enr;                      /* metodo C: routing dell'ULTIMO token per layer */
     uint64_t eclock, hits, miss, ereq;
     uint64_t hit_pin, hit_ecache;                /* split di hits per tier (#336): pin vs LRU ecache */
+    uint64_t hit_vk;                             /* VK VRAM tier hits (registry-served, no RAM load) */
     uint64_t gpu_expert_calls; int gpu_expert_count; int64_t gpu_expert_bytes;
     uint64_t n_fw, n_emit;                       /* metodo E: forward di decode / token emessi */
     uint64_t route_slots, route_swaps;            /* CACHE_ROUTE: slots chosen / substituted vs true top-K */
@@ -303,6 +304,12 @@ static struct ColiVkTensor **g_vk_reg;   /* [(layer*E+eid)*3 + {gate,up,down}] *
 static int g_vk_reg_n, g_vk_reg_E;
 static inline struct ColiVkTensor **vk_reg_at(int layer,int eid){
     return g_vk_reg ? &g_vk_reg[((size_t)layer*g_vk_reg_E+eid)*3] : NULL;
+}
+static int g_vk_reg_NL;                  /* registry layer bound (n_layers, MTP excluded) */
+/* Will the VK tier serve this expert at decode? (prefetch/pilot can skip its I/O.) */
+static inline int vk_reg_served(int layer,int eid){
+    if(!g_vk_reg || layer<0 || layer>=g_vk_reg_NL || eid<0 || eid>=g_vk_reg_E) return 0;
+    return g_vk_reg[((size_t)layer*g_vk_reg_E+eid)*3] != NULL;
 }
 static int g_vk_dense;        /* COLI_VK_DENSE=1: run the resident dense matmuls (attention
                                * projections + shared expert) on Vulkan too */
@@ -3336,7 +3343,19 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
     for(int base=0;base<nu;base+=64){
         int nb = nu-base<64 ? nu-base : 64;
         ESlot *use[64]; int missk[64]; int qof[64]; int nmiss=0;
+#ifdef COLI_VULKAN
+        int vk_hit[64]={0};
+#endif
         for(int j=0;j<nb;j++){ int eid=uniq[base+j]; use[j]=NULL; qof[j]=-1;
+#ifdef COLI_VULKAN
+            /* VK VRAM tier first: registry-served experts need NO RAM slot and NO disk
+             * load (the whole point) — and skipping the LRU recency bump lets them age
+             * out of the RAM cache, freeing capacity for the CPU-served experts. */
+            if(vk_active && layer<c->n_layers){
+                ColiVkTensor **rg=vk_reg_at(layer,eid);
+                if(rg && rg[0]){ vk_hit[j]=1; m->hits++; m->hit_vk++; continue; }
+            }
+#endif
             ESlot *P=m->pin[layer];
             for(int z=0;z<m->npin[layer];z++) if(P[z].eid==eid){ m->hits++; m->hit_pin++; use[j]=&P[z]; break; }
             if(!use[j]){ ESlot *Sl=m->ecache[layer]; int nn=m->ecn[layer];
@@ -3424,6 +3443,9 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
             int nb2 = nu-(base+64)<64 ? nu-(base+64) : 64;
             for(int j=0;j<nb2;j++){ int eid=uniq[base+64+j]; int found=0;
                 ESlot *P=m->pin[layer];
+#ifdef COLI_VULKAN
+                if(vk_active && vk_reg_served(layer,eid)) found=1;   /* VK-tier-served at decode */
+#endif
                 for(int z=0;z<m->npin[layer] && !found;z++) if(P[z].eid==eid) found=1;
                 ESlot *Sl=m->ecache[layer];
                 for(int z=0;z<m->ecn[layer] && !found;z++) if(Sl[z].eid==eid) found=1;
@@ -3617,28 +3639,29 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
              * pipe + RAM-loads the GPU-side slots (cache invariants: every dispatched slot
              * waited, every use[] slot loaded before the end-of-block LRU swap); pass 4
              * takes the GPU results (fallback: recompute those rows on the CPU). */
-            ColiVkTensor *vg[64],*vu[64],*vd[64]; ESlot *ve[64]; int vrows[64], voff[64], vrmap[64*4]; float vwmap[64*4]; int vqof[64];
+            ColiVkTensor *vg[64],*vu[64],*vd[64]; int veid[64]; int vrows[64], voff[64], vrmap[64*4]; float vwmap[64*4];
             ESlot *ce[64]; int cnr[64], crmap[64*4]; float cwmap[64*4]; int cqof[64];
             int nvk=0, vtot=0, ncpu=0;
             double t0=now_s();
-            for(int j=0;j<nb;j++){ int eid=uniq[base+j]; ESlot *e=use[j];
+            for(int j=0;j<nb;j++){ int eid=uniq[base+j];
                 int nr=0;
                 for(int s=0;s<S;s++) for(int kk=0;kk<keff[s];kk++)
                     if(idxs[(int64_t)s*K+kk]==eid){ rows[nr]=s; rw[nr]=ws[(int64_t)s*K+kk]; nr++; break; }
                 if(!nr){ if(g_pipe && qof[j]>=0){ double tw=now_s(); pipe_wait(qof[j]); m->t_ewait += now_s()-tw; } continue; }
-                ColiVkTensor **reg = layer<c->n_layers ? vk_reg_at(layer,eid) : NULL;
-                if(reg && reg[0] && nvk<64 && (vtot+nr)<=S*K){
+                if(vk_hit[j]){          /* registry-served: no RAM slot, no disk load */
+                    ColiVkTensor **reg=vk_reg_at(layer,eid);
                     voff[nvk]=vtot;
                     for(int r=0;r<nr;r++){ memcpy(vk_xh+(int64_t)(vtot+r)*D, x+(int64_t)rows[r]*D, D*sizeof(float));
                         vrmap[nvk*S+r]=rows[r]; vwmap[nvk*S+r]=rw[r]; }
-                    vg[nvk]=reg[0]; vu[nvk]=reg[1]; vd[nvk]=reg[2]; ve[nvk]=e; vrows[nvk]=nr; vqof[nvk]=qof[j]; vtot+=nr; nvk++;
+                    vg[nvk]=reg[0]; vu[nvk]=reg[1]; vd[nvk]=reg[2]; veid[nvk]=eid; vrows[nvk]=nr; vtot+=nr; nvk++;
                 } else {
-                    ce[ncpu]=e; cnr[ncpu]=nr; cqof[ncpu]=qof[j];
+                    ce[ncpu]=use[j]; cnr[ncpu]=nr; cqof[ncpu]=qof[j];
                     for(int r=0;r<nr;r++){ crmap[ncpu*S+r]=rows[r]; cwmap[ncpu*S+r]=rw[r]; }
                     ncpu++;
                 }
             }
             int vk_issued = nvk>0 && coli_vk_expert_group_issue(vg,vu,vd,vrows,nvk,vk_xh);
+            double t_cpu0=now_s();
             for(int c2=0;c2<ncpu;c2++){ ESlot *e=ce[c2]; int nr=cnr[c2];
                 if(g_pipe && cqof[c2]>=0){ double tw=now_s(); pipe_wait(cqof[c2]); m->t_ewait += now_s()-tw; }
                 if(!e->slab) expert_load(m,layer,e->eid,e,1);
@@ -3648,18 +3671,20 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                 matmul_qt(hh, gg, &e->d, nr);
                 for(int r=0;r<nr;r++){ float *os=out+(int64_t)crmap[c2*S+r]*D, wgt=cwmap[c2*S+r], *hr=hh+(int64_t)r*D;
                     for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
+                if(g_prof){ m->cpu_expert_bytes+=qt_bytes(&e->g)+qt_bytes(&e->u)+qt_bytes(&e->d);
+                    m->cpu_expert_rows+=(uint64_t)nr; }
             }
-            for(int c2=0;c2<nvk;c2++){
-                if(g_pipe && vqof[c2]>=0){ double tw=now_s(); pipe_wait(vqof[c2]); m->t_ewait += now_s()-tw; }
-                ESlot *e=ve[c2]; if(!e->slab) expert_load(m,layer,e->eid,e,1);
-            }
+            if(g_prof) m->t_ecpu+=now_s()-t_cpu0;
+            double t_take0=now_s();
             int vk_ok = vk_issued && coli_vk_expert_group_take(vk_yh);
+            if(g_prof) m->t_egpu+=now_s()-t_take0;
             for(int c2=0;c2<nvk;c2++){ int nr=vrows[c2];
                 if(vk_ok){ int o=voff[c2];
                     for(int r=0;r<nr;r++){ float *os=out+(int64_t)vrmap[c2*S+r]*D, wgt=vwmap[c2*S+r], *src=vk_yh+(int64_t)(o+r)*D;
                         for(int d=0;d<D;d++) os[d]+=wgt*src[d]; }
-                } else {   /* issue/take failed: recompute this expert's rows on the CPU */
-                    ESlot *e=ve[c2];
+                } else {   /* issue/take failed (device lost): load + recompute on the CPU */
+                    ESlot *e=&m->ws[nmiss<63?nmiss:63];
+                    if(e->eid!=veid[c2] || !e->slab) expert_load(m,layer,veid[c2],e,1);
                     for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)vrmap[c2*S+r]*D, D*sizeof(float));
                     expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
                     for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
@@ -3668,7 +3693,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                         for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
                 }
             }
-            double dt=now_s()-t0; m->t_emm+=dt; if(g_prof) m->t_egpu+=dt;
+            double dt=now_s()-t0; m->t_emm+=dt;
         }
 #endif
         if(!metal_done && !xexp_done && !vk_active)
@@ -4044,6 +4069,9 @@ static void pilot_realload(Model *m, int layer, int eid){
         pthread_mutex_unlock(&g_pilot_mx); return;      /* il main possiede gia' questo layer */
     }
     ESlot *P=m->pin[layer];                             /* gia' residente (pin o ecache)? skip */
+#ifdef COLI_VULKAN
+    if(vk_reg_served(layer,eid)){ pthread_mutex_unlock(&g_pilot_mx); return; }   /* VK-tier-served: no load */
+#endif
     for(int z=0;z<m->npin[layer];z++) if(P[z].eid==eid){ pthread_mutex_unlock(&g_pilot_mx); return; }
     ESlot *Sl=m->ecache[layer]; int nn=m->ecn[layer];
     for(int z=0;z<nn;z++) if(Sl[z].eid==eid){ pthread_mutex_unlock(&g_pilot_mx); return; }
@@ -4102,6 +4130,9 @@ static void pilot_uring_batch(Model *m){
             pthread_mutex_unlock(&g_pilot_mx); continue;
         }
         int found=0; ESlot *P=m->pin[layer];
+#ifdef COLI_VULKAN
+        if(vk_reg_served(layer,eid)) found=1;               /* VK-tier-served: no load */
+#endif
         for(int z=0;z<m->npin[layer];z++) if(P[z].eid==eid){found=1;break;}
         ESlot *Sl=m->ecache[layer]; int nn=m->ecn[layer];
         for(int z=0;z<nn && !found;z++) if(Sl[z].eid==eid || Sl[z].eid==-(eid+2)) found=1;
@@ -4244,6 +4275,9 @@ static void couple_prefetch(Model *m, int layer, const int *idx, int Ke){
             int found=0;                            /* residency scan, same locking as pilot */
             pthread_mutex_lock(&g_pilot_mx);
             ESlot *P=m->pin[lt];
+#ifdef COLI_VULKAN
+            if(vk_reg_served(lt,best)) found=1;             /* VK-tier-served: no load */
+#endif
             for(int z=0;z<m->npin[lt] && !found;z++) if(P[z].eid==best) found=1;
             ESlot *Sl=m->ecache[lt];
             for(int z=0;z<m->ecn[lt] && !found;z++)
@@ -4306,6 +4340,9 @@ static void pilot_prefetch(Model *m, int lnext, const float *x, int S){
             int found=0;
             pthread_mutex_lock(&g_pilot_mx);
             ESlot *P=m->pin[lnext];
+#ifdef COLI_VULKAN
+            if(vk_reg_served(lnext,best)) found=1;          /* VK-tier-served: no load */
+#endif
             for(int z=0;z<m->npin[lnext] && !found;z++) if(P[z].eid==best) found=1;
             ESlot *Sl=m->ecache[lnext];
             for(int z=0;z<m->ecn[lnext] && !found;z++)
@@ -5452,7 +5489,7 @@ static void run_replay(Model *m, const int *full, int nfull, int np){
     if(np<2||nfull<=np){ fprintf(stderr,"REPLAY requires a non-empty prompt and continuation\n"); return; }
     kv_alloc(m,nfull+2);
     float *logit=step(m,full,np-1,0); free(logit);
-    m->hits=m->miss=m->ereq=m->gpu_expert_calls=0; m->hit_pin=m->hit_ecache=0;
+    m->hits=m->miss=m->ereq=m->gpu_expert_calls=0; m->hit_pin=m->hit_ecache=0; m->hit_vk=0;
     profile_reset(m);
     ProfBase pb; prof_base(m,&pb);
     atomic_store(&g_mir_bytes[0],0); atomic_store(&g_mir_bytes[1],0);
@@ -5516,7 +5553,7 @@ static void run_text(Model *m, const char *snap, const char *prompt, int ngen){
     }
     prefill_t=now_s()-prefill_t;
     printf("PROFILO PREFILL (%.2fs):\n",prefill_t); profile_print(m,prefill_t);
-    m->hits=m->miss=m->ereq=m->gpu_expert_calls=0; m->hit_pin=m->hit_ecache=0;
+    m->hits=m->miss=m->ereq=m->gpu_expert_calls=0; m->hit_pin=m->hit_ecache=0; m->hit_vk=0;
     m->n_emit=m->n_fw=0;
     g_last_repin=0;
     profile_reset(m);
@@ -5529,9 +5566,11 @@ static void run_text(Model *m, const char *snap, const char *prompt, int ngen){
     double tot=m->hits+m->miss;
     int nsp=0; for(int i=0;i<c->n_layers;i++) if(m->L[i].sparse) nsp++;
     printf("\n---\nprefill %d tokens in %.2fs | decode %d tokens in %.2fs (%.2f tok/s) | "
-           "expert hit rate %.1f%% (pin %.1f%% + lru %.1f%%) | RSS %.2f GB",       /* split #336: quale tier serve gli hit */
+           "expert hit rate %.1f%% (pin %.1f%% + lru %.1f%%%s) | RSS %.2f GB",     /* split #336 (+VK VRAM tier) */
         np,prefill_t,produced,dt,produced/dt,tot?100.0*m->hits/tot:0.0,
-        tot?100.0*m->hit_pin/tot:0.0, tot?100.0*m->hit_ecache/tot:0.0, rss_gb());
+        tot?100.0*m->hit_pin/tot:0.0, tot?100.0*m->hit_ecache/tot:0.0,
+        m->hit_vk?({ static char vkb[40]; snprintf(vkb,sizeof(vkb)," + vk %.1f%%",tot?100.0*m->hit_vk/tot:0.0); vkb; }):"",
+        rss_gb());
     if(g_cache_route && m->route_slots)
         printf(" | swap %.1f%% (%llu/%llu)",
             100.0*m->route_swaps/m->route_slots,
@@ -6482,7 +6521,7 @@ static void vk_registry_fill(Model *m){
     for(int i=0;i<NL;i++) if(m->eusage[i]) for(int e=0;e<E;e++)
         if(m->eusage[i][e]) cand[n++]=(VkCand){m->eusage[i][e],i,e};
     qsort(cand,(size_t)n,sizeof(VkCand),vk_cand_cmp);
-    g_vk_reg=calloc((size_t)NL*E*3,sizeof(*g_vk_reg)); g_vk_reg_E=E;
+    g_vk_reg=calloc((size_t)NL*E*3,sizeof(*g_vk_reg)); g_vk_reg_E=E; g_vk_reg_NL=NL;
     if(!g_vk_reg){ free(cand); return; }
     ESlot tmp; memset(&tmp,0,sizeof(tmp)); tmp.eid=-1;
     double t0=now_s(); int64_t bytes=0; int tried=0;

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -2783,7 +2783,10 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
          * the MTP layer, or any backend failure — output identical either way. */
         if(!cuda_core&&g_vk_attn&&!kvs&&!positions&&S<=4&&layer<c->n_layers&&
            (l->kv_b.fmt==1||l->kv_b.fmt==2)&&kvl<=512&&c->qk_nope<=256&&c->qk_rope<=64&&
-           m->vk_kv_valid){
+           m->vk_kv_valid&&m->Lc[layer]&&m->Rc[layer]){   /* f32 KV only: a quantized-KV cache
+                                                * (upstream #399 KV8/TQ leaves Lc/Rc NULL)
+                                                * falls back to the CPU path until the VK
+                                                * mirror learns fp8 */
             int dsa_on=0; if(dnsel) for(int s=0;s<S;s++) if(dnsel[s]>0) dsa_on=1;
             int st0=m->kv_start[layer], T=pos_base+S;
             if(!dsa_on&&T<=m->max_t&&coli_vk_kv_ensure(layer,m->max_t,kvl,c->qk_rope)){

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -4776,7 +4776,17 @@ static void layer_forward_rows(Model *m, Layer *l, int li, float *x, int S, int 
                                KVState *const *kvs, const int *positions, float *nrm, float *tmp){
     Cfg *c=&m->c; int D=c->hidden;
     if(g_spec && g_prefetch && l->sparse && m->enr[li]>0)
-        for(int z=0;z<m->enr[li];z++) expert_prefetch(m,li,m->eroute[li][z]);
+        for(int z=0;z<m->enr[li];z++){
+            int pe=m->eroute[li][z];
+#ifdef COLI_VULKAN
+            /* VK-tier-served experts never need host bytes at decode — their pages are
+             * never demand-read, so on a RAM-tight box this WILLNEED would re-fetch the
+             * same hot experts from disk every time cache pressure evicts them (#523).
+             * S>4 = prefill batches, where the tier doesn't serve and the hint stays. */
+            if(S<=4 && vk_reg_served(li,pe)) continue;
+#endif
+            expert_prefetch(m,li,pe);
+        }
     if(g_looka && S==1 && li<c->n_layers && l->sparse) la_predict(m,li,x,0);
 #ifdef COLI_METAL
     /* FULL-LAYER CB: in_ln + attention + residuo + post_ln + shared expert + router/top-K

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -362,18 +362,19 @@ static void qt_vk_reset(QT *t){
 /* Dense matmul on the Vulkan tier: y[S,O] = x[S,I] @ dequant(t)^T. Uploads the resident
  * int8/int4/int3-g64 weight once (t->vk), then reuses it. Returns 0 (caller runs the CPU
  * matmul) when VK-dense is off, the format is unsupported, or upload/compute fails. */
+#define VK_FMT_OK(t) ((t)->fmt==1||(t)->fmt==2||(t)->fmt==5||((t)->fmt==4&&(t)->gs>=8&&(t)->gs%8==0))
 static int vk_matmul_qt(QT *t, float *y, const float *x, int S){
-    if(!g_vk_dense || (t->fmt!=1 && t->fmt!=2 && t->fmt!=5)) return 0;
+    if(!g_vk_dense || !VK_FMT_OK(t)) return 0;
     const void *w = t->fmt==1 ? (const void*)t->q8 : (const void*)t->q4;
-    return coli_vk_matmul(&t->vk, y, x, w, t->s, t->fmt, S, t->I, t->O);
+    return coli_vk_matmul(&t->vk, y, x, w, t->s, t->fmt, S, t->I, t->O, t->gs);
 }
 /* Two same-input resident matmuls in one submit (q_a + kv_a read the same x). */
 static int vk_matmul_pair_qt(QT *a, float *ya, QT *b, float *yb, const float *x, int S){
-    if(!g_vk_dense || a->fmt!=b->fmt || (a->fmt!=1 && a->fmt!=2 && a->fmt!=5) || a->I!=b->I) return 0;
+    if(!g_vk_dense || a->fmt!=b->fmt || !VK_FMT_OK(a) || a->gs!=b->gs || a->I!=b->I) return 0;
     const void *wa = a->fmt==1 ? (const void*)a->q8 : (const void*)a->q4;
     const void *wb = b->fmt==1 ? (const void*)b->q8 : (const void*)b->q4;
     return coli_vk_matmul_pair(&a->vk, ya, wa, a->s, a->O,
-                               &b->vk, yb, wb, b->s, b->O, a->fmt, x, S, a->I);
+                               &b->vk, yb, wb, b->s, b->O, a->fmt, x, S, a->I, a->gs);
 }
 #endif
 #ifdef COLI_CUDA
@@ -2796,7 +2797,7 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
          * on rewrite/rebind/resize). Falls back to CPU on DSA top-k selection, ragged KV,
          * the MTP layer, or any backend failure — output identical either way. */
         if(!cuda_core&&g_vk_attn&&!kvs&&!positions&&S<=4&&layer<c->n_layers&&
-           (l->kv_b.fmt==1||l->kv_b.fmt==2||l->kv_b.fmt==5)&&kvl<=512&&c->qk_nope<=256&&c->qk_rope<=64&&
+           VK_FMT_OK(&l->kv_b)&&kvl<=512&&c->qk_nope<=256&&c->qk_rope<=64&&
            m->vk_kv_valid&&m->Lc[layer]&&m->Rc[layer]){   /* f32 KV only: a quantized-KV cache
                                                 * (upstream #399 KV8/TQ leaves Lc/Rc NULL)
                                                 * falls back to the CPU path until the VK
@@ -2812,15 +2813,15 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
                     m->vk_kv_valid[layer]=T;
                     const void *kw=l->kv_b.fmt==1?(const void*)l->kv_b.q8:(const void*)l->kv_b.q4;
                     /* fused absorb + o-projection: ctx never leaves the device */
-                    if((l->o.fmt==1||l->o.fmt==2||l->o.fmt==5)&&
-                       coli_vk_attention_absorb_project(&l->kv_b.vk,kw,l->kv_b.s,l->kv_b.fmt,
+                    if(VK_FMT_OK(&l->o)&&
+                       coli_vk_attention_absorb_project(&l->kv_b.vk,kw,l->kv_b.s,l->kv_b.fmt,l->kv_b.gs,
                             &l->o.vk,l->o.fmt==1?(const void*)l->o.q8:(const void*)l->o.q4,
-                            l->o.s,l->o.fmt,out,Q,layer,S,H,c->qk_nope,c->qk_rope,
+                            l->o.s,l->o.fmt,l->o.gs,out,Q,layer,S,H,c->qk_nope,c->qk_rope,
                             vh,kvl,st0,T,c->attn_scale,D))
                         vk_core=vk_projected=1;
                     if(!vk_core)
                         vk_core=coli_vk_attention_absorb(&l->kv_b.vk,kw,
-                            l->kv_b.s,l->kv_b.fmt,ctx,Q,layer,S,H,c->qk_nope,c->qk_rope,
+                            l->kv_b.s,l->kv_b.fmt,l->kv_b.gs,ctx,Q,layer,S,H,c->qk_nope,c->qk_rope,
                             vh,kvl,st0,T,c->attn_scale);
                 }
             }
@@ -3970,9 +3971,9 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
         if(g_vk_dense && !omp_in_parallel() && (fsh==1||fsh==2||fsh==5) &&
            l->sh_up.fmt==fsh && l->sh_down.fmt==fsh){
             #define SW_(t) ((t).fmt==1?(const void*)(t).q8:(const void*)(t).q4)
-            if(coli_vk_tensor_ensure(&l->sh_gate.vk,SW_(l->sh_gate),l->sh_gate.s,fsh,D,sI)&&
-               coli_vk_tensor_ensure(&l->sh_up.vk,  SW_(l->sh_up),  l->sh_up.s,  fsh,D,sI)&&
-               coli_vk_tensor_ensure(&l->sh_down.vk,SW_(l->sh_down),l->sh_down.s,fsh,sI,D)){
+            if(coli_vk_tensor_ensure(&l->sh_gate.vk,SW_(l->sh_gate),l->sh_gate.s,fsh,D,sI,l->sh_gate.gs)&&
+               coli_vk_tensor_ensure(&l->sh_up.vk,  SW_(l->sh_up),  l->sh_up.s,  fsh,D,sI,l->sh_up.gs)&&
+               coli_vk_tensor_ensure(&l->sh_down.vk,SW_(l->sh_down),l->sh_down.s,fsh,sI,D,l->sh_down.gs)){
                 ColiVkTensor *vg=l->sh_gate.vk,*vu=l->sh_up.vk,*vd=l->sh_down.vk;
                 int rows1[1]={S};
                 if(coli_vk_expert_group(&vg,&vu,&vd,rows1,1,hh,x)) shared_cuda=1;
@@ -6594,16 +6595,18 @@ static void vk_registry_fill(Model *m){
                 if(++loadfail<4) fprintf(stderr,"[VK] tier fill: expert_load(%d,%d) failed\n",layer,eid);
                 if(loadfail>=64) break;                     /* disk trouble: stop burning time */
                 continue; } src=&tmp; }
-        int xf=src->g.fmt;   /* int4 (2) and int3-g64 (5) tiers; gate/up must share fmt for
-                              * the fused gate_up shader, down may differ per-projection */
-        if((xf!=2&&xf!=5)||src->u.fmt!=xf||(src->d.fmt!=2&&src->d.fmt!=5)){
+        int xf=src->g.fmt;   /* int4 (2), grouped int4 (4), int3-g64 (5) tiers; gate/up must
+                              * share fmt for the fused gate_up shader, down may differ */
+        if((xf!=2&&xf!=4&&xf!=5)||src->u.fmt!=xf||src->u.gs!=src->g.gs
+           ||(src->d.fmt!=2&&src->d.fmt!=4&&src->d.fmt!=5)
+           ||(xf==4&&(src->g.gs<8||src->g.gs%8))||(src->d.fmt==4&&(src->d.gs<8||src->d.gs%8))){
             if(tried<4) fprintf(stderr,"[VK] tier fill: (%d,%d) fmt %d/%d/%d not int4/int3-g64 (src=%s)\n",
                 layer,eid,src->g.fmt,src->u.fmt,src->d.fmt,src==&tmp?"load":"pin");
             continue; }
         ColiVkTensor **slot=vk_reg_at(layer,eid);
-        if(!coli_vk_tensor_ensure(&slot[0],src->g.q4,src->g.s,xf,c->hidden,c->moe_inter)||
-           !coli_vk_tensor_ensure(&slot[1],src->u.q4,src->u.s,xf,c->hidden,c->moe_inter)||
-           !coli_vk_tensor_ensure(&slot[2],src->d.q4,src->d.s,src->d.fmt,c->moe_inter,c->hidden)){
+        if(!coli_vk_tensor_ensure(&slot[0],src->g.q4,src->g.s,xf,c->hidden,c->moe_inter,src->g.gs)||
+           !coli_vk_tensor_ensure(&slot[1],src->u.q4,src->u.s,xf,c->hidden,c->moe_inter,src->u.gs)||
+           !coli_vk_tensor_ensure(&slot[2],src->d.q4,src->d.s,src->d.fmt,c->moe_inter,c->hidden,src->d.gs)){
             if(slot[0]){coli_vk_tensor_free(slot[0]);slot[0]=NULL;}
             if(slot[1]){coli_vk_tensor_free(slot[1]);slot[1]=NULL;}
             fprintf(stderr,"[VK] expert tier: VRAM full after %d experts\n",g_vk_reg_n);

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -317,7 +317,7 @@ static int g_vk_budget2;      /* COLI_VK_EXPERTS2: dev2 expert-tier cap (with CO
 static int g_vk_reg_n2;       /* experts resident on the dev2 tier */
 /* PROF anatomy of the VK expert block (master-thread accumulated in moe(), printed by
  * profile_print): where a decode block's wall goes besides t_ecpu/t_ewait/t_egpu. */
-static double g_vkb_cls, g_vkb_issue, g_vkb_acc;
+static double g_vkb_cls, g_vkb_issue, g_vkb_acc, g_vkb_wrk, g_vkb_join;
 static int64_t g_vkb_blocks, g_vkb_nvk, g_vkb_nvk2, g_vkb_ncpu;
 static int g_vk_attn;         /* COLI_VK_ATTN=1: run the MLA absorb attention core on Vulkan
                                * (mirrors COLI_CUDA_ATTN; KV latent cache mirrored on-device) */
@@ -3055,10 +3055,12 @@ static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_ba
  * dev0-only) while the 580's exec itself finishes early (take-wait 0.1s) — off-thread
  * it overlaps dev0's issue + the CPU expert share. All Vulkan state it touches is
  * G2-private, and moe() joins before take2, preserving the one-in-flight invariant. */
-typedef struct { ColiVkTensor **g,**u,**d; const int *rows; int n; const float *x; int rc; } Vk2Iss;
+typedef struct { ColiVkTensor **g,**u,**d; const int *rows; int n; const float *x; int rc; double dt; } Vk2Iss;
 static void *vk2_issue_worker(void *p){
     Vk2Iss *j=(Vk2Iss*)p;
+    double t0=now_s();
     j->rc = coli_vk_expert_group_issue2(j->g,j->u,j->d,j->rows,j->n,j->x);
+    j->dt = now_s()-t0;
     return NULL;
 }
 #endif
@@ -3801,7 +3803,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
             /* issue the SLOWER device first so it gets the longest overlap window;
              * dev2's submit runs on a worker thread (joined before take2 below) so its
              * per-block cost overlaps dev0 issue + the CPU share instead of serializing */
-            Vk2Iss iss2 = { vg2, vu2, vd2, vrows2, nvk2, vk_xh2, 0 };
+            Vk2Iss iss2 = { vg2, vu2, vd2, vrows2, nvk2, vk_xh2, 0, 0 };
             pthread_t iss2_th; int iss2_threaded=0;
             if(nvk2>0){
                 if(pthread_create(&iss2_th,NULL,vk2_issue_worker,&iss2)==0) iss2_threaded=1;
@@ -3863,7 +3865,8 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
             }
             /* dev2 group: taken AFTER dev0's accumulate so the slower card gets the
              * extra overlap; same per-expert CPU recompute fallback on failure. */
-            if(iss2_threaded) pthread_join(iss2_th,NULL);
+            if(iss2_threaded){ double t_j0=now_s(); pthread_join(iss2_th,NULL);
+                if(g_prof){ g_vkb_join+=now_s()-t_j0; g_vkb_wrk+=iss2.dt; } }
             int vk2_ok = iss2.rc && coli_vk_expert_group_take2(vk_yh2);
             for(int c2=0;c2<nvk2;c2++){ int nr=vrows2[c2];
                 if(vk2_ok){ int o=voff2[c2];
@@ -5582,9 +5585,9 @@ static void profile_print(Model *m, double elapsed){
         elapsed-m->t_ewait-m->t_emm-m->t_attn-m->t_head-m->t_route-m->t_p2p:0);
 #ifdef COLI_VULKAN
     if(g_prof && g_vkb_blocks)
-        printf("VK-BLOCK: %lld blocks | avg nvk %.2f (dev2 %.2f) / ncpu %.2f | classify %.3fs | issue %.3fs | take+acc %.3fs (take-wait %.3fs) | cpu exec %.3fs wait %.3fs\n",
+        printf("VK-BLOCK: %lld blocks | avg nvk %.2f (dev2 %.2f) / ncpu %.2f | classify %.3fs | issue %.3fs | take+acc %.3fs (take-wait %.3fs) | d2-iss wrk %.3fs join %.3fs | cpu exec %.3fs wait %.3fs\n",
             (long long)g_vkb_blocks,(double)g_vkb_nvk/g_vkb_blocks,(double)g_vkb_nvk2/g_vkb_blocks,(double)g_vkb_ncpu/g_vkb_blocks,
-            g_vkb_cls,g_vkb_issue,g_vkb_acc,m->t_egpu,m->t_ecpu,m->t_ewait);
+            g_vkb_cls,g_vkb_issue,g_vkb_acc,m->t_egpu,g_vkb_wrk,g_vkb_join,m->t_ecpu,m->t_ewait);
 #endif
     if(g_mirror){
         double br[MIR_REPS]={0}, bt=0;
@@ -5614,7 +5617,7 @@ static void profile_reset(Model *m){
     m->t_ecpu=m->t_egpu=m->t_route=m->t_p2p=0;m->n_p2p=0;
     m->cpu_expert_bytes=0;m->cpu_expert_rows=0;
 #ifdef COLI_VULKAN
-    g_vkb_cls=g_vkb_issue=g_vkb_acc=0; g_vkb_blocks=g_vkb_nvk=g_vkb_nvk2=g_vkb_ncpu=0;
+    g_vkb_cls=g_vkb_issue=g_vkb_acc=g_vkb_wrk=g_vkb_join=0; g_vkb_blocks=g_vkb_nvk=g_vkb_nvk2=g_vkb_ncpu=0;
 #endif
     m->t_aproj=m->t_acore=m->t_aout=0;
     atomic_store_explicit(&g_edisk_ns,0,memory_order_relaxed);

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -6524,13 +6524,19 @@ static void vk_registry_fill(Model *m){
     g_vk_reg=calloc((size_t)NL*E*3,sizeof(*g_vk_reg)); g_vk_reg_E=E; g_vk_reg_NL=NL;
     if(!g_vk_reg){ free(cand); return; }
     ESlot tmp; memset(&tmp,0,sizeof(tmp)); tmp.eid=-1;
-    double t0=now_s(); int64_t bytes=0; int tried=0;
+    double t0=now_s(); int64_t bytes=0; int tried=0, loadfail=0;
     for(int64_t i2=0;i2<n && g_vk_reg_n<g_vk_budget;i2++){
         int layer=cand[i2].layer, eid=cand[i2].eid; tried++;
         ESlot *src=NULL, *P=m->pin[layer];
         for(int z=0;z<m->npin[layer];z++) if(P[z].eid==eid && P[z].slab){ src=&P[z]; break; }
-        if(!src){ if(!expert_load(m,layer,eid,&tmp,0)) continue; src=&tmp; }
-        if(src->g.fmt!=2||src->u.fmt!=2||src->d.fmt!=2) continue;   /* int4 tier only */
+        if(!src){ if(expert_load(m,layer,eid,&tmp,0)!=0){   /* 0 = success (impl convention) */
+                if(++loadfail<4) fprintf(stderr,"[VK] tier fill: expert_load(%d,%d) failed\n",layer,eid);
+                if(loadfail>=64) break;                     /* disk trouble: stop burning time */
+                continue; } src=&tmp; }
+        if(src->g.fmt!=2||src->u.fmt!=2||src->d.fmt!=2){
+            if(tried<4) fprintf(stderr,"[VK] tier fill: (%d,%d) fmt %d/%d/%d != int4 (src=%s)\n",
+                layer,eid,src->g.fmt,src->u.fmt,src->d.fmt,src==&tmp?"load":"pin");
+            continue; }   /* int4 tier only */
         ColiVkTensor **slot=vk_reg_at(layer,eid);
         if(!coli_vk_tensor_ensure(&slot[0],src->g.q4,src->g.s,2,c->hidden,c->moe_inter)||
            !coli_vk_tensor_ensure(&slot[1],src->u.q4,src->u.s,2,c->hidden,c->moe_inter)||

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -202,6 +202,9 @@ typedef struct {
     ESlot **ecache; int *ecn; int ecap;          /* LRU expert per-layer */
     float **kv_dev_L, **kv_dev_R; int *kv_dev_valid; /* ombra KV su device (decode) */
     float **ln_dev;                              /* in_ln/post_ln cached on device: [layer*2+{0,1}] (Inc.4) */
+#ifdef COLI_VULKAN
+    int *vk_kv_valid;                            /* righe [0,v) specchiate nella cache KV Vulkan */
+#endif
     ESlot ws[64];                                /* working set del layer corrente (load paralleli) */
     ESlot **pin; int *npin;                      /* HOT-STORE: expert pinnati in RAM (mai evicted) */
     uint32_t **eusage;                           /* contatori persistenti (per STATS/PIN) */
@@ -295,6 +298,8 @@ static int g_vk_budget;       /* COLI_VK_EXPERTS: max experts uploaded to VK VRA
 static int g_vk_resident;     /* how many experts currently VK-resident */
 static int g_vk_dense;        /* COLI_VK_DENSE=1: run the resident dense matmuls (attention
                                * projections + shared expert) on Vulkan too */
+static int g_vk_attn;         /* COLI_VK_ATTN=1: run the MLA absorb attention core on Vulkan
+                               * (mirrors COLI_CUDA_ATTN; KV latent cache mirrored on-device) */
 #endif
 #ifdef COLI_CUDA
 static int g_cuda_enabled;
@@ -1205,6 +1210,9 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
     m->ecap=cap; m->ecache=calloc(NR,sizeof(ESlot*)); m->ecn=calloc(NR,sizeof(int));
     m->kv_dev_L=calloc(NR,sizeof(float*)); m->kv_dev_R=calloc(NR,sizeof(float*));
     m->kv_dev_valid=calloc(NR,sizeof(int));
+#ifdef COLI_VULKAN
+    m->vk_kv_valid=calloc(NR,sizeof(int));
+#endif
     m->eroute=calloc(NR,sizeof(int*)); m->enr=calloc(NR,sizeof(int));
     m->pin=calloc(NR,sizeof(ESlot*)); m->npin=calloc(NR,sizeof(int));
     m->eusage=calloc(NR,sizeof(uint32_t*)); m->eheat=calloc(NR,sizeof(uint32_t*));
@@ -2533,6 +2541,10 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
         if(ks==m->kv&&m->kv_dev_valid&&layer<=c->n_layers&&m->kv_dev_valid[layer]>pos)
             m->kv_dev_valid[layer]=pos;              /* riga riscritta: l'ombra si accorcia */
 #endif
+#ifdef COLI_VULKAN
+        if(ks==m->kv&&m->vk_kv_valid&&layer<=c->n_layers&&m->vk_kv_valid[layer]>pos)
+            m->vk_kv_valid[layer]=pos;               /* riga riscritta: la cache VK si accorcia */
+#endif
         memcpy(Ldst, cs, c->kv_lora*sizeof(float));
         rmsnorm(Ldst, Ldst, l->kv_a_ln, c->kv_lora, c->eps);     /* latente normato */
         memcpy(Rdst, cs+c->kv_lora, c->qk_rope*sizeof(float));
@@ -2733,7 +2745,34 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
             }
         }
 #endif
-        if(!cuda_core){
+        int vk_core=0;
+#ifdef COLI_VULKAN
+        /* Vulkan MLA absorb core (COLI_VK_ATTN=1): scores/softmax/latent/value rows for all
+         * S x H in ONE submit per layer, reading the persistent on-device KV mirror (rows
+         * appended incrementally; vk_kv_valid = watermark, invalidated like the CUDA shadow
+         * on rewrite/rebind/resize). Falls back to CPU on DSA top-k selection, ragged KV,
+         * the MTP layer, or any backend failure — output identical either way. */
+        if(!cuda_core&&g_vk_attn&&!kvs&&!positions&&S<=4&&layer<c->n_layers&&
+           (l->kv_b.fmt==1||l->kv_b.fmt==2)&&kvl<=512&&c->qk_nope<=256&&c->qk_rope<=64&&
+           m->vk_kv_valid){
+            int dsa_on=0; if(dnsel) for(int s=0;s<S;s++) if(dnsel[s]>0) dsa_on=1;
+            int st0=m->kv_start[layer], T=pos_base+S;
+            if(!dsa_on&&T<=m->max_t&&coli_vk_kv_ensure(layer,m->max_t,kvl,c->qk_rope)){
+                int ok=1;
+                for(int t=m->vk_kv_valid[layer];t<T&&ok;t++)
+                    ok=coli_vk_kv_row(layer,t,coli_kv_row(m->Lc[layer],t,kvl),
+                                      coli_kv_row(m->Rc[layer],t,c->qk_rope));
+                if(ok){
+                    m->vk_kv_valid[layer]=T;
+                    vk_core=coli_vk_attention_absorb(&l->kv_b.vk,
+                        l->kv_b.fmt==1?(const void*)l->kv_b.q8:(const void*)l->kv_b.q4,
+                        l->kv_b.s,l->kv_b.fmt,ctx,Q,layer,S,H,c->qk_nope,c->qk_rope,
+                        vh,kvl,st0,T,c->attn_scale);
+                }
+            }
+        }
+#endif
+        if(!cuda_core&&!vk_core){
         /* Causal rows grow with s; round-robin pairs keep that work balanced. */
         #pragma omp parallel for collapse(2) schedule(static,1)
         for(int s=0;s<S;s++) for(int h=0;h<H;h++){
@@ -4553,6 +4592,12 @@ static void kv_alloc(Model *m, int max_t){
         m->kv_dev_valid[i]=0;
     }
 #endif
+#ifdef COLI_VULKAN
+    if(g_vulkan&&m->vk_kv_valid){                        /* dimensioni cambiate: cache VK da rifare */
+        coli_vk_kv_reset();
+        for(int i=0;i<c->n_layers+1;i++) m->vk_kv_valid[i]=0;
+    }
+#endif
     if(k->Lc){ for(int i=0;i<c->n_layers+1;i++){
 #ifdef COLI_METAL
         if(g_metal_enabled){ coli_metal_unregister(k->Lc[i]); coli_metal_unregister(k->Rc[i]); }
@@ -4587,6 +4632,10 @@ static void kv_alloc(Model *m, int max_t){
 static void kv_bind(Model *m, KVState *k){
     if(m->kv!=k && m->kv_dev_valid)                 /* ombra legata al KVState corrente */
         for(int i=0;i<m->c.n_layers+1;i++) m->kv_dev_valid[i]=0;
+#ifdef COLI_VULKAN
+    if(m->kv!=k && m->vk_kv_valid)                  /* la cache VK specchia la KV corrente */
+        for(int i=0;i<m->c.n_layers+1;i++) m->vk_kv_valid[i]=0;
+#endif
     m->kv=k; m->Lc=k->Lc; m->Rc=k->Rc; m->Ic=k->Ic;
     m->max_t=k->max_t; m->kv_start=k->kv_start;
 }
@@ -7189,8 +7238,10 @@ int main(int argc, char **argv){
         if(!g_vulkan){ fprintf(stderr,"[VK] Vulkan backend unavailable (need libvulkan + shaders/qmatmul{,_gate_up}.spv)\n"); return 2; }
         g_vk_budget = getenv("COLI_VK_EXPERTS") ? atoi(getenv("COLI_VK_EXPERTS")) : 1024;
         g_vk_dense = getenv("COLI_VK_DENSE") ? atoi(getenv("COLI_VK_DENSE")) : 0;
-        fprintf(stderr,"[VK] expert tier active: routed int4 experts on the GPU (budget %d)%s\n",
-                g_vk_budget, g_vk_dense ? " + dense projections + shared expert" : "");
+        g_vk_attn = getenv("COLI_VK_ATTN") ? atoi(getenv("COLI_VK_ATTN")) : 0;
+        fprintf(stderr,"[VK] expert tier active: routed int4 experts on the GPU (budget %d)%s%s\n",
+                g_vk_budget, g_vk_dense ? " + dense projections + shared expert" : "",
+                g_vk_attn ? " + absorb attention core" : "");
     }
 #endif
 #ifdef COLI_CUDA

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -2552,6 +2552,28 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
         pipe_done=attn_pipe_prefill(m,l,layer,x,0,S,pos_base,out,NULL);
 #endif
     if(!pipe_done){
+        int vk_qp=0; (void)vk_qp;
+#ifdef COLI_VULKAN
+        /* Single-submit q-prep chain: [q_a+kv_a] -> rmsnorm(q latent, on-GPU) -> q_b.
+         * One fence where the split path pays three (the CPU norm forced the extra
+         * roundtrips). Q and comp are written directly; QR is skipped entirely. */
+        static int g_vk_qprep=-1;
+        if(g_vk_qprep<0) g_vk_qprep=getenv("COLI_VK_QPREP")?atoi(getenv("COLI_VK_QPREP")):1;
+        float *dbgQ=NULL,*dbgC=NULL;
+        if(g_vk_qprep==2){ dbgQ=falloc((int64_t)S*l->q_b.O); dbgC=falloc((int64_t)S*l->kv_a.O); }
+        if(g_vk_qprep && g_vk_dense && l->q_a.fmt==l->kv_a.fmt && l->q_a.fmt==l->q_b.fmt && VK_FMT_OK(&l->q_a)
+           && l->q_a.gs==l->kv_a.gs && l->q_a.gs==l->q_b.gs)
+            vk_qp=coli_vk_attn_qprep(layer,
+                &l->q_a.vk, l->q_a.fmt==1?(const void*)l->q_a.q8:(const void*)l->q_a.q4, l->q_a.s, l->q_a.O,
+                &l->kv_a.vk, l->kv_a.fmt==1?(const void*)l->kv_a.q8:(const void*)l->kv_a.q4, l->kv_a.s, l->kv_a.O,
+                &l->q_b.vk, l->q_b.fmt==1?(const void*)l->q_b.q8:(const void*)l->q_b.q4, l->q_b.s, l->q_b.O,
+                l->q_a.fmt, l->q_a.gs, l->q_a_ln, c->eps, x, S, l->q_a.I,
+                g_vk_qprep==2?dbgQ:Q, g_vk_qprep==2?dbgC:comp,
+                g_vk_qprep==2?NULL:QR);   /* the DSA indexer reads the NORMED latent from QR */
+        int qp_ran=vk_qp;
+        if(g_vk_qprep==2 && vk_qp) vk_qp=0;   /* verify mode: chain ran, split path is authoritative */
+        if(!vk_qp){
+#endif
         int vk_pair=0; (void)vk_pair;
 #ifdef COLI_VULKAN
         /* q_a and kv_a read the SAME x: one fused submit for the pair (one x upload,
@@ -2572,6 +2594,14 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
         if(!vk_matmul_qt(&l->kv_a, comp, x, S))
 #endif
         matmul_qt_ex(comp, x, &l->kv_a, S, 0);
+#ifdef COLI_VULKAN
+        }
+        if(dbgQ){ float mq=0,mc=0;
+            for(int64_t i2=0;i2<(int64_t)S*l->q_b.O;i2++){ float d=fabsf(dbgQ[i2]-Q[i2])/(fabsf(Q[i2])+1e-3f); if(d>mq) mq=d; }
+            for(int64_t i2=0;i2<(int64_t)S*l->kv_a.O;i2++){ float d=fabsf(dbgC[i2]-comp[i2])/(fabsf(comp[i2])+1e-3f); if(d>mc) mc=d; }
+            fprintf(stderr,"[QPREP-VERIFY] layer %d S=%d ran=%d maxrel q %.4g kv %.4g\n",layer,S,qp_ran,mq,mc);
+            free(dbgQ); free(dbgC); }
+#endif
     }
     if(!pipe_done) for(int s=0;s<S;s++){
         KVState *ks=kvs?kvs[s]:m->kv;

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -890,11 +890,6 @@ static int g_pilot_real=0;/* PILOT_REAL=1: il pilota fa LOAD VERI cross-layer de
 static int g_pilot_two=0; /* PILOT_TWO=1: two-step prefetch — before running L+1's router,
                           * approximate MoE(L) using only the shared expert (resident, no disk)
                           * and add it to the state. Trades 3 small matmuls for +2.3% recall. */
-static int g_pilot_evict_guard=1;/* PILOT_EVICT_GUARD=0 -> old behavior (a speculation evicts the plain LRU).
-                          * Default ON: protect a RESIDENT demand-loaded expert from a speculation only when
-                          * it is genuinely WARM (>=2 accesses) AND clearly hotter than the predicted expert
-                          * by tier_pick_lfru's 25%+4-freq hysteresis; otherwise the speculation may evict the
-                          * plain-LRU victim as before. Cache placement only -> output byte-identical. (#441, #490) */
 /* Handshake main<->pilota per il load-vero cross-layer. Invariante di sicurezza in DUE parti:
  *  1) Percorso MATMUL (moe): il pilota scrive SOLO ecache[layer] con layer > g_cur_moe_layer;
  *     il matmul in moe() legge SOLO ecache[layer]==g_cur_moe_layer, e la barriera a inizio moe()
@@ -910,6 +905,12 @@ static pthread_mutex_t g_pilot_mx=PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t g_pilot_cv=PTHREAD_COND_INITIALIZER;
 static _Atomic int g_cur_moe_layer=-1;   /* massimo layer moe in cui il MAIN e' entrato (per forward) */
 static int g_pilot_inflight[256];        /* protected by g_pilot_mx; URING can load a layer concurrently */
+static int g_pilot_nw=1;                 /* PILOT_WORKERS: blocking-path pilot threads (SPMC ring). 1 = today's behaviour (byte-identical). Only the non-URING PILOT_REAL path fans out; URING already batches to QD>1. */
+static int g_pilot_evict_guard=1;/* PILOT_EVICT_GUARD=0 -> old plain-LRU eviction (A/B). Default ON:
+                          * a speculative pilot load may evict a RESIDENT expert only if the predicted
+                          * expert is historically HOTTER than the victim (same LFRU hysteresis as
+                          * tier_pick_lfru); else it drops the speculation rather than thrash a warm
+                          * demand-loaded expert. Cache placement only -> output byte-identical. (#441/#474) */
 static _Atomic long g_pilot_loads=0;     /* load cross-layer VERI completati (banda spesa) */
 static _Atomic long g_pilot_drops=0;     /* predizioni scartate perche' il main possiede gia' il layer */
 /* format from `bits`: >=16 f32, 5..8 int8, 4 int4-packed, 3 int3-g64 (group scales), <=2 int2 */
@@ -4188,7 +4189,7 @@ static void la_predict(Model *m, int target, const float *h, int kind){
  * del fadvise BLOCCA (~0.5ms x 169k chiamate = +92s/48 token, misurato) — inline
  * il pilota costava piu' di quanto rendesse. Ring lock-free 1P/1C; pieno = scarta
  * (un hint perso non e' un errore). */
-static struct { int l,e; } pilot_q[4096];
+static struct { _Atomic int l,e; } pilot_q[4096];  /* payload atomico (relaxed): la claim SPMC legge speculativamente prima della CAS e scarta se perde -> senza _Atomic sarebbe una data race C11 col produttore. int e' sempre lock-free: stessa size/align. */
 static volatile unsigned pilot_w=0, pilot_r=0;
 static Model *pilot_m=NULL;
 /* PILOT_REAL: load VERO dell'expert predetto dentro la LRU del layer FUTURO. Vedi
@@ -4196,49 +4197,63 @@ static Model *pilot_m=NULL;
  * il lock protegge solo la scelta/pubblicazione dello slot e l'handshake col main. */
 static void pilot_realload(Model *m, int layer, int eid){
     pthread_mutex_lock(&g_pilot_mx);
-    if(layer <= atomic_load_explicit(&g_cur_moe_layer,memory_order_acquire)){
-        atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);
-        pthread_mutex_unlock(&g_pilot_mx); return;      /* il main possiede gia' questo layer */
+    if(layer<0 || layer>=256 || layer <= atomic_load_explicit(&g_cur_moe_layer,memory_order_acquire)){
+        atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);   /* fuori range (come il ramo URING) o main gia' su questo layer */
+        pthread_mutex_unlock(&g_pilot_mx); return;
     }
     ESlot *P=m->pin[layer];                             /* gia' residente (pin o ecache)? skip */
 #ifdef COLI_VULKAN
     if(vk_reg_served(layer,eid)){ pthread_mutex_unlock(&g_pilot_mx); return; }   /* VK-tier-served: no load */
 #endif
     for(int z=0;z<m->npin[layer];z++) if(P[z].eid==eid){ pthread_mutex_unlock(&g_pilot_mx); return; }
-    ESlot *Sl=m->ecache[layer]; int nn=m->ecn[layer];
-    for(int z=0;z<nn;z++) if(Sl[z].eid==eid){ pthread_mutex_unlock(&g_pilot_mx); return; }
-    int slot,isnew;                                     /* cresci se c'e' posto, altrimenti LRU */
-    if(nn<m->ecap){ slot=nn; isnew=1; }
-    else { int lru=0; for(int z=1;z<nn;z++) if(Sl[z].used<Sl[lru].used) lru=z; slot=lru; isnew=0;
-        /* LFRU eviction guard (#441, fix #490): a speculation must not drop a WARM
-         * demand-loaded expert. We PROTECT the victim only when it is genuinely warm
-         * (>=2 demand accesses) AND clearly hotter than the speculation by tier_pick_lfru's
-         * 25%+4-freq hysteresis. The original #441 formula tested the speculation's score
-         * against victim+margin, which — because a speculation is by definition historically
-         * colder than a just-used demand expert — dropped ~all speculations once the cache
-         * was full, collapsing the LRU hit share (#490). Cache placement only -> output
-         * byte-identical (a dropped speculation is demand-loaded later, same value). */
-        if(g_pilot_evict_guard && m->eheat && m->elast && Sl[lru].eid>=0){
-            int vid=Sl[lru].eid; uint32_t vh=m->eheat[layer][vid];
+    ESlot *Sl=m->ecache[layer]; int nn=m->ecn[layer];   /* dedup contro residenti E prenotazioni in volo -(eid+2) */
+    for(int z=0;z<nn;z++) if(Sl[z].eid==eid || Sl[z].eid==-(eid+2)){ pthread_mutex_unlock(&g_pilot_mx); return; }
+    /* SPMC (PILOT_WORKERS>1): scegli lo slot sotto lock e MARCALO prenotato prima di
+     * rilasciarlo, cosi' gli altri worker non lo scelgono come vittima ne' ricaricano
+     * lo stesso eid. Stesso schema del ramo URING (prenotazione visibile -(eid+2),
+     * ecn bumpato subito, scan-vittima che salta le prenotazioni). */
+    int slot,isnew=0;
+    if(nn<m->ecap){ slot=nn; isnew=1; m->ecn[layer]=nn+1; }   /* cresci: pubblica subito lo slot (marcato prenotato) */
+    else {
+        slot=-1;
+        for(int z=0;z<nn;z++){
+            if(Sl[z].eid==-1){ slot=z; break; }         /* riusa uno slot libero/fallito */
+            if(Sl[z].eid< -1) continue;                 /* prenotazione di un ALTRO worker: mai vittima */
+            if(slot<0 || Sl[z].used<Sl[slot].used) slot=z;
+        }
+        if(slot<0){ atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);
+                    pthread_mutex_unlock(&g_pilot_mx); return; }   /* tutti gli slot sono in volo */
+        /* LFRU eviction guard (#441, narrowed by #497 — folded into the SPMC selection):
+         * protect the victim only when genuinely WARM (>=2 demand accesses) AND clearly
+         * hotter than the speculation by tier_pick_lfru's 25%+4-freq hysteresis; the
+         * un-narrowed #474 test dropped ~all speculations on a full cache (#490).
+         * Skips free slots (eid==-1). Cache placement only -> output unchanged. */
+        if(g_pilot_evict_guard && m->eheat && m->elast && Sl[slot].eid>=0){
+            int vid=Sl[slot].eid; uint32_t vh=m->eheat[layer][vid];
             if(vh>=2){
                 uint64_t vs=tier_lfru_score(vh,m->elast[layer][vid],m->eaccess_clock);
                 uint64_t cs=tier_lfru_score(m->eheat[layer][eid],m->elast[layer][eid],m->eaccess_clock);
                 if(vs+(vs>>2)+(4u<<8)>cs){ atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);
-                                            pthread_mutex_unlock(&g_pilot_mx); return; } } } }
+                                            pthread_mutex_unlock(&g_pilot_mx); return; } } }
+    }
     ESlot *dst=&Sl[slot];
-    dst->eid=-1;                                        /* nascondi dagli scan-hint mentre carica */
+    dst->eid=-(eid+2);                                  /* prenotazione VISIBILE: dedup + scan-vittima degli altri worker la vedono (isnew) */
+    (void)isnew;
+    dst->used=(uint64_t)-1;                             /* sentinella "in carica": mai vittima LRU finche' expert_load non pubblica l'eid reale
+                                                         * (chiude la finestra eid-reale/used-vecchio: uno snapshot di eclock si sarebbe potuto
+                                                         * far superare da altri load durante il pread). used fresco ristampato al successo. */
     g_pilot_inflight[layer]++;
     pthread_mutex_unlock(&g_pilot_mx);
 
-    int rc=expert_load(m,layer,eid,dst,0,0);            /* pread VERO — fuori dal lock, sovrapposto al compute; fatal=0: un errore su una speculazione NON deve uccidere il server; demand=0: speculative, never classified */
+    int rc=expert_load(m,layer,eid,dst,0,0);            /* pread VERO — fuori dal lock, concorrente fra worker (come i PIPE demand); fatal=0: una speculazione fallita NON uccide il server; demand=0: speculative, never classified. Al successo expert_load setta dst->eid=eid. */
 
     pthread_mutex_lock(&g_pilot_mx);
     if(rc==0){
-        dst->used=(uint64_t)__atomic_add_fetch(&m->eclock,1,__ATOMIC_RELAXED);
-        if(isnew) m->ecn[layer]=slot+1;                 /* pubblica lo slot SOLO ora che eid e' valido */
+        dst->used=(uint64_t)__atomic_add_fetch(&m->eclock,1,__ATOMIC_RELAXED);  /* eid gia' reale (expert_load); timbra used fresco */
         atomic_fetch_add_explicit(&g_pilot_loads,1,memory_order_relaxed);
     } else {
-        atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed); /* load fallito: slot resta nascosto (eid=-1), mai pubblicato */
+        dst->eid=-1;                                    /* load fallito: libera la prenotazione (slot resta in ecn ma nascosto, riusabile) */
+        atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);
     }
     g_pilot_inflight[layer]--;
     pthread_cond_broadcast(&g_pilot_cv);
@@ -4254,7 +4269,7 @@ static void pilot_uring_batch(Model *m){
     unsigned r=__atomic_load_n(&pilot_r,__ATOMIC_ACQUIRE);
     unsigned w=__atomic_load_n(&pilot_w,__ATOMIC_ACQUIRE);
     while(r!=w && nd<URING_LOAD_MAX){
-        int layer=pilot_q[r&4095].l,eid=pilot_q[r&4095].e; r++;
+        int layer=atomic_load_explicit(&pilot_q[r&4095].l,memory_order_relaxed),eid=atomic_load_explicit(&pilot_q[r&4095].e,memory_order_relaxed); r++;
         if(layer<0 || layer>=256){ atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed); continue; }
         pthread_mutex_lock(&g_pilot_mx);
         if(layer<=atomic_load_explicit(&g_cur_moe_layer,memory_order_acquire)){
@@ -4278,21 +4293,17 @@ static void pilot_uring_batch(Model *m){
                 if(Sl[z].eid< -1) continue;          /* URING reservation in flight */
                 if(slot<0 || Sl[z].used<Sl[slot].used) slot=z;
             }
-            /* LFRU eviction guard (#441, fix #490): protect a WARM resident from a speculation.
-             * Same corrected test as pilot_realload: victim must be genuinely warm (>=2 accesses)
-             * AND clearly hotter (25%+4-freq hysteresis). See pilot_realload for the rationale and
-             * the #490 regression the original formula caused. */
-            if(slot>=0 && Sl[slot].eid>=0 && g_pilot_evict_guard && m->eheat && m->elast){
-                int vid=Sl[slot].eid; uint32_t vh=m->eheat[layer][vid];
-                if(vh>=2){
-                    uint64_t vs=tier_lfru_score(vh,m->elast[layer][vid],m->eaccess_clock);
-                    uint64_t cs=tier_lfru_score(m->eheat[layer][eid],m->elast[layer][eid],m->eaccess_clock);
-                    if(vs+(vs>>2)+(4u<<8)>cs){ atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);
-                                                pthread_mutex_unlock(&g_pilot_mx); continue; }
-                }
-            }
         }
         if(slot<0){ atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed); pthread_mutex_unlock(&g_pilot_mx); continue; }
+        /* LFRU eviction guard (#441, narrowed by #497): protect only a genuinely WARM
+         * resident (>=2 accesses) that is clearly hotter (see pilot_realload) */
+        if(g_pilot_evict_guard && m->eheat && m->elast && Sl[slot].eid>=0){
+            int vid=Sl[slot].eid; uint32_t vh=m->eheat[layer][vid];
+            if(vh>=2){
+                uint64_t vs=tier_lfru_score(vh,m->elast[layer][vid],m->eaccess_clock);
+                uint64_t cs=tier_lfru_score(m->eheat[layer][eid],m->elast[layer][eid],m->eaccess_clock);
+                if(vs+(vs>>2)+(4u<<8)>cs){ atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);
+                                            pthread_mutex_unlock(&g_pilot_mx); continue; } } }
         ESlot *dst=&Sl[slot];
         dst->eid=-(eid+2);                         /* visible reservation; never considered resident/evictable */
         g_pilot_inflight[layer]++;
@@ -4334,22 +4345,63 @@ static void pilot_uring_batch(Model *m){
     }
 }
 #endif
-static void *pilot_worker(void *arg){
-    (void)arg;
+/* SPMC ring claim: each of N pilot workers grabs a UNIQUE ring index via CAS, never
+ * advancing past pilot_w. Returns 1 and *out=index, or 0 if the ring is empty. The
+ * producer stays single (main thread, only pilot_w) — this only splits the consumer. */
+static int pilot_ring_claim(int *out_l, int *out_e){
     for(;;){
         unsigned r=__atomic_load_n(&pilot_r,__ATOMIC_ACQUIRE);
         unsigned w=__atomic_load_n(&pilot_w,__ATOMIC_ACQUIRE);
-        if(r==w){ usleep(200); continue; }
-        if(g_pilot_real){
-#ifdef __linux__
-            if(g_uring){ pilot_uring_batch(pilot_m); continue; }
-#endif
-            pilot_realload(pilot_m, pilot_q[r&4095].l, pilot_q[r&4095].e);
+        if(r==w) return 0;                              /* empty */
+        /* Read the payload BEFORE committing the claim. While pilot_r==r the slot at
+         * index r cannot be overwritten (the producer's w-r<4096 guard keeps pilot_w
+         * below r+4096). If the CAS succeeds, pilot_r was r the whole time -> the read
+         * is valid. If it fails, another worker advanced pilot_r; we discard and retry
+         * (a torn read there is thrown away, never used). */
+        int l=atomic_load_explicit(&pilot_q[r&4095].l,memory_order_relaxed), e=atomic_load_explicit(&pilot_q[r&4095].e,memory_order_relaxed);
+        if(__atomic_compare_exchange_n(&pilot_r,&r,r+1,/*weak=*/1,
+                                       __ATOMIC_ACQ_REL,__ATOMIC_ACQUIRE)){
+            *out_l=l; *out_e=e; return 1;                /* claimed exactly one item, payload valid */
         }
-        else             expert_prefetch(pilot_m, pilot_q[r&4095].l, pilot_q[r&4095].e);
-        __atomic_store_n(&pilot_r,r+1,__ATOMIC_RELEASE);
+        /* lost the CAS race to another worker -> retry */
+    }
+}
+static void *pilot_worker(void *arg){
+    (void)arg;
+    for(;;){
+#ifdef __linux__
+        if(g_pilot_real && g_uring){                    /* URING drains a whole batch itself -> single worker (nw==1) */
+            unsigned r=__atomic_load_n(&pilot_r,__ATOMIC_ACQUIRE);
+            unsigned w=__atomic_load_n(&pilot_w,__ATOMIC_ACQUIRE);
+            if(r==w){ usleep(200); continue; }
+            pilot_uring_batch(pilot_m);
+            continue;
+        }
+#endif
+        int l,e;                                        /* blocking / hint path: SPMC, one item per worker */
+        if(!pilot_ring_claim(&l,&e)){ usleep(200); continue; }
+        if(g_pilot_real) pilot_realload(pilot_m, l, e); /* QD=N: N concurrent preads instead of 1 */
+        else             expert_prefetch(pilot_m, l, e);
     }
     return NULL;
+}
+/* Spawn the pilot worker(s) ONCE, from the MAIN thread (first pilot_prefetch/couple_prefetch).
+ * Only the blocking PILOT_REAL path fans out to g_pilot_nw threads; the URING path already
+ * batches to QD>1 and hint-only is cheap fadvise, so both keep a single worker. */
+static void pilot_spawn(Model *m){
+    if(pilot_m) return;                                 /* pilot_m is the once-guard; only the main thread calls this */
+    pilot_m=m;
+    int uring_active=0;
+#ifdef __linux__
+    uring_active=g_uring;
+#endif
+    /* INVARIANTE: con URING attivo nw DEVE restare 1 — pilot_uring_batch e' un
+     * consumatore SINGOLO (avanza pilot_r con uno store semplice, non la CAS di
+     * pilot_ring_claim); due drainer URING concorrenti corromperebbero pilot_r.
+     * Il ramo blocking (pilot_ring_claim, CAS) e' invece SPMC-safe a N. */
+    int nw=(g_pilot_real && !uring_active)?g_pilot_nw:1;
+    if(nw<1) nw=1; if(nw>16) nw=16;
+    for(int i=0;i<nw;i++){ pthread_t t; pthread_create(&t,NULL,pilot_worker,NULL); }
 }
 /* parse .coli_pairs (see tools/route_pairs.py): "COLIPAIRS 1 <n>" then
  * "<L> <dL> <e> f:c f:c ..." lines. Needs c->n_experts/n_layers -> called post-init. */
@@ -4390,7 +4442,7 @@ static void couple_load(Model *m, const char *path){
 static void couple_prefetch(Model *m, int layer, const int *idx, int Ke){
     Cfg *c=&m->c; int E=c->n_experts;
     if(E>512) return;
-    if(!pilot_m){ pilot_m=m; pthread_t t; pthread_create(&t,NULL,pilot_worker,NULL); }
+    pilot_spawn(m);
     for(int dL=1; dL<=g_couple_d; dL++){
         int lt=layer+dL;
         if(lt>=c->n_layers || !m->L[lt].sparse) continue;
@@ -4418,7 +4470,7 @@ static void couple_prefetch(Model *m, int layer, const int *idx, int Ke){
             if(!found){
                 unsigned w=__atomic_load_n(&pilot_w,__ATOMIC_RELAXED);
                 if(w-__atomic_load_n(&pilot_r,__ATOMIC_ACQUIRE)<4096){
-                    pilot_q[w&4095].l=lt; pilot_q[w&4095].e=best;
+                    atomic_store_explicit(&pilot_q[w&4095].l,lt,memory_order_relaxed); atomic_store_explicit(&pilot_q[w&4095].e,best,memory_order_relaxed);
                     __atomic_store_n(&pilot_w,w+1,__ATOMIC_RELEASE);
                     g_cp_enq++;
                 }
@@ -4429,7 +4481,7 @@ static void couple_prefetch(Model *m, int layer, const int *idx, int Ke){
 static void pilot_prefetch(Model *m, int lnext, const float *x, int S){
     Cfg *c=&m->c; Layer *l=&m->L[lnext]; int D=c->hidden, E=c->n_experts;
     int K = g_pilot_k<c->topk ? g_pilot_k : c->topk;
-    if(!pilot_m){ pilot_m=m; pthread_t t; pthread_create(&t,NULL,pilot_worker,NULL); }
+    pilot_spawn(m);
     float *nrm=falloc(D), *ch=falloc(E);
     /* Two-step workspace (allocated once, reused across positions) */
     float *snrm=NULL, *sg=NULL, *su=NULL, *sout=NULL, *hc=NULL;
@@ -4483,7 +4535,7 @@ static void pilot_prefetch(Model *m, int lnext, const float *x, int S){
             if(!found){
                 unsigned w=__atomic_load_n(&pilot_w,__ATOMIC_RELAXED);
                 if(w-__atomic_load_n(&pilot_r,__ATOMIC_ACQUIRE)<4096){
-                    pilot_q[w&4095].l=lnext; pilot_q[w&4095].e=best;
+                    atomic_store_explicit(&pilot_q[w&4095].l,lnext,memory_order_relaxed); atomic_store_explicit(&pilot_q[w&4095].e,best,memory_order_relaxed);
                     __atomic_store_n(&pilot_w,w+1,__ATOMIC_RELEASE);
                 }
             }
@@ -7527,13 +7579,18 @@ int main(int argc, char **argv){
     if(g_pilot_real) g_pilot=1;                           /* PILOT_REAL implica il pilota attivo */
     g_pilot_two = getenv("PILOT_TWO")?atoi(getenv("PILOT_TWO")):0; /* 1 = two-step: shared-expert-corrected router prediction (+2.3% recall, 3 extra matmuls) */
     if(g_pilot_two) g_pilot=1;                            /* PILOT_TWO implies PILOT active */
-    g_pilot_evict_guard = getenv("PILOT_EVICT_GUARD")?atoi(getenv("PILOT_EVICT_GUARD")):1; /* 0 = old LRU eviction (A/B) */
     /* Default K: hint-only PILOT keeps 8 (WILLNEED hints are free, no eviction).
      * Under PILOT_REAL the speculative loads are REAL and create LRU eviction
      * pressure, so at ~28% mispredict a large K thrashes the cache — default to 6
      * (best-measured this session) unless the user set PILOT_K explicitly. */
     g_pilot_k = getenv("PILOT_K")?atoi(getenv("PILOT_K")):(g_pilot_real?6:8);
     if(g_pilot_k<1) g_pilot_k=1;
+    /* PILOT_WORKERS: blocking-path pilot threads (SPMC ring). Default 1 = today's
+     * behaviour, byte-identical. >1 raises NVMe queue depth on the non-URING
+     * PILOT_REAL path (the URING path already batches). Clamp [1,16]. */
+    g_pilot_nw = getenv("PILOT_WORKERS")?atoi(getenv("PILOT_WORKERS")):1;
+    if(g_pilot_nw<1) g_pilot_nw=1; if(g_pilot_nw>16) g_pilot_nw=16;
+    g_pilot_evict_guard = getenv("PILOT_EVICT_GUARD")?atoi(getenv("PILOT_EVICT_GUARD")):1; /* 0 = old LRU eviction (A/B) */
     g_disk_split = getenv("DISK_SPLIT")?atoi(getenv("DISK_SPLIT")):0; /* 1 = split dei disk load nelle stats */
     g_pipe = getenv("PIPE")?atoi(getenv("PIPE")):
 #ifdef _WIN32

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -356,16 +356,16 @@ static void qt_vk_reset(QT *t){
     t->vk_eligible=0;
 }
 /* Dense matmul on the Vulkan tier: y[S,O] = x[S,I] @ dequant(t)^T. Uploads the resident
- * int4/int8 weight once (t->vk), then reuses it. Returns 0 (caller runs the CPU matmul)
- * when VK-dense is off, the format is unsupported, or upload/compute fails. */
+ * int8/int4/int3-g64 weight once (t->vk), then reuses it. Returns 0 (caller runs the CPU
+ * matmul) when VK-dense is off, the format is unsupported, or upload/compute fails. */
 static int vk_matmul_qt(QT *t, float *y, const float *x, int S){
-    if(!g_vk_dense || (t->fmt!=1 && t->fmt!=2)) return 0;
+    if(!g_vk_dense || (t->fmt!=1 && t->fmt!=2 && t->fmt!=5)) return 0;
     const void *w = t->fmt==1 ? (const void*)t->q8 : (const void*)t->q4;
     return coli_vk_matmul(&t->vk, y, x, w, t->s, t->fmt, S, t->I, t->O);
 }
 /* Two same-input resident matmuls in one submit (q_a + kv_a read the same x). */
 static int vk_matmul_pair_qt(QT *a, float *ya, QT *b, float *yb, const float *x, int S){
-    if(!g_vk_dense || a->fmt!=b->fmt || (a->fmt!=1 && a->fmt!=2) || a->I!=b->I) return 0;
+    if(!g_vk_dense || a->fmt!=b->fmt || (a->fmt!=1 && a->fmt!=2 && a->fmt!=5) || a->I!=b->I) return 0;
     const void *wa = a->fmt==1 ? (const void*)a->q8 : (const void*)a->q4;
     const void *wb = b->fmt==1 ? (const void*)b->q8 : (const void*)b->q4;
     return coli_vk_matmul_pair(&a->vk, ya, wa, a->s, a->O,
@@ -909,7 +909,7 @@ static _Atomic long g_pilot_loads=0;     /* load cross-layer VERI completati (ba
 static _Atomic long g_pilot_drops=0;     /* predizioni scartate perche' il main possiede gia' il layer */
 /* format from `bits`: >=16 f32, 5..8 int8, 4 int4-packed, 3 int3-g64 (group scales), <=2 int2 */
 static void qt_alloc(QT *t, int O, int I, int bits){
-    t->O=O; t->I=I; t->qf=NULL; t->q8=NULL; t->q4=NULL; t->s=NULL;
+    t->O=O; t->I=I; t->gs=0; t->qf=NULL; t->q8=NULL; t->q4=NULL; t->s=NULL;
     if(bits>=16){ t->fmt=0; t->qf=falloc((int64_t)O*I); }
     else if(bits>=5 || g_nopack){ t->fmt=1; t->q8=qalloc((int64_t)O*I); t->s=qsalloc(O); }
     else if(bits>=4){ t->fmt=2; t->q4=qalloc((int64_t)O*((I+1)/2)); t->s=qsalloc(O); }
@@ -2782,7 +2782,7 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
          * on rewrite/rebind/resize). Falls back to CPU on DSA top-k selection, ragged KV,
          * the MTP layer, or any backend failure — output identical either way. */
         if(!cuda_core&&g_vk_attn&&!kvs&&!positions&&S<=4&&layer<c->n_layers&&
-           (l->kv_b.fmt==1||l->kv_b.fmt==2)&&kvl<=512&&c->qk_nope<=256&&c->qk_rope<=64&&
+           (l->kv_b.fmt==1||l->kv_b.fmt==2||l->kv_b.fmt==5)&&kvl<=512&&c->qk_nope<=256&&c->qk_rope<=64&&
            m->vk_kv_valid&&m->Lc[layer]&&m->Rc[layer]){   /* f32 KV only: a quantized-KV cache
                                                 * (upstream #399 KV8/TQ leaves Lc/Rc NULL)
                                                 * falls back to the CPU path until the VK
@@ -2798,7 +2798,7 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
                     m->vk_kv_valid[layer]=T;
                     const void *kw=l->kv_b.fmt==1?(const void*)l->kv_b.q8:(const void*)l->kv_b.q4;
                     /* fused absorb + o-projection: ctx never leaves the device */
-                    if((l->o.fmt==1||l->o.fmt==2)&&
+                    if((l->o.fmt==1||l->o.fmt==2||l->o.fmt==5)&&
                        coli_vk_attention_absorb_project(&l->kv_b.vk,kw,l->kv_b.s,l->kv_b.fmt,
                             &l->o.vk,l->o.fmt==1?(const void*)l->o.q8:(const void*)l->o.q4,
                             l->o.s,l->o.fmt,out,Q,layer,S,H,c->qk_nope,c->qk_rope,
@@ -3929,7 +3929,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
          * via the expert-group primitive with count=1 — replaces 3 separate VK matmuls
          * (x read once, 1 fence instead of 3). Falls through to the per-matmul chain. */
         int fsh=l->sh_gate.fmt;
-        if(g_vk_dense && !omp_in_parallel() && (fsh==1||fsh==2) &&
+        if(g_vk_dense && !omp_in_parallel() && (fsh==1||fsh==2||fsh==5) &&
            l->sh_up.fmt==fsh && l->sh_down.fmt==fsh){
             #define SW_(t) ((t).fmt==1?(const void*)(t).q8:(const void*)(t).q4)
             if(coli_vk_tensor_ensure(&l->sh_gate.vk,SW_(l->sh_gate),l->sh_gate.s,fsh,D,sI)&&
@@ -6536,14 +6536,16 @@ static void vk_registry_fill(Model *m){
                 if(++loadfail<4) fprintf(stderr,"[VK] tier fill: expert_load(%d,%d) failed\n",layer,eid);
                 if(loadfail>=64) break;                     /* disk trouble: stop burning time */
                 continue; } src=&tmp; }
-        if(src->g.fmt!=2||src->u.fmt!=2||src->d.fmt!=2){
-            if(tried<4) fprintf(stderr,"[VK] tier fill: (%d,%d) fmt %d/%d/%d != int4 (src=%s)\n",
+        int xf=src->g.fmt;   /* int4 (2) and int3-g64 (5) tiers; gate/up must share fmt for
+                              * the fused gate_up shader, down may differ per-projection */
+        if((xf!=2&&xf!=5)||src->u.fmt!=xf||(src->d.fmt!=2&&src->d.fmt!=5)){
+            if(tried<4) fprintf(stderr,"[VK] tier fill: (%d,%d) fmt %d/%d/%d not int4/int3-g64 (src=%s)\n",
                 layer,eid,src->g.fmt,src->u.fmt,src->d.fmt,src==&tmp?"load":"pin");
-            continue; }   /* int4 tier only */
+            continue; }
         ColiVkTensor **slot=vk_reg_at(layer,eid);
-        if(!coli_vk_tensor_ensure(&slot[0],src->g.q4,src->g.s,2,c->hidden,c->moe_inter)||
-           !coli_vk_tensor_ensure(&slot[1],src->u.q4,src->u.s,2,c->hidden,c->moe_inter)||
-           !coli_vk_tensor_ensure(&slot[2],src->d.q4,src->d.s,2,c->moe_inter,c->hidden)){
+        if(!coli_vk_tensor_ensure(&slot[0],src->g.q4,src->g.s,xf,c->hidden,c->moe_inter)||
+           !coli_vk_tensor_ensure(&slot[1],src->u.q4,src->u.s,xf,c->hidden,c->moe_inter)||
+           !coli_vk_tensor_ensure(&slot[2],src->d.q4,src->d.s,src->d.fmt,c->moe_inter,c->hidden)){
             if(slot[0]){coli_vk_tensor_free(slot[0]);slot[0]=NULL;}
             if(slot[1]){coli_vk_tensor_free(slot[1]);slot[1]=NULL;}
             fprintf(stderr,"[VK] expert tier: VRAM full after %d experts\n",g_vk_reg_n);

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -1461,17 +1461,20 @@ static void *map_of_fd(int fd){
     return base;
 }
 
-/* ==================== DUAL-SSD: two model copies, two drives ====================
- * COLI_MODEL_MIRROR=<dir> registers a SECOND (read-only) copy of the model on
- * another drive; expert reads are split between the two according to
- * COLI_DISK_WEIGHTS=<primary>,<mirror> (relative bandwidth; without the env it
- * is measured at startup with the engine's own access pattern). Cold decode is
- * disk-bound (~11 GB/token): two NVMe drives reading in parallel add up. */
-static const char *g_mirror_dir=NULL;  /* COLI_MODEL_MIRROR / SNAP_MIRROR */
+/* ==================== MULTI-SSD: N model copies, N drives ====================
+ * COLI_MODEL_MIRROR=<dir>[;<dir>...] registers additional read-only copies of
+ * the model on other drives; expert reads split across all copies according to
+ * COLI_DISK_WEIGHTS=<primary>,<mirror>[,<mirror2>...] (relative bandwidth;
+ * without the env it is measured at startup with the engine's own access
+ * pattern). Cold decode is disk-bound (~11 GB/token): N NVMe drives reading in
+ * parallel add up. */
+#define MIR_REPS (1+ST_MAX_MIR)        /* replicas incl. the primary */
+static const char *g_mirror_dir=NULL;  /* COLI_MODEL_MIRROR / SNAP_MIRROR (dir list) */
 static int g_mirror=0;                 /* 1 = mirror active (at least one shard accepted) */
-static int g_mir_share=64;             /* expert share routed to the mirror, out of 256 */
-static _Atomic int64_t g_mir_bytes[2]; /* bytes served per drive: [0] primary, [1] mirror */
-static _Atomic int64_t g_mir_nread[2];
+static int g_mir_nrep=1;               /* replicas incl. the primary */
+static int g_mir_cut[MIR_REPS]={256};  /* cumulative hash cuts of 256: replica r serves h in [cut[r-1],cut[r]) */
+static _Atomic int64_t g_mir_bytes[MIR_REPS]; /* bytes served per drive: [0] primary, [r] mirror r */
+static _Atomic int64_t g_mir_nread[MIR_REPS];
 
 /* replica of one expert: DETERMINISTIC hash of (layer,eid). Determinism is a
  * requirement, not a style choice: the readahead/PILOT WILLNEED and the demand
@@ -1481,7 +1484,9 @@ static inline int expert_route(int layer,int eid){
     if(!g_mirror) return 0;
     uint32_t h=(uint32_t)layer*2654435761u ^ (uint32_t)eid*0x9E3779B9u;
     h^=h>>16; h*=0x45d9f3bu; h^=h>>16;
-    return (int)(h&255) < g_mir_share;
+    int hv=(int)(h&255), r=0;
+    while(hv>=g_mir_cut[r]) r++;       /* cut[nrep-1]==256 terminates the scan */
+    return r;
 }
 
 /* buffered fd of the replica, falling back to the primary if the file is not mirrored */
@@ -1498,7 +1503,7 @@ static int pread_full(int fd, void *buf, int64_t n, int64_t off, const char *tag
  * Accounts bytes per drive. Returns 0 = ok, -1 = real error/EOF (like pread_full). */
 static ssize_t mir_pread(shards *S,int fd,int rep,void *buf,int64_t n,int64_t off,const char *tag){
     int rfd = st_fd_rep(S,fd,rep);
-    int used = rep && rfd>=0;
+    int used = (rep && rfd>=0) ? rep : 0;
     if(rfd<0) rfd=fd;
     int rc=pread_full(rfd,buf,n,off,tag);
     if(rc && used){
@@ -1623,7 +1628,7 @@ static int expert_load_impl(Model *m, int layer, int eid, ESlot *s, int fatal, i
                                 __atomic_add_fetch(&m->bytes_main,(uint64_t)tb,__ATOMIC_RELAXED); }
     }
     int rep=expert_route(layer,eid);             /* DUAL-SSD: this expert's replica */
-    if(rep && st_fd_rep(&m->S,tw[0]->fd,1)<0) rep=0;   /* shard not in the mirror (partial) */
+    if(rep && st_fd_rep(&m->S,tw[0]->fd,rep)<0) rep=0; /* shard not in that mirror (partial) */
     if(g_mmap){
         void *bw[3],*bq[3]; int okm=1;
         for(int k=0;k<3;k++){
@@ -5420,12 +5425,14 @@ static void profile_print(Model *m, double elapsed){
             g_vkb_cls,g_vkb_issue,g_vkb_acc,m->t_egpu,m->t_ecpu,m->t_ewait);
 #endif
     if(g_mirror){
-        double b0=atomic_load_explicit(&g_mir_bytes[0],memory_order_relaxed)/1e9;
-        double b1=atomic_load_explicit(&g_mir_bytes[1],memory_order_relaxed)/1e9;
-        printf("MIRROR: primary %.2f GB (%lld reads) | mirror %.2f GB (%lld reads) — %.0f%% of expert bytes from the mirror\n",
-            b0,(long long)atomic_load_explicit(&g_mir_nread[0],memory_order_relaxed),
-            b1,(long long)atomic_load_explicit(&g_mir_nread[1],memory_order_relaxed),
-            b0+b1>0?100.0*b1/(b0+b1):0.0);
+        double br[MIR_REPS]={0}, bt=0;
+        for(int r=0;r<g_mir_nrep;r++){ br[r]=atomic_load_explicit(&g_mir_bytes[r],memory_order_relaxed)/1e9; bt+=br[r]; }
+        printf("MIRROR: primary %.2f GB (%lld reads)",
+            br[0],(long long)atomic_load_explicit(&g_mir_nread[0],memory_order_relaxed));
+        for(int r=1;r<g_mir_nrep;r++)
+            printf(" | mirror%d %.2f GB (%lld reads)",
+                r,br[r],(long long)atomic_load_explicit(&g_mir_nread[r],memory_order_relaxed));
+        printf(" — %.0f%% of expert bytes from the mirrors\n", bt>0?100.0*(bt-br[0])/bt:0.0);
     }
 #ifdef COLI_METAL
     if(g_metal_enabled){ uint64_t ok=0,fb=0,ex=0; double su=0,gp=0,sc=0;
@@ -5573,8 +5580,7 @@ static void run_replay(Model *m, const int *full, int nfull, int np){
     m->hits=m->miss=m->ereq=m->gpu_expert_calls=0; m->hit_pin=m->hit_ecache=0; m->hit_vk=0;
     profile_reset(m);
     ProfBase pb; prof_base(m,&pb);
-    atomic_store(&g_mir_bytes[0],0); atomic_store(&g_mir_bytes[1],0);
-    atomic_store(&g_mir_nread[0],0); atomic_store(&g_mir_nread[1],0);
+    for(int r=0;r<MIR_REPS;r++){ atomic_store(&g_mir_bytes[r],0); atomic_store(&g_mir_nread[r],0); }
     double t0=now_s(); int steps=0;
     for(int i=np-1;i<nfull-1;i++){
         double tf0=g_prof?now_s():0;
@@ -6762,16 +6768,16 @@ static void pin_wire(Model *m){
 static double mirror_probe_bw(shards *S,int rep){
     int big=-1; int64_t bsz=0;
     for(int i=0;i<S->nfd;i++){
-        if(rep && S->mfds[i]<0) continue;
-        int64_t sz=lseek(rep?S->mfds[i]:S->fds[i],0,SEEK_END);
+        if(rep && S->mfds[rep-1][i]<0) continue;
+        int64_t sz=lseek(rep?S->mfds[rep-1][i]:S->fds[i],0,SEEK_END);
         if(sz>bsz){ bsz=sz; big=i; }
     }
     const int64_t blk=19ll<<20; const int NB=8;
     if(big<0 || bsz<blk*(NB+1)) return 0;
-    int dfd = rep? S->mdfds[big] : S->dfds[big];
-    int fd  = dfd>=0? dfd : (rep? S->mfds[big] : S->fds[big]);
-    if(dfd<0) fprintf(stderr,"[MIRROR] no O_DIRECT on %s: the probe may read the page cache — "
-                             "set COLI_DISK_WEIGHTS for an accurate split\n", rep?"the mirror":"the primary");
+    int dfd = rep? S->mdfds[rep-1][big] : S->dfds[big];
+    int fd  = dfd>=0? dfd : (rep? S->mfds[rep-1][big] : S->fds[big]);
+    if(dfd<0) fprintf(stderr,"[MIRROR] no O_DIRECT on replica %d: the probe may read the page cache — "
+                             "set COLI_DISK_WEIGHTS for an accurate split\n", rep);
     double t0=now_s(); int64_t tot=0;
     #pragma omp parallel for schedule(dynamic,1) reduction(+:tot)
     for(int i=0;i<NB;i++){
@@ -6787,37 +6793,82 @@ static double mirror_probe_bw(shards *S,int rep){
     return (dt>0 && tot>0)? tot/1e9/dt : 0;
 }
 
-/* DUAL-SSD setup: register the mirror copy, derive the read split from
- * COLI_DISK_WEIGHTS=<primary>,<mirror> or from a startup bandwidth probe.
- * Runs after model_init (needs the shard index) and BEFORE any pin/autopin
- * load, so the OMP-parallel pin warmup already streams from both drives. */
+/* MULTI-SSD setup: register every mirror copy listed in COLI_MODEL_MIRROR
+ * (';' or ',' separated dirs), derive the read split from
+ * COLI_DISK_WEIGHTS=<primary>,<mirror>[,<mirror2>...] or from a startup
+ * bandwidth probe. Runs after model_init (needs the shard index) and BEFORE
+ * any pin/autopin load, so the OMP-parallel pin warmup streams from all drives. */
 static void mirror_setup(Model *m){
     if(!g_mirror_dir) return;
-    const char *snap=getenv("SNAP");
-    if(snap && !strcmp(snap,g_mirror_dir)){
-        fprintf(stderr,"[MIRROR] mirror dir equals the model dir — ignored\n"); return;
+    const char *snap=getenv("SNAP"); if(!snap||!*snap) snap=getenv("COLI_MODEL");
+    st_mirror_reset(&m->S);
+    int nrep=1;
+    {   char buf[4096]; snprintf(buf,sizeof(buf),"%s",g_mirror_dir);
+        char *p=buf;
+        while(p && *p){
+            char *sep=p; while(*sep && *sep!=';' && *sep!=',') sep++;
+            int last=(*sep==0); *sep=0;
+            while(*p==' ') p++;
+            size_t plen=strlen(p); while(plen>0 && p[plen-1]==' ') p[--plen]=0;
+            if(*p){
+                if(snap && !strcmp(snap,p))
+                    fprintf(stderr,"[MIRROR] %s equals the model dir — ignored\n",p);
+                else if(nrep>=MIR_REPS)
+                    fprintf(stderr,"[MIRROR] %s: too many mirrors (max %d) — ignored\n",p,ST_MAX_MIR);
+                else {
+                    int nf=st_mirror_add(&m->S,p);
+                    if(nf<=0)
+                        fprintf(stderr,"[MIRROR] %s: no usable shard (missing or divergent copy) — skipped\n",p);
+                    else {
+                        fprintf(stderr,"[MIRROR] %s: %d/%d shards (replica %d)\n",p,nf,m->S.nfd,nrep);
+                        nrep++;
+                    }
+                }
+            }
+            p=last?NULL:sep+1;
+        }
     }
-    int nf=st_mirror_init(&m->S,g_mirror_dir);
-    if(nf<=0){
-        fprintf(stderr,"[MIRROR] %s: no usable shard (missing or divergent copy) — "
-                       "running on the primary drive only\n",g_mirror_dir);
+    if(nrep<2){
+        fprintf(stderr,"[MIRROR] no usable mirror — running on the primary drive only\n");
         return;
     }
-    g_mirror=1;
-    double wp=0,wm=0; const char *w=getenv("COLI_DISK_WEIGHTS"); const char *how="COLI_DISK_WEIGHTS";
-    if(w && (sscanf(w," %lf , %lf",&wp,&wm)!=2 || wp<=0 || wm<=0)){
-        fprintf(stderr,"[MIRROR] invalid COLI_DISK_WEIGHTS '%s' (want e.g. 9,3) — probing instead\n",w);
-        wp=wm=0;
+    g_mirror=1; g_mir_nrep=nrep;
+    double wt[MIR_REPS]; int have=0;
+    const char *w=getenv("COLI_DISK_WEIGHTS"); const char *how="COLI_DISK_WEIGHTS";
+    if(w && *w){
+        char wb[256]; snprintf(wb,sizeof(wb),"%s",w); int wn=0, bad=0;
+        for(char *tok=strtok(wb,", "); tok; tok=strtok(NULL,", ")){
+            double v=atof(tok);
+            if(v<=0 || wn>=MIR_REPS){ bad=1; break; }
+            wt[wn++]=v;
+        }
+        if(!bad && wn==nrep) have=1;
+        else fprintf(stderr,"[MIRROR] invalid COLI_DISK_WEIGHTS '%s' (want %d positive comma-separated "
+                            "weights, e.g. 9,3) — probing instead\n",w,nrep);
     }
-    if(wp<=0||wm<=0){
-        wp=mirror_probe_bw(&m->S,0); wm=mirror_probe_bw(&m->S,1); how="measured";
-        if(wp>0&&wm>0) fprintf(stderr,"[MIRROR] probe: primary %.2f GB/s, mirror %.2f GB/s\n",wp,wm);
-        else { wp=wm=1; how="fallback 1:1 (probe failed)"; }
+    if(!have){
+        have=1; how="measured";
+        for(int r=0;r<nrep;r++){ wt[r]=mirror_probe_bw(&m->S,r); if(wt[r]<=0) have=0; }
+        if(have){
+            fprintf(stderr,"[MIRROR] probe:");
+            for(int r=0;r<nrep;r++) fprintf(stderr,"%s %s %.2f GB/s",r?" |":"",r?"mirror":"primary",wt[r]);
+            fprintf(stderr,"\n");
+        } else { for(int r=0;r<nrep;r++) wt[r]=1; how="fallback 1:1 (probe failed)"; }
     }
-    int share=(int)(256.0*wm/(wp+wm)+0.5);
-    g_mir_share = share<1?1 : share>255?255 : share;
-    fprintf(stderr,"[MIRROR] %s: %d/%d shards | read split primary %.0f%% / mirror %.0f%% (%s)\n",
-        g_mirror_dir,nf,m->S.nfd,100.0*(256-g_mir_share)/256,100.0*g_mir_share/256,how);
+    double W=0; for(int r=0;r<nrep;r++) W+=wt[r];
+    int acc=0; double cum=0;
+    for(int r=0;r<nrep;r++){
+        cum+=wt[r];
+        int c=(int)(256.0*cum/W+0.5);
+        if(c<=acc) c=acc+1;            /* every replica keeps a non-empty slice */
+        if(c>256) c=256;
+        g_mir_cut[r]=c; acc=c;
+    }
+    g_mir_cut[nrep-1]=256;             /* the last replica absorbs rounding */
+    fprintf(stderr,"[MIRROR] %d drives | read split",nrep);
+    for(int r=0;r<nrep;r++){ int lo=r?g_mir_cut[r-1]:0;
+        fprintf(stderr,"%s %.0f%%",r?" /":"",100.0*(g_mir_cut[r]-lo)/256); }
+    fprintf(stderr," (%s)\n",how);
 }
 
 typedef struct { int l,e; uint32_t c; } PinRec;

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -294,8 +294,16 @@ static int g_repin;
 static uint64_t g_last_repin;
 #ifdef COLI_VULKAN
 static int g_vulkan;          /* COLI_VULKAN=1: compute routed experts on the Vulkan tier */
-static int g_vk_budget;       /* COLI_VK_EXPERTS: max experts uploaded to VK VRAM (default 1024) */
+static int g_vk_budget;       /* COLI_VK_EXPERTS: pinned VK expert tier size (0 = tier off) */
 static int g_vk_resident;     /* how many experts currently VK-resident */
+/* Pinned VK expert tier: top heat-ranked routed experts uploaded ONCE at startup into a
+ * registry keyed by (layer,eid), decoupled from the RAM cache slots — stable residency
+ * (no LRU churn, no uploads on the decode critical path), mirroring the HIP VRAM tier. */
+static struct ColiVkTensor **g_vk_reg;   /* [(layer*E+eid)*3 + {gate,up,down}] */
+static int g_vk_reg_n, g_vk_reg_E;
+static inline struct ColiVkTensor **vk_reg_at(int layer,int eid){
+    return g_vk_reg ? &g_vk_reg[((size_t)layer*g_vk_reg_E+eid)*3] : NULL;
+}
 static int g_vk_dense;        /* COLI_VK_DENSE=1: run the resident dense matmuls (attention
                                * projections + shared expert) on Vulkan too */
 static int g_vk_attn;         /* COLI_VK_ATTN=1: run the MLA absorb attention core on Vulkan
@@ -3319,8 +3327,8 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
 #endif
     int vk_active = 0; (void)vk_active;
 #ifdef COLI_VULKAN
-    vk_active = g_vulkan && g_vk_budget>0 && !omp_in_parallel() && S<=4;   /* budget 0 = tier off,
-                                                * experts stay on the normal (parallel) CPU loop */
+    vk_active = g_vulkan && g_vk_reg_n>0 && !omp_in_parallel() && S<=4;   /* empty registry (tier
+                                                * off / no usage history) = normal CPU expert loop */
     float *vk_xh = vk_active?falloc((int64_t)S*K*D):NULL;
     float *vk_yh = vk_active?falloc((int64_t)S*K*D):NULL;
 #endif
@@ -3603,57 +3611,60 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
          * coli_vk_expert_group (fused gate+up+silu -> down, on-device); the rest + misses
          * fall back to the CPU below. Decode-only (S<=4). Measured ~35% faster than ROCm. */
         if(vk_active && !metal_done){
-            ColiVkTensor *vg[64],*vu[64],*vd[64]; ESlot *ve[64]; int vrows[64], voff[64], vrmap[64*4]; float vwmap[64*4];
-            ESlot *ce[64]; int cnr[64], crmap[64*4]; float cwmap[64*4];
+            /* Pinned+async VK expert tier. Pass 1 partitions by REGISTRY residency (the
+             * heat-pinned startup uploads — no uploads, no loads here); pass 2 ISSUES the
+             * GPU batch async and computes the CPU share while it runs; pass 3 drains the
+             * pipe + RAM-loads the GPU-side slots (cache invariants: every dispatched slot
+             * waited, every use[] slot loaded before the end-of-block LRU swap); pass 4
+             * takes the GPU results (fallback: recompute those rows on the CPU). */
+            ColiVkTensor *vg[64],*vu[64],*vd[64]; ESlot *ve[64]; int vrows[64], voff[64], vrmap[64*4]; float vwmap[64*4]; int vqof[64];
+            ESlot *ce[64]; int cnr[64], crmap[64*4]; float cwmap[64*4]; int cqof[64];
             int nvk=0, vtot=0, ncpu=0;
             double t0=now_s();
             for(int j=0;j<nb;j++){ int eid=uniq[base+j]; ESlot *e=use[j];
-                if(g_pipe && qof[j]>=0){ double tw=now_s(); pipe_wait(qof[j]); m->t_ewait += now_s()-tw; }
                 int nr=0;
                 for(int s=0;s<S;s++) for(int kk=0;kk<keff[s];kk++)
                     if(idxs[(int64_t)s*K+kk]==eid){ rows[nr]=s; rw[nr]=ws[(int64_t)s*K+kk]; nr++; break; }
-                if(!nr) continue;
-                if(!e->slab) expert_load(m,layer,e->eid,e,1);
-                int elig = e->slab && e->g.fmt==2 && e->u.fmt==2 && e->d.fmt==2 && nvk<64 && (vtot+nr)<=S*K;
-                if(elig && !e->g.vk_eligible && g_vk_resident < g_vk_budget
-                   && (uint8_t*)e->g.q4>=e->slab && (uint8_t*)e->d.q4>=e->slab){
-                    if(coli_vk_tensor_ensure(&e->g.vk,e->g.q4,e->g.s,2,D,I)
-                       && coli_vk_tensor_ensure(&e->u.vk,e->u.q4,e->u.s,2,D,I)
-                       && coli_vk_tensor_ensure(&e->d.vk,e->d.q4,e->d.s,2,I,D)){
-                        e->g.vk_eligible=e->u.vk_eligible=e->d.vk_eligible=1; g_vk_resident++;
-                    }
-                }
-                if(elig && e->g.vk_eligible){
+                if(!nr){ if(g_pipe && qof[j]>=0){ double tw=now_s(); pipe_wait(qof[j]); m->t_ewait += now_s()-tw; } continue; }
+                ColiVkTensor **reg = layer<c->n_layers ? vk_reg_at(layer,eid) : NULL;
+                if(reg && reg[0] && nvk<64 && (vtot+nr)<=S*K){
                     voff[nvk]=vtot;
                     for(int r=0;r<nr;r++){ memcpy(vk_xh+(int64_t)(vtot+r)*D, x+(int64_t)rows[r]*D, D*sizeof(float));
                         vrmap[nvk*S+r]=rows[r]; vwmap[nvk*S+r]=rw[r]; }
-                    vg[nvk]=e->g.vk; vu[nvk]=e->u.vk; vd[nvk]=e->d.vk; ve[nvk]=e; vrows[nvk]=nr; vtot+=nr; nvk++;
+                    vg[nvk]=reg[0]; vu[nvk]=reg[1]; vd[nvk]=reg[2]; ve[nvk]=e; vrows[nvk]=nr; vqof[nvk]=qof[j]; vtot+=nr; nvk++;
                 } else {
-                    ce[ncpu]=e; cnr[ncpu]=nr;
+                    ce[ncpu]=e; cnr[ncpu]=nr; cqof[ncpu]=qof[j];
                     for(int r=0;r<nr;r++){ crmap[ncpu*S+r]=rows[r]; cwmap[ncpu*S+r]=rw[r]; }
                     ncpu++;
                 }
             }
-            int vk_ok = nvk>0 && coli_vk_expert_group(vg,vu,vd,vrows,nvk,vk_yh,vk_xh);
-            for(int c=0;c<ncpu;c++){ ESlot *e=ce[c]; int nr=cnr[c];
-                for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)crmap[c*S+r]*D, D*sizeof(float));
+            int vk_issued = nvk>0 && coli_vk_expert_group_issue(vg,vu,vd,vrows,nvk,vk_xh);
+            for(int c2=0;c2<ncpu;c2++){ ESlot *e=ce[c2]; int nr=cnr[c2];
+                if(g_pipe && cqof[c2]>=0){ double tw=now_s(); pipe_wait(cqof[c2]); m->t_ewait += now_s()-tw; }
+                if(!e->slab) expert_load(m,layer,e->eid,e,1);
+                for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)crmap[c2*S+r]*D, D*sizeof(float));
                 expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
                 for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
                 matmul_qt(hh, gg, &e->d, nr);
-                for(int r=0;r<nr;r++){ float *os=out+(int64_t)crmap[c*S+r]*D, wgt=cwmap[c*S+r], *hr=hh+(int64_t)r*D;
+                for(int r=0;r<nr;r++){ float *os=out+(int64_t)crmap[c2*S+r]*D, wgt=cwmap[c2*S+r], *hr=hh+(int64_t)r*D;
                     for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
             }
-            for(int c=0;c<nvk;c++){ int nr=vrows[c];
-                if(vk_ok){ int o=voff[c];
-                    for(int r=0;r<nr;r++){ float *os=out+(int64_t)vrmap[c*S+r]*D, wgt=vwmap[c*S+r], *src=vk_yh+(int64_t)(o+r)*D;
+            for(int c2=0;c2<nvk;c2++){
+                if(g_pipe && vqof[c2]>=0){ double tw=now_s(); pipe_wait(vqof[c2]); m->t_ewait += now_s()-tw; }
+                ESlot *e=ve[c2]; if(!e->slab) expert_load(m,layer,e->eid,e,1);
+            }
+            int vk_ok = vk_issued && coli_vk_expert_group_take(vk_yh);
+            for(int c2=0;c2<nvk;c2++){ int nr=vrows[c2];
+                if(vk_ok){ int o=voff[c2];
+                    for(int r=0;r<nr;r++){ float *os=out+(int64_t)vrmap[c2*S+r]*D, wgt=vwmap[c2*S+r], *src=vk_yh+(int64_t)(o+r)*D;
                         for(int d=0;d<D;d++) os[d]+=wgt*src[d]; }
-                } else {   /* group failed: recompute this expert's rows on the CPU via its ESlot */
-                    ESlot *e=ve[c];
-                    for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)vrmap[c*S+r]*D, D*sizeof(float));
+                } else {   /* issue/take failed: recompute this expert's rows on the CPU */
+                    ESlot *e=ve[c2];
+                    for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)vrmap[c2*S+r]*D, D*sizeof(float));
                     expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
                     for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
                     matmul_qt(hh, gg, &e->d, nr);
-                    for(int r=0;r<nr;r++){ float *os=out+(int64_t)vrmap[c*S+r]*D, wgt=vwmap[c*S+r], *hr=hh+(int64_t)r*D;
+                    for(int r=0;r<nr;r++){ float *os=out+(int64_t)vrmap[c2*S+r]*D, wgt=vwmap[c2*S+r], *hr=hh+(int64_t)r*D;
                         for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
                 }
             }
@@ -6449,6 +6460,57 @@ static int *read_arr(jval*o,const char*k,int*n){
 
 /* telemetry, stats, usage persistence — moved to telemetry.h */
 
+#ifdef COLI_VULKAN
+/* Pinned VK expert tier fill: upload the top-COLI_VK_EXPERTS heat-ranked routed experts
+ * ONCE at startup (mirrors the HIP VRAM tier: stable residency, zero uploads at decode).
+ * Ranking comes from the persistent usage history; already-pinned RAM slots feed the
+ * upload directly, the rest stream through one transient slot and are freed after. */
+typedef struct { uint32_t u; int layer, eid; } VkCand;
+static int vk_cand_cmp(const void *a, const void *b){
+    uint32_t ua=((const VkCand*)a)->u, ub=((const VkCand*)b)->u;
+    return ua<ub ? 1 : ua>ub ? -1 : 0;
+}
+static void vk_registry_fill(Model *m){
+    Cfg *c=&m->c; int E=c->n_experts, NL=c->n_layers;
+    if(!g_vulkan || g_vk_budget<=0) return;
+    int64_t nz=0;
+    for(int i=0;i<NL;i++) if(m->eusage[i]) for(int e=0;e<E;e++) if(m->eusage[i][e]) nz++;
+    if(!nz){ fprintf(stderr,"[VK] expert tier: no usage history yet — tier empty this run "
+                     "(it seeds from %s as you use the model)\n", g_usage_path); return; }
+    VkCand *cand=malloc((size_t)nz*sizeof(VkCand)); if(!cand) return;
+    int64_t n=0;
+    for(int i=0;i<NL;i++) if(m->eusage[i]) for(int e=0;e<E;e++)
+        if(m->eusage[i][e]) cand[n++]=(VkCand){m->eusage[i][e],i,e};
+    qsort(cand,(size_t)n,sizeof(VkCand),vk_cand_cmp);
+    g_vk_reg=calloc((size_t)NL*E*3,sizeof(*g_vk_reg)); g_vk_reg_E=E;
+    if(!g_vk_reg){ free(cand); return; }
+    ESlot tmp; memset(&tmp,0,sizeof(tmp)); tmp.eid=-1;
+    double t0=now_s(); int64_t bytes=0; int tried=0;
+    for(int64_t i2=0;i2<n && g_vk_reg_n<g_vk_budget;i2++){
+        int layer=cand[i2].layer, eid=cand[i2].eid; tried++;
+        ESlot *src=NULL, *P=m->pin[layer];
+        for(int z=0;z<m->npin[layer];z++) if(P[z].eid==eid && P[z].slab){ src=&P[z]; break; }
+        if(!src){ if(!expert_load(m,layer,eid,&tmp,0)) continue; src=&tmp; }
+        if(src->g.fmt!=2||src->u.fmt!=2||src->d.fmt!=2) continue;   /* int4 tier only */
+        ColiVkTensor **slot=vk_reg_at(layer,eid);
+        if(!coli_vk_tensor_ensure(&slot[0],src->g.q4,src->g.s,2,c->hidden,c->moe_inter)||
+           !coli_vk_tensor_ensure(&slot[1],src->u.q4,src->u.s,2,c->hidden,c->moe_inter)||
+           !coli_vk_tensor_ensure(&slot[2],src->d.q4,src->d.s,2,c->moe_inter,c->hidden)){
+            if(slot[0]){coli_vk_tensor_free(slot[0]);slot[0]=NULL;}
+            if(slot[1]){coli_vk_tensor_free(slot[1]);slot[1]=NULL;}
+            fprintf(stderr,"[VK] expert tier: VRAM full after %d experts\n",g_vk_reg_n);
+            break;
+        }
+        bytes+=coli_vk_tensor_bytes(slot[0])+coli_vk_tensor_bytes(slot[1])+coli_vk_tensor_bytes(slot[2]);
+        g_vk_reg_n++;
+    }
+    if(tmp.slab){ compat_aligned_free(tmp.slab); free(tmp.fslab); }
+    free(cand);
+    fprintf(stderr,"[VK] expert tier: %d hot experts resident (%.2f GB VRAM, %.1fs, top-%d of history)\n",
+            g_vk_reg_n,bytes/1e9,now_s()-t0,tried);
+}
+#endif
+
 /* HOT-STORE ("il redis del colibri'"): carica in RAM, UNA VOLTA e per sempre, i top expert
  * per frequenza d'uso misurata (file STATS di un run precedente), entro un budget in GB.
  * Ogni hit evita una lettura dal disco lento. */
@@ -7480,6 +7542,9 @@ int main(int argc, char **argv){
       cap_for_ram(&m, ram_env, ebits, est_ctx);
       g_prof = getenv("PROF")?atoi(getenv("PROF")):0;   /* PROF=1: opt-in performance profile */
       if(g_prof) prof_config(&m, ram_env, est_ctx); }
+#ifdef COLI_VULKAN
+    vk_registry_fill(&m);   /* pinned VK expert tier: needs the usage history loaded above */
+#endif
     const char *stats=getenv("STATS");   /* STATS=<file> -> istogramma uso expert a fine run */
 
     /* modo scoring per benchmark: SCORE=<requests.txt> -> log-likelihood per riga */

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -6596,6 +6596,37 @@ static int vk_cand_cmp(const void *a, const void *b){
     uint32_t ua=((const VkCand*)a)->u, ub=((const VkCand*)b)->u;
     return ua<ub ? 1 : ua>ub ? -1 : 0;
 }
+/* Upload the VK dense working set (attention projections, absorb kv_b, o-proj,
+ * shared expert) at startup, BEFORE the tier fill. These ~8 GB otherwise
+ * allocate lazily on the first forwards — AFTER the tier has filled to its
+ * budget — and on a 16 GB card the late arrivals overflow to GTT (measured
+ * 2.1 GB spilled with a 320-expert int4 tier; every per-token attention
+ * submit then pays PCIe latency: absorb 1.69 → 2.26 ms/call, +34%). Claiming
+ * the dense set first lets the budget-capped tier fill see the true remainder
+ * and self-size to what actually fits in device memory. */
+static void vk_dense_preload(Model *m){
+    Cfg *c=&m->c;
+    if(!g_vulkan || !g_vk_dense) return;
+    double t0=now_s(); int64_t bytes=0; int nt=0, full=0;
+    for(int i=0;i<=c->n_layers && !full;i++){
+        Layer *l = i<c->n_layers ? &m->L[i] : &m->mtpL;
+        QT *ts[]={&l->q_a,&l->q_b,&l->kv_a,&l->kv_b,&l->o,&l->sh_gate,&l->sh_up,&l->sh_down};
+        for(size_t k=0;k<sizeof(ts)/sizeof(ts[0]);k++){
+            QT *t=ts[k];
+            if(t->vk || !VK_FMT_OK(t) || t->I<=0 || t->O<=0) continue;
+            const void *w = t->fmt==1 ? (const void*)t->q8 : (const void*)t->q4;
+            if(!w || !t->s) continue;
+            if(!coli_vk_tensor_ensure(&t->vk,w,t->s,t->fmt,t->I,t->O,t->gs)){
+                fprintf(stderr,"[VK] dense preload: VRAM full at layer %d — remaining tensors stay lazy\n",i);
+                full=1; break;
+            }
+            bytes+=coli_vk_tensor_bytes(t->vk); nt++;
+        }
+    }
+    if(nt) fprintf(stderr,"[VK] dense preloaded: %d tensors, %.2f GB VRAM in %.1fs\n",
+                   nt,bytes/1e9,now_s()-t0);
+}
+
 static void vk_registry_fill(Model *m){
     Cfg *c=&m->c; int E=c->n_experts, NL=c->n_layers;
     if(!g_vulkan || g_vk_budget<=0) return;
@@ -7741,6 +7772,7 @@ int main(int argc, char **argv){
       g_prof = getenv("PROF")?atoi(getenv("PROF")):0;   /* PROF=1: opt-in performance profile */
       if(g_prof) prof_config(&m, ram_env, est_ctx); }
 #ifdef COLI_VULKAN
+    vk_dense_preload(&m);   /* dense claims VRAM first — the tier fill sizes to the remainder */
     vk_registry_fill(&m);   /* pinned VK expert tier: needs the usage history loaded above */
 #endif
     const char *stats=getenv("STATS");   /* STATS=<file> -> istogramma uso expert a fine run */

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -348,6 +348,14 @@ static int vk_matmul_qt(QT *t, float *y, const float *x, int S){
     const void *w = t->fmt==1 ? (const void*)t->q8 : (const void*)t->q4;
     return coli_vk_matmul(&t->vk, y, x, w, t->s, t->fmt, S, t->I, t->O);
 }
+/* Two same-input resident matmuls in one submit (q_a + kv_a read the same x). */
+static int vk_matmul_pair_qt(QT *a, float *ya, QT *b, float *yb, const float *x, int S){
+    if(!g_vk_dense || a->fmt!=b->fmt || (a->fmt!=1 && a->fmt!=2) || a->I!=b->I) return 0;
+    const void *wa = a->fmt==1 ? (const void*)a->q8 : (const void*)a->q4;
+    const void *wb = b->fmt==1 ? (const void*)b->q8 : (const void*)b->q4;
+    return coli_vk_matmul_pair(&a->vk, ya, wa, a->s, a->O,
+                               &b->vk, yb, wb, b->s, b->O, a->fmt, x, S, a->I);
+}
 #endif
 #ifdef COLI_CUDA
 static int qt_cuda_upload(QT *t){
@@ -2514,7 +2522,12 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
         pipe_done=attn_pipe_prefill(m,l,layer,x,0,S,pos_base,out,NULL);
 #endif
     if(!pipe_done){
+        int vk_pair=0; (void)vk_pair;
 #ifdef COLI_VULKAN
+        /* q_a and kv_a read the SAME x: one fused submit for the pair (one x upload,
+         * one fence) instead of two full roundtrips. Fallback = the single calls. */
+        vk_pair=vk_matmul_pair_qt(&l->q_a, QR, &l->kv_a, comp, x, S);
+        if(!vk_pair)
         if(!vk_matmul_qt(&l->q_a, QR, x, S))
 #endif
         matmul_qt_ex(QR, x, &l->q_a, S, 0);
@@ -2525,6 +2538,7 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
 #endif
         matmul_qt_ex(Q, QR, &l->q_b, S, 0);
 #ifdef COLI_VULKAN
+        if(!vk_pair)
         if(!vk_matmul_qt(&l->kv_a, comp, x, S))
 #endif
         matmul_qt_ex(comp, x, &l->kv_a, S, 0);

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -2745,7 +2745,7 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
             }
         }
 #endif
-        int vk_core=0;
+        int vk_core=0, vk_projected=0;
 #ifdef COLI_VULKAN
         /* Vulkan MLA absorb core (COLI_VK_ATTN=1): scores/softmax/latent/value rows for all
          * S x H in ONE submit per layer, reading the persistent on-device KV mirror (rows
@@ -2764,10 +2764,18 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
                                       coli_kv_row(m->Rc[layer],t,c->qk_rope));
                 if(ok){
                     m->vk_kv_valid[layer]=T;
-                    vk_core=coli_vk_attention_absorb(&l->kv_b.vk,
-                        l->kv_b.fmt==1?(const void*)l->kv_b.q8:(const void*)l->kv_b.q4,
-                        l->kv_b.s,l->kv_b.fmt,ctx,Q,layer,S,H,c->qk_nope,c->qk_rope,
-                        vh,kvl,st0,T,c->attn_scale);
+                    const void *kw=l->kv_b.fmt==1?(const void*)l->kv_b.q8:(const void*)l->kv_b.q4;
+                    /* fused absorb + o-projection: ctx never leaves the device */
+                    if((l->o.fmt==1||l->o.fmt==2)&&
+                       coli_vk_attention_absorb_project(&l->kv_b.vk,kw,l->kv_b.s,l->kv_b.fmt,
+                            &l->o.vk,l->o.fmt==1?(const void*)l->o.q8:(const void*)l->o.q4,
+                            l->o.s,l->o.fmt,out,Q,layer,S,H,c->qk_nope,c->qk_rope,
+                            vh,kvl,st0,T,c->attn_scale,D))
+                        vk_core=vk_projected=1;
+                    if(!vk_core)
+                        vk_core=coli_vk_attention_absorb(&l->kv_b.vk,kw,
+                            l->kv_b.s,l->kv_b.fmt,ctx,Q,layer,S,H,c->qk_nope,c->qk_rope,
+                            vh,kvl,st0,T,c->attn_scale);
                 }
             }
         }
@@ -2841,7 +2849,7 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
         }
         }
         m->t_acore+=now_s()-tac; double tao=now_s();
-        if(!cuda_projected){
+        if(!cuda_projected&&!vk_projected){
 #ifdef COLI_VULKAN
             if(!vk_matmul_qt(&l->o, out, ctx, S))
 #endif
@@ -3863,6 +3871,25 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
     }
 #endif
     if(!shared_cuda){
+#ifdef COLI_VULKAN
+        /* Whole shared expert as ONE fused submit (gate+up+silu -> down, hidden on-device)
+         * via the expert-group primitive with count=1 — replaces 3 separate VK matmuls
+         * (x read once, 1 fence instead of 3). Falls through to the per-matmul chain. */
+        int fsh=l->sh_gate.fmt;
+        if(g_vk_dense && !omp_in_parallel() && (fsh==1||fsh==2) &&
+           l->sh_up.fmt==fsh && l->sh_down.fmt==fsh){
+            #define SW_(t) ((t).fmt==1?(const void*)(t).q8:(const void*)(t).q4)
+            if(coli_vk_tensor_ensure(&l->sh_gate.vk,SW_(l->sh_gate),l->sh_gate.s,fsh,D,sI)&&
+               coli_vk_tensor_ensure(&l->sh_up.vk,  SW_(l->sh_up),  l->sh_up.s,  fsh,D,sI)&&
+               coli_vk_tensor_ensure(&l->sh_down.vk,SW_(l->sh_down),l->sh_down.s,fsh,sI,D)){
+                ColiVkTensor *vg=l->sh_gate.vk,*vu=l->sh_up.vk,*vd=l->sh_down.vk;
+                int rows1[1]={S};
+                if(coli_vk_expert_group(&vg,&vu,&vd,rows1,1,hh,x)) shared_cuda=1;
+            }
+            #undef SW_
+        }
+        if(!shared_cuda){
+#endif
         sg=falloc((int64_t)S*sI);su=falloc((int64_t)S*sI);
 #ifdef COLI_VULKAN
         if(!vk_matmul_qt(&l->sh_gate, sg, x, S))
@@ -3877,6 +3904,9 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
         if(!vk_matmul_qt(&l->sh_down, hh, sg, S))
 #endif
         matmul_qt(hh, sg, &l->sh_down, S);
+#ifdef COLI_VULKAN
+        }
+#endif
     }
     if(shared_cuda!=2) for(int64_t z=0;z<(int64_t)S*D;z++) out[z]+=hh[z];
     free(sg); free(su);

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -70,6 +70,9 @@ static inline int omp_get_thread_num(void){ return 0; }
 #ifdef COLI_CUDA
 #include "backend_cuda.h"
 #endif
+#ifdef COLI_VULKAN
+#include "backend_vulkan.h"
+#endif
 #ifdef COLI_METAL
 #include "backend_metal.h"
 #include <omp.h>
@@ -114,6 +117,9 @@ typedef struct {
     int fmt; float *qf; int8_t *q8; uint8_t *q4; float *s; int O, I, gs;  /* gs=group size (0=per-row, 128=grouped) */
 #ifdef COLI_CUDA
     ColiCudaTensor *cuda;
+#endif
+#ifdef COLI_VULKAN
+    ColiVkTensor *vk; int vk_eligible;   /* resident on the Vulkan expert tier */
 #endif
     int cuda_eligible, cuda_failed, cuda_device;  /* resident tensor, never a reused expert slot */
 } QT;
@@ -283,6 +289,11 @@ static void expert_gate_up(float *g,float *u,const float *x,QT *wg,QT *wu,int S)
 
 static int g_repin;
 static uint64_t g_last_repin;
+#ifdef COLI_VULKAN
+static int g_vulkan;          /* COLI_VULKAN=1: compute routed experts on the Vulkan tier */
+static int g_vk_budget;       /* COLI_VK_EXPERTS: max experts uploaded to VK VRAM (default 1024) */
+static int g_vk_resident;     /* how many experts currently VK-resident */
+#endif
 #ifdef COLI_CUDA
 static int g_cuda_enabled;
 static double g_cuda_expert_gb;
@@ -315,6 +326,15 @@ static void cuda_disabled_note(void){
         CUDA_DISABLED_LOUD_AT);
 }
 static int g_cuda_e8_ready;   /* codebook published to the devices (see cuda_boot) */
+#endif
+#ifdef COLI_VULKAN
+/* Drop a QT's Vulkan-resident copy (slot reused for a different expert). */
+static void qt_vk_reset(QT *t){
+    if(t->vk){ coli_vk_tensor_free(t->vk); t->vk=NULL; }
+    t->vk_eligible=0;
+}
+#endif
+#ifdef COLI_CUDA
 static int qt_cuda_upload(QT *t){
     if(t->fmt==5) return 0;   /* int3-g64: no CUDA kernel yet — tensor stays CPU-side */
     if(t->fmt==6 && !g_cuda_e8_ready) return 0;   /* E8 without its codebook would decode garbage */
@@ -1513,6 +1533,14 @@ static int expert_load_impl(Model *m, int layer, int eid, ESlot *s, int fatal, i
     /* A live REPIN may reuse a GPU-enabled pinned slot for a different expert.
      * Keep its tier assignment, but invalidate the old device weights. */
     if(s->eid!=eid){ qt_cuda_reset(&s->g); qt_cuda_reset(&s->u); qt_cuda_reset(&s->d); }
+#endif
+#ifdef COLI_VULKAN
+    /* Slot reused for a different expert: free the stale VK-resident weights so the new
+     * expert re-uploads instead of computing with the old expert's tensors. */
+    if(s->eid!=eid){
+        if(s->g.vk_eligible) g_vk_resident--;
+        qt_vk_reset(&s->g); qt_vk_reset(&s->u); qt_vk_reset(&s->d);
+    }
 #endif
     Cfg *c=&m->c; int I=c->moe_inter, D=c->hidden, b=m->ebits;
     /* suf as a bounded char[][16] (not const char*) lets GCC prove the %s in the
@@ -3204,6 +3232,12 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
     int *group_row=group_enabled?xalloc((size_t)64*S*sizeof(int),"moe group_row"):NULL;
     float *group_weight=group_enabled?xalloc((size_t)64*S*sizeof(float),"moe group_weight"):NULL;
 #endif
+    int vk_active = 0; (void)vk_active;
+#ifdef COLI_VULKAN
+    vk_active = g_vulkan && !omp_in_parallel() && S<=4;
+    float *vk_xh = vk_active?falloc((int64_t)S*K*D):NULL;
+    float *vk_yh = vk_active?falloc((int64_t)S*K*D):NULL;
+#endif
     int shared_on_gpu=0; (void)shared_on_gpu;   /* set by the Metal path when Phase E was fused */
     for(int base=0;base<nu;base+=64){
         int nb = nu-base<64 ? nu-base : 64;
@@ -3422,7 +3456,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
          * on GLM-5.2 int4: identical 256-token greedy output, and on the int4 tiny
          * oracle). Gated off the speculation window like every S-dependent kernel switch. */
         int xexp_done=0;
-        if(g_xexp && !metal_done && S==1 && !nmiss && !spec_pinned() && g_idot && g_i4s<=1
+        if(g_xexp && !metal_done && !vk_active && S==1 && !nmiss && !spec_pinned() && g_idot && g_i4s<=1
 #ifdef COLI_CUDA
            && !g_cuda_enabled
 #endif
@@ -3477,7 +3511,70 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                 }
             }
         }
-        if(!metal_done && !xexp_done)
+#ifdef COLI_VULKAN
+        /* Vulkan expert tier (COLI_VULKAN=1): upload routed int4 experts to the GPU once
+         * (capped by COLI_VK_EXPERTS), then compute the resident ones as one batched
+         * coli_vk_expert_group (fused gate+up+silu -> down, on-device); the rest + misses
+         * fall back to the CPU below. Decode-only (S<=4). Measured ~35% faster than ROCm. */
+        if(vk_active && !metal_done){
+            ColiVkTensor *vg[64],*vu[64],*vd[64]; ESlot *ve[64]; int vrows[64], voff[64], vrmap[64*4]; float vwmap[64*4];
+            ESlot *ce[64]; int cnr[64], crmap[64*4]; float cwmap[64*4];
+            int nvk=0, vtot=0, ncpu=0;
+            double t0=now_s();
+            for(int j=0;j<nb;j++){ int eid=uniq[base+j]; ESlot *e=use[j];
+                if(g_pipe && qof[j]>=0){ double tw=now_s(); pipe_wait(qof[j]); m->t_ewait += now_s()-tw; }
+                int nr=0;
+                for(int s=0;s<S;s++) for(int kk=0;kk<keff[s];kk++)
+                    if(idxs[(int64_t)s*K+kk]==eid){ rows[nr]=s; rw[nr]=ws[(int64_t)s*K+kk]; nr++; break; }
+                if(!nr) continue;
+                if(!e->slab) expert_load(m,layer,e->eid,e,1);
+                int elig = e->slab && e->g.fmt==2 && e->u.fmt==2 && e->d.fmt==2 && nvk<64 && (vtot+nr)<=S*K;
+                if(elig && !e->g.vk_eligible && g_vk_resident < g_vk_budget
+                   && (uint8_t*)e->g.q4>=e->slab && (uint8_t*)e->d.q4>=e->slab){
+                    if(coli_vk_tensor_ensure(&e->g.vk,e->g.q4,e->g.s,2,D,I)
+                       && coli_vk_tensor_ensure(&e->u.vk,e->u.q4,e->u.s,2,D,I)
+                       && coli_vk_tensor_ensure(&e->d.vk,e->d.q4,e->d.s,2,I,D)){
+                        e->g.vk_eligible=e->u.vk_eligible=e->d.vk_eligible=1; g_vk_resident++;
+                    }
+                }
+                if(elig && e->g.vk_eligible){
+                    voff[nvk]=vtot;
+                    for(int r=0;r<nr;r++){ memcpy(vk_xh+(int64_t)(vtot+r)*D, x+(int64_t)rows[r]*D, D*sizeof(float));
+                        vrmap[nvk*S+r]=rows[r]; vwmap[nvk*S+r]=rw[r]; }
+                    vg[nvk]=e->g.vk; vu[nvk]=e->u.vk; vd[nvk]=e->d.vk; ve[nvk]=e; vrows[nvk]=nr; vtot+=nr; nvk++;
+                } else {
+                    ce[ncpu]=e; cnr[ncpu]=nr;
+                    for(int r=0;r<nr;r++){ crmap[ncpu*S+r]=rows[r]; cwmap[ncpu*S+r]=rw[r]; }
+                    ncpu++;
+                }
+            }
+            int vk_ok = nvk>0 && coli_vk_expert_group(vg,vu,vd,vrows,nvk,vk_yh,vk_xh);
+            for(int c=0;c<ncpu;c++){ ESlot *e=ce[c]; int nr=cnr[c];
+                for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)crmap[c*S+r]*D, D*sizeof(float));
+                expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
+                for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
+                matmul_qt(hh, gg, &e->d, nr);
+                for(int r=0;r<nr;r++){ float *os=out+(int64_t)crmap[c*S+r]*D, wgt=cwmap[c*S+r], *hr=hh+(int64_t)r*D;
+                    for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
+            }
+            for(int c=0;c<nvk;c++){ int nr=vrows[c];
+                if(vk_ok){ int o=voff[c];
+                    for(int r=0;r<nr;r++){ float *os=out+(int64_t)vrmap[c*S+r]*D, wgt=vwmap[c*S+r], *src=vk_yh+(int64_t)(o+r)*D;
+                        for(int d=0;d<D;d++) os[d]+=wgt*src[d]; }
+                } else {   /* group failed: recompute this expert's rows on the CPU via its ESlot */
+                    ESlot *e=ve[c];
+                    for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)vrmap[c*S+r]*D, D*sizeof(float));
+                    expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
+                    for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
+                    matmul_qt(hh, gg, &e->d, nr);
+                    for(int r=0;r<nr;r++){ float *os=out+(int64_t)vrmap[c*S+r]*D, wgt=vwmap[c*S+r], *hr=hh+(int64_t)r*D;
+                        for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
+                }
+            }
+            double dt=now_s()-t0; m->t_emm+=dt; if(g_prof) m->t_egpu+=dt;
+        }
+#endif
+        if(!metal_done && !xexp_done && !vk_active)
         for(int j=0;j<nb;j++){ int eid=uniq[base+j]; ESlot *e=use[j];
 #ifdef COLI_CUDA
             if(early_issued && done_j[j]) continue;    /* computing on the GPU right now */
@@ -3718,6 +3815,9 @@ shared_done:
 #ifdef COLI_CUDA
     free(group_x);free(group_y);
     free(group_row); free(group_weight);
+#endif
+#ifdef COLI_VULKAN
+    free(vk_xh); free(vk_yh);
 #endif
 }
 
@@ -7048,6 +7148,17 @@ int main(int argc, char **argv){
         g_cuda_e8_ready=coli_cuda_e8_set_grid(e8_grid);
     }
     g_cuda_dense=getenv("CUDA_DENSE")?atoi(getenv("CUDA_DENSE")):0;
+#endif
+#ifdef COLI_VULKAN
+    if(getenv("COLI_VULKAN") && atoi(getenv("COLI_VULKAN"))){
+        const char *spv = getenv("COLI_VK_SHADERS"); if(!spv) spv = "shaders/qmatmul.spv";
+        g_vulkan = coli_vk_init(spv);
+        if(!g_vulkan){ fprintf(stderr,"[VK] Vulkan backend unavailable (need libvulkan + shaders/qmatmul{,_gate_up}.spv)\n"); return 2; }
+        g_vk_budget = getenv("COLI_VK_EXPERTS") ? atoi(getenv("COLI_VK_EXPERTS")) : 1024;
+        fprintf(stderr,"[VK] expert tier active: routed int4 experts on the GPU (budget %d)\n", g_vk_budget);
+    }
+#endif
+#ifdef COLI_CUDA
     g_cuda_pipe=getenv("COLI_CUDA_PIPE")?atoi(getenv("COLI_CUDA_PIPE")):0;
     g_cuda_router=getenv("COLI_CUDA_ROUTER")?atoi(getenv("COLI_CUDA_ROUTER")):0;
     g_cuda_resid=getenv("COLI_CUDA_RESID")?atoi(getenv("COLI_CUDA_RESID")):0;

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -3049,6 +3049,20 @@ static void attention(Model *m, Layer *l, int layer, float *x, int S, int pos_ba
  * una volta sola e moltiplicato per tutte le posizioni che lo usano (pesi letti 1 volta);
  * lo shared expert e' un unico matmul a S righe. Per posizione l'accumulo resta
  * nell'ordine (routed nel loro ordine di union, poi shared). */
+#ifdef COLI_VULKAN
+/* dev2 group issue on a worker thread: the Polaris/x4 submit path costs ~0.8ms per
+ * dev2-active block serialized on the main thread (measured 3.2s/decode vs 0.15s
+ * dev0-only) while the 580's exec itself finishes early (take-wait 0.1s) — off-thread
+ * it overlaps dev0's issue + the CPU expert share. All Vulkan state it touches is
+ * G2-private, and moe() joins before take2, preserving the one-in-flight invariant. */
+typedef struct { ColiVkTensor **g,**u,**d; const int *rows; int n; const float *x; int rc; } Vk2Iss;
+static void *vk2_issue_worker(void *p){
+    Vk2Iss *j=(Vk2Iss*)p;
+    j->rc = coli_vk_expert_group_issue2(j->g,j->u,j->d,j->rows,j->n,j->x);
+    return NULL;
+}
+#endif
+
 /* pin ∪ LRU residency probe (used by CACHE_ROUTE max-rank fill). */
 static int expert_is_resident(Model *m, int layer, int eid){
     ESlot *P=m->pin[layer];
@@ -3784,8 +3798,15 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
             }
             if(g_prof){ g_vkb_cls+=now_s()-t0; g_vkb_blocks++; g_vkb_nvk+=nvk+nvk2; g_vkb_nvk2+=nvk2; g_vkb_ncpu+=ncpu; }
             double t_iss0=now_s();
-            /* issue the SLOWER device first so it gets the longest overlap window */
-            int vk2_issued = nvk2>0 && coli_vk_expert_group_issue2(vg2,vu2,vd2,vrows2,nvk2,vk_xh2);
+            /* issue the SLOWER device first so it gets the longest overlap window;
+             * dev2's submit runs on a worker thread (joined before take2 below) so its
+             * per-block cost overlaps dev0 issue + the CPU share instead of serializing */
+            Vk2Iss iss2 = { vg2, vu2, vd2, vrows2, nvk2, vk_xh2, 0 };
+            pthread_t iss2_th; int iss2_threaded=0;
+            if(nvk2>0){
+                if(pthread_create(&iss2_th,NULL,vk2_issue_worker,&iss2)==0) iss2_threaded=1;
+                else iss2.rc = coli_vk_expert_group_issue2(vg2,vu2,vd2,vrows2,nvk2,vk_xh2);
+            }
             int vk_issued = nvk>0 && coli_vk_expert_group_issue(vg,vu,vd,vrows,nvk,vk_xh);
             if(g_prof) g_vkb_issue+=now_s()-t_iss0;
             /* CPU share stays SERIAL over experts with row-parallel kernels: a decode
@@ -3842,7 +3863,8 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
             }
             /* dev2 group: taken AFTER dev0's accumulate so the slower card gets the
              * extra overlap; same per-expert CPU recompute fallback on failure. */
-            int vk2_ok = vk2_issued && coli_vk_expert_group_take2(vk_yh2);
+            if(iss2_threaded) pthread_join(iss2_th,NULL);
+            int vk2_ok = iss2.rc && coli_vk_expert_group_take2(vk_yh2);
             for(int c2=0;c2<nvk2;c2++){ int nr=vrows2[c2];
                 if(vk2_ok){ int o=voff2[c2];
                     for(int r=0;r<nr;r++){ float *os=out+(int64_t)vrmap2[c2*S+r]*D, wgt=vwmap2[c2*S+r], *src=vk_yh2+(int64_t)(o+r)*D;

--- a/c/sample.h
+++ b/c/sample.h
@@ -97,6 +97,23 @@ static int dist_sample(int V, int ban){
 /* next token from logits: greedy if g_temp<=0, sampling otherwise.
  * ban = token excluded because it was rejected by speculative verification. */
 static int pick_tok(const float *lo, int V, int ban){
+    /* COLI_LOGIT_DUMP=1: top-5 (id:logit) per step to stderr — for comparing two
+     * engine configs on identical forced context (backend-exactness triage). */
+    static int dump = -1;
+    if (dump < 0) dump = getenv("COLI_LOGIT_DUMP") ? 1 : 0;
+    if (dump){
+        int id[5]={-1,-1,-1,-1,-1}; float v[5]={-3e38f,-3e38f,-3e38f,-3e38f,-3e38f};
+        for (int t = 0; t < V; t++){
+            float x = lo[t];
+            for (int k = 0; k < 5; k++) if (x > v[k]){
+                for (int j = 4; j > k; j--){ v[j]=v[j-1]; id[j]=id[j-1]; }
+                v[k]=x; id[k]=t; break;
+            }
+        }
+        fprintf(stderr,"[LOGITS]");
+        for (int k = 0; k < 5; k++) fprintf(stderr," %d:%.6f", id[k], v[k]);
+        fprintf(stderr,"\n");
+    }
     if (g_temp <= 0) return argmax_v(lo, V);
     dist_build(lo, V);
     return dist_sample(V, ban);

--- a/c/shaders/attention_absorb.comp
+++ b/c/shaders/attention_absorb.comp
@@ -33,6 +33,7 @@ layout(push_constant) uniform P {
     int rowWords;   // uint32 words per kv_b row (K-dim)
     int cap;        // score scratch stride per (s,h) = T-st0
     float scale;    // attention scale
+    int gs;         // fmt=4 group size (multiple of 8; host gates otherwise)
 } p;
 
 shared float qsc[256];    // q_nope pre-multiplied by its row scale
@@ -70,7 +71,7 @@ void main() {
     // Row-scale formats fold each kv_b row's scale into the query element once (the
     // scale factors out of the i-sum). fmt=5 scales vary along i (per 64-group), so
     // qsc[] stays UNSCALED and the (row,group) scale applies inside pass 1.
-    for (int d = tid; d < p.Q; d += nth) qsc[d] = p.fmt == 5 ? q[qoff + d] : q[qoff + d] * wsc[rbase + d];
+    for (int d = tid; d < p.Q; d += nth) qsc[d] = (p.fmt == 5 || p.fmt == 4) ? q[qoff + d] : q[qoff + d] * wsc[rbase + d];
     for (int d = tid; d < p.R; d += nth) qr[d] = q[qoff + p.Q + d];
     barrier();
 
@@ -85,6 +86,10 @@ void main() {
             int gi = i >> 6;                        // this thread's i sits in ONE group per row
             for (int d = 0; d < p.Q; d++)
                 acc += qsc[d] * i3v(rbase + d, i) * wsc[(rbase + d) * ng + gi];
+        } else if (p.fmt == 4) {                    // grouped int4: nibble + per-group scale
+            int wi = i >> 3, l = i & 7, gi = i / p.gs, ng4 = (p.K + p.gs - 1) / p.gs;
+            for (int d = 0; d < p.Q; d++)
+                acc += qsc[d] * i4(w[(rbase + d) * p.rowWords + wi], l) * wsc[(rbase + d) * ng4 + gi];
         } else {
             int wi = i >> 3, l = i & 7;
             for (int d = 0; d < p.Q; d++) acc += qsc[d] * i4(w[(rbase + d) * p.rowWords + wi], l);
@@ -150,6 +155,14 @@ void main() {
                 }
                 acc += a * wsc[row * ng + g];
             }
+        } else if (p.fmt == 4) {   // grouped int4: per-word group scale (gs%8==0, host-gated)
+            int words = (p.K + 7) / 8, ng4 = (p.K + p.gs - 1) / p.gs;
+            for (int wi = lane; wi < words; wi += sgsize) {
+                uint pk = w[rb + uint(wi)]; int i0 = wi * 8;
+                float a = 0.0;
+                for (int k = 0; k < 8; k++) { int i = i0 + k; if (i < p.K) a += clat[i] * i4(pk, k); }
+                acc += a * wsc[row * ng4 + uint(i0 / p.gs)];
+            }
         } else {
             int words = (p.K + 7) / 8;
             for (int wi = lane; wi < words; wi += sgsize) {
@@ -158,6 +171,6 @@ void main() {
             }
         }
         float tot = subgroupAdd(acc);
-        if (lane == 0) ctx[(s * p.H + h) * p.V + v] = p.fmt == 5 ? tot : tot * wsc[row];
+        if (lane == 0) ctx[(s * p.H + h) * p.V + v] = (p.fmt == 5 || p.fmt == 4) ? tot : tot * wsc[row];
     }
 }

--- a/c/shaders/attention_absorb.comp
+++ b/c/shaders/attention_absorb.comp
@@ -1,0 +1,127 @@
+#version 450
+// MLA weight-absorption attention core (decode), the VK equivalent of
+// coli_cuda_attention_absorb / glm.c's CPU absorb loop. One workgroup per
+// (query row s = WorkGroupID.y, head h = WorkGroupID.x); the whole core for
+// one head runs in a single dispatch:
+//   qabs[i]  = sum_d q_nope[d] * dequant(Wkv_b[h*(Q+V)+d])[i]        (absorbed query)
+//   score_t  = (qabs . L_t + q_rope . R_t) * scale     t in [st0, T-S+s]  (causal)
+//   p        = softmax(score)
+//   clat[i]  = sum_t p_t * L_t[i]                                    (latent context)
+//   ctx[v]   = clat . dequant(Wkv_b[h*(Q+V)+Q+v])                    (value rows)
+// L/R are the PERSISTENT device-side latent/rope caches (rows appended by the
+// host each token, absolute position indexing). Queries arrive already roped;
+// cache rows already normed+roped (host writes them that way).
+// fmt: 1=int8, 2=int4 (nibble-8). Limits: Q<=256, R<=64, K<=512 (shared arrays).
+#extension GL_KHR_shader_subgroup_arithmetic : require
+layout(local_size_x = 256) in;
+
+layout(std430, binding = 0) readonly  buffer QB { float q[]; };      // [S,H,Q+R] roped
+layout(std430, binding = 1) readonly  buffer WB { uint  w[]; };      // kv_b [H*(Q+V), K] quant
+layout(std430, binding = 2) readonly  buffer SB { float wsc[]; };    // kv_b row scales
+layout(std430, binding = 3) readonly  buffer LB { float lc[]; };     // latent cache [max_t, K]
+layout(std430, binding = 4) readonly  buffer RB { float rc[]; };     // rope cache [max_t, R]
+layout(std430, binding = 5) buffer SC           { float sc[]; };     // scores [S,H,cap] scratch
+layout(std430, binding = 6) writeonly buffer CB { float ctx[]; };    // [S,H,V] out
+
+layout(push_constant) uniform P {
+    int fmt;        // 1=int8, 2=int4
+    int S, H, Q, R, V, K;   // Q=qk_nope, R=qk_rope, V=v_head, K=kv_lora
+    int st0, T;     // attend rows [st0, T-S+s]; T = absolute rows incl. final query
+    int rowWords;   // uint32 words per kv_b row (K-dim)
+    int cap;        // score scratch stride per (s,h) = T-st0
+    float scale;    // attention scale
+} p;
+
+shared float qsc[256];    // q_nope pre-multiplied by its row scale
+shared float qr[64];      // q_rope
+shared float qabs[512];   // absorbed query in latent space
+shared float clat[512];   // latent context
+shared float red[256];    // reduction scratch
+
+float i8(uint x, int l) { int b = int((x >> (uint(l) * 8u)) & 0xffu); if (b >= 128) b -= 256; return float(b); }
+float i4(uint x, int l) { return float(int((x >> (uint(l) * 4u)) & 0xfu) - 8); }
+
+void main() {
+    int h   = int(gl_WorkGroupID.x);
+    int s   = int(gl_WorkGroupID.y);
+    int tid = int(gl_LocalInvocationID.x);
+    int nth = int(gl_WorkGroupSize.x);
+    int lane   = int(gl_SubgroupInvocationID);
+    int sgsize = int(gl_SubgroupSize);
+    int sg     = int(gl_SubgroupID);
+    int nsg    = nth / sgsize;
+
+    int nt    = (p.T - p.S + s + 1) - p.st0;              // causal window for query s
+    int rbase = h * (p.Q + p.V);                          // head's row block in kv_b
+    int qoff  = (s * p.H + h) * (p.Q + p.R);
+    int scoff = (s * p.H + h) * p.cap;
+
+    for (int d = tid; d < p.Q; d += nth) qsc[d] = q[qoff + d] * wsc[rbase + d];
+    for (int d = tid; d < p.R; d += nth) qr[d] = q[qoff + p.Q + d];
+    barrier();
+
+    /* 1) absorbed query: qabs = Wnope^T qsc — thread-parallel over latent dim i */
+    for (int i = tid; i < p.K; i += nth) {
+        float acc = 0.0;
+        if (p.fmt == 1) {
+            int wi = i >> 2, l = i & 3;
+            for (int d = 0; d < p.Q; d++) acc += qsc[d] * i8(w[(rbase + d) * p.rowWords + wi], l);
+        } else {
+            int wi = i >> 3, l = i & 7;
+            for (int d = 0; d < p.Q; d++) acc += qsc[d] * i4(w[(rbase + d) * p.rowWords + wi], l);
+        }
+        qabs[i] = acc;
+    }
+    barrier();
+
+    /* 2) scores: one subgroup per cached token, lanes split the K+R dot */
+    float lmax = -3.0e38;
+    for (int j = sg; j < nt; j += nsg) {
+        int t = p.st0 + j;
+        float a = 0.0;
+        for (int i = lane; i < p.K; i += sgsize) a += qabs[i] * lc[t * p.K + i];
+        for (int d = lane; d < p.R; d += sgsize) a += qr[d] * rc[t * p.R + d];
+        float tot = subgroupAdd(a) * p.scale;
+        if (lane == 0) { sc[scoff + j] = tot; lmax = max(lmax, tot); }
+    }
+    red[tid] = lmax; barrier();
+    for (int o = nth / 2; o > 0; o >>= 1) { if (tid < o) red[tid] = max(red[tid], red[tid + o]); barrier(); }
+    float wmax = red[0]; barrier();
+
+    /* 3) softmax: exp in place + workgroup sum */
+    float lsum = 0.0;
+    for (int j = tid; j < nt; j += nth) { float e = exp(sc[scoff + j] - wmax); sc[scoff + j] = e; lsum += e; }
+    red[tid] = lsum; barrier();
+    for (int o = nth / 2; o > 0; o >>= 1) { if (tid < o) red[tid] += red[tid + o]; barrier(); }
+    float inv = 1.0 / red[0]; barrier();
+
+    /* 4) latent context: clat = sum_t p_t L_t — thread-parallel over i (coalesced rows) */
+    for (int i = tid; i < p.K; i += nth) {
+        float acc = 0.0;
+        for (int j = 0; j < nt; j++) acc += sc[scoff + j] * lc[(p.st0 + j) * p.K + i];
+        clat[i] = acc * inv;
+    }
+    barrier();
+
+    /* 5) value rows: ctx[v] = dequant(row rbase+Q+v) . clat — one subgroup per row */
+    for (int v = sg; v < p.V; v += nsg) {
+        int row = rbase + p.Q + v;
+        uint rb = uint(row) * uint(p.rowWords);
+        float acc = 0.0;
+        if (p.fmt == 1) {
+            int words = (p.K + 3) / 4;
+            for (int wi = lane; wi < words; wi += sgsize) {
+                uint pk = w[rb + uint(wi)]; int i0 = wi * 4;
+                for (int k = 0; k < 4; k++) { int i = i0 + k; if (i < p.K) acc += clat[i] * i8(pk, k); }
+            }
+        } else {
+            int words = (p.K + 7) / 8;
+            for (int wi = lane; wi < words; wi += sgsize) {
+                uint pk = w[rb + uint(wi)]; int i0 = wi * 8;
+                for (int k = 0; k < 8; k++) { int i = i0 + k; if (i < p.K) acc += clat[i] * i4(pk, k); }
+            }
+        }
+        float tot = subgroupAdd(acc);
+        if (lane == 0) ctx[(s * p.H + h) * p.V + v] = tot * wsc[row];
+    }
+}

--- a/c/shaders/attention_absorb.comp
+++ b/c/shaders/attention_absorb.comp
@@ -11,7 +11,10 @@
 // L/R are the PERSISTENT device-side latent/rope caches (rows appended by the
 // host each token, absolute position indexing). Queries arrive already roped;
 // cache rows already normed+roped (host writes them that way).
-// fmt: 1=int8, 2=int4 (nibble-8). Limits: Q<=256, R<=64, K<=512 (shared arrays).
+// fmt: 1=int8, 2=int4 (nibble-8), 5=int3-g64 (24B/64-group two-plane packing, ONE
+// f32 scale per group: wsc[] holds rows*ceil(K/64) entries; for the row-scale
+// formats the scale folds into qsc[] once, for fmt=5 it is applied per (row,group)
+// inside the passes). Limits: Q<=256, R<=64, K<=512 (shared arrays).
 #extension GL_KHR_shader_subgroup_arithmetic : require
 layout(local_size_x = 256) in;
 
@@ -40,6 +43,14 @@ shared float red[256];    // reduction scratch
 
 float i8(uint x, int l) { int b = int((x >> (uint(l) * 8u)) & 0xffu); if (b >= 128) b -= 256; return float(b); }
 float i4(uint x, int l) { return float(int((x >> (uint(l) * 4u)) & 0xfu) - 8); }
+// int3-g64: raw integer value in [-4,3] of element i of weight row `row` (scale separate)
+float i3v(int row, int i) {
+    int g = i >> 6, j = i & 63;
+    uint blo = w[row * p.rowWords + g * 6 + (j >> 4)];
+    uint bhi = w[row * p.rowWords + g * 6 + 4 + (j >> 5)];
+    uint u = ((blo >> uint((j & 15) * 2)) & 3u) | (((bhi >> uint(j & 31)) & 1u) << 2);
+    return float(int(u) - 4);
+}
 
 void main() {
     int h   = int(gl_WorkGroupID.x);
@@ -56,16 +67,24 @@ void main() {
     int qoff  = (s * p.H + h) * (p.Q + p.R);
     int scoff = (s * p.H + h) * p.cap;
 
-    for (int d = tid; d < p.Q; d += nth) qsc[d] = q[qoff + d] * wsc[rbase + d];
+    // Row-scale formats fold each kv_b row's scale into the query element once (the
+    // scale factors out of the i-sum). fmt=5 scales vary along i (per 64-group), so
+    // qsc[] stays UNSCALED and the (row,group) scale applies inside pass 1.
+    for (int d = tid; d < p.Q; d += nth) qsc[d] = p.fmt == 5 ? q[qoff + d] : q[qoff + d] * wsc[rbase + d];
     for (int d = tid; d < p.R; d += nth) qr[d] = q[qoff + p.Q + d];
     barrier();
 
     /* 1) absorbed query: qabs = Wnope^T qsc — thread-parallel over latent dim i */
+    int ng = (p.K + 63) >> 6;                       // int3-g64 groups per kv_b row
     for (int i = tid; i < p.K; i += nth) {
         float acc = 0.0;
         if (p.fmt == 1) {
             int wi = i >> 2, l = i & 3;
             for (int d = 0; d < p.Q; d++) acc += qsc[d] * i8(w[(rbase + d) * p.rowWords + wi], l);
+        } else if (p.fmt == 5) {
+            int gi = i >> 6;                        // this thread's i sits in ONE group per row
+            for (int d = 0; d < p.Q; d++)
+                acc += qsc[d] * i3v(rbase + d, i) * wsc[(rbase + d) * ng + gi];
         } else {
             int wi = i >> 3, l = i & 7;
             for (int d = 0; d < p.Q; d++) acc += qsc[d] * i4(w[(rbase + d) * p.rowWords + wi], l);
@@ -114,6 +133,23 @@ void main() {
                 uint pk = w[rb + uint(wi)]; int i0 = wi * 4;
                 for (int k = 0; k < 4; k++) { int i = i0 + k; if (i < p.K) acc += clat[i] * i8(pk, k); }
             }
+        } else if (p.fmt == 5) {   // lanes stride 16-value low-plane words, group scale per partial
+            for (int m = lane; m < ng * 4; m += sgsize) {
+                int g = m >> 2, mw = m & 3;
+                uint blo = w[rb + uint(g) * 6u + uint(mw)];
+                uint bhi = w[rb + uint(g) * 6u + 4u + uint(mw >> 1)];
+                int hs = (mw & 1) * 16;
+                int i0 = (g << 6) + (mw << 4);
+                float a = 0.0;
+                for (int k = 0; k < 16; k++) {
+                    int i = i0 + k;
+                    if (i < p.K) {
+                        uint u = ((blo >> uint(k * 2)) & 3u) | (((bhi >> uint(hs + k)) & 1u) << 2);
+                        a += clat[i] * float(int(u) - 4);
+                    }
+                }
+                acc += a * wsc[row * ng + g];
+            }
         } else {
             int words = (p.K + 7) / 8;
             for (int wi = lane; wi < words; wi += sgsize) {
@@ -122,6 +158,6 @@ void main() {
             }
         }
         float tot = subgroupAdd(acc);
-        if (lane == 0) ctx[(s * p.H + h) * p.V + v] = tot * wsc[row];
+        if (lane == 0) ctx[(s * p.H + h) * p.V + v] = p.fmt == 5 ? tot : tot * wsc[row];
     }
 }

--- a/c/shaders/qmatmul.comp
+++ b/c/shaders/qmatmul.comp
@@ -1,0 +1,74 @@
+#version 450
+// Quantized mat-vec/mat-mat mirroring colibri's CUDA quant_matmul:
+//   y[s,o] = ( sum_i x[s,i] * dequant(W[o,i]) ) * scale[o]
+// fmt: 1=int8, 2=int4 (packed 2/byte, nibble-8). Weights are a byte buffer
+// exposed as uint32 words; we extract bytes/nibbles manually (no 8-bit-storage
+// extension dependency). One workgroup per (o,s); threads reduce over I.
+layout(local_size_x = 256) in;
+
+layout(std430, binding = 0) readonly buffer X  { float x[]; };
+layout(std430, binding = 1) readonly buffer W  { uint  w[]; };   // row-major, row o at o*rowWords
+layout(std430, binding = 2) readonly buffer Sc { float scale[]; };
+layout(std430, binding = 3) writeonly buffer Y { float y[]; };
+
+layout(push_constant) uniform P {
+    int fmt;   // 1=int8, 2=int4
+    int S, I, O;
+    int rowWords;  // uint32 words per weight row
+} p;
+
+shared float partial[256];
+
+// signed int8 from a uint32 word's byte lane
+float i8(uint word, int lane) {
+    int b = int((word >> (uint(lane) * 8u)) & 0xffu);
+    if (b >= 128) b -= 256;
+    return float(b);
+}
+// int4 (value - 8) from a uint32 word's nibble lane (0..7)
+float i4(uint word, int lane) {
+    int nib = int((word >> (uint(lane) * 4u)) & 0xfu);
+    return float(nib - 8);
+}
+
+void main() {
+    int o = int(gl_WorkGroupID.x);
+    int s = int(gl_WorkGroupID.y);
+    int t = int(gl_LocalInvocationID.x);
+    int nth = int(gl_WorkGroupSize.x);
+
+    uint rowBase = uint(o) * uint(p.rowWords);
+    int xbase = s * p.I;
+    float sum = 0.0;
+
+    if (p.fmt == 1) {
+        // 4 int8 weights per uint word; stride threads over words.
+        int words = (p.I + 3) / 4;
+        for (int wi = t; wi < words; wi += nth) {
+            uint packed = w[rowBase + uint(wi)];
+            int i0 = wi * 4;
+            for (int k = 0; k < 4; k++) {
+                int i = i0 + k;
+                if (i < p.I) sum += x[xbase + i] * i8(packed, k);
+            }
+        }
+    } else { // fmt == 2, int4
+        int words = (p.I + 7) / 8;
+        for (int wi = t; wi < words; wi += nth) {
+            uint packed = w[rowBase + uint(wi)];
+            int i0 = wi * 8;
+            for (int k = 0; k < 8; k++) {
+                int i = i0 + k;
+                if (i < p.I) sum += x[xbase + i] * i4(packed, k);
+            }
+        }
+    }
+
+    partial[t] = sum;
+    barrier();
+    for (int n = nth >> 1; n > 0; n >>= 1) {
+        if (t < n) partial[t] += partial[t + n];
+        barrier();
+    }
+    if (t == 0) y[s * p.O + o] = partial[0] * scale[o];
+}

--- a/c/shaders/qmatmul.comp
+++ b/c/shaders/qmatmul.comp
@@ -1,8 +1,11 @@
 #version 450
 // Quantized mat-vec/mat-mat mirroring colibri's CUDA quant_matmul:
 //   y[s,o] = ( sum_i x[s,i] * dequant(W[o,i]) ) * scale[o]
-// fmt: 1=int8, 2=int4 (packed 2/byte, nibble-8). Weights are a byte buffer
-// exposed as uint32 words; bytes/nibbles are extracted manually.
+// fmt: 1=int8, 2=int4 (packed 2/byte, nibble-8), 5=int3-g64 (per 64-input group:
+// 24 bytes = 16B low plane [2 bits/val] + 8B high plane [1 bit/val], values v+4 in
+// [-4,3], ONE f32 scale PER GROUP — scale[] holds O*ceil(I/64) entries and the
+// per-row multiply at the end does not apply). Weights are a byte buffer exposed
+// as uint32 words; bytes/nibbles/planes are extracted manually.
 //
 // Optimized decode (S=1) GEMV, techniques adapted from llama.cpp's mul_mat_vec
 // (MIT) to colibri's per-row int4/int8 layout:
@@ -23,7 +26,7 @@ layout(std430, binding = 2) readonly buffer Sc { float scale[]; };
 layout(std430, binding = 3) writeonly buffer Y { float y[]; };
 
 layout(push_constant) uniform P {
-    int fmt;        // 1=int8, 2=int4
+    int fmt;        // 1=int8, 2=int4, 5=int3-g64
     int S, I, O;
     int rowWords;   // uint32 words per weight row
 } p;
@@ -72,6 +75,27 @@ void main() {
                 uint pk = w[rowBase + uint(wi)]; int i0 = wi * 4;
                 for (int k = 0; k < 4; k++) { int i = i0 + k; if (i < p.I) sum += x[xoff + i] * i8(pk, k); }
             }
+        } else if (p.fmt == 5) { // int3-g64: lanes stride the 16-value LOW-PLANE words;
+            // all 16 values of one low word share a group, so its scale multiplies the
+            // 16-wide partial directly and the per-row scale at the end must NOT run.
+            int ng = (p.I + 63) >> 6;
+            uint sb = uint(o) * uint(ng);
+            for (int m = lane; m < ng * 4; m += sgsize) {
+                int g = m >> 2, mw = m & 3;                   // group, low-word within group
+                uint blo = w[rowBase + uint(g) * 6u + uint(mw)];
+                uint bhi = w[rowBase + uint(g) * 6u + 4u + uint(mw >> 1)];
+                int hs = (mw & 1) * 16;                       // this word's bits in the high plane
+                int i0 = (g << 6) + (mw << 4);
+                float a = 0.0;
+                for (int k = 0; k < 16; k++) {
+                    int i = i0 + k;
+                    if (i < p.I) {
+                        uint u = ((blo >> uint(k * 2)) & 3u) | (((bhi >> uint(hs + k)) & 1u) << 2);
+                        a += (staged ? xsh[i] : x[xoff + i]) * float(int(u) - 4);
+                    }
+                }
+                sum += a * scale[sb + uint(g)];
+            }
         } else { // int4
             int words = (p.I + 7) / 8;
             if (staged) for (int wi = lane; wi < words; wi += sgsize) {
@@ -83,6 +107,6 @@ void main() {
             }
         }
         float tot = subgroupAdd(sum);
-        if (lane == 0) y[s * p.O + o] = tot * scale[o];
+        if (lane == 0) y[s * p.O + o] = p.fmt == 5 ? tot : tot * scale[o];
     }
 }

--- a/c/shaders/qmatmul.comp
+++ b/c/shaders/qmatmul.comp
@@ -2,73 +2,76 @@
 // Quantized mat-vec/mat-mat mirroring colibri's CUDA quant_matmul:
 //   y[s,o] = ( sum_i x[s,i] * dequant(W[o,i]) ) * scale[o]
 // fmt: 1=int8, 2=int4 (packed 2/byte, nibble-8). Weights are a byte buffer
-// exposed as uint32 words; we extract bytes/nibbles manually (no 8-bit-storage
-// extension dependency). One workgroup per (o,s); threads reduce over I.
+// exposed as uint32 words; bytes/nibbles are extracted manually.
+//
+// Optimized decode (S=1) GEMV, techniques adapted from llama.cpp's mul_mat_vec
+// (MIT) to colibri's per-row int4/int8 layout:
+//   - x[s,:] loaded ONCE into shared memory, reused across every output row in
+//     the workgroup (x lives in host-visible scratch, so this avoids re-reading
+//     it over the BAR for each row);
+//   - one SUBGROUP per output row: its lanes stride the row's weight words with
+//     full coalescing, then a single subgroupAdd replaces the barrier-heavy
+//     shared-memory tree reduction;
+//   - grid-stride over rows so a fixed, occupancy-friendly workgroup count
+//     covers any O and any subgroup width (RADV wave32/64).
+#extension GL_KHR_shader_subgroup_arithmetic : require
 layout(local_size_x = 256) in;
 
 layout(std430, binding = 0) readonly buffer X  { float x[]; };
-layout(std430, binding = 1) readonly buffer W  { uint  w[]; };   // row-major, row o at o*rowWords
+layout(std430, binding = 1) readonly buffer W  { uint  w[]; };   // row o at o*rowWords
 layout(std430, binding = 2) readonly buffer Sc { float scale[]; };
 layout(std430, binding = 3) writeonly buffer Y { float y[]; };
 
 layout(push_constant) uniform P {
-    int fmt;   // 1=int8, 2=int4
+    int fmt;        // 1=int8, 2=int4
     int S, I, O;
-    int rowWords;  // uint32 words per weight row
+    int rowWords;   // uint32 words per weight row
 } p;
 
-shared float partial[256];
+// Max hidden dim across GLM expert matmuls is 6144 (24 KB LDS); down-proj uses 2048.
+shared float xsh[6144];
 
-// signed int8 from a uint32 word's byte lane
 float i8(uint word, int lane) {
     int b = int((word >> (uint(lane) * 8u)) & 0xffu);
     if (b >= 128) b -= 256;
     return float(b);
 }
-// int4 (value - 8) from a uint32 word's nibble lane (0..7)
 float i4(uint word, int lane) {
-    int nib = int((word >> (uint(lane) * 4u)) & 0xfu);
-    return float(nib - 8);
+    return float(int((word >> (uint(lane) * 4u)) & 0xfu) - 8);
 }
 
 void main() {
-    int o = int(gl_WorkGroupID.x);
-    int s = int(gl_WorkGroupID.y);
-    int t = int(gl_LocalInvocationID.x);
+    int s   = int(gl_WorkGroupID.y);
+    int tid = int(gl_LocalInvocationID.x);
     int nth = int(gl_WorkGroupSize.x);
 
-    uint rowBase = uint(o) * uint(p.rowWords);
-    int xbase = s * p.I;
-    float sum = 0.0;
-
-    if (p.fmt == 1) {
-        // 4 int8 weights per uint word; stride threads over words.
-        int words = (p.I + 3) / 4;
-        for (int wi = t; wi < words; wi += nth) {
-            uint packed = w[rowBase + uint(wi)];
-            int i0 = wi * 4;
-            for (int k = 0; k < 4; k++) {
-                int i = i0 + k;
-                if (i < p.I) sum += x[xbase + i] * i8(packed, k);
-            }
-        }
-    } else { // fmt == 2, int4
-        int words = (p.I + 7) / 8;
-        for (int wi = t; wi < words; wi += nth) {
-            uint packed = w[rowBase + uint(wi)];
-            int i0 = wi * 8;
-            for (int k = 0; k < 8; k++) {
-                int i = i0 + k;
-                if (i < p.I) sum += x[xbase + i] * i4(packed, k);
-            }
-        }
-    }
-
-    partial[t] = sum;
+    // Stage x[s,:] into shared once; all rows this workgroup computes reuse it.
+    for (int i = tid; i < p.I; i += nth) xsh[i] = x[s * p.I + i];
     barrier();
-    for (int n = nth >> 1; n > 0; n >>= 1) {
-        if (t < n) partial[t] += partial[t + n];
-        barrier();
+
+    int sg      = int(gl_SubgroupID);
+    int lane    = int(gl_SubgroupInvocationID);
+    int sgsize  = int(gl_SubgroupSize);
+    int nsg     = nth / sgsize;                       // subgroups (= rows) per workgroup
+    int stride  = int(gl_NumWorkGroups.x) * nsg;      // grid-stride over output rows
+
+    for (int o = int(gl_WorkGroupID.x) * nsg + sg; o < p.O; o += stride) {
+        uint rowBase = uint(o) * uint(p.rowWords);
+        float sum = 0.0;
+        if (p.fmt == 1) {
+            int words = (p.I + 3) / 4;
+            for (int wi = lane; wi < words; wi += sgsize) {
+                uint pk = w[rowBase + uint(wi)]; int i0 = wi * 4;
+                for (int k = 0; k < 4; k++) { int i = i0 + k; if (i < p.I) sum += xsh[i] * i8(pk, k); }
+            }
+        } else { // int4
+            int words = (p.I + 7) / 8;
+            for (int wi = lane; wi < words; wi += sgsize) {
+                uint pk = w[rowBase + uint(wi)]; int i0 = wi * 8;
+                for (int k = 0; k < 8; k++) { int i = i0 + k; if (i < p.I) sum += xsh[i] * i4(pk, k); }
+            }
+        }
+        float tot = subgroupAdd(sum);
+        if (lane == 0) y[s * p.O + o] = tot * scale[o];
     }
-    if (t == 0) y[s * p.O + o] = partial[0] * scale[o];
 }

--- a/c/shaders/qmatmul.comp
+++ b/c/shaders/qmatmul.comp
@@ -26,9 +26,10 @@ layout(std430, binding = 2) readonly buffer Sc { float scale[]; };
 layout(std430, binding = 3) writeonly buffer Y { float y[]; };
 
 layout(push_constant) uniform P {
-    int fmt;        // 1=int8, 2=int4, 5=int3-g64
+    int fmt;        // 1=int8, 2=int4, 4=grouped int4, 5=int3-g64
     int S, I, O;
     int rowWords;   // uint32 words per weight row
+    int gs;         // fmt=4 group size (multiple of 8; host gates otherwise)
 } p;
 
 // Max hidden dim across GLM expert matmuls is 6144 (24 KB LDS); down-proj uses 2048.
@@ -96,6 +97,18 @@ void main() {
                 }
                 sum += a * scale[sb + uint(g)];
             }
+        } else if (p.fmt == 4) { // grouped int4 (#298 semantics): nibble decode, one scale
+            // per gs inputs — gs % 8 == 0 (host-gated), so a packed word never straddles
+            // a group and its scale multiplies the 8-wide partial. Per-row scale must NOT run.
+            int words = (p.I + 7) / 8, ng = (p.I + p.gs - 1) / p.gs;
+            uint sb = uint(o) * uint(ng);
+            for (int wi = lane; wi < words; wi += sgsize) {
+                uint pk = w[rowBase + uint(wi)]; int i0 = wi * 8;
+                float a = 0.0;
+                for (int k = 0; k < 8; k++) { int i = i0 + k;
+                    if (i < p.I) a += (staged ? xsh[i] : x[xoff + i]) * i4(pk, k); }
+                sum += a * scale[sb + uint(i0 / p.gs)];
+            }
         } else { // int4
             int words = (p.I + 7) / 8;
             if (staged) for (int wi = lane; wi < words; wi += sgsize) {
@@ -107,6 +120,6 @@ void main() {
             }
         }
         float tot = subgroupAdd(sum);
-        if (lane == 0) y[s * p.O + o] = p.fmt == 5 ? tot : tot * scale[o];
+        if (lane == 0) y[s * p.O + o] = (p.fmt == 5 || p.fmt == 4) ? tot : tot * scale[o];
     }
 }

--- a/c/shaders/qmatmul.comp
+++ b/c/shaders/qmatmul.comp
@@ -29,6 +29,9 @@ layout(push_constant) uniform P {
 } p;
 
 // Max hidden dim across GLM expert matmuls is 6144 (24 KB LDS); down-proj uses 2048.
+// Rows longer than the staging array (o_proj: I = H*vh = 16384) skip shared staging
+// and read x straight from the storage buffer — an unstaged read is coalesced across
+// the subgroup and still correct, while an unchecked stage would write past xsh.
 shared float xsh[6144];
 
 float i8(uint word, int lane) {
@@ -46,8 +49,10 @@ void main() {
     int nth = int(gl_WorkGroupSize.x);
 
     // Stage x[s,:] into shared once; all rows this workgroup computes reuse it.
-    for (int i = tid; i < p.I; i += nth) xsh[i] = x[s * p.I + i];
+    bool staged = p.I <= 6144;
+    if (staged) for (int i = tid; i < p.I; i += nth) xsh[i] = x[s * p.I + i];
     barrier();
+    int xoff = s * p.I;
 
     int sg      = int(gl_SubgroupID);
     int lane    = int(gl_SubgroupInvocationID);
@@ -60,15 +65,21 @@ void main() {
         float sum = 0.0;
         if (p.fmt == 1) {
             int words = (p.I + 3) / 4;
-            for (int wi = lane; wi < words; wi += sgsize) {
+            if (staged) for (int wi = lane; wi < words; wi += sgsize) {
                 uint pk = w[rowBase + uint(wi)]; int i0 = wi * 4;
                 for (int k = 0; k < 4; k++) { int i = i0 + k; if (i < p.I) sum += xsh[i] * i8(pk, k); }
+            } else for (int wi = lane; wi < words; wi += sgsize) {
+                uint pk = w[rowBase + uint(wi)]; int i0 = wi * 4;
+                for (int k = 0; k < 4; k++) { int i = i0 + k; if (i < p.I) sum += x[xoff + i] * i8(pk, k); }
             }
         } else { // int4
             int words = (p.I + 7) / 8;
-            for (int wi = lane; wi < words; wi += sgsize) {
+            if (staged) for (int wi = lane; wi < words; wi += sgsize) {
                 uint pk = w[rowBase + uint(wi)]; int i0 = wi * 8;
                 for (int k = 0; k < 8; k++) { int i = i0 + k; if (i < p.I) sum += xsh[i] * i4(pk, k); }
+            } else for (int wi = lane; wi < words; wi += sgsize) {
+                uint pk = w[rowBase + uint(wi)]; int i0 = wi * 8;
+                for (int k = 0; k < 8; k++) { int i = i0 + k; if (i < p.I) sum += x[xoff + i] * i4(pk, k); }
             }
         }
         float tot = subgroupAdd(sum);

--- a/c/shaders/qmatmul_gate_up.comp
+++ b/c/shaders/qmatmul_gate_up.comp
@@ -21,9 +21,10 @@ layout(std430, binding = 4) readonly buffer SU { float uscale[]; };
 layout(std430, binding = 5) writeonly buffer H { float hid[]; };
 
 layout(push_constant) uniform P {
-    int fmt;        // 1=int8, 2=int4, 5=int3-g64
+    int fmt;        // 1=int8, 2=int4, 4=grouped int4, 5=int3-g64
     int S, I, O;    // I = input dim (hidden), O = moe_inter
     int rowWords;   // uint32 words per weight row (of the I-dim rows)
+    int gs;         // fmt=4 group size (multiple of 8; host gates otherwise)
 } p;
 
 shared float xsh[6144];
@@ -79,6 +80,16 @@ void main() {
                 g += ga * gscale[sb + uint(gi)];
                 u += ua * uscale[sb + uint(gi)];
             }
+        } else if (p.fmt == 4) { // grouped int4: nibble decode, per-word group scale (gs%8==0)
+            int words = (p.I + 7) / 8, ng = (p.I + p.gs - 1) / p.gs;
+            uint sb = uint(o) * uint(ng);
+            for (int wi = lane; wi < words; wi += sgsize) {
+                uint gp = wg[rb + uint(wi)], upk = wu[rb + uint(wi)]; int i0 = wi * 8;
+                float ga = 0.0, ua = 0.0;
+                for (int k = 0; k < 8; k++) { int i = i0 + k; if (i < p.I) { float xv = xsh[i]; ga += xv * i4(gp, k); ua += xv * i4(upk, k); } }
+                float sc_g = gscale[sb + uint(i0 / p.gs)], sc_u = uscale[sb + uint(i0 / p.gs)];
+                g += ga * sc_g; u += ua * sc_u;
+            }
         } else { // int4
             int words = (p.I + 7) / 8;
             for (int wi = lane; wi < words; wi += sgsize) {
@@ -87,7 +98,7 @@ void main() {
             }
         }
         float gt = subgroupAdd(g), ut = subgroupAdd(u);
-        if (p.fmt != 5) { gt *= gscale[o]; ut *= uscale[o]; }   // per-row formats only
+        if (p.fmt != 5 && p.fmt != 4) { gt *= gscale[o]; ut *= uscale[o]; }   // per-row formats only
         if (lane == 0) hid[s * p.O + o] = (gt / (1.0 + exp(-gt))) * ut;   // silu(gate)*up
     }
 }

--- a/c/shaders/qmatmul_gate_up.comp
+++ b/c/shaders/qmatmul_gate_up.comp
@@ -7,7 +7,9 @@
 // The whole expert MLP first half in ONE dispatch: x is read ONCE from shared and
 // reused for both projections (half the activation traffic + one launch instead of
 // two), one subgroup per output row, subgroupAdd reduction, grid-stride over rows.
-// fmt: 1=int8, 2=int4 (nibble-8).
+// fmt: 1=int8, 2=int4 (nibble-8), 5=int3-g64 (24B/64-group two-plane packing with
+// ONE f32 scale per group — gscale/uscale hold O*ceil(I/64) entries; the per-row
+// multiply after the reduction does not apply, the group scale folds in per-lane).
 #extension GL_KHR_shader_subgroup_arithmetic : require
 layout(local_size_x = 256) in;
 
@@ -19,7 +21,7 @@ layout(std430, binding = 4) readonly buffer SU { float uscale[]; };
 layout(std430, binding = 5) writeonly buffer H { float hid[]; };
 
 layout(push_constant) uniform P {
-    int fmt;        // 1=int8, 2=int4
+    int fmt;        // 1=int8, 2=int4, 5=int3-g64
     int S, I, O;    // I = input dim (hidden), O = moe_inter
     int rowWords;   // uint32 words per weight row (of the I-dim rows)
 } p;
@@ -52,6 +54,31 @@ void main() {
                 uint gp = wg[rb + uint(wi)], upk = wu[rb + uint(wi)]; int i0 = wi * 4;
                 for (int k = 0; k < 4; k++) { int i = i0 + k; if (i < p.I) { float xv = xsh[i]; g += xv * i8(gp, k); u += xv * i8(upk, k); } }
             }
+        } else if (p.fmt == 5) { // int3-g64: lanes stride 16-value low-plane words; one
+            // group scale per word-partial (gate and up have independent scale arrays)
+            int ng = (p.I + 63) >> 6;
+            uint sb = uint(o) * uint(ng);
+            for (int m = lane; m < ng * 4; m += sgsize) {
+                int gi = m >> 2, mw = m & 3;
+                uint wbase = rb + uint(gi) * 6u;
+                uint glo = wg[wbase + uint(mw)], ghi = wg[wbase + 4u + uint(mw >> 1)];
+                uint ulo = wu[wbase + uint(mw)], uhi = wu[wbase + 4u + uint(mw >> 1)];
+                int hs = (mw & 1) * 16;
+                int i0 = (gi << 6) + (mw << 4);
+                float ga = 0.0, ua = 0.0;
+                for (int k = 0; k < 16; k++) {
+                    int i = i0 + k;
+                    if (i < p.I) {
+                        float xv = xsh[i];
+                        uint gv = ((glo >> uint(k * 2)) & 3u) | (((ghi >> uint(hs + k)) & 1u) << 2);
+                        uint uv = ((ulo >> uint(k * 2)) & 3u) | (((uhi >> uint(hs + k)) & 1u) << 2);
+                        ga += xv * float(int(gv) - 4);
+                        ua += xv * float(int(uv) - 4);
+                    }
+                }
+                g += ga * gscale[sb + uint(gi)];
+                u += ua * uscale[sb + uint(gi)];
+            }
         } else { // int4
             int words = (p.I + 7) / 8;
             for (int wi = lane; wi < words; wi += sgsize) {
@@ -59,8 +86,8 @@ void main() {
                 for (int k = 0; k < 8; k++) { int i = i0 + k; if (i < p.I) { float xv = xsh[i]; g += xv * i4(gp, k); u += xv * i4(upk, k); } }
             }
         }
-        float gt = subgroupAdd(g) * gscale[o];
-        float ut = subgroupAdd(u) * uscale[o];
+        float gt = subgroupAdd(g), ut = subgroupAdd(u);
+        if (p.fmt != 5) { gt *= gscale[o]; ut *= uscale[o]; }   // per-row formats only
         if (lane == 0) hid[s * p.O + o] = (gt / (1.0 + exp(-gt))) * ut;   // silu(gate)*up
     }
 }

--- a/c/shaders/qmatmul_gate_up.comp
+++ b/c/shaders/qmatmul_gate_up.comp
@@ -1,0 +1,66 @@
+#version 450
+// Fused dual projection + SiLU gate, the VK equivalent of colibri's
+// grouped_hidden_w4_dual:  hidden[s,o] = silu(gate[s,o]) * up[s,o]
+//   gate[s,o] = (sum_i x[s,i]*dequant(Wg[o,i])) * gscale[o]
+//   up  [s,o] = (sum_i x[s,i]*dequant(Wu[o,i])) * uscale[o]
+//   silu(z)   = z / (1 + exp(-z))
+// The whole expert MLP first half in ONE dispatch: x is read ONCE from shared and
+// reused for both projections (half the activation traffic + one launch instead of
+// two), one subgroup per output row, subgroupAdd reduction, grid-stride over rows.
+// fmt: 1=int8, 2=int4 (nibble-8).
+#extension GL_KHR_shader_subgroup_arithmetic : require
+layout(local_size_x = 256) in;
+
+layout(std430, binding = 0) readonly buffer X  { float x[]; };
+layout(std430, binding = 1) readonly buffer WG { uint  wg[]; };   // gate weights
+layout(std430, binding = 2) readonly buffer SG { float gscale[]; };
+layout(std430, binding = 3) readonly buffer WU { uint  wu[]; };   // up weights
+layout(std430, binding = 4) readonly buffer SU { float uscale[]; };
+layout(std430, binding = 5) writeonly buffer H { float hid[]; };
+
+layout(push_constant) uniform P {
+    int fmt;        // 1=int8, 2=int4
+    int S, I, O;    // I = input dim (hidden), O = moe_inter
+    int rowWords;   // uint32 words per weight row (of the I-dim rows)
+} p;
+
+shared float xsh[6144];
+
+float i8(uint w, int l) { int b = int((w >> (uint(l) * 8u)) & 0xffu); if (b >= 128) b -= 256; return float(b); }
+float i4(uint w, int l) { return float(int((w >> (uint(l) * 4u)) & 0xfu) - 8); }
+
+void main() {
+    int s   = int(gl_WorkGroupID.y);
+    int tid = int(gl_LocalInvocationID.x);
+    int nth = int(gl_WorkGroupSize.x);
+
+    for (int i = tid; i < p.I; i += nth) xsh[i] = x[s * p.I + i];
+    barrier();
+
+    int lane   = int(gl_SubgroupInvocationID);
+    int sgsize = int(gl_SubgroupSize);
+    int sg     = int(gl_SubgroupID);
+    int nsg    = nth / sgsize;
+    int stride = int(gl_NumWorkGroups.x) * nsg;
+
+    for (int o = int(gl_WorkGroupID.x) * nsg + sg; o < p.O; o += stride) {
+        uint rb = uint(o) * uint(p.rowWords);
+        float g = 0.0, u = 0.0;
+        if (p.fmt == 1) {
+            int words = (p.I + 3) / 4;
+            for (int wi = lane; wi < words; wi += sgsize) {
+                uint gp = wg[rb + uint(wi)], upk = wu[rb + uint(wi)]; int i0 = wi * 4;
+                for (int k = 0; k < 4; k++) { int i = i0 + k; if (i < p.I) { float xv = xsh[i]; g += xv * i8(gp, k); u += xv * i8(upk, k); } }
+            }
+        } else { // int4
+            int words = (p.I + 7) / 8;
+            for (int wi = lane; wi < words; wi += sgsize) {
+                uint gp = wg[rb + uint(wi)], upk = wu[rb + uint(wi)]; int i0 = wi * 8;
+                for (int k = 0; k < 8; k++) { int i = i0 + k; if (i < p.I) { float xv = xsh[i]; g += xv * i4(gp, k); u += xv * i4(upk, k); } }
+            }
+        }
+        float gt = subgroupAdd(g) * gscale[o];
+        float ut = subgroupAdd(u) * uscale[o];
+        if (lane == 0) hid[s * p.O + o] = (gt / (1.0 + exp(-gt))) * ut;   // silu(gate)*up
+    }
+}

--- a/c/shaders/rmsnorm.comp
+++ b/c/shaders/rmsnorm.comp
@@ -1,0 +1,37 @@
+#version 450
+// RMS norm over S rows of length D: y[s,i] = x[s,i] * w[i] / sqrt(mean(x[s,:]^2) + eps).
+// Mirrors colibri.c rmsnorm() (fp32 accumulate here vs f64 on CPU: for the q-latent
+// D=1536 the difference is ~1e-7 relative — far under the quantized-weight noise).
+// One 256-thread workgroup per row; used to CHAIN q_a -> norm -> q_b inside one
+// submit (coli_vk_attn_qprep) so the middle CPU roundtrip and its fence disappear.
+
+layout(local_size_x = 256) in;
+
+layout(std430, binding = 0) readonly  buffer X { float x[]; };
+layout(std430, binding = 1) readonly  buffer W { float w[]; };
+layout(std430, binding = 2) writeonly buffer Y { float y[]; };
+
+layout(push_constant) uniform P {
+    int S, D;
+    float eps;
+} p;
+
+shared float red[256];
+
+void main() {
+    int s = int(gl_WorkGroupID.x);
+    if (s >= p.S) return;
+    int tid = int(gl_LocalInvocationID.x);
+    uint base = uint(s) * uint(p.D);
+
+    float acc = 0.0;
+    for (int i = tid; i < p.D; i += 256) { float v = x[base + uint(i)]; acc += v * v; }
+    red[tid] = acc;
+    barrier();
+    for (int off = 128; off > 0; off >>= 1) {
+        if (tid < off) red[tid] += red[tid + off];
+        barrier();
+    }
+    float r = 1.0 / sqrt(red[0] / float(p.D) + p.eps);
+    for (int i = tid; i < p.D; i += 256) y[base + uint(i)] = x[base + uint(i)] * r * w[i];
+}

--- a/c/st.h
+++ b/c/st.h
@@ -40,9 +40,11 @@ typedef struct {
     int        dfds[512];  /* gemelli O_DIRECT (aperti pigramente): -2 = non ancora provato */
     char      *paths[512];
     int        nfd;
-    int        mfds[512];  /* MIRROR: fds of the second model copy (dual-SSD), -1 = absent */
-    int        mdfds[512]; /* O_DIRECT twins of the second copy, -1 = absent */
-    int        nmirror;    /* files accepted into the mirror (0 = mirror inactive) */
+#define ST_MAX_MIR 4       /* extra read replicas beyond the primary (multi-SSD) */
+    int        mfds[ST_MAX_MIR][512];  /* MIRROR: fds of replica copy r+1 (multi-SSD), -1 = absent */
+    int        mdfds[ST_MAX_MIR][512]; /* O_DIRECT twins of the replica copies, -1 = absent */
+    int        nmirror[ST_MAX_MIR];    /* files accepted into replica r+1 */
+    int        nrep;       /* registered replica copies (0 = mirror inactive) */
     int       *hidx;      /* hash map nome->indice (open addressing): con ~120k tensori
                            * (GLM: 256 expert x 78 layer x 3 x 2) la scansione lineare
                            * costava decine di secondi/token (misurato sul primo run reale) */
@@ -110,34 +112,41 @@ static int st_direct_fd(shards *S, int fd) {
     int i = st_fidx(S, fd); return i < 0 ? -1 : S->dfds[i];
 }
 
-/* ---- MIRROR (dual-SSD): second read-only copy of the model on another drive ----
- * st_fd_rep/st_direct_fd_rep: fd of replica `rep` (0 = primary, 1 = mirror) for
- * the SAME file identified by its primary fd. -1 if that replica is absent. */
+/* ---- MIRROR (multi-SSD): read-only copies of the model on other drives ----
+ * st_fd_rep/st_direct_fd_rep: fd of replica `rep` (0 = primary, 1..nrep =
+ * mirrors) for the SAME file identified by its primary fd. -1 if absent. */
 static int st_fd_rep(shards *S, int fd, int rep) {
     if (!rep) return fd;
-    if (!S->nmirror) return -1;
-    int i = st_fidx(S, fd); return i < 0 ? -1 : S->mfds[i];
+    if (rep > S->nrep) return -1;
+    int i = st_fidx(S, fd); return i < 0 ? -1 : S->mfds[rep-1][i];
 }
 static int st_direct_fd_rep(shards *S, int fd, int rep) {
     if (!rep) return st_direct_fd(S, fd);
-    if (!S->nmirror) return -1;
-    int i = st_fidx(S, fd); return i < 0 ? -1 : S->mdfds[i];
+    if (rep > S->nrep) return -1;
+    int i = st_fidx(S, fd); return i < 0 ? -1 : S->mdfds[rep-1][i];
 }
 
-/* Registers <dir>/<basename> as a read replica of every already-indexed shard.
- * A file is accepted ONLY if its size and safetensors header are byte-identical
- * to the primary: the data_offsets then match by construction, so every pread
- * is valid on either copy. Missing or divergent files simply stay on the
- * primary (the mirror may be partial, e.g. a smaller SSD holding only the
- * expert shards). Returns the number of accepted files. The mirror is NEVER
- * written to: .coli_usage/.coli_kv keep deriving from the primary alone. */
-static int st_mirror_init(shards *S, const char *dir) {
-    if (S->nmirror) for (int i = 0; i < S->nfd; i++) {   /* re-init: drop the old replica */
-        if (S->mfds[i] >= 0) close(S->mfds[i]);
-        if (S->mdfds[i] >= 0) close(S->mdfds[i]);
+/* Registers <dir>/<basename> as read replica S->nrep+1 of every already-indexed
+ * shard. A file is accepted ONLY if its size and safetensors header are
+ * byte-identical to the primary: the data_offsets then match by construction,
+ * so every pread is valid on any copy. Missing or divergent files simply stay
+ * on the primary (a mirror may be partial, e.g. a smaller SSD holding only the
+ * expert shards). Returns the number of accepted files; a dir contributing 0
+ * files claims no replica slot. Mirrors are NEVER written to: .coli_usage /
+ * .coli_kv keep deriving from the primary alone. */
+static void st_mirror_reset(shards *S) {           /* re-init: drop every replica */
+    for (int r = 0; r < S->nrep; r++) for (int i = 0; i < S->nfd; i++) {
+        if (S->mfds[r][i] >= 0) close(S->mfds[r][i]);
+        if (S->mdfds[r][i] >= 0) close(S->mdfds[r][i]);
     }
-    for (int i = 0; i < ST_MAX_SHARDS; i++) { S->mfds[i] = -1; S->mdfds[i] = -1; }
-    S->nmirror = 0;
+    memset(S->nmirror, 0, sizeof(S->nmirror));
+    S->nrep = 0;
+}
+static int st_mirror_add(shards *S, const char *dir) {
+    if (S->nrep >= ST_MAX_MIR) return 0;
+    int r = S->nrep;
+    for (int i = 0; i < ST_MAX_SHARDS; i++) { S->mfds[r][i] = -1; S->mdfds[r][i] = -1; }
+    S->nmirror[r] = 0;
     for (int i = 0; i < S->nfd; i++) {
         const char *base = strrchr(S->paths[i], '/');
 #ifdef _WIN32
@@ -166,15 +175,21 @@ static int st_mirror_init(shards *S, const char *dir) {
             fprintf(stderr, "[MIRROR] %s: header differs from the primary copy — file skipped\n", mp);
             close(mfd); continue;
         }
-        S->mfds[i] = mfd;
+        S->mfds[r][i] = mfd;
 #ifdef O_DIRECT
-        S->mdfds[i] = open(mp, COMPAT_O_RDONLY | O_DIRECT);
+        S->mdfds[r][i] = open(mp, COMPAT_O_RDONLY | O_DIRECT);
 #elif defined(__APPLE__) || defined(_WIN32)
-        S->mdfds[i] = compat_open_direct(mp);
+        S->mdfds[r][i] = compat_open_direct(mp);
 #endif
-        S->nmirror++;
+        S->nmirror[r]++;
     }
-    return S->nmirror;
+    if (S->nmirror[r] > 0) { S->nrep++; return S->nmirror[r]; }
+    return 0;
+}
+/* backward-compatible single-mirror entry point */
+static int st_mirror_init(shards *S, const char *dir) {
+    st_mirror_reset(S);
+    return st_mirror_add(S, dir);
 }
 
 /* indicizza tutti i model-*.safetensors in snap_dir */

--- a/c/tests/test_pilot_ring.c
+++ b/c/tests/test_pilot_ring.c
@@ -1,0 +1,74 @@
+/* Concurrency test for the SPMC pilot ring claim (pilot_ring_claim): with N worker
+ * threads draining a single-producer ring, every enqueued item must be claimed by
+ * EXACTLY ONE worker -- none lost, none double-claimed, none torn by ring wrap.
+ *
+ * This gates the new lock-free primitive without needing a model (the slot
+ * reservation logic in pilot_realload is exercised end-to-end by the token-exact
+ * oracle; here we prove the ring claim itself). Includes colibri.c for the real
+ * pilot_ring_claim / pilot_q / pilot_w / pilot_r (same pattern as the other tests).
+ */
+#define main coli_glm_main_unused
+#include "../colibri.c"
+#undef main
+#include <pthread.h>
+#include <stdint.h>
+
+#define NITEMS   300000
+#define NTHREADS 8
+static _Atomic int seen[NITEMS];
+static _Atomic long total_claimed = 0;
+static _Atomic int  torn = 0;
+static _Atomic int  producer_done = 0;
+
+static void *consumer(void *arg){
+    (void)arg;
+    for(;;){
+        int v, e;
+        if(pilot_ring_claim(&v, &e)){
+            if(v < 0 || v >= NITEMS || e != v){          /* out-of-range or mismatched => torn read leaked through */
+                atomic_store_explicit(&torn, 1, memory_order_relaxed);
+                continue;
+            }
+            atomic_fetch_add_explicit(&seen[v], 1, memory_order_relaxed);
+            atomic_fetch_add_explicit(&total_claimed, 1, memory_order_relaxed);
+        } else if(atomic_load_explicit(&producer_done, memory_order_acquire)){
+            unsigned r = __atomic_load_n(&pilot_r, __ATOMIC_ACQUIRE);
+            unsigned w = __atomic_load_n(&pilot_w, __ATOMIC_ACQUIRE);
+            if(r == w) return NULL;                       /* producer finished AND ring drained */
+        }
+    }
+}
+
+int main(void){
+    for(int i=0;i<NITEMS;i++) atomic_store_explicit(&seen[i],0,memory_order_relaxed);
+    pthread_t th[NTHREADS];
+    for(int i=0;i<NTHREADS;i++) pthread_create(&th[i],NULL,consumer,NULL);
+
+    for(int i=0;i<NITEMS;i++){                            /* single producer: only pilot_w */
+        for(;;){
+            unsigned w = __atomic_load_n(&pilot_w,__ATOMIC_ACQUIRE);
+            unsigned r = __atomic_load_n(&pilot_r,__ATOMIC_ACQUIRE);
+            if(w - r < 4096){                            /* ring has space */
+                atomic_store_explicit(&pilot_q[w & 4095].l, i, memory_order_relaxed);
+                atomic_store_explicit(&pilot_q[w & 4095].e, i, memory_order_relaxed);
+                __atomic_store_n(&pilot_w, w+1, __ATOMIC_RELEASE);
+                break;
+            }
+            /* full: let consumers drain (they advance pilot_r via CAS) */
+        }
+    }
+    atomic_store_explicit(&producer_done, 1, memory_order_release);
+    for(int i=0;i<NTHREADS;i++) pthread_join(th[i],NULL);
+
+    int fail=0;
+    if(atomic_load_explicit(&torn,memory_order_relaxed)){
+        fprintf(stderr,"FAIL: torn/overwritten ring slot observed\n"); fail=1; }
+    long tc=atomic_load_explicit(&total_claimed,memory_order_relaxed);
+    if(tc!=NITEMS){ fprintf(stderr,"FAIL: total claimed %ld != %d\n",tc,NITEMS); fail=1; }
+    for(int i=0;i<NITEMS && !fail;i++){
+        int s=atomic_load_explicit(&seen[i],memory_order_relaxed);
+        if(s!=1){ fprintf(stderr,"FAIL: item %d claimed %d times (want exactly 1)\n",i,s); fail=1; }
+    }
+    if(!fail) printf("test_pilot_ring: ok — %d items across %d workers, each claimed exactly once\n",NITEMS,NTHREADS);
+    return fail;
+}

--- a/c/tests/test_st_mirror.c
+++ b/c/tests/test_st_mirror.c
@@ -1,6 +1,6 @@
-/* Dual-SSD mirror (st_mirror_init & friends): a second read-only model copy is
+/* Multi-SSD mirror (st_mirror_add & friends): read-only model copies are
  * accepted only when byte-identical in size and safetensors header, reads on
- * either replica return the same bytes, and divergent/missing copies degrade
+ * any replica return the same bytes, and divergent/missing copies degrade
  * to the primary instead of being trusted. Fixture dirs are created in the
  * current working directory and removed on exit. */
 #include <stdint.h>
@@ -32,6 +32,7 @@
 #define DIR_C "tmp_mirror_c"   /* same size, divergent header */
 #define DIR_D "tmp_mirror_d"   /* different size */
 #define DIR_E "tmp_mirror_e"   /* empty (missing file) */
+#define DIR_F "tmp_mirror_f"   /* second identical copy (multi-SSD) */
 
 /* one-tensor safetensors file; flip lets us corrupt one header byte and
  * pad lets us grow the payload, both without changing anything else */
@@ -54,8 +55,8 @@ static int write_model(const char *dir, int flip, int pad) {
 }
 
 static void cleanup(void) {
-    const char *dirs[] = {DIR_A, DIR_B, DIR_C, DIR_D, DIR_E};
-    for (int i = 0; i < 5; i++) {
+    const char *dirs[] = {DIR_A, DIR_B, DIR_C, DIR_D, DIR_E, DIR_F};
+    for (int i = 0; i < 6; i++) {
         char path[256];
         snprintf(path, sizeof(path), "%s/model.safetensors", dirs[i]);
         remove(path);
@@ -66,11 +67,12 @@ static void cleanup(void) {
 int main(void) {
     cleanup();
     CHECK(MKDIR(DIR_A) == 0 && MKDIR(DIR_B) == 0 && MKDIR(DIR_C) == 0 &&
-          MKDIR(DIR_D) == 0 && MKDIR(DIR_E) == 0);
+          MKDIR(DIR_D) == 0 && MKDIR(DIR_E) == 0 && MKDIR(DIR_F) == 0);
     CHECK(write_model(DIR_A, 0, 0) == 0);
     CHECK(write_model(DIR_B, 0, 0) == 0);
     CHECK(write_model(DIR_C, 1, 0) == 0);
     CHECK(write_model(DIR_D, 0, 64) == 0);
+    CHECK(write_model(DIR_F, 0, 0) == 0);
 
     shards S;
     st_init(&S, DIR_A);
@@ -108,6 +110,29 @@ int main(void) {
 
     /* unknown fd never maps to a replica */
     CHECK(st_fd_rep(&S, 987654, 1) == -1);
+
+    /* ---- multi-SSD: two identical copies become replicas 1 and 2 ---- */
+    st_mirror_reset(&S);
+    CHECK(st_mirror_add(&S, DIR_B) == 1);
+    CHECK(st_mirror_add(&S, DIR_F) == 1);
+    CHECK(S.nrep == 2);
+    int f1 = st_fd_rep(&S, t->fd, 1), f2 = st_fd_rep(&S, t->fd, 2);
+    CHECK(f1 >= 0 && f2 >= 0 && f1 != f2 && f1 != t->fd && f2 != t->fd);
+    float c2[8];
+    CHECK(pread(f2, c2, t->nbytes, t->off) == t->nbytes);
+    CHECK(memcmp(a, c2, sizeof(a)) == 0);
+    st_prefetch_rep(&S, "t0", 2);   /* smoke: WILLNEED on the second mirror */
+
+    /* a divergent dir claims no replica slot; existing replicas survive */
+    CHECK(st_mirror_add(&S, DIR_C) == 0);
+    CHECK(S.nrep == 2);
+    CHECK(st_fd_rep(&S, t->fd, 1) == f1 && st_fd_rep(&S, t->fd, 2) == f2);
+    CHECK(st_fd_rep(&S, t->fd, 3) == -1);
+
+    /* reset drops every replica */
+    st_mirror_reset(&S);
+    CHECK(S.nrep == 0);
+    CHECK(st_fd_rep(&S, t->fd, 1) == -1);
 
     cleanup();
     puts("safetensors mirror tests: ok");

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -93,7 +93,7 @@ Per-drive byte counts are reported in a `MIRROR:` stats line. Combine with `DIRE
 | Variable | Default | Effect |
 |---|---|---|
 | `COLI_VULKAN` | off | Enable the Vulkan backend. Requires a `make VK=1` build; fails at startup (no silent fallback) if libvulkan or the compiled shaders are missing. |
-| `COLI_VK_SHADERS` | `shaders/qmatmul.spv` | Path to the compiled main shader; the gate_up and attention shaders are found next to it. |
+| `COLI_VK_SHADERS` | auto | Path to the compiled `qmatmul.spv` **or** the directory holding the `.spv` set; the other shaders are found next to it. Unset: `shaders/` next to the binary, then CWD-relative `shaders/qmatmul.spv`. |
 | `COLI_VK_EXPERTS` | `320` | Pinned VRAM expert tier size: top-N experts by `.coli_usage` heat uploaded once at startup and served from VRAM with no RAM slot or disk read. `0` disables the tier (experts stay on the CPU path). ~19 MB VRAM per int4 expert. |
 | `COLI_VK_DENSE` | `0` | Run the resident dense matmuls (attention projections, shared expert) on the GPU. |
 | `COLI_VK_ATTN` | `0` | Run the S≤4 MLA absorb attention core (+ fused o-projection) on the GPU, with a persistent device-side KV mirror. |

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -83,8 +83,8 @@ Format: `VAR` — default — effect.
 | Variable | Default | Effect |
 |---|---|---|
 | `COLI_MODEL_DIRS` | unset | SPLIT the model across 2+ drives: a `;`/`,`-separated list of extra directories, each holding a **distinct** subset of the `.safetensors` shards (no duplication). Shards act as a search path — every shard is read from whichever drive holds it, so concurrent expert loads parallelise across drives and combined capacity is used. Scales to N drives. Metadata (config/tokenizer/`.coli_usage`) stays in the primary `COLI_MODEL` dir. Pairs well with `PIPE=1` (concurrent loaders) + `DIRECT=1`. Distinct from — and composable with — `COLI_MODEL_MIRROR`: the mirror is matched per-shard by basename against the merged (split) index, so a mirror dir may hold a copy of any subset of the split's shards. |
-| `COLI_MODEL_MIRROR` | unset | Path to a second, byte-identical (read-only) copy of the model on another drive; expert reads are split across both. Partial mirrors work (only the shards present are used). |
-| `COLI_DISK_WEIGHTS` | unset (startup bandwidth probe) | Split ratio `<primary>,<mirror>` (e.g. `1,1` for 50/50, `9,3` for a fast+slow pair). Unset = probe both drives with the engine's own access pattern at startup. |
+| `COLI_MODEL_MIRROR` | unset | `;`/`,`-separated list of directories, each a byte-identical (read-only) copy of the model on another drive; expert reads split across the primary and every mirror. Partial mirrors work (only the shards present are used). |
+| `COLI_DISK_WEIGHTS` | unset (startup bandwidth probe) | Split ratio `<primary>,<mirror>[,<mirror2>...]` — one positive weight per drive (e.g. `1,1` for 50/50, `9,3` for a fast+slow pair, `1,1,1` for a 3-way mirror). Unset = probe every drive with the engine's own access pattern at startup. |
 
 Per-drive byte counts are reported in a `MIRROR:` stats line. Combine with `DIRECT=1` so the two copies never compete for page cache.
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -88,6 +88,18 @@ Format: `VAR` — default — effect.
 
 Per-drive byte counts are reported in a `MIRROR:` stats line. Combine with `DIRECT=1` so the two copies never compete for page cache.
 
+## Vulkan (any GPU with a Vulkan 1.2 driver)
+
+| Variable | Default | Effect |
+|---|---|---|
+| `COLI_VULKAN` | off | Enable the Vulkan backend. Requires a `make VK=1` build; fails at startup (no silent fallback) if libvulkan or the compiled shaders are missing. |
+| `COLI_VK_SHADERS` | `shaders/qmatmul.spv` | Path to the compiled main shader; the gate_up and attention shaders are found next to it. |
+| `COLI_VK_EXPERTS` | `320` | Pinned VRAM expert tier size: top-N experts by `.coli_usage` heat uploaded once at startup and served from VRAM with no RAM slot or disk read. `0` disables the tier (experts stay on the CPU path). ~19 MB VRAM per int4 expert. |
+| `COLI_VK_DENSE` | `0` | Run the resident dense matmuls (attention projections, shared expert) on the GPU. |
+| `COLI_VK_ATTN` | `0` | Run the S≤4 MLA absorb attention core (+ fused o-projection) on the GPU, with a persistent device-side KV mirror. |
+
+See [docs/vulkan.md](vulkan.md). On multi-core boxes also set `COLI_NO_OMP_TUNE=1` (see that doc for why).
+
 ## CUDA (NVIDIA)
 
 | Variable | Default | Effect |

--- a/docs/vulkan.md
+++ b/docs/vulkan.md
@@ -26,6 +26,20 @@ Set `COLI_NO_OMP_TUNE=1` on multi-core boxes: the engine's OMP self-tune
 Vulkan, and spinning worker threads starve the async I/O pool (measured
 CPU expert bandwidth 28 → 5 GB/s without it).
 
+**Discrete cards need Resizable BAR.** The weight tiers allocate
+HOST_VISIBLE|DEVICE_LOCAL memory; with ReBAR disabled that combination only
+exists in a ~256 MB BAR window, and the driver silently places everything
+beyond it in system RAM — the tier then *reports* resident experts while every
+access crosses PCIe, slower than the CPU path (measured 0.11 vs 0.24 tok/s
+either side of the BIOS toggle on an RX 9070 XT). The engine now warns at init
+when the host-visible slice of VRAM is small; if you see that warning, enable
+Resizable BAR / Smart Access Memory in the BIOS. Unified-memory APUs are
+unaffected.
+
+The compiled shaders are found via `COLI_VK_SHADERS` (either the
+`qmatmul.spv` file or the directory holding the `.spv` set); unset, the
+engine looks in `shaders/` next to the binary, then relative to the CWD.
+
 ## What runs on the GPU
 
 | Piece | Env | Mechanism |
@@ -64,6 +78,27 @@ NVMe-streamed) decode on a 12-core Zen2 + RX 9070 box: Vulkan
 The two write-combined-memory rules that make this possible: buffers the CPU
 reads back must be HOST_CACHED (ReBAR VRAM reads at ~40 MB/s otherwise), and
 everything else lives HOST_VISIBLE|DEVICE_LOCAL.
+
+## Benchmarking against other backends
+
+Two defaults will silently skew any Vulkan-vs-CUDA/HIP comparison:
+
+- **MTP speculation**: CUDA/HIP builds disable model drafts by default
+  (`DRAFT` auto-resolves to 0 under `COLI_CUDA=1`, see #163), while CPU and
+  Vulkan runs keep `DRAFT=3`. The arms then execute different decode loops —
+  the speculative arm routes ~2× the expert positions per emitted token
+  (rejected draft positions still pay their expert I/O), which dominates on
+  storage-bound boxes. Output is identical either way (greedy verify is
+  lossless), so nothing looks wrong. Pin `DRAFT=0` (or `DRAFT=3
+  COLI_CUDA_MTP=1`) explicitly on **both** arms.
+- **GPU clocks**: decode dispatches are microsecond bursts that never ramp
+  DPM on their own; the memory clock can sit parked through an entire run.
+  Pin `power_dpm_force_performance_level=high` (both arms) or disclose it.
+
+Also note `experts loaded/token` in the run stats counts *routed positions*
+(including rejected speculative ones) before any cache/tier is consulted —
+it does not fall when the VK tier serves a hit; the `vk` bucket in the
+hit-rate line is the tier-effectiveness number.
 
 ## Limits and future work
 

--- a/docs/vulkan.md
+++ b/docs/vulkan.md
@@ -1,0 +1,76 @@
+# Vulkan backend (any GPU with a Vulkan 1.2 driver)
+
+colibrì includes an opt-in Vulkan compute backend that runs the whole GLM
+decode compute path on any GPU a Vulkan driver can see — no CUDA, no ROCm.
+That includes cards the vendor stacks have dropped (ROCm 7 removed Polaris:
+an RX 580 runs here via RADV) and, measured on an RX 9070 (RDNA4), it is
+*faster* than the ROCm/HIP backend on the same card.
+
+```bash
+cd c
+make glm VK=1                # needs libvulkan + glslc (shaderc) for the shaders
+COLI_VULKAN=1 COLI_VK_DENSE=1 COLI_VK_ATTN=1 \
+PIN=<model>/.coli_usage PIN_GB=0 COLI_NO_OMP_TUNE=1 \
+./coli run "Hello" --topp 0.7
+```
+
+Requirements: `libvulkan` and a Vulkan **1.2** ICD with
+`GL_KHR_shader_subgroup_arithmetic` (any Mesa RADV, AMDVLK, NVIDIA or Intel
+ANV driver from the last several years), plus `glslc` at build time. The
+backend picks the most capable physical device (discrete > integrated) and
+degrades to the CPU path on any failure — a wedged GPU can slow a run, never
+corrupt it.
+
+Set `COLI_NO_OMP_TUNE=1` on multi-core boxes: the engine's OMP self-tune
+(active spin-wait) is skipped under `COLI_CUDA`/`COLI_METAL` but not under
+Vulkan, and spinning worker threads starve the async I/O pool (measured
+CPU expert bandwidth 28 → 5 GB/s without it).
+
+## What runs on the GPU
+
+| Piece | Env | Mechanism |
+|---|---|---|
+| Routed experts (hot set) | `COLI_VK_EXPERTS=N` (default 320) | Top-N experts by `.coli_usage` heat uploaded **once at startup** into a VRAM registry; at decode they are served from VRAM with **no RAM slot, no disk read, no prefetch**, as one async fused batch (gate+up+silu→down, hidden on-device) overlapped with the CPU computing the remaining experts. Shown as the `vk` bucket in the hit-rate line. |
+| Dense projections | `COLI_VK_DENSE=1` | q_a+kv_a fused into one submit, q_b, o; shared expert as a single fused expert-group submit. Resident int4/int8 weights upload once. |
+| MLA attention core | `COLI_VK_ATTN=1` | One dispatch per layer: absorbed query, scores over the KV window, softmax, weighted latent, value rows, **fused with the o-projection** (the context vector never leaves the GPU). The latent/rope KV lives in a persistent per-layer device mirror, appended ~2.3 KB/token/layer with the same invalidation points as the CUDA KV shadow. |
+
+The `PIN_GB=0` (with `PIN` still set) in the example is deliberate: the VRAM
+registry holds the same hot experts a RAM pin would, so the pin's RAM is
+better spent on the adaptive LRU cache. Keep `PIN` set so AUTOPIN does not
+re-pin from history.
+
+## Correctness
+
+- `gcc -O3 -DVK_TEST backend_vulkan.c -o test_vk -lvulkan -lm && ./test_vk
+  shaders/qmatmul.spv` runs a CPU-reference exactness harness over every
+  primitive (GEMV int4/int8 across shapes incl. the long-row o-projection,
+  fused gate+up, the full expert group sync and async, the matmul pair, and
+  the absorb attention core incl. causal S=2, kv_start windows, int8, and
+  long-context cases). Typical maxrel ~1e-5..2e-3 (fp32 reduction order).
+- Engine-level: greedy decode with the full stack matches the pure-CPU
+  engine token-for-token on the validation prompt.
+- int4 weights decode as offset-binary (nibble−8), byte-identical layout to
+  the CPU path — no repacking.
+
+## Measured performance (AMD RX 9070, RDNA4, RADV/Mesa 26.1)
+
+Expert-MLP primitive (K experts, int4 6144→2048→6144, per-call incl. readback):
+Vulkan **0.11–0.13 ms/expert** vs the production ROCm/HIP expert group
+**0.179 ms/expert** — ~35% faster. The decode MLA attention core runs 3.7×
+faster than the HIP kernel on the same card. End-to-end GLM-5.2 (744B int4,
+NVMe-streamed) decode on a 12-core Zen2 + RX 9070 box: Vulkan
+**1.7–1.8 tok/s** (64-token) / **1.6** (256-token) / **1.58 sustained**
+(512-token) vs the HIP backend at 1.5–1.55 on identical settings.
+The two write-combined-memory rules that make this possible: buffers the CPU
+reads back must be HOST_CACHED (ReBAR VRAM reads at ~40 MB/s otherwise), and
+everything else lives HOST_VISIBLE|DEVICE_LOCAL.
+
+## Limits and future work
+
+- Decode-focused: the expert tier and attention core serve `S<=4`; prefill
+  uses the CPU/batched paths (dense projections do run on VK at prefill).
+- DSA top-k selection, ragged multi-slot serving, and quantized-KV caches
+  fall back to the CPU attention path.
+- Not yet done: cooperative-matrix (coopmat) prefill kernels, a fully
+  resident-layer pipeline, Polaris/gfx803 validation on real hardware (the
+  shaders use dynamic subgroup sizes and are wave64-safe by construction).


### PR DESCRIPTION

## Summary

An opt-in Vulkan compute backend (`make glm VK=1`, runtime `COLI_VULKAN=1`) that runs the GLM decode compute path on any GPU with a Vulkan 1.2 driver — no CUDA, no ROCm. Three tiers, each independently switchable and each falling back to the CPU path on any failure:

- **Pinned VRAM expert tier** (`COLI_VK_EXPERTS`, default 320): the top-N routed experts by `.coli_usage` heat are uploaded once at startup and served from VRAM with **no RAM slot, no disk read, no prefetch** — issued as one fused async batch per layer (gate+up+silu→down, hidden on-device) that overlaps with the CPU computing the remaining experts. Appears as a new `vk` bucket in the hit-rate line.
- **Dense projections** (`COLI_VK_DENSE=1`): q_a+kv_a fused into one submit, q_b, the o-projection, and the shared expert as a single fused expert-group submit.
- **MLA absorb attention core** (`COLI_VK_ATTN=1`): one dispatch per layer covering absorbed query → scores → softmax → weighted latent → value rows, **fused with the o-projection** so the context vector never leaves the GPU. The latent/rope KV lives in a persistent per-layer device mirror appended at ~2.3 KB/token/layer, with the same invalidation points as the CUDA KV shadow (row rewrite, rebind, resize).

This is a continuation of @kryptt's #84 (the original backend skeleton, tensor-resident `coli_vk_matmul`, and the int4 nibble-8 shader decode are his design — thank you!). It addresses the two things asked for there: it is rebased onto current `dev`, and it ships a **CPU-reference exactness harness** covering every primitive.

## Why

1. **Hardware reach.** Vulkan is the only compute stack that runs everywhere: cards ROCm dropped (RX 580/Polaris via RADV), iGPUs, and boxes where installing a vendor stack isn't an option. The backend needs only `libvulkan` + a Vulkan 1.2 ICD with subgroup arithmetic, and `glslc` at build time.
2. **It's fast.** On an RX 9070 (RDNA4) via Mesa/RADV, the Vulkan expert primitive beats the production ROCm/HIP expert group by ~35%, the attention core beats the HIP kernel by 3.7×, and end-to-end decode is at or above the HIP backend on the same card (numbers below). The llama.cpp folklore that RADV can outrun vendor stacks on AMD holds here once the shaders are properly fused.

## Correctness

- **Standalone harness** (`gcc -O3 -DVK_TEST backend_vulkan.c -o test_vk -lvulkan -lm && ./test_vk shaders/qmatmul.spv`): CPU-reference exactness for every primitive — int4/int8 GEMV across shapes including the long-row o-projection (I=16384), fused gate+up, the full expert group (sync and async issue/take, verified bit-identical to each other), the q_a+kv_a pair, and the absorb attention core including causal S=2, `kv_start` windows, int8, and long-context (T=2000) cases. Typical maxrel 1e-5…2e-3 (fp32 reduction order on 6144-long dots).
- **Engine-level**: greedy decode with the full stack enabled matches the pure-CPU engine token-for-token on the validation prompt.
- int4 decodes as offset-binary (nibble−8) with the CPU byte layout — weights upload with a plain memcpy, no repacking.
- Default build: all engine hooks are behind `#ifdef COLI_VULKAN`; `make glm` without `VK=1` compiles the same code as before (plus three always-false locals). `make test-c` fully green on the branch.

## Measured performance

**Hardware/software**: AMD RX 9070 16 GB (RDNA4/gfx1201, PCIe 4.0 x16 effective), Ryzen 9 3900X (12C/24T Zen2, `OMP_NUM_THREADS=12`, threads pinned), 64 GB DDR4-3200 dual-rank, GLM-5.2 744B int4 streamed from NVMe (~19 MB/expert). Mesa/RADV 26.1.4, Vulkan 1.4 ICD; ROCm 7.2.4 + HIP for the comparison backend. Model: 78 layers, 256 experts/layer, kv_lora 512, MLA/DSA.

**Primitive microbenchmarks** (per-call including readback, K-expert int4 MLP 6144→2048→6144):

| Primitive | Vulkan (RADV) | ROCm/HIP production |
|---|---|---|
| Expert group, K=8 | **0.117 ms/expert** | 0.179 ms/expert |
| Expert group, K=32 | **0.107 ms/expert** | 0.179 ms/expert |
| Decode attention core (t_acore, 16 tok × 78 layers) | **0.61 s** | 2.2 s (HIP kernel: 5.7 s CPU: n/a) |

**End-to-end GLM-5.2 decode** (same box, same engine settings, expert-routing top-p 0.7, drafts off, interleaved/batched A/B runs; our fork additionally carries an unrelated dual-SSD-mirror patch on the same base — active for **both** backends in every comparison, so the deltas are backend-attributable):

| Generation length | Vulkan | ROCm/HIP |
|---|---|---|
| 64 tokens | **1.74–1.78 tok/s** | 1.53–1.56 tok/s |
| 256 tokens | **1.53–1.67 tok/s** | 1.51–1.53 tok/s |
| 512 tokens (sustained, 5.4 min) | **1.58 tok/s** | — |
| Prefill (11–23 tokens) | **7.2–8.5 s** | 8.1–12.4 s |

Run-to-run variance on this box is ±0.1 tok/s; the 64-token advantage (~+13%) narrows to ~+5% at long form as the attention window and expert-I/O share grow for both backends.

**The two memory-type rules that made it work** (documented in `docs/vulkan.md`, learned the hard way):
1. Buffers the CPU reads back must be `HOST_CACHED` — reading write-combined ReBAR VRAM from the CPU runs at ~40 MB/s and was a hidden 5.6× per-call penalty.
2. Everything else (weights, inputs, the KV mirror) lives `HOST_VISIBLE|DEVICE_LOCAL`, so uploads are plain memcpys and the GPU reads at VRAM speed.

## Integration surface

- New: `c/backend_vulkan.c` (~1.3k lines, plain C99 + libvulkan), `c/backend_vulkan.h`, `c/shaders/qmatmul.comp`, `c/shaders/qmatmul_gate_up.comp`, `c/shaders/attention_absorb.comp`, `docs/vulkan.md`.
- Modified: `c/glm.c` (hooks under `#ifdef COLI_VULKAN`), `c/Makefile` (`VK=1` block + `glslc` rule), `docs/ENVIRONMENT.md`, `README.md`.
- Env: `COLI_VULKAN`, `COLI_VK_SHADERS`, `COLI_VK_EXPERTS`, `COLI_VK_DENSE`, `COLI_VK_ATTN`.
- 18 bisectable commits, each building; the history walks port → shader fusion → integration → attention core → tier.

One operational note worth flagging beyond this PR: the engine's OMP self-tune (`OMP_WAIT_POLICY=active` + spin) is skipped under `COLI_CUDA`/`COLI_METAL` but not under other configurations. With 12 pinned spinning threads the async I/O pool starves (measured 28 → 5 GB/s CPU expert bandwidth, ~2.8× end-to-end). `docs/vulkan.md` tells Vulkan users to set `COLI_NO_OMP_TUNE=1`; extending the self-tune skip to any GPU backend (or to `PIPE=1` runs) may be worth a separate look.

## Limits / future work

- Decode-focused: the expert tier and attention core serve `S≤4`; prefill keeps the CPU/batched paths (dense projections do run on VK at prefill, which is why prefill got faster).
- DSA top-k selection, ragged multi-slot serving, and quantized-KV caches fall back to the CPU attention path (same guards as the CUDA absorb).
- Validated on RDNA4/RADV. The shaders use dynamic subgroup sizes (wave32/64-safe) and Vulkan 1.2 only, so Polaris/gfx803 and other vendors should work — testers welcome, especially RX 580 owners.
- Ready as follow-ups, deliberately not in this PR: an fp8 KV mirror for #399's `KV8=1` (already implemented and validated against `kv_fp8.h` on our side — the absorb shader decodes e4m3 in place, 4× less mirror traffic; this PR just cleanly falls back to CPU attention when the f32 cache is absent), cooperative-matrix prefill kernels, and a fully resident-layer pipeline.

## How to run

```bash
cd c && make glm VK=1
COLI_VULKAN=1 COLI_VK_DENSE=1 COLI_VK_ATTN=1 \
PIN=<model>/.coli_usage PIN_GB=0 COLI_NO_OMP_TUNE=1 \
./coli run "Hello" --topp 0.7
```
