### PR TITLE
omp: reset CPU affinity before the tuning re-exec (fixes #471)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -6016,6 +6016,18 @@ int main(int argc, char **argv){
         setenv("COLI_OMP_TUNED","1",1);
 #ifdef __linux__
         fprintf(stderr,"[OMP] hot-thread tuning: re-exec once (COLI_NO_OMP_TUNE=1 to skip)\n");
+        /* #471: execv PRESERVES the CPU affinity mask. If the user exported
+         * OMP_PROC_BIND/OMP_PLACES, libgomp's constructor already bound THIS thread to
+         * place 0 (one core's SMT siblings) before main() ran; the re-exec'd image would
+         * inherit that 1-core mask, enumerate OMP_PLACES=cores inside it, and jail the
+         * whole team on one core (measured ~20x slowdown). Reset to all online CPUs so
+         * the fresh libgomp binds from the full set — the user's OMP_* env still wins. */
+        { cpu_set_t all; CPU_ZERO(&all);
+          long ncpu = sysconf(_SC_NPROCESSORS_ONLN);
+          if(ncpu > CPU_SETSIZE) ncpu = CPU_SETSIZE;
+          for(long i = 0; i < ncpu; i++) CPU_SET((int)i, &all);
+          if(sched_setaffinity(0, sizeof(all), &all) != 0)
+              perror("[OMP] sched_setaffinity pre-reexec (continuing)"); }
         execv("/proc/self/exe", argv);         /* returns only on failure -> fall through and run untuned */
         perror("[OMP] execv self-reexec failed, running untuned");
 #endif

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -40,6 +40,13 @@ Auto-tier plans size OpenMP from physical cores and bind workers across cores.
 Memory-bound quantized kernels can regress sharply when SMT siblings compete for
 limited memory channels; explicit `OMP_*` settings always take precedence.
 
+> Note (#471): exporting `OMP_PROC_BIND`/`OMP_PLACES` used to interact badly with
+> the engine's one-time OpenMP tuning re-exec on Linux — the re-exec'd image
+> inherited the first image's place-0 thread binding and the whole team landed on
+> one core (~20× slowdown). The engine now resets its affinity to all online CPUs
+> right before the re-exec, so explicit `OMP_*` pinning works as documented.
+> `COLI_OMP_TUNED=1` remains the escape hatch that skips the re-exec entirely.
+
 ```bash
 coli plan --model /models/glm52_i4 --policy quality
 coli run --auto-tier --policy quality "Explain MoE offloading"


### PR DESCRIPTION
Implements the fix you sketched in #471: reset the master thread's affinity to all online CPUs immediately before the `execv`, so the second image's libgomp constructor enumerates places from the full core set and the user's `OMP_PROC_BIND`/`OMP_PLACES` work as documented. Clamped to `CPU_SETSIZE`, and a `sched_setaffinity` failure just warns and proceeds (the re-exec still happens, behaviour = status quo).

Also adds the #471 note to `docs/tuning.md` next to the "explicit `OMP_*` settings always take precedence" paragraph, with `COLI_OMP_TUNED=1` documented as the escape hatch.

### Verified on the affected host (2× Xeon 8370C, 48C/2 NUMA, GLM-5.2 int4 fully resident)

Repro env from #471 (`OMP_NUM_THREADS=48 OMP_PROC_BIND=spread OMP_PLACES=cores`, no escape hatch, re-exec taken — `[OMP] hot-thread tuning: re-exec once` present in stderr):

| | before | after |
|---|---|---|
| `Cpus_allowed_list` (engine, mid-decode) | `0-1` | `0-95` |
| greedy decode | 0.11 tok/s | 4.34 tok/s (32-token run; matches this host's normal I4S=1 rate) |

Build: 0 warnings; oracle 32/32 TF passes.

One nuance from the issue thread, made explicit: a deliberate outer restriction (`taskset`/`numactl -C` around the whole process) is also widened by this reset. If that matters, gating the reset on "current mask ⊂ one core while `OMP_PROC_BIND` is set" is a follow-up option; kept to your simpler version here.
