### PR TITLE
sampling: COLI_TEMP replaces the TEMP env var — $TEMP belongs to ROCm and Windows (#509)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -199,7 +199,7 @@ else
 PYTHON    ?= python3
 endif
 CUDA_OBJ  =
-TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_st_mirror$(EXE) tests/test_st_pread$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_grouped$(EXE) tests/test_stops$(EXE) tests/test_topp$(EXE) tests/test_sample_nan$(EXE) tests/test_tok_o200k$(EXE) tests/test_kv_alloc$(EXE) tests/test_int3$(EXE) tests/test_int3_load$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE) tests/test_dsa_select$(EXE) tests/test_logit_nan$(EXE) tests/test_pipe_block$(EXE) tests/test_e8_kernel$(EXE)
+TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_st_mirror$(EXE) tests/test_st_pread$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_grouped$(EXE) tests/test_stops$(EXE) tests/test_topp$(EXE) tests/test_sample_nan$(EXE) tests/test_temp_env$(EXE) tests/test_tok_o200k$(EXE) tests/test_kv_alloc$(EXE) tests/test_int3$(EXE) tests/test_int3_load$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE) tests/test_dsa_select$(EXE) tests/test_logit_nan$(EXE) tests/test_pipe_block$(EXE) tests/test_e8_kernel$(EXE)
 ifneq (,$(LINUX))
 TEST_BINS += tests/test_uring$(EXE)
 endif
@@ -399,6 +399,9 @@ tests/bench_topp$(EXE): tests/bench_topp.c colibri.c st.h uring.h json.h tok.h t
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_sample_nan$(EXE): tests/test_sample_nan.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+tests/test_temp_env$(EXE): tests/test_temp_env.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_kv_alloc$(EXE): tests/test_kv_alloc.c colibri.c st.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h

