### PR TITLE
release verify: grep for "colibr" — the banner's accented "colibrì" failed the ASCII match

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,9 @@ jobs:
           case "$out" in
             *"engine is not built"*) echo "FAIL: coli cannot find the packaged engine"; exit 1 ;;
           esac
-          echo "$out" | grep -q "colibri" || { echo "FAIL: coli did not run"; exit 1; }
+          # "colibr", not "colibri": the banner spells the name "colibrì" (accented ì),
+          # so the ASCII-only grep matched nothing and failed the v1.1.0 tag build.
+          echo "$out" | grep -q "colibr" || { echo "FAIL: coli did not run"; exit 1; }
           echo "OK: coli locates the engine in the published archive"
 
       # Only the archives -- never the loose files. `dist/colibri-*.*` used to work by accident


### PR DESCRIPTION
Third tag build attempt, third distinct failure — but this one proves the pipeline works: build ✓, packaging ✓, clean-dir extract ✓, `coli info` runs and reports `engine ready ✓`. The [run](https://github.com/JustVugg/colibri/actions/runs/29899179565) then died on the final assertion: `grep -q "colibri"` — and the banner spells the name **colibrì**, accented ì, so no ASCII `colibri` exists in the output.

Fix: grep for the ASCII prefix `colibr`, which matches both spellings.

Verified locally by simulating the exact package+verify step (tar → clean dir → extract → `coli info` → assertions): old grep FAIL exactly as in CI, new grep PASS.

After merge: one more dev→main + re-tag, and this time the verify step has been executed end-to-end locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)