### PR TITLE
Fix GPU detection on unified-memory chips (e.g. NVIDIA GB10); wire HF_TOKEN into downloader

### DIFF
--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -157,9 +157,22 @@ def discover_gpus():
         if len(fields) != 4:
             continue
         try:
-            index, total, free = int(fields[0]), int(fields[2]), int(fields[3])
+            index = int(fields[0])
         except ValueError:
             continue
+        # Unified-memory chips (e.g. NVIDIA GB10 Grace Blackwell) have no
+        # discrete VRAM pool, so nvidia-smi reports memory.total/memory.free
+        # as "[N/A]" rather than a number. Fall back to system RAM figures
+        # in that case instead of silently dropping the GPU from discovery.
+        try:
+            total, free = int(fields[2]), int(fields[3])
+        except ValueError:
+            try:
+                meminfo = Path("/proc/meminfo").read_text()
+                total = int(re.search(r"MemTotal:\s+(\d+)", meminfo).group(1)) // 1024
+                free = memory_available() // (1024 * 1024)
+            except (OSError, AttributeError):
+                total = free = 0
         devices.append({"index": index, "name": fields[1],
                         "total_bytes": total * 1024 * 1024,
                         "free_bytes": free * 1024 * 1024})

--- a/c/tools/convert_fp8_to_int4.py
+++ b/c/tools/convert_fp8_to_int4.py
@@ -587,8 +587,9 @@ def main():
             s0, s1 = segs[t]
             while done[t] < s1 - s0 and not stopfail:
                 pos = s0 + done[t]
-                req = urllib.request.Request(url, headers={"User-Agent": "colibri-convert",
-                                                           "Range": f"bytes={pos}-{s1-1}"})
+                _hdrs = {"User-Agent": "colibri-convert", "Range": f"bytes={pos}-{s1-1}"}
+                if os.environ.get("HF_TOKEN"): _hdrs["Authorization"] = f"Bearer {os.environ['HF_TOKEN']}"
+                req = urllib.request.Request(url, headers=_hdrs)
                 try:
                     with urllib.request.urlopen(req, timeout=8) as r:
                         if r.status != 206:               # Range ignorato: multi-stream impossibile
@@ -651,6 +652,7 @@ def main():
             have0 = have
             req = urllib.request.Request(url, headers={"User-Agent": "colibri-convert"})
             if have: req.add_header("Range", f"bytes={have}-")
+            if os.environ.get("HF_TOKEN"): req.add_header("Authorization", f"Bearer {os.environ['HF_TOKEN']}")
             try:
                 with urllib.request.urlopen(req, timeout=8) as r:
                     if have and r.status == 200:          # server ha ignorato il Range: riparti pulito


### PR DESCRIPTION
Found and fixed while running GLM-5.2 on an NVIDIA GB10 (Grace Blackwell, sm_121, unified memory, no discrete VRAM).

**GPU detection**: `discover_gpus()` does a bare `int()` on nvidia-smi's `memory.total`/`memory.free` columns. On unified-memory hardware those come back as the literal string `[N/A]`, the resulting `ValueError` is swallowed, and the GPU silently disappears from the device list — `coli doctor` then reports "no NVIDIA GPU detected" even though `nvidia-smi` sees the card fine. This patch falls back to `/proc/meminfo` system-RAM figures when the memory fields aren't numeric.

Verified end-to-end: after the fix, `coli doctor` flips from `skip` to `pass` ("CUDA engine and devices are available"), and live `nvidia-smi dmon` monitoring during generation shows real SM utilization (bursts to 20-45%) that was flat 0% before the fix.

**HF_TOKEN**: the custom multi-stream downloader never read `HF_TOKEN` or sent an `Authorization` header on either the multi-stream or single-stream path, even though the tool prints a warning about unauthenticated requests from a separate `HfApi` call elsewhere. Now wired through on both paths.

Tested on: Ubuntu 24.04 aarch64, GB10, CUDA 13.0, driver 580.159.03.