### PR TITLE
idot: independent accumulators on the AVX-VNNI int8/int4 dot kernels (x86 parity with the NEON path)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -352,6 +352,11 @@ tests/test_dsa_select$(EXE): tests/test_dsa_select.c colibri.c st.h uring.h json
 tests/bench_dsa_select$(EXE): tests/bench_dsa_select.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
+# bench_idot: microbenchmark (single-acc vs independent-acc AVX-VNNI idot), NOT a test gate.
+# Build on demand on an AVX-VNNI CPU: make tests/bench_idot ARCH=native
+tests/bench_idot$(EXE): tests/bench_idot.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
 tests/test_uring$(EXE): tests/test_uring.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 

--- a/c/quant.h
+++ b/c/quant.h
@@ -314,12 +314,27 @@ static inline int32_t dot_i8i8(const int8_t *w, const int8_t *x, int I){
     }
     sum=_mm512_reduce_add_epi32(acc);
 #elif defined(__AVXVNNI__) && defined(__AVX2__)
-    __m128i acc=_mm_setzero_si128();
+    /* 4 accumulatori indipendenti (64 byte/iter): un solo acc incatena i vpdpbusd
+     * (latenza-bound ~5c). Somme intere associative -> bit-identico. Stessa struttura
+     * dei 4 accumulatori del ramo NEON piu' sotto.
+     * EN: four independent accumulators break the serial vpdpbusd->acc chain; integer
+     * adds are associative, so the result is bit-identical (mirrors the NEON path). */
+    __m128i a0=_mm_setzero_si128(),a1=_mm_setzero_si128(),a2=_mm_setzero_si128(),a3=_mm_setzero_si128();
+    for(;i+64<=I;i+=64){
+        __m128i w0=_mm_loadu_si128((const __m128i*)(w+i)),    x0=_mm_loadu_si128((const __m128i*)(x+i));
+        __m128i w1=_mm_loadu_si128((const __m128i*)(w+i+16)), x1=_mm_loadu_si128((const __m128i*)(x+i+16));
+        __m128i w2=_mm_loadu_si128((const __m128i*)(w+i+32)), x2=_mm_loadu_si128((const __m128i*)(x+i+32));
+        __m128i w3=_mm_loadu_si128((const __m128i*)(w+i+48)), x3=_mm_loadu_si128((const __m128i*)(x+i+48));
+        a0=_mm_dpbusd_epi32(a0,_mm_abs_epi8(w0),_mm_sign_epi8(x0,w0));
+        a1=_mm_dpbusd_epi32(a1,_mm_abs_epi8(w1),_mm_sign_epi8(x1,w1));
+        a2=_mm_dpbusd_epi32(a2,_mm_abs_epi8(w2),_mm_sign_epi8(x2,w2));
+        a3=_mm_dpbusd_epi32(a3,_mm_abs_epi8(w3),_mm_sign_epi8(x3,w3));
+    }
+    __m128i acc=_mm_add_epi32(_mm_add_epi32(a0,a1),_mm_add_epi32(a2,a3));
     for(;i+16<=I;i+=16){
         __m128i wv=_mm_loadu_si128((const __m128i*)(w+i));
         __m128i xv=_mm_loadu_si128((const __m128i*)(x+i));
-        __m128i xs=_mm_sign_epi8(xv,wv);
-        acc=_mm_dpbusd_epi32(acc,_mm_abs_epi8(wv),xs);
+        acc=_mm_dpbusd_epi32(acc,_mm_abs_epi8(wv),_mm_sign_epi8(xv,wv));
     }
     sum=hsum128_i32(acc);
 #elif defined(__AVX2__)
@@ -390,13 +405,32 @@ static inline int32_t dot_i4i8(const uint8_t *w4, const int8_t *x, int I){
     }
     sum=_mm512_reduce_add_epi32(acc);
 #elif defined(__AVXVNNI__) && defined(__AVX2__)
+    /* 4 accumulatori indipendenti (64 elementi = 32 byte packed/iter): un solo acc
+     * incatena i vpdpbusd (latenza-bound ~5c). Somme intere associative -> bit-identico.
+     * Stessa struttura dei 4 accumulatori del ramo NEON piu' sotto.
+     * EN: four independent accumulators break the serial vpdpbusd->acc chain; integer
+     * adds are associative, so the result is bit-identical (mirrors the NEON path). */
     const __m128i m4=_mm_set1_epi8(0x0F); const __m128i b8=_mm_set1_epi8(8);
