### PR TITLE
pilot: LFRU-aware eviction guard — a speculative load never evicts a warm demand expert (#441)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -733,6 +733,11 @@ static int g_pilot_real=0;/* PILOT_REAL=1: il pilota fa LOAD VERI cross-layer de
 static int g_pilot_two=0; /* PILOT_TWO=1: two-step prefetch — before running L+1's router,
                           * approximate MoE(L) using only the shared expert (resident, no disk)
                           * and add it to the state. Trades 3 small matmuls for +2.3% recall. */
+static int g_pilot_evict_guard=1;/* PILOT_EVICT_GUARD=0 -> old behavior (a speculation evicts the plain LRU).
+                          * Default ON: a speculative pilot load may evict a RESIDENT expert only if the
+                          * predicted expert is historically HOTTER than the victim (same LFRU hysteresis as
+                          * tier_pick_lfru); otherwise it drops the speculation rather than thrash a warm
+                          * demand-loaded expert. Cache placement only -> output byte-identical. (#441) */
 /* Handshake main<->pilota per il load-vero cross-layer. Invariante di sicurezza in DUE parti:
  *  1) Percorso MATMUL (moe): il pilota scrive SOLO ecache[layer] con layer > g_cur_moe_layer;
  *     il matmul in moe() legge SOLO ecache[layer]==g_cur_moe_layer, e la barriera a inizio moe()
@@ -3427,7 +3432,16 @@ static void pilot_realload(Model *m, int layer, int eid){
     for(int z=0;z<nn;z++) if(Sl[z].eid==eid){ pthread_mutex_unlock(&g_pilot_mx); return; }
     int slot,isnew;                                     /* cresci se c'e' posto, altrimenti LRU */
     if(nn<m->ecap){ slot=nn; isnew=1; }
-    else { int lru=0; for(int z=1;z<nn;z++) if(Sl[z].used<Sl[lru].used) lru=z; slot=lru; isnew=0; }
+    else { int lru=0; for(int z=1;z<nn;z++) if(Sl[z].used<Sl[lru].used) lru=z; slot=lru; isnew=0;
+        /* LFRU eviction guard (#441): a speculation must not drop a WARM demand-loaded expert.
+         * Evict only if the predicted expert's history is hotter than the victim by tier_pick_lfru's
+         * hysteresis (25% + 4 freq); else drop the speculation. Cache placement only -> output unchanged. */
+        if(g_pilot_evict_guard && m->eheat && m->elast && Sl[lru].eid>=0){
+            int vid=Sl[lru].eid;
+            uint64_t vs=tier_lfru_score(m->eheat[layer][vid],m->elast[layer][vid],m->eaccess_clock);
+            uint64_t cs=tier_lfru_score(m->eheat[layer][eid],m->elast[layer][eid],m->eaccess_clock);
+            if(cs<=vs+(vs>>2)+(4u<<8)){ atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);
+                                        pthread_mutex_unlock(&g_pilot_mx); return; } } }
     ESlot *dst=&Sl[slot];
     dst->eid=-1;                                        /* nascondi dagli scan-hint mentre carica */
     g_pilot_inflight[layer]++;
@@ -3477,6 +3491,14 @@ static void pilot_uring_batch(Model *m){
                 if(Sl[z].eid==-1){ slot=z; break; }
                 if(Sl[z].eid< -1) continue;          /* URING reservation in flight */
                 if(slot<0 || Sl[z].used<Sl[slot].used) slot=z;
+            }
+            /* LFRU eviction guard (#441): don't drop a warm resident for a speculation (see pilot_realload) */
+            if(slot>=0 && Sl[slot].eid>=0 && g_pilot_evict_guard && m->eheat && m->elast){
+                int vid=Sl[slot].eid;
+                uint64_t vs=tier_lfru_score(m->eheat[layer][vid],m->elast[layer][vid],m->eaccess_clock);
+                uint64_t cs=tier_lfru_score(m->eheat[layer][eid],m->elast[layer][eid],m->eaccess_clock);
+                if(cs<=vs+(vs>>2)+(4u<<8)){ atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);
+                                            pthread_mutex_unlock(&g_pilot_mx); continue; }
             }
         }
         if(slot<0){ atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed); pthread_mutex_unlock(&g_pilot_mx); continue; }
