### PR TITLE
pilot: multi-worker PILOT_REAL prefetch (PILOT_WORKERS) — byte-identical base for the #441 hardware A/B

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -199,7 +199,7 @@ else
 PYTHON    ?= python3
 endif
 CUDA_OBJ  =
-TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_st_mirror$(EXE) tests/test_st_pread$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_grouped$(EXE) tests/test_stops$(EXE) tests/test_topp$(EXE) tests/test_sample_nan$(EXE) tests/test_temp_env$(EXE) tests/test_tok_o200k$(EXE) tests/test_kv_alloc$(EXE) tests/test_int3$(EXE) tests/test_int3_load$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE) tests/test_dsa_select$(EXE) tests/test_logit_nan$(EXE) tests/test_router_nan$(EXE) tests/test_pipe_block$(EXE) tests/test_e8_kernel$(EXE)
+TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_st_mirror$(EXE) tests/test_st_pread$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_grouped$(EXE) tests/test_stops$(EXE) tests/test_topp$(EXE) tests/test_sample_nan$(EXE) tests/test_temp_env$(EXE) tests/test_tok_o200k$(EXE) tests/test_kv_alloc$(EXE) tests/test_int3$(EXE) tests/test_int3_load$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE) tests/test_dsa_select$(EXE) tests/test_logit_nan$(EXE) tests/test_router_nan$(EXE) tests/test_pipe_block$(EXE) tests/test_e8_kernel$(EXE) tests/test_pilot_ring$(EXE)
 ifneq (,$(LINUX))
 TEST_BINS += tests/test_uring$(EXE)
 endif
@@ -466,6 +466,9 @@ tests/test_uring$(EXE): tests/test_uring.c colibri.c st.h uring.h json.h tok.h t
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_pipe_block$(EXE): tests/test_pipe_block.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+tests/test_pilot_ring$(EXE): tests/test_pilot_ring.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 test-c: $(TEST_BINS)

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -797,6 +797,7 @@ static pthread_mutex_t g_pilot_mx=PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t g_pilot_cv=PTHREAD_COND_INITIALIZER;
 static _Atomic int g_cur_moe_layer=-1;   /* massimo layer moe in cui il MAIN e' entrato (per forward) */
 static int g_pilot_inflight[256];        /* protected by g_pilot_mx; URING can load a layer concurrently */
+static int g_pilot_nw=1;                 /* PILOT_WORKERS: blocking-path pilot threads (SPMC ring). 1 = today's behaviour (byte-identical). Only the non-URING PILOT_REAL path fans out; URING already batches to QD>1. */
 static _Atomic long g_pilot_loads=0;     /* load cross-layer VERI completati (banda spesa) */
 static _Atomic long g_pilot_drops=0;     /* predizioni scartate perche' il main possiede gia' il layer */
 /* format from `bits`: >=16 f32, 5..8 int8, 4 int4-packed, 3 int3-g64 (group scales), <=2 int2 */
