### PR TITLE
rss_guard: free the evicted expert slab under g_pilot_mx (fixes a use-after-free with the pilot prefetcher)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -4331,16 +4331,21 @@ static void rss_guard(Model *m){
             if(lru<0){ pthread_mutex_unlock(&g_pilot_mx); continue; }
             ESlot *s=&m->ecache[l][lru];
             s->eid=-1;                                    /* nascosto: nessun hit/evict altrui */
-            pthread_mutex_unlock(&g_pilot_mx);
             int64_t sb=s->slab_cap + s->fslab_cap*4;
 #ifdef COLI_METAL
             if(s->slab && g_metal_enabled) coli_metal_unregister(s->slab);
 #endif
+            /* La free resta SOTTO g_pilot_mx. Sbloccando prima, lo slot e' visibile come
+             * {eid=-1, slab ancora valido}: il pilota (pilot_realload) riusa per primo gli
+             * slot eid==-1, quindi puo' prenderlo e fare pread dentro lo slab MENTRE lo
+             * liberiamo -> use-after-free / double-free. Slab valido e slot riusabile
+             * devono restare mutuamente esclusivi finche' il puntatore non e' NULL. */
             compat_aligned_free(s->slab); free(s->fslab);
             s->slab=NULL; s->fslab=NULL; s->slab_cap=s->fslab_cap=0;
             QT *q[3]={&s->g,&s->u,&s->d};
             for(int k=0;k<3;k++){ q[k]->qf=NULL; q[k]->q8=NULL; q[k]->q4=NULL; q[k]->s=NULL; }
             s->used=0;                                    /* primo candidato al riuso */
+            pthread_mutex_unlock(&g_pilot_mx);
             freed += sb; dropped++;
         }
         if(m->ecap>2) m->ecap--;                           /* il tetto scende: niente ricrescita */


### PR DESCRIPTION
## Summary

`rss_guard` published an evicted expert slot as free (`eid = -1`) **under `g_pilot_mx`, then
unlocked, and only then freed `s->slab`**. In that window the slot reads as
`{eid = -1, slab still valid}` — precisely the state `pilot_realload`'s victim scan reuses first
(`if(Sl[z].eid == -1){ slot = z; break; }`). A pilot worker can claim it and `pread` into the
slab while `rss_guard` frees it: **use-after-free**, or a **double-free** if the loader takes its
own realloc path.

This PR keeps the free (and the NULLing) **inside the critical section**, so "slab valid" and
"slot reusable" are never simultaneously observable.

Full analysis in #448.

## Why it matters

- Triggers whenever the RAM guard is active (`RSS_GUARD_GB`, or any resolved `g_ram_budget_gb`)
  **and** the pilot is on — i.e. exactly on RAM-constrained hosts under memory pressure.
- **Reproduces with a single pilot worker**: `rss_guard` runs on the main thread while the pilot
  worker runs in the background. It is not tied to any multi-worker experiment.
- `rss_guard` also decrements `m->ecap`, pushing workers into the reuse branch — so the collision
  gets *more* likely exactly when the guard fires.

## The change

One hunk: move `compat_aligned_free(s->slab); free(s->fslab);` and the pointer/capacity NULLing
above the `pthread_mutex_unlock(&g_pilot_mx)`. The lock is now held across a `free()` (µs); pilot
workers only take it briefly for scan+reserve, so contention is unchanged in practice.

## Validation

- [x] `make -C c check` — portable build 0 warnings, all C unit tests + Python tests pass
- [x] Native (`ARCH=native`) build 0 warnings
- [x] No behaviour change on the non-guard path: the guard's logic, accounting (`freed`,
      `dropped`, `ecap--`) and log line are untouched; only the unlock moves.
- [ ] CUDA (`make -C c cuda-test`) — N/A, CPU-side eviction path only

## Compatibility

- [x] Default CPU build remains dependency-free
- [x] No model files, binaries, or artifacts included

---
*Found and fixed with AI assistance (Claude) while reviewing eviction paths for #441, per the
project's AI-contribution precedent (#428, #398).*
