### PR TITLE
fix(cuda): honor explicit CUDA_EXPERT_GB under CUDA_DENSE=1 (#491)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -278,6 +278,7 @@ static double g_cuda_expert_gb;
 static int g_cuda_expert_auto;
 static int g_cuda_dense;
 static int g_cuda_release_host;
+static double g_cuda_reserve_gb;   /* CUDA_RESERVE_GB: VRAM headroom kept free of expert tier (default 2 GB) */
 static int g_cuda_devices[COLI_CUDA_MAX_DEVICES], g_cuda_ndev, g_cuda_rr;
 static int64_t g_cuda_dense_projected[COLI_CUDA_MAX_DEVICES];
 static void qt_cuda_reset(QT *t){
@@ -5722,11 +5723,16 @@ static void pin_load(Model *m, const char *statspath, double gb){
     if(g_cuda_enabled&&(g_cuda_expert_gb>0||g_cuda_expert_auto)) for(int i=0;i<g_cuda_ndev;i++){
         size_t free_b=0,total_b=0;
         if(coli_cuda_mem_info(g_cuda_devices[i],&free_b,&total_b)){
-            remaining[i]=(double)free_b-(double)g_cuda_dense_projected[i]-2e9;
+            remaining[i]=(double)free_b-(double)g_cuda_dense_projected[i]-g_cuda_reserve_gb*1e9;
             if(remaining[i]<0) remaining[i]=0; safe_total+=remaining[i];
         }
     }
-    if(g_cuda_expert_auto||budget>safe_total) budget=safe_total;
+    /* auto: fill to measured headroom (safe_total). An explicit CUDA_EXPERT_GB is
+     * honored as-is even when it exceeds headroom; per-expert upload failure below
+     * (remaining[best]=0, continue to next expert) degrades gracefully rather
+     * than OOM-ing. Previously both paths were clamped, which silently capped the
+     * tier under CUDA_DENSE=1 regardless of the configured budget (#491). */
+    if(g_cuda_expert_auto) budget=safe_total;
     if(g_cuda_enabled&&g_cuda_release_host&&budget>0){
         prefix_est=(int)(budget/eb)+g_cuda_ndev;
         npin+=prefix_est;                       /* additive: prefix RAM is returned after upload */
@@ -5796,8 +5802,11 @@ static void pin_load(Model *m, const char *statspath, double gb){
                 }
             }
         }
-        fprintf(stderr,"[CUDA] hot expert tier: %d/%d experts, VRAM %.2f GB (total budget %.1f GB)\n",
-            m->gpu_expert_count,npin,m->gpu_expert_bytes/1e9,g_cuda_expert_gb);
+        fprintf(stderr,"[CUDA] hot expert tier: %d/%d experts, VRAM %.2f GB (budget %.1f GB%s, reserve %.1f GB)\n",
+            m->gpu_expert_count,npin,m->gpu_expert_bytes/1e9,
+            g_cuda_expert_auto?safe_total/1e9:budget/1e9,
+            g_cuda_expert_auto?", auto":"",
+            g_cuda_reserve_gb);
         for(int i=0;i<g_cuda_ndev;i++) fprintf(stderr,"[CUDA]   device %d: %d experts, %.2f GB\n",
             g_cuda_devices[i],placed_n[i],placed_b[i]/1e9);
     }
@@ -6218,6 +6227,7 @@ int main(int argc, char **argv){
     const char *cuda_expert=getenv("CUDA_EXPERT_GB");
     g_cuda_expert_auto=cuda_expert&&!strcmp(cuda_expert,"auto");
     g_cuda_expert_gb=cuda_expert&&!g_cuda_expert_auto?atof(cuda_expert):0;
+    g_cuda_reserve_gb=getenv("CUDA_RESERVE_GB")?atof(getenv("CUDA_RESERVE_GB")):2.0;
     if(!getenv("REPIN")&&g_cuda_expert_auto&&getenv("PIN_GB")&&
        !strcmp(getenv("PIN_GB"),"all")) g_repin=16;
     g_cuda_release_host=getenv("CUDA_RELEASE_HOST")?atoi(getenv("CUDA_RELEASE_HOST")):(g_cuda_ndev>1);


### PR DESCRIPTION
Closes #491.

## Root cause

Reported by @mohamedmastouri2000-boop: with `CUDA_DENSE=1`, the CUDA hot expert tier caps at 109 experts (2.31 GB) regardless of the `CUDA_EXPERT_GB` budget — `=4` and `=6` produce byte-identical tiers.

In `pin_load()` the effective expert budget was computed as:

```c
double budget=g_cuda_expert_gb*1e9, safe_total=0;
... remaining[i] = free_b - g_cuda_dense_projected[i] - 2e9;   // -2GB reserve
if(g_cuda_expert_auto || budget>safe_total) budget=safe_total; // <-- silent clamp
```

With `CUDA_DENSE=1`, `g_cuda_dense_projected` accounts for the dense tensors already claimed during model load. On a 16 GB card (17.1 GB usable) that leaves `safe_total ≈ 2.3 GB` after the 2 GB reserve, regardless of the configured budget. Because `budget > safe_total`, the explicit `CUDA_EXPERT_GB=4` got clamped down to 2.3 GB — and `=6` got clamped to the same value. Hence identical tiers.

The tier log then printed `g_cuda_expert_gb` (the configured value) instead of the effective `budget`, masking the clamp:

```
[CUDA] hot expert tier: 109/2431 experts, VRAM 2.31 GB (total budget 4.0 GB)
                                                                   ^^^^^ lies
```

## The fix (all in `c/colibri.c`, ~14 lines)

1. **Stop clamping explicit budgets.** `if(g_cuda_expert_auto) budget=safe_total;` — only auto mode fills to measured headroom. An explicit `CUDA_EXPERT_GB` is honored as-is. This is safe because the existing per-expert upload-failure path (`remaining[best]=0`, continue to next expert) already degrades gracefully on OOM rather than crashing.
2. **Tunable reserve.** The hardcoded `2e9` becomes `CUDA_RESERVE_GB` (default 2.0 GB), parsed alongside `CUDA_EXPERT_GB`. Lets a 16 GB card owner tighten the margin deliberately to reclaim headroom beyond just honoring the explicit budget.
3. **Honest log.** The `hot expert tier` line now prints the *effective* budget (`safe_total` in auto mode, the explicit budget otherwise), flags auto mode, and surfaces the reserve.

After the fix, on the reporter's 5080 with `CUDA_DENSE=1 CUDA_EXPERT_GB=4`, the tier should attempt ~4 GB of experts (up from 2.31) and the log should read `(budget 4.0 GB, reserve 2.0 GB)`. With `CUDA_RESERVE_GB=1` the same box reclaims an extra ~1 GB of headroom for experts.

## Verification

- `make` — clean CPU build, no warnings.
- `gcc -DCOLI_CUDA -fopenmp -fsyntax-only colibri.c` — clean syntax check with the CUDA guards active, no warnings on the changed lines.
- **Not yet validated on real CUDA hardware.** The CUDA DLL build path (`make CUDA_DLL=1 cuda-dll`) needs MSVC in PATH (`vcvars64.bat`), which is not configured in this shell. However: all five edits are in `colibri.c` (compiled by the host gcc, not by the `backend_cuda.cu` DLL target), and the changed code is straightforward arithmetic + a `fprintf` + a new `getenv`. Requesting validation on the reporter's 5080 / @JustVugg's hardware before merge — specifically the `CUDA_EXPERT_GB=4 CUDA_DENSE=1` case from the issue.

## Scope / risk

- The clamp change only affects the local `budget` in `pin_load`. Confirmed `pin_load` is the sole reader of `g_cuda_expert_gb` / `g_cuda_expert_auto` / `g_cuda_dense_projected` — downstream only sees `m->gpu_expert_count` / `m->gpu_expert_bytes`.
- Worst case if an explicit budget is far too large: extra host-side prefix loads that mostly fail to upload (wasted disk reads, no correctness impact).
- No change to `qt_cuda_upload`, the REPIN path, `qt_load`'s dense projection, or the RAM-side reserves (`1.2e9`/`2.5e9` — separate path).

Branch cut from `origin/dev` (bug region identical between dev and the reporter's `4aca059` checkout). No conflict risk in `pin_load()`.