### PR TITLE
release verify: match the exact banner name "colibrì" (tightens #516)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,9 +96,10 @@ jobs:
           case "$out" in
             *"engine is not built"*) echo "FAIL: coli cannot find the packaged engine"; exit 1 ;;
           esac
-          # "colibr", not "colibri": the banner spells the name "colibrì" (accented ì),
-          # so the ASCII-only grep matched nothing and failed the v1.1.0 tag build.
-          echo "$out" | grep -q "colibr" || { echo "FAIL: coli did not run"; exit 1; }
+          # Exact name as the banner prints it: "colibrì", accented ì. The ASCII-only
+          # grep "colibri" matched nothing and failed the v1.1.0 tag build; the fixed
+          # string here is a locale-independent byte match (verified with LC_ALL=C).
+          echo "$out" | grep -q "colibrì" || { echo "FAIL: coli did not run"; exit 1; }
           echo "OK: coli locates the engine in the published archive"
 
       # Only the archives -- never the loose files. `dist/colibri-*.*` used to work by accident


### PR DESCRIPTION
Per review on #516: the ASCII-prefix `colibr` was looser than it needed to be. The verify step now greps for the exact name the banner prints — `colibrì`, accented — which is strictly tighter than the original `colibri` (which never appeared in the output at all, hence the tag-build failure).

Verified locally against the real packaged `coli info` output, including `LC_ALL=C` (fixed-string grep is a pure byte match, no locale dependence on the runners), plus a negative control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)