### PR TITLE
docs: explain the prebuilt Windows binary — what the .exe is and how to run it (#450)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,13 @@ COLI_MODEL=/nvme/glm52_i4 ./coli doctor   # read-only readiness check
 The engine at runtime is pure C — python is only used by the one-time converter
 and the optional API gateway.
 
+**On Windows?** You don't need to build. Download the
+`colibri-<version>-windows-x86_64.zip` from
+[Releases](https://github.com/JustVugg/colibri/releases), unzip it, rename
+`colibri-*-windows-x86_64.exe` → `glm.exe` (so the `coli` launcher finds the
+engine), install [Python 3](https://www.python.org/downloads/), then run
+`coli chat`. Full walkthrough in the [Quick Start guide](docs/quickstart.md#windows).
+
 Prefer a `coli` command on your PATH? From a checkout, `pip install -e .`
 registers it (the engine itself still lives in `c/` — this is an editable
 install from the clone, not a standalone wheel).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -42,11 +42,31 @@ engine needs.
 You have two options.
 
 **Option A — download a prebuilt binary (no compiler needed).**
-Grab the latest `colibri-<version>-windows-x86_64.zip` from the
-[Releases page](https://github.com/JustVugg/colibri/releases), unzip it, and
-skip to [step 3](#3-get-the-model). Python 3 (from
-[python.org](https://www.python.org/downloads/)) is still needed if you want to
-convert a model yourself.
+Grab `colibri-<version>-windows-x86_64.zip` from the
+[Releases page](https://github.com/JustVugg/colibri/releases) and unzip it.
+Inside you'll find:
+
+| File | What it is |
+|---|---|
+| `colibri-<version>-windows-x86_64.exe` | **the engine** — the C program that actually runs the model |
+| `coli` | the command-line launcher (`chat`, `serve`, `convert`, `doctor`, …) |
+| `openai_server.py`, `resource_plan.py`, `doctor.py` | Python support for the API server and placement planner |
+
+Two setup steps:
+
+1. **Rename the engine to `glm.exe`** so the launcher can find it (it looks for a
+   binary named `glm`):
+   ```powershell
+   Rename-Item colibri-*-windows-x86_64.exe glm.exe
+   ```
+2. **Install Python 3** from [python.org](https://www.python.org/downloads/) — the
+   `coli` launcher and the API gateway are Python scripts (the engine itself is
+   pure C and needs nothing).
+
+Then continue to [step 3](#3-get-the-model). Prefer to skip the launcher? You can
+run the engine directly — `.\glm.exe` reads the model path from the `SNAP`
+environment variable (see [docs/windows.md](windows.md)) — but `coli chat` is the
+easy path.
 
 **Option B — build from source with MSYS2.**
 Install [MSYS2](https://www.msys2.org/), open the **UCRT64** shell, and run:


### PR DESCRIPTION
Closes #450.

The v1.0.0 release ships `colibri-<ver>-windows-x86_64.zip`, but neither the README nor the docs said **what the .exe is for or how to run it** — as @sinand99 pointed out.

Fixes:
- **quickstart.md, Windows Option A**: now lists what's in the zip (the engine `.exe`, the `coli` launcher, the Python support files) and gives the two steps that were missing: **rename the engine to `glm.exe`** so `coli` finds it, and **install Python 3** for the launcher/gateway.
- **README run section**: a short Windows-prebuilt pointer to the same walkthrough.

Docs-only, no code. Reaches `main` with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)