@@ -6105,6 +6127,7 @@ int main(int argc, char **argv){
     if(g_pilot_real) g_pilot=1;                           /* PILOT_REAL implica il pilota attivo */
     g_pilot_two = getenv("PILOT_TWO")?atoi(getenv("PILOT_TWO")):0; /* 1 = two-step: shared-expert-corrected router prediction (+2.3% recall, 3 extra matmuls) */
     if(g_pilot_two) g_pilot=1;                            /* PILOT_TWO implies PILOT active */
+    g_pilot_evict_guard = getenv("PILOT_EVICT_GUARD")?atoi(getenv("PILOT_EVICT_GUARD")):1; /* 0 = old LRU eviction (A/B) */
     /* Default K: hint-only PILOT keeps 8 (WILLNEED hints are free, no eviction).
      * Under PILOT_REAL the speculative loads are REAL and create LRU eviction
      * pressure, so at ~28% mispredict a large K thrashes the cache — default to 6


### PR DESCRIPTION
## Summary

The durable finding from the multi-worker pilot investigation on #441 wasn't the queue depth —
it was the **eviction policy**. A speculative pilot load picks the plain-LRU slot and can evict an
expert that was **just demand-loaded and is still hot**; that expert is then re-read on its next
selection. In the controlled 2×2 A/B on #441 this thrash showed up directly in the byte counter:
**+9–18% expert bytes read for +0.5–0.7 pt hit rate**. You named the fix in your reply:

> *"the pilot must never drop a hot demand-loaded expert to stage a speculative one … an
> LFRU-aware pilot eviction … that's worth a PR on its own, separate from the worker count."*

This is that PR.

## What it does

When the pilot wants to stage a speculative expert into a **full** `ecache[layer]`, it now evicts
the LRU resident **only if** the predicted expert is historically hotter than the victim, by the
**same hysteresis `tier_pick_lfru` already uses** (25% + 4 frequency counts, via `tier_lfru_score`).
Otherwise it **drops the speculation** rather than displace a warm slot. Growing into a free slot is
unchanged (always allowed). Applied to both speculative eviction sites — `pilot_realload`
(blocking) and `pilot_uring_batch` (io_uring) — and to **neither** the demand-promotion path in
`moe()` nor the RAM-reclaim path in `rss_guard()`, which must keep their current behavior.

## Output-preserving

Cache placement only — it changes *which* experts are cached, never their values. The `moe()`
per-layer barrier still fences every layer against in-flight pilot loads, and a dropped speculation
is simply demand-loaded later (same expert, same value). Verified byte-identical on the full
GLM-5.2 744B int4 model, cold-streamed so the pilot actually loads and the guard actually runs:

```
sha256(greedy completion)   arm
43d9126f…415805             PILOT off
43d9126f…415805             PILOT_REAL=1, guard ON  (default)
43d9126f…415805             PILOT_REAL=1, guard OFF (PILOT_EVICT_GUARD=0)
```
(DIRECT=1, greedy TEMP=0, 12-token decode, same prompt — all three byte-identical. Full hash
`43d9126f6d29da8ab5883d50539b68e71cc404fc45380311f72657f594415805`.) This same run also **proves
the guard fires**: guard ON vs OFF diverge sharply in the cache counters (see the table below — 13 GB
and 2× felt-wait apart), so the guard changed placement on every layer, yet the emitted tokens are
identical.

**Concurrency note (deliberate):** the guard reads the heat/recency counters
(`eheat`/`elast`/`eaccess_clock`) on the pilot worker while `moe()` bumps them on the main thread
without a shared lock — a best-effort read, exactly like the existing LRU `used` clock. Indices are
always valid (the candidate is a router arg-max in `[0,n_experts)`, the victim is gated on
`eid>=0`), so a torn/stale counter can only make a single keep-or-drop decision marginally
suboptimal; it cannot fault and cannot change output (placement-only). Happy to make it a
relaxed-atomic load if you'd prefer it explicit.

## Scope / knobs

- Default **ON**, but only reachable on the opt-in `PILOT_REAL=1` path, so no default-config user
  changes behavior.
- `PILOT_EVICT_GUARD=0` restores the old plain-LRU eviction — a **single-binary A/B**.
- Reuses the existing `tier_lfru_score` (the pin tier's scorer) and the existing `g_pilot_drops`
  counter; no new machinery.

## Performance — a single-run illustration + the honest caveat

The change removes a *provably wasted* re-read (evicting a warm expert for an unproven
speculation), so on output it **cannot regress**. A within-binary A/B on my box (same prompt,
back-to-back, byte-identical output as above):

| arm | demand hit | GB fetched | felt-wait |
|---|---|---|---|
| PILOT off | 36.4% | 80.4 | 28.2s |
| PILOT_REAL, **guard ON** | 36.4% | 80.5 | 28.3s |
| PILOT_REAL, **guard OFF** | 53.4% | 93.6 | 59.5s |

Guard **OFF** lets the pilot thrash: it buys a higher nominal hit rate (53%) by speculatively
evicting warm experts, but reads **+16% bytes** and **doubles felt-wait**, because those evicted
experts get re-read — PILOT_REAL *without* the guard is a net regression versus no pilot at all.
Guard **ON** drops those speculations and holds PILOT_REAL at PILOT-off parity. (Single run, but the
effect is large and mechanistic — the byte counter *is* the mechanism, not warm-up noise.)

The one thing this box **can't** show is the upside. With a per-layer ecache of only ~9 slots there
are no genuinely-cold slots for a speculation to fill without displacing something warm, so the
guard (correctly) drops ~all of them and the pilot collapses toward PILOT-off — it can prevent the
regression here but not demonstrate a gain. That wants a host with **enough RAM for a real cache AND
a drive with idle bandwidth / a QD sweet spot** — exactly the #389 / #161 / #431 machines you
offered to flag. The knob + byte-identical output make that A/B a single-binary run; I don't have
such a box.

## Validation

- [x] `make -C c check` (111/111 pass, native + portable, 0 warnings)
- [x] Byte-identical output across guard on / off / PILOT off (above)
- [ ] Cold-stream throughput A/B on a big-RAM + QD-scaling host — pending hardware (byte-identical,
      so it cannot regress output either way)

## Compatibility

- [x] Default CPU build stays dependency-free
- [x] No model files, binaries, or artifacts included

---
*Implemented and measured with AI assistance (Claude), per the project's AI-contribution precedent
(#428, #398). Byte-identity verified on the full model; the throughput A/B is explicitly deferred
to hardware that can exercise a real cache + queue.*