### PR TITLE
release: ship the engine under its plain name so the archive actually runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,12 @@ jobs:
         run: |
           TAG=${GITHUB_REF#refs/tags/}
           mkdir -p dist
-          cp c/glm${{ matrix.ext }} dist/colibri-${TAG}-${{ matrix.name }}${{ matrix.ext }}
+          # The engine goes in under its PLAIN name. `coli` locates the engine by looking for
+          # "colibri"/"colibri.exe" (then "glm") next to itself, so shipping it as
+          # colibri-<tag>-<platform>.exe made every downloaded archive fail with
+          # "engine is not built. Run: coli build" -- with the engine sitting right there.
+          # The version lives in the ARCHIVE name, which is where a downloader looks for it.
+          cp c/glm${{ matrix.ext }} dist/colibri${{ matrix.ext }}
           cp c/coli dist/
           cp c/version.py dist/
           cp c/openai_server.py dist/
@@ -73,10 +78,36 @@ jobs:
             tar czf colibri-${TAG}-${{ matrix.name }}.tar.gz *
           fi
 
+      # Unpack what we are about to publish, in a clean directory, and prove `coli` finds the
+      # engine. A packaging mistake is invisible to every other job in this repo: the build is
+      # green, the tests are green, and the artifact is still unusable. Assert on behaviour.
+      - name: Verify the packaged archive actually runs
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          mkdir -p verify && cd verify
+          if [ "${{ matrix.ext }}" = ".exe" ]; then
+            7z x ../dist/colibri-${TAG}-${{ matrix.name }}.zip > /dev/null
+          else
+            tar xzf ../dist/colibri-${TAG}-${{ matrix.name }}.tar.gz
+          fi
+          test -x colibri${{ matrix.ext }} || { echo "engine missing from archive"; ls -la; exit 1; }
+          out=$(python3 coli info 2>&1 || true)
+          echo "$out"
+          case "$out" in
+            *"engine is not built"*) echo "FAIL: coli cannot find the packaged engine"; exit 1 ;;
+          esac
+          echo "$out" | grep -q "colibri" || { echo "FAIL: coli did not run"; exit 1; }
+          echo "OK: coli locates the engine in the published archive"
+
+      # Only the archives -- never the loose files. `dist/colibri-*.*` used to work by accident
+      # (the engine was versioned, so it did not match); now that the engine is plainly named,
+      # be explicit about what gets published.
       - uses: actions/upload-artifact@v4
         with:
           name: colibri-${{ matrix.name }}
-          path: dist/colibri-*.*
+          path: |
+            dist/colibri-*.zip
+            dist/colibri-*.tar.gz
 
   release:
     needs: build


### PR DESCRIPTION
**Every published release archive is unusable, on every platform, including v1.0.0.**

Download it, unpack it, run `coli chat`:

```
engine is not built. Run: coli build
```

— with the engine sitting right there in the same directory.

## Cause

`coli` locates the engine by looking for `colibri` / `colibri.exe` (then `glm`) next to itself, or `$COLI_ENGINE`. The Package step copied it in as `colibri-<tag>-<platform>[.exe]`, which matches none of those, so it fell through to the `$PREFIX/libexec/colibri` layout that does not exist in an unpacked archive.

So anyone who downloaded a prebuilt binary — the whole point of publishing binaries — was told to build from source.

## Fix

The version belongs in the **archive** name, which is where someone downloading it looks. It does not belong in the executable that a launcher has to find by name.

Reproduced the Package step locally, both ways:

```
before:  $ python3 coli chat --model <model>
         engine is not built. Run: coli build

after:   $ python3 coli info
             (\      colibrì v1.1.0
              )·>     tiny engine, immense model
         $ python3 coli chat --model <model>
         └─ 1024 tok · 633.41 tok/s · hit 100% · RSS 0.2 GB · 2s
```

## Plus a gate so this cannot happen again

A packaging mistake is invisible to every other job in this repo: the build is green, the tests are green, and the artifact is still broken. Added a step that unpacks the archive **we are about to publish** into a clean directory and asserts `coli` finds the engine — asserting on behaviour, not on compilation.

The upload glob is now explicit about publishing only archives; it previously worked by accident, because the versioned engine name happened not to match `colibri-*.*`.

## Note

This should land before the v1.1.0 tag, otherwise v1.1.0 ships the same broken archives.