### PR TITLE
name: the program is plain-ASCII "colibri" — banner, --version, release title (unblocks the v1.1.0 tag build)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,9 +96,9 @@ jobs:
           case "$out" in
             *"engine is not built"*) echo "FAIL: coli cannot find the packaged engine"; exit 1 ;;
           esac
-          # "colibr", not "colibri": the banner spells the name "colibrì" (accented ì),
-          # so the ASCII-only grep matched nothing and failed the v1.1.0 tag build.
-          echo "$out" | grep -q "colibr" || { echo "FAIL: coli did not run"; exit 1; }
+          # The program name is plain ASCII "colibri" -- exactly what the banner prints.
+          # (The v1.1.0 tag build failed here when the banner still said "colibrì".)
+          echo "$out" | grep -q "colibri" || { echo "FAIL: coli did not run"; exit 1; }
           echo "OK: coli locates the engine in the published archive"
 
       # Only the archives -- never the loose files. `dist/colibri-*.*` used to work by accident
@@ -133,5 +133,5 @@ jobs:
             NOTES="Release ${TAG}"
           fi
           gh release create "$TAG" artifacts/* \
-            --title "colibrì ${TAG}" \
+            --title "colibri ${TAG}" \
             --notes "$NOTES"

--- a/c/coli
+++ b/c/coli
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-colibrì — tiny engine, immense model.
+colibri — tiny engine, immense model.
 Run GLM-5.2 (744B) locally on CPU with roughly 15-26 GB of RAM.
 
   coli chat                 interactive chat (loads the model once)
@@ -90,7 +90,7 @@ class C:
 TTY = sys.stdout.isatty() or os.environ.get("COLI_COLOR")=="1"
 if not TTY: C.off()
 
-# ---------- colibrì 8-bit (pixel art, 2 pixel verticali per carattere) ----------
+# ---------- colibri 8-bit (pixel art, 2 pixel verticali per carattere) ----------
 SPRITE = [
     "....MMM.........",
     "...MMMMM..w.....",
@@ -124,7 +124,7 @@ def sprite_lines():
 def banner(sub=""):
     sp=sprite_lines()
     txt=[
-        f"{C.teal}{C.b}colibrì{C.r} {C.dim}v{_version}{C.r}",
+        f"{C.teal}{C.b}colibri{C.r} {C.dim}v{_version}{C.r}",
         f"{C.dim}tiny engine, immense model{C.r}",
         f"{C.gray}GLM-5.2 · 744B MoE · int4 · streaming CPU{C.r}",
         f"{C.dgray}{sub}{C.r}" if sub else "",
@@ -608,7 +608,7 @@ def chat_attached(a, base, model_id):
         req=urllib.request.Request(base.rstrip("/")+"/v1/chat/completions", data=body,
                                    headers={"Content-Type":"application/json"})
         if a.api_key: req.add_header("Authorization", f"Bearer {a.api_key}")
-        print(f"\n  {C.teal}◆ colibrì{C.r}")
+        print(f"\n  {C.teal}◆ colibri{C.r}")
         sp=Spinner("thinking…"); sp.start()
         md=MDStream("  "); reply=[]; first=True; t0=time.time(); interrupted=False
         try:
@@ -772,7 +772,7 @@ def cmd_chat(a):
                 p.stdin.write(b"\x02MORE\n"); p.stdin.flush()
             else:
                 p.stdin.write((msg.replace("\n"," ")+"\n").encode()); p.stdin.flush()
-            print(f"\n  {C.teal}◆ colibrì{C.r}")
+            print(f"\n  {C.teal}◆ colibri{C.r}")
             dec=codecs.getincrementaldecoder("utf-8")("replace")
             state={"first":True}
             def prefill_tick(path=errlog.name):
@@ -963,8 +963,8 @@ def main():
     common.add_argument("--cap", type=int, default=8); common.add_argument("--ngen", type=int, default=1024)  # rete di sicurezza: la fine vera la decidono gli stop token
     common.add_argument("--topp", type=float, default=0); common.add_argument("--topk", type=int, default=0)
     common.add_argument("--temp", type=float, default=None)  # temperatura token (0=greedy, default 1.0+nucleus .95)
-    ap=argparse.ArgumentParser(prog="coli", parents=[common], description="colibrì — run GLM-5.2 locally")
-    ap.add_argument("--version", action="version", version=f"colibrì {_version}")
+    ap=argparse.ArgumentParser(prog="coli", parents=[common], description="colibri — run GLM-5.2 locally")
+    ap.add_argument("--version", action="version", version=f"colibri {_version}")
     sub=ap.add_subparsers(dest="cmd")
     sub.add_parser("build", parents=[common]); sub.add_parser("info", parents=[common])
     pp=sub.add_parser("plan",parents=[common])

--- a/c/version.py
+++ b/c/version.py
@@ -1,3 +1,3 @@
-"""Single source of truth for the colibrì version number."""
+"""Single source of truth for the colibri version number."""
 
 __version__ = "1.1.0"


### PR DESCRIPTION
The v1.1.0 tag build kept failing on the release verify step, which greps `coli info` output for `colibri`. Root cause: the launcher banner printed the name **with an accent**, while the binary, the pip package, the commands and the archive names are all plain ASCII `colibri` — so the string the check looked for never appeared.

**Fix the name, not the check.** The program name is `colibri`, everywhere:

- banner, `--version`, argparse description and the two section headers in `c/coli`
- the GitHub Release title (`colibri v1.1.0`), matching the archives it ships
- the verify step keeps its **exact** `grep -q "colibri"` — this reverts the looser prefix match from #516, which accepted more than it should have

Verified by replaying the CI package+verify sequence locally end-to-end (tar → clean-dir extract → `coli info` → assertions): banner reads `colibri v1.1.0`, exact grep PASS. `make test-python` green (135 tests); no test referenced the accented spelling.

Prose in README/docs still writes the name with the accent where it's used as a word rather than as the program's identity — untouched here on purpose, happy to sweep that separately if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)