### PR TITLE
serve: Anthropic Messages API on /v1/messages — Claude Code talks to colibri (#343)

### DIFF
--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -437,6 +437,152 @@ def render_chat(messages, enable_thinking=False, reasoning_effort=None, tools=No
     return "".join(prompt)
 
 
+# ---- Anthropic Messages API (#343) --------------------------------------------------------
+# A translation layer, NOT a second engine path: /v1/messages rewrites an Anthropic-shaped
+# request into the exact OpenAI-shaped body the existing path already validates, so prompt
+# rendering, scheduling, generation and tool parsing stay single-sourced. Only the request
+# translation and the response/SSE shapes are new. Claude Code is the reference client.
+
+def _anthropic_block_text(blocks, param):
+    """Text out of an Anthropic content array (tool_result content is the same shape)."""
+    if isinstance(blocks, str):
+        return blocks
+    if not isinstance(blocks, list):
+        raise APIError(400, "Content must be a string or an array of blocks.", param)
+    parts = []
+    for index, block in enumerate(blocks):
+        if not isinstance(block, dict) or block.get("type") != "text":
+            raise APIError(400, "Colibri currently supports text blocks only here.",
+                           f"{param}.{index}", "unsupported_content_type")
+        if not isinstance(block.get("text"), str):
+            raise APIError(400, "Text blocks require a string `text` field.", f"{param}.{index}.text")
+        parts.append(block["text"])
+    return "".join(parts)
+
+
+def anthropic_to_openai(body):
+    """Anthropic request -> (messages, tools, tool_choice) in OpenAI shape."""
+    messages = []
+    system = body.get("system")
+    if isinstance(system, str):
+        if system:
+            messages.append({"role": "system", "content": system})
+    elif isinstance(system, list):
+        text = _anthropic_block_text(system, "system")
+        if text:
+            messages.append({"role": "system", "content": text})
+    elif system is not None:
+        raise APIError(400, "`system` must be a string or an array of text blocks.", "system")
+
+    raw = body.get("messages")
+    if not isinstance(raw, list) or not raw:
+        raise APIError(400, "`messages` must be a non-empty array.", "messages")
+    for index, message in enumerate(raw):
+        if not isinstance(message, dict):
+            raise APIError(400, "Each message must be an object.", f"messages.{index}")
+        role = message.get("role")
+        if role not in ("user", "assistant"):
+            raise APIError(400, f"Unsupported message role: {role!r}. Anthropic messages are "
+                           "`user` or `assistant`; a system prompt goes in the top-level `system`.",
+                           f"messages.{index}.role", "unsupported_role")
+        content = message.get("content")
+        if isinstance(content, str):
+            messages.append({"role": role, "content": content})
+            continue
+        if not isinstance(content, list):
+            raise APIError(400, "Message content must be a string or an array of blocks.",
+                           f"messages.{index}.content")
+        texts, calls, results = [], [], []
+        for j, block in enumerate(content):
+            where = f"messages.{index}.content.{j}"
+            if not isinstance(block, dict):
+                raise APIError(400, "Each content block must be an object.", where)
+            kind = block.get("type")
+            if kind == "text":
+                if not isinstance(block.get("text"), str):
+                    raise APIError(400, "Text blocks require a string `text` field.", f"{where}.text")
+                texts.append(block["text"])
+            elif kind == "tool_use":
+                name = block.get("name")
+                if not isinstance(name, str) or not name:
+                    raise APIError(400, "`tool_use` blocks require a string `name`.", f"{where}.name")
+                arguments = block.get("input")
+                if arguments is None:
+                    arguments = {}
+                if not isinstance(arguments, dict):
+                    raise APIError(400, "`tool_use.input` must be an object.", f"{where}.input")
+                calls.append({"id": block.get("id") or ("toolu_" + uuid.uuid4().hex[:24]),
+                              "type": "function",
+                              "function": {"name": name,
+                                           "arguments": json.dumps(arguments, ensure_ascii=False)}})
+            elif kind == "tool_result":
+                results.append({"role": "tool",
+                                "tool_call_id": block.get("tool_use_id") or "",
+                                "content": _anthropic_block_text(block.get("content", ""),
+                                                                 f"{where}.content")})
+            else:
+                raise APIError(400, "Colibri supports `text`, `tool_use` and `tool_result` "
+                               "content blocks only.", f"{where}.type", "unsupported_content_type")
+        # tool results precede the user's own text: they answer the previous assistant turn
+        messages.extend(results)
+        text = "".join(texts)
+        if role == "assistant":
+            if text or calls:
+                entry = {"role": "assistant", "content": text or None}
+                if calls:
+                    entry["tool_calls"] = calls
+                messages.append(entry)
+        elif text or not results:
+            messages.append({"role": "user", "content": text})
+    return messages
+
+
+def anthropic_tools(body):
+    """Anthropic tools/tool_choice -> OpenAI shape (validated downstream by generation_options)."""
+    raw = body.get("tools")
+    if raw is None:
+        tools = None
+    elif not isinstance(raw, list):
+        raise APIError(400, "`tools` must be an array.", "tools")
+    else:
+        tools = []
+        for index, tool in enumerate(raw):
+            if not isinstance(tool, dict):
+                raise APIError(400, "Each tool must be an object.", f"tools.{index}")
+            name = tool.get("name")
+            if not isinstance(name, str) or not name:
+                raise APIError(400, "Each tool requires a string `name`.", f"tools.{index}.name")
+            schema = tool.get("input_schema")
+            if schema is not None and not isinstance(schema, dict):
+                raise APIError(400, "`input_schema` must be an object.", f"tools.{index}.input_schema")
+            function = {"name": name, "parameters": schema or {"type": "object", "properties": {}}}
+            if isinstance(tool.get("description"), str):
+                function["description"] = tool["description"]
+            tools.append({"type": "function", "function": function})
+        tools = tools or None
+
+    choice = body.get("tool_choice")
+    if choice is None:
+        return tools, None
+    if not isinstance(choice, dict):
+        raise APIError(400, "`tool_choice` must be an object.", "tool_choice")
+    kind = choice.get("type")
+    if kind == "auto":
+        return tools, "auto"
+    if kind == "any":
+        return tools, "required"
+    if kind == "none":
+        return tools, "none"
+    if kind == "tool":
+        name = choice.get("name")
+        if not isinstance(name, str) or not name:
+            raise APIError(400, "`tool_choice.name` is required when type is `tool`.",
+                           "tool_choice.name")
+        return tools, {"type": "function", "function": {"name": name}}
+    raise APIError(400, "`tool_choice.type` must be auto, any, none, or tool.", "tool_choice.type",
+                   "unsupported_value")
+
+
 # Generic whitespace-tolerant JSON grammar for response_format {"type": "json_object"}.
 # Draft-source semantics: positions with one legal byte draft; jws points just keep
 # the walker alive through the model's own spacing (see docs/grammar-draft.md).
@@ -856,7 +1002,7 @@ class APIHandler(BaseHTTPRequestHandler):
             return
         self.send_header("Access-Control-Allow-Origin", "*" if "*" in self.server.cors_origins else origin)
         self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "Authorization, Content-Type")
+        self.send_header("Access-Control-Allow-Headers", "Authorization, Content-Type, x-api-key, anthropic-version")
         self.send_header("Access-Control-Expose-Headers",
                          "x-request-id, x-colibri-queue-wait-ms, Retry-After")
         self.send_header("Access-Control-Max-Age", "600")
@@ -866,12 +1012,16 @@ class APIHandler(BaseHTTPRequestHandler):
     LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1", ""}
 
     def _is_authed(self):
-        """True if no key is configured, or a correct Bearer key was presented."""
+        """True if no key is configured, or a correct key was presented. Anthropic clients
+        (Claude Code, the Anthropic SDKs) authenticate with `x-api-key`, not `Bearer` — both
+        are accepted, and both are compared in constant time."""
         if not self.server.api_key:
             return True
         import hmac
-        provided = self.headers.get("Authorization", "")
-        return hmac.compare_digest(provided, f"Bearer {self.server.api_key}")
+        if hmac.compare_digest(self.headers.get("Authorization", ""),
+                               f"Bearer {self.server.api_key}"):
+            return True
+        return hmac.compare_digest(self.headers.get("x-api-key", ""), self.server.api_key)
 
     def require_auth(self):
         if not self._is_authed():
@@ -1023,10 +1173,12 @@ class APIHandler(BaseHTTPRequestHandler):
                 self.chat_completion(body, request_id)
             elif path == "/v1/completions":
                 self.completion(body, request_id)
+            elif path == "/v1/messages":
+                self.anthropic_messages(body, request_id)
             else:
                 raise APIError(404, "Not found.", None, "not_found")
         except APIError as error:
-            self.send_json(error.status, error_object(error), request_id, error.headers)
+            self.send_json(error.status, self.error_body(error), request_id, error.headers)
         except ClientCancelled:
             pass
         except (BrokenPipeError, ConnectionResetError):
@@ -1036,9 +1188,15 @@ class APIHandler(BaseHTTPRequestHandler):
             api_error = APIError(500, "The colibri engine failed to process the request.",
                                  None, "engine_error", "server_error")
             try:
-                self.send_json(500, error_object(api_error), request_id)
+                self.send_json(500, self.error_body(api_error), request_id)
             except OSError:
                 pass
+
+    def error_body(self, error):
+        """Anthropic clients parse a different error envelope; the OpenAI one is unchanged."""
+        if urlsplit(self.path).path != "/v1/messages":
+            return error_object(error)
+        return {"type": "error", "error": {"type": error.error_type, "message": error.message}}
 
     def generation(self, body, prompt, request_id, chat, tools=None, tool_choice=None):
         # COLI_DEBUG tees the engine transaction to stderr: 1 = decoded output stream only,
@@ -1260,6 +1418,189 @@ class APIHandler(BaseHTTPRequestHandler):
         prompt = render_chat(body.get("messages"), enable_thinking, reasoning_effort, tools,
                              tool_choice)
         self.generation(body, prompt, request_id, True, tools, tool_choice)
+
+    # ---- Anthropic /v1/messages (#343) ----------------------------------------------------
+    ANTHROPIC_STOP = {"stop": "end_turn", "length": "max_tokens", "tool_calls": "tool_use"}
+
+    def anthropic_messages(self, body, request_id):
+        for unsupported, why in (("stop_sequences", "custom stop sequences"),
+                                 ("top_k", "top-k sampling")):
+            if body.get(unsupported) not in (None, [], ""):
+                raise APIError(400, f"Colibri does not support `{unsupported}` ({why}) yet.",
+                               unsupported, "unsupported_value")
+        messages = anthropic_to_openai(body)
+        tools, tool_choice = anthropic_tools(body)
+        thinking = body.get("thinking")
+        if thinking is not None and not isinstance(thinking, dict):
+            raise APIError(400, "`thinking` must be an object.", "thinking")
+        enable_thinking = bool(thinking and thinking.get("type") == "enabled")
+        if not enable_thinking and thinking is None and os.environ.get("COLI_THINK", "0") == "1":
+            enable_thinking = True
+        if body.get("max_tokens") is None:
+            raise APIError(400, "`max_tokens` is required.", "max_tokens")
+        # Reuse the OpenAI path's own validation by handing it an equivalent body.
+        translated = {"messages": messages, "max_tokens": body.get("max_tokens"),
+                      "temperature": body.get("temperature"), "top_p": body.get("top_p"),
+                      "stream": body.get("stream", False), "cache_slot": body.get("cache_slot")}
+        if tools:
+            translated["tools"] = tools
+        if tool_choice is not None:
+            translated["tool_choice"] = tool_choice
+        if tool_choice == "none":
+            tools = None
+        prompt = render_chat(messages, enable_thinking, "high" if enable_thinking else None,
+                             tools, tool_choice)
+        self.anthropic_generation(translated, prompt, request_id, tools)
+
+    def anthropic_generation(self, body, prompt, request_id, tools):
+        maximum, temperature, top_p, grammar = generation_options(body, self.server.max_tokens)
+        cache_slot = body.get("cache_slot")
+        if (cache_slot is not None and
+                (isinstance(cache_slot, bool) or not isinstance(cache_slot, int) or
+                 not 0 <= cache_slot < self.server.kv_slots)):
+            raise APIError(400, f"`cache_slot` must be an integer between 0 and {self.server.kv_slots - 1}.",
+                           "cache_slot")
+        stream = body.get("stream", False)
+        if not isinstance(stream, bool):
+            raise APIError(400, "`stream` must be a boolean.", "stream")
+        message_id = "msg_" + uuid.uuid4().hex[:24]
+
+        def blocks_and_stop(text, stats):
+            """Split a finished reply into Anthropic content blocks + stop_reason."""
+            calls = []
+            if tools:
+                text, calls = parse_tool_calls(text, tools)
+            content = []
+            if text:
+                content.append({"type": "text", "text": text})
+            for call in calls:
+                function = call["function"]
+                try:
+                    arguments = json.loads(function["arguments"])
+                except (json.JSONDecodeError, TypeError):
+                    arguments = {}
+                content.append({"type": "tool_use", "id": call["id"],
+                                "name": function["name"], "input": arguments})
+            reason = "tool_calls" if calls else ("length" if stats["length_limited"] else "stop")
+            return content, self.ANTHROPIC_STOP[reason]
+
+        with self.server.scheduler.admit(self.client_disconnected, cache_slot) as admission:
+            queue_wait, cache_slot = admission
+            queue_headers = {"x-colibri-queue-wait-ms": str(round(queue_wait * 1000))}
+            if not stream:
+                output = []
+                stats = self.server.engine.generate(
+                    prompt, maximum, temperature, top_p, output.append, cache_slot,
+                    self.client_disconnected, grammar=grammar)
+                content, stop_reason = blocks_and_stop("".join(output), stats)
+                self.send_json(200, {
+                    "id": message_id, "type": "message", "role": "assistant",
+                    "model": self.server.model_id, "content": content,
+                    "stop_reason": stop_reason, "stop_sequence": None,
+                    "usage": {"input_tokens": stats["prompt_tokens"],
+                              "output_tokens": stats["completion_tokens"]}},
+                    request_id, queue_headers)
+                return
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("X-Accel-Buffering", "no")
+            self.send_header("x-request-id", request_id)
+            for name, value in queue_headers.items():
+                self.send_header(name, value)
+            self.send_cors_headers()
+            self.end_headers()
+            connected = [True]
+            write_lock = threading.Lock()
+            last_write = [time.time()]
+            ka_stop = threading.Event()
+
+            def send_event(name, payload):
+                if not connected[0]:
+                    return
+                data = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+                with write_lock:
+                    try:
+                        self.wfile.write(f"event: {name}\ndata: {data}\n\n".encode())
+                        self.wfile.flush()
+                        last_write[0] = time.time()
+                    except OSError:
+                        connected[0] = False
+
+            # Anthropic has a first-class keepalive event, so the cold prefill (minutes) does
+            # not need the OpenAI path's reasoning-delta trick: `ping` is in the protocol.
+            def keepalive():
+                while not ka_stop.wait(1.0):
+                    if not connected[0]:
+                        return
+                    if time.time() - last_write[0] >= 10.0:
+                        send_event("ping", {"type": "ping"})
+
+            send_event("message_start", {"type": "message_start", "message": {
+                "id": message_id, "type": "message", "role": "assistant",
+                "model": self.server.model_id, "content": [], "stop_reason": None,
+                "stop_sequence": None, "usage": {"input_tokens": 0, "output_tokens": 0}}})
+            send_event("content_block_start", {"type": "content_block_start", "index": 0,
+                                               "content_block": {"type": "text", "text": ""}})
+            ka_thread = threading.Thread(target=keepalive, daemon=True)
+            ka_thread.start()
+
+            raw = []
+            state = {"buf": "", "in_tool": False}
+            hold = len(BOX_START) - 1
+
+            def on_text(chunk):
+                raw.append(chunk)
+                if not tools:
+                    send_event("content_block_delta", {"type": "content_block_delta", "index": 0,
+                        "delta": {"type": "text_delta", "text": chunk}})
+                    return
+                if state["in_tool"]:
+                    return                       # tool markers never reach the client as text
+                state["buf"] += chunk
+                cut = state["buf"].find(BOX_START)
+                if cut >= 0:
+                    if cut:
+                        send_event("content_block_delta", {"type": "content_block_delta", "index": 0,
+                            "delta": {"type": "text_delta", "text": state["buf"][:cut]}})
+                    state["buf"] = ""
+                    state["in_tool"] = True
+                    return
+                flush = max(0, len(state["buf"]) - hold)
+                if flush:
+                    send_event("content_block_delta", {"type": "content_block_delta", "index": 0,
+                        "delta": {"type": "text_delta", "text": state["buf"][:flush]}})
+                    state["buf"] = state["buf"][flush:]
+
+            stats = self.server.engine.generate(
+                prompt, maximum, temperature, top_p, on_text, cache_slot,
+                lambda: not connected[0], grammar=grammar)
+            if tools and not state["in_tool"] and state["buf"]:
+                send_event("content_block_delta", {"type": "content_block_delta", "index": 0,
+                    "delta": {"type": "text_delta", "text": state["buf"]}})
+            ka_stop.set()
+            ka_thread.join(timeout=2)
+            send_event("content_block_stop", {"type": "content_block_stop", "index": 0})
+
+            content, stop_reason = blocks_and_stop("".join(raw), stats)
+            index = 1
+            for block in content:
+                if block["type"] != "tool_use":
+                    continue                     # text already streamed as block 0
+                send_event("content_block_start", {"type": "content_block_start", "index": index,
+                    "content_block": {"type": "tool_use", "id": block["id"],
+                                      "name": block["name"], "input": {}}})
+                send_event("content_block_delta", {"type": "content_block_delta", "index": index,
+                    "delta": {"type": "input_json_delta",
+                              "partial_json": json.dumps(block["input"], ensure_ascii=False)}})
+                send_event("content_block_stop", {"type": "content_block_stop", "index": index})
+                index += 1
+            send_event("message_delta", {"type": "message_delta",
+                "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+                "usage": {"output_tokens": stats["completion_tokens"]}})
+            send_event("message_stop", {"type": "message_stop"})
+            self.close_connection = True
 
     def completion(self, body, request_id):
         prompt = body.get("prompt")

--- a/c/tests/test_anthropic_messages.py
+++ b/c/tests/test_anthropic_messages.py
@@ -1,0 +1,220 @@
+"""Anthropic Messages API (#343): /v1/messages as a translation layer over the same
+generation path the OpenAI endpoint uses.
+
+The point of these tests is the *contract a real Anthropic client depends on* — Claude Code
+is the reference client from the issue — not merely that the handler returns 200:
+  - request translation: system prompt, content blocks, tool_use/tool_result round trips;
+  - response shape: content blocks, stop_reason, usage with Anthropic's own field names;
+  - the SSE event sequence, in order, with named events (a client that keys off
+    `event:` names breaks on a data-only stream even if the JSON is right);
+  - `x-api-key` auth, which is how Anthropic clients authenticate — Bearer keeps working;
+  - the Anthropic error envelope, which is not the OpenAI one.
+"""
+import json
+import threading
+import unittest
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from openai_server import (APIServer, anthropic_to_openai, anthropic_tools, APIError)
+
+
+class FakeEngine:
+    """Emits whatever `script` says, so a test can drive tool syntax through the parser."""
+    def __init__(self, script=("Hé", "llo"), length_limited=False):
+        self.script = script
+        self.length_limited = length_limited
+        self.prompts = []
+
+    def generate(self, prompt, maximum, temperature, top_p, on_text, cache_slot=0,
+                 cancelled=None, grammar=None):
+        self.prompts.append(prompt)
+        for chunk in self.script:
+            on_text(chunk)
+        return {"prompt_tokens": 11, "completion_tokens": 3,
+                "length_limited": self.length_limited}
+
+
+class TranslationTest(unittest.TestCase):
+    def test_system_and_blocks_become_openai_messages(self):
+        messages = anthropic_to_openai({
+            "system": [{"type": "text", "text": "Be brief."}],
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}],
+        })
+        self.assertEqual(messages, [{"role": "system", "content": "Be brief."},
+                                    {"role": "user", "content": "Hi"}])
+
+    def test_tool_use_and_result_round_trip(self):
+        messages = anthropic_to_openai({"messages": [
+            {"role": "user", "content": "weather?"},
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "toolu_1", "name": "get_weather",
+                 "input": {"city": "Rome"}}]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_1", "content": "18C"},
+                {"type": "text", "text": "and tomorrow?"}]},
+        ]})
+        self.assertEqual(messages[1]["tool_calls"][0]["function"]["name"], "get_weather")
+        self.assertEqual(json.loads(messages[1]["tool_calls"][0]["function"]["arguments"]),
+                         {"city": "Rome"})
+        # the tool result must precede the user's new question, or the model reads the
+        # answer as arriving after a question it has not been asked yet
+        self.assertEqual([m["role"] for m in messages[2:]], ["tool", "user"])
+        self.assertEqual(messages[2]["content"], "18C")
+        self.assertEqual(messages[3]["content"], "and tomorrow?")
+
+    def test_tool_result_only_message_adds_no_empty_user_turn(self):
+        messages = anthropic_to_openai({"messages": [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "t1", "name": "f", "input": {}}]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": "done"}]},
+        ]})
+        self.assertEqual([m["role"] for m in messages], ["user", "assistant", "tool"])
+
+    def test_tools_and_choice_translate(self):
+        tools, choice = anthropic_tools({
+            "tools": [{"name": "f", "description": "d",
+                       "input_schema": {"type": "object", "properties": {"x": {"type": "string"}}}}],
+            "tool_choice": {"type": "tool", "name": "f"}})
+        self.assertEqual(tools[0]["type"], "function")
+        self.assertEqual(tools[0]["function"]["parameters"]["properties"], {"x": {"type": "string"}})
+        self.assertEqual(choice, {"type": "function", "function": {"name": "f"}})
+        self.assertEqual(anthropic_tools({"tool_choice": {"type": "any"}})[1], "required")
+        self.assertEqual(anthropic_tools({"tool_choice": {"type": "auto"}})[1], "auto")
+
+    def test_rejects_system_role_in_messages(self):
+        with self.assertRaises(APIError) as caught:
+            anthropic_to_openai({"messages": [{"role": "system", "content": "no"}]})
+        self.assertIn("system", caught.exception.message)
+
+
+class MessagesHTTPTest(unittest.TestCase):
+    def setUp(self):
+        self.engine = FakeEngine()
+        self.server = APIServer(("127.0.0.1", 0), self.engine, "test-model", "secret", 64,
+                                kv_slots=2)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base = f"http://127.0.0.1:{self.server.server_port}"
+
+    def tearDown(self):
+        self.server.scheduler.close()
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+
+    def post(self, body, headers=None, path="/v1/messages"):
+        head = {"Content-Type": "application/json", "x-api-key": "secret"}
+        head.update(headers or {})
+        return urlopen(Request(self.base + path, data=json.dumps(body).encode(), headers=head),
+                       timeout=3)
+
+    def base_body(self, **extra):
+        body = {"model": "test-model", "max_tokens": 32,
+                "messages": [{"role": "user", "content": "Hi"}]}
+        body.update(extra)
+        return body
+
+    def test_message_response_shape(self):
+        with self.post(self.base_body()) as response:
+            payload = json.load(response)
+        self.assertEqual(payload["type"], "message")
+        self.assertEqual(payload["role"], "assistant")
+        self.assertEqual(payload["content"], [{"type": "text", "text": "Héllo"}])
+        self.assertEqual(payload["stop_reason"], "end_turn")
+        self.assertIsNone(payload["stop_sequence"])
+        # Anthropic's usage field names, not OpenAI's prompt_tokens/completion_tokens
+        self.assertEqual(payload["usage"], {"input_tokens": 11, "output_tokens": 3})
+        self.assertTrue(payload["id"].startswith("msg_"))
+
+    def test_x_api_key_and_bearer_both_authenticate(self):
+        with self.post(self.base_body(), {"x-api-key": "secret"}) as response:
+            self.assertEqual(response.status, 200)
+        with self.post(self.base_body(), {"x-api-key": None and "" or "",
+                                          "Authorization": "Bearer secret"}) as response:
+            self.assertEqual(response.status, 200)
+        with self.assertRaises(HTTPError) as caught:
+            self.post(self.base_body(), {"x-api-key": "wrong"})
+        self.assertEqual(caught.exception.code, 401)
+
+    def test_error_envelope_is_anthropic_shaped(self):
+        with self.assertRaises(HTTPError) as caught:
+            self.post({"model": "test-model", "messages": [{"role": "user", "content": "x"}]})
+        payload = json.load(caught.exception)
+        self.assertEqual(payload["type"], "error")
+        self.assertEqual(payload["error"]["type"], "invalid_request_error")
+        self.assertIn("max_tokens", payload["error"]["message"])
+        self.assertNotIn("param", payload)          # OpenAI's envelope must not leak here
+
+    def test_max_tokens_maps_to_stop_reason(self):
+        self.engine.length_limited = True
+        with self.post(self.base_body()) as response:
+            self.assertEqual(json.load(response)["stop_reason"], "max_tokens")
+
+    def test_stream_emits_named_events_in_order(self):
+        with self.post(self.base_body(stream=True)) as response:
+            raw = response.read().decode()
+        names = [line[len("event: "):] for line in raw.splitlines() if line.startswith("event: ")]
+        self.assertEqual(names, ["message_start", "content_block_start", "content_block_delta",
+                                 "content_block_delta", "content_block_stop", "message_delta",
+                                 "message_stop"])
+        payloads = [json.loads(line[len("data: "):]) for line in raw.splitlines()
+                    if line.startswith("data: ")]
+        text = "".join(p["delta"]["text"] for p in payloads
+                       if p["type"] == "content_block_delta")
+        self.assertEqual(text, "Héllo")
+        self.assertEqual(payloads[-2]["delta"]["stop_reason"], "end_turn")
+        self.assertEqual(payloads[-2]["usage"]["output_tokens"], 3)
+
+    def test_tool_call_becomes_tool_use_block(self):
+        self.engine.script = ("Sure. <tool_call>get_weather<arg_key>city</arg_key>"
+                              "<arg_value>Rome</arg_value></tool_call>",)
+        body = self.base_body(tools=[{"name": "get_weather", "description": "w",
+                                      "input_schema": {"type": "object",
+                                                       "properties": {"city": {"type": "string"}},
+                                                       "required": ["city"]}}])
+        with self.post(body) as response:
+            payload = json.load(response)
+        self.assertEqual(payload["stop_reason"], "tool_use")
+        kinds = [block["type"] for block in payload["content"]]
+        self.assertEqual(kinds, ["text", "tool_use"])
+        call = payload["content"][1]
+        self.assertEqual(call["name"], "get_weather")
+        self.assertEqual(call["input"], {"city": "Rome"})
+        self.assertTrue(call["id"])
+        # the raw <tool_call> markup must never surface as visible text
+        self.assertNotIn("tool_call", payload["content"][0]["text"])
+
+    def test_streamed_tool_call_uses_input_json_delta(self):
+        self.engine.script = ("<tool_call>f<arg_key>x</arg_key><arg_value>1</arg_value></tool_call>",)
+        body = self.base_body(stream=True, tools=[{"name": "f", "input_schema": {
+            "type": "object", "properties": {"x": {"type": "string"}}}}])
+        with self.post(body) as response:
+            raw = response.read().decode()
+        self.assertIn('"type":"input_json_delta"', raw)
+        payloads = [json.loads(line[len("data: "):]) for line in raw.splitlines()
+                    if line.startswith("data: ")]
+        start = [p for p in payloads if p["type"] == "content_block_start"
+                 and p["content_block"]["type"] == "tool_use"]
+        self.assertEqual(len(start), 1)
+        self.assertEqual(start[0]["content_block"]["name"], "f")
+        self.assertEqual(start[0]["index"], 1)      # block 0 is the text block
+        self.assertEqual(payloads[-2]["delta"]["stop_reason"], "tool_use")
+
+    def test_thinking_enabled_renders_reasoning_prompt(self):
+        self.post(self.base_body(thinking={"type": "enabled"})).close()
+        self.assertIn("Reasoning Effort", self.engine.prompts[-1])
+        self.assertTrue(self.engine.prompts[-1].endswith("<|assistant|><think>"))
+
+    def test_unsupported_fields_refuse_loudly(self):
+        for field, value in (("stop_sequences", ["STOP"]), ("top_k", 40)):
+            with self.assertRaises(HTTPError) as caught:
+                self.post(self.base_body(**{field: value}))
+            self.assertEqual(caught.exception.code, 400)
+            self.assertIn(field, json.load(caught.exception)["error"]["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/api.md
+++ b/docs/api.md
@@ -49,6 +49,46 @@ errors before streaming headers are sent. `GET /health` exposes
 active/queued/completed/rejected counters, and successful generation responses
 include `x-colibri-queue-wait-ms`.
 
+## Anthropic-protocol endpoint (`/v1/messages`)
+
+The same server also speaks the **Anthropic Messages API**, so clients that only talk
+to Anthropic endpoints — Claude Code, the Anthropic SDKs — work against colibri
+without a shim. Nothing to enable: `/v1/messages` is served alongside
+`/v1/chat/completions` on the same port.
+
+```bash
+curl http://127.0.0.1:8000/v1/messages \
+  -H 'x-api-key: local' -H 'content-type: application/json' \
+  -d '{"model":"glm-5.2-colibri","max_tokens":128,
+       "messages":[{"role":"user","content":"Hello"}]}'
+```
+
+For Claude Code, point it at the server and give it any non-empty key:
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=local            # only enforced if you set COLI_API_KEY
+export ANTHROPIC_MODEL=glm-5.2-colibri
+claude
+```
+
+Supported: system prompts (string or text blocks), multi-turn `user`/`assistant`
+messages, `text` / `tool_use` / `tool_result` content blocks, tools with
+`input_schema`, every `tool_choice` mode, streaming with the full named-event
+sequence (`message_start` → `content_block_*` → `message_delta` → `message_stop`,
+plus protocol `ping` keepalives during long prefills), `stop_reason`
+(`end_turn` / `max_tokens` / `tool_use`), Anthropic `usage` field names, and
+`x-api-key` authentication (`Authorization: Bearer` also works). Extended
+thinking is enabled with `{"thinking": {"type": "enabled"}}`.
+
+Not supported, and refused explicitly rather than ignored: `stop_sequences`,
+`top_k`, and non-text content blocks (images, documents). Errors use Anthropic's
+own `{"type":"error","error":{...}}` envelope on this path.
+
+> The prefill warning below applies here too, and applies *hardest* to Claude Code:
+> its system prompt and tool catalog are large, and on a disk-streaming CPU path
+> that is a long silent wait before the first token. Read it before you connect.
+
 ## Connect a coding CLI or editor
 
 The API is OpenAI-compatible, so most coding CLIs and editor extensions work by


### PR DESCRIPTION
Closes #343.

@yurivict wants to drive colibri with **Claude Code**, which only speaks to Anthropic endpoints. This serves `/v1/messages` alongside `/v1/chat/completions` on the same port — nothing to enable, no second process.

**It is a translation layer, not a second engine path.** The Anthropic request is rewritten into the exact OpenAI-shaped body the existing path already validates, so prompt rendering, scheduling, generation and tool parsing stay single-sourced and cannot drift between protocols. Only the request translation and the response/SSE shapes are new.

Supported: system prompt (string or text blocks), multi-turn messages, `text`/`tool_use`/`tool_result` blocks, tools with `input_schema`, all four `tool_choice` modes, streaming with the complete named-event sequence (`message_start` → `content_block_start`/`_delta`/`_stop` → `message_delta` → `message_stop`), `stop_reason` mapping (`end_turn`/`max_tokens`/`tool_use`), Anthropic `usage` field names, `{"thinking":{"type":"enabled"}}`, and **`x-api-key`** auth (Bearer still works; both compared in constant time). Errors use Anthropic's envelope on this path only.

Two details a real client notices, and that a naive adapter gets wrong:
- **tool results are emitted before the user's own text** within the same message — otherwise the model reads an answer to a question it has not been asked yet;
- **the cold-prefill keepalive uses the protocol's own `ping` event** rather than the OpenAI path's reasoning-delta workaround. Anthropic has a first-class keepalive; use it.

Refused explicitly rather than silently ignored: `stop_sequences`, `top_k`, non-text blocks.

**Testing**: 14 new tests asserting the *client-visible* contract (event names and their order, not just status 200), full Python suite green (149 tests, no OpenAI regression). What I cannot test here is Claude Code itself against a real 744B model — @yurivict, this is exactly your ask: `ANTHROPIC_BASE_URL=http://localhost:8000`, `ANTHROPIC_MODEL=<your --model-id>`, any dummy `ANTHROPIC_API_KEY`. A report either way would be valuable, especially on tool-use turns. Fair warning from the docs: Claude Code's system prompt and tool catalog are large, and prefill on a disk-streaming CPU path is slow — the first token takes a while.

🤖 Generated with [Claude Code](https://claude.com/claude-code)