@@ -3743,7 +3744,7 @@ static void la_predict(Model *m, int target, const float *h, int kind){
  * del fadvise BLOCCA (~0.5ms x 169k chiamate = +92s/48 token, misurato) — inline
  * il pilota costava piu' di quanto rendesse. Ring lock-free 1P/1C; pieno = scarta
  * (un hint perso non e' un errore). */
-static struct { int l,e; } pilot_q[4096];
+static struct { _Atomic int l,e; } pilot_q[4096];  /* payload atomico (relaxed): la claim SPMC legge speculativamente prima della CAS e scarta se perde -> senza _Atomic sarebbe una data race C11 col produttore. int e' sempre lock-free: stessa size/align. */
 static volatile unsigned pilot_w=0, pilot_r=0;
 static Model *pilot_m=NULL;
 /* PILOT_REAL: load VERO dell'expert predetto dentro la LRU del layer FUTURO. Vedi
@@ -3751,46 +3752,61 @@ static Model *pilot_m=NULL;
  * il lock protegge solo la scelta/pubblicazione dello slot e l'handshake col main. */
 static void pilot_realload(Model *m, int layer, int eid){
     pthread_mutex_lock(&g_pilot_mx);
-    if(layer <= atomic_load_explicit(&g_cur_moe_layer,memory_order_acquire)){
-        atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);
-        pthread_mutex_unlock(&g_pilot_mx); return;      /* il main possiede gia' questo layer */
+    if(layer<0 || layer>=256 || layer <= atomic_load_explicit(&g_cur_moe_layer,memory_order_acquire)){
+        atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);   /* fuori range (come il ramo URING) o main gia' su questo layer */
+        pthread_mutex_unlock(&g_pilot_mx); return;
     }
     ESlot *P=m->pin[layer];                             /* gia' residente (pin o ecache)? skip */
     for(int z=0;z<m->npin[layer];z++) if(P[z].eid==eid){ pthread_mutex_unlock(&g_pilot_mx); return; }
-    ESlot *Sl=m->ecache[layer]; int nn=m->ecn[layer];
-    for(int z=0;z<nn;z++) if(Sl[z].eid==eid){ pthread_mutex_unlock(&g_pilot_mx); return; }
-    int slot,isnew;                                     /* cresci se c'e' posto, altrimenti LRU */
-    if(nn<m->ecap){ slot=nn; isnew=1; }
-    else { int lru=0; for(int z=1;z<nn;z++) if(Sl[z].used<Sl[lru].used) lru=z; slot=lru; isnew=0;
+    ESlot *Sl=m->ecache[layer]; int nn=m->ecn[layer];   /* dedup contro residenti E prenotazioni in volo -(eid+2) */
+    for(int z=0;z<nn;z++) if(Sl[z].eid==eid || Sl[z].eid==-(eid+2)){ pthread_mutex_unlock(&g_pilot_mx); return; }
+    /* SPMC (PILOT_WORKERS>1): scegli lo slot sotto lock e MARCALO prenotato prima di
+     * rilasciarlo, cosi' gli altri worker non lo scelgono come vittima ne' ricaricano
+     * lo stesso eid. Stesso schema del ramo URING (prenotazione visibile -(eid+2),
+     * ecn bumpato subito, scan-vittima che salta le prenotazioni). */
+    int slot,isnew=0;
+    if(nn<m->ecap){ slot=nn; isnew=1; m->ecn[layer]=nn+1; }   /* cresci: pubblica subito lo slot (marcato prenotato) */
+    else {
+        slot=-1;
+        for(int z=0;z<nn;z++){
+            if(Sl[z].eid==-1){ slot=z; break; }         /* riusa uno slot libero/fallito */
+            if(Sl[z].eid< -1) continue;                 /* prenotazione di un ALTRO worker: mai vittima */
+            if(slot<0 || Sl[z].used<Sl[slot].used) slot=z;
+        }
+        if(slot<0){ atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);
+                    pthread_mutex_unlock(&g_pilot_mx); return; }   /* tutti gli slot sono in volo */
         /* LFRU eviction guard (#441, fix #490): a speculation must not drop a WARM
          * demand-loaded expert. We PROTECT the victim only when it is genuinely warm
          * (>=2 demand accesses) AND clearly hotter than the speculation by tier_pick_lfru's
-         * 25%+4-freq hysteresis. The original #441 formula tested the speculation's score
-         * against victim+margin, which — because a speculation is by definition historically
-         * colder than a just-used demand expert — dropped ~all speculations once the cache
-         * was full, collapsing the LRU hit share (#490). Cache placement only -> output
-         * byte-identical (a dropped speculation is demand-loaded later, same value). */
-        if(g_pilot_evict_guard && m->eheat && m->elast && Sl[lru].eid>=0){
-            int vid=Sl[lru].eid; uint32_t vh=m->eheat[layer][vid];
+         * 25%+4-freq hysteresis; otherwise the speculation may evict the LRU victim as
+         * before. Skips free slots (eid==-1) and other workers' reservations (eid<-1,
+         * excluded by the scan above). Cache placement only -> output byte-identical. */
+        if(g_pilot_evict_guard && m->eheat && m->elast && Sl[slot].eid>=0){
+            int vid=Sl[slot].eid; uint32_t vh=m->eheat[layer][vid];
             if(vh>=2){
                 uint64_t vs=tier_lfru_score(vh,m->elast[layer][vid],m->eaccess_clock);
                 uint64_t cs=tier_lfru_score(m->eheat[layer][eid],m->elast[layer][eid],m->eaccess_clock);
                 if(vs+(vs>>2)+(4u<<8)>cs){ atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);
-                                            pthread_mutex_unlock(&g_pilot_mx); return; } } } }
+                                            pthread_mutex_unlock(&g_pilot_mx); return; } } }
+    }
     ESlot *dst=&Sl[slot];
