### PR TITLE
nix: re-use existing pkgs binding

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -120,7 +120,7 @@
           };
         };
 
-        formatter = (import nixpkgs {inherit system;}).alejandra;
+        formatter = pkgs.alejandra;
 
         devShells.default = pkgs.mkShell {
           inputsFrom = [colibri];


### PR DESCRIPTION
I missed this in my recently merged PR, #409.