### PR TITLE
Release v1.1.0, take two: fix the tag-build workflow (#512) + COLI_TEMP / ROCm collision (#513)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Build engine
         run: |
           cd c
-          make glm ${{ matrix.make_args }}
-          ls -lh glm${{ matrix.ext }}
+          make colibri ${{ matrix.make_args }}
+          ls -lh colibri${{ matrix.ext }}
 
       - name: Package
         run: |
@@ -64,7 +64,7 @@ jobs:
           # colibri-<tag>-<platform>.exe made every downloaded archive fail with
           # "engine is not built. Run: coli build" -- with the engine sitting right there.
           # The version lives in the ARCHIVE name, which is where a downloader looks for it.
-          cp c/glm${{ matrix.ext }} dist/colibri${{ matrix.ext }}
+          cp c/colibri${{ matrix.ext }} dist/colibri${{ matrix.ext }}
           cp c/coli dist/
           cp c/version.py dist/
           cp c/openai_server.py dist/

--- a/README.md
+++ b/README.md
@@ -206,10 +206,10 @@ scale-granularity/rotation ablations live in
 > through install → build → model → first chat step by step for Linux, Windows,
 > and macOS. On **Windows** you don't even need to build: download the
 > `colibri-<version>-windows-x86_64.zip` from
-> [Releases](https://github.com/JustVugg/colibri/releases), unzip it, rename
-> `colibri-*-windows-x86_64.exe` → `glm.exe`, install
-> [Python 3](https://www.python.org/downloads/), and run `coli chat` — full
-> details in the [Windows section](docs/quickstart.md#windows).
+> [Releases](https://github.com/JustVugg/colibri/releases), unzip it, install
+> [Python 3](https://www.python.org/downloads/), and run `coli chat` — the
+> engine ships ready to run as `colibri.exe`, the launcher finds it by itself.
+> Full details in the [Windows section](docs/quickstart.md#windows).
 
 ### 1. Get the model
 
@@ -245,10 +245,10 @@ and the optional API gateway.
 
 **On Windows?** You don't need to build. Download the
 `colibri-<version>-windows-x86_64.zip` from
-[Releases](https://github.com/JustVugg/colibri/releases), unzip it, rename
-`colibri-*-windows-x86_64.exe` → `glm.exe` (so the `coli` launcher finds the
-engine), install [Python 3](https://www.python.org/downloads/), then run
-`coli chat`. Full walkthrough in the [Quick Start guide](docs/quickstart.md#windows).
+[Releases](https://github.com/JustVugg/colibri/releases), unzip it, install
+[Python 3](https://www.python.org/downloads/), then run `coli chat` — the
+engine is already named `colibri.exe` and the launcher finds it next to
+itself. Full walkthrough in the [Quick Start guide](docs/quickstart.md#windows).
 
 Prefer a `coli` command on your PATH? From a checkout, `pip install -e .`
 registers it (the engine itself still lives in `c/` — this is an editable

--- a/c/Makefile
+++ b/c/Makefile
@@ -199,7 +199,7 @@ else
 PYTHON    ?= python3
 endif
 CUDA_OBJ  =
-TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_st_mirror$(EXE) tests/test_st_pread$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_grouped$(EXE) tests/test_stops$(EXE) tests/test_topp$(EXE) tests/test_sample_nan$(EXE) tests/test_tok_o200k$(EXE) tests/test_kv_alloc$(EXE) tests/test_int3$(EXE) tests/test_int3_load$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE) tests/test_dsa_select$(EXE) tests/test_logit_nan$(EXE) tests/test_pipe_block$(EXE) tests/test_e8_kernel$(EXE)
+TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_st_mirror$(EXE) tests/test_st_pread$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_grouped$(EXE) tests/test_stops$(EXE) tests/test_topp$(EXE) tests/test_sample_nan$(EXE) tests/test_temp_env$(EXE) tests/test_tok_o200k$(EXE) tests/test_kv_alloc$(EXE) tests/test_int3$(EXE) tests/test_int3_load$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE) tests/test_dsa_select$(EXE) tests/test_logit_nan$(EXE) tests/test_pipe_block$(EXE) tests/test_e8_kernel$(EXE)
 ifneq (,$(LINUX))
 TEST_BINS += tests/test_uring$(EXE)
 endif
@@ -399,6 +399,9 @@ tests/bench_topp$(EXE): tests/bench_topp.c colibri.c st.h uring.h json.h tok.h t
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_sample_nan$(EXE): tests/test_sample_nan.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+tests/test_temp_env$(EXE): tests/test_temp_env.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_kv_alloc$(EXE): tests/test_kv_alloc.c colibri.c st.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h

--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -7,6 +7,10 @@
 #include <cstring>
 #include <mutex>
 
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIP__)
+#include <sys/stat.h>
+#endif
+
 struct RaggedKVEntry {
     const void *key;
     const float *host_l,*host_r;
@@ -482,6 +486,19 @@ static int reserve_pinned(float **ptr,size_t *cap,size_t bytes){
 }
 
 extern "C" int coli_cuda_init(const int *devices, int count) {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIP__)
+    /* #509: the ROCm runtime (comgr, MIOpen, roctracer) reads $TEMP as a temp-dir
+     * path. A stray numeric TEMP (the engine's legacy sampling alias) makes comgr's
+     * lazy init fail inside the first stream create -- SIGSEGV in the error-unwind
+     * on gfx1100, clean hipErrorOutOfMemory on gfx1030. The engine has already
+     * parsed g_temp by the time we get here, so a TEMP that is not a real directory
+     * is safe to drop before the first ROCm call; a genuine temp-dir is preserved. */
+    {
+        const char *t = std::getenv("TEMP");
+        struct stat st;
+        if (t && *t && (stat(t, &st) != 0 || !S_ISDIR(st.st_mode))) unsetenv("TEMP");
+    }
+#endif
     int available = 0;
     if (!devices || count < 1 || count > COLI_CUDA_MAX_DEVICES) return 0;
     if (!cuda_ok(cudaGetDeviceCount(&available), "device discovery")) return 0;

--- a/c/coli
+++ b/c/coli
@@ -215,7 +215,8 @@ def env_for(a):
     if a.ngen: e["NGEN"]=str(a.ngen)
     if a.topp: e["TOPP"]=str(a.topp)
     if a.topk: e["TOPK"]=str(a.topk)
-    if a.temp is not None: e["TEMP"]=str(a.temp)   # 0 = greedy; default motore: 1.0 + nucleus 0.95
+    if a.temp is not None: e["COLI_TEMP"]=str(a.temp)   # 0 = greedy; default motore: 1.0 + nucleus 0.95
+                                                        # COLI_TEMP, non TEMP: ROCm e Windows leggono $TEMP come dir temporanea (#509)
     if a.repin: e["REPIN"]=str(a.repin)
     if a.ctx: e["CTX"]=str(a.ctx)
     if a.auto_tier:

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -571,8 +571,19 @@ static int g_prefetch=0; /* PREFETCH=1 -> riabilita il WILLNEED cross-layer (met
 static int g_direct=0;   /* DIRECT=1 -> O_DIRECT sugli slab expert. Default OFF: su questo host
                           * (VHDX su NVMe DRAM-less, latenza serializzata ~60ms/req) il buffered
                           * liscio e' risultato il migliore; su NVMe veri DIRECT=1 rende di piu'. */
-static float g_temp=-1;  /* TEMP: temperatura di sampling sui TOKEN. <0 = auto (1.0 in chat/testo,
-                          * 0=greedy in validazione). 0 = greedy puro. */
+static float g_temp=-1;  /* COLI_TEMP: temperatura di sampling sui TOKEN. <0 = auto (1.0 in chat/
+                          * testo, 0=greedy in validazione). 0 = greedy puro. */
+
+/* #509: COLI_TEMP e' il canale primario; TEMP resta come alias legacy ma SOLO se
+ * interamente numerica. $TEMP e' la directory temporanea per ROCm (comgr/MIOpen) e
+ * per Windows: un valore tipo 0.6 fa fallire l'init HIP, e sulle build native
+ * Windows atof("C:\...\Temp")==0 avrebbe silenziosamente forzato greedy sempre. */
+static float temp_from_env(const char *coli_temp, const char *temp){
+    if(coli_temp) return (float)atof(coli_temp);
+    if(temp && *temp){ char *tend; double tv=strtod(temp,&tend);
+                       if(tend!=temp && *tend=='\0') return (float)tv; }
+    return -1.f;
+}
 static float g_nuc=0.95f;/* NUCLEUS: top-p sul vocabolario (default dal generation_config GLM-5.2) */
 static int g_topk=0;     /* TOPK=n -> usa n expert/token invece di config (ricerca: meno disco) */
 static float g_topp=0;   /* TOPP=p (0..1) -> top-p adattivo: tieni gli expert fino a peso cumulato p */
@@ -6449,7 +6460,7 @@ int main(int argc, char **argv){
      * getenv was missing, so the knob did nothing. I4S=<n> -> int4 IDOT only for S>=n. */
     if(getenv("I4S")) g_i4s=atoi(getenv("I4S"));
     if(getenv("XEXP")) g_xexp=atoi(getenv("XEXP"))!=0;
-    g_temp = getenv("TEMP")?atof(getenv("TEMP")):-1;       /* -1 = auto (1.0 chat/testo, greedy altrove) */
+    g_temp = temp_from_env(getenv("COLI_TEMP"),getenv("TEMP")); /* -1 = auto (1.0 chat/testo, greedy altrove) */
     g_nuc  = getenv("NUCLEUS")?atof(getenv("NUCLEUS")):0.90f;  /* piu' stretto dell'ufficiale 0.95: la coda int4 e' rumore */
     if(getenv("SEED")) g_rng = (uint64_t)atoll(getenv("SEED"))*0x9E3779B97F4A7C15ULL+1;
     else { struct timespec ts; clock_gettime(CLOCK_MONOTONIC,&ts); g_rng ^= (uint64_t)ts.tv_nsec<<20 ^ (uint64_t)getpid(); }

--- a/c/tests/test_temp_env.c
+++ b/c/tests/test_temp_env.c
@@ -1,0 +1,46 @@
+/* Regressione #509: il canale della temperatura era l'env var TEMP, che ROCm
+ * (comgr/MIOpen) e Windows possiedono gia' come path della directory temporanea.
+ * Due danni: (a) `coli --temp 0.6` esportava TEMP=0.6 e l'init HIP moriva dentro
+ * comgr (SIGSEGV su gfx1100, hipErrorOutOfMemory su gfx1030); (b) sulle build
+ * native Windows TEMP e' SEMPRE definita come path e atof("C:\...\Temp")==0
+ * forzava silenziosamente greedy su ogni run senza override.
+ *
+ * Contratto di temp_from_env(COLI_TEMP, TEMP):
+ *   - COLI_TEMP presente -> vince sempre (canale primario);
+ *   - altrimenti TEMP e' accettata SOLO se interamente numerica (alias legacy);
+ *   - un TEMP non numerico (path) o assente -> -1 = auto. */
+#define main coli_glm_main_unused
+#include "../colibri.c"
+#undef main
+#include <stdio.h>
+
+static int feq(float a,float b){ return fabsf(a-b)<1e-6f; }
+
+int main(void){
+    int fail=0;
+    struct { const char *ct, *t; float want; const char *why; } C[] = {
+        {"0.6",  NULL,                    0.6f, "COLI_TEMP da solo"},
+        {"0",    "/tmp",                  0.0f, "COLI_TEMP=0 (greedy) vince su un TEMP-directory"},
+        {"0.7",  "0.2",                   0.7f, "COLI_TEMP batte un TEMP numerico legacy"},
+        {NULL,   "0.6",                   0.6f, "alias legacy: TEMP interamente numerico"},
+        {NULL,   "0",                     0.0f, "alias legacy: TEMP=0 = greedy (test interni)"},
+        {NULL,   "C:\\Users\\u\\AppData\\Local\\Temp", -1.f, "Windows: il path NON e' una temperatura"},
+        {NULL,   "/tmp",                 -1.f, "POSIX: una directory NON e' una temperatura"},
+        {NULL,   "0.6abc",               -1.f, "numero+spazzatura: rifiutato per intero"},
+        {NULL,   "",                     -1.f, "stringa vuota -> auto"},
+        {NULL,   NULL,                   -1.f, "niente env -> auto"},
+        {"-1",   "C:\\Temp",             -1.f, "COLI_TEMP=-1 esplicito = auto"},
+    };
+    int n = (int)(sizeof C/sizeof C[0]);
+    for(int i=0;i<n;i++){
+        float got = temp_from_env(C[i].ct, C[i].t);
+        if(!feq(got, C[i].want)){
+            printf("  FAIL: (COLI_TEMP=%s, TEMP=%s) -> %g, atteso %g  [%s]\n",
+                   C[i].ct?C[i].ct:"(unset)", C[i].t?C[i].t:"(unset)", got, C[i].want, C[i].why);
+            fail=1;
+        }
+    }
+    if(!fail) printf("  %d casi: primario/alias/path-Windows/auto              ok\n", n);
+    printf(fail?"test_temp_env: FAIL\n":"test_temp_env: ok\n");
+    return fail;
+}

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -19,7 +19,7 @@ Format: `VAR` — default — effect.
 | `RAM_GB` | `0` (auto ≈ 88% of free RAM) | RAM budget in GB for the resident/streamed expert working set. Higher → more experts stay hot → higher cache hit rate. |
 | `CTX` | `4096` | Maximum context length (tokens) the KV cache is sized for. |
 | `NGEN` | `256` (engine) | Max tokens to generate before stopping (stop tokens can end sooner). `coli --ngen` defaults to `1024`. |
-| `TEMP` | `-1` (auto: `1.0` for chat/text, greedy elsewhere) | Sampling temperature. **`TEMP=0` = greedy/argmax = deterministic.** |
+| `COLI_TEMP` | `-1` (auto: `1.0` for chat/text, greedy elsewhere) | Sampling temperature. **`COLI_TEMP=0` = greedy/argmax = deterministic.** `TEMP` still works as a deprecated alias, but only if fully numeric: `$TEMP` is the temp-*directory* path on Windows and for the ROCm runtime (#509), so prefer `COLI_TEMP`. |
 | `NUCLEUS` | `0.90` | Nucleus (top-p) mass kept when sampling. Slightly tighter than the official 0.95 because the int4 tail is noisy. |
 | `TOPK` | `0` (off) | Top-k filter on the sampling distribution (`0` = no limit). |
 | `TOPP` | `0` (off) | Top-p filter (`0` = use `NUCLEUS`). |
@@ -201,6 +201,6 @@ COLI_METAL=1 DIRECT=1 COLI_NO_OMP_TUNE=1 PIPE=1 PIPE_WORKERS=6 MTP=0 \
   ./coli run --model /path/to/model --ram 113 "your prompt"
 
 # same, but reproducible (greedy):
-TEMP=0 COLI_METAL=1 DIRECT=1 COLI_NO_OMP_TUNE=1 PIPE=1 PIPE_WORKERS=6 MTP=0 \
+COLI_TEMP=0 COLI_METAL=1 DIRECT=1 COLI_NO_OMP_TUNE=1 PIPE=1 PIPE_WORKERS=6 MTP=0 \
   ./coli run --model /path/to/model --ram 113 "your prompt"
 ```

--- a/docs/cuda.md
+++ b/docs/cuda.md
@@ -10,7 +10,7 @@ cd c
 make cuda-test CUDA=1                  # q8/q4/q2/f32 kernel correctness
 make CUDA=1
 # optional dense-path experiment (hot experts are configured below)
-COLI_CUDA=1 COLI_GPU=0 CUDA_DENSE=1 SNAP=/nvme/glm52_i4 ./glm 64 4 4
+COLI_CUDA=1 COLI_GPU=0 CUDA_DENSE=1 SNAP=/nvme/glm52_i4 ./colibri 64 4 4
 ```
 
 Requirements: Linux, an NVIDIA driver, and a CUDA Toolkit under
@@ -26,19 +26,19 @@ A measured `PIN` profile promotes its hottest experts into a persistent VRAM
 tier while keeping the rest in RAM:
 
 ```bash
-STATS=stats.txt SNAP=/nvme/glm52_i4 ./glm 64 4 4   # collect routing frequencies first
+STATS=stats.txt SNAP=/nvme/glm52_i4 ./colibri 64 4 4   # collect routing frequencies first
 COLI_CUDA=1 COLI_GPU=0 CUDA_EXPERT_GB=16 \
-PIN=stats.txt PIN_GB=160 SNAP=/nvme/glm52_i4 ./glm 64 4 4
+PIN=stats.txt PIN_GB=160 SNAP=/nvme/glm52_i4 ./colibri 64 4 4
 
 # multi-GPU expert tier, 150 GB total budget across six 32 GB devices
 COLI_CUDA=1 COLI_GPUS=0,1,2,3,4,5 CUDA_EXPERT_GB=150 \
 CUDA_DENSE=1 PIN=stats.txt PIN_GB=300 RAM_GB=226 \
-SNAP=/nvme/glm52_i4 ./glm 64 4 4
+SNAP=/nvme/glm52_i4 ./colibri 64 4 4
 
 # large-RAM host: fill safe VRAM, then keep every remaining expert in RAM
 COLI_CUDA=1 COLI_GPUS=0,1,2,3,4,5 CUDA_EXPERT_GB=auto \
 CUDA_DENSE=1 COLI_CUDA_ATTN=1 PIN=stats.txt PIN_GB=all RAM_GB=auto \
-SNAP=/nvme/glm52_i4 ./glm 64 4 4
+SNAP=/nvme/glm52_i4 ./colibri 64 4 4
 ```
 
 Selected experts are uploaded during startup, so capacity failures occur before

--- a/docs/grammar-draft.md
+++ b/docs/grammar-draft.md
@@ -31,7 +31,7 @@ Fewer forwards also means less LRU churn, which compounds with cache hit rate.
 ## Usage
 
 ```bash
-GRAMMAR=fit.gbnf COLI_TEMP=0 PROMPT="..." ./glm 64 4 8
+GRAMMAR=fit.gbnf COLI_TEMP=0 PROMPT="..." ./colibri 64 4 8
 ```
 
 - `GRAMMAR=<file.gbnf>` — arm the draft source with a grammar. Byte-level GBNF

--- a/docs/grammar-draft.md
+++ b/docs/grammar-draft.md
@@ -31,7 +31,7 @@ Fewer forwards also means less LRU churn, which compounds with cache hit rate.
 ## Usage
 
 ```bash
-GRAMMAR=fit.gbnf TEMP=0 PROMPT="..." ./glm 64 4 8
+GRAMMAR=fit.gbnf COLI_TEMP=0 PROMPT="..." ./glm 64 4 8
 ```
 
 - `GRAMMAR=<file.gbnf>` — arm the draft source with a grammar. Byte-level GBNF

--- a/docs/metal.md
+++ b/docs/metal.md
@@ -9,7 +9,7 @@ Token-exact vs the CPU path.
 
 ```bash
 cd c
-make glm METAL=1          # macOS only; no Xcode needed (shader compiles at runtime)
+make colibri METAL=1          # macOS only; no Xcode needed (shader compiles at runtime)
 make metal-test           # standalone kernel/attention correctness vs CPU reference
 COLI_METAL=1 COLI_MODEL=/path/glm52_i4 ./coli chat --ram 96
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -48,23 +48,17 @@ Inside you'll find:
 
 | File | What it is |
 |---|---|
-| `colibri-<version>-windows-x86_64.exe` | **the engine** — the C program that actually runs the model |
+| `colibri.exe` | **the engine** — the C program that actually runs the model |
 | `coli` | the command-line launcher (`chat`, `serve`, `convert`, `doctor`, …) |
 | `openai_server.py`, `resource_plan.py`, `doctor.py` | Python support for the API server and placement planner |
 
-Two setup steps:
-
-1. **Rename the engine to `glm.exe`** so the launcher can find it (it looks for a
-   binary named `glm`):
-   ```powershell
-   Rename-Item colibri-*-windows-x86_64.exe glm.exe
-   ```
-2. **Install Python 3** from [python.org](https://www.python.org/downloads/) — the
-   `coli` launcher and the API gateway are Python scripts (the engine itself is
-   pure C and needs nothing).
+One setup step: **install Python 3** from
+[python.org](https://www.python.org/downloads/) — the `coli` launcher and the
+API gateway are Python scripts (the engine itself is pure C and needs nothing).
+No renaming, no configuration: the launcher finds `colibri.exe` next to itself.
 
 Then continue to [step 3](#3-get-the-model). Prefer to skip the launcher? You can
-run the engine directly — `.\glm.exe` reads the model path from the `SNAP`
+run the engine directly — `.\colibri.exe` reads the model path from the `SNAP`
 environment variable (see [docs/windows.md](windows.md)) — but `coli chat` is the
 easy path.
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -31,7 +31,7 @@ Use the container recommended in the README (with **int8 MTP heads** — int4 he
 From a normal PowerShell, in the repo's `c\` directory:
 
 ```powershell
-make glm.exe ARCH=native      # ARCH=native unlocks AVX-VNNI on Alder Lake+/Arrow Lake
+make colibri.exe ARCH=native      # ARCH=native unlocks AVX-VNNI on Alder Lake+/Arrow Lake
 make iobench.exe              # disk benchmark, useful before committing to the download
 ```
 
@@ -39,10 +39,10 @@ Warnings about `#pragma comment` and unused variables are normal (MSVC-isms gcc 
 
 ### ⚠️ Smart App Control will block your fresh binary
 
-On Windows 11 machines with **Smart App Control** enforced (`VerifiedAndReputablePolicyState = 1`), running your self-compiled `glm.exe` fails with:
+On Windows 11 machines with **Smart App Control** enforced (`VerifiedAndReputablePolicyState = 1`), running your self-compiled `colibri.exe` fails with:
 
 ```
-Program 'glm.exe' failed to run: An Application Control policy has blocked this file
+Program 'colibri.exe' failed to run: An Application Control policy has blocked this file
 ```
 
 This is not Defender and not Mark-of-the-Web — SAC blocks *all* unsigned, unknown binaries, which includes anything you compile yourself. **Fix:** Windows Security → App & browser control → Smart App Control settings → **Off**, then **reboot** (the policy only reloads on restart). Note SAC is one-way: re-enabling later requires resetting Windows. If the settings page is missing, the registry equivalent is setting `HKLM:\SYSTEM\CurrentControlSet\Control\CI\Policy\VerifiedAndReputablePolicyState` to `0` (admin PowerShell), then rebooting. Check your current state before touching anything:
@@ -64,13 +64,13 @@ nvcc needs MSVC as host compiler, so this one step must run from a shell with th
 
 ```cmd
 make cuda-dll CUDA_ARCH=sm_120        # match your GPU: sm_120 Blackwell, sm_89 Ada, ...
-make glm.exe CUDA_DLL=1 ARCH=native   # relink host with the runtime loader
+make colibri.exe CUDA_DLL=1 ARCH=native   # relink host with the runtime loader
 ```
 
 Two pitfalls, both fixed on current `dev` (#314) but worth knowing on older checkouts:
 
 - **Spaces in `CUDA_HOME`** (`C:\Program Files\...`) used to break the recipe → fixed; nvcc now comes from PATH and `"$(NVCC)"` is quoted.
-- **`make glm.exe CUDA_DLL=1` after a CPU-only build** used to report `up to date` and silently keep the CPU-only binary (GPU tier never engages, no error). Current `dev` has a build-config stamp that forces the relink. On older trees: delete `glm.exe` first.
+- **`make colibri.exe CUDA_DLL=1` after a CPU-only build** used to report `up to date` and silently keep the CPU-only binary (GPU tier never engages, no error). Current `dev` has a build-config stamp that forces the relink. On older trees: delete the binary (`colibri.exe`; `glm.exe` pre-rename) first.
 
 Sanity check: first GPU run should print `[CUDA] device 0: <your GPU>, ... sm_XX` and `[CUDA] mode: routed experts + resident dense tensors`.
 
@@ -99,10 +99,10 @@ Size `CUDA_EXPERT_GB` so dense (~10 GB) + experts + working set stays under your
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `'printf' is not recognized` / `The system cannot find the path specified` during `make glm.exe` | scoop MinGW has no `sh.exe`; make fell back to cmd.exe (#478) | §0 — use MSYS2/w64devkit, or `set PATH=%PATH%;C:\msys64\usr\bin` |
+| `'printf' is not recognized` / `The system cannot find the path specified` during `make colibri.exe` | scoop MinGW has no `sh.exe`; make fell back to cmd.exe (#478) | §0 — use MSYS2/w64devkit, or `set PATH=%PATH%;C:\msys64\usr\bin` |
 | `An Application Control policy has blocked this file` | Smart App Control | §2 — turn SAC off + **reboot** |
 | `cuda-dll ... Error 1` immediately | old tree: spaced CUDA_HOME / MSVC rejects `-Wextra` | update to current `dev` (#314) |
-| `glm.exe is up to date` but GPU never engages | old tree: stale CPU-only binary | update to `dev`, or delete `glm.exe` and rebuild |
+| `colibri.exe is up to date` but GPU never engages | old tree: stale CPU-only binary | update to `dev`, or delete the binary and rebuild |
 | `cl.exe (MSVC) not in PATH` | built from plain PowerShell | use the x64 Native Tools prompt |
 | `nvcc fatal: unsupported gpu architecture 'sm_120'` | CUDA < 12.8 | install CUDA 12.8+ |
 | MTP `0% (0/0)` on CPU path | int4 MTP heads in the container | use the int8-MTP container |
@@ -116,15 +116,15 @@ Size `CUDA_EXPERT_GB` so dense (~10 GB) + experts + working set stays under your
 # dot-product instruction (VPDPBUSD) the engine can use for ~1.3x faster
 # quantized matmul. The x86-64-v3 default (portable AVX2) compiles it out;
 # build for THIS machine to enable it:
-make glm.exe ARCH=native                       # banner prints "idot: avx-vnni"
+make colibri.exe ARCH=native                       # banner prints "idot: avx-vnni"
 
 # Verify (tiny model, 2.4 MB):
 pip install torch transformers safetensors huggingface_hub
 python tools/make_glm_oracle.py                # generate tiny oracle
-SNAP=./glm_tiny TF=1 ./glm.exe 64 16 16        # expect "32/32 positions"
+SNAP=./glm_tiny TF=1 ./colibri.exe 64 16 16        # expect "32/32 positions"
 
 # Run with real model:
-SNAP=D:\glm52_i4 ./glm.exe 64 4 16            # batch inference
+SNAP=D:\glm52_i4 ./colibri.exe 64 4 16            # batch inference
 python coli chat --model D:\glm52_i4            # interactive chat
 python coli serve --model D:\glm52_i4            # OpenAI-compatible API
 ```
@@ -149,7 +149,7 @@ completion.
 
 On Windows the engine is built with MinGW gcc but CUDA kernels require MSVC +
 nvcc. The split is clean: build the CUDA backend into a standalone
-`coli_cuda.dll` (nvcc + MSVC), then the host `glm.exe` loads it at runtime via
+`coli_cuda.dll` (nvcc + MSVC), then the host `colibri.exe` loads it at runtime via
 `LoadLibrary` (`c/backend_loader.c`). The host never links cudart directly; if
 the DLL is absent the engine falls back to CPU without error.
 
@@ -161,7 +161,7 @@ make cuda-dll CUDA_HOME="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.
 
 # Build the host with the runtime loader (CUDA_DLL=1 adds -DCOLI_CUDA and
 # links backend_loader.o instead of cudart):
-make glm.exe CUDA_DLL=1 ARCH=native
+make colibri.exe CUDA_DLL=1 ARCH=native
 
 # Run with the GPU expert tier (8 GB VRAM budget here; scale to your free VRAM):
 $env:COLI_CUDA="1"; $env:COLI_GPU="0"; $env:CUDA_EXPERT_GB="8"


### PR DESCRIPTION
The v1.1.0 tag build died before publishing anything: `release.yml` still built and copied the engine under its pre-#391 name ([failed run](https://github.com/JustVugg/colibri/actions/runs/29895998617)). This brings main the fix plus one real bug fix that landed meanwhile:

- **#512** — release workflow builds `make colibri` and copies `c/colibri`, matching ci.yml. Only a tag push exercises this file, which is why every CI was green while the tag build failed.
- **#513** — the sampling temperature moves to `COLI_TEMP` (fixes #509): `$TEMP` is the ROCm/Windows temp-directory, so `--temp 0.6` crashed HIP init on AMD, and on native Windows `atof("C:\\...\\Temp")==0` silently forced greedy on every run. Legacy numeric `TEMP` still accepted; HIP-only env scrub as defense-in-depth; contract pinned by `tests/test_temp_env.c`.

After merge: delete and re-push the `v1.1.0` tag on the new main head (safe — no release was published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)