### PR TITLE
metal: grouped-int4 (fmt=4) GEMV support + two latent fmt=4 fixes

### DIFF
--- a/c/backend_metal.h
+++ b/c/backend_metal.h
@@ -27,16 +27,19 @@ void coli_metal_stats(size_t *tensor_count, size_t *tensor_bytes);
 int  coli_metal_mem_info(size_t *used_bytes, size_t *total_bytes);
 
 /*
- * y[S,O] = (x[S,I] @ W[O,I]^T) * scale[o].
- * fmt matches QT in glm.c: 0=f32, 1=int8, 2=int4(packed), 3=int2(packed).
- * The first successful call wraps W and its row scales in GPU-visible buffers;
- * later calls reuse them (weights are assumed stable at the same address).
+ * y[S,O] = (x[S,I] @ W[O,I]^T) * scale[o]. fmt=4 (grouped int4) instead folds a
+ * PER-GROUP scale into the accumulation -- see the shader comment in backend_metal.mm.
+ * fmt matches QT in colibri.c: 0=f32, 1=int8, 2=int4(packed), 3=int2(packed),
+ * 4=int4(packed, same layout as 2)+per-group scale (gs = group size along I; scale
+ * array is [O, ceil(I/gs)] floats instead of [O]). gs is ignored for fmt!=4 (pass 0).
+ * The first successful call wraps W and its scales in GPU-visible buffers (sized from
+ * fmt+gs); later calls reuse them (weights are assumed stable at the same address).
  * Returns 1 on success, 0 if Metal is unavailable or fmt is invalid.
  */
 int coli_metal_matmul(ColiMetalTensor **tensor,
                       float *y, const float *x,
                       const void *weights, const float *scales,
-                      int fmt, int S, int I, int O);
+                      int fmt, int S, int I, int O, int gs);
 
 void   coli_metal_tensor_free(ColiMetalTensor *tensor);
 size_t coli_metal_tensor_bytes(const ColiMetalTensor *tensor);
@@ -68,14 +71,14 @@ void coli_metal_unregister(void *base);
  */
 int coli_metal_layer_decode(float *x,
     const float *in_ln, const float *post_ln,
-    const void *qa_w, const float *qa_s, int qa_fmt, const float *qa_ln,
-    const void *qb_w, const float *qb_s, int qb_fmt,
-    const void *kva_w, const float *kva_s, int kva_fmt, const float *kva_ln,
+    const void *qa_w, const float *qa_s, int qa_fmt, int qa_gs, const float *qa_ln,
+    const void *qb_w, const float *qb_s, int qb_fmt, int qb_gs,
+    const void *kva_w, const float *kva_s, int kva_fmt, int kva_gs, const float *kva_ln,
     const void *kvb_w, const float *kvb_s, int kvb_fmt,
-    const void *o_w, const float *o_s, int o_fmt,
-    const void *shg_w, const float *shg_s, int shg_fmt,
-    const void *shu_w, const float *shu_s, int shu_fmt,
-    const void *shd_w, const float *shd_s, int shd_fmt,
+    const void *o_w, const float *o_s, int o_fmt, int o_gs,
+    const void *shg_w, const float *shg_s, int shg_fmt, int shg_gs,
+    const void *shu_w, const float *shu_s, int shu_fmt, int shu_gs,
+    const void *shd_w, const float *shd_s, int shd_fmt, int shd_gs,
     const float *router_w, const float *router_bias,
     int E, int K, int Ksel, float topp, int normk, float rscale,
     float *Lc, float *Rc, int S, int pos_base, int st0,
@@ -83,7 +86,7 @@ int coli_metal_layer_decode(float *x,
     float *inrm_out, float *nrm_out, float *sh_out, int *idx_out, float *w_out, int *keff_out);
 
 int coli_metal_gemm(float *y, const float *x, const void *weights, const float *scales,
-                    int fmt, int S, int I, int O);   /* large-batch sync GEMM; 0 -> CPU */
+                    int fmt, int S, int I, int O, int gs);   /* large-batch sync GEMM; 0 -> CPU. gs: fmt=4 group size (0 otherwise) */
 /* Parallel top-8 expert selection (r_top8_par): run ONE top-8 selection kernel standalone
  * on host arrays — par=0 the serial r_top8, par=1 the parallel exact-match replica gated
  * in the engine by COLI_RTOP8 (default ON; COLI_RTOP8=0 opts out to the serial kernel).
@@ -104,11 +107,11 @@ int coli_metal_rtop8(int par, const float *sig, const float *bias, int S, int E,
 void coli_metal_attn_counts(uint64_t *ok, double *wall, double *kernel);
 void coli_metal_attn_lat(double *ksched, double *gsched);
 int coli_metal_attn_decode(const float *x,
-    const void *qa_w, const float *qa_s, int qa_fmt, const float *qa_ln,
-    const void *qb_w, const float *qb_s, int qb_fmt,
-    const void *kva_w, const float *kva_s, int kva_fmt, const float *kva_ln,
+    const void *qa_w, const float *qa_s, int qa_fmt, int qa_gs, const float *qa_ln,
+    const void *qb_w, const float *qb_s, int qb_fmt, int qb_gs,
+    const void *kva_w, const float *kva_s, int kva_fmt, int kva_gs, const float *kva_ln,
     const void *kvb_w, const float *kvb_s, int kvb_fmt,
-    const void *o_w, const float *o_s, int o_fmt,
+    const void *o_w, const float *o_s, int o_fmt, int o_gs,
     float *Lc, float *Rc, int S, int pos_base, int st0, float eps, float theta, float ascale, float *out);
 
 /* Diagnostics: GPU blocks executed, CPU-fallback blocks, experts run on GPU. */
@@ -129,7 +132,11 @@ int coli_metal_resset_stats(double *flush_s);
  *  D           = hidden size, Iinter = moe intermediate size
  *  g/u/d[e]    = pointers to expert e's gate/up/down quantized weights (in RAM slabs)
  *  gs/us/ds[e] = pointers to expert e's per-row scales
- *  fmt         = quant format (shared across experts)
+ *  fmt         = quant format (shared across experts). NOTE: fmt=4 (grouped int4) is
+ *                NOT yet supported here -- gates to {1,2} and returns 0 (CPU fallback)
+ *                for fmt=4 experts, same as before this stage. Grouped-int4 gained GPU
+ *                support in mm_gemv (coli_metal_matmul/coli_metal_gemm/bind_gemv) only;
+ *                extending the batched routed-expert path is future work (see PR_BODY.md).
  *  xg          = packed activations [total_rows, D]; xoff[e] = row offset of expert e
  *  nr[e]       = rows for expert e; rows[]/rw[] map packed rows back to out positions
  *  out         = [S, D] accumulate target

--- a/c/backend_metal.mm
+++ b/c/backend_metal.mm
@@ -9,17 +9,22 @@
 
 // ---- shader: general quantized GEMV, one threadgroup per output element (o,si) ----
 // y[si,o] = (sum_i dequant(W[o,i]) * x[si,i]) * scale[o]. fmt: 0=f32 1=i8 2=i4 3=i2.
