### PR TITLE
Release v1.1.0, final: the verify grep vs the accented banner (#516)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,9 @@ jobs:
           case "$out" in
             *"engine is not built"*) echo "FAIL: coli cannot find the packaged engine"; exit 1 ;;
           esac
-          echo "$out" | grep -q "colibri" || { echo "FAIL: coli did not run"; exit 1; }
+          # "colibr", not "colibri": the banner spells the name "colibrì" (accented ì),
+          # so the ASCII-only grep matched nothing and failed the v1.1.0 tag build.
+          echo "$out" | grep -q "colibr" || { echo "FAIL: coli did not run"; exit 1; }
           echo "OK: coli locates the engine in the published archive"
 
       # Only the archives -- never the loose files. `dist/colibri-*.*` used to work by accident


### PR DESCRIPTION
One line: the release verify step grepped for `colibri` but the banner spells `colibrì` — the third tag build passed build, packaging, and extraction, and died on the accent. Now greps the ASCII prefix `colibr`; the full package+verify sequence has been executed locally end-to-end (old grep FAIL, new grep PASS).

After merge: re-point the `v1.1.0` tag once more. Everything upstream of this assertion is already proven green in [run 29899179565](https://github.com/JustVugg/colibri/actions/runs/29899179565).

🤖 Generated with [Claude Code](https://claude.com/claude-code)