### PR TITLE
windows: $(file) build-config stamp + document scoop/VS-prompt sh.exe gap (#478)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -228,7 +228,13 @@ glm: colibri$(EXE)
 BUILD_CONFIG     := $(CC)|$(CFLAGS)|$(LDFLAGS)|CUDA=$(CUDA)|CUDA_DLL=$(CUDA_DLL)|ARCH=$(ARCH)|CUDA_ARCH=$(CUDA_ARCH)|METAL=$(METAL)
 BUILD_CONFIG_OLD := $(shell cat .build-config 2>/dev/null)
 ifneq "$(BUILD_CONFIG)" "$(BUILD_CONFIG_OLD)"
-$(shell printf '%s' '$(BUILD_CONFIG)' > .build-config)
+# $(file ...) writes via make's own primitive (GNU Make >= 4.0, 2013), NOT by
+# spawning a shell. The earlier `$(shell printf '%s' ... > .build-config)`
+# required a POSIX `printf` on PATH — present under MSYS2/Git-Bash but NOT under
+# cmd.exe, so `make glm.exe` from the VS Native Tools prompt or with scoop MinGW
+# (neither ships sh.exe) failed with "'printf' is not recognized" and left the
+# stamp stale. $(file ...) works regardless of the shell make falls back to. (#478)
+$(file >.build-config,$(BUILD_CONFIG))
 endif
 .build-config: ;
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -8,6 +8,8 @@ A start-to-finish, reproducible path from a fresh Windows 11 machine to GLM-5.2 
 |---|---|---|
 | git, Python 3 | clone + `coli` launcher | winget / python.org |
 | MinGW-w64 gcc + make | builds the engine (MSVC can't) | `scoop install mingw-winlibs`, MSYS2, or portable **w64devkit** (no admin, unzip and go) |
+
+> **scoop MinGW caveat (#478):** `scoop install mingw-winlibs` ships `gcc` + `make` but **no `sh.exe`** — the Makefile's recipes use POSIX shell idioms (`command -v`, `{ ...; }`, redirect to `/dev/null`) that GNU make runs through `/bin/sh`. Without sh.exe on PATH, make falls back to `cmd.exe` and the build fails with `'printf' is not recognized` / `The system cannot find the path specified`. Two fixes: install **MSYS2** (recommended — it's what the recipes target), or `set PATH=%PATH%;C:\msys64\usr\bin` in any shell you build from. The portable **w64devkit** bundle includes sh.exe and works as-is.
 | CUDA Toolkit ≥ 12.8 | GPU tier; ≥12.8 required for Blackwell/sm_120 | `winget install Nvidia.CUDA` |
 | MSVC Build Tools (C++ workload) | nvcc's host compiler for the CUDA DLL | `winget install Microsoft.VisualStudio.2022.BuildTools` + "Desktop development with C++" |
 | ~400 GB free on a local NVMe | the int4 model (~370–384 GB) | NTFS is fine; **never** a network mount |
@@ -54,6 +56,12 @@ This is not Defender and not Mark-of-the-Web — SAC blocks *all* unsigned, unkn
 
 nvcc needs MSVC as host compiler, so this one step must run from a shell with the MSVC environment: open **"x64 Native Tools Command Prompt for VS 2022"** from the Start menu (plain PowerShell will fail the `cl` check). Then:
 
+> **The VS prompt has no `sh.exe` (#478):** that prompt is a `cmd.exe` shell, and the `cuda-dll` recipe uses POSIX idioms (`command -v`, `{ ...; }`) that need `/bin/sh`. Run this once in the VS prompt before building:
+> ```cmd
+> set PATH=%PATH%;C:\msys64\usr\bin
+> ```
+> (adjust the path if you installed MSYS2 elsewhere). If you skipped MSYS2 in favor of w64devkit or scoop MinGW, point this at wherever `sh.exe` lives.
+
 ```cmd
 make cuda-dll CUDA_ARCH=sm_120        # match your GPU: sm_120 Blackwell, sm_89 Ada, ...
 make glm.exe CUDA_DLL=1 ARCH=native   # relink host with the runtime loader
@@ -91,6 +99,7 @@ Size `CUDA_EXPERT_GB` so dense (~10 GB) + experts + working set stays under your
 
 | Symptom | Cause | Fix |
 |---|---|---|
+| `'printf' is not recognized` / `The system cannot find the path specified` during `make glm.exe` | scoop MinGW has no `sh.exe`; make fell back to cmd.exe (#478) | §0 — use MSYS2/w64devkit, or `set PATH=%PATH%;C:\msys64\usr\bin` |
 | `An Application Control policy has blocked this file` | Smart App Control | §2 — turn SAC off + **reboot** |
 | `cuda-dll ... Error 1` immediately | old tree: spaced CUDA_HOME / MSVC rejects `-Wextra` | update to current `dev` (#314) |
 | `glm.exe is up to date` but GPU never engages | old tree: stale CPU-only binary | update to `dev`, or delete `glm.exe` and rebuild |


### PR DESCRIPTION
Fixes the common-path half of #478 and documents the rest. cc @xl-ji — the report and both workarounds made the diagnosis essentially complete; co-authored / reported-by.

## The failure

`docs/windows.md` step 2 (`make glm.exe` — the **common CPU build**) failed with:

```
printf is not recognized as an internal or external command
The system cannot find the path specified.
```

whenever GNU make fell back to `cmd.exe`, which happens in two real setups @xl-ji reported:

1. **scoop MinGW** (`scoop install mingw-winlibs`) — ships `gcc` + `make` but no `sh.exe`.
2. **The VS "x64 Native Tools Command Prompt"** — a `cmd.exe` shell with no `sh` on PATH.

## Root cause

The `.build-config` stamp write (c/Makefile:231, the #306 relink-on-config-change mechanism) was:

```make
$(shell printf %s  > .build-config)
```

`$(shell ...)` spawns the shell make picked. Under MSYS2/Git-Bash that is `/bin/sh` and `printf` works. Under `cmd.exe` there is no `printf`, the write fails silently, and the build stops.

## Fix

Switch to GNU Make's `$(file >PATH,TEXT)` primitive (≥ 4.0, 2013), which writes the file directly from make — no shell spawn, no `printf` dependency:

```make
$(file >.build-config,$(BUILD_CONFIG))
```

Verified (full regression in the commit message):
- stamp content byte-identical to the old `printf` write
- the #306 relink-on-config-change behavior still fires (`make colibri CUDA_DLL=1` correctly relinks with `backend_loader.o`)
- repeat `make` is a no-op (no spurious rebuilds from `$(file ...)`'s trailing newline)
- `glm_tiny` TF oracle unchanged (30/32 — no engine behavior change, build-system only)

## What this PR does NOT do

The cuda-dll recipe (step 3) also uses POSIX idioms (`command -v`, `{ ...; }`, redirect to `/dev/null`) that fail under `cmd.exe`. I deliberately left those alone — rewriting 5 recipes to be cmd.exe-native is a larger, riskier change that could disturb the working MSYS2/Git-Bash path every existing Windows contributor uses. Instead, this PR documents the workaround @xl-ji found:

- **§0 install table** — scoop MinGW caveat (no `sh.exe`); use MSYS2/w64devkit, or `set PATH=%PATH%;C:\msys64\usr\bin`.
- **§3 CUDA DLL** — the VS-prompt `set PATH=%PATH%;C:\msys64\usr\bin` step.
- **Quick failure index** — new row for the `'printf' is not recognized` symptom.

The recipe-level POSIX cleanup is a sensible follow-up PR if a maintainer wants cmd.exe-native recipes; happy to take it on separately.

## Credit

@xl-ji — the report and both workarounds. The diagnosis was essentially complete; this PR lands the Makefile half and documents the rest.