+// fmt=4 (grouped int4, dev e9b3614 matmul_i4_grouped, #298/#451 CUDA twin): same packed
+// nibble layout as fmt=2, but scale is PER-GROUP (gsz elements of I), buffer(1) holds
+// [O, ceil(I/gsz)] floats indexed scale[o*ng+g] -- so unlike fmt 1-3, the group scale is
+// folded into the accumulation itself (see the fmt==4 branch), not applied once at the end.
 static const char *SHADER = R"METAL(
 #include <metal_stdlib>
 using namespace metal;
 
 kernel void mm_gemv(device const uchar* w      [[buffer(0)]],   // raw weight bytes
-                    device const float* scale  [[buffer(1)]],   // [O]
+                    device const float* scale  [[buffer(1)]],   // [O] (fmt<4) or [O,ceil(I/gsz)] (fmt==4)
                     device const float* x      [[buffer(2)]],   // [S,I]
                     device float*       y      [[buffer(3)]],   // [S,O]
                     constant int& S [[buffer(4)]], constant int& I [[buffer(5)]],
                     constant int& O [[buffer(6)]], constant int& fmt [[buffer(7)]],
                     constant int& NT [[buffer(8)]],
+                    constant int& gsz [[buffer(9)]],             // fmt==4 group size (ignored otherwise)
                     uint tg [[threadgroup_position_in_grid]],
                     uint slane [[thread_index_in_simdgroup]],
                     uint sgid [[simdgroup_index_in_threadgroup]]) {
@@ -53,6 +58,23 @@ kernel void mm_gemv(device const uchar* w      [[buffer(0)]],   // raw weight by
     for (int i = slane; i < I; i += 32) {
       uchar b = wr[i>>2]; int v = (b >> (2*(i&3))) & 0x3; acc += float(v-2) * xr[i];
     }
+  } else if (fmt == 4) {                            // int4 GROUPED: same nibble packing as fmt=2,
+                                                     // one f32 scale per gsz-element group along I.
+                                                     // Each lane owns one packed byte (2 elements) per
+                                                     // 64-lane stride -> memory access stays coalesced,
+                                                     // and a group never splits a byte (gsz is even).
+    int rb = (I+1)/2; int ng = (I+gsz-1)/gsz;
+    device const uchar* wr = w + (long)o * rb;
+    device const float* scl = scale + (long)o * ng;
+    for (int i = slane*2; i < I; i += 64) {
+      uchar b = wr[i>>1];
+      int g0 = i / gsz; float sc0 = scl[g0];
+      acc += float(int(b&0xF)-8) * xr[i] * sc0;
+      if (i+1 < I) {
+        int g1 = (i+1) / gsz; float sc1 = (g1==g0) ? sc0 : scl[g1];
+        acc += float(int(b>>4)-8) * xr[i+1] * sc1;
+      }
+    }
   } else {                                          // f32
     device const float* wr = (device const float*)(w) + (long)o * I;
     device const float4* w4 = (device const float4*)wr;
@@ -60,7 +82,8 @@ kernel void mm_gemv(device const uchar* w      [[buffer(0)]],   // raw weight by
     for (int i = I8*8 + slane; i < I; i += 32) acc += wr[i] * xr[i];
   }
   acc = simd_sum(acc);
-  if (slane == 0) y[row] = acc * scale[o];
+  // fmt==4 already folded the per-group scale into acc above -- do not scale again.
+  if (slane == 0) y[row] = (fmt == 4) ? acc : acc * scale[o];
 }
 
 // Batched bindless expert GEMV: each row gr belongs to expert erow[gr], whose weight and
@@ -401,7 +424,13 @@ static size_t fmt_bytes(int fmt, int I, int O) {
   if (fmt == 1) return (size_t)O * I;
   if (fmt == 2) return (size_t)O * ((I+1)/2);
   if (fmt == 3) return (size_t)O * ((I+3)/4);
+  if (fmt == 4) return (size_t)O * ((I+1)/2);   // grouped int4: identical packed-nibble layout to fmt=2
   return (size_t)O * I * sizeof(float);
+}
+// Grouped-int4 (fmt=4) scale-array size: one f32 per gsz-element group, per row -> O*ceil(I/gsz).
+static size_t fmt_scale_bytes(int fmt, int I, int O, int gs) {
+  if (fmt == 4) return (size_t)O * ((I + gs - 1) / gs) * sizeof(float);
+  return (size_t)O * sizeof(float);
 }
 
 // Wrap host memory zero-copy if page-aligned, else copy into a shared buffer.
@@ -560,15 +589,15 @@ extern "C" int  coli_metal_mem_info(size_t *used, size_t *total) {
 
 extern "C" int coli_metal_matmul(ColiMetalTensor **tp, float *y, const float *x,
                                  const void *weights, const float *scales,
-                                 int fmt, int S, int I, int O) {
-  if (!g_dev || fmt < 0 || fmt > 3) return 0;
+                                 int fmt, int S, int I, int O, int gs) {
+  if (!g_dev || fmt < 0 || fmt > 4) return 0;
   @autoreleasepool {
     ColiMetalTensor *t = *tp;
     if (!t) {
       t = new ColiMetalTensor();
       t->fmt = fmt; t->I = I; t->O = O; t->wbytes = fmt_bytes(fmt, I, O);
       t->w = wrap(weights, t->wbytes);
-      t->s = wrap(scales, (size_t)O * sizeof(float));
+      t->s = wrap(scales, fmt_scale_bytes(fmt, I, O, gs));
       *tp = t;
       g_tensor_count++; g_tensor_bytes += t->wbytes;
     }
@@ -582,7 +611,7 @@ extern "C" int coli_metal_matmul(ColiMetalTensor **tp, float *y, const float *x,
     int NT=S*O;
     [e setBytes:&S length:4 atIndex:4]; [e setBytes:&I length:4 atIndex:5];
     [e setBytes:&O length:4 atIndex:6]; [e setBytes:&fmt length:4 atIndex:7];
-    [e setBytes:&NT length:4 atIndex:8];
+    [e setBytes:&NT length:4 atIndex:8]; [e setBytes:&gs length:4 atIndex:9];
     [e dispatchThreadgroups:MTLSizeMake(((size_t)NT+3)/4,1,1) threadsPerThreadgroup:MTLSizeMake(128,1,1)];
     [e endEncoding]; [cb commit]; [cb waitUntilCompleted];
     memcpy(y, [by contents], (size_t)S*O*sizeof(float));
@@ -605,7 +634,9 @@ static void attn_scratch_init(){
 }
 // y[S,O] = quantized-weight(w) applied to xin[S,I]. Weights are registered (page-aligned,
 // zero-copy) at model load; resolve to (buffer,offset). Returns false to fall back to CPU.
-static bool bind_gemv(id<MTLComputeCommandEncoder> e, const void* w, const float* s, int fmt, int I, int O,
+// gs: fmt=4 group size (ignored for fmt!=4; callers pass QT.gs, which is 0 for non-grouped
+// tensors -- harmless, since the shader only reads it when fmt==4).
+static bool bind_gemv(id<MTLComputeCommandEncoder> e, const void* w, const float* s, int fmt, int gs, int I, int O,
                       id<MTLBuffer> xin, id<MTLBuffer> yout, int S){
   uint64_t wa=0,sa=0; id<MTLBuffer> wb=resolve(w,&wa); id<MTLBuffer> sb=resolve(s,&sa);
   if(!wb||!sb) return false;
@@ -616,19 +647,22 @@ static bool bind_gemv(id<MTLComputeCommandEncoder> e, const void* w, const float
   [e setBuffer:xin offset:0 atIndex:2]; [e setBuffer:yout offset:0 atIndex:3];
   int NT=S*O;
   [e setBytes:&S length:4 atIndex:4]; [e setBytes:&I length:4 atIndex:5]; [e setBytes:&O length:4 atIndex:6]; [e setBytes:&fmt length:4 atIndex:7];
-  [e setBytes:&NT length:4 atIndex:8];
+  [e setBytes:&NT length:4 atIndex:8]; [e setBytes:&gs length:4 atIndex:9];
   [e dispatchThreadgroups:MTLSizeMake(((size_t)NT+3)/4,1,1) threadsPerThreadgroup:MTLSizeMake(128,1,1)];
   return true;
 }
 
 // Weight-pointer bundle for one layer's attention (+optional layer tail). All pointers
-// must be inside registered allocations.
+// must be inside registered allocations. *_gs: fmt=4 group size for the corresponding
+// weight (0 if that weight isn't grouped). kv_b has none: it never flows through bind_gemv
+// -- a_qabs/a_ctx dequantize it inline with a PER-ROW-only helper (a_deqrow), so a fmt=4
+// kv_b is out of scope for this stage (see PR_BODY.md UNCERTAINTIES).
 typedef struct {
-  const void *qa_w; const float *qa_s; int qa_fmt; const float *qa_ln;
-  const void *qb_w; const float *qb_s; int qb_fmt;
-  const void *kva_w; const float *kva_s; int kva_fmt; const float *kva_ln;
+  const void *qa_w; const float *qa_s; int qa_fmt; int qa_gs; const float *qa_ln;
+  const void *qb_w; const float *qb_s; int qb_fmt; int qb_gs;
+  const void *kva_w; const float *kva_s; int kva_fmt; int kva_gs; const float *kva_ln;
   const void *kvb_w; const float *kvb_s; int kvb_fmt;
-  const void *o_w;  const float *o_s;  int o_fmt;
+  const void *o_w;  const float *o_s;  int o_fmt; int o_gs;
 } AttnW;
 
 // Encode the fused attention chain into encoder e. Input: ax_ holds the NORMED x [S,AH].
@@ -651,10 +685,10 @@ static bool encode_attention(id<MTLComputeCommandEncoder> e, const AttnW *W,
       [e setBuffer:acomp_ offset:0 atIndex:0]; [e setBytes:&off length:4 atIndex:1]; [e setBytes:&ss length:4 atIndex:2];
       [e setBuffer:dst offset:doff atIndex:3]; [e setBytes:&n length:4 atIndex:4]; [e setBytes:&n length:4 atIndex:5];
       [e dispatchThreads:MTLSizeMake((size_t)S*n,1,1) threadsPerThreadgroup:MTLSizeMake(64,1,1)]; };
-    bind_gemv(e,W->qa_w,W->qa_s,W->qa_fmt,AH,AQLORA,ax_,aqr_,S);
-    bind_gemv(e,W->kva_w,W->kva_s,W->kva_fmt,AH,AKVL+AROPE,ax_,acomp_,S); BAR();
+    bind_gemv(e,W->qa_w,W->qa_s,W->qa_fmt,W->qa_gs,AH,AQLORA,ax_,aqr_,S);
+    bind_gemv(e,W->kva_w,W->kva_s,W->kva_fmt,W->kva_gs,AH,AKVL+AROPE,ax_,acomp_,S); BAR();
     rms(aqr_,0,aqaln_,AQLORA,S); cpy(0,Lb,Loff,AKVL); cpy(AKVL,Rb,Roff,AROPE); BAR();
-    bind_gemv(e,W->qb_w,W->qb_s,W->qb_fmt,AQLORA,AHQH,aqr_,aqf_,S); rms(Lb,Loff,akvaln_,AKVL,S); rope(Rb,Roff,0,AROPE,0,1); BAR();
+    bind_gemv(e,W->qb_w,W->qb_s,W->qb_fmt,W->qb_gs,AQLORA,AHQH,aqr_,aqf_,S); rms(Lb,Loff,akvaln_,AKVL,S); rope(Rb,Roff,0,AROPE,0,1); BAR();
     rope(aqf_,0,ANOPE,AHQH,AQH,AHEADS); BAR();
     [e setComputePipelineState:g_a_qabs]; [e setBuffer:kvbW offset:kvbwoff atIndex:0]; [e setBuffer:kvbS offset:kvbsoff atIndex:1]; [e setBuffer:aqf_ offset:0 atIndex:2]; [e setBuffer:aqabs_ offset:0 atIndex:3];
     [e dispatchThreads:MTLSizeMake((size_t)S*AHEADS*AKVL,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; BAR();
@@ -667,7 +701,7 @@ static bool encode_attention(id<MTLComputeCommandEncoder> e, const AttnW *W,
     [e dispatchThreads:MTLSizeMake((size_t)S*AHEADS*AKVL,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; BAR();
     [e setComputePipelineState:g_a_ctx]; [e setBuffer:kvbW offset:kvbwoff atIndex:0]; [e setBuffer:kvbS offset:kvbsoff atIndex:1]; [e setBuffer:aclat_ offset:0 atIndex:2]; [e setBuffer:actx_ offset:0 atIndex:3];
     [e dispatchThreads:MTLSizeMake((size_t)S*AHEADS*AVH,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; BAR();
-    bind_gemv(e,W->o_w,W->o_s,W->o_fmt,AHVH,AH,actx_,aout_,S);
+    bind_gemv(e,W->o_w,W->o_s,W->o_fmt,W->o_gs,AHVH,AH,actx_,aout_,S);
     return true;
 }
 // Resolve Lc/Rc + kv_b (+pre-check the projection weights). Returns false -> CPU fallback.
@@ -685,18 +719,18 @@ static bool resolve_attn(const AttnW *W, float *Lc, float *Rc,
 }
 
 extern "C" int coli_metal_attn_decode(const float* x,
-    const void* qa_w,const float* qa_s,int qa_fmt,const float* qa_ln,
-    const void* qb_w,const float* qb_s,int qb_fmt,
-    const void* kva_w,const float* kva_s,int kva_fmt,const float* kva_ln,
+    const void* qa_w,const float* qa_s,int qa_fmt,int qa_gs,const float* qa_ln,
+    const void* qb_w,const float* qb_s,int qb_fmt,int qb_gs,
+    const void* kva_w,const float* kva_s,int kva_fmt,int kva_gs,const float* kva_ln,
     const void* kvb_w,const float* kvb_s,int kvb_fmt,
-    const void* o_w,const float* o_s,int o_fmt,
+    const void* o_w,const float* o_s,int o_fmt,int o_gs,
     float* Lc,float* Rc,int S,int pos_base,int st0,float eps,float theta,float ascale,float* out){
   if(!g_dev) return 0;
   if(st0!=0 || S<1 || S>AMAXS) return 0;     // partial-KV / S>4 -> CPU
   int T=pos_base+S;
   @autoreleasepool {
     attn_scratch_init();
-    AttnW W={qa_w,qa_s,qa_fmt,qa_ln,qb_w,qb_s,qb_fmt,kva_w,kva_s,kva_fmt,kva_ln,kvb_w,kvb_s,kvb_fmt,o_w,o_s,o_fmt};
+    AttnW W={qa_w,qa_s,qa_fmt,qa_gs,qa_ln,qb_w,qb_s,qb_fmt,qb_gs,kva_w,kva_s,kva_fmt,kva_gs,kva_ln,kvb_w,kvb_s,kvb_fmt,o_w,o_s,o_fmt,o_gs};
     id<MTLBuffer> Lb,Rb,kvbW,kvbS; size_t loff,roff,kvbwoff,kvbsoff;
     if(!resolve_attn(&W,Lc,Rc,&Lb,&loff,&Rb,&roff,&kvbW,&kvbwoff,&kvbS,&kvbsoff)) return 0;
     ascore_=ensure(ascore_,&ascore_cap,(size_t)S*AHEADS*T*4);
@@ -723,14 +757,14 @@ extern "C" int coli_metal_attn_decode(const float* x,
 // idx/w/keff (routing). Returns 0 -> CPU fallback (whole layer falls back).
 extern "C" int coli_metal_layer_decode(float *x,
     const float *in_ln, const float *post_ln,
-    const void* qa_w,const float* qa_s,int qa_fmt,const float* qa_ln,
-    const void* qb_w,const float* qb_s,int qb_fmt,
-    const void* kva_w,const float* kva_s,int kva_fmt,const float* kva_ln,
+    const void* qa_w,const float* qa_s,int qa_fmt,int qa_gs,const float* qa_ln,
+    const void* qb_w,const float* qb_s,int qb_fmt,int qb_gs,
+    const void* kva_w,const float* kva_s,int kva_fmt,int kva_gs,const float* kva_ln,
     const void* kvb_w,const float* kvb_s,int kvb_fmt,
-    const void* o_w,const float* o_s,int o_fmt,
-    const void* shg_w,const float* shg_s,int shg_fmt,
-    const void* shu_w,const float* shu_s,int shu_fmt,
-    const void* shd_w,const float* shd_s,int shd_fmt,
+    const void* o_w,const float* o_s,int o_fmt,int o_gs,
+    const void* shg_w,const float* shg_s,int shg_fmt,int shg_gs,
+    const void* shu_w,const float* shu_s,int shu_fmt,int shu_gs,
+    const void* shd_w,const float* shd_s,int shd_fmt,int shd_gs,
     const float *router_w, const float *router_bias,
     int E, int K, int Ksel, float topp, int normk, float rscale,
     float *Lc, float *Rc, int S, int pos_base, int st0,
@@ -741,7 +775,7 @@ extern "C" int coli_metal_layer_decode(float *x,
   int T=pos_base+S; const int SI=2048;
   @autoreleasepool {
     attn_scratch_init();
-    AttnW W={qa_w,qa_s,qa_fmt,qa_ln,qb_w,qb_s,qb_fmt,kva_w,kva_s,kva_fmt,kva_ln,kvb_w,kvb_s,kvb_fmt,o_w,o_s,o_fmt};
+    AttnW W={qa_w,qa_s,qa_fmt,qa_gs,qa_ln,qb_w,qb_s,qb_fmt,qb_gs,kva_w,kva_s,kva_fmt,kva_gs,kva_ln,kvb_w,kvb_s,kvb_fmt,o_w,o_s,o_fmt,o_gs};
     id<MTLBuffer> Lb,Rb,kvbW,kvbS; size_t loff,roff,kvbwoff,kvbsoff;
     if(!resolve_attn(&W,Lc,Rc,&Lb,&loff,&Rb,&roff,&kvbW,&kvbwoff,&kvbS,&kvbsoff)) return 0;
     uint64_t ina=0,pna=0,rwa=0,rba=0,d;
@@ -778,8 +812,8 @@ extern "C" int coli_metal_layer_decode(float *x,
     [e dispatchThreads:MTLSizeMake((size_t)S*AH,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; BAR();
     copyrow(axr_,anrm_,AH); BAR(); rmsw(anrm_,pnB,pnoff,AH,S); BAR();
     // 4) shared expert gate/up + router (all read anrm_, independent)
-    bind_gemv(e,shg_w,shg_s,shg_fmt,AH,SI,anrm_,ash1_,S);
-    bind_gemv(e,shu_w,shu_s,shu_fmt,AH,SI,anrm_,ash2_,S);
+    bind_gemv(e,shg_w,shg_s,shg_fmt,shg_gs,AH,SI,anrm_,ash1_,S);
+    bind_gemv(e,shu_w,shu_s,shu_fmt,shu_gs,AH,SI,anrm_,ash2_,S);
     { int NT=S*E, D=AH; [e setComputePipelineState:g_r_router];
       [e setBuffer:rwB offset:rwoff atIndex:0]; [e setBuffer:anrm_ offset:0 atIndex:1]; [e setBuffer:asig_ offset:0 atIndex:2];
       [e setBytes:&E length:4 atIndex:3]; [e setBytes:&D length:4 atIndex:4]; [e setBytes:&NT length:4 atIndex:5];
@@ -806,7 +840,7 @@ extern "C" int coli_metal_layer_decode(float *x,
       else        [e dispatchThreads:MTLSizeMake(S,1,1) threadsPerThreadgroup:MTLSizeMake(S,1,1)]; }
     BAR();
     // 6) shared down
-    bind_gemv(e,shd_w,shd_s,shd_fmt,SI,AH,ash1_,ashout_,S);
+    bind_gemv(e,shd_w,shd_s,shd_fmt,shd_gs,SI,AH,ash1_,ashout_,S);
     double tc=mnow();
     [e endEncoding]; [cb commit]; [cb waitUntilCompleted];
     if(cb.status==MTLCommandBufferStatusError){ fprintf(stderr,"[metal] layer cmdbuf error: %s\n", cb.error?[[cb.error localizedDescription]UTF8String]:"?"); return 0; }
@@ -827,8 +861,8 @@ extern "C" int coli_metal_layer_decode(float *x,
 // registered (zero-copy); x/y go through grow-only shared scratch. Returns 0 -> CPU fallback.
 static id<MTLBuffer> g_gx, g_gy; static size_t g_gx_cap, g_gy_cap;
 extern "C" int coli_metal_gemm(float *y, const float *x, const void *wp, const float *sp,
-                               int fmt, int S, int I, int O) {
-  if (!g_dev || (fmt!=1 && fmt!=2)) return 0;
+                               int fmt, int S, int I, int O, int gs) {
+  if (!g_dev || (fmt!=1 && fmt!=2 && fmt!=4)) return 0;
   @autoreleasepool {
     uint64_t wa=0,sa=0; id<MTLBuffer> wb=resolve(wp,&wa), sb=resolve(sp,&sa);
     if(!wb||!sb) return 0;
@@ -841,6 +875,7 @@ extern "C" int coli_metal_gemm(float *y, const float *x, const void *wp, const f
     [e setBuffer:wb offset:woff atIndex:0]; [e setBuffer:sb offset:soff atIndex:1];
     [e setBytes:&I length:4 atIndex:5];
     [e setBytes:&O length:4 atIndex:6]; [e setBytes:&fmt length:4 atIndex:7];
+    [e setBytes:&gs length:4 atIndex:9];   /* loop-invariant, like I/O/fmt: group size for fmt=4 (0 = per-row) */
     // Grid-size cap. One dispatch of NT=S*O output elements launches (NT+3)/4 threadgroups; past
     // a device grid limit (observed on M-series: kv_b grid ~3.1e7 tg clean at S=4376, ~5.4e7 tg
     // CORRUPT at S=7478) rows beyond the limit are silently never computed and the output keeps

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -547,9 +547,9 @@ static void matmul_i4_grouped_pair(float *yg, float *yu, const float *x,
  * (~+12% perplexity), measured. Every other prefill matmul keeps IDOT as before. */
 static void matmul_qt_ex(float *y, const float *x, QT *w, int S, int allow_idot){
 #ifdef COLI_METAL
-    if(g_metal_enabled && S>=g_metal_gemm_min && !spec_pinned() && (w->fmt==1||w->fmt==2) && !omp_in_parallel()){
+    if(g_metal_enabled && S>=g_metal_gemm_min && !spec_pinned() && (w->fmt==1||w->fmt==2||w->fmt==4) && !omp_in_parallel()){
         const void *wp = w->fmt==1 ? (const void*)w->q8 : (const void*)w->q4;
-        if(coli_metal_gemm(y,x,wp,w->s,w->fmt,S,w->I,w->O)) return;
+        if(coli_metal_gemm(y,x,wp,w->s,w->fmt,S,w->I,w->O,w->gs)) return;
     }
 #endif
 #ifdef COLI_CUDA
@@ -2374,11 +2374,11 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
             }
             #define WP_(q) ((q).fmt==1?(const void*)(q).q8:(const void*)(q).q4)
             int ok = coli_metal_attn_decode(x,
-                WP_(l->q_a), l->q_a.s, l->q_a.fmt, l->q_a_ln,
-                WP_(l->q_b), l->q_b.s, l->q_b.fmt,
-                WP_(l->kv_a), l->kv_a.s, l->kv_a.fmt, l->kv_a_ln,
+                WP_(l->q_a), l->q_a.s, l->q_a.fmt, l->q_a.gs, l->q_a_ln,
+                WP_(l->q_b), l->q_b.s, l->q_b.fmt, l->q_b.gs,
+                WP_(l->kv_a), l->kv_a.s, l->kv_a.fmt, l->kv_a.gs, l->kv_a_ln,
                 WP_(l->kv_b), l->kv_b.s, l->kv_b.fmt,
-                WP_(l->o), l->o.s, l->o.fmt,
+                WP_(l->o), l->o.s, l->o.fmt, l->o.gs,
                 m->Lc[layer], m->Rc[layer], S, pos_base, m->kv_start[layer], c->eps, c->theta, c->attn_scale, out);
             #undef WP_
             if(ok){ m->t_attn += now_s()-ta0; return; }
@@ -4207,14 +4207,14 @@ static void layer_forward_rows(Model *m, Layer *l, int li, float *x, int S, int 
             double ta0=now_s();
             #define WP_(q) ((q).fmt==1?(const void*)(q).q8:(const void*)(q).q4)
             int ok = coli_metal_layer_decode(x, l->in_ln, l->post_ln,
-                WP_(l->q_a), l->q_a.s, l->q_a.fmt, l->q_a_ln,
-                WP_(l->q_b), l->q_b.s, l->q_b.fmt,
-                WP_(l->kv_a), l->kv_a.s, l->kv_a.fmt, l->kv_a_ln,
+                WP_(l->q_a), l->q_a.s, l->q_a.fmt, l->q_a.gs, l->q_a_ln,
+                WP_(l->q_b), l->q_b.s, l->q_b.fmt, l->q_b.gs,
+                WP_(l->kv_a), l->kv_a.s, l->kv_a.fmt, l->kv_a.gs, l->kv_a_ln,
                 WP_(l->kv_b), l->kv_b.s, l->kv_b.fmt,
-                WP_(l->o), l->o.s, l->o.fmt,
-                WP_(l->sh_gate), l->sh_gate.s, l->sh_gate.fmt,
-                WP_(l->sh_up),   l->sh_up.s,   l->sh_up.fmt,
-                WP_(l->sh_down), l->sh_down.s, l->sh_down.fmt,
+                WP_(l->o), l->o.s, l->o.fmt, l->o.gs,
+                WP_(l->sh_gate), l->sh_gate.s, l->sh_gate.fmt, l->sh_gate.gs,
+                WP_(l->sh_up),   l->sh_up.s,   l->sh_up.fmt,   l->sh_up.gs,
+                WP_(l->sh_down), l->sh_down.s, l->sh_down.fmt, l->sh_down.gs,
                 l->router, l->router_bias,
                 c->n_experts, c->topk, Ksel, tp, c->norm_topk, c->routed_scale,
                 m->Lc[li], m->Rc[li], S, pos_base, m->kv_start[li],

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -1039,7 +1039,14 @@ static void qt_from_disk(Model *m, const char *name, int O, int I, int bits, int
         int fmt = qt_resolve_fmt(name,O,I,nb,ns,&gs);
         if(fmt==1){ if(t->fmt!=1||!t->q8){ t->fmt=1; t->O=O; t->I=I; t->gs=0; t->q8=qalloc(nb); t->s=qsalloc(O); } st_read_raw(&m->S,name,t->q8,drop); }
         else if(fmt==4){ int ng=(I+gs-1)/gs;
-            if(t->fmt!=4||!t->q4){ t->fmt=4; t->O=O; t->I=I; t->gs=gs; t->q4=qalloc(nb); t->s=falloc((int64_t)O*ng); }
+            /* METAL: t->s must be page-aligned + coli_metal_register'd like every other
+             * fmt's scale buffer (qsalloc, used by fmt 1/2/3 just below/above), or
+             * bind_gemv/coli_metal_gemm's resolve(t->s,...) can never find it and the
+             * whole GPU dispatch silently CPU-falls-back (safe, but defeats the point of
+             * wiring fmt=4 into the shader at all). falloc() here was a plain malloc --
+             * O*ng floats never registered -- found while tracing the per-row-scale path
+             * this stage extends to per-group; fixed alongside it. */
+            if(t->fmt!=4||!t->q4){ t->fmt=4; t->O=O; t->I=I; t->gs=gs; t->q4=qalloc(nb); t->s=(float*)qalloc((size_t)O*(size_t)ng*sizeof(float)); }
             st_read_raw(&m->S,name,t->q4,drop); }
         else if(fmt==5){ int64_t ng=i3_groups(I);   /* int3-g64: 24B/group weights + O*ng group scales */
             if(t->fmt!=5||!t->q4){ t->fmt=5; t->O=O; t->I=I; t->gs=0; t->q4=qalloc(nb); t->s=falloc((int64_t)O*ng); }

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -1045,7 +1045,13 @@ static void qt_from_disk(Model *m, const char *name, int O, int I, int bits, int
              * whole GPU dispatch silently CPU-falls-back (safe, but defeats the point of
              * wiring fmt=4 into the shader at all). falloc() here was a plain malloc --
              * O*ng floats never registered -- found while tracing the per-row-scale path
-             * this stage extends to per-group; fixed alongside it. */
+             * this stage extends to per-group; fixed alongside it.
+             * Trade-off (this site is NOT #ifdef COLI_METAL): on a CPU-only build this
+             * swaps falloc's checked-exit overflow/OOM guard for qalloc's unchecked
+             * malloc -- same hole qsalloc already has for fmt 1/2/3, so consistency,
+             * not a new class; noted rather than silent. fmt=5's group scales (just
+             * below) still use falloc and so remain Metal-inert -- pre-existing,
+             * inconsistent after this change, a candidate for whoever wires fmt=5. */
             if(t->fmt!=4||!t->q4){ t->fmt=4; t->O=O; t->I=I; t->gs=gs; t->q4=qalloc(nb); t->s=(float*)qalloc((size_t)O*(size_t)ng*sizeof(float)); }
             st_read_raw(&m->S,name,t->q4,drop); }
         else if(fmt==5){ int64_t ng=i3_groups(I);   /* int3-g64: 24B/group weights + O*ng group scales */

--- a/c/tests/test_backend_metal.mm
+++ b/c/tests/test_backend_metal.mm
@@ -1,5 +1,8 @@
 // Kernel-correctness test for the Metal backend: coli_metal_matmul vs CPU reference
 // (dequant->f32 MAC * per-row scale) for f32/int8/int4/int2 across real GLM shapes.
+// fmt=4 (grouped int4, dev e9b3614 matmul_i4_grouped / CUDA #298 twin) gets its own
+// reference (cpu_ref_grouped) and harness (run_grouped) below -- unlike fmt 1-3 the
+// group scale is per-GROUP, not per-row, so it can't share cpu_ref's [O] scale layout.
 #include "../backend_metal.h"
 #include <cstdio>
 #include <cstdlib>
@@ -7,7 +10,7 @@
 #include <cmath>
 #include <vector>
 
-enum { F32=0, I8=1, I4=2, I2=3 };
+enum { F32=0, I8=1, I4=2, I2=3, I4G=4 };
 
 static void cpu_ref(int fmt, const void *W, const float *s, const float *x,
                     float *y, int S, int I, int O) {
@@ -41,13 +44,91 @@ static int run(int fmt, int O, int I, int S, const char *name) {
   for(auto&v:x) v=((rand()%2000)-1000)/1000.f;
   cpu_ref(fmt, Wp, s.data(), x.data(), yr.data(), S, I, O);
   ColiMetalTensor *t=nullptr;
-  if (!coli_metal_matmul(&t, yg.data(), x.data(), Wp, s.data(), fmt, S, I, O)) {
+  if (!coli_metal_matmul(&t, yg.data(), x.data(), Wp, s.data(), fmt, S, I, O, 0)) {
     printf("  %-22s FAIL (matmul returned 0)\n", name); return 1; }
   double maxabs=0, ymax=0;
   for(size_t i=0;i<(size_t)S*O;i++){ maxabs=fmax(maxabs,fabs(yg[i]-yr[i])); ymax=fmax(ymax,fabs(yr[i])); }
   double nerr=maxabs/(ymax+1e-9);
   int ok = nerr < 1e-4;
   printf("  %-22s nerr=%.2e  %s\n", name, nerr, ok?"ok":"*** MISMATCH");
+  coli_metal_tensor_free(t);
+  return ok?0:1;
+}
+
+// ---- fmt=4 (grouped int4): own CPU reference + harness -----------------------------
+// cpu_ref's [O] per-row scale layout can't express fmt=4's [O,ceil(I/gs)] per-group
+// scale, so this is a separate reference rather than a branch of cpu_ref. Mirrors
+// quant.h's matmul_i4_grouped exactly (same nibble decode, same group indexing i/gs)
+// and accumulates in DOUBLE, matching the convention tests/test_i4_grouped.c already
+// established as the fmt=4 oracle for the CUDA port (#298) -- reusing it here means the
+// Metal kernel is checked against the same "known exact" reference, not a third one.
+static void cpu_ref_grouped(const uint8_t *q4, const float *scale, const float *x,
+                            double *y, double *mag, int S, int I, int O, int gs) {
+  int rb=(I+1)/2, ng=(I+gs-1)/gs;
+  for (int o=0;o<O;o++){
+    const uint8_t *w = q4 + (size_t)o*rb;
+    const float *scl = scale + (size_t)o*ng;
+    for (int s=0;s<S;s++){
+      const float *xs = x + (size_t)s*I; double a=0, m=0;
+      for (int i=0;i<I;i++){
+        uint8_t b = w[i>>1]; int nib = (i&1) ? (int)(b>>4) : (int)(b&0xF);
+        double term = (double)xs[i] * (double)(nib-8) * (double)scl[i/gs];
+        a += term; m += fabs(term);
+      }
+      y[(size_t)s*O+o] = a; mag[(size_t)s*O+o] = m;
+    }
+  }
+}
+
+// Tolerance: magnitude-relative (error / sum of |terms|), NOT the ymax-relative-max-
+// abs-error convention run() above uses. Reason: a dot product over many groups can
+// land near zero from signed-term cancellation, and a fixed-point-ish absolute GPU/CPU
+// rounding difference then reads as a huge relative error against the (near-zero)
+// RESULT -- that is the accumulator's precision, not a kernel defect. Comparing against
+// the sum of |terms| instead means a wrong scale index or wrong group boundary is still
+// caught as an O(1) relative error (it shifts the result by a fraction of the terms),
+// while cancellation noise is not misreported as a bug. This is the exact convention
+// tests/test_i4_grouped.c uses for the same kernel's CPU-side oracle (see its
+// `ref_grouped`/`mag` comment) -- reused here for a GPU oracle of the same format.
+// 1e-4 (vs. test_i4_grouped.c's 1e-6) because the GPU sums in a different order --
+// byte-pair-strided across 32 SIMD lanes then simd_sum -- than the scalar double
+// reference; that's the same 1e-4 slack run()'s f32-vs-f32 comparisons already carry
+// for fmt 1-3 above, just applied to a magnitude-relative rather than max-relative base.
+static int run_grouped(int O, int I, int gs, int S, int outlier, const char *name) {
+  int rb=(I+1)/2, ng=(I+gs-1)/gs;
+  std::vector<uint8_t> W((size_t)O*rb);
+  std::vector<float> scale((size_t)O*ng), x((size_t)S*I), yg((size_t)S*O);
+  std::vector<double> yr((size_t)S*O), mag((size_t)S*O);
+  srand(4110 + I*7 + O*3 + gs + S*13 + outlier*97);
+  for (auto &b : W) b = (uint8_t)(rand()&0xFF);
+  // scales span orders of magnitude -- a wrong group index shows up big, not as noise.
+  for (auto &v : scale) v = (0.001f + (rand()%1000)/1000.0f) * ((rand()&1) ? 1.f : -1.f);
+  for (auto &v : x) v = ((rand()%2000)-1000)/1000.0f;
+  if (outlier) {
+    // Tail-clipping regime grouped scales exist for: one huge activation per row,
+    // confined to group 0. A per-row quantizer's single scale would have to stretch to
+    // cover this outlier, crushing every other group's precision; per-group scaling
+    // contains the damage to group 0's scale and leaves the rest of the row exact. This
+    // isn't a property of matmul_i4_grouped's weights (which are the same random bytes
+    // as the non-outlier case) -- it's the activation-side stress the format is FOR, and
+    // it exercises the SAME code path (still just per-group scale lookup + MAC), so a
+    // reconstruction win here is really a check that group boundaries/indices are right
+    // under the shape that would most expose a wrong one.
+    for (int s=0; s<S; s++) x[(size_t)s*I+0] = 50.0f;
+  }
+  cpu_ref_grouped(W.data(), scale.data(), x.data(), yr.data(), mag.data(), S, I, O, gs);
+  ColiMetalTensor *t=nullptr;
+  if (!coli_metal_matmul(&t, yg.data(), x.data(), W.data(), scale.data(), I4G, S, I, O, gs)) {
+    printf("  %-34s FAIL (matmul returned 0)\n", name); return 1; }
+  double worst=0; int bad=0;
+  for (size_t i=0; i<(size_t)S*O; i++) {
+    double d = fabs((double)yg[i] - yr[i]);
+    double rel = mag[i] > 1e-30 ? d/mag[i] : d;
+    if (rel > worst) worst = rel;
+    if (rel > 1e-4) bad++;
+  }
+  int ok = (bad == 0);
+  printf("  %-34s worst_rel=%.2e (I=%d gs=%d ng=%d S=%d)  %s\n", name, worst, I, gs, ng, S, ok?"ok":"*** MISMATCH");
   coli_metal_tensor_free(t);
   return ok?0:1;
 }
@@ -115,6 +196,22 @@ static TW t_mkw(int O,int I){ TW t; int rb=(I+1)/2;
   for(size_t i=0;i<(size_t)O*rb;i++) t.w[i]=(uint8_t)(rand()&0xFF);
   for(int i=0;i<O;i++) t.s[i]=0.01f+(rand()%40)/40000.f;
   coli_metal_register(t.w,t.wb); coli_metal_register(t.s,t.sb); return t; }
+// Grouped-int4 (fmt=4) variant of t_mkw: same packed-nibble weight layout, but the
+// scale slab holds O*ceil(I/gs) floats. Used to prove the bind_gemv/AttnW/
+// coli_metal_attn_decode plumbing (not just the standalone GEMV) threads gs correctly.
+static TW t_mkw_g(int O,int I,int gs){ TW t; int rb=(I+1)/2, ng=(I+gs-1)/gs;
+  t.wb=((size_t)O*rb+16383)&~(size_t)16383; t.sb=((size_t)O*(size_t)ng*4+16383)&~(size_t)16383;
+  posix_memalign((void**)&t.w,16384,t.wb); posix_memalign((void**)&t.s,16384,t.sb);
+  for(size_t i=0;i<(size_t)O*rb;i++) t.w[i]=(uint8_t)(rand()&0xFF);
+  for(int i=0;i<O*ng;i++) t.s[i]=(0.001f+(rand()%1000)/1000.f)*((rand()&1)?1.f:-1.f);
+  coli_metal_register(t.w,t.wb); coli_metal_register(t.s,t.sb); return t; }
+// Grouped-int4 CPU reference GEMV, mirroring t_gemv4 but with a per-group scale lookup
+// (same semantics as quant.h's matmul_i4_grouped / cpu_ref_grouped above).
+static void t_gemv4g(float*y,const float*x,const uint8_t*w,const float*sc,int O,int I,int gs){
+  int rb=(I+1)/2, ng=(I+gs-1)/gs;
+  for(int o=0;o<O;o++){ const uint8_t*r=w+(size_t)o*rb; const float* scl=sc+(size_t)o*ng; float a=0;
+    for(int i=0;i<I;i++){ uint8_t b=r[i>>1]; int v=(i&1)?(b>>4):(b&0xF); a+=(float)(v-8)*x[i]*scl[i/gs]; }
+    y[o]=a; } }
 static int run_attn(int S, int pos_base, const char* name){
   const float eps=1e-5f, theta=10000.f, ascale=1.f/16.f;
   srand(4242+S+pos_base);
@@ -160,8 +257,8 @@ static int run_attn(int S, int pos_base, const char* name){
     t_gemv4(&ref[(size_t)s*TH],ctx.data(),o.w,o.s,TH,THH*TVH);
   }
   std::vector<float> got((size_t)S*TH);
-  int ok=coli_metal_attn_decode(x.data(), qa.w,qa.s,2,qaln.data(), qb.w,qb.s,2,
-        kva.w,kva.s,2,kvaln.data(), kvb.w,kvb.s,2, o.w,o.s,2,
+  int ok=coli_metal_attn_decode(x.data(), qa.w,qa.s,2,0,qaln.data(), qb.w,qb.s,2,0,
+        kva.w,kva.s,2,0,kvaln.data(), kvb.w,kvb.s,2, o.w,o.s,2,0,
         Lc,Rc,S,pos_base,0,eps,theta,ascale,got.data());
   double ma=0,ym=0; for(size_t i=0;i<ref.size();i++){ ma=fmax(ma,fabs(got[i]-ref[i])); ym=fmax(ym,fabs(ref[i])); }
   // also verify the cache write-back (Lc/Rc for the new positions)
@@ -239,6 +336,73 @@ static int run_rtop8(int mode, int S, int E, float topp, int normk, float rscale
   return 0;
 }
 
+// Same fused-attention pipeline as run_attn, but q_a is fmt=4 (grouped int4, gs) while
+// q_b/kv_a/kv_b/o stay fmt=2 -- proves the bind_gemv/AttnW/coli_metal_attn_decode
+// plumbing (qa_gs threaded through encode_attention) is wired correctly end-to-end
+// through the SAME fused command buffer real decode uses (attention_rows in colibri.c),
+// not just the standalone coli_metal_matmul entry point run_grouped() above exercises.
+// kv_b is deliberately left fmt=2: it never flows through bind_gemv (a_qabs/a_ctx
+// dequantize it with a per-row-only helper) -- a fmt=4 kv_b is out of scope for this
+// stage (see PR_BODY.md UNCERTAINTIES).
+static int run_attn_grouped(int S, int pos_base, int gs, const char* name){
+  const float eps=1e-5f, theta=10000.f, ascale=1.f/16.f;
+  srand(5150+S+pos_base+gs);
+  TW qa=t_mkw_g(TQL,TH,gs), qb=t_mkw(THH*TQH,TQL), kva=t_mkw(TKVL+TROPE,TH), kvb=t_mkw(THH*TROWSH,TKVL), o=t_mkw(TH,THH*TVH);
+  std::vector<float> qaln(TQL), kvaln(TKVL);
+  for(auto&v:qaln) v=0.5f+(rand()%1000)/1000.f; for(auto&v:kvaln) v=0.5f+(rand()%1000)/1000.f;
+  int T=pos_base+S; size_t lcb=(((size_t)T*TKVL*4)+16383)&~(size_t)16383, rcb=(((size_t)T*TROPE*4)+16383)&~(size_t)16383;
+  float *Lc,*Rc; posix_memalign((void**)&Lc,16384,lcb); posix_memalign((void**)&Rc,16384,rcb);
+  coli_metal_register(Lc,lcb); coli_metal_register(Rc,rcb);
+  for(int t=0;t<pos_base;t++){ for(int i=0;i<TKVL;i++) Lc[(size_t)t*TKVL+i]=((rand()%2000)-1000)/1500.f;
+    for(int i=0;i<TROPE;i++) Rc[(size_t)t*TROPE+i]=((rand()%2000)-1000)/1500.f; }
+  std::vector<float> x((size_t)S*TH); for(auto&v:x) v=((rand()%2000)-1000)/1000.f;
+  std::vector<float> Lr((size_t)T*TKVL), Rr((size_t)T*TROPE);
+  memcpy(Lr.data(),Lc,(size_t)pos_base*TKVL*4); memcpy(Rr.data(),Rc,(size_t)pos_base*TROPE*4);
+  std::vector<float> Q((size_t)S*THH*TQH), ref((size_t)S*TH);
+  for(int s=0;s<S;s++){ int pos=pos_base+s;
+    std::vector<float> qr(TQL), comp(TKVL+TROPE);
+    t_gemv4g(qr.data(),&x[(size_t)s*TH],qa.w,qa.s,TQL,TH,gs); t_rms(qr.data(),qr.data(),qaln.data(),TQL,eps);   // <- grouped
+    t_gemv4(&Q[(size_t)s*THH*TQH],qr.data(),qb.w,qb.s,THH*TQH,TQL);
+    for(int h=0;h<THH;h++) t_rope(&Q[(size_t)s*THH*TQH+(size_t)h*TQH+TNOPE],pos,theta);
+    t_gemv4(comp.data(),&x[(size_t)s*TH],kva.w,kva.s,TKVL+TROPE,TH);
+    t_rms(&Lr[(size_t)pos*TKVL],comp.data(),kvaln.data(),TKVL,eps);
+    memcpy(&Rr[(size_t)pos*TROPE],&comp[TKVL],TROPE*4); t_rope(&Rr[(size_t)pos*TROPE],pos,theta);
+  }
+  int rb=(TKVL+1)/2;
+  for(int s=0;s<S;s++){ int pos=pos_base+s; std::vector<float> ctx((size_t)THH*TVH);
+    for(int h=0;h<THH;h++){ int rbase=h*TROWSH;
+      const float* qp=&Q[(size_t)s*THH*TQH+(size_t)h*TQH]; const float* qro=qp+TNOPE;
+      std::vector<float> qabs(TKVL,0);
+      for(int d=0;d<TNOPE;d++){ const uint8_t*r=kvb.w+(size_t)(rbase+d)*rb; float sc=kvb.s[rbase+d];
+        for(int i=0;i<TKVL;i++){ uint8_t b=r[i>>1]; int v=(i&1)?(b>>4):(b&0xF); qabs[i]+=qp[d]*(float)(v-8)*sc; } }
+      std::vector<float> a(pos+1);
+      for(int t=0;t<=pos;t++){ const float*Lt=&Lr[(size_t)t*TKVL]; const float*Rt=&Rr[(size_t)t*TROPE];
+        float v=0; for(int i=0;i<TKVL;i++) v+=qabs[i]*Lt[i]; for(int d=0;d<TROPE;d++) v+=qro[d]*Rt[d]; a[t]=v*ascale; }
+      float mx=-1e30f; for(float v:a) mx=fmaxf(mx,v); float sum=0; for(float&v:a){ v=expf(v-mx); sum+=v; } for(float&v:a) v/=sum;
+      std::vector<float> cl(TKVL,0);
+      for(int t=0;t<=pos;t++){ const float*Lt=&Lr[(size_t)t*TKVL]; for(int i=0;i<TKVL;i++) cl[i]+=a[t]*Lt[i]; }
+      for(int j=0;j<TVH;j++){ const uint8_t*r=kvb.w+(size_t)(rbase+TNOPE+j)*rb; float sc=kvb.s[rbase+TNOPE+j];
+        float v=0; for(int i=0;i<TKVL;i++){ uint8_t b=r[i>>1]; int vv=(i&1)?(b>>4):(b&0xF); v+=cl[i]*(float)(vv-8)*sc; }
+        ctx[(size_t)h*TVH+j]=v; } }
+    t_gemv4(&ref[(size_t)s*TH],ctx.data(),o.w,o.s,TH,THH*TVH);
+  }
+  std::vector<float> got((size_t)S*TH);
+  int ok=coli_metal_attn_decode(x.data(), qa.w,qa.s,4,gs,qaln.data(), qb.w,qb.s,2,0,      // <- qa fmt=4/gs
+        kva.w,kva.s,2,0,kvaln.data(), kvb.w,kvb.s,2, o.w,o.s,2,0,
+        Lc,Rc,S,pos_base,0,eps,theta,ascale,got.data());
+  double ma=0,ym=0; for(size_t i=0;i<ref.size();i++){ ma=fmax(ma,fabs(got[i]-ref[i])); ym=fmax(ym,fabs(ref[i])); }
+  double mc=0; for(int s=0;s<S;s++){ int pos=pos_base+s;
+    for(int i=0;i<TKVL;i++) mc=fmax(mc,fabs(Lc[(size_t)pos*TKVL+i]-Lr[(size_t)pos*TKVL+i]));
+    for(int i=0;i<TROPE;i++) mc=fmax(mc,fabs(Rc[(size_t)pos*TROPE+i]-Rr[(size_t)pos*TROPE+i])); }
+  double nerr=ma/(ym+1e-9);
+  int pass = ok && nerr<2e-4 && mc<1e-4;
+  printf("  %-24s nerr=%.2e cache=%.2e  %s\n", name, nerr, mc, pass?"ok":"*** MISMATCH");
+  auto freew=[&](TW&t){ coli_metal_unregister(t.w); coli_metal_unregister(t.s); free(t.w); free(t.s); };
+  freew(qa); freew(qb); freew(kva); freew(kvb); freew(o);
+  coli_metal_unregister(Lc); coli_metal_unregister(Rc); free(Lc); free(Rc);
+  return pass?0:1;
+}
+
 int main(void) {
   if (!coli_metal_init()) { printf("Metal unavailable (skipping)\n"); return 0; }
   printf("Metal backend kernel tests:\n");
@@ -251,6 +415,21 @@ int main(void) {
   fail |= run(I8, 2048,6144,4, "int8 gate/up S=4");
   fail |= run(I4, 2048,6144,7, "int4 gate/up S=7 (odd)");
   fail |= run(I4, 2050,6146,3, "int4 non-mult-4 dims");
+  printf("Metal fmt=4 grouped-int4 tests (coli_metal_matmul vs matmul_i4_grouped semantics):\n");
+  // I multiple of gs=64, S=1 and S>1 (real g64-checkpoint shapes: gate/up I=6144, down I=2048)
+  fail |= run_grouped(2048,6144,64,1,0, "grouped gate/up I=6144(mult64) S=1");
+  fail |= run_grouped(6144,2048,64,1,0, "grouped down I=2048(mult64) S=1");
+  fail |= run_grouped(2048,6144,64,4,0, "grouped gate/up I=6144(mult64) S=4");
+  // I NOT a multiple of gs=64 (partial last group, the glen-clamp off-by-one)
+  fail |= run_grouped(6,   200, 64,2,0, "grouped I=200 (non-mult-64) S=2");
+  fail |= run_grouped(5,   201, 64,3,0, "grouped I=201 (odd, non-mult-64) S=3");
+  // I<=64 degenerate: single group (ng=1), including I<gs
+  fail |= run_grouped(3,   64,  64,1,0, "grouped I=64 (degenerate, ng=1) S=1");
+  fail |= run_grouped(3,   40,  64,1,0, "grouped I=40 (<gs, single partial group) S=1");
+  // random + outlier-heavy rows: one large-magnitude activation per row (the
+  // tail-clipping regime grouped scales exist for), verified end-to-end through the GPU.
+  fail |= run_grouped(5,   512, 64,3,1, "grouped I=512(mult64) outlier-heavy S=3");
+  fail |= run_grouped(5,   201, 64,2,1, "grouped I=201(non-mult-64) outlier-heavy S=2");
   printf("Metal batched moe_block tests:\n");
   fail |= run_moe({1,1,1,1,1,1,1,1}, "moe decode nb=8");
   fail |= run_moe({3,1,4,2,1,5},     "moe ragged nb=6");
@@ -265,10 +444,30 @@ int main(void) {
     std::vector<float> x((size_t)S*I), yr((size_t)S*O), yg((size_t)S*O);
     for(auto&v:x) v=((rand()%2000)-1000)/1000.f;
     cpu_ref(I4,W,Sc,x.data(),yr.data(),S,I,O);
-    int ok=coli_metal_gemm(yg.data(),x.data(),W,Sc,2,S,I,O);
+    int ok=coli_metal_gemm(yg.data(),x.data(),W,Sc,2,S,I,O,0);
     double ma=0,ym=0; for(size_t i=0;i<yr.size();i++){ ma=fmax(ma,fabs(yg[i]-yr[i])); ym=fmax(ym,fabs(yr[i])); }
     int pass = ok && ma/(ym+1e-9)<1e-4;
     printf("  gemm S=64 int4          nerr=%.2e  %s\n", ma/(ym+1e-9), pass?"ok":"*** MISMATCH");
+    fail |= !pass;
+    coli_metal_unregister(W); coli_metal_unregister(Sc); free(W); free(Sc);
+  }
+  { // registered GROUPED int4 (fmt=4) weights, S=64: coli_metal_gemm vs cpu_ref_grouped
+    // -- covers the matmul_qt_ex prefill dispatch path (colibri.c), the second of the
+    // two directly-named "gemm-test pattern" entry points mm_gemv is reached through.
+    srand(881); int O=2048,I=6144,S=64,gs=64,rb=(I+1)/2,ng=(I+gs-1)/gs;
+    size_t wb=(((size_t)O*rb)+16383)&~(size_t)16383, sbg=(((size_t)O*(size_t)ng*4)+16383)&~(size_t)16383;
+    uint8_t*W; float*Sc; posix_memalign((void**)&W,16384,wb); posix_memalign((void**)&Sc,16384,sbg);
+    for(size_t i=0;i<(size_t)O*rb;i++) W[i]=(uint8_t)(rand()&0xFF);
+    for(int i=0;i<O*ng;i++) Sc[i]=(0.001f+(rand()%1000)/1000.f)*((rand()&1)?1.f:-1.f);
+    coli_metal_register(W,wb); coli_metal_register(Sc,sbg);
+    std::vector<float> x((size_t)S*I), yg((size_t)S*O);
+    std::vector<double> yr((size_t)S*O), mag((size_t)S*O);
+    for(auto&v:x) v=((rand()%2000)-1000)/1000.f;
+    cpu_ref_grouped(W,Sc,x.data(),yr.data(),mag.data(),S,I,O,gs);
+    int ok=coli_metal_gemm(yg.data(),x.data(),W,Sc,4,S,I,O,gs);
+    double worst=0; for(size_t i=0;i<yg.size();i++){ double d=fabs((double)yg[i]-yr[i]); double rel=mag[i]>1e-30?d/mag[i]:d; if(rel>worst) worst=rel; }
+    int pass = ok && worst<1e-4;
+    printf("  gemm S=64 int4-grouped   worst_rel=%.2e  %s\n", worst, pass?"ok":"*** MISMATCH");
     fail |= !pass;
     coli_metal_unregister(W); coli_metal_unregister(Sc); free(W); free(Sc);
   }
@@ -277,6 +476,11 @@ int main(void) {
   fail |= run_attn(1, 37,  "attn S=1 pos=37");
   fail |= run_attn(4, 12,  "attn S=4 pos=12 (MTP)");
   fail |= run_attn(3, 0,   "attn S=3 pos=0");
+  printf("Metal fused attention tests (fmt=4 grouped q_a, proves bind_gemv gs plumbing):\n");
+  fail |= run_attn_grouped(1, 0,  64, "attn grouped-qa S=1 pos=0");
+  fail |= run_attn_grouped(4, 12, 64, "attn grouped-qa S=4 pos=12 (MTP)");
+  printf("Metal negative control: fmt 1/2/3 unaffected by the fmt=4 shader branch --\n"
+         "  see the runs above (int8/int4/int2/f32/moe/gemm/attn cases): all still ok.\n");
   printf("Metal top-8 select serial-vs-parallel tests (exact-match contract, E=256):\n");
   fail |= run_rtop8(0, 1, 256, 0.0f,  1, 1.0f,   "top8 generic S=1");
   fail |= run_rtop8(0, 4, 256, 0.0f,  1, 1.0f,   "top8 generic S=4");

--- a/c/tests/test_backend_metal.mm
+++ b/c/tests/test_backend_metal.mm
@@ -344,6 +344,23 @@ static int run_rtop8(int mode, int S, int E, float topp, int normk, float rscale
 // kv_b is deliberately left fmt=2: it never flows through bind_gemv (a_qabs/a_ctx
 // dequantize it with a per-row-only helper) -- a fmt=4 kv_b is out of scope for this
 // stage (see PR_BODY.md UNCERTAINTIES).
+//
+// Two blind spots closed here (review round 1 -- see PR_BODY.md sec 10):
+//  (a) pos_base must be >0 for any S=1 case. At pos_base=0, T=pos_base+S=1: softmax
+//      over a SINGLE key is identically 1.0 regardless of the score's value, so the
+//      final output is provably independent of q_a's kernel output entirely -- an S=1
+//      pos=0 case cannot catch ANY defect in q_a, not just scale bugs. Every S=1 call
+//      below now uses pos_base>0 (mirroring run_attn's own S=1 pos=37 case, which exists
+//      for the same reason on the non-grouped kernels).
+//  (b) RMSNorm(c*v) == RMSNorm(v) for any positive scalar c -- it divides out any
+//      UNIFORM rescale of its input before qb/RoPE/attention ever see it. So even with
+//      T>1, a whole-tensor scale-calibration bug in q_a's grouped-int4 kernel (every
+//      group's scale off by the same factor) would be invisible in `got`/`ref` below no
+//      matter how the rest of the pipeline is shaped -- fixing (a) alone does not fix
+//      this. Closed by comparing q_a's RAW GEMV output (before RMSNorm swallows it)
+//      directly against the CPU oracle, via the standalone coli_metal_matmul entry point
+//      on the EXACT weight/scale/x data this attention test generated (not a re-run of
+//      run_grouped()'s own separate random data) -- see the qraw block below.
 static int run_attn_grouped(int S, int pos_base, int gs, const char* name){
   const float eps=1e-5f, theta=10000.f, ascale=1.f/16.f;
   srand(5150+S+pos_base+gs);
@@ -359,9 +376,24 @@ static int run_attn_grouped(int S, int pos_base, int gs, const char* name){
   std::vector<float> Lr((size_t)T*TKVL), Rr((size_t)T*TROPE);
   memcpy(Lr.data(),Lc,(size_t)pos_base*TKVL*4); memcpy(Rr.data(),Rc,(size_t)pos_base*TROPE*4);
   std::vector<float> Q((size_t)S*THH*TQH), ref((size_t)S*TH);
+  ColiMetalTensor *traw=nullptr;         // persistent handle for the raw-qa GPU probe (blind spot (b))
+  double qraw_worst=0; int qraw_bad=0;
   for(int s=0;s<S;s++){ int pos=pos_base+s;
     std::vector<float> qr(TQL), comp(TKVL+TROPE);
-    t_gemv4g(qr.data(),&x[(size_t)s*TH],qa.w,qa.s,TQL,TH,gs); t_rms(qr.data(),qr.data(),qaln.data(),TQL,eps);   // <- grouped
+    t_gemv4g(qr.data(),&x[(size_t)s*TH],qa.w,qa.s,TQL,TH,gs);                          // <- grouped, RAW (pre-RMSNorm)
+    { // Blind spot (b): compare this RAW q_a output against the CPU oracle BEFORE
+      // t_rms below overwrites qr in place -- RMSNorm is what makes the post-norm
+      // comparison blind to a uniform scale error, so the check has to happen here,
+      // not on `got`/`ref`. Same magnitude-relative construction as run_grouped().
+      std::vector<double> qrd(TQL), qrmag(TQL);
+      cpu_ref_grouped(qa.w,qa.s,&x[(size_t)s*TH],qrd.data(),qrmag.data(),1,TH,TQL,gs);
+      std::vector<float> qraw(TQL);
+      int qok=coli_metal_matmul(&traw,qraw.data(),&x[(size_t)s*TH],qa.w,qa.s,4,1,TH,TQL,gs);
+      if(!qok) qraw_bad++;
+      for(int i=0;i<TQL;i++){ double d=fabs((double)qraw[i]-qrd[i]); double rel=qrmag[i]>1e-30?d/qrmag[i]:d;
+        if(rel>qraw_worst) qraw_worst=rel; if(rel>1e-4) qraw_bad++; }
+    }
+    t_rms(qr.data(),qr.data(),qaln.data(),TQL,eps);   // <- grouped
     t_gemv4(&Q[(size_t)s*THH*TQH],qr.data(),qb.w,qb.s,THH*TQH,TQL);
     for(int h=0;h<THH;h++) t_rope(&Q[(size_t)s*THH*TQH+(size_t)h*TQH+TNOPE],pos,theta);
     t_gemv4(comp.data(),&x[(size_t)s*TH],kva.w,kva.s,TKVL+TROPE,TH);
@@ -395,8 +427,9 @@ static int run_attn_grouped(int S, int pos_base, int gs, const char* name){
     for(int i=0;i<TKVL;i++) mc=fmax(mc,fabs(Lc[(size_t)pos*TKVL+i]-Lr[(size_t)pos*TKVL+i]));
     for(int i=0;i<TROPE;i++) mc=fmax(mc,fabs(Rc[(size_t)pos*TROPE+i]-Rr[(size_t)pos*TROPE+i])); }
   double nerr=ma/(ym+1e-9);
-  int pass = ok && nerr<2e-4 && mc<1e-4;
-  printf("  %-24s nerr=%.2e cache=%.2e  %s\n", name, nerr, mc, pass?"ok":"*** MISMATCH");
+  int pass = ok && nerr<2e-4 && mc<1e-4 && qraw_bad==0;
+  printf("  %-24s nerr=%.2e cache=%.2e qraw=%.2e  %s\n", name, nerr, mc, qraw_worst, pass?"ok":"*** MISMATCH");
+  coli_metal_tensor_free(traw);
   auto freew=[&](TW&t){ coli_metal_unregister(t.w); coli_metal_unregister(t.s); free(t.w); free(t.s); };
   freew(qa); freew(qb); freew(kva); freew(kvb); freew(o);
   coli_metal_unregister(Lc); coli_metal_unregister(Rc); free(Lc); free(Rc);
@@ -477,7 +510,10 @@ int main(void) {
   fail |= run_attn(4, 12,  "attn S=4 pos=12 (MTP)");
   fail |= run_attn(3, 0,   "attn S=3 pos=0");
   printf("Metal fused attention tests (fmt=4 grouped q_a, proves bind_gemv gs plumbing):\n");
-  fail |= run_attn_grouped(1, 0,  64, "attn grouped-qa S=1 pos=0");
+  // pos_base=37 (not 0): at T=1 softmax is identically 1.0 regardless of q_a's output,
+  // so an S=1 pos=0 case cannot catch ANY q_a defect (review round 1, auditor -- see
+  // PR_BODY.md sec 10). Both cases also carry the raw pre-RMSNorm qraw check internally.
+  fail |= run_attn_grouped(1, 37, 64, "attn grouped-qa S=1 pos=37");
   fail |= run_attn_grouped(4, 12, 64, "attn grouped-qa S=4 pos=12 (MTP)");
   printf("Metal negative control: fmt 1/2/3 unaffected by the fmt=4 shader branch --\n"
          "  see the runs above (int8/int4/int2/f32/moe/gemm/attn cases): all still ok.\n");

--- a/c/tests/test_gemm_largebatch.mm
+++ b/c/tests/test_gemm_largebatch.mm
@@ -59,8 +59,8 @@ static int run_gemm(int fmt, int O, int I, int S, const char *name) {
   for(auto&v:x) v=((rand()%2000)-1000)/1000.f;
 
   cpu_ref(fmt, W, Sc, x.data(), yr.data(), S, I, O);
-  int ok1 = coli_metal_gemm(yg.data(),  x.data(), W, Sc, fmt, S, I, O);
-  int ok2 = coli_metal_gemm(yg2.data(), x.data(), W, Sc, fmt, S, I, O);
+  int ok1 = coli_metal_gemm(yg.data(),  x.data(), W, Sc, fmt, S, I, O, 0);  /* gs=0: per-row scales */
+  int ok2 = coli_metal_gemm(yg2.data(), x.data(), W, Sc, fmt, S, I, O, 0);
 
   // GPU vs CPU: max normalized error + first diverging element.
   double maxabs=0, ymax=0; long badidx=-1;


### PR DESCRIPTION
# metal: grouped-int4 (fmt=4) GEMV support — the Metal twin of #298/#451

Cross-references: **#298** and **#451** (CUDA fmt=4 support, read READ-ONLY for
layout/naming conventions — `gs`/`ng` field names, "same packed layout as fmt=2, scale
folded into the accumulation" semantics, and the "new ABI entry rather than break the
existing symbol" caution both echoed below). **#168** (Team A's int3-g64 reconciliation
— Stage 2 of this same effort, not started here; see §7). Campaign context, same framing
as **#447**: no maintainer of this repository has Metal hardware — this lab is the test
surface for the Apple GPU tier of every quantization format the CPU/CUDA tiers gain.

Branch: `metal/grouped-gemv`, based on `origin/dev` @ `e9b3614`. Touches
`c/backend_metal.h`, `c/backend_metal.mm`, `c/colibri.c`, `c/tests/test_backend_metal.mm`.

---

## 1. The problem: two latent defects that mutually masked each other at stock

**Durable claim:** dev's grouped-int4 format (fmt=4 — packed int4 nibbles, same layout
as fmt=2, but one f32 scale per `gs`-element group along I instead of one scale per row)
has a CPU reference (`matmul_i4_grouped`, `c/quant.h:150`) and an active CUDA tier
(#298/#451). The Metal GEMV shader (`mm_gemv` in `c/backend_metal.mm`) only branched on
`fmt == 1|2|3`; anything else — including fmt=4 — fell through to the unconditional
`else` arm and was decoded **as raw f32**. Taken in isolation, that is not a "CPU
fallback, no GPU acceleration" gap — it is a silent-wrong-answer defect: a code path that
reaches the Metal GEMV with an fmt=4 tensor gets a real, non-error, numerically-wrong
result. That structural claim is unchanged from the first revision of this document, and
the code evidence for it (below) is unchanged too. What changed, on review (credit:
review round 1, auditor — see §10), is the REACHABILITY claim that followed it.

**Revised: this defect was NOT live at stock `e9b3614`.** A second, independent defect
masked it, and §2(d) already contained the evidence — this section just failed to draw
the conclusion from it. §2(d) traces the actual allocation site of the fmt=4 scale
buffer: `qt_from_disk`'s fmt=4 branch allocated it with `falloc` — a bare `malloc`, never
page-aligned, never `coli_metal_register`'d — while `resolve()` in `backend_metal.mm`
only finds pointers inside registered slabs. That means at stock, `resolve(t->s, ...)`
on *any* fmt=4 scale buffer always fails, so `resolve_attn`/`bind_gemv` always return
`false` and the caller always falls back to CPU — for every fmt=4 tensor,
unconditionally, before the shader's fmt=4 fallthrough ever gets a chance to execute.
**The two defects mutually cancel at stock: the allocator bug is what kept the shader bug
from ever firing.** Stock was accidentally safe, not correctly handled — an important
distinction, covered next — but that is not the same claim as "this was a live landmine
in stock `e9b3614`," which the first revision of this section overclaimed by tracing only
the shader/dispatch side (`bind_gemv`'s missing fmt gate, quoted below) without also
propagating §2(d)'s own resolve()-fails finding back into this section's reachability
claim.

**Where the shader defect *would* become live, and how this branch's commit ORDER avoids
it.** Fix either defect alone, and depending on which one lands first, the other may stop
providing cover before the real fix arrives. If the allocator fix landed before the
shader fix, the intermediate commit would be ARMED: the scale buffer resolves
successfully, but the shader still doesn't know what fmt=4 means, so `bind_gemv` would
dispatch straight into the f32 fallthrough and silently compute garbage — a state
strictly worse than stock (stock's defect was masked; this one wouldn't be), reachable by
anyone who bisects or cherry-picks that single commit. An earlier revision of this branch
carried exactly that ordering — corrected on review (credit: review round 1, coordinator
— see §10) before this PR was finalized, not left as a residual risk.

This branch's actual, final commit order avoids the armed state by construction rather
than by discipline: **`f0fa5a9`** (the `mm_gemv` shader fix + all host plumbing, §3/§4)
lands FIRST, and **`2ba12d8`** (the `qt_from_disk` allocator fix, §2(d)) lands SECOND. At
`f0fa5a9` alone, the new shader branch is already correct, but the allocator bug still
keeps every real fmt=4 scale buffer from resolving — the capability lands **inert**, not
armed: verified (this branch, this session) that `make glm METAL=0`/`METAL=1` build
clean at that commit and `make metal-test` still passes 27/27, because metal-test's fmt=4
cases construct their own tensors directly via `posix_memalign`+`coli_metal_register` and
never go through `qt_from_disk` — the test suite exercises and proves the new shader
correct at this commit, it just isn't reachable yet from a real loaded model (§6).
`2ba12d8` then activates that already-correct capability by fixing the one thing that was
keeping it unreachable — verified clean/27-27 again at that commit. **No commit in this
three-commit sequence is ever unsafe to check out alone:** capability lands inert first,
the activation commit completes it. The third commit (**`fc0f5a5`**, the attn-test
blind-spot fix, §10) is a test-only strengthening layered on top afterward, with no
bearing on either commit's reachability argument. A reviewer or maintainer bisecting this
branch, or merging a prefix of it, never lands on the armed ordering described above — it
does not exist anywhere in this branch's actual history.

**What doesn't change from the prior framing:** both defects are real (validator
independently confirmed both with quotes — see §10), both are fixed by this PR, and the
trace below (including the QUOTED gate at `colibri.c:1958-1960` showing `attention_rows`
never checked `q_a`/`q_b`/`kv_a`/`o`'s fmt) is accurate as a description of the CODE'S
STRUCTURE — `bind_gemv` genuinely has no fmt validity gate, and the shader genuinely
mishandles fmt=4 if reached:

```c
if(g_metal_enabled && !kvs && S<=4 && (g_absorb==1||(g_absorb<0&&S<=4)) && m->kv_start[layer]==0
   && D==6144 && H==64 && c->q_lora==2048 && c->kv_lora==512 && c->qk_nope==192
   && c->qk_rope==64 && vh==256 && l->kv_b.fmt==2){
```

(the pre-existing gate, `git show e9b3614:c/colibri.c` lines 1958-1960, unmodified in
shape by this PR — only the argument list changed, see §4). No known field model
currently ships an fmt=4 dense/attention weight next to an fmt=2 `kv_b` (fmt=4
checkpoints are new), so even the structural gap was latent, not observed-in-the-wild.
What was wrong in the prior revision was conflating "structurally reachable in general"
with "reachable at stock `e9b3614` specifically" — the allocator bug traced independently
in §2(d) closes that gap at stock, even though the shader-side structural gap is real and
this PR still closes it (§3) for every path that reaches `mm_gemv`, not just the one this
PR's test matrix targets, and regardless of whether any known checkpoint currently
exercises it.

## 2. The trace: how a per-row scale reaches the shader today (quoted before any edit)

Three, and only three, host functions dispatch the `mm_gemv` kernel; all three pass
`scale` as `buffer(1)` and (before this PR) never told the shader anything about grouping:

**(a) `coli_metal_matmul`** (`backend_metal.mm`, the persistent-tensor entry point
metal-test's `run()`/`run_grouped()` harnesses call) — wraps weights and scales into
`MTLBuffer`s on first use:

```c
extern "C" int coli_metal_matmul(ColiMetalTensor **tp, float *y, const float *x,
                                 const void *weights, const float *scales,
                                 int fmt, int S, int I, int O) {
  if (!g_dev || fmt < 0 || fmt > 3) return 0;
  ...
      t->w = wrap(weights, t->wbytes);
      t->s = wrap(scales, (size_t)O * sizeof(float));     // <- hardcoded O floats
```

`fmt > 3` was rejected outright, and the scale buffer was always wrapped at exactly `O`
floats — for fmt=4 the real scale array is `O*ceil(I/gs)` floats, so even lifting the
`fmt>3` guard alone would have UNDER-wrapped the buffer (`wrap()` sizes the `MTLBuffer`
from this byte count) and the shader would read past it.

**(b) `coli_metal_gemm`** (the large-batch prefill GEMM path, reached from
`matmul_qt_ex` in `colibri.c` for `S >= g_metal_gemm_min`) — resolves already-registered
slabs rather than wrapping, so no buffer-size bug here, but the fmt gate excluded 4
outright and no `gs` was threaded through:

```c
extern "C" int coli_metal_gemm(float *y, const float *x, const void *wp, const float *sp,
                               int fmt, int S, int I, int O) {
  if (!g_dev || (fmt!=1 && fmt!=2)) return 0;
```

reached from (`colibri.c:421-424`, `matmul_qt_ex` — the general-purpose matvec dispatch
every dense/attention/shared-expert projection goes through):

```c
if(g_metal_enabled && S>=g_metal_gemm_min && !spec_pinned() && (w->fmt==1||w->fmt==2) && !omp_in_parallel()){
    const void *wp = w->fmt==1 ? (const void*)w->q8 : (const void*)w->q4;
    if(coli_metal_gemm(y,x,wp,w->s,w->fmt,S,w->I,w->O)) return;
}
```

**(c) `bind_gemv`** (the internal helper used by the fused single-command-buffer decode
kernels, `encode_attention` and `coli_metal_layer_decode`'s shared-expert calls) — no fmt
gate at all (§1), and no `gs` parameter to pass even if it wanted to honor one:

```c
static bool bind_gemv(id<MTLComputeCommandEncoder> e, const void* w, const float* s, int fmt, int I, int O,
                      id<MTLBuffer> xin, id<MTLBuffer> yout, int S){
  ...
  [e setBytes:&S ...]; [e setBytes:&I ...]; [e setBytes:&O ...]; [e setBytes:&fmt ...];
  [e setBytes:&NT ...];
```

reached, per weight, from `colibri.c`'s `attention_rows`/`layer_forward_rows` via a
`WP_(q)` macro that already correctly resolves fmt=4 tensors to their `.q4` pointer
(dev's own CPU-side dispatch does the same — `qt_from_disk` stores grouped weights in
`t->q4`, confirmed at `colibri.c:824`):

```c
#define WP_(q) ((q).fmt==1?(const void*)(q).q8:(const void*)(q).q4)
int ok = coli_metal_attn_decode(x,
    WP_(l->q_a), l->q_a.s, l->q_a.fmt, l->q_a_ln, ...
```

**(d) One more link in the chain, found by tracing to the actual allocation site, not
just the dispatch call sites:** `qt_from_disk` (`colibri.c:823-825`, unmodified in shape
by this PR except the one-line fix in §4) allocates the fmt=4 scale array with plain
`falloc` — a bare `malloc`, not page-aligned and never `coli_metal_register`'d — while
every other fmt uses `qsalloc` (`qalloc` under the hood), which page-aligns and registers
under `COLI_METAL`:

```c
else if(fmt==4){ int ng=(I+gs-1)/gs;
    if(t->fmt!=4||!t->q4){ t->fmt=4; t->O=O; t->I=I; t->gs=gs; t->q4=qalloc(nb); t->s=falloc((int64_t)O*ng); }
```

`resolve()` in `backend_metal.mm` only finds pointers inside `coli_metal_register`'d
slabs. A scale buffer allocated with `falloc` can never be found by `resolve()`, so
`bind_gemv`/`coli_metal_gemm` would `return false`/`0` for it — **safe** (CPU fallback,
no wrong answer), but it means fixing (a)-(c) alone would not have mattered in practice:
every real fmt=4 dense/attention tensor's scale buffer would have permanently missed the
GPU path. Found while tracing the per-row-scale path this stage extends to per-group;
fixed alongside it (§4) since it is the literal allocation site of the buffer this whole
PR is about.

## 3. The shader change: per-group scale folded into the accumulation, not applied once

Unlike fmt 1-3 (`y[row] = acc * scale[o]`, one multiply after the full dot product),
fmt=4's group scale must be applied **per group, before summing across groups** — this is
`matmul_i4_grouped`'s actual math (`quant.h:150-184`), not a simplification of it. The new
`fmt==4` branch in `mm_gemv`:

```metal
} else if (fmt == 4) {            // int4 GROUPED: same nibble packing as fmt=2,
                                   // one f32 scale per gsz-element group along I.
  int rb = (I+1)/2; int ng = (I+gsz-1)/gsz;
  device const uchar* wr = w + (long)o * rb;
  device const float* scl = scale + (long)o * ng;
  for (int i = slane*2; i < I; i += 64) {
    uchar b = wr[i>>1];
    int g0 = i / gsz; float sc0 = scl[g0];
    acc += float(int(b&0xF)-8) * xr[i] * sc0;
    if (i+1 < I) {
      int g1 = (i+1) / gsz; float sc1 = (g1==g0) ? sc0 : scl[g1];
      acc += float(int(b>>4)-8) * xr[i+1] * sc1;
    }
  }
} else { ... }
...
acc = simd_sum(acc);
if (slane == 0) y[row] = (fmt == 4) ? acc : acc * scale[o];   // fmt=4: don't scale again
```

Each of the 32 SIMD lanes owns one packed byte (2 elements) per 64-wide stride — memory
access stays coalesced (`wr[i>>1]` is contiguous across lanes), and a group never splits
a byte because `gs` is always even (dev's own loader only accepts `gs` from the candidate
list `{16,32,48,64,96,128,192,256}`, `colibri.c:777`). This is intentionally the
straightforward per-element form, not vectorized like fmt=2's `uchar4`/`float4` path —
see §7 (Not done) for why that tradeoff was made deliberately, not by oversight.

A new `constant int& gsz [[buffer(9)]]` parameter carries the group size; it is ignored
for every other fmt (callers pass the tensor's `QT.gs`, which is 0 for non-grouped
tensors — harmless, since the shader only reads it when `fmt==4`).

## 4. The host-side plumbing: what changed at each traced site

- **`fmt_bytes`** gained an `fmt==4` case (same packed-nibble byte count as fmt=2 — the
  weight layout is identical, only the scale layout differs, matching #298's "row_bytes:
  fmt=4 = same packed int4 layout as fmt=2" note). New `fmt_scale_bytes(fmt,I,O,gs)`
  computes `O*ceil(I/gs)*sizeof(float)` for fmt=4, `O*sizeof(float)` otherwise — this is
  what `coli_metal_matmul` now uses to size the `wrap()` call in §2(a), fixing the
  under-wrap.
- **`coli_metal_matmul`**, **`coli_metal_gemm`**, **`bind_gemv`** all gained a `gs`
  parameter (appended at the call site, inserted right after the paired `fmt` in the
  fused-decode signatures — mirrors #451's convention of adding `gs` fields alongside
  `fmt`), and their fmt gates now accept 4. `coli_metal_matmul`'s doc comment in
  `backend_metal.h` states the new contract explicitly.
- **`AttnW`** (the per-layer weight-pointer bundle used by `encode_attention`) gained
  `qa_gs`/`qb_gs`/`kva_gs`/`o_gs` fields. **`coli_metal_attn_decode`** and
  **`coli_metal_layer_decode`** gained the matching parameters, threaded through to their
  `bind_gemv` calls (attention projections q_a/q_b/kv_a/o, plus shared-expert
  gate/up/down in the layer-decode variant).
- **`colibri.c`** call sites: `matmul_qt_ex`'s Metal-GEMM gate now includes `w->fmt==4`
  and passes `w->gs`; `attention_rows`/`layer_forward_rows` pass `.gs` alongside each
  `.fmt` already being passed (the field defaults to 0 for non-grouped tensors, so this
  is a no-op for every model that isn't using fmt=4 anywhere).
- **`qt_from_disk`**: the one-line allocator fix from §2(d) — `t->s` for fmt=4 now comes
  from `qalloc` (page-aligned + `coli_metal_register`'d) instead of `falloc`.

**`kv_b` is deliberately untouched.** It never flows through `bind_gemv`/`mm_gemv` at
all — the MLA absorption kernels (`a_qabs`, `a_ctx`) dequantize it inline with a
hand-written, per-row-only helper (`a_deqrow`, `backend_metal.mm`), a structurally
separate kernel family from the GEMV this PR extends. The existing `l->kv_b.fmt==2` gate
(§1) is left exactly as-is — not relaxed — specifically so an fmt=4 `kv_b` continues to
CPU-fallback safely rather than hitting `a_deqrow`'s per-row-only math. See §7.

**`coli_metal_moe_block`/`moe_gemv`** (the batched routed-expert path, a third,
independent kernel family from `mm_gemv`) is also untouched. It was already safely gated
to `fmt!=1 && fmt!=2 -> return 0/nil` before this PR — fmt=4 experts already CPU-fall-back
correctly today, with no wrong-answer risk, so this was a coverage gap, not a
correctness bug, and out of scope for this stage. See §7.

## 5. What was verified, and how (RAN, this branch)

`metal-test` follows the existing `run()`/inline-gemm-test pattern the spec named,
extended with an fmt=4-specific CPU reference (`cpu_ref_grouped`) and harness
(`run_grouped`) — `cpu_ref`'s `[O]` per-row scale layout cannot express fmt=4's
`[O,ceil(I/gs)]` layout, so it is a sibling reference, not a branch of the existing one.
`cpu_ref_grouped` mirrors `quant.h`'s `matmul_i4_grouped` nibble-decode and group-index
math exactly, accumulating in **double** — the same construction
`tests/test_i4_grouped.c` (dev's own CPU-side fmt=4 oracle, unmodified by this PR)
already established as the "known exact" reference for this format.

**Tolerance, stated and justified against the existing convention:** the pre-existing
`run()` cases compare `max|Δ| / max|y_ref|` (ymax-relative) at `1e-4`. The new
`run_grouped`/gemm-grouped/attn-grouped cases instead compare, per output element,
`|Δ| / Σ|term_i|` (magnitude-relative, summing `|xs[i]*(nib-8)*scale|` over every term of
that dot product) at the same `1e-4`. Reason: a grouped dot product over many
groups/signed terms can land near zero from cancellation — an ordinary fixed
GPU-vs-double rounding difference then reads as an enormous relative error against a
near-zero **result**, which is the accumulator's precision, not a kernel defect.
Comparing against the summed magnitude of the terms instead means a wrong scale index or
wrong group boundary is still caught as an O(1) relative error (it shifts the result by a
fraction of the terms actually summed), while cancellation noise is not misreported as a
bug. This is exactly the convention `tests/test_i4_grouped.c` uses for the same kernel's
CPU-side oracle (see its `ref_grouped`/`mag` comment, unmodified by this PR) — reused
here for a GPU oracle of the same format, not invented fresh. `1e-4` (vs.
`test_i4_grouped.c`'s `1e-6`) carries the same slack the existing `run()` cases already
accept for GPU-vs-CPU float comparisons in this file, because the GPU sums in a different
order (byte-pair-strided across 32 SIMD lanes, then `simd_sum`) than the scalar double
reference.

**Shape matrix (spec §"Validation"), all via `coli_metal_matmul` unless noted:**

| Case | Shapes | Evidence |
|---|---|---|
| I multiple of gs=64 | gate/up I=6144, down I=2048 (real g64-checkpoint dims), S=1 and S=4 | RAN, ok |
| I NOT a multiple of gs=64 | I=200 (even), I=201 (odd, exercises the nibble tail) | RAN, ok |
| I≤64 degenerate (single group) | I=64 (ng=1, exact), I=40 (<gs, single partial group) | RAN, ok |
| S=1 and S>1 | covered throughout (S∈{1,2,3,4}) | RAN, ok |
| Random + outlier-heavy rows | one activation forced to 50.0 in group 0, I=512 and I=201, verifying grouped reconstruction end-to-end through the GPU path (not just that the kernel runs) | RAN, ok |
| Large-batch GEMM path (`coli_metal_gemm`) | O=2048,I=6144,S=64,gs=64 — the second of the two directly-named GEMV entry points | RAN, ok |
| Fused-decode path (`bind_gemv` via `coli_metal_attn_decode`) | q_a set to fmt=4/gs=64 inside the real fused attention command buffer (S=1 pos=37, S=4 pos=12/MTP — **not** pos=0, see §10: at T=1 softmax is provably independent of q_a). Each case additionally compares q_a's raw pre-RMSNorm GEMV output against the CPU oracle directly (`qraw` metric), closing RMSNorm's blindness to a uniform scale error — proves the plumbing in §4 end-to-end, not just the standalone kernel, and not just modulo RMSNorm's invariances | RAN, ok |
| Negative control: fmt 1/2/3 unchanged | all 8 original `run()` cases + 2 moe_block + 1 gemm(int4) + 4 attn cases, unmodified assertions | RAN, ok (identical nerr values to the pre-PR baseline run, see §6) |

fmt=5 (stage 2): not attempted — blocked on Team A's `int3/g64-rebased` semantics, see §7.

## 6. Gates run on this branch (all RAN, 2026-07-19, macOS 26.5.2, Apple M5 Max 128 GB)

- **`make glm METAL=0`** and **`make glm METAL=1`**: clean, **0 warnings** (`-Wall
  -Wextra`), both before this PR's changes (stock `e9b3614`) and after — verified by
  capturing both build logs and grepping for `warning` (0 hits in all four: stock×2,
  branch×2).
- **`make metal-test`**: **before this PR (stock `e9b3614`): 15/15 cases pass.**
  **After this PR: 27/27 cases pass** — the original 15 unchanged (byte-identical `nerr`
  values, the negative control from §5), plus **12 new fmt=4 cases**: 9
  `run_grouped()` shape-matrix cases, 1 grouped `coli_metal_gemm` case, 2
  `run_attn_grouped()` fused-decode-path cases. **Case COUNT unchanged at 27/27 after
  review round 1** (§10) — the two `run_attn_grouped()` cases were strengthened in place
  (pos_base moved off the degenerate T=1 point; each case gained an internal raw
  pre-RMSNorm comparison against the CPU oracle, printed as `qraw=...`), not added
  alongside as new cases. See §10 for the mutation-detection matrix proving the
  strengthened cases actually catch what the original two could not.
- **`make test-c`** (all suites in `TEST_BINS`, including `tests/test_i4_grouped` — dev's
  own CPU-side fmt=4 oracle, unmodified by this PR): exit 0, 0 failures reported by any
  suite (e.g. `test_topp: 123 cases run, 0 failure(s)`, `test_dsa_select: 129 cases run,
  0 failure(s)`, `test_i4_grouped: ok`).
- **`make test-python`**: **83/83 tests, OK**, exit 0.
- `git diff e9b3614 --numstat` (this branch, after review round 1): 4 files —
  `c/backend_metal.h` (+25/-18), `c/backend_metal.mm` (+70/-36), `c/colibri.c` (+21/-14),
  `c/tests/test_backend_metal.mm` (+245/-5). No file outside `c/backend_metal.{h,mm}`,
  `c/colibri.c`, and its own test file was touched.

## 7. Scope statement: what this PR does NOT do (read before assuming full coverage)

- **`coli_metal_moe_block`/`moe_gemv` (batched routed-expert MoE path) does not gain
  fmt=4 support.** It was already safely gated to CPU-fallback for fmt=4 before this PR
  (§4) and remains so — extending it means a second, independent per-group-scale kernel
  branch (`moe_gemv` is bindless/pointer-array-based, structurally different from
  `mm_gemv`) plus new per-expert `gs` array parameters on `coli_metal_moe_block`/
  `coli_metal_moe_block_begin`. Given fmt=4 is primarily an *expert* format in practice
  (per #298's framing), this is real follow-up work, not a footnote — flagged here rather
  than attempted under this task's time/scope, with the header doc comment in
  `backend_metal.h` updated to say so explicitly.
- **`kv_b` (MLA absorption core: `a_qabs`/`a_ctx`) does not gain fmt=4 support.** These
  hand-written kernels dequantize inline with a per-row-only helper (`a_deqrow`) that
  never touches `mm_gemv`/`bind_gemv` — extending it is a different, larger shader change
  (new `a_deqrow_grouped` plus threading `gs` through `a_qabs`/`a_ctx`'s own buffer
  lists), and the existing `l->kv_b.fmt==2` gate (§1, §4) already keeps this safe by
  construction: an fmt=4 `kv_b` simply never reaches this GPU path. Not relaxed, not
  attempted.
- **Stage 2 (fmt=5, int3-g64) was not started.** Per the governing spec: build stage 1
  fully first if Team A's `int3/g64-rebased` reconciled semantics aren't yet available.
  This worker did not check out or read that branch — a finished stage 1 beats a
  speculative stage 2, and stage 2's addendum is explicitly gated on #168's merge, so
  starting it now would mean guessing at semantics likely to change. See UNCERTAINTIES.
- **The shader arithmetic is not vectorized** the way fmt=2's `uchar4`/`float4` path is.
  fmt=4's per-group scale lookup means a byte's two nibbles can belong to different
  groups (`g0`/`g1` in §3), which doesn't compose cleanly with the 8-wide vector loads
  the other formats use without either restricting `gs` to specific alignments beyond
  what the loader already guarantees, or adding a second code path for the aligned case.
  Given the spec's own framing ("the shader arithmetic is small" — correctness is the
  ask, not throughput) and no model-run performance measurement being permitted under
  this task's constraints anyway, the straightforward per-element form was chosen
  deliberately. A vectorized fast path for `gs`-aligned regions is natural follow-up work
  once real g64-checkpoint throughput numbers exist to justify it.
- **No CUDA files were touched.** #298/#451 were read read-only for convention only.

## 8. DEVIATIONS from the spec

- Spec's validation matrix names shapes generically ("I multiple of 64... I≤64
  degenerate"); this PR's `run_grouped` calls hardcode `gs=64` throughout (the real
  g64-checkpoint value, per #298's title and description) rather than also sweeping
  `gs∈{16,32,...,256}` the loader's `detect_group_size` candidate list supports. The
  shader itself is fully generic over `gs` (nothing in §3 assumes 64 specifically, only
  evenness) — this is a test-coverage choice, not an implementation limitation. Flagged
  as a deviation because the spec's shape matrix could be read as wanting the full
  candidate-list swept; it was not.
- Added a bind_gemv/fused-decode-path integration test (`run_attn_grouped`, §5) that
  the spec did not explicitly request (its validation section names `coli_metal_matmul`-
  style GEMV comparison and the gemm-test pattern). Added because §2/§4's plumbing work
  (`AttnW`, `coli_metal_attn_decode`/`coli_metal_layer_decode` signature changes) would
  otherwise be exercised by nothing — an untested code path in a PR whose entire premise
  is "a wrong PASS is the worst possible output" seemed like the wrong tradeoff to leave
  unaddressed even though not explicitly named.
- Fixed the `qt_from_disk` allocator bug (§2(d), §4) even though it lives outside
  `c/backend_metal.*` and is arguably "dev's pre-existing code, not this PR's shader
  work." Kept in-scope because it is the literal allocation site of the buffer this
  entire PR's plumbing traces and extends — leaving it unfixed would make §3/§4's shader
  and host-side work unreachable by any real fmt=4 dense tensor.

## 9. UNCERTAINTIES

- **Whether any current field checkpoint actually has fmt=4 on q_a/q_b/kv_a/o/shared-
  expert weights (as opposed to only MoE routed experts) is unknown to this worker.**
  §1's landmine and §4's plumbing are real given the loader's generic `qt_resolve_fmt`
  (any tensor loaded via `qt_from_disk` can be detected as fmt=4), but no specific
  checkpoint was inspected — this task ran no model and downloaded nothing. If in
  practice fmt=4 is expert-only today, §7's moe_gemv gap matters more in the field than
  this PR's bind_gemv fix does; both were done regardless, since the spec asked to trace
  "wherever the current per-row scale buffer flows into the shader," not to guess which
  path is hottest in practice.
- **Real-model throughput/quality impact is entirely unmeasured.** No model runs were
  permitted under this task's constraints; every number in §5/§6 is a synthetic
  kernel-vs-reference comparison. Whether fmt=4 dense tensors reaching the Metal GEMV
  produces a measurable decode-speed change (vs. today's CPU fallback) is UNVERIFIED.
- **`gs` values outside `{16,32,48,64,96,128,192,256}` (the loader's candidate list) were
  not tested**, though the shader and host plumbing place no restriction on `gs` beyond
  evenness. Untested does not mean unsupported, but it is UNVERIFIED beyond the tested
  set (which does include 64, the only value #298/#451's own checkpoints use).
- **Stage 2 (fmt=5) semantics, timeline, and #168's state were not checked** beyond
  confirming the branch name `int3/g64-rebased` exists in the spec's own text — this
  worker did not fetch or read it, per §7.

## 10. Review round 1 (credit — house style: the review record is part of the PR's evidence)

Three findings from independent review, all FIX-FIRST, all addressed on this branch. The
final commit sequence — **`f0fa5a9`** (shader + host plumbing + original tests),
**`2ba12d8`** (allocator activation), **`fc0f5a5`** (attn-test blind-spot fix) — already
reflects all three; there was an earlier, different commit sequence during review that
the third finding below corrected, but it was never pushed and left no trace other than
the two SHAs (`142ddd2`/`9315efa`/`5e3acd8`) some of the discussion below still names for
context. `git diff 5e3acd8 HEAD` is empty and the two states' tree hashes are identical
(`95ff3e6f...`) — the reorder changed commit BOUNDARIES and ORDER only, not one byte of
final content.

**Auditor:** traced that §1 (first revision) overclaimed reachability at stock — the
`falloc`/`resolve()` evidence already present in §2(d) shows the allocator bug masks the
shader bug at stock `e9b3614`, so the two defects mutually cancel there rather than the
shader bug being independently live. §1 above is rewritten to reflect this; nothing about
either defect's reality was retracted, only the "live landmine in stock" framing.

**Validator:** found two proven blind spots in the `run_attn_grouped()` fused-decode-path
cases (§5): (a) the original S=1 case used `pos_base=0`, giving `T=pos_base+S=1` — softmax
over a single key is identically `1.0` regardless of the score's value, so that case's
final output was provably independent of q_a's kernel entirely, not merely insensitive to
some subset of defects; (b) both cases fed q_a's output through RMSNorm before comparing
anything downstream, and `RMSNorm(c·v) == RMSNorm(v)` for any positive scalar `c` — a
whole-tensor uniform-scale-calibration bug in q_a's kernel would be completely invisible
to the fused-path comparison (`nerr`/`cache`) no matter how `pos_base` was chosen, since
(b) is independent of (a).

**Fixes applied** (both in `tests/test_backend_metal.mm`, third commit): the S=1 case now
uses `pos_base=37` (mirroring `run_attn`'s own non-grouped S=1 pos=37 case, which exists
for the identical reason); both cases now additionally capture q_a's raw GEMV output
*before* `t_rms` overwrites it in place, and compare that raw output directly against the
CPU oracle (`cpu_ref_grouped`, the same magnitude-relative construction `run_grouped()`
uses) via a standalone `coli_metal_matmul` call on the exact weight/scale/x data the
attention test generated — reported as `qraw=...` in the test's printed line, folded into
that case's overall pass/fail (not a separately counted case; §6).

**Coordinator (final micro-round):** read §1's own rewritten atomicity paragraph (the one
correcting the auditor's finding above) and noticed it proves too much against itself —
§1 stated the armed state ("allocator resolves, shader doesn't handle fmt=4") is reachable
by bisecting or cherry-picking a single commit, and this branch's THEN-current order
(allocator fix landing before the shader fix — the original `142ddd2`→`9315efa`
sequence) put exactly that armed state at the first of the two commits: green build,
15/15 `metal-test`, and armed, checked out alone. Directed a reorder to shader-first so
the hazard §1 itself describes cannot occur anywhere in this branch's history, not just
in the branch's final (squashed-view) state. This is the reorder reflected in the commit
list at the top of this section and in §1's current text.

**Verification of the reorder (RAN, this branch, this session):** each of the three
resulting commits was built and tested standing alone (`git reset`/re-edit to that
commit's exact tree, not merely inspected) before being committed:

| Commit (final SHA) | Content | `METAL=0`/`METAL=1` build | `make metal-test` |
|---|---|---|---|
| `f0fa5a9` (1st) | shader fmt=4 branch + host plumbing + original (blind-spotted) tests | clean, 0 warnings both | **27/27** — fmt=4 cases construct tensors directly (`posix_memalign`+`coli_metal_register`), never through `qt_from_disk`, so none depend on the allocator fix landing first; the new shader is exercised and proven correct here, just not yet reachable from a real loaded model |
| `2ba12d8` (2nd) | + `qt_from_disk` allocator activation | clean, 0 warnings both | **27/27** (unchanged from 1st — metal-test's cases never touched `qt_from_disk`, so this commit doesn't change metal-test's outcome, only real-model reachability) |
| `fc0f5a5` (3rd) | + attn-test blind-spot fix | clean, 0 warnings both | **27/27** (`qraw` metric now present; see the mutation matrix below) |

No test in the 12 new fmt=4 cases needed to become "self-allocating" or move commits —
they already self-allocate (they always have; `qt_from_disk` is a `colibri.c` model-load
function metal-test's binary doesn't even link against — `make metal-test`'s build recipe
compiles only `tests/test_backend_metal.mm` + `backend_metal.mm`, never `colibri.c`).
Tree identity: `git diff 5e3acd8 HEAD` — empty; `git rev-parse 5e3acd8^{tree}` and
`git rev-parse HEAD^{tree}` — identical (`95ff3e6f...`). The reorder is a pure permutation
of the same three diffs across commit boundaries, verified byte-for-byte, not a
re-derivation that could have silently changed something.

**Verification (RAN, this branch, this session):** re-derived the validator's three
mutation classes by temporarily editing `mm_gemv`'s fmt==4 branch in `backend_metal.mm`
(reverted after each run; final `backend_metal.mm` is byte-identical to the pre-mutation
state — confirmed with `diff`), and ran four configurations of a temporary diagnostic
harness (`run_attn_grouped_diag`, not committed) isolating fix (a) from fix (b):

| Mutation | OLD: S=1 pos=0, no qraw check | fix (a) only: S=1 pos=37, no qraw | fix (b) only: S=1 pos=0, qraw | **fix (a+b) — shipped**: S=1 pos=37, qraw |
|---|---|---|---|---|
| Off-by-one group index (`g = i/gs`, biased down by 1 when `>0`) | not caught | **caught** (nerr 4.6e-6→1.34) | **caught** (qraw 1.8e-8→9.4e-2) | **caught** |
| Swapped nibbles (`b&0xF`/`b>>4` swapped) | not caught | **caught** (nerr→2.38) | **caught** (qraw→9.6e-2) | **caught** |
| Uniform 1% scale error (`scale *= 1.01`) | not caught | **not caught** (nerr 5.78e-6, still passes) | **caught** (qraw 1.8e-8→6.4e-4) | **caught** |

Reading the table: the OLD column (validator's claim) caught nothing, confirming the
blind spot was real, not theoretical. Fix (a) alone closes the off-by-one and
swapped-nibble classes but — exactly as the RMSNorm-invariance argument predicts —
**still misses the uniform-scale class even at pos_base=37**, empirically confirming that
(a) and (b) are independent fixes and neither subsumes the other. Fix (b) alone (the
`qraw` check) catches all three classes regardless of `pos_base`, because it inspects
q_a's kernel output directly rather than through the RMSNorm/attention pipeline; fix (a)
remains independently worth keeping because it makes the FUSED-PATH comparison itself
(not just the auxiliary `qraw` probe) sensitive to q_a, which matters for defects in the
integration (e.g. how `qa_gs` is threaded through `bind_gemv`'s buffer indexing inside
`encode_attention`) rather than in the standalone GEMV kernel `qraw` isolates. The shipped
configuration (rightmost column) is what `run_attn_grouped()` now runs unconditionally —
3/3 mutation classes caught, `make metal-test` still exits 0 (27/27) with none of the
three mutations present. Also noted in passing: `run_grouped()`'s own shape-matrix cases
(§5), un-related to this attn-level fix, independently caught the uniform-scale mutation
too (`worst_rel` 7.1e-4 to 3.5e-3 across shapes, above the 1e-4 threshold) — the attn-level
blind spot was specifically about the FUSED attention output hiding the bug via RMSNorm,
not about fmt=4 GEMV correctness being unchecked elsewhere.

## 11. CUDA platform parity (#298 / #451) — added 2026-07-20

A structured comparison against the in-flight CUDA fmt=4 work (PR #298's design +
PR #451's expert-group kernels, both read at head on 2026-07-20) so the two platform
tiers can be reviewed as companions:

- **Format contract: fully aligned.** Same packed-nibble layout (`(I+1)/2` row
  bytes), same `[O, ceil(I/gs)]` f32 scale shape with `scale[o*ng+g]` indexing,
  same `g = i/gs` group math. The one apparent decode divergence (CUDA's
  upload-time XOR-0x88 to two's-complement vs our direct offset-binary `-8`) is
  mathematically equivalent — and deliberately not interchangeable: CUDA mutates a
  device-private copy, while Metal buffers can alias host memory the CPU fallback
  still reads, so an in-place transform is not an option on this backend.
- **Test oracle:** our cases use the magnitude-relative tolerance
  (`|Δ| / Σ|terms|`), matching dev's own `test_i4_grouped.c` and the review
  guidance given on #298 regarding cancellation in grouped dot products.
- **Scope split:** this PR covers the `mm_gemv` family (dense / attention /
  fused-decode). The batched routed-expert path (`moe_submit`/`moe_gemv`) remains
  gated to fmt {1,2} with CPU fallback — the Metal counterpart of #451's
  expert-group work is planned as a follow-up ("stage 3"), for which #451's
  per-tensor `GroupDesc` (per-expert fmt/gs) is the reference shape; Metal's
  current batch path assumes a single scalar fmt per block, which stage 3 must
  make explicit or generalize.
- **End-to-end gate:** all results in this PR are synthetic kernel-vs-oracle
  comparisons (§5–6). A CPU-vs-Metal token-stream identity check on a real
  grouped-int4 container (the determinism gate requested on #298) is planned as a
  follow-up comment once a g64 container is minted from the FP8 source.

---
**Coordinate stamp:** 2026-07-19/20 (session spanned midnight), macOS 26.5.2, Apple M5 Max
128 GB (Mac17,7) — the same machine/lab referenced in #447. All RAN evidence in this
document (§5, §6, §10) was captured on this branch, this session, this machine. No model
runs; no GitHub writes; no pushes.
