### PR TITLE
io: skip the wasted WILLNEED on expert weights under DIRECT=1 (#441 safe half)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -1701,12 +1701,21 @@ static void expert_host_ensure(Model *m, int layer, ESlot *s){
 #endif
 
 /* prefetch asincrono dei pesi di un expert (e delle sue scale .qs): avvia il readahead
- * cosi' le letture sincrone successive trovano la page-cache calda. */
+ * cosi' le letture sincrone successive trovano la page-cache calda.
+ * Sotto g_direct i PESI vengono letti con O_DIRECT (bypassa la page-cache, vedi
+ * expert_load): il WILLNEED su di essi scalda pagine che la lettura di domanda non
+ * consuma -> readahead sprecato sul disco, la risorsa piu' scarsa nello streaming.
+ * Le scale .qs restano SEMPRE bufferizzate (pread sul fd normale), quindi il loro
+ * WILLNEED resta utile anche con DIRECT=1. fadvise e' solo consultivo: saltarlo non
+ * cambia mai l'output (bit-identico), riduce solo I/O sprecato.
+ * EN: under O_DIRECT the weights bypass the page cache, so their WILLNEED is wasted;
+ * the .qs scales are always buffered, so keep theirs. Advisory hint -> output-preserving. */
 static void expert_prefetch(Model *m, int layer, int eid){
     char nm[300];
     const char *suf[3]={"gate_proj.weight","up_proj.weight","down_proj.weight"};
     for(int k=0;k<3;k++){
-        snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.%d.%s",layer,eid,suf[k]); st_prefetch(&m->S,nm);
+        snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.%d.%s",layer,eid,suf[k]);
+        if(!g_direct) st_prefetch(&m->S,nm);
         char qs[320]; snprintf(qs,sizeof(qs),"%s.qs",nm); st_prefetch(&m->S,qs);
     }
 }


### PR DESCRIPTION
> **Now measured** — see "Measurement" below. Two independent A/Bs exist: @michael-denyer's
> on Apple Silicon (a decisive **−36 % throughput** from the wasted WILLNEED) and mine on
> x86/Linux NVMe (directionally right but **much weaker: flat tok/s, −3 % disk service**).
> Reporting both, including the one that doesn't flatter the change. This is the **safe
> half of #441**.

## Summary

Under `DIRECT=1`, `expert_load` reads the expert **weights** through the O_DIRECT
fd (bypassing the page cache). But `expert_prefetch` still issues
`POSIX_FADV_WILLNEED` on those same weight tensors — warming pages the O_DIRECT
demand read never consumes. That's **wasted readahead on the disk**, the scarcest
resource when streaming.

The `.qs` **scales are always read buffered** (`pread_full` on the normal fd,
`expert_load` ~L1329), so their WILLNEED still helps — this PR keeps it and skips
only the weight WILLNEED under `g_direct`:

```c
for(int k=0;k<3;k++){
    snprintf(nm,...,suf[k]);
    if(!g_direct) st_prefetch(&m->S,nm);   // weights go O_DIRECT under DIRECT -> WILLNEED wasted
    char qs[320]; snprintf(qs,...); st_prefetch(&m->S,qs);  // scales always buffered -> keep
}
```

This only affects the hint-only PILOT path (`PILOT=1`, `PILOT_REAL=0`) combined
with `DIRECT=1`. `fadvise` is advisory, so **output is bit-identical** — no
rounding, no routing change.

## Why draft / what's left

The benefit is *avoided wasted disk I/O*, which only shows up when actually
cold-streaming experts. The measurement to run (and attach here before marking
ready):

```sh
# baseline dev vs this branch, same prompt, cold cache, greedy:
PILOT=1 DIRECT=1 ./coli run --temp 0 --model /path/glm52 "<prompt>"
# compare tok/s and the disk-service line, with/without the patch
```

The **riskier half of #441** — multi-threading the single pilot prefetch thread
(NVMe queue-depth 1 → 8-32) and forcing `PILOT_REAL` under DIRECT — is a separate
change that engages the cross-layer real-load machinery; it stays out of this PR
and lands with its own runtime A/B.

## Validation (so far)

- [x] `make -C c check` — portable build 0 warnings, all C unit + 83 Python tests pass
- [x] Native (`ARCH=native`) build 0 warnings
- [x] Bit-identical by construction (advisory `fadvise` only; no compute/routing touched)
- [x] **Cold-stream A/B on real NVMe** — done (see Measurement; weak on x86/Linux, decisive on Apple Silicon per @michael-denyer)

## Compatibility

- [x] Default CPU build stays dependency-free
- [x] No model files, binaries, or artifacts included

Closes part of #441 (the weights-WILLNEED-under-DIRECT half).

---
*Prepared with AI assistance (Claude), per the project's AI-contribution precedent
(#428, #398). Build + `make check` run locally; cold-stream A/B now measured (below).*

---

## Measurement

### A — @michael-denyer, Apple Silicon (decisive; posted in the thread below)

M5 Pro, 64 GB, macOS 26.5.2, GLM-5.2 REAP-504B int4 (168 experts/layer),
`DIRECT=1 PIPE=1 PIPE_WORKERS=8`, greedy 128-token decode, interleaved runs:

| arm | tok/s | expert hit | disk-wait |
|---|---|---|---|
| baseline | 2.63 | 64.9 % | 26.0 s |
| `PILOT=1` hint-only WILLNEED | 1.68 | 65.0 % | 42.2 s |

Advisory WILLNEED under `DIRECT=1` cost **36 % throughput and +62 % disk-wait at a flat hit
rate** — precisely the mechanism this PR removes. They also confirmed the `.qs` distinction
this PR makes ("correct and finer than ours was") and adopted it.

### B — mine, x86/Linux (much weaker; reported as measured)

i7-12700H, 62 GB RAM, NVMe, full GLM-5.2 744B int4 (358 GB), `DIRECT=1 PILOT=1` (hint-only),
greedy `--temp 0`, 17-token prompt / 20-token decode, `dev` vs this branch:

| arm | tok/s | expert hit | disk service (decode) | disk wait |
|---|---|---|---|---|
| `dev` | 0.22 | 41.0 % | 602.7 s | 49.9 s |
| this PR | 0.22 | 42.1 % | **583.9 s** | 49.0 s |

**Flat on throughput, ~−3 % disk service.** Direction is right, magnitude is nowhere near the
Apple-Silicon result. Plausible reasons: Linux `POSIX_FADV_WILLNEED` + O_DIRECT behaves
differently from macOS `F_NOCACHE`; my decode window is short (20 vs 128 tokens) and my hit
rate regime differs (41 % vs 65 %). Single run per arm, no medians.

```sh
cd c && COLI_MODEL=/path/glm52_i4 DIRECT=1 PILOT=1 ./coli run --gpu none --temp 0 --ngen 20 \
  "Give three prime numbers and explain why each is prime."
# compare the decode-block PROFILE 'expert-disk … service' between dev and this branch
```

**Honest summary:** the change removes I/O that is *provably* wasted under `DIRECT=1`
(O_DIRECT bypasses exactly the pages the WILLNEED warms) and is bit-identical in output, so it
cannot be a regression. Whether it converts to throughput appears strongly platform-dependent:
decisive on Apple Silicon, marginal on this x86/Linux NVMe.