--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -7,6 +7,10 @@
 #include <cstring>
 #include <mutex>
 
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIP__)
+#include <sys/stat.h>
+#endif
+
 struct RaggedKVEntry {
     const void *key;
     const float *host_l,*host_r;
@@ -482,6 +486,19 @@ static int reserve_pinned(float **ptr,size_t *cap,size_t bytes){
 }
 
 extern "C" int coli_cuda_init(const int *devices, int count) {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIP__)
+    /* #509: the ROCm runtime (comgr, MIOpen, roctracer) reads $TEMP as a temp-dir
+     * path. A stray numeric TEMP (the engine's legacy sampling alias) makes comgr's
+     * lazy init fail inside the first stream create -- SIGSEGV in the error-unwind
+     * on gfx1100, clean hipErrorOutOfMemory on gfx1030. The engine has already
+     * parsed g_temp by the time we get here, so a TEMP that is not a real directory
+     * is safe to drop before the first ROCm call; a genuine temp-dir is preserved. */
+    {
+        const char *t = std::getenv("TEMP");
+        struct stat st;
+        if (t && *t && (stat(t, &st) != 0 || !S_ISDIR(st.st_mode))) unsetenv("TEMP");
+    }
+#endif
     int available = 0;
     if (!devices || count < 1 || count > COLI_CUDA_MAX_DEVICES) return 0;
     if (!cuda_ok(cudaGetDeviceCount(&available), "device discovery")) return 0;

--- a/c/coli
+++ b/c/coli
@@ -215,7 +215,8 @@ def env_for(a):
     if a.ngen: e["NGEN"]=str(a.ngen)
     if a.topp: e["TOPP"]=str(a.topp)
     if a.topk: e["TOPK"]=str(a.topk)
-    if a.temp is not None: e["TEMP"]=str(a.temp)   # 0 = greedy; default motore: 1.0 + nucleus 0.95
+    if a.temp is not None: e["COLI_TEMP"]=str(a.temp)   # 0 = greedy; default motore: 1.0 + nucleus 0.95
+                                                        # COLI_TEMP, non TEMP: ROCm e Windows leggono $TEMP come dir temporanea (#509)
     if a.repin: e["REPIN"]=str(a.repin)
     if a.ctx: e["CTX"]=str(a.ctx)
     if a.auto_tier:

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -571,8 +571,19 @@ static int g_prefetch=0; /* PREFETCH=1 -> riabilita il WILLNEED cross-layer (met
 static int g_direct=0;   /* DIRECT=1 -> O_DIRECT sugli slab expert. Default OFF: su questo host
                           * (VHDX su NVMe DRAM-less, latenza serializzata ~60ms/req) il buffered
                           * liscio e' risultato il migliore; su NVMe veri DIRECT=1 rende di piu'. */
-static float g_temp=-1;  /* TEMP: temperatura di sampling sui TOKEN. <0 = auto (1.0 in chat/testo,
-                          * 0=greedy in validazione). 0 = greedy puro. */
+static float g_temp=-1;  /* COLI_TEMP: temperatura di sampling sui TOKEN. <0 = auto (1.0 in chat/
+                          * testo, 0=greedy in validazione). 0 = greedy puro. */
+
+/* #509: COLI_TEMP e' il canale primario; TEMP resta come alias legacy ma SOLO se
+ * interamente numerica. $TEMP e' la directory temporanea per ROCm (comgr/MIOpen) e
+ * per Windows: un valore tipo 0.6 fa fallire l'init HIP, e sulle build native
+ * Windows atof("C:\...\Temp")==0 avrebbe silenziosamente forzato greedy sempre. */
+static float temp_from_env(const char *coli_temp, const char *temp){
+    if(coli_temp) return (float)atof(coli_temp);
+    if(temp && *temp){ char *tend; double tv=strtod(temp,&tend);
+                       if(tend!=temp && *tend=='\0') return (float)tv; }
+    return -1.f;
+}
 static float g_nuc=0.95f;/* NUCLEUS: top-p sul vocabolario (default dal generation_config GLM-5.2) */
 static int g_topk=0;     /* TOPK=n -> usa n expert/token invece di config (ricerca: meno disco) */
 static float g_topp=0;   /* TOPP=p (0..1) -> top-p adattivo: tieni gli expert fino a peso cumulato p */
@@ -6449,7 +6460,7 @@ int main(int argc, char **argv){
      * getenv was missing, so the knob did nothing. I4S=<n> -> int4 IDOT only for S>=n. */
     if(getenv("I4S")) g_i4s=atoi(getenv("I4S"));
     if(getenv("XEXP")) g_xexp=atoi(getenv("XEXP"))!=0;
-    g_temp = getenv("TEMP")?atof(getenv("TEMP")):-1;       /* -1 = auto (1.0 chat/testo, greedy altrove) */
+    g_temp = temp_from_env(getenv("COLI_TEMP"),getenv("TEMP")); /* -1 = auto (1.0 chat/testo, greedy altrove) */
     g_nuc  = getenv("NUCLEUS")?atof(getenv("NUCLEUS")):0.90f;  /* piu' stretto dell'ufficiale 0.95: la coda int4 e' rumore */
     if(getenv("SEED")) g_rng = (uint64_t)atoll(getenv("SEED"))*0x9E3779B97F4A7C15ULL+1;
     else { struct timespec ts; clock_gettime(CLOCK_MONOTONIC,&ts); g_rng ^= (uint64_t)ts.tv_nsec<<20 ^ (uint64_t)getpid(); }

--- a/c/tests/test_temp_env.c
+++ b/c/tests/test_temp_env.c
@@ -1,0 +1,46 @@
+/* Regressione #509: il canale della temperatura era l'env var TEMP, che ROCm
+ * (comgr/MIOpen) e Windows possiedono gia' come path della directory temporanea.
+ * Due danni: (a) `coli --temp 0.6` esportava TEMP=0.6 e l'init HIP moriva dentro
+ * comgr (SIGSEGV su gfx1100, hipErrorOutOfMemory su gfx1030); (b) sulle build
+ * native Windows TEMP e' SEMPRE definita come path e atof("C:\...\Temp")==0
+ * forzava silenziosamente greedy su ogni run senza override.
+ *
+ * Contratto di temp_from_env(COLI_TEMP, TEMP):
+ *   - COLI_TEMP presente -> vince sempre (canale primario);
+ *   - altrimenti TEMP e' accettata SOLO se interamente numerica (alias legacy);
+ *   - un TEMP non numerico (path) o assente -> -1 = auto. */
+#define main coli_glm_main_unused
+#include "../colibri.c"
+#undef main
+#include <stdio.h>
+
+static int feq(float a,float b){ return fabsf(a-b)<1e-6f; }
+
+int main(void){
+    int fail=0;
+    struct { const char *ct, *t; float want; const char *why; } C[] = {
+        {"0.6",  NULL,                    0.6f, "COLI_TEMP da solo"},
+        {"0",    "/tmp",                  0.0f, "COLI_TEMP=0 (greedy) vince su un TEMP-directory"},
+        {"0.7",  "0.2",                   0.7f, "COLI_TEMP batte un TEMP numerico legacy"},
+        {NULL,   "0.6",                   0.6f, "alias legacy: TEMP interamente numerico"},
+        {NULL,   "0",                     0.0f, "alias legacy: TEMP=0 = greedy (test interni)"},
+        {NULL,   "C:\\Users\\u\\AppData\\Local\\Temp", -1.f, "Windows: il path NON e' una temperatura"},
+        {NULL,   "/tmp",                 -1.f, "POSIX: una directory NON e' una temperatura"},
+        {NULL,   "0.6abc",               -1.f, "numero+spazzatura: rifiutato per intero"},
+        {NULL,   "",                     -1.f, "stringa vuota -> auto"},
+        {NULL,   NULL,                   -1.f, "niente env -> auto"},
+        {"-1",   "C:\\Temp",             -1.f, "COLI_TEMP=-1 esplicito = auto"},
+    };
+    int n = (int)(sizeof C/sizeof C[0]);
+    for(int i=0;i<n;i++){
+        float got = temp_from_env(C[i].ct, C[i].t);
+        if(!feq(got, C[i].want)){
+            printf("  FAIL: (COLI_TEMP=%s, TEMP=%s) -> %g, atteso %g  [%s]\n",
+                   C[i].ct?C[i].ct:"(unset)", C[i].t?C[i].t:"(unset)", got, C[i].want, C[i].why);
+            fail=1;
+        }
+    }
+    if(!fail) printf("  %d casi: primario/alias/path-Windows/auto              ok\n", n);
+    printf(fail?"test_temp_env: FAIL\n":"test_temp_env: ok\n");
+    return fail;
+}

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -19,7 +19,7 @@ Format: `VAR` — default — effect.
 | `RAM_GB` | `0` (auto ≈ 88% of free RAM) | RAM budget in GB for the resident/streamed expert working set. Higher → more experts stay hot → higher cache hit rate. |
 | `CTX` | `4096` | Maximum context length (tokens) the KV cache is sized for. |
 | `NGEN` | `256` (engine) | Max tokens to generate before stopping (stop tokens can end sooner). `coli --ngen` defaults to `1024`. |
-| `TEMP` | `-1` (auto: `1.0` for chat/text, greedy elsewhere) | Sampling temperature. **`TEMP=0` = greedy/argmax = deterministic.** |
+| `COLI_TEMP` | `-1` (auto: `1.0` for chat/text, greedy elsewhere) | Sampling temperature. **`COLI_TEMP=0` = greedy/argmax = deterministic.** `TEMP` still works as a deprecated alias, but only if fully numeric: `$TEMP` is the temp-*directory* path on Windows and for the ROCm runtime (#509), so prefer `COLI_TEMP`. |
 | `NUCLEUS` | `0.90` | Nucleus (top-p) mass kept when sampling. Slightly tighter than the official 0.95 because the int4 tail is noisy. |
 | `TOPK` | `0` (off) | Top-k filter on the sampling distribution (`0` = no limit). |
 | `TOPP` | `0` (off) | Top-p filter (`0` = use `NUCLEUS`). |
@@ -201,6 +201,6 @@ COLI_METAL=1 DIRECT=1 COLI_NO_OMP_TUNE=1 PIPE=1 PIPE_WORKERS=6 MTP=0 \
   ./coli run --model /path/to/model --ram 113 "your prompt"
 
 # same, but reproducible (greedy):
-TEMP=0 COLI_METAL=1 DIRECT=1 COLI_NO_OMP_TUNE=1 PIPE=1 PIPE_WORKERS=6 MTP=0 \
+COLI_TEMP=0 COLI_METAL=1 DIRECT=1 COLI_NO_OMP_TUNE=1 PIPE=1 PIPE_WORKERS=6 MTP=0 \
   ./coli run --model /path/to/model --ram 113 "your prompt"
 ```

--- a/docs/grammar-draft.md
+++ b/docs/grammar-draft.md
@@ -31,7 +31,7 @@ Fewer forwards also means less LRU churn, which compounds with cache hit rate.
 ## Usage
 
 ```bash
-GRAMMAR=fit.gbnf TEMP=0 PROMPT="..." ./glm 64 4 8
+GRAMMAR=fit.gbnf COLI_TEMP=0 PROMPT="..." ./glm 64 4 8
 ```
 
 - `GRAMMAR=<file.gbnf>` — arm the draft source with a grammar. Byte-level GBNF


### PR DESCRIPTION
Fixes #509.

`coli --temp` exported the sampling temperature as `TEMP` — a name the platform already owns. The ROCm runtime (comgr, MIOpen, roctracer) reads `$TEMP` as a temp-*directory* path, so `TEMP=0.6` broke HIP init inside comgr's lazy first use: SIGSEGV in the runtime error-unwind on gfx1100 (@icedream's gdb trace), clean `hipErrorOutOfMemory` on gfx1030 (@ab2m). Three RDNA generations, three failure modes, one collision — and @rofl0r's point stands: `TEMP` is a Windows var, POSIX uses `TMPDIR`; either way the engine shouldn't have squatted on it.

**Bonus latent bug this fixes**: on native Windows builds `TEMP` is *always* set to a path, and `atof("C:\\...\\Temp")==0` — so every Windows run without an explicit `--temp` was silently **greedy** instead of auto. The alias now only accepts a fully-numeric `TEMP`.

As discussed in the thread (@noobdev-ph: "complementary, not alternatives"), this takes **both** fixes:

1. **`COLI_TEMP` primary channel** — `coli --temp` exports `COLI_TEMP`; engine reads it first (@ab2m's diff).
2. **Legacy alias, validated** — `TEMP` still works if `strtod` consumes the whole string: internal scripts/tests using `TEMP=0` keep working; directory paths are rejected → auto.
3. **HIP-only scrub in `coli_cuda_init`** (@noobdev-ph's #339 follow-up) — a `$TEMP` that isn't a real directory is dropped before the first ROCm call, covering a stray manual `TEMP=0.6` on the raw binary; a genuine temp-dir is preserved. Guarded by `__HIP_PLATFORM_AMD__`, CUDA/CPU untouched.

The parse is factored into `temp_from_env()` and pinned by a new regression test (`tests/test_temp_env.c`, 11 cases: precedence, alias, Windows path, auto). Docs updated (`ENVIRONMENT.md`, `grammar-draft.md`).

**Verified locally**: full `make test-c` (incl. new test) + `make test-python` (135 tests) green. HIP compile check deferred to CI's syntax job — would appreciate a real-silicon confirmation from the #509 reporters (`--temp 0.6` on gfx1100, `--temp 0` on gfx1030).

🤖 Generated with [Claude Code](https://claude.com/claude-code)