-    __m128i acc=_mm_setzero_si128();
-    for(;i+32<=I;i+=32){
+    __m128i a0=_mm_setzero_si128(),a1=_mm_setzero_si128(),a2=_mm_setzero_si128(),a3=_mm_setzero_si128();
+    for(;i+64<=I;i+=64){
+        __m128i by0=_mm_loadu_si128((const __m128i*)(w4+(i>>1)));       /* elem i..i+31  */
+        __m128i by1=_mm_loadu_si128((const __m128i*)(w4+(i>>1)+16));    /* elem i+32..i+63 */
+        __m128i lo0=_mm_and_si128(by0,m4), hi0=_mm_and_si128(_mm_srli_epi16(by0,4),m4);
+        __m128i lo1=_mm_and_si128(by1,m4), hi1=_mm_and_si128(_mm_srli_epi16(by1,4),m4);
+        __m128i w0=_mm_sub_epi8(_mm_unpacklo_epi8(lo0,hi0),b8), w1=_mm_sub_epi8(_mm_unpackhi_epi8(lo0,hi0),b8);
+        __m128i w2=_mm_sub_epi8(_mm_unpacklo_epi8(lo1,hi1),b8), w3=_mm_sub_epi8(_mm_unpackhi_epi8(lo1,hi1),b8);
+        __m128i x0=_mm_loadu_si128((const __m128i*)(x+i)),    x1=_mm_loadu_si128((const __m128i*)(x+i+16));
+        __m128i x2=_mm_loadu_si128((const __m128i*)(x+i+32)), x3=_mm_loadu_si128((const __m128i*)(x+i+48));
+        a0=_mm_dpbusd_epi32(a0,_mm_abs_epi8(w0),_mm_sign_epi8(x0,w0));
+        a1=_mm_dpbusd_epi32(a1,_mm_abs_epi8(w1),_mm_sign_epi8(x1,w1));
+        a2=_mm_dpbusd_epi32(a2,_mm_abs_epi8(w2),_mm_sign_epi8(x2,w2));
+        a3=_mm_dpbusd_epi32(a3,_mm_abs_epi8(w3),_mm_sign_epi8(x3,w3));
+    }
+    __m128i acc=_mm_add_epi32(_mm_add_epi32(a0,a1),_mm_add_epi32(a2,a3));
+    for(;i+32<=I;i+=32){   /* 32-nibble remainder: 2 dpbusd, same unpack */
         __m128i by=_mm_loadu_si128((const __m128i*)(w4+(i>>1)));
         __m128i lo=_mm_and_si128(by,m4), hi=_mm_and_si128(_mm_srli_epi16(by,4),m4);
-        __m128i n0=_mm_unpacklo_epi8(lo,hi), n1=_mm_unpackhi_epi8(lo,hi);
-        __m128i w0=_mm_sub_epi8(n0,b8), w1=_mm_sub_epi8(n1,b8);
+        __m128i w0=_mm_sub_epi8(_mm_unpacklo_epi8(lo,hi),b8), w1=_mm_sub_epi8(_mm_unpackhi_epi8(lo,hi),b8);
         __m128i x0=_mm_loadu_si128((const __m128i*)(x+i));
         __m128i x1=_mm_loadu_si128((const __m128i*)(x+i+16));
         acc=_mm_dpbusd_epi32(acc,_mm_abs_epi8(w0),_mm_sign_epi8(x0,w0));

--- a/c/tests/bench_idot.c
+++ b/c/tests/bench_idot.c
@@ -1,0 +1,92 @@
+/* Microbenchmark: old (single-accumulator) vs new (independent-accumulator) AVX-VNNI
+ * int8/int4 dot kernels (quant.h). NOT a unit test -- test_idot.c proves correctness.
+ * This measures the headline claim: breaking the serial vpdpbusd->acc chain lifts
+ * per-core kernel throughput, the same win the NEON path already took ("26->63 GB/s, 2.4x").
+ *
+ * It re-implements the OLD single-acc AVX-VNNI kernels inline and calls the REAL (new)
+ * ones via the include-colibri.c pattern -- one process, identical frozen inputs, warm
+ * caches. Reports median ns/call + GB/s-of-weights + new/old ratio. Measures the kernel's
+ * compute ceiling (warm caches), NOT end-to-end tok/s.
+ *
+ * Run:  make tests/bench_idot ARCH=native && ./tests/bench_idot   (not in TEST_BINS -- not a gate)
+ */
+#define main coli_glm_main_unused
+#include "../colibri.c"
+#undef main
+#include <stdint.h>
+#include <string.h>
+
+static uint32_t rs=0x2545F491u;
+static uint32_t xr(void){ rs^=rs<<13; rs^=rs>>17; rs^=rs<<5; return rs; }
+
+/* ---- OLD kernels: verbatim copies of the pre-change __AVXVNNI__ branches (single acc) ---- */
+#if defined(__AVXVNNI__) && defined(__AVX2__)
+static int32_t dot_i8i8_old(const int8_t *w, const int8_t *x, int I){
+    int32_t sum=0; int i=0;
+    __m128i acc=_mm_setzero_si128();
+    for(;i+16<=I;i+=16){
+        __m128i wv=_mm_loadu_si128((const __m128i*)(w+i));
+        __m128i xv=_mm_loadu_si128((const __m128i*)(x+i));
+        __m128i xs=_mm_sign_epi8(xv,wv);
+        acc=_mm_dpbusd_epi32(acc,_mm_abs_epi8(wv),xs);
+    }
+    sum=hsum128_i32(acc);
+    for(;i<I;i++) sum+=(int32_t)w[i]*x[i];
+    return sum;
+}
+static int32_t dot_i4i8_old(const uint8_t *w4, const int8_t *x, int I){
+    int32_t sum=0; int i=0;
+    const __m128i m4=_mm_set1_epi8(0x0F); const __m128i b8=_mm_set1_epi8(8);
+    __m128i acc=_mm_setzero_si128();
+    for(;i+32<=I;i+=32){
+        __m128i by=_mm_loadu_si128((const __m128i*)(w4+(i>>1)));
+        __m128i lo=_mm_and_si128(by,m4), hi=_mm_and_si128(_mm_srli_epi16(by,4),m4);
+        __m128i n0=_mm_unpacklo_epi8(lo,hi), n1=_mm_unpackhi_epi8(lo,hi);
+        __m128i w0=_mm_sub_epi8(n0,b8), w1=_mm_sub_epi8(n1,b8);
+        __m128i x0=_mm_loadu_si128((const __m128i*)(x+i));
+        __m128i x1=_mm_loadu_si128((const __m128i*)(x+i+16));
+        acc=_mm_dpbusd_epi32(acc,_mm_abs_epi8(w0),_mm_sign_epi8(x0,w0));
+        acc=_mm_dpbusd_epi32(acc,_mm_abs_epi8(w1),_mm_sign_epi8(x1,w1));
+    }
+    sum=hsum128_i32(acc);
+    for(;i<I;i++){ uint8_t b=w4[i>>1]; int v=(i&1)?((int)(b>>4)-8):((int)(b&0xF)-8); sum+=v*x[i]; }
+    return sum;
+}
+#else
+#error "bench_idot requires an AVX-VNNI build: make tests/bench_idot ARCH=native on an AVX-VNNI CPU"
+#endif
+
+#define I_DIM 6144
+#define N_REPEAT 20000
+static int cmp_d(const void*a,const void*b){ double x=*(const double*)a,y=*(const double*)b; return x<y?-1:x>y?1:0; }
+
+int main(void){
+    static int8_t w8[I_DIM], x8[I_DIM]; static uint8_t w4[I_DIM/2];
+    for(int i=0;i<I_DIM;i++){ w8[i]=(int8_t)(xr()&0xFF); x8[i]=(int8_t)((int)(xr()%255)-127); }
+    for(int i=0;i<I_DIM/2;i++) w4[i]=(uint8_t)(xr()&0xFF);
+
+    /* correctness sanity: new must equal old (bit-exact) */
+    if(dot_i8i8(w8,x8,I_DIM)!=dot_i8i8_old(w8,x8,I_DIM)){ fprintf(stderr,"MISMATCH i8i8\n"); return 1; }
+    if(dot_i4i8(w4,x8,I_DIM)!=dot_i4i8_old(w4,x8,I_DIM)){ fprintf(stderr,"MISMATCH i4i8\n"); return 1; }
+
+    static double t[N_REPEAT]; volatile int32_t sink=0;
+    const char *names[4]={"i8i8 old","i8i8 new","i4i8 old","i4i8 new"};
+    double gbs[4];
+    for(int k=0;k<4;k++){
+        for(int wi=0;wi<200;wi++) sink+= (k==0)?dot_i8i8_old(w8,x8,I_DIM):(k==1)?dot_i8i8(w8,x8,I_DIM)
+                                      :(k==2)?dot_i4i8_old(w4,x8,I_DIM):dot_i4i8(w4,x8,I_DIM); /* warmup */
+        for(int r=0;r<N_REPEAT;r++){
+            double t0=now_s();
+            sink+= (k==0)?dot_i8i8_old(w8,x8,I_DIM):(k==1)?dot_i8i8(w8,x8,I_DIM)
+                 :(k==2)?dot_i4i8_old(w4,x8,I_DIM):dot_i4i8(w4,x8,I_DIM);
+            t[r]=(now_s()-t0)*1e9;
+        }
+        qsort(t,N_REPEAT,sizeof(double),cmp_d);
+        double med=t[N_REPEAT/2];
+        double bytes=(k<2)?I_DIM:(double)I_DIM/2;   /* weight bytes touched */
+        gbs[k]=bytes/med;
+        printf("%-9s  %8.1f ns/call   %6.2f GB/s\n", names[k], med, gbs[k]);
+    }
+    printf("ratio i8i8 new/old: %.2fx   |   ratio i4i8 new/old: %.2fx\n", gbs[1]/gbs[0], gbs[3]/gbs[2]);
+    (void)sink; return 0;
+}


### PR DESCRIPTION
## Summary

The `__AVXVNNI__` branches of `dot_i8i8` and `dot_i4i8` accumulate every
`vpdpbusd` into a **single** register. `vpdpbusd` is latency-bound (~5 cycles on
Golden Cove / Zen4), so one accumulator serialises the loop on that ~5c chain.

This PR uses **4 independent accumulators**, exactly mirroring the NEON SDOT path
already in the same functions (whose comment documents the same fix: *"con un solo
acc la catena seriale strozza il core … con 4 lane indipendenti … 26 → 63 GB/s per
core, 2.4x"*). It is the smallest change that breaks the chain — no new intrinsics
(`_mm_dpbusd_epi32` is reused), no new dependencies, nothing outside the two
`#elif defined(__AVXVNNI__)` branches.

Why this path matters on x86: the tiled SMMLA `_mm` drivers are ARM-only
(`__ARM_FEATURE_MATMUL_INT8`), so on x86 `matmul_q_idot` / `matmul_i4_idot` call
`dot_i8i8` / `dot_i4i8` per output row for **both** prefill (S≥2) and decode (S=1).
IDOT is on by default (`g_idot=1`) and int8 IDOT is the default expert/dense kernel
("wins 1.4–2.5×" per the in-code note), so these two dots are the x86 integer
matmul hot path.

**Correctness:** integer accumulation is associative, so N independent
accumulators are **bit-identical** to the single-accumulator result — no rounding,
no token-flip risk. `tests/test_idot` passes bit-for-bit (kernel + driver, across
odd tails and the `w=−128` edge).

## Measurement

Microbenchmark `tests/bench_idot` (added here; build-on-demand, **not** in
`TEST_BINS`). It re-implements the old single-accumulator kernels inline and A/Bs
them against the new ones in one process on identical frozen inputs (same pattern
as `bench_topp`/`bench_dsa_select`). It measures the **kernel's warm-cache compute
ceiling**, not end-to-end tok/s.

Hardware: 12th Gen Intel Core i7-12700H (Alder Lake, AVX-VNNI), GCC `-O3
-march=native`, single P-core (`taskset -c 0`), `I=6144`, median of 20000 calls:

| kernel | before | after | speedup |
|---|---|---|---|
| `dot_i8i8` (int8) | 6.85 GB/s | 19.26 GB/s | **2.81×** |
| `dot_i4i8` (int4) | 3.41 GB/s |  7.25 GB/s | **2.13×** |

Reproduce:
```sh
make -C c tests/bench_idot ARCH=native
taskset -c 0 ./c/tests/bench_idot     # drop taskset on non-hybrid CPUs
```

End-to-end decode tok/s on the full model is a separate measurement (partly
memory-bound once experts stream) and is not claimed here.

## Scope

- **In scope:** the two `__AVXVNNI__` 128-bit branches only.
- **Out of scope (follow-up in the companion issue #443):** the
  `__AVX512VNNI__` and `__AVX512F__` branches have the same single-accumulator
  structure and would benefit identically, but I can't build/validate AVX-512 on
  this machine, so I've left them untouched rather than ship an unverified change.
  Tracked in #443.

## Validation

- [x] `make -C c check` (portable build, 0 warnings; all C unit tests + 77 Python tests pass)
- [x] `./c/tests/test_idot` passes bit-for-bit on an `ARCH=native` (AVX-VNNI) build
- [ ] CUDA changes were tested with `make -C c cuda-test` (N/A — CPU-only change)
- [x] Performance claims include hardware, commands, and repeatable measurements

## Compatibility

- [x] The default CPU build remains dependency-free (no new intrinsics; the branch
  only compiles under `ARCH=native` on an AVX-VNNI CPU — the portable `x86-64-v3`
  CI build is byte-unchanged)
- [x] No model files, generated binaries, or benchmark artifacts are included

---
*Investigated and implemented with AI assistance (Claude), following the project's
precedent for AI-assisted contributions (#428, #398). Everything above was built,
tested (`test_idot` + `make check`), and measured locally before submission.*

---

## End-to-end: I could NOT demonstrate a gain — correction of an earlier claim

I first posted a "−17 % `expert-matmul`" end-to-end figure here from a single run per arm.
**That number does not hold up and I am retracting it.** Repeating the A/B with two passes per
arm showed the comparison was confounded by warm-up drift, not by the kernel:

full GLM-5.2 744B int4 (358 GB) on i7-12700H / 62 GB / NVMe, greedy, 20-token decode,
runs in chronological order:

| # | arm | `expert-matmul` | decode tok/s |
|---|---|---|---|
| 1 | `dev` | 22.737 s | 0.17 |
| 2 | this PR | 21.160 s | 0.18 |
| 3 | `dev` | **20.363 s** | 0.18 |
| 4 | this PR | 19.958 s | 0.18 |

The time falls monotonically with run order **regardless of arm** — and `dev` run 3 (20.363 s)
beats this PR's run 2 (21.160 s). Within-arm spread for `dev` alone is 22.7 → 20.4 s (≈11 %),
larger than the between-arm gap (≈2 % on the most-settled pair). **Conclusion: no end-to-end
effect is distinguishable from noise on this machine.**

Why: this workload never becomes compute-bound here (358 GB model vs 62 GB RAM → expert hit rate
stuck at ~40 %, ~970 s disk service vs ~20 s matmul), and the matmul itself streams
freshly-loaded expert weights from memory, so it is bandwidth-bound rather than
dot-throughput-bound. The microbench's working set is resident and small, which is exactly why it
can isolate the kernel ceiling — and why that ceiling doesn't transfer here.

**What this PR does and does not claim:**
- **Claimed, and measured:** the two AVX-VNNI dot kernels are **2.13–2.81× faster in isolation**
  (`tests/bench_idot`, controlled A/B in one process on frozen inputs, stable across repeats),
  with **bit-identical** output.
- **Not claimed:** any end-to-end tok/s or decode-time improvement. I could not demonstrate one,
  and I am not going to assert one I did not measure.

The change remains worth taking on its own terms: it is strictly less work per dot, bit-exact,
confined to two `#elif defined(__AVXVNNI__)` branches, and brings x86 to parity with the NEON
path's existing 4-accumulator structure. On a resident / compute-bound deployment (large-RAM or
full-residency setups, e.g. #389) it should convert better than it does here — but I have no such
box, so that stays a hypothesis rather than a claim.
