### PR TITLE
Fixed (I hope) broken anchor links

### DIFF
--- a/docker/README.IT.md
+++ b/docker/README.IT.md
@@ -9,23 +9,23 @@ Una guida semplice per eseguire **Colibrì**, un motore di inferenza locale basa
 
 ## 📋 Sommario
 
-- [Cosa è Colibrì?](#cosa-è-colibrì)
-- [Cosa serve](#cosa-serve)
-    - [Hardware](#hardware)
-    - [Software](#software)
-- [Come iniziare](#come-iniziare)
-    - [Passo 1: Scarica il modello](#passo-1-scarica-il-modello)
-    - [Passo 2: Scarica il Dockerfile di Colibrì](#passo-2-scarica-il-dockerfile-di-colibrì)
-    - [Passo 3: Compila l'immagine Docker](#passo-3-compila-limmagine-docker)
-    - [Passo 4: Avvia Colibrì](#passo-4-avvia-colibr%C3%AC)
-    - [Cosa significa quel comando?](#cosa-significa-quel-comando)
-    - [Usare Colibrì](#usare-colibrì)
-- [Entrare in una console Linux dentro il container](#entrare-in-una-console-linux-dentro-il-container)
-- [Risoluzione dei problemi](#risoluzione-dei-problemi)
-- [Note tecniche](#note-tecniche)
-- [Domande frequenti](#domande-frequenti)
-- [Supporto e contributi](#supporto-e-contributi)
-- [Test sul mio PC](#test-sul-mio-pc)
+- [Cosa è Colibrì?](https://github.com/JustVugg/colibri/blob/main/docker/README.IT.md#cosa-%C3%A8-colibr%C3%AC)
+- [Cosa serve](https://github.com/JustVugg/colibri/blob/main/docker/README.IT.md#cosa-serve)
+    - [Hardware](https://github.com/JustVugg/colibri/blob/main/docker/README.IT.md#hardware)
+    - [Software](https://github.com/JustVugg/colibri/blob/main/docker/README.IT.md#software)
+- [Come iniziare](https://github.com/JustVugg/colibri/blob/main/docker/README.IT.md#come-iniziare)
+    - [Passo 1: Scarica il modello](https://github.com/JustVugg/colibri/blob/main/docker/README.IT.md#passo-1-scarica-il-modello)
+    - [Passo 2: Scarica il Dockerfile di Colibrì](https://github.com/JustVugg/colibri/blob/main/docker/README.IT.md#passo-2-scarica-il-dockerfile-di-colibr%C3%AC)
+    - [Passo 3: Compila l'immagine Docker](https://github.com/JustVugg/colibri/blob/main/docker/README.IT.md#passo-3-compila-limmagine-docker)
+    - [Passo 4: Avvia Colibrì](https://github.com/JustVugg/colibri/blob/main/docker/README.IT.md#passo-4-avvia-colibr%C3%AC)
+    - [Cosa significa quel comando?](https://github.com/JustVugg/colibri/blob/main/docker/README.IT.md#cosa-significa-quel-comando)
+    - [Usare Colibrì](https://github.com/JustVugg/colibri/blob/main/docker/README.IT.md#usare-colibr%C3%AC)
+- [Entrare nel container](https://github.com/JustVugg/colibri/blob/main/docker/README.IT.md#entrare-nel-container)
+- [Risoluzione dei problemi](https://github.com/JustVugg/colibri/blob/main/docker/README.IT.md#risoluzione-dei-problemi)
+- [Note tecniche](https://github.com/JustVugg/colibri/blob/main/docker/README.IT.md#note-tecniche)
+- [Domande frequenti](https://github.com/JustVugg/colibri/blob/main/docker/README.IT.md#domande-frequenti)
+- [Supporto e contributi](https://github.com/JustVugg/colibri/blob/main/docker/README.IT.md#supporto-e-contributi)
+- [Testing on a low resource PC](https://github.com/JustVugg/colibri/blob/main/docker/README.IT.md#test-su-un-pc-con-poche-risorse)
 
 ---
 
@@ -196,7 +196,7 @@ Il modello capisce **italiano, inglese, cinese e altre lingue**, anche se è ott
 
 ---
 
-## Entrare in una console Linux dentro il container
+## Entrare nel container
 
 Se vuoi esplorare il container come fosse una macchina Linux normale:
 
@@ -408,7 +408,7 @@ Buon divertimento! 🐦
 
 ---
 
-## Test sul mio PC
+## Test su un PC con poche risorse
 
 Nel primo caso ho fatto una domanda in italiano, nel secondo in giapponese, e nel terzo ho rifatto la domanda in giapponese ma ho richiesto una risposta in italiano. 
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,23 +9,23 @@ A simple guide to running **Colibrì**, a local inference engine based on GLM 5.
 
 ## 📋 Table of Contents
 
-* [What is Colibrì?](https://www.google.com/search?q=#what-is-colibr%C3%AC)
-* [Requirements](https://www.google.com/search?q=#requirements)
-    * [Hardware](https://www.google.com/search?q=#hardware)
-    * [Software](https://www.google.com/search?q=#software)
-* [How to get started](https://www.google.com/search?q=#how-to-get-started)
-    * [Step 1: Download the model](https://www.google.com/search?q=#step-1-download-the-model)
-    * [Step 2: Download the Colibrì Dockerfile](https://www.google.com/search?q=#step-2-download-the-colibr%C3%AC-dockerfile)
-    * [Step 3: Build the Docker image](https://www.google.com/search?q=#step-3-build-the-docker-image)
-    * [Step 4: Start Colibrì](https://www.google.com/search?q=#step-4-start-colibr%C3%AC)
-    * [What does that command mean?](https://www.google.com/search?q=#what-does-that-command-mean)
-    * [Using Colibrì](https://www.google.com/search?q=#using-colibr%C3%AC)
-* [Entering a Linux console inside the container](https://www.google.com/search?q=#entering-a-linux-console-inside-the-container)
-* [Troubleshooting](https://www.google.com/search?q=#troubleshooting)
-* [Technical notes](https://www.google.com/search?q=#technical-notes)
-* [Frequently Asked Questions](https://www.google.com/search?q=#frequently-asked-questions)
-* [Support and contributions](https://www.google.com/search?q=#support-and-contributions)
-* [Tests on my PC](https://www.google.com/search?q=#tests-on-my-pc)
+* [What is Colibrì?](https://github.com/JustVugg/colibri/blob/main/docker/README.md#what-is-colibr%C3%AC)
+* [Requirements](https://github.com/JustVugg/colibri/blob/main/docker/README.md#requirements)
+    * [Hardware](https://github.com/JustVugg/colibri/blob/main/docker/README.md#hardware)
+    * [Software](https://github.com/JustVugg/colibri/blob/main/docker/README.md#software)
+* [How to get started](https://github.com/JustVugg/colibri/blob/main/docker/README.md#how-to-get-started)
+    * [Step 1: Download the model](https://github.com/JustVugg/colibri/blob/main/docker/README.md#step-2-download-the-colibr%C3%AC-dockerfile)
+    * [Step 2: Download the Colibrì Dockerfile](https://github.com/JustVugg/colibri/blob/main/docker/README.md#step-2-download-the-colibr%C3%AC-dockerfile)
+    * [Step 3: Build the Docker image](https://github.com/JustVugg/colibri/blob/main/docker/README.md#step-3-build-the-docker-image)
+    * [Step 4: Start Colibrì](https://github.com/JustVugg/colibri/blob/main/docker/README.md#step-4-start-colibr%C3%AC)
+    * [What does that command mean?](https://github.com/JustVugg/colibri/blob/main/docker/README.md#what-does-that-command-mean)
+    * [Using Colibrì](https://github.com/JustVugg/colibri/blob/main/docker/README.md#using-colibr%C3%AC)
+* [Enter the container](https://github.com/JustVugg/colibri/blob/main/docker/README.md#entering-a-linux-console-inside-the-container)
+* [Troubleshooting](https://github.com/JustVugg/colibri/blob/main/docker/README.md#troubleshooting)
+* [Technical notes](https://github.com/JustVugg/colibri/blob/main/docker/README.md#technical-notes)
+* [Frequently Asked Questions](https://github.com/JustVugg/colibri/blob/main/docker/README.md#frequently-asked-questions)
+* [Support and contributions](https://github.com/JustVugg/colibri/blob/main/docker/README.md#support-and-contributions)
+* [Testing on a low resource PC](https://github.com/JustVugg/colibri/blob/main/docker/README.md#testing-on-a-low-resource-pc)
 
 ---
 
@@ -206,7 +206,7 @@ The model understands **Italian, English, Chinese, and other languages**, althou
 
 ---
 
-## Entering a Linux console inside the container
+## Enter the container
 
 If you want to explore the container as if it were a normal Linux machine:
 
@@ -439,7 +439,7 @@ Have fun! 🐦
 
 ---
 
-## Tests on my PC
+## Testing on a low resource PC
 
 In the first case, I asked a question in Italian; in the second, in Japanese; and in the third, I repeated the question in Japanese but requested an answer in Italian.
 


### PR DESCRIPTION
## Summary

All the redmi summary anchor links related to using docker were not working. I tried putting absolute anchor links

## Validation

I'll only be able to find out if they really work once they're online. If they still don't work I remove the anchor links. 
**Sorry** for the inconvenience.

## Compatibility

Nope
