### PR TITLE
cuda: decode expert groups take the grouped kernels even under TC_W4A16 — launches −43%/token (#431)

### DIFF
--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -689,7 +689,15 @@ extern "C" int coli_cuda_expert_group(ColiCudaTensor *const *gates,
         quantize_s4_rows<<<total,256,0,ctx->stream>>>(ctx->qx,ctx->qscale,ctx->gate,total,I);
         grouped_s4_wmma<<<dim3((unsigned)((D+63)/64),(unsigned)count),256,0,ctx->stream>>>(ctx->y,ctx->qx,ctx->qscale,dev,I,D,2);
     }else if(all_s4&&ctx->compute_major>=7&&getenv("COLI_CUDA_TC_W4A16")&&
-             atoi(getenv("COLI_CUDA_TC_W4A16"))){
+             atoi(getenv("COLI_CUDA_TC_W4A16"))&&
+             [&]{ int tc16_min=getenv("COLI_CUDA_TC_W4A16_MIN")?atoi(getenv("COLI_CUDA_TC_W4A16_MIN")):16;
+                  for(int c=0;c<count;c++) if(rows[c]>=tc16_min) return 1;
+                  return 0; }()){
+        /* At least one expert has enough rows for a Tensor Core tile. Groups
+         * where EVERY expert is below the threshold (decode: r=1) fall through
+         * to the grouped-W4 path below — 3 launches for the whole group instead
+         * of 4 per expert (#431: the launch flood measured at ~981 micro-kernels
+         * per token came from decode riding this branch's per-expert fallback). */
         /* W4A16 Tensor Core per gruppo: attivazioni fp16 per tile (lossless al
          * contrario del path W4A4), un lancio per expert dentro lo stream —
          * l'overhead di lancio e' trascurabile rispetto ai GEMM. */


### PR DESCRIPTION
Second increment of #431 (independent of #432 — one 9-line gate in `coli_cuda_expert_group`).

## The bug shape

The `TC_W4A16` branch handles every expert in a per-expert loop: rows ≥ threshold get the Tensor Core path, everything below falls back to **4 naive launches per expert**. At decode every expert has 1 row, so the whole group rode the fallback — that is where #431's measured flood of **~981 `quant_matmul` micro-launches per token** came from — while the grouped 3-launch path (`grouped_hidden_w4_dual` + `silu` + `grouped_down_w4`) sat one `else-if` below, unreachable whenever the *prefill* tuning flag was set.

## The fix

Gate the branch on *“at least one expert in the group reaches the TC row threshold”*. All-small groups (decode) fall through to the grouped kernels; mixed and prefill-sized groups keep today's behaviour exactly.

## Measured (6× RTX 5090, full residency, champion env, `TEMP=0 DRAFT=0`)

- **Launches**: expert-side `quant_matmul` **981 → 337 per forward**; `grouped_*` at 159/forward each; total ≈ **1,490 → ~850 launches/token (−43%)** (nsys, 39-forward capture).
- **Wall**: parity at the A/B operating point (75.1 vs 73.6–74.4 s / 96 tokens — noise band). The tax this removes is ~1.8% of wall *here*; its value is structural — PR-C's graph gets half the nodes, and the launch share grows as the other #431 increments push tok/s up.
- **Behavioural fix folded in**: before this change, toggling `TC_W4A16` — a **prefill-only** optimization — changed *decode* output text (kernel-family divergence, #100 class: the flag silently switched decode between `quant_matmul` and the grouped family). After it, decode always uses the grouped family: **`TC_W4A16=1` and `=0` now produce byte-identical decode text** (verified, 96-token greedy), and the flag affects only the prefill it was built for.

Honest note on exactness: relative to *old* `TC_W4A16=1` decode, text can differ (it is a kernel-family switch — the same one every `TC_W4A16=0` user already runs). Relative to the grouped incumbent, it is byte-identical.

`make check` 77/77; CUDA build zero warnings.