-    dst->eid=-1;                                        /* nascondi dagli scan-hint mentre carica */
+    dst->eid=-(eid+2);                                  /* prenotazione VISIBILE: dedup + scan-vittima degli altri worker la vedono (isnew) */
+    (void)isnew;
+    dst->used=(uint64_t)-1;                             /* sentinella "in carica": mai vittima LRU finche' expert_load non pubblica l'eid reale
+                                                         * (chiude la finestra eid-reale/used-vecchio: uno snapshot di eclock si sarebbe potuto
+                                                         * far superare da altri load durante il pread). used fresco ristampato al successo. */
     g_pilot_inflight[layer]++;
     pthread_mutex_unlock(&g_pilot_mx);
 
-    int rc=expert_load(m,layer,eid,dst,0,0);            /* pread VERO — fuori dal lock, sovrapposto al compute; fatal=0: un errore su una speculazione NON deve uccidere il server; demand=0: speculative, never classified */
+    int rc=expert_load(m,layer,eid,dst,0,0);            /* pread VERO — fuori dal lock, concorrente fra worker (come i PIPE demand); fatal=0: una speculazione fallita NON uccide il server; demand=0: speculative, never classified. Al successo expert_load setta dst->eid=eid. */
 
     pthread_mutex_lock(&g_pilot_mx);
     if(rc==0){
-        dst->used=(uint64_t)__atomic_add_fetch(&m->eclock,1,__ATOMIC_RELAXED);
-        if(isnew) m->ecn[layer]=slot+1;                 /* pubblica lo slot SOLO ora che eid e' valido */
+        dst->used=(uint64_t)__atomic_add_fetch(&m->eclock,1,__ATOMIC_RELAXED);  /* eid gia' reale (expert_load); timbra used fresco */
         atomic_fetch_add_explicit(&g_pilot_loads,1,memory_order_relaxed);
     } else {
-        atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed); /* load fallito: slot resta nascosto (eid=-1), mai pubblicato */
+        dst->eid=-1;                                    /* load fallito: libera la prenotazione (slot resta in ecn ma nascosto, riusabile) */
+        atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);
     }
     g_pilot_inflight[layer]--;
     pthread_cond_broadcast(&g_pilot_cv);
