### PR TITLE
feat(st): COLI_MODEL_DIRS ΓÇö split model shards across N drives, no duplication (capacity aggregation; composable with #421 mirror)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -1031,7 +1031,9 @@ static void layer_cuda_shard_kvb(Layer *l,int H,int Q,int V){
 
 static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits){
     memset(m,0,sizeof(*m)); m->ebits=ebits; m->dbits=dbits;
-    load_cfg(&m->c,snap); st_init(&m->S,snap);
+    load_cfg(&m->c,snap);
+    { const char *xd=getenv("COLI_MODEL_DIRS");        /* SPLIT: model shards spread across N drives */
+      st_init_multi(&m->S,snap,(xd&&*xd)?xd:NULL); }
     Cfg *c=&m->c; char nm[256]; int H=c->n_heads, D=c->hidden;
     /* embed e lm_head sono il confine I/O: tenerli ad alta precisione (come i quant dynamic
      * reali). A bf16 ~1.9GB su GLM reale: trascurabile. dbits>=8 -> qui f32; piu' basso -> dbits. */

--- a/c/st.h
+++ b/c/st.h
@@ -210,21 +210,66 @@ static void st_pread_full(int fd, void *buf, int64_t n, int64_t off, const char 
     }
 }
 
-static void st_init(shards *S, const char *snap_dir) {
+/* Scan one directory for *.safetensors shards, appending to files[] (dedup by
+ * basename, so a list of directories acts as a SEARCH PATH: the same shard
+ * present on two drives is taken from the first-listed one only). *added
+ * returns how many shards this dir contributed. */
+static void st_scan_dir(const char *dir, char files[][1024], int *nf, int *added) {
+    DIR *d = opendir(dir); struct dirent *e;
+    if (!d) { perror(dir); exit(1); }
+    int base_n = *nf;
+    while ((e = readdir(d))) {
+        const char *dot = strrchr(e->d_name, '.');
+        if (dot && !strcmp(dot, ".safetensors")) {  /* model.safetensors o model-0000N-of-... */
+            int dup = 0;
+            for (int i = 0; i < *nf; i++) {
+                const char *b = strrchr(files[i], '/');
+#ifdef _WIN32
+                const char *b2 = strrchr(files[i], '\\'); if (b2 && (!b || b2 > b)) b = b2;
+#endif
+                b = b ? b + 1 : files[i];
+                if (!strcmp(b, e->d_name)) { dup = 1; break; }  /* already taken from a higher-priority drive */
+            }
+            if (dup) continue;
+            if (*nf >= ST_MAX_SHARDS) { fprintf(stderr, "too many shards (>%d): raise ST_MAX_SHARDS\n", ST_MAX_SHARDS); exit(1); }
+            snprintf(files[(*nf)++], 1024, "%s/%s", dir, e->d_name);
+        }
+    }
+    closedir(d);
+    if (added) *added = *nf - base_n;
+}
+
+/* Index shards from snap_dir, optionally SPLIT across extra drives listed in
+ * extra_dirs (';' or ',' separated). Each shard lives on exactly ONE drive
+ * (no duplication — unlike the dual-SSD mirror); a demand pread hits whichever
+ * drive holds that shard, so concurrent expert loads parallelise across drives
+ * and combined capacity is used. Scales to N drives. Metadata (config /
+ * tokenizer / .coli_usage / .coli_kv) is read from snap_dir only. */
+static void st_init_multi(shards *S, const char *snap_dir, const char *extra_dirs) {
     memset(S, 0, sizeof(*S));
     S->cap = 4096; S->t = calloc(S->cap, sizeof(st_tensor));
     /* raccoglie ordinatamente i nomi dei file shard */
     static char files[ST_MAX_SHARDS][1024]; int nf = 0;
-    DIR *d = opendir(snap_dir); struct dirent *e;
-    if (!d) { perror(snap_dir); exit(1); }
-    while ((e = readdir(d))) {
-        const char *dot = strrchr(e->d_name, '.');
-        if (dot && !strcmp(dot, ".safetensors")) {  /* model.safetensors o model-0000N-of-... */
-            if (nf >= ST_MAX_SHARDS) { fprintf(stderr, "too many shards (>%d): raise ST_MAX_SHARDS\n", ST_MAX_SHARDS); exit(1); }
-            snprintf(files[nf++], 1024, "%s/%s", snap_dir, e->d_name);
+    int c0 = 0; st_scan_dir(snap_dir, files, &nf, &c0);
+    int ndir = 1;
+    if (extra_dirs && *extra_dirs) {
+        char buf[4096]; snprintf(buf, sizeof(buf), "%s", extra_dirs);
+        char *p = buf;
+        while (p && *p) {
+            char *sep = p; while (*sep && *sep != ';' && *sep != ',') sep++;
+            int last = (*sep == 0); *sep = 0;
+            while (*p == ' ') p++;
+            size_t plen = strlen(p); while (plen > 0 && p[plen-1] == ' ') p[--plen] = 0;
+            if (*p) {
+                int cN = 0; st_scan_dir(p, files, &nf, &cN);
+                fprintf(stderr, "[SPLIT] +%s -> %d shard(s)\n", p, cN);
+                ndir++;
+            }
+            p = last ? NULL : sep + 1;
         }
+        fprintf(stderr, "[SPLIT] model across %d dir(s): %d shard(s) total (primary %s -> %d shard(s)), no duplication\n",
+                ndir, nf, snap_dir, c0);
     }
-    closedir(d);
     for (int a = 0; a < nf; a++) for (int b = a+1; b < nf; b++)
         if (strcmp(files[a], files[b]) > 0) { char tmp[1024]; strcpy(tmp, files[a]); strcpy(files[a], files[b]); strcpy(files[b], tmp); }
 
@@ -304,6 +349,9 @@ static void st_init(shards *S, const char *snap_dir) {
         S->hidx[h] = i;
     }
 }
+
+/* backward-compatible single-directory entry point */
+static void st_init(shards *S, const char *snap_dir) { st_init_multi(S, snap_dir, NULL); }
 
 static st_tensor *st_find(shards *S, const char *name) {
     if (S->hidx) {

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -82,6 +82,7 @@ Format: `VAR` — default — effect.
 
 | Variable | Default | Effect |
 |---|---|---|
+| `COLI_MODEL_DIRS` | unset | SPLIT the model across 2+ drives: a `;`/`,`-separated list of extra directories, each holding a **distinct** subset of the `.safetensors` shards (no duplication). Shards act as a search path — every shard is read from whichever drive holds it, so concurrent expert loads parallelise across drives and combined capacity is used. Scales to N drives. Metadata (config/tokenizer/`.coli_usage`) stays in the primary `COLI_MODEL` dir. Pairs well with `PIPE=1` (concurrent loaders) + `DIRECT=1`. Distinct from — and composable with — `COLI_MODEL_MIRROR`: the mirror is matched per-shard by basename against the merged (split) index, so a mirror dir may hold a copy of any subset of the split's shards. |
 | `COLI_MODEL_MIRROR` | unset | Path to a second, byte-identical (read-only) copy of the model on another drive; expert reads are split across both. Partial mirrors work (only the shards present are used). |
 | `COLI_DISK_WEIGHTS` | unset (startup bandwidth probe) | Split ratio `<primary>,<mirror>` (e.g. `1,1` for 50/50, `9,3` for a fast+slow pair). Unset = probe both drives with the engine's own access pattern at startup. |
 


### PR DESCRIPTION
## What

Per the green light in #467 (finding 4): `COLI_MODEL_DIRS=<dir>[;<dir>...]` — split the model's `.safetensors` shards across **N drives with no duplication**. Complementary to #421's mirror, not a competitor.

## Why

The mirror gives 2× read bandwidth at 2× disk cost. The split gives **capacity aggregation**, which the mirror fundamentally can't: a 400 GB container fits across two smaller drives that individually can't hold it (or three, or N — `ST_MAX_SHARDS` is the only bound). Demand preads hit whichever drive holds the shard, so concurrent expert loads still parallelise across spindles when routing spreads.

## Design

- The dir list acts as a **search path with dedup by basename**: a shard present in two dirs is taken from the first-listed one (primary `COLI_MODEL` first). No layout convention imposed — any partition of the shards works; users move files between drives freely.
- Each shard opens its own fd from its own path, exactly as today — the split needs **no read-path changes at all**: `st_open_fd`/`pread`/O_DIRECT twins/`PIPE` workers all work per-fd already. The whole feature is in indexing.
- **Composable with `COLI_MODEL_MIRROR`** (the init-order ask from #467): `st_mirror_init` runs after indexing and matches per-shard **by basename against the merged index**, so a mirror dir may hold a copy of any subset of the split's shards — partial mirrors of a split are valid, divergent files are rejected per-file exactly as on a single-dir model. They cannot fight at init: split resolves *which file is primary*, mirror only ever *adds a replica fd* to an already-indexed shard.
- Metadata (`config.json`, tokenizer, `.coli_usage`, `.coli_kv`) stays in the primary `COLI_MODEL` dir only — extra dirs are weights-only, never written.
- `st_init(S, dir)` remains as a one-line back-compat wrapper over the new `st_init_multi(S, dir, extra)`; every existing call site and test is untouched.
- Startup logs the layout: `[SPLIT] +C:\glm_split_b -> 70 shard(s)` / `[SPLIT] model across 2 dir(s): 142 shard(s) total (primary ... -> 72 shard(s)), no duplication`.

## Verification (RTX 5080 / Windows 11, g64 container, 142 shards, 399.8 GB)

- 72 even shards on drive 1 + 70 odd shards on drive 2 (hardlink layout, zero duplication): correct indexing, coherent greedy output, zero fallbacks, `CUDA_DENSE=1` full residency.
- Decode parity with single-drive at full RAM: 0.92 vs 0.89–0.90 tok/s — as expected there (84% expert hit ⇒ decode barely touches disk). Honest framing per #467: on this box the value is capacity, not speed; a bandwidth-bound host with dedicated data drives is where the parallel-read side should show.
- Full protocol + raw logs in #467.

## Scope

+61/−10 over `c/st.h` (scan/dedup/init-multi), one call site in `c/colibri.c` (env read at `model_init`), `docs/ENVIRONMENT.md` row. No kernel, no read-path, no format changes. Happy to add a `test_st_split.c` sibling of `test_st_mirror.c` (dedup priority, partial-dir, missing-dir error) if you want one in-tree — say the word and I'll push it to this branch.
