### PR TITLE
release workflow: build/copy the engine under its post-rename name (v1.1.0 tag build failed)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Build engine
         run: |
           cd c
-          make glm ${{ matrix.make_args }}
-          ls -lh glm${{ matrix.ext }}
+          make colibri ${{ matrix.make_args }}
+          ls -lh colibri${{ matrix.ext }}
 
       - name: Package
         run: |
@@ -64,7 +64,7 @@ jobs:
           # colibri-<tag>-<platform>.exe made every downloaded archive fail with
           # "engine is not built. Run: coli build" -- with the engine sitting right there.
           # The version lives in the ARCHIVE name, which is where a downloader looks for it.
-          cp c/glm${{ matrix.ext }} dist/colibri${{ matrix.ext }}
+          cp c/colibri${{ matrix.ext }} dist/colibri${{ matrix.ext }}
           cp c/coli dist/
           cp c/version.py dist/
           cp c/openai_server.py dist/


### PR DESCRIPTION
The v1.1.0 tag build failed before publishing anything: `release.yml` still ran `make glm` and then `ls -lh glm` / `cp c/glm`. Since #391 the alias builds a binary named `colibri`, so the macOS job died at the `ls`, the other jobs were cancelled by fail-fast, and the release job was skipped ([run](https://github.com/JustVugg/colibri/actions/runs/29895998617)).

CI stays green through all of this because only a tag push executes this workflow — the same blind spot the v1.0.0 msys2 shell bug exploited, and exactly what the verify step in this file warns about.

Fix: `make colibri` + `ls -lh colibri` in the build step, `cp c/colibri` in the package step — matching what ci.yml already does. The packaged filename inside the archive is unchanged (plain `colibri`, per #508).

After merge this needs to reach main and the `v1.1.0` tag re-pointed (no release was published, so deleting and re-pushing the tag is safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)