@@ -3806,7 +3822,7 @@ static void pilot_uring_batch(Model *m){
     unsigned r=__atomic_load_n(&pilot_r,__ATOMIC_ACQUIRE);
     unsigned w=__atomic_load_n(&pilot_w,__ATOMIC_ACQUIRE);
     while(r!=w && nd<URING_LOAD_MAX){
-        int layer=pilot_q[r&4095].l,eid=pilot_q[r&4095].e; r++;
+        int layer=atomic_load_explicit(&pilot_q[r&4095].l,memory_order_relaxed),eid=atomic_load_explicit(&pilot_q[r&4095].e,memory_order_relaxed); r++;
         if(layer<0 || layer>=256){ atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed); continue; }
         pthread_mutex_lock(&g_pilot_mx);
         if(layer<=atomic_load_explicit(&g_cur_moe_layer,memory_order_acquire)){
@@ -3883,22 +3899,63 @@ static void pilot_uring_batch(Model *m){
     }
 }
 #endif
-static void *pilot_worker(void *arg){
-    (void)arg;
+/* SPMC ring claim: each of N pilot workers grabs a UNIQUE ring index via CAS, never
+ * advancing past pilot_w. Returns 1 and *out=index, or 0 if the ring is empty. The
+ * producer stays single (main thread, only pilot_w) — this only splits the consumer. */
+static int pilot_ring_claim(int *out_l, int *out_e){
     for(;;){
         unsigned r=__atomic_load_n(&pilot_r,__ATOMIC_ACQUIRE);
         unsigned w=__atomic_load_n(&pilot_w,__ATOMIC_ACQUIRE);
-        if(r==w){ usleep(200); continue; }
-        if(g_pilot_real){
-#ifdef __linux__
-            if(g_uring){ pilot_uring_batch(pilot_m); continue; }
-#endif
-            pilot_realload(pilot_m, pilot_q[r&4095].l, pilot_q[r&4095].e);
+        if(r==w) return 0;                              /* empty */
+        /* Read the payload BEFORE committing the claim. While pilot_r==r the slot at
+         * index r cannot be overwritten (the producer's w-r<4096 guard keeps pilot_w
+         * below r+4096). If the CAS succeeds, pilot_r was r the whole time -> the read
+         * is valid. If it fails, another worker advanced pilot_r; we discard and retry
+         * (a torn read there is thrown away, never used). */
+        int l=atomic_load_explicit(&pilot_q[r&4095].l,memory_order_relaxed), e=atomic_load_explicit(&pilot_q[r&4095].e,memory_order_relaxed);
+        if(__atomic_compare_exchange_n(&pilot_r,&r,r+1,/*weak=*/1,
+                                       __ATOMIC_ACQ_REL,__ATOMIC_ACQUIRE)){
+            *out_l=l; *out_e=e; return 1;                /* claimed exactly one item, payload valid */
         }
-        else             expert_prefetch(pilot_m, pilot_q[r&4095].l, pilot_q[r&4095].e);
-        __atomic_store_n(&pilot_r,r+1,__ATOMIC_RELEASE);
+        /* lost the CAS race to another worker -> retry */
+    }
+}
+static void *pilot_worker(void *arg){
+    (void)arg;
+    for(;;){
+#ifdef __linux__
+        if(g_pilot_real && g_uring){                    /* URING drains a whole batch itself -> single worker (nw==1) */
+            unsigned r=__atomic_load_n(&pilot_r,__ATOMIC_ACQUIRE);
+            unsigned w=__atomic_load_n(&pilot_w,__ATOMIC_ACQUIRE);
+            if(r==w){ usleep(200); continue; }
+            pilot_uring_batch(pilot_m);
+            continue;
+        }
+#endif
+        int l,e;                                        /* blocking / hint path: SPMC, one item per worker */
+        if(!pilot_ring_claim(&l,&e)){ usleep(200); continue; }
+        if(g_pilot_real) pilot_realload(pilot_m, l, e); /* QD=N: N concurrent preads instead of 1 */
+        else             expert_prefetch(pilot_m, l, e);
     }
     return NULL;
+}
+/* Spawn the pilot worker(s) ONCE, from the MAIN thread (first pilot_prefetch/couple_prefetch).
+ * Only the blocking PILOT_REAL path fans out to g_pilot_nw threads; the URING path already
+ * batches to QD>1 and hint-only is cheap fadvise, so both keep a single worker. */
+static void pilot_spawn(Model *m){
+    if(pilot_m) return;                                 /* pilot_m is the once-guard; only the main thread calls this */
+    pilot_m=m;
+    int uring_active=0;
+#ifdef __linux__
+    uring_active=g_uring;
+#endif
+    /* INVARIANTE: con URING attivo nw DEVE restare 1 — pilot_uring_batch e' un
+     * consumatore SINGOLO (avanza pilot_r con uno store semplice, non la CAS di
+     * pilot_ring_claim); due drainer URING concorrenti corromperebbero pilot_r.
+     * Il ramo blocking (pilot_ring_claim, CAS) e' invece SPMC-safe a N. */
+    int nw=(g_pilot_real && !uring_active)?g_pilot_nw:1;
+    if(nw<1) nw=1; if(nw>16) nw=16;
+    for(int i=0;i<nw;i++){ pthread_t t; pthread_create(&t,NULL,pilot_worker,NULL); }
 }
 /* parse .coli_pairs (see tools/route_pairs.py): "COLIPAIRS 1 <n>" then
  * "<L> <dL> <e> f:c f:c ..." lines. Needs c->n_experts/n_layers -> called post-init. */
@@ -3939,7 +3996,7 @@ static void couple_load(Model *m, const char *path){
 static void couple_prefetch(Model *m, int layer, const int *idx, int Ke){
     Cfg *c=&m->c; int E=c->n_experts;
     if(E>512) return;
-    if(!pilot_m){ pilot_m=m; pthread_t t; pthread_create(&t,NULL,pilot_worker,NULL); }
+    pilot_spawn(m);
     for(int dL=1; dL<=g_couple_d; dL++){
         int lt=layer+dL;
         if(lt>=c->n_layers || !m->L[lt].sparse) continue;
@@ -3964,7 +4021,7 @@ static void couple_prefetch(Model *m, int layer, const int *idx, int Ke){
             if(!found){
                 unsigned w=__atomic_load_n(&pilot_w,__ATOMIC_RELAXED);
                 if(w-__atomic_load_n(&pilot_r,__ATOMIC_ACQUIRE)<4096){
-                    pilot_q[w&4095].l=lt; pilot_q[w&4095].e=best;
+                    atomic_store_explicit(&pilot_q[w&4095].l,lt,memory_order_relaxed); atomic_store_explicit(&pilot_q[w&4095].e,best,memory_order_relaxed);
                     __atomic_store_n(&pilot_w,w+1,__ATOMIC_RELEASE);
                     g_cp_enq++;
                 }
@@ -3975,7 +4032,7 @@ static void couple_prefetch(Model *m, int layer, const int *idx, int Ke){
 static void pilot_prefetch(Model *m, int lnext, const float *x, int S){
     Cfg *c=&m->c; Layer *l=&m->L[lnext]; int D=c->hidden, E=c->n_experts;
     int K = g_pilot_k<c->topk ? g_pilot_k : c->topk;
-    if(!pilot_m){ pilot_m=m; pthread_t t; pthread_create(&t,NULL,pilot_worker,NULL); }
+    pilot_spawn(m);
     float *nrm=falloc(D), *ch=falloc(E);
     /* Two-step workspace (allocated once, reused across positions) */
     float *snrm=NULL, *sg=NULL, *su=NULL, *sout=NULL, *hc=NULL;
@@ -4026,7 +4083,7 @@ static void pilot_prefetch(Model *m, int lnext, const float *x, int S){
             if(!found){
                 unsigned w=__atomic_load_n(&pilot_w,__ATOMIC_RELAXED);
                 if(w-__atomic_load_n(&pilot_r,__ATOMIC_ACQUIRE)<4096){
-                    pilot_q[w&4095].l=lnext; pilot_q[w&4095].e=best;
+                    atomic_store_explicit(&pilot_q[w&4095].l,lnext,memory_order_relaxed); atomic_store_explicit(&pilot_q[w&4095].e,best,memory_order_relaxed);
                     __atomic_store_n(&pilot_w,w+1,__ATOMIC_RELEASE);
                 }
             }
@@ -6689,13 +6746,18 @@ int main(int argc, char **argv){
     if(g_pilot_real) g_pilot=1;                           /* PILOT_REAL implica il pilota attivo */
     g_pilot_two = getenv("PILOT_TWO")?atoi(getenv("PILOT_TWO")):0; /* 1 = two-step: shared-expert-corrected router prediction (+2.3% recall, 3 extra matmuls) */
     if(g_pilot_two) g_pilot=1;                            /* PILOT_TWO implies PILOT active */
-    g_pilot_evict_guard = getenv("PILOT_EVICT_GUARD")?atoi(getenv("PILOT_EVICT_GUARD")):1; /* 0 = old LRU eviction (A/B) */
     /* Default K: hint-only PILOT keeps 8 (WILLNEED hints are free, no eviction).
      * Under PILOT_REAL the speculative loads are REAL and create LRU eviction
      * pressure, so at ~28% mispredict a large K thrashes the cache — default to 6
      * (best-measured this session) unless the user set PILOT_K explicitly. */
     g_pilot_k = getenv("PILOT_K")?atoi(getenv("PILOT_K")):(g_pilot_real?6:8);
     if(g_pilot_k<1) g_pilot_k=1;
+    /* PILOT_WORKERS: blocking-path pilot threads (SPMC ring). Default 1 = today's
+     * behaviour, byte-identical. >1 raises NVMe queue depth on the non-URING
+     * PILOT_REAL path (the URING path already batches). Clamp [1,16]. */
+    g_pilot_nw = getenv("PILOT_WORKERS")?atoi(getenv("PILOT_WORKERS")):1;
+    if(g_pilot_nw<1) g_pilot_nw=1; if(g_pilot_nw>16) g_pilot_nw=16;
+    g_pilot_evict_guard = getenv("PILOT_EVICT_GUARD")?atoi(getenv("PILOT_EVICT_GUARD")):1; /* 0 = old LRU eviction (A/B) */
     g_disk_split = getenv("DISK_SPLIT")?atoi(getenv("DISK_SPLIT")):0; /* 1 = split dei disk load nelle stats */
     g_pipe = getenv("PIPE")?atoi(getenv("PIPE")):
 #ifdef _WIN32

--- a/c/tests/test_pilot_ring.c
+++ b/c/tests/test_pilot_ring.c
@@ -1,0 +1,74 @@
+/* Concurrency test for the SPMC pilot ring claim (pilot_ring_claim): with N worker
+ * threads draining a single-producer ring, every enqueued item must be claimed by
+ * EXACTLY ONE worker -- none lost, none double-claimed, none torn by ring wrap.
+ *
+ * This gates the new lock-free primitive without needing a model (the slot
+ * reservation logic in pilot_realload is exercised end-to-end by the token-exact
+ * oracle; here we prove the ring claim itself). Includes colibri.c for the real
+ * pilot_ring_claim / pilot_q / pilot_w / pilot_r (same pattern as the other tests).
+ */
+#define main coli_glm_main_unused
+#include "../colibri.c"
+#undef main
+#include <pthread.h>
+#include <stdint.h>
+
+#define NITEMS   300000
+#define NTHREADS 8
+static _Atomic int seen[NITEMS];
+static _Atomic long total_claimed = 0;
+static _Atomic int  torn = 0;
+static _Atomic int  producer_done = 0;
+
+static void *consumer(void *arg){
+    (void)arg;
+    for(;;){
+        int v, e;
+        if(pilot_ring_claim(&v, &e)){
+            if(v < 0 || v >= NITEMS || e != v){          /* out-of-range or mismatched => torn read leaked through */
+                atomic_store_explicit(&torn, 1, memory_order_relaxed);
+                continue;
+            }
+            atomic_fetch_add_explicit(&seen[v], 1, memory_order_relaxed);
+            atomic_fetch_add_explicit(&total_claimed, 1, memory_order_relaxed);
+        } else if(atomic_load_explicit(&producer_done, memory_order_acquire)){
+            unsigned r = __atomic_load_n(&pilot_r, __ATOMIC_ACQUIRE);
+            unsigned w = __atomic_load_n(&pilot_w, __ATOMIC_ACQUIRE);
+            if(r == w) return NULL;                       /* producer finished AND ring drained */
+        }
+    }
+}
+
+int main(void){
+    for(int i=0;i<NITEMS;i++) atomic_store_explicit(&seen[i],0,memory_order_relaxed);
+    pthread_t th[NTHREADS];
+    for(int i=0;i<NTHREADS;i++) pthread_create(&th[i],NULL,consumer,NULL);
+
+    for(int i=0;i<NITEMS;i++){                            /* single producer: only pilot_w */
+        for(;;){
+            unsigned w = __atomic_load_n(&pilot_w,__ATOMIC_ACQUIRE);
+            unsigned r = __atomic_load_n(&pilot_r,__ATOMIC_ACQUIRE);
+            if(w - r < 4096){                            /* ring has space */
+                atomic_store_explicit(&pilot_q[w & 4095].l, i, memory_order_relaxed);
+                atomic_store_explicit(&pilot_q[w & 4095].e, i, memory_order_relaxed);
+                __atomic_store_n(&pilot_w, w+1, __ATOMIC_RELEASE);
+                break;
+            }
+            /* full: let consumers drain (they advance pilot_r via CAS) */
+        }
+    }
+    atomic_store_explicit(&producer_done, 1, memory_order_release);
+    for(int i=0;i<NTHREADS;i++) pthread_join(th[i],NULL);
+
+    int fail=0;
+    if(atomic_load_explicit(&torn,memory_order_relaxed)){
+        fprintf(stderr,"FAIL: torn/overwritten ring slot observed\n"); fail=1; }
+    long tc=atomic_load_explicit(&total_claimed,memory_order_relaxed);
+    if(tc!=NITEMS){ fprintf(stderr,"FAIL: total claimed %ld != %d\n",tc,NITEMS); fail=1; }
+    for(int i=0;i<NITEMS && !fail;i++){
+        int s=atomic_load_explicit(&seen[i],memory_order_relaxed);
+        if(s!=1){ fprintf(stderr,"FAIL: item %d claimed %d times (want exactly 1)\n",i,s); fail=1; }
+    }
+    if(!fail) printf("test_pilot_ring: ok — %d items across %d workers, each claimed exactly once\n",NITEMS,NTHREADS);
+    return fail;
+}


### PR DESCRIPTION
> **Draft / not a merge request (yet).** This is the byte-identical base for the good-hardware
> A/B you offered to flag on #441 — opened as a PR because you asked for exactly that ("open the
> `PILOT_WORKERS` branch as a PR with default=1 and the eviction guard added, I'll flag it to the
> enterprise-NVMe / big-RAM folks"). **Please don't merge it until that A/B shows a win** — on every
> box I can measure it doesn't. Default behavior is unchanged (`PILOT_WORKERS=1`).

## What this is

Part-1 of #441: multi-thread the blocking `PILOT_REAL` prefetcher so speculative loads run at
queue-depth *N* instead of 1. SPMC ring (`pilot_ring_claim`, CAS claim, read-payload-before-claim),
`PILOT_WORKERS` env (**default 1 = today's exact behavior**), the URING path's visible `-(eid+2)`
reservation ported to the blocking loader, and the LFRU eviction guard re-applied on top of the new
SPMC slot-selection — in its **corrected #497 form** since the 2026-07-26 rebase. Rebased onto
current `dev`.

## Why it's a draft, not a merge request

On every drive I can test it **regresses or no-ops**, and your own gate on #441 is the right one:
multi-worker *needs* (a) LFRU-aware eviction (merged as #474, corrected in #497) **and** (b) a good-hardware A/B
before it ships even opt-in. This PR is (a)-done + the vehicle for (b). It should merge **only** if
the enterprise-NVMe / big-RAM A/B shows a real win.

## What I measured (and why it isn't a win *here*)

> **Updated 2026-07-26, on the rebased base.** The numbers first posted here were taken with my
> original #474 guard, which [#497 showed was over-dropping](https://github.com/JustVugg/colibri/pull/497)
> (~100% of speculations once the cache filled, the #490 regression). That old table is a broken
> baseline — its `guard ON` arm sat at PILOT-off parity, which in hindsight *is* the #490 signature.
> Everything below is re-measured on current `dev` with the corrected guard.

Controlled 2×2 on my QLC / 62 GB box — `PILOT_WORKERS {1,8}` × `PILOT_EVICT_GUARD {0,1}`, frozen
`.coli_usage` restored before every run, `CAP_RAISE=0` (cap 8/layer everywhere), one native build,
interleaved, 2 reps in reversed order, `DIRECT=1`, greedy, 12-token decode. **Output byte-identical
across all 11 runs** (sha256 of the generated text):

| arm | expert hit | MB/token | felt wait | decode wall |
|---|---|---|---|---|
| PILOT off | 44.1 / 44.2 % | 5662 / 5654 | 25.0 / 25.0 s | 57.2 / 57.4 s |
| workers=1, guard ON | 49.3 / 49.7 % | 5887 / 5865 | 24.8 / 23.8 s | 78.2 / 57.2 s |
| workers=8, guard ON | 49.0 / 49.8 % | 5953 / 5868 | 26.3 / 24.8 s | 80.1 / 56.0 s |
| workers=1, guard OFF | 67.5 / 67.8 % | 7322 / 7265 | 18.6 / 17.5 s | 86.6 / 55.7 s |
| workers=8, guard OFF | 67.6 / 68.1 % | 7416 / 7311 | 29.6 / 32.5 s | 66.9 / 65.9 s |

(rep1 / rep2. Wall clock is drift-dominated in rep 1 and should not be read across reps; hit rate,
MB/token and felt-wait reproduce tightly and are the trustworthy columns.)

**workers=8 still doesn't pay here.** Guard ON it costs +1.0/+1.5 s felt wait for +0-1% bytes;
guard OFF it costs +11/+15 s. **There are no cold slots at cap 8/layer for extra queue depth to
fill, so this box structurally can't show the upside** — that needs a host with a real cache
(big RAM) + a drive with a QD8-32 sweet spot / idle bandwidth during compute.

## Output-preserving

Cache placement + prefetch scheduling only — never a value. The `moe()` per-layer barrier fences
every layer against in-flight pilot loads; reservations (`-(eid+2)`) and loading slots (`eid=-1`)
are never matmul'd; a dropped/late speculation is just demand-loaded. **sha256-identical** across
PILOT off / workers 1 / workers 8 / guard on / guard off on the full GLM-5.2 744B model (11/11 runs
on the rebased base, 9/9 before it).

## What's in it

- SPMC pilot ring + `PILOT_WORKERS` (default 1), visible `-(eid+2)` reservations on the blocking path
- `tests/test_pilot_ring.c` (N-thread ring stress: each item claimed exactly once, no loss/dup/torn)
- LFRU eviction guard (#474, corrected form from #497) re-applied into the SPMC slot-selection
  (`PILOT_EVICT_GUARD`, default on)
- Vetted by 3 adversarial subagent reviews for the barrier + byte-identity; the `rss_guard`
  eviction UAF this surfaced already shipped separately as #449.

## How to run the A/B (single binary)

```
# baseline arm = today's behavior
PILOT_REAL=1 PILOT_WORKERS=1 PILOT_EVICT_GUARD=1 DIRECT=1 ./coli run ...
# deeper queue
PILOT_REAL=1 PILOT_WORKERS=8 PILOT_EVICT_GUARD=1 DIRECT=1 ./coli run ...
```
Report `PROF=1`'s byte counter (MB/token) + felt-wait (and tok/s). `PILOT_EVICT_GUARD=0` isolates
the eviction-thrash component.

## Validation

- [x] `make -C c check` — 111/111, native + portable, 0 warnings
- [x] Byte-identical output across all four quadrants + PILOT-off (sha256, 11/11 runs on the
      rebased base)
- [ ] Throughput A/B on a QD-scaling / big-RAM host — **the missing datapoint this draft exists for**

## Compatibility

- [x] Default `PILOT_WORKERS=1` = current behavior; no default-config user is affected
- [x] Default CPU build stays dependency-free; no model files / binaries / artifacts

---
*Implemented, reviewed, and measured with AI assistance (Claude), per the project's AI-contribution
precedent (#428, #398). Kept as a draft on purpose — it should not merge without the good-hardware
win it's built to let you measure.*
