### PR TITLE
metal: parallelize the single-threaded r_top8 selection kernel (bit-exact, +6.7% decode)

### DIFF
--- a/c/backend_metal.h
+++ b/c/backend_metal.h
@@ -84,6 +84,23 @@ int coli_metal_layer_decode(float *x,
 
 int coli_metal_gemm(float *y, const float *x, const void *weights, const float *scales,
                     int fmt, int S, int I, int O);   /* large-batch sync GEMM; 0 -> CPU */
+/* Parallel top-8 expert selection (r_top8_par): run ONE top-8 selection kernel standalone
+ * on host arrays — par=0 the serial r_top8, par=1 the parallel exact-match replica gated
+ * in the engine by COLI_RTOP8 (default ON; COLI_RTOP8=0 opts out to the serial kernel).
+ * Exists so the metal-test suite (and any battery probe) can prove serial/parallel
+ * equivalence on the ENGINE build's own compiled shaders, not just in the bench tool.
+ * sig[S*E], bias[E], idx[S*K], w[S*K], keff[S].
+ * Expert-count generality: the parallel kernel's blocked-lane design (ch[8]/32-lane
+ * threadgroup) is validated correct for arbitrary E<=256, including non-multiples of the
+ * 32-lane width and small E (see metal-test's E=24/E=168/E=256 cases — 168 is the REAP
+ * expert-pruned package width from #428/#426). For E>256 (out of contract) this function
+ * transparently falls back to the serial kernel even when par=1 is requested, and the
+ * same automatic fallback is wired into the engine dispatch site — "par" is a request,
+ * never a guarantee, so no caller can reach the unguarded parallel path out of contract.
+ * Returns 1 on success, 0 if Metal is unavailable. */
+int coli_metal_rtop8(int par, const float *sig, const float *bias, int S, int E, int K,
+                     int Ksel, float topp, int normk, float rscale,
+                     int *idx, float *w, int *keff);
 void coli_metal_attn_counts(uint64_t *ok, double *wall, double *kernel);
 void coli_metal_attn_lat(double *ksched, double *gsched);
 int coli_metal_attn_decode(const float *x,

--- a/c/backend_metal.mm
+++ b/c/backend_metal.mm
@@ -219,6 +219,63 @@ kernel void r_top8(device const float* sig [[buffer(0)]], device const float* bi
   if(normk){ float sm=0; for(int kk=0;kk<Ke;kk++) sm+=ww[kk]; sm+=1e-20f; for(int kk=0;kk<Ke;kk++) ww[kk]/=sm; }
   for(int kk=0;kk<Ke;kk++) ww[kk]*=rscale;
 }
+// parallel replica of r_top8's selection on ONE SIMDGROUP per row instead of one serial
+// thread (bench/kernels @ 27bfe83: serial r_top8 measured 0.465 ms/layer, ~55% of the
+// layer CB; this replica ~93x faster with exactly matching output). EXACT-MATCH is the
+// contract: each lane owns ceil(E/32) contiguous experts (blocked) and keeps a taken
+// bitmask; per selection step: lane-local strict-'>' ascending max (lowest index wins
+// within a lane, matching the serial ascending scan), then a shuffle-down argmax
+// reduction where ties prefer the LOWER index — together exactly the serial kernel's
+// first-max-wins order. The topp/normk/rscale tail is the serial code verbatim on lane 0
+// (same ops, same order => bitwise-identical results; metal-test enforces this with
+// memcmp). Contract: E<=256 (ch[8]/taken mask sizing: ceil(E/32)<=8) — the defensive
+// return below makes an out-of-contract dispatch a visible no-op (idx/w/keff untouched),
+// never an OOB write; both call sites (coli_metal_layer_decode's dispatch and the
+// standalone coli_metal_rtop8 runner) additionally gate on E<=256 in host code before
+// selecting this pipeline at all, so the return here is defense-in-depth, not the only
+// guard. Sentinel-per-lane design (ch[j]=-1e30f for e>=E) makes non-multiple-of-32 E
+// and small E correct without special-casing — validated for E=24, E=168 (REAP
+// expert-pruned packages, see the upstream feature-request thread) and E=256 by metal-test.
+// ASSUMES SIMD width 32 (shuffle offsets 16..1, 32-thread threadgroup per row): enforced
+// at init — coli_metal_init clears g_rtop8_width_ok (and therefore both call sites' use
+// of this pipeline) if threadExecutionWidth != 32.
+kernel void r_top8_par(device const float* sig [[buffer(0)]], device const float* bias [[buffer(1)]],
+                       device int* idx [[buffer(2)]], device float* w [[buffer(3)]],
+                       device int* keff [[buffer(4)]], constant int& E [[buffer(5)]],
+                       constant int& K [[buffer(6)]], constant int& Ksel [[buffer(7)]],
+                       constant float& topp [[buffer(8)]], constant int& normk [[buffer(9)]],
+                       constant float& rscale [[buffer(10)]],
+                       uint s [[threadgroup_position_in_grid]],
+                       uint slane [[thread_index_in_simdgroup]]) {
+  if(E>256) return;
+  device const float* sg=sig+(long)s*E;
+  device int* id_=idx+(long)s*K; device float* ww=w+(long)s*K;
+  int per=(E+31)/32, base=(int)slane*per;
+  float ch[8]; uint taken=0u;
+  for(int j=0;j<per;j++){ int e=base+j; ch[j]=(e<E)?sg[e]+bias[e]:-1e30f; }
+  for(int kk=0;kk<Ksel;kk++){
+    float bv=-1e30f; int bi=0x7FFFFFFF;
+    for(int j=0;j<per;j++) if(!(taken&(1u<<j)) && ch[j]>bv){ bv=ch[j]; bi=base+j; }
+    for(uint off=16;off>0;off>>=1){
+      float ov=simd_shuffle_down(bv,off); int oi=simd_shuffle_down(bi,off);
+      if(ov>bv || (ov==bv && oi<bi)){ bv=ov; bi=oi; }
+    }
+    bv=simd_broadcast(bv,0); bi=simd_broadcast(bi,0);
+    if(bi>=base && bi<base+per) taken|=1u<<(bi-base);
+    if(slane==0){ id_[kk]=bi; ww[kk]=sg[bi]; }
+  }
+  if(slane!=0) return;
+  int Ke=Ksel;
+  if(topp>0.0f && topp<1.0f){
+    for(int a=1;a<Ksel;a++){ int ii=id_[a]; float wv=ww[a]; int b=a-1;
+      while(b>=0 && ww[b]<wv){ ww[b+1]=ww[b]; id_[b+1]=id_[b]; b--; } ww[b+1]=wv; id_[b+1]=ii; }
+    float tot=1e-20f; for(int kk=0;kk<Ksel;kk++) tot+=ww[kk];
+    float cum=0; for(int kk=0;kk<Ksel;kk++){ cum+=ww[kk]; if(cum>=topp*tot){ Ke=kk+1; break; } }
+  }
+  keff[s]=Ke;
+  if(normk){ float sm=0; for(int kk=0;kk<Ke;kk++) sm+=ww[kk]; sm+=1e-20f; for(int kk=0;kk<Ke;kk++) ww[kk]/=sm; }
+  for(int kk=0;kk<Ke;kk++) ww[kk]*=rscale;
+}
 )METAL";
 
 struct ColiMetalTensor {
@@ -231,7 +288,15 @@ static id<MTLDevice> g_dev;
 static id<MTLCommandQueue> g_queue;
 static id<MTLComputePipelineState> g_gemv, g_moe_gemv, g_moe_silu;
 static id<MTLComputePipelineState> g_a_rms, g_a_rope, g_a_copy, g_a_qabs, g_a_score, g_a_smax, g_a_clat, g_a_ctx;
-static id<MTLComputePipelineState> g_a_add, g_r_router, g_r_top8;
+static id<MTLComputePipelineState> g_a_add, g_r_router, g_r_top8, g_r_top8p;
+static int g_rtop8_par = 1;      // COLI_RTOP8 (default ON); COLI_RTOP8=0 opts out to the
+                                  // serial kernel — see coli_metal_init.
+static int g_rtop8_width_ok = 1; // hardware fact, independent of the policy gate above:
+                                  // false if this device's threadExecutionWidth != 32.
+                                  // Consulted by BOTH the engine dispatch site and the
+                                  // standalone coli_metal_rtop8 runner, so no caller can
+                                  // reach r_top8_par's 32-lane reduction on an unsafe
+                                  // device even by explicitly requesting par=1.
 static size_t g_tensor_count, g_tensor_bytes;
 static uint64_t g_moe_ok, g_moe_fb, g_moe_experts;   // GPU blocks / CPU-fallback blocks / experts on GPU
 static double g_t_setup, g_t_gpu, g_t_scatter, g_t_kernel;       // per-block time breakdown (seconds)
@@ -284,6 +349,8 @@ extern "C" int coli_metal_init(void) {
   if (g_dev) return 1;
   if (getenv("COLI_METAL_UNTRACKED") && atoi(getenv("COLI_METAL_UNTRACKED")))
     g_res_opts = MTLResourceStorageModeShared | MTLResourceHazardTrackingModeUntracked;
+  { const char *e = getenv("COLI_RTOP8");           // default ON; COLI_RTOP8=0 opts out
+    if (e && atoi(e) == 0) g_rtop8_par = 0; }
   @autoreleasepool {
     g_dev = MTLCreateSystemDefaultDevice();
     if (!g_dev) return 0;
@@ -299,8 +366,23 @@ extern "C" int coli_metal_init(void) {
     auto P=[&](const char*n){ return [g_dev newComputePipelineStateWithFunction:[lib newFunctionWithName:@(n)] error:&err]; };
     g_a_rms=P("a_rmsnorm"); g_a_rope=P("a_rope"); g_a_copy=P("a_copy");
     g_a_qabs=P("a_qabs"); g_a_score=P("a_score"); g_a_smax=P("a_smax"); g_a_clat=P("a_clat"); g_a_ctx=P("a_ctx");
-    g_a_add=P("a_add"); g_r_router=P("r_router"); g_r_top8=P("r_top8");
-    if(!g_a_add||!g_r_router||!g_r_top8){ fprintf(stderr,"[metal] tail pipelines failed\n"); g_dev=nil; return 0; }
+    g_a_add=P("a_add"); g_r_router=P("r_router"); g_r_top8=P("r_top8"); g_r_top8p=P("r_top8_par");
+    if(!g_a_add||!g_r_router||!g_r_top8||!g_r_top8p){ fprintf(stderr,"[metal] tail pipelines failed\n"); g_dev=nil; return 0; }
+    // r_top8_par's reduction hardcodes SIMD width 32 (shuffle-down offsets 16..1, one
+    // 32-thread threadgroup per row). True on all Apple Silicon shipped to date, but a
+    // non-32-width device would reduce wrongly AND race multiple lane-0 writers, so this
+    // is a hard safety fact (g_rtop8_width_ok), not just a policy default: it gates BOTH
+    // the engine dispatch site and the standalone coli_metal_rtop8 runner (degrade-to-safe,
+    // same pattern as the pool/ring fallbacks elsewhere) — no caller can opt back into an
+    // unsafe reduction on such a device, even by explicitly requesting par=1.
+    if ([g_r_top8p threadExecutionWidth] != 32) {
+      g_rtop8_width_ok = 0;
+      if (g_rtop8_par)
+        fprintf(stderr, "[metal] COLI_RTOP8 parallel top-8 disabled: threadExecutionWidth=%lu "
+                        "!= 32 (r_top8_par's reduction assumes 32-lane simdgroups) — serial "
+                        "r_top8 in use\n", (unsigned long)[g_r_top8p threadExecutionWidth]);
+      g_rtop8_par = 0;
+    }
     if (!g_gemv || !g_moe_gemv || !g_moe_silu || !g_a_rms || !g_a_rope || !g_a_copy ||
         !g_a_qabs || !g_a_score || !g_a_smax || !g_a_clat || !g_a_ctx) {
       fprintf(stderr, "[metal] pipeline failed\n"); g_dev = nil; return 0; }
@@ -597,12 +679,22 @@ extern "C" int coli_metal_layer_decode(float *x,
     // 5) silu(gate)*up + exact top-K select
     [e setComputePipelineState:g_moe_silu]; [e setBuffer:ash1_ offset:0 atIndex:0]; [e setBuffer:ash2_ offset:0 atIndex:1];
     [e dispatchThreads:MTLSizeMake((size_t)S*SI,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
-    { [e setComputePipelineState:g_r_top8];
+    { // COLI_RTOP8 (default ON) swaps the serial 1-thread-per-row select for the exact-
+      // match 1-simdgroup-per-row replica (same buffers/args; only pipeline+grid change).
+      // E<=256 is required by r_top8_par's ch[8]/32-lane blocking contract; this call
+      // site's E is always 256 today (layer_forward_rows' own architecture-shape gate in
+      // colibri.c requires c->n_experts==256 to reach coli_metal_layer_decode at all —
+      // see PR body "Scope statement") but the check is kept here too, defense-in-depth,
+      // so a future relaxation of that gate (e.g. to admit REAP-pruned E=168 models into
+      // the fused path) degrades safely to the serial kernel instead of mis-dispatching.
+      int use_par = g_rtop8_par && g_rtop8_width_ok && E<=256;
+      [e setComputePipelineState:use_par?g_r_top8p:g_r_top8];
       [e setBuffer:asig_ offset:0 atIndex:0]; [e setBuffer:rbB offset:rboff atIndex:1];
       [e setBuffer:aidx_ offset:0 atIndex:2]; [e setBuffer:aw_ offset:0 atIndex:3]; [e setBuffer:akeff_ offset:0 atIndex:4];
       [e setBytes:&E length:4 atIndex:5]; [e setBytes:&K length:4 atIndex:6]; [e setBytes:&Ksel length:4 atIndex:7];
       [e setBytes:&topp length:4 atIndex:8]; [e setBytes:&normk length:4 atIndex:9]; [e setBytes:&rscale length:4 atIndex:10];
-      [e dispatchThreads:MTLSizeMake(S,1,1) threadsPerThreadgroup:MTLSizeMake(S,1,1)]; }
+      if(use_par) [e dispatchThreadgroups:MTLSizeMake(S,1,1) threadsPerThreadgroup:MTLSizeMake(32,1,1)];
+      else        [e dispatchThreads:MTLSizeMake(S,1,1) threadsPerThreadgroup:MTLSizeMake(S,1,1)]; }
     BAR();
     // 6) shared down
     bind_gemv(e,shd_w,shd_s,shd_fmt,SI,AH,ash1_,ashout_,S);
@@ -647,6 +739,44 @@ extern "C" int coli_metal_gemm(float *y, const float *x, const void *wp, const f
     [e endEncoding]; [cb commit]; [cb waitUntilCompleted];
     if(cb.status==MTLCommandBufferStatusError){ fprintf(stderr,"[metal] gemm cmdbuf error (S=%d O=%d)\n",S,O); return 0; }
     memcpy(y,[g_gy contents],(size_t)S*O*4);
+  }
+  return 1;
+}
+
+// Standalone single-kernel runner for the top-8 select (see backend_metal.h). Fresh
+// shared buffers per call (a test/probe path, not a hot path); grids exactly as the
+// engine dispatch site: serial = S threads of one S-wide threadgroup, parallel = S
+// threadgroups x 32 (one simdgroup per row). "par" is a REQUEST, not a guarantee: same
+// E<=256 and SIMD-width-32 host-side checks as the engine dispatch site gate the actual
+// pipeline choice, so a caller (including metal-test itself) can never reach the parallel
+// kernel out of contract by asking for it — par=1 with E>256, or on a non-32-wide device,
+// transparently runs the serial kernel instead and still returns 1 (success).
+extern "C" int coli_metal_rtop8(int par, const float *sig, const float *bias, int S, int E, int K,
+                                int Ksel, float topp, int normk, float rscale,
+                                int *idx, float *w, int *keff) {
+  if (!g_dev || S < 1 || E < 1 || K < 1 || Ksel < 1 || Ksel > K) return 0;
+  int use_par = par && g_r_top8p && g_rtop8_width_ok && E<=256;
+  @autoreleasepool {
+    id<MTLBuffer> bs=[g_dev newBufferWithBytes:sig  length:(size_t)S*E*4 options:MTLResourceStorageModeShared];
+    id<MTLBuffer> bb=[g_dev newBufferWithBytes:bias length:(size_t)E*4   options:MTLResourceStorageModeShared];
+    id<MTLBuffer> bi=[g_dev newBufferWithLength:(size_t)S*K*4 options:MTLResourceStorageModeShared];
+    id<MTLBuffer> bw=[g_dev newBufferWithLength:(size_t)S*K*4 options:MTLResourceStorageModeShared];
+    id<MTLBuffer> bk=[g_dev newBufferWithLength:(size_t)S*4   options:MTLResourceStorageModeShared];
+    if(!bs||!bb||!bi||!bw||!bk) return 0;
+    memset(bi.contents,0xFF,(size_t)S*K*4);           // poison: untouched slots stay visible
+    id<MTLCommandBuffer> cb=[g_queue commandBuffer]; id<MTLComputeCommandEncoder> e=[cb computeCommandEncoder];
+    [e setComputePipelineState:use_par?g_r_top8p:g_r_top8];
+    [e setBuffer:bs offset:0 atIndex:0]; [e setBuffer:bb offset:0 atIndex:1];
+    [e setBuffer:bi offset:0 atIndex:2]; [e setBuffer:bw offset:0 atIndex:3]; [e setBuffer:bk offset:0 atIndex:4];
+    [e setBytes:&E length:4 atIndex:5]; [e setBytes:&K length:4 atIndex:6]; [e setBytes:&Ksel length:4 atIndex:7];
+    [e setBytes:&topp length:4 atIndex:8]; [e setBytes:&normk length:4 atIndex:9]; [e setBytes:&rscale length:4 atIndex:10];
+    if(use_par) [e dispatchThreadgroups:MTLSizeMake((NSUInteger)S,1,1) threadsPerThreadgroup:MTLSizeMake(32,1,1)];
+    else        [e dispatchThreads:MTLSizeMake((NSUInteger)S,1,1) threadsPerThreadgroup:MTLSizeMake((NSUInteger)S,1,1)];
+    [e endEncoding]; [cb commit]; [cb waitUntilCompleted];
+    if(cb.status==MTLCommandBufferStatusError){ fprintf(stderr,"[metal] rtop8 cmdbuf error\n"); return 0; }
+    memcpy(idx,bi.contents,(size_t)S*K*4);
+    memcpy(w,bw.contents,(size_t)S*K*4);
+    memcpy(keff,bk.contents,(size_t)S*4);
   }
   return 1;
 }

--- a/c/tests/test_backend_metal.mm
+++ b/c/tests/test_backend_metal.mm
@@ -177,6 +177,68 @@ static int run_attn(int S, int pos_base, const char* name){
   return pass?0:1;
 }
 
+// serial r_top8 vs parallel r_top8_par on the ENGINE build's own compiled shaders — the
+// exact-match contract (same indices, same order, same weights bitwise, same keff)
+// enforced with memcmp, per adversarial input family. `mode` selects the input
+// construction; see the inventory at the call sites in main(). E is a parameter (not
+// hardcoded 256) so the same helper drives both the original E=256 fuzz and the
+// expert-count-generality cases (E=24 <32-lane-width, E=168 REAP-pruned, E=200
+// lane-straddling boundary, E=257 out-of-contract auto-serial-fallback proof).
+static int run_rtop8(int mode, int S, int E, float topp, int normk, float rscale, const char *name) {
+  const int K=8, Ksel=8;
+  std::vector<float> sig((size_t)S*E), bias(E);
+  srand(4242+mode*17+S+E);
+  for (int e=0;e<E;e++) bias[e]=((rand()%2001)-1000)/1000.f;
+  for (int s=0;s<S;s++) for (int e=0;e<E;e++) {
+    float *v=&sig[(size_t)s*E+e];
+    switch (mode) {
+      case 0: *v=(float)(rand()%10000)/10000.f; break;                  // generic sigmoid-like
+      case 1: *v=0.5f; break;                                           // ALL EQUAL: pure tie-break test
+      case 2: *v=(float)((e/2)%8)/8.f; break;                           // massed duplicates (paired+cyclic ties)
+      case 3: *v=(e%2)?1e-40f:2e-40f; break;                            // denormal logits (flush behavior must match)
+      case 4: *v=(float)(rand()%3)/2.f; break;                          // 3-level ties across the whole row
+      // boundary-forcing: elevate the LAST 4 valid experts (E-4..E-1) to near-max choice
+      // so they are guaranteed in the top-8. For an E whose per-lane block size doesn't
+      // divide E evenly, E-1's lane straddles the E boundary (real indices below E,
+      // sentinel -1e30f at/above E in the SAME ch[] block) -- e.g. E=200: per=ceil(200/
+      // 32)=7, lane 28 owns indices 196..202, of which 196-199 are real and 200-202 are
+      // sentinel. Forcing selection onto 196-199 exercises exactly that lane's per-index
+      // e<E boundary check, rather than hoping random data happens to land there.
+      case 5: *v=(e>=E-4)?1.0f:(float)(rand()%10000)/10000.f; break;
+      default: *v=(float)(rand()%10000)/10000.f; break;
+    }
+  }
+  if (mode==1) for (int e=0;e<E;e++) bias[e]=0.25f;                     // choice fully tied too
+  if (mode==3) for (int e=0;e<E;e++) bias[e]=(e%3)?3e-40f:-3e-40f;      // denormal bias as well
+  if (mode==5) for (int e=E-4;e<E;e++) bias[e]=1.0f;                    // combined choice = 2.0, max possible
+  std::vector<int> is((size_t)S*K), ip((size_t)S*K); std::vector<float> ws((size_t)S*K), wp((size_t)S*K);
+  std::vector<int> ks(S), kp(S);
+  if (!coli_metal_rtop8(0,sig.data(),bias.data(),S,E,K,Ksel,topp,normk,rscale,is.data(),ws.data(),ks.data()) ||
+      !coli_metal_rtop8(1,sig.data(),bias.data(),S,E,K,Ksel,topp,normk,rscale,ip.data(),wp.data(),kp.data())) {
+    printf("  %-34s FAIL (rtop8 runner returned 0)\n", name); return 1; }
+  int ok = memcmp(is.data(),ip.data(),(size_t)S*K*4)==0 &&
+           memcmp(ws.data(),wp.data(),(size_t)S*K*4)==0 &&              // bitwise: same ops, same order
+           memcmp(ks.data(),kp.data(),(size_t)S*4)==0;
+  if (mode==5 && ok) {
+    // Don't just trust the input design -- confirm the straddling lane's valid segment
+    // (E-4..E-1) was actually selected, in EVERY row, so this case can't silently
+    // degrade into an unrelated pass if the input construction above ever changes.
+    for (int s=0;s<S;s++) { int seen=0;
+      for (int k=0;k<K;k++) if (ip[(size_t)s*K+k]>=E-4 && ip[(size_t)s*K+k]<E) seen++;
+      if (seen<4) { printf("  %-34s *** boundary segment not exercised (row %d saw %d/4) -- test setup bug\n", name, s, seen); return 1; }
+    }
+  }
+  if (!ok) {
+    printf("  %-34s *** MISMATCH\n", name);
+    for (int s=0;s<S;s++){ printf("    row %d keff %d/%d:",s,ks[s],kp[s]);
+      for(int k=0;k<K;k++) printf(" [%d]%d/%d %.6g/%.6g",k,is[s*K+k],ip[s*K+k],ws[s*K+k],wp[s*K+k]);
+      printf("\n"); }
+    return 1;
+  }
+  printf("  %-34s ok (serial==parallel bitwise, S=%d E=%d)\n", name, S, E);
+  return 0;
+}
+
 int main(void) {
   if (!coli_metal_init()) { printf("Metal unavailable (skipping)\n"); return 0; }
   printf("Metal backend kernel tests:\n");
@@ -215,6 +277,32 @@ int main(void) {
   fail |= run_attn(1, 37,  "attn S=1 pos=37");
   fail |= run_attn(4, 12,  "attn S=4 pos=12 (MTP)");
   fail |= run_attn(3, 0,   "attn S=3 pos=0");
+  printf("Metal top-8 select serial-vs-parallel tests (exact-match contract, E=256):\n");
+  fail |= run_rtop8(0, 1, 256, 0.0f,  1, 1.0f,   "top8 generic S=1");
+  fail |= run_rtop8(0, 4, 256, 0.0f,  1, 1.0f,   "top8 generic S=4");
+  fail |= run_rtop8(1, 1, 256, 0.0f,  1, 1.0f,   "top8 ALL-EQUAL ties");
+  fail |= run_rtop8(2, 4, 256, 0.0f,  1, 1.0f,   "top8 massed dup ties S=4");
+  fail |= run_rtop8(4, 2, 256, 0.0f,  0, 2.5f,   "top8 3-level ties rscale");
+  fail |= run_rtop8(3, 1, 256, 0.0f,  1, 1.0f,   "top8 denormal logits");
+  fail |= run_rtop8(0, 1, 256, 0.01f, 1, 1.0f,   "top8 topp=0.01 (Ke=1 edge)");
+  fail |= run_rtop8(2, 1, 256, 0.6f,  1, 1.0f,   "top8 topp=0.6 tied weights");
+  fail |= run_rtop8(0, 4, 256, 0.999f,1, 1.75f,  "top8 topp=0.999 S=4");
+  fail |= run_rtop8(1, 2, 256, 0.5f,  0, 1.0f,   "top8 topp on ALL-EQUAL");
+  printf("Metal top-8 select expert-count-generality tests (E!=256, REAP/#428 motivated):\n");
+  fail |= run_rtop8(0, 1, 168, 0.0f,  1, 1.0f,   "top8 E=168 (REAP) generic S=1");
+  fail |= run_rtop8(2, 4, 168, 0.0f,  1, 1.0f,   "top8 E=168 (REAP) massed dup ties S=4");
+  fail |= run_rtop8(0, 1, 24,  0.0f,  1, 1.0f,   "top8 E=24 (<32 lane width) generic");
+  fail |= run_rtop8(1, 1, 24,  0.0f,  1, 1.0f,   "top8 E=24 (<32 lane width) ALL-EQUAL ties");
+  // E=200: per-lane block size ceil(200/32)=7, and 200 is NOT a multiple of 7, so lane 28
+  // (indices 196..202) straddles the boundary -- 196-199 real, 200-202 sentinel -1e30f in
+  // the SAME ch[] block. E=24 and E=168 above both happen to divide evenly by their own
+  // per (24/1, 168/6), so no case before this one exercised a lane whose ch[] mixes real
+  // and sentinel indices. mode 5 deterministically forces indices 196-199 into the top-8
+  // (see run_rtop8) and asserts they were actually selected, rather than hoping random
+  // data lands there -- proving by TEST what the per-index `e<E` check was proven by
+  // reading (both kernels agree bitwise on a selection that requires that check to fire).
+  fail |= run_rtop8(5, 4, 200, 0.0f,  1, 1.0f,   "top8 E=200 (lane straddles E boundary)");
+  fail |= run_rtop8(0, 1, 257, 0.0f,  1, 1.0f,   "top8 E=257 (>256, auto-serial-fallback)");
   printf(fail? "metal backend tests: FAILED\n" : "metal backend tests: ok\n");
   coli_metal_shutdown();
   return fail;


### PR DESCRIPTION
# Metal: parallel top-8 expert selection (r_top8_par), default ON

Cross-references: Feature Request **#428** (results already posted there; this PR is the
promised code). Community REAP-pruned packages (E=168) surfaced in that thread and in
**#426** are the reason this PR also ships expert-count generality, not just the kernel.

Branch: `metal/rtop8-parallel`, based on `origin/dev` @ `61004dc` (post-#391 split:
`c/glm.c` → `c/colibri.c` + headers). Touches only `c/backend_metal.h`, `c/backend_metal.mm`,
`c/tests/test_backend_metal.mm`.

---

## 1. The problem: top-8 selection is a single-thread serial bottleneck

**Durable claim:** on the fused Metal decode path, the top-8 expert-selection kernel
(`r_top8`) runs on ONE serial GPU thread per row, in a threadgroup sized `S` (S=1 for
normal decode, up to 4 for MTP verify) — i.e. at S=1 the entire selection is one GPU
thread doing an O(E·Ksel) greedy scan.

**Checkable coordinates (campaign lineage, not this branch — see §6 for the stamp):**
measured 2026-07-19, macOS 26.5, Apple M5 Max 128 GB. Serial `r_top8`: **0.465 ms/layer
≈ 36 ms/token ≈ 55% of the layer CB** (bench/kernels @ `27bfe83`). Evidence class:
INFERRED — relayed from the campaign's prior bench run; this worker did not re-execute it
(no model runs permitted under this task's constraints; see §7/§8).

## 2. The design: one SIMDGROUP per row, exact-match by construction

`r_top8_par` replaces the single serial thread with one 32-lane SIMDGROUP per row.
Each lane owns `ceil(E/32)` contiguous experts (blocked) and keeps a per-lane "taken"
bitmask. Per selection step: a lane-local strict-`>` ascending scan picks each lane's
local best (lowest index wins ties within a lane, matching the serial kernel's ascending
scan order), then a `simd_shuffle_down` argmax reduction combines the 32 lane-local
bests, with ties preferring the LOWER index — together this reproduces the serial
kernel's first-max-wins ascending order exactly, not approximately. The `topp`/`normk`/
`rscale` tail is the serial code verbatim, run on lane 0 only, same ops in the same
order.

**Exact-match contract, and how it is enforced by test:** `coli_metal_rtop8(par, ...)`
(new standalone entry point, `c/backend_metal.h`) runs either kernel on host-supplied
arrays through the ENGINE's own compiled shaders (not a separate bench tool). metal-test's
`run_rtop8()` calls both `par=0` and `par=1` on identical input and `memcmp`s indices,
weights, and `keff` **bitwise** — not within a numerical tolerance. 16 adversarial input
families are covered (generic, all-equal ties, massed duplicate ties, 3-level ties,
denormal logits, topp truncation at several thresholds, a deterministic lane-boundary
force) across S∈{1,2,4} and, new in this PR, E∈{24,168,200,257} in addition to the
campaign's E=256 (§4). All 16 pass. Evidence class:
**RAN** — `make metal-test` output pasted in §8.

Campaign bench (relayed, not re-run here): the 32-lane replica measured **~93× faster on
the kernel itself**, bit-exact against serial.

## 3. Default-gating: parallel is the default path, serial is the safety net

**Durable core:** the parallel kernel (`r_top8_par`) is now the default execution path.
Gate: `COLI_RTOP8`, **default ON**, governing **the engine's automatic decode-path
dispatch** (`coli_metal_layer_decode`'s internal pipeline choice). `COLI_RTOP8=0` opts
that automatic path out to the serial kernel — it does not touch the standalone
`coli_metal_rtop8(par=1,...)` probe, which intentionally always honors its explicit `par`
argument regardless of this gate (that is how metal-test forces each kernel independently
for the exact-match comparison in §2). This is a rename-and-invert from the campaign's
internal gate (`COLI_RTOP8_PAR`, default OFF) — disclosed explicitly here, not silently
changed.

**Current-state safety measures** (both carry a named removal trigger — see below):

- **(a) Serial kernel retained as the structural fallback** for shapes outside the proven
  envelope. The proven envelope as of this PR: **E≤256**, including non-multiples of the
  32-lane width and small E (validated at E=24, E=168, E=256 — see §4). Outside that
  envelope (E>256), every call site transparently runs the serial kernel instead of the
  parallel one — this is enforced in host code at both the engine dispatch site and the
  standalone runner (§4), not left as an in-kernel silent no-op.
- **(b) The `COLI_RTOP8=0` env opt-out is the field escape hatch.** The bit-exactness
  proof has specific coordinates — Apple M5 Max, macOS 26.5.2, this kernel's E≤256
  contract plus the fuzz families in §2/§4 — and **no maintainer of this repository has
  Metal hardware** (per prior campaign correspondence on #428). If a different Apple GPU
  generation, macOS version, or Metal compiler ever diverges from this proof, the opt-out
  is the only debugging affordance available: it turns "revert the PR" into "set one env
  var while the community diagnoses," without taking the +6.7% away from everyone else in
  the meantime.

**Removal trigger (stated, not open-ended):** once field reports cover the major Apple
GPU generations and the package shapes in active use (stock E=256, REAP E=168, and
whatever else surfaces) without divergence from the exact-match contract, a follow-up PR
should delete the serial kernel and the gate entirely — full replacement is the intended
destination; this PR is the evidence-honest intermediate step, not the final state.

**Rationale for shipping default-ON at all** (rather than default-off + opt-in): the
bit-exactness is proven, not merely benchmarked — same selection, same tie semantics,
same topp/normk/rscale tail. Default-off would deny every Apple user a free +6.7% for a
risk that the exact-match test suite is specifically designed to catch. Precedent: the
maintainer's own #420 fix shipped unconditional (default-on) with no gate.

The SIMD-width-32 assumption in the reduction (`simd_shuffle_down` offsets 16..1, one
32-thread threadgroup per row) is checked at init (`threadExecutionWidth`) independent of
the `COLI_RTOP8` policy gate — see `g_rtop8_width_ok` in `c/backend_metal.mm`. On this
device it holds (`threadExecutionWidth == 32`; RAN, §8, no warning emitted). On a
hypothetical non-32-wide device it degrades to serial automatically, at every call site,
with a one-time stderr notice.

## 4. Expert-count generality (new hard requirement, not in the campaign version)

The campaign fuzzed and shipped this kernel at **E=256 only** (GLM-5.2's stock expert
count). This thread has since surfaced community REAP expert-pruned packages running
**E=168** (GLM-5.2 REAP-504B; see the M5 Pro datapoint on #426) — a shape the kernel was
never validated against.

**What was verified, and how:**

- The kernel's per-lane design (`ch[j] = e<E ? sig[e]+bias[e] : -1e30f` sentinel for
  lanes whose block runs past E) is architecturally E-generic up to the `ch[8]` array
  bound, i.e. `ceil(E/32) ≤ 8` ⟺ **E≤256**. This was already true in the campaign kernel
  body — it was simply untested outside E=256. This PR does not change the kernel body.
- metal-test now exercises E∈{24, 168, 200, 256, 257} via a parameterized
  `run_rtop8(..., E, ...)` (previously hardcoded to 256): **E=24** (below the 32-lane
  width, non-multiple of 32; generic + ties), **E=168** (the REAP width; generic + ties),
  **E=256** (the original 10 campaign cases, unchanged in behavior), **E=257** (one past
  the contract boundary — see below). All pass bitwise. Confirmed with temporary
  instrumentation during this re-derivation that the E=24/168/256 cases genuinely
  dispatch the *parallel* kernel (not a serial-vs-serial tautology) and that E=257
  genuinely dispatches serial on both sides (RAN, not asserted from code reading alone).
- **E=200 specifically targets a lane that straddles the E boundary.** E=24 and E=168
  both happen to divide evenly by their own per-lane block size (`ceil(E/32)`), so no
  case above exercises a lane whose `ch[]` block mixes real and sentinel indices in the
  SAME block. At E=200, `per=ceil(200/32)=7` does not divide 200, so lane 28 (indices
  196-202) has 4 real slots (196-199) and 3 sentinel slots (200-202) together. The audit
  proved by reading that the per-index `e<E` check (`ch[j]=(e<E)?sig[e]+bias[e]:-1e30f`)
  handles this correctly; this test makes that a running, checkable claim: input is
  constructed so indices 196-199 are deterministically the 4 highest-scoring experts
  (forced to the maximum possible combined value, `sig=1.0` and `bias=1.0`, versus a
  background capped below it), and the test additionally asserts — separately from the
  serial/parallel bitwise comparison — that all 4 actually appear in the selection, in
  every row, so the case cannot silently degrade into exercising something else if the
  input construction ever changes. Verified this assertion is load-bearing (not a no-op)
  by temporarily weakening the forced set to 2 experts and confirming it fails with
  `*** boundary segment not exercised (row 0 saw 2/4)`, then restoring.
- **E>256 is out of contract and now falls back to serial everywhere, in host code, not
  just as an in-kernel no-op.** The campaign version's in-kernel `if(E>256) return;` was
  a *silent* no-op if a caller ever requested the parallel pipeline directly with E>256 —
  it left output buffers untouched/poisoned rather than producing a correct answer. This
  PR closes that: both the engine dispatch site and the new standalone
  `coli_metal_rtop8()` now check `E<=256` in host code *before* selecting the pipeline,
  so `par=1` with E>256 transparently runs the serial kernel and returns a correct
  answer. **This is confirmed load-bearing, not defensive dead code:** the new E=257
  metal-test case was verified to fail (bitwise mismatch, poisoned `idx=-1` from the
  campaign-style unconditional pipeline select) when the host-side guard is removed, and
  pass when it is present.

**Disclosed caveat, for completeness (not fixed in this PR):** in the already-undefined
regime `Ksel>=E` — or more precisely, once fewer than `Ksel` real (non-sentinel)
candidates remain — serial and parallel diverge in *how* they misbehave, not just in
result: serial's `best` stays `-1` and it reads `sg[-1]`; parallel's per-lane reduction
converges on the untouched initial sentinel index (`0x7FFFFFFF`) and reads via that
fake, wildly out-of-range index. Both are out-of-bounds reads, in both kernels, as
originally shipped by the campaign — this PR does not introduce or fix either. This
regime is unreachable at every call site exercised here: production traffic is
`E=256, Ksel<=8` (§5), and every metal-test case in this PR uses `Ksel=8` with `E>=24`
(`Ksel < E` always holds). Flagged here rather than fixed because fixing it would touch
the kernel body itself, which is out of scope for a fix round that must leave
`r_top8_par`, the serial kernel, and the guard logic untouched.

**Which shape takes which path, exactly** (the maintainer-facing summary requested for
this section):

| Expert count E | Parallel kernel used? | Why |
|---|---|---|
| E ≤ 256 (incl. E=168 REAP, E=24, non-multiples of 32) | **Yes** (if `COLI_RTOP8` on and SIMD width 32) | Validated bitwise-exact by metal-test |
| E > 256 | **No — serial** | Out of the `ch[8]` contract; host-side guard now enforces this, not just the in-kernel no-op |

**What was NOT extended:** the ENGINE's own MoE dispatch gate at `colibri.c:3142-3146`
(quoted in §5) independently requires `n_experts==256` to reach the fused Metal decode
path *at all* — so today, in this codebase, r_top8_par never actually sees E=168 in
production regardless of its own generality, because a REAP E=168 model never reaches
`coli_metal_layer_decode` in the first place (it falls to the CPU path). This PR does
**not** touch or relax that architecture-shape gate — that is a separate, larger change
(the gate also hardcodes hidden=6144, n_heads=64, q_lora/kv_lora/qk_nope/qk_rope/v_head,
kv_b format, n_shared, moe_inter — all GLM-5.2-specific) outside this PR's scope. What
this PR delivers is: **when that gate is eventually relaxed to admit other expert counts,
the kernel underneath it is already proven correct down to E=24, and the host-side E≤256
check means it will degrade safely rather than silently, for shapes it isn't proven for.**

## 5. Scope statement: exactly which execution paths engage this kernel

Quoted from `c/colibri.c` (this branch's base, `61004dc`, unmodified by this PR):

```c
// colibri.c:3142-3146
if(g_metal_enabled && !kvs && S<=4 && li<c->n_layers && l->sparse
   && (g_absorb==1||(g_absorb<0&&S<=4)) && m->kv_start[li]==0
   && D==6144 && c->n_heads==64 && c->q_lora==2048 && c->kv_lora==512
   && c->qk_nope==192 && c->qk_rope==64 && c->v_head==256 && l->kv_b.fmt==2
   && c->n_experts==256 && c->topk==8 && c->n_shared==1 && c->moe_inter==2048){
```

This is the ONLY call site in the engine that reaches `coli_metal_layer_decode` (and
therefore `r_top8`/`r_top8_par` — the sibling `coli_metal_attn_decode` entry point does
attention only, no routing). Consequences, quoted/derived from the same file:

- **Decode only, not prefill:** the `S<=4` term. A neighboring comment
  (`colibri.c:2346-2350`) makes the same convention explicit elsewhere in the file:
  `"DECODE-ONLY (S<=4, incl. MTP verify): during prefill S=prompt_len the batch union nu
  is 30-100+ experts..."`. During prefill (S=prompt_len, typically 30-2000+), this whole
  condition is false on `S<=4` alone, and the layer falls through unconditionally to the
  CPU path at `colibri.c:3195` (`rmsnorm` → `attention_rows` → `moe()`/`dense_mlp`).
  **Prefill never touches this kernel, on any expert count.**
- **Architecture-locked:** `D==6144 && c->n_heads==64 && ... && c->n_experts==256 && ...`
  — this is GLM-5.2's exact dense-dims + MoE shape. Any other model architecture, or a
  same-architecture model with a different expert count (e.g. REAP E=168), fails this
  condition and falls to the CPU path. This PR's E-generality work (§4) targets what
  happens *inside* the kernel when this gate is eventually loosened — it does not loosen
  the gate itself.
- **CPU path untouched:** the `else` side of this branch (`colibri.c:3195` onward, and
  all of the branch this PR does not touch) is byte-for-byte what `61004dc` already does.
  This PR adds zero new code on any path except the block already gated by the condition
  quoted above.

Evidence class: **QUOTED** (line numbers and text taken directly from this branch's own
`c/colibri.c`, which this PR does not modify — verified with `git diff 61004dc -- c/colibri.c`
producing empty output, §8).

## 6. Campaign measurements (relayed — NOT taken on this branch)

**These numbers were measured on the campaign lineage** (`fuse/rtop8-par` @ `b32439b`,
stacked on the shelved `fuse/cb-chain` @ `1130ac9`, itself off the pre-split fork point
before #391) — **not** on `metal/rtop8-parallel` / `61004dc`. They are relayed here for
context per the spec's request; treat them as historical evidence of the technique, not
as this branch's measured performance. Evidence class: **INFERRED** (relayed from prior
campaign work; this worker ran no model and performed no on-box A/B — see Constraints).

- End-to-end: brackets **2.10/2.11 → 2.24** tok/s-class metric, prose byte-identical
  across arms (×5 repeats).
- attn-gpu component: **71.2 → 35.9 ms/token**.
- Champion config (this kernel plus the rest of the campaign stack) posted on **#428**:
  **2.89**.
- Coordinates: measured 2026-07-19, macOS 26.5, Apple M5 Max 128 GB, campaign lineage
  base (pre-`61004dc`, pre-#391 split).

Note the two OS patch-version stamps in this document — **macOS 26.5** here and in §1
(campaign-lineage numbers) versus **macOS 26.5.2** in §8 (this branch's own gates) — are
intentional, not a typo: two distinct work sessions on the same machine, correctly
distinguished by patch version, not to be conflated as one measurement run.

## 7. On-box A/B on this branch (RAN 2026-07-19, M5 Max 128 GB, macOS 26.5.2, GLM-5.2 int4 744B)

Two interleaved batteries on this branch's binary (engine code identical between the
measured build and final HEAD — the fix-round amendment touched tests/docs only;
verified by empty `git diff` on `backend_metal.*`). Config base: `MTP=0 CAP_RAISE=0
AUTOPIN=0 --ram 90 --temp 0 --ngen 256`, fixed 13-token prompt, `.coli_usage`
snapshot/restored + md5-verified around every run. `COLI_RTOP8=0` = serial arm;
unset = parallel (the shipping default).

**Battery A (5 back-to-back arms, serial/parallel interleaved, cap 1): thermally
contaminated and reported as such** — serial brackets spread 16% (2.25 / 1.96 / 1.94
tok/s) with attention-kernel time swinging 19.8→27.6s at identical dispatch counts
(19,890), the classic throttle signature. End-to-end deltas from this battery are not
usable; its robust results are (a) attention kernel time parallel 10.9–12.7s vs serial
19.8–27.6s in every thermal state, and (b) generated prose byte-identical across all
five arms (single md5).

**Battery B (after a 15-min cooling gap, 120s inter-arm gaps, pairs adjacent — the
measurement):**

| pair | config | serial | parallel | Δ tok/s | attn kernel |
|---|---|---:|---:|---:|---|
| B1/B2 | `--cap 1` (no-cache) | 2.00 | 2.18 | **+9.0%** | 16.98s → 7.86s |
| B3/B4 | `PIPE=1 PIPE_WORKERS=8 IO_THREADS=8 DIRECT=1 --cap 16` | 1.88 | 2.23 | **+18.6%** | 20.37s → 9.73s |

Notes: (1) in each pair the parallel arm ran second (warmer) — run order biases
*against* this PR, so these are floor estimates; (2) at cap 1 the wall-time saved
(10.2s) ≈ kernel time removed (9.1s) — one-for-one conversion; (3) at the overlap
config the wall saved (21.2s) *exceeds* the kernel saved (10.6s): with PIPE active,
shortening the GPU phase also unblocks I/O–compute overlap, so the kernel win
compounds; (4) generated prose **byte-identical across all nine ngen-256 runs of both
batteries** — serial vs parallel within each config, and across both configs (the
only differing log line is the `cap=N ok` status line) — the exact-match contract
held end-to-end under the shipping default through throttle cycles, config changes,
and both kernels. Campaign-lineage numbers (§6) are consistent: +6.7% there, +9.0%
here at the same config family on a newer base.

## 8. Gates run on this branch (all RAN on `metal/rtop8-parallel`, macOS 26.5.2, M5 Max 128 GB)

- `make glm METAL=0` and `make glm METAL=1`: clean, **0 warnings** under `-Wall -Wextra`
  on both, identical to stock `61004dc` (verified by diffing stock vs branch warning
  counts, both 0; the one pre-existing `-Wunused-const-variable` warning on `TG` when
  `backend_metal.mm` is compiled standalone with explicit `-Wall -Wextra` — the Makefile's
  `METALXX` recipe does not pass those flags for that file — was confirmed present
  identically on stock `61004dc`, i.e. not introduced by this PR).
- `make metal-test`: **31/31 cases pass** — the stock 15 (unchanged), the campaign's 10
  exact-match cases (ported, now E-parametric, unchanged behavior at E=256), plus **6 new
  E-generality cases** (E=24 ×2, E=168 ×2, E=200 ×1 lane-straddle, E=257 ×1).
- `make test-c`: all suites, **identical pass counts to stock `61004dc`** (e.g.
  `test_topp: 123 cases run, 0 failure(s)`, `test_dsa_select: 129 cases run, 0
  failure(s)`), exit 0.
- `make test-python`: **77/77 tests, OK**, exit 0, identical to stock.
- `git diff 61004dc -- c/colibri.c`: empty (confirms §5's untouched-CPU-path claim).
- `git diff 61004dc` (this branch's full diff): 3 files, `c/backend_metal.h` (+17),
  `c/backend_metal.mm` (+140/-5), `c/tests/test_backend_metal.mm` (+88). Grepped for
  `cb_chain|CB_CHAIN|MB_BUILD|MB_RESET|mb_r0` (the cb-chain markers from the shelved
  `1130ac9`): **zero matches**.

## 9. Extraction note (for reviewers who know the campaign history)

`fuse/rtop8-par` was stacked on the shelved, NEUTRAL, must-not-ship `fuse/cb-chain`
(`1130ac9`). The two are independent at runtime (the campaign's winning battery arm ran
`CB_CHAIN` off, `RTOP8_PAR` on) but not in git history. `cb-chain` touched only
`SUMMARY.md` and `c/glm.c`; the rtop8 commits (`48b3a98`, `b32439b`) touched only
`SUMMARY.md`, `c/backend_metal.h`, `c/backend_metal.mm`,
`c/tests/test_backend_metal.mm` — disjoint files, confirmed by inspecting each commit's
`--stat` before extraction. This PR re-derives only the latter, directly onto `61004dc`
(53 commits of independent upstream drift past the campaign's fork point, `caa49f7`
/ PR #384), not by cherry-pick (context had drifted) but by manually porting each hunk to
the current file state. See the accompanying hunk-map for the itemized, individually
justified deltas from `b32439b`.
