### PR TITLE
metal: advance the LFRU recency clock on the GPU-prerouted decode path (#417)

### DIFF
--- a/c/glm.c
+++ b/c/glm.c
@@ -2931,6 +2931,11 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                 m->eusage[layer][idxs[(int64_t)s*K+kk]]++;
                 ehit_mark(m,layer,idxs[(int64_t)s*K+kk]);
                 if(m->eheat[layer][idxs[(int64_t)s*K+kk]]<UINT32_MAX) m->eheat[layer][idxs[(int64_t)s*K+kk]]++;
+                /* #417: la scorciatoia GPU-prerouted deve far avanzare l'orologio di recency
+                 * come il percorso router completo (riga ~3055), altrimenti elast/eaccess_clock
+                 * si congelano a fine prefill e il tie-breaker LFRU di REPIN gira su punteggi
+                 * stantii durante il decode su Metal. */
+                m->elast[layer][idxs[(int64_t)s*K+kk]]=++m->eaccess_clock;
             }
             for(int d=0;d<D;d++) out[(int64_t)s*D+d]=0;
         }


### PR DESCRIPTION
Closes #417.

**The bug** (found by @monotophic with a clean `ELAST_TRACE` source-level repro): on Metal, when routing is precomputed on the GPU (`g_pre_idx`), the moe fast path bumps `eusage`/`ehit`/`eheat` for the selected experts but **omits one line** the full CPU router does at the equivalent site — `m->elast[layer][e] = ++m->eaccess_clock`. Result: the session-local recency clock advances during prefill (full router runs) then **freezes** the instant GPU-prerouted decode begins, so `REPIN`'s `tier_pick_lfru()` tie-breaker runs on stale recency for the rest of the run.

**The fix**: mirror the exact update the non-Metal path already does at `glm.c:~3055`, in the `#ifdef COLI_METAL` prerouted loop.

**Why it's safe:**
- Inside `#ifdef COLI_METAL` → **CPU and CUDA builds are byte-identical**.
- The added line uses the same `m->elast` / `m->eaccess_clock` / `idxs[...]` identifiers already used in the three lines directly above it, so it's guaranteed in-scope and type-correct.
- `elast` only feeds the LFRU **eviction heuristic** — it cannot change model output, only which experts REPIN keeps warm.

**Honest limitation**: I have no Metal hardware, so this is **inspection-verified** (a literal copy of the proven CPU line) but not compiled/run on Metal here. @monotophic — could you confirm with your `ELAST_TRACE` repro that `eaccess_clock` now advances through decode? Non-Metal syntax build verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)