### PR TITLE
Metal: fix grid-size truncation in coli_metal_gemm at large prefill (long-context corruption)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -311,6 +311,12 @@ metal-test: tests/test_backend_metal.mm backend_metal.mm backend_metal.h
 	$(METALXX) tests/test_backend_metal.mm backend_metal.mm -framework Metal -framework Foundation -o backend_metal_test
 	./backend_metal_test
 
+# Standalone large-batch GEMM correctness sweep — reproduces the long-context prefill
+# corruption in seconds (no model). OMP-parallel CPU reference.
+gemm-test: tests/test_gemm_largebatch.mm backend_metal.mm backend_metal.h
+	$(METALXX) $(OMPC) tests/test_gemm_largebatch.mm backend_metal.mm $(OMPL) -framework Metal -framework Foundation -o gemm_largebatch_test
+	./gemm_largebatch_test
+
 cuda-test: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/test_backend_cuda.cu
 	@command -v "$(GPUCC)" >/dev/null 2>&1 || { echo "$(GPUCC_NAME) not found" >&2; exit 1; }
 	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/test_backend_cuda.cu -o backend_cuda_test$(EXE)

--- a/c/backend_metal.mm
+++ b/c/backend_metal.mm
@@ -847,13 +847,21 @@ extern "C" int coli_metal_gemm(float *y, const float *x, const void *wp, const f
     // its prior contents -- fresh-zero standalone (nerr=1.0), stale scratch in-engine (the
     // nondeterministic long-context corruption). Chunk over rows so each dispatch stays <=2^25
     // elements (grid <=2^23 tg, ~4x under the observed-clean bound). Chunks write disjoint g_gy
-    // ranges; g_gx/g_gy offsets are 16B-aligned (I,O multiples of 4).
+    // ranges. Offset alignment is STRUCTURAL, not shape-dependent (holds for any I,O -- a tiny
+    // oracle checkpoint or a future container with odd dims, not just GLM's shapes): g_gy is only
+    // ever written scalar (y[row]), so r0*O*4 needs just 4B; and the 16B float4 loads on g_gx
+    // execute only inside loops gated by I8=(I&7)?0:(I/8), i.e. only when I%8==0, where r0*I*4 is
+    // a multiple of 32. With I%8!=0, I8=0, x4 is never dereferenced and x is read scalar via xr[i].
     // COLI_GEMM_CHUNK=0 disables chunking (one full dispatch = the buggy pre-fix behavior) so the
     // fix can be A/B'd on a single binary. Default on.
     static int chunk_on=-1;
     if(chunk_on<0){ const char*e=getenv("COLI_GEMM_CHUNK"); chunk_on=(e&&e[0]=='0'&&!e[1])?0:1; }
     const int64_t NT_MAX = chunk_on ? ((int64_t)1<<25) : ((int64_t)1<<62);
-    int CH=(int)(NT_MAX/O); if(CH<1) CH=1; if((int64_t)CH>S) CH=S;
+    // Clamp in 64-bit BEFORE narrowing: with chunking off NT_MAX/O is ~1.6e14 for kv_b (O=28672),
+    // far past INT_MAX, so casting first is implementation-defined. Were it to truncate negative
+    // on some toolchain, CH=1 would make the disable path dispatch one row at a time and silently
+    // STOP reproducing the bug it exists to demonstrate. After the clamp CH <= S <= INT_MAX.
+    int64_t ch64=NT_MAX/O; if(ch64<1) ch64=1; if(ch64>S) ch64=S; int CH=(int)ch64;
     for(int r0=0;r0<S;r0+=CH){
       int ch=(S-r0<CH)?(S-r0):CH; int NT=ch*O;
       [e setBuffer:g_gx offset:(size_t)r0*I*4 atIndex:2];

--- a/c/backend_metal.mm
+++ b/c/backend_metal.mm
@@ -839,12 +839,29 @@ extern "C" int coli_metal_gemm(float *y, const float *x, const void *wp, const f
     [e useResource:wb usage:MTLResourceUsageRead]; [e useResource:sb usage:MTLResourceUsageRead];
     [e setComputePipelineState:g_gemv];
     [e setBuffer:wb offset:woff atIndex:0]; [e setBuffer:sb offset:soff atIndex:1];
-    [e setBuffer:g_gx offset:0 atIndex:2]; [e setBuffer:g_gy offset:0 atIndex:3];
-    int NT=S*O;
-    [e setBytes:&S length:4 atIndex:4]; [e setBytes:&I length:4 atIndex:5];
+    [e setBytes:&I length:4 atIndex:5];
     [e setBytes:&O length:4 atIndex:6]; [e setBytes:&fmt length:4 atIndex:7];
-    [e setBytes:&NT length:4 atIndex:8];
-    [e dispatchThreadgroups:MTLSizeMake(((size_t)NT+3)/4,1,1) threadsPerThreadgroup:MTLSizeMake(128,1,1)];
+    // Grid-size cap. One dispatch of NT=S*O output elements launches (NT+3)/4 threadgroups; past
+    // a device grid limit (observed on M-series: kv_b grid ~3.1e7 tg clean at S=4376, ~5.4e7 tg
+    // CORRUPT at S=7478) rows beyond the limit are silently never computed and the output keeps
+    // its prior contents -- fresh-zero standalone (nerr=1.0), stale scratch in-engine (the
+    // nondeterministic long-context corruption). Chunk over rows so each dispatch stays <=2^25
+    // elements (grid <=2^23 tg, ~4x under the observed-clean bound). Chunks write disjoint g_gy
+    // ranges; g_gx/g_gy offsets are 16B-aligned (I,O multiples of 4).
+    // COLI_GEMM_CHUNK=0 disables chunking (one full dispatch = the buggy pre-fix behavior) so the
+    // fix can be A/B'd on a single binary. Default on.
+    static int chunk_on=-1;
+    if(chunk_on<0){ const char*e=getenv("COLI_GEMM_CHUNK"); chunk_on=(e&&e[0]=='0'&&!e[1])?0:1; }
+    const int64_t NT_MAX = chunk_on ? ((int64_t)1<<25) : ((int64_t)1<<62);
+    int CH=(int)(NT_MAX/O); if(CH<1) CH=1; if((int64_t)CH>S) CH=S;
+    for(int r0=0;r0<S;r0+=CH){
+      int ch=(S-r0<CH)?(S-r0):CH; int NT=ch*O;
+      [e setBuffer:g_gx offset:(size_t)r0*I*4 atIndex:2];
+      [e setBuffer:g_gy offset:(size_t)r0*O*4 atIndex:3];
+      [e setBytes:&ch length:4 atIndex:4];
+      [e setBytes:&NT length:4 atIndex:8];
+      [e dispatchThreadgroups:MTLSizeMake(((size_t)NT+3)/4,1,1) threadsPerThreadgroup:MTLSizeMake(128,1,1)];
+    }
     [e endEncoding]; [cb commit]; [cb waitUntilCompleted];
     if(cb.status==MTLCommandBufferStatusError){ fprintf(stderr,"[metal] gemm cmdbuf error (S=%d O=%d)\n",S,O); return 0; }
     memcpy(y,[g_gy contents],(size_t)S*O*4);

--- a/c/tests/test_gemm_largebatch.mm
+++ b/c/tests/test_gemm_largebatch.mm
@@ -1,0 +1,106 @@
+// Standalone large-batch correctness test for coli_metal_gemm — reproduces the
+// long-context OpenCode prefill corruption WITHOUT the model or a 33-minute run.
+//
+// Isolation established (see INVESTIGATION_LOG_metal_moe_race.md): corruption <=> dense
+// GEMM on GPU (`coli_metal_gemm`), independent of MoE. The engine's existing kernel tests
+// only exercise S<=64, which is why the S>=~2400 fault was never caught.
+//
+// This sweeps S across the clean/corrupt bracket for a few real GLM matmul shapes,
+// compares GPU vs CPU reference, prints the first diverging (row,col), AND runs the GPU
+// twice to report determinism (race vs fixed compute error).
+//
+// Build/run:  make gemm-test
+#include "../backend_metal.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cmath>
+#include <vector>
+
+enum { I8=1, I4=2 };
+
+// CPU reference: dequant->f32 MAC * per-row scale. OMP-parallel over output cols so the
+// big shapes stay fast.
+static void cpu_ref(int fmt, const void *W, const float *s, const float *x,
+                    float *y, int S, int I, int O) {
+  const int8_t *q8 = (const int8_t*)W; const uint8_t *q4 = (const uint8_t*)W;
+  int rb4=(I+1)/2;
+  #pragma omp parallel for schedule(static)
+  for (int o=0;o<O;o++) for (int si=0;si<S;si++){
+    const float *xr = x + (size_t)si*I; float acc=0;
+    for (int i=0;i<I;i++){
+      float w;
+      if (fmt==I8) w=(float)q8[(size_t)o*I+i];
+      else { uint8_t b=q4[(size_t)o*rb4+(i>>1)]; int v=(i&1)?(b>>4):(b&0xF); w=(float)(v-8); }
+      acc += w*xr[i];
+    }
+    y[(size_t)si*O+o]=acc*s[o];
+  }
+}
+
+static size_t roundpg(size_t n){ size_t p=16384; return ((n+p-1)/p)*p; }
+
+// One (fmt,O,I,S) case: GPU vs CPU + GPU-vs-GPU determinism. Returns 0 = clean.
+static int run_gemm(int fmt, int O, int I, int S, const char *name) {
+  int rb4=(I+1)/2;
+  size_t wn = (fmt==I8)?(size_t)O*I : (size_t)O*rb4;
+  size_t wb = roundpg(wn), sb = roundpg((size_t)O*4);
+  uint8_t *W=nullptr; float *Sc=nullptr;
+  posix_memalign((void**)&W,16384,wb); posix_memalign((void**)&Sc,16384,sb);
+  srand(1234 + S*7 + fmt);
+  for(size_t i=0;i<wn;i++) W[i]=(uint8_t)((fmt==I8)?((rand()%255)-127):(rand()&0xFF));
+  for(int i=0;i<O;i++) Sc[i]=0.01f+(rand()%50)/50000.f;
+  coli_metal_register(W,wb); coli_metal_register(Sc,sb);
+
+  std::vector<float> x((size_t)S*I), yr((size_t)S*O), yg((size_t)S*O), yg2((size_t)S*O);
+  for(auto&v:x) v=((rand()%2000)-1000)/1000.f;
+
+  cpu_ref(fmt, W, Sc, x.data(), yr.data(), S, I, O);
+  int ok1 = coli_metal_gemm(yg.data(),  x.data(), W, Sc, fmt, S, I, O);
+  int ok2 = coli_metal_gemm(yg2.data(), x.data(), W, Sc, fmt, S, I, O);
+
+  // GPU vs CPU: max normalized error + first diverging element.
+  double maxabs=0, ymax=0; long badidx=-1;
+  for(size_t i=0;i<(size_t)S*O;i++){
+    double d=fabs((double)yg[i]-yr[i]);
+    if(d>maxabs) maxabs=d;
+    if(fabs(yr[i])>ymax) ymax=fabs(yr[i]);
+    if(badidx<0 && d > 1e-2*(fabs(yr[i])+1e-6)) badidx=(long)i;
+  }
+  double nerr = maxabs/(ymax+1e-9);
+  // GPU vs GPU: determinism.
+  long detdiff=0; for(size_t i=0;i<(size_t)S*O;i++) if(yg[i]!=yg2[i]) detdiff++;
+
+  int clean = ok1 && ok2 && nerr < 1e-3;
+  printf("  %-26s S=%-5d O=%-6d I=%-5d  nerr=%.2e  det:%s  %s",
+         name, S, O, I, nerr,
+         detdiff? "RACE(diff)" : "same",
+         clean? "ok" : "*** CORRUPT");
+  if(badidx>=0) printf("  first-bad row=%ld col=%ld (gpu=%.4g cpu=%.4g)",
+                       badidx/O, badidx%O, (double)yg[badidx], (double)yr[badidx]);
+  if(detdiff) printf("  [%ld/%zu gpu elems differ run-to-run]", detdiff, (size_t)S*O);
+  printf("\n");
+
+  coli_metal_unregister(W); coli_metal_unregister(Sc); free(W); free(Sc);
+  return clean?0:1;
+}
+
+int main(void){
+  if(!coli_metal_init()){ printf("Metal unavailable (skipping)\n"); return 0; }
+  printf("coli_metal_gemm large-batch sweep (GPU vs CPU, + determinism):\n");
+  int fail=0;
+  // Real GLM-5.2 matmul shapes. kv_b (O=28672,I=512) has the largest S*O.
+  struct { int O,I; const char*n; } shapes[] = {
+    { 2048, 6144, "gate/up (O2048,I6144)" },
+    { 6144, 2048, "down    (O6144,I2048)" },
+    { 28672, 512, "kv_b    (O28672,I512)" },
+  };
+  int Ss[] = { 512, 2153, 4376, 7478 };   // clean control / clean bracket / corrupt bracket / worst
+  for(auto &sh : shapes){
+    for(int S : Ss) fail |= run_gemm(I4, sh.O, sh.I, S, sh.n);
+    printf("\n");
+  }
+  printf(fail? "GEMM large-batch: CORRUPTION DETECTED\n" : "GEMM large-batch: all clean\n");
+  coli_metal_shutdown();
+  return fail;
+}

--- a/c/tests/test_gemm_largebatch.mm
+++ b/c/tests/test_gemm_largebatch.mm
@@ -3,7 +3,10 @@
 //
 // Isolation established (see INVESTIGATION_LOG_metal_moe_race.md): corruption <=> dense
 // GEMM on GPU (`coli_metal_gemm`), independent of MoE. The engine's existing kernel tests
-// only exercise S<=64, which is why the S>=~2400 fault was never caught.
+// only exercise S<=64, which is why this fault was never caught. The trigger is the DISPATCH
+// GRID (NT=S*O), not S alone: only the largest-O shape here (kv_b, O=28672) crosses the device
+// limit, and only at S=7478 (~5.4e7 tg) -- it is still clean at S=4376 (~3.1e7 tg), and the
+// smaller-O shapes (gate/up, down) stay clean at every S in the sweep.
 //
 // This sweeps S across the clean/corrupt bracket for a few real GLM matmul shapes,
 // compares GPU vs CPU reference, prints the first diverging (row,col), AND runs the GPU
@@ -95,7 +98,7 @@ int main(void){
     { 6144, 2048, "down    (O6144,I2048)" },
     { 28672, 512, "kv_b    (O28672,I512)" },
   };
-  int Ss[] = { 512, 2153, 4376, 7478 };   // clean control / clean bracket / corrupt bracket / worst
+  int Ss[] = { 512, 2153, 4376, 7478 };   // control / clean / clean, just under the kv_b cliff / CORRUPT for kv_b
   for(auto &sh : shapes){
     for(int S : Ss) fail |= run_gemm(I4, sh.O, sh.I, S, sh.n);
     printf("\n");


### PR DESCRIPTION
# Metal: fix grid-size truncation in `coli_metal_gemm` at large prefill (long-context corruption)

## Summary

On the Metal backend, dense GEMMs with a very large output (`S × O` elements) are dispatched as a
**single** grid. Past a device threadgroup-grid limit the grid is silently truncated — the tail
output rows are **never computed** and keep whatever was in the buffer. In the engine that buffer is
reused scratch, so the stale contents are nondeterministic garbage → **corrupted generation at long
context**. This fixes it by chunking the dispatch so no single launch exceeds a safe grid size. No
kernel change; output is bit-exact vs. CPU.

## Motivation — this is what makes Metal + OpenCode/agent backends usable

colibri on Metal (`COLI_METAL=1`) is currently **unusable as an OpenCode / coding-agent backend**
because of this bug. Agent front-ends prepend a large fixed system header — tool declarations, rules,
worked examples — that is **several thousand tokens before the user types anything** and cannot be
trimmed. That header alone requires a large context (we run `CTX=40960` just to fit it) and drives a
big prefill on the *first* message of *every* session. That prefill is exactly the regime that
crosses the grid limit, so the GPU path returns garbage from the first token, while the CPU path is
correct but far slower. In other words: without this fix, Metal + OpenCode simply does not work; with
it, the GPU path produces coherent output and well-formed tool calls at real agentic context sizes.
(Nobody upstream hit this because Metal validation uses tiny 8–13-token prompts — see "Why it evaded
detection".)

## Symptom / impact

- Long prompts on `COLI_METAL=1` produce corrupted output (dropped/blank tokens, degrading to token
  salad); the **identical prompt is correct on CPU** (`COLI_METAL=0`) and correct on Metal at short
  lengths.
- Because the trigger is the fixed agent header, it hits the **first turn of every OpenCode session**
  on Metal — i.e. the GPU backend is effectively dead for coding-agent workloads until this lands.

## Root cause

`matmul_qt_ex` routes dense matmuls with `S ≥ COLI_METAL_GEMM_MIN` to `coli_metal_gemm`, which
dispatches `NT = S*O` output elements as one grid of `(NT+3)/4` threadgroups. The largest projection
(`kv_b`, O≈28672) crosses the device grid limit at large `S`: on M-series, `kv_b` at S=4376
(grid ≈ 3.1e7 tg) computes fully, but at S=7478 (grid ≈ 5.4e7 tg) the tail is not computed. It is
**not** an out-of-bounds (Metal shader validation is silent) and **not** dispatch-arithmetic
overflow (`NT` stays ≈ 9e7 ≪ 2³¹) — it's the raw grid size exceeding what a single dispatch schedules.

## Fix

Chunk `coli_metal_gemm` over output rows so each dispatch is ≤ 2²⁵ elements (grid ≤ 2²³ tg, ~4× under
the observed-clean bound), using `g_gx`/`g_gy` buffer offsets — no shader change, chunks write
disjoint output ranges, negligible overhead, and it's a no-op for small `S` (single chunk) and decode
(S=1). Gated by `COLI_GEMM_CHUNK` (default **on**; `=0` restores the old single-dispatch path for A/B).

## Reproduction & test (seconds, no model)

New `make gemm-test` (`tests/test_gemm_largebatch.mm`) calls `coli_metal_gemm` directly across a size
sweep of real GLM shapes vs. an OMP CPU reference, and includes a GPU-vs-GPU determinism check:

- **Before the fix** (`COLI_GEMM_CHUNK=0`): `kv_b S=7478` → `nerr = 1.00e+00` (`*** CORRUPT`).
- **After the fix** (default): all shapes/sizes clean, `nerr ~1e-6`.

## Validation

- `make gemm-test`: all clean after the fix; the S=7478 `kv_b` case is corrupt with `COLI_GEMM_CHUNK=0`
  and clean with it on (same binary A/B).
- End-to-end: a full ~7478-token OpenCode-scale prefill produces coherent output + well-formed tool
  calls (previously token salad).

## Why it evaded detection

The truncation is at the grid *boundary*, so it's **nondeterministic across process launches** (a
given launch may land just under or just over) and only manifests at **agentic prefill sizes**.
Existing Metal kernel tests exercise `S ≤ 64`; nothing upstream drives a multi-thousand-token prefill
through Metal, so it never surfaced.

## Scope / not included

- The batched MoE-expert GEMV (`moe_submit`/`moe_gemv`) has the same single-dispatch pattern and
  could hit the limit at very large per-block row counts; not triggered in the confirmed repro
  (MoE-on-GPU alone is clean at these sizes), so it's left for a follow-up with its own test.
- Multi-turn KV reuse / prefill latency (re-prefilling the header each turn) is a **separate**
  performance limitation, not addressed here.

<details>
<summary>Investigation notes — hypotheses ruled out (full log attached)</summary>

Ruled out en route (each by a measured run; full forensic detail in the attached investigation log):
DSA sparse attention (model has no indexer weights), RoPE extrapolation (max_position 1M, per-position
angles), CTX-scaled allocation, int32 `NT` overflow, CPU-attention score buffers (#110/#117, target
8192), the residency set (`COLI_METAL_RESSET` on/off both corrupt), the async I/O pipeline (`PIPE=0`
still corrupt), pilot prefetch (off by default), a GEMM+MoE interaction (corrupts with MoE on CPU),
and macOS-compressor eviction of scratch (`setBuffer:`-bound buffers are auto-resident). The 2×2
GEMM×MoE placement matrix isolated corruption to **dense GEMM on GPU**; the standalone `gemm-test`
then proved the GEMM is bit-exact *in isolation*, localizing the fault to the single-dispatch grid
size — deterministically reproduced once the sweep reached `kv_b S=7478`.

**Separately noticed (not fixed here):** `openai_server.py`'s `--engine` default still points at
`glm` after the `glm.c`→`colibri.c` rename (#391); direct invocation is broken on a clean checkout,
and silently runs a stale `glm` if one exists. Worth a one-line fix (default to `colibri`, fall back
to `glm`).
</details>
