### PR TITLE
fp8-e4m3-b128 passthrough weight format — CPU + Metal + repack tool (#524)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -214,7 +214,7 @@ else
 PYTHON    ?= python3
 endif
 CUDA_OBJ  =
-TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_st_mirror$(EXE) tests/test_st_pread$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_grouped$(EXE) tests/test_stops$(EXE) tests/test_topp$(EXE) tests/test_sample_nan$(EXE) tests/test_temp_env$(EXE) tests/test_tok_o200k$(EXE) tests/test_kv_alloc$(EXE) tests/test_int3$(EXE) tests/test_int3_load$(EXE) tests/test_fp8_passthrough$(EXE) tests/test_fp8_load$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE) tests/test_dsa_select$(EXE) tests/test_logit_nan$(EXE) tests/test_router_nan$(EXE) tests/test_pipe_block$(EXE) tests/test_e8_kernel$(EXE) tests/test_rans$(EXE) tests/test_corpus_draft$(EXE) tests/test_pilot_ring$(EXE)
+TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_st_mirror$(EXE) tests/test_st_pread$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_grouped$(EXE) tests/test_stops$(EXE) tests/test_topp$(EXE) tests/test_sample_nan$(EXE) tests/test_temp_env$(EXE) tests/test_tok_o200k$(EXE) tests/test_kv_alloc$(EXE) tests/test_int3$(EXE) tests/test_int3_load$(EXE) tests/test_fp8_passthrough$(EXE) tests/test_fp8_load$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE) tests/test_dsa_select$(EXE) tests/test_logit_nan$(EXE) tests/test_router_nan$(EXE) tests/test_pipe_block$(EXE) tests/test_e8_kernel$(EXE) tests/test_qt_addrow$(EXE) tests/test_rans$(EXE) tests/test_corpus_draft$(EXE) tests/test_pilot_ring$(EXE)
 ifneq (,$(LINUX))
 TEST_BINS += tests/test_uring$(EXE)
 endif
@@ -546,6 +546,9 @@ tests/test_fp8_passthrough$(EXE): tests/test_fp8_passthrough.c quant.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_fp8_load$(EXE): tests/test_fp8_load.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+tests/test_qt_addrow$(EXE): tests/test_qt_addrow.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_logit_nan$(EXE): tests/test_logit_nan.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h

--- a/c/Makefile
+++ b/c/Makefile
@@ -214,7 +214,7 @@ else
 PYTHON    ?= python3
 endif
 CUDA_OBJ  =
-TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_st_mirror$(EXE) tests/test_st_pread$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_grouped$(EXE) tests/test_stops$(EXE) tests/test_topp$(EXE) tests/test_sample_nan$(EXE) tests/test_temp_env$(EXE) tests/test_tok_o200k$(EXE) tests/test_kv_alloc$(EXE) tests/test_int3$(EXE) tests/test_int3_load$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE) tests/test_dsa_select$(EXE) tests/test_logit_nan$(EXE) tests/test_router_nan$(EXE) tests/test_pipe_block$(EXE) tests/test_e8_kernel$(EXE) tests/test_rans$(EXE) tests/test_corpus_draft$(EXE) tests/test_pilot_ring$(EXE)
+TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_st_mirror$(EXE) tests/test_st_pread$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_grouped$(EXE) tests/test_stops$(EXE) tests/test_topp$(EXE) tests/test_sample_nan$(EXE) tests/test_temp_env$(EXE) tests/test_tok_o200k$(EXE) tests/test_kv_alloc$(EXE) tests/test_int3$(EXE) tests/test_int3_load$(EXE) tests/test_fp8_passthrough$(EXE) tests/test_fp8_load$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE) tests/test_dsa_select$(EXE) tests/test_logit_nan$(EXE) tests/test_router_nan$(EXE) tests/test_pipe_block$(EXE) tests/test_e8_kernel$(EXE) tests/test_rans$(EXE) tests/test_corpus_draft$(EXE) tests/test_pilot_ring$(EXE)
 ifneq (,$(LINUX))
 TEST_BINS += tests/test_uring$(EXE)
 endif
@@ -540,6 +540,12 @@ tests/test_int3$(EXE): tests/test_int3.c colibri.c st.h uring.h json.h tok.h tok
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_int3_load$(EXE): tests/test_int3_load.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+tests/test_fp8_passthrough$(EXE): tests/test_fp8_passthrough.c quant.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+tests/test_fp8_load$(EXE): tests/test_fp8_load.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_logit_nan$(EXE): tests/test_logit_nan.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h

--- a/c/backend_metal.h
+++ b/c/backend_metal.h
@@ -29,9 +29,15 @@ int  coli_metal_mem_info(size_t *used_bytes, size_t *total_bytes);
 /*
  * y[S,O] = (x[S,I] @ W[O,I]^T) * scale[o]. fmt=4 (grouped int4) instead folds a
  * PER-GROUP scale into the accumulation -- see the shader comment in backend_metal.mm.
+ * fmt=7 (fp8 passthrough -- see colibri.c) likewise folds its per-128x128-block
+ * scale into the accumulation.
  * fmt matches QT in colibri.c: 0=f32, 1=int8, 2=int4(packed), 3=int2(packed),
  * 4=int4(packed, same layout as 2)+per-group scale (gs = group size along I; scale
- * array is [O, ceil(I/gs)] floats instead of [O]). gs is ignored for fmt!=4 (pass 0).
+ * array is [O, ceil(I/gs)] floats instead of [O]),
+ * 7=fp8-e4m3 (one raw byte/element, same layout as fmt=1) + per-128x128-
+ * block scale (scale array is [ceil(O/128),ceil(I/128)] floats; no group-size
+ * parameter needed -- the block is a fixed 128x128, not caller-configurable).
+ * gs is ignored for fmt!=4 (pass 0).
  * The first successful call wraps W and its scales in GPU-visible buffers (sized from
  * fmt+gs); later calls reuse them (weights are assumed stable at the same address).
  * Returns 1 on success, 0 if Metal is unavailable or fmt is invalid.

--- a/c/backend_metal.h
+++ b/c/backend_metal.h
@@ -29,12 +29,12 @@ int  coli_metal_mem_info(size_t *used_bytes, size_t *total_bytes);
 /*
  * y[S,O] = (x[S,I] @ W[O,I]^T) * scale[o]. fmt=4 (grouped int4) instead folds a
  * PER-GROUP scale into the accumulation -- see the shader comment in backend_metal.mm.
- * fmt=7 (fp8 passthrough -- see colibri.c) likewise folds its per-128x128-block
+ * fmt=8 (fp8 passthrough -- see colibri.c) likewise folds its per-128x128-block
  * scale into the accumulation.
  * fmt matches QT in colibri.c: 0=f32, 1=int8, 2=int4(packed), 3=int2(packed),
  * 4=int4(packed, same layout as 2)+per-group scale (gs = group size along I; scale
  * array is [O, ceil(I/gs)] floats instead of [O]),
- * 7=fp8-e4m3 (one raw byte/element, same layout as fmt=1) + per-128x128-
+ * 8=fp8-e4m3 (one raw byte/element, same layout as fmt=1) + per-128x128-
  * block scale (scale array is [ceil(O/128),ceil(I/128)] floats; no group-size
  * parameter needed -- the block is a fixed 128x128, not caller-configurable).
  * gs is ignored for fmt!=4 (pass 0).

--- a/c/backend_metal.mm
+++ b/c/backend_metal.mm
@@ -13,7 +13,7 @@
 // nibble layout as fmt=2, but scale is PER-GROUP (gsz elements of I), buffer(1) holds
 // [O, ceil(I/gsz)] floats indexed scale[o*ng+g] -- so unlike fmt 1-3, the group scale is
 // folded into the accumulation itself (see the fmt==4 branch), not applied once at the end.
-// fmt=7 (native FP8-e4m3 passthrough -- see colibri.c): raw byte
+// fmt=8 (native FP8-e4m3 passthrough -- see colibri.c): raw byte
 // layout identical to fmt=1 (one e4m3 byte per element, no packing), but the scale is
 // per-128x128 BLOCK of [O,I] -- buffer(1) holds [ceil(O/128),ceil(I/128)] floats indexed
 // scale[(o/128)*nblkI+i/128]. Folded into acc like fmt=4's per-group scale, for the
@@ -85,7 +85,7 @@ kernel void mm_gemv(device const uchar* w      [[buffer(0)]],   // raw weight by
         acc += float(int(b>>4)-8) * xr[i+1] * sc1;
       }
     }
-  } else if (fmt == 7) {                            // fp8 e4m3 passthrough: one raw byte per
+  } else if (fmt == 8) {                            // fp8 e4m3 passthrough: one raw byte per
                                                      // element (like fmt=1), scale per 128x128
                                                      // block folded into acc (like a grouped fmt).
     int nblkI = (I + 127) / 128;
@@ -111,9 +111,9 @@ kernel void mm_gemv(device const uchar* w      [[buffer(0)]],   // raw weight by
     for (int i = I8*8 + slane; i < I; i += 32) acc += wr[i] * xr[i];
   }
   acc = simd_sum(acc);
-  // fmt==4 (per-group) and fmt==7 (per-block) already folded their scale into acc
+  // fmt==4 (per-group) and fmt==8 (per-block) already folded their scale into acc
   // above -- do not scale again.
-  if (slane == 0) y[row] = (fmt == 4 || fmt == 7) ? acc : acc * scale[o];
+  if (slane == 0) y[row] = (fmt == 4 || fmt == 8) ? acc : acc * scale[o];
 }
 
 // Batched bindless expert GEMV: each row gr belongs to expert erow[gr], whose weight and
@@ -477,20 +477,20 @@ static size_t fmt_bytes(int fmt, int I, int O) {
   if (fmt == 2) return (size_t)O * ((I+1)/2);
   if (fmt == 3) return (size_t)O * ((I+3)/4);
   if (fmt == 4) return (size_t)O * ((I+1)/2);   // grouped int4: identical packed-nibble layout to fmt=2
-  if (fmt == 7) return (size_t)O * I;           // fp8 e4m3: one raw byte/element, same as fmt=1
+  if (fmt == 8) return (size_t)O * I;           // fp8 e4m3: one raw byte/element, same as fmt=1
   return (size_t)O * I * sizeof(float);
 }
 // Grouped-int4 (fmt=4) scale-array size: one f32 per gsz-element group, per row -> O*ceil(I/gsz).
-// fp8 (fmt=7) scale-array size: one f32 per 128x128 BLOCK -> ceil(O/128)*ceil(I/128) (2D,
+// fp8 (fmt=8) scale-array size: one f32 per 128x128 BLOCK -> ceil(O/128)*ceil(I/128) (2D,
 // not per-row -- quant.h isn't included here, so the ceil-div is inlined rather than sharing
 // colibri.c's qt_scale_bytes/quant.h's fp8_nblk). The block is a fixed 128x128, so gs is
-// ignored for fmt==7. f32 is this build's implemented scale
-// ENCODING for fmt=7 (see quant.h/colibri.c) -- this file has no reason to know that a
+// ignored for fmt==8. f32 is this build's implemented scale
+// ENCODING for fmt=8 (see quant.h/colibri.c) -- this file has no reason to know that a
 // UE8M0 encoding exists at all: qt_resolve_fmt refuses it on the CPU read path before any
 // tensor in that encoding could ever reach this Metal-side sizing helper.
 static size_t fmt_scale_bytes(int fmt, int I, int O, int gs) {
   if (fmt == 4) return (size_t)O * ((I + gs - 1) / gs) * sizeof(float);
-  if (fmt == 7) return (size_t)((O + 127) / 128) * (size_t)((I + 127) / 128) * sizeof(float);
+  if (fmt == 8) return (size_t)((O + 127) / 128) * (size_t)((I + 127) / 128) * sizeof(float);
   return (size_t)O * sizeof(float);
 }
 
@@ -658,9 +658,9 @@ extern "C" int  coli_metal_mem_info(size_t *used, size_t *total) {
 extern "C" int coli_metal_matmul(ColiMetalTensor **tp, float *y, const float *x,
                                  const void *weights, const float *scales,
                                  int fmt, int S, int I, int O, int gs) {
-  /* fmt==7 (fp8 passthrough) is an explicit allow-list entry, not folded into the 0..4
+  /* fmt==8 (fp8 passthrough) is an explicit allow-list entry, not folded into the 0..4
    * contiguous range check below: it is not adjacent to it. */
-  if (!g_dev || fmt < 0 || (fmt > 4 && fmt != 7)) return 0;
+  if (!g_dev || fmt < 0 || (fmt > 4 && fmt != 8)) return 0;
   @autoreleasepool {
     ColiMetalTensor *t = *tp;
     if (!t) {

--- a/c/backend_metal.mm
+++ b/c/backend_metal.mm
@@ -13,6 +13,16 @@
 // nibble layout as fmt=2, but scale is PER-GROUP (gsz elements of I), buffer(1) holds
 // [O, ceil(I/gsz)] floats indexed scale[o*ng+g] -- so unlike fmt 1-3, the group scale is
 // folded into the accumulation itself (see the fmt==4 branch), not applied once at the end.
+// fmt=7 (native FP8-e4m3 passthrough -- see colibri.c): raw byte
+// layout identical to fmt=1 (one e4m3 byte per element, no packing), but the scale is
+// per-128x128 BLOCK of [O,I] -- buffer(1) holds [ceil(O/128),ceil(I/128)] floats indexed
+// scale[(o/128)*nblkI+i/128]. Folded into acc like fmt=4's per-group scale, for the
+// same reason: it is not constant across one output row. e4m3->float is bit manipulation
+// in-kernel (sign/exp/mantissa, OCP E4M3-FN: exp==0 subnormal, exp==0xF&&mant==0x7 is the
+// only NaN code) -- BW-bound kernel, decode ALU is free, no LUT texture. Must byte-match
+// quant.h's E4M3_LUT/e4m3_decode (the CPU reference) including the NaN policy, which is
+// why the metal-test suite runs all 256 byte codes through this exact kernel path (not
+// just spot values) -- see run_fp8_lut().
 static const char *SHADER = R"METAL(
 #include <metal_stdlib>
 using namespace metal;
@@ -75,6 +85,25 @@ kernel void mm_gemv(device const uchar* w      [[buffer(0)]],   // raw weight by
         acc += float(int(b>>4)-8) * xr[i+1] * sc1;
       }
     }
+  } else if (fmt == 7) {                            // fp8 e4m3 passthrough: one raw byte per
+                                                     // element (like fmt=1), scale per 128x128
+                                                     // block folded into acc (like a grouped fmt).
+    int nblkI = (I + 127) / 128;
+    device const uchar* wr = w + (long)o * I;
+    device const float* scl = scale + (long)(o/128) * nblkI;
+    for (int i = slane; i < I; i += 32) {
+      uchar b = wr[i];
+      uint sign = b >> 7, exp = (b >> 3) & 0xF, mant = b & 0x7;
+      float wv;
+      if (exp == 0xF && mant == 0x7) {
+        wv = as_type<float>(0x7fc00000u);           // qNaN -- matches quant.h's e4m3_decode
+      } else {
+        float mag = (exp == 0) ? (float(mant) * 0.001953125f)                 // subnormal: mant*2^-9
+                                : (1.0f + float(mant)*0.125f) * exp2(float(int(exp) - 7));
+        wv = sign ? -mag : mag;
+      }
+      acc += wv * xr[i] * scl[i/128];
+    }
   } else {                                          // f32
     device const float* wr = (device const float*)(w) + (long)o * I;
     device const float4* w4 = (device const float4*)wr;
@@ -82,8 +111,9 @@ kernel void mm_gemv(device const uchar* w      [[buffer(0)]],   // raw weight by
     for (int i = I8*8 + slane; i < I; i += 32) acc += wr[i] * xr[i];
   }
   acc = simd_sum(acc);
-  // fmt==4 already folded the per-group scale into acc above -- do not scale again.
-  if (slane == 0) y[row] = (fmt == 4) ? acc : acc * scale[o];
+  // fmt==4 (per-group) and fmt==7 (per-block) already folded their scale into acc
+  // above -- do not scale again.
+  if (slane == 0) y[row] = (fmt == 4 || fmt == 7) ? acc : acc * scale[o];
 }
 
 // Batched bindless expert GEMV: each row gr belongs to expert erow[gr], whose weight and
@@ -447,11 +477,20 @@ static size_t fmt_bytes(int fmt, int I, int O) {
   if (fmt == 2) return (size_t)O * ((I+1)/2);
   if (fmt == 3) return (size_t)O * ((I+3)/4);
   if (fmt == 4) return (size_t)O * ((I+1)/2);   // grouped int4: identical packed-nibble layout to fmt=2
+  if (fmt == 7) return (size_t)O * I;           // fp8 e4m3: one raw byte/element, same as fmt=1
   return (size_t)O * I * sizeof(float);
 }
 // Grouped-int4 (fmt=4) scale-array size: one f32 per gsz-element group, per row -> O*ceil(I/gsz).
+// fp8 (fmt=7) scale-array size: one f32 per 128x128 BLOCK -> ceil(O/128)*ceil(I/128) (2D,
+// not per-row -- quant.h isn't included here, so the ceil-div is inlined rather than sharing
+// colibri.c's qt_scale_bytes/quant.h's fp8_nblk). The block is a fixed 128x128, so gs is
+// ignored for fmt==7. f32 is this build's implemented scale
+// ENCODING for fmt=7 (see quant.h/colibri.c) -- this file has no reason to know that a
+// UE8M0 encoding exists at all: qt_resolve_fmt refuses it on the CPU read path before any
+// tensor in that encoding could ever reach this Metal-side sizing helper.
 static size_t fmt_scale_bytes(int fmt, int I, int O, int gs) {
   if (fmt == 4) return (size_t)O * ((I + gs - 1) / gs) * sizeof(float);
+  if (fmt == 7) return (size_t)((O + 127) / 128) * (size_t)((I + 127) / 128) * sizeof(float);
   return (size_t)O * sizeof(float);
 }
 
@@ -619,7 +658,9 @@ extern "C" int  coli_metal_mem_info(size_t *used, size_t *total) {
 extern "C" int coli_metal_matmul(ColiMetalTensor **tp, float *y, const float *x,
                                  const void *weights, const float *scales,
                                  int fmt, int S, int I, int O, int gs) {
-  if (!g_dev || fmt < 0 || fmt > 4) return 0;
+  /* fmt==7 (fp8 passthrough) is an explicit allow-list entry, not folded into the 0..4
+   * contiguous range check below: it is not adjacent to it. */
+  if (!g_dev || fmt < 0 || (fmt > 4 && fmt != 7)) return 0;
   @autoreleasepool {
     ColiMetalTensor *t = *tp;
     if (!t) {

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -2932,6 +2932,31 @@ done:
 }
 #endif
 
+/* POSITIVE allowlist for the two fused Metal decode gates below
+ * (attention_rows / layer_forward_rows): only the mm_gemv shader's explicit
+ * INTEGER-format branches (fmt 1/2/3/4) may enter the fused path -- the
+ * exact set that was BOTH admitted by the old negative guard AND computed
+ * correctly. Anything else falls back to the CPU path (correct, slower).
+ * INVARIANT this predicate names: a NEGATIVE guard (the previous
+ * `fmt!=8` form) is fail-OPEN for every format it doesn't name --
+ * bind_gemv (backend_metal.mm) has no fmt allowlist of its own, and the
+ * mm_gemv shader's dispatch chain ends in an unconditional f32 fallback
+ * branch, so a resident fmt=5 or fmt=6 tensor slipping through would have
+ * its REAL weight bytes (they live in q4, which is exactly what the WP_()
+ * macro hands the kernel) silently misread as f32 garbage, with no error.
+ * This form is fail-CLOSED: a future format is excluded until someone
+ * proves it on the fused path and adds it here. fmt=3 (int2) is included
+ * because it was legal-and-correct here before this change (explicit
+ * mm_gemv branch, real q4 bytes) -- excluding it would be this change's
+ * only regression. fmt=0 (f32) stays excluded: it never actually fused --
+ * WP_() hands the shader q4, which is NULL for fmt=0 (weights live in qf)
+ * -- so admitting it would be dead permissiveness, not a preserved
+ * behavior. fmt=5/6 (misread hazard), fmt=8 (NULL-q4 variant), and every
+ * future format remain excluded.
+ * Defined unconditionally (not #ifdef COLI_METAL) so the CPU test build
+ * can unit-test the truth table (tests/test_fp8_load.c Part F). */
+static inline int metal_fused_fmt_ok(int fmt){ return fmt==1 || fmt==2 || fmt==3 || fmt==4; }
+
 static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int pos_base,
                            KVState *const *kvs, const int *positions, float *out){
     Cfg *c=&m->c; int H=c->n_heads, D=c->hidden, qh=c->qk_head, vh=c->v_head;
@@ -2946,24 +2971,28 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
      * would rope every row at position 0 and attend over a 1-token window of the wrong
      * cache -> greedy decode hits EOS at token 2 (mux answers truncated to 1 token).
      * Ragged rows take the CPU absorb path below, which reads kvs[s]/positions[s].
-     * fmt!=8 guards (q_a/q_b/kv_a/o): STALE-COMMENT FIX -- this PR's own mm_gemv
-     * Metal shader (backend_metal.mm) DOES have a real fmt==8 branch (fp8-e4m3
-     * decode + per-128x128-block scale); the shader is not the gap. The actual
-     * blocker is the WP_() macro two lines below: it picks q8 only for fmt==1,
-     * else q4 -- and q4 is NULL/unallocated for fmt=8 (same convention as fmt=1,
-     * see the QT struct comment), so an fmt=8 tensor reaching
-     * coli_metal_attn_decode would hand the kernel a NULL weight pointer, not a
-     * misread-as-f32 shader. Fail closed to the CPU path below instead
-     * (matmul_qt_ex there dispatches fmt=8 correctly via matmul_fp8); fixing
-     * WP_() and actually wiring fmt=8 through bind_gemv/coli_metal_attn_decode is
-     * a deferred follow-up (see this PR's GPU-path note), not done in this
-     * round. kv_b is already pinned to fmt==2 above for an unrelated reason (its
-     * absorb kernel is int4-only); these four checks are the same discipline
-     * extended to the tensors that flow through the shared per-fmt shader. */
+     * metal_fused_fmt_ok(q_a/q_b/kv_a/o): POSITIVE allowlist (fmt 1/2/4, see the
+     * predicate's own comment above attention_rows). Previously these were
+     * negative fmt!=8 guards -- fail-OPEN for everything they didn't name: for
+     * fmt=8 specifically the WP_() macro two lines below picks q8 only for
+     * fmt==1, else q4 -- and q4 is NULL/unallocated for fmt=8 (same convention
+     * as fmt=1, see the QT struct comment), so an fmt=8 tensor reaching
+     * coli_metal_attn_decode would hand the kernel a NULL weight pointer; for
+     * fmt=5/6 the hazard is WORSE -- their real weight bytes live in q4, so
+     * WP_() hands the shader a valid pointer and mm_gemv's terminal f32
+     * fallback branch silently misreads them as f32 garbage. The allowlist
+     * fails CLOSED to the CPU path below for all of them (matmul_qt_ex there
+     * dispatches every format correctly, incl. fmt=8 via matmul_fp8); wiring
+     * fmt=8 through bind_gemv/coli_metal_attn_decode stays a deferred
+     * follow-up (see this PR's GPU-path note). kv_b is already pinned to
+     * fmt==2 above for an unrelated reason (its absorb kernel is int4-only);
+     * these four checks are the same discipline extended to the tensors that
+     * flow through the shared per-fmt shader. */
     if(g_metal_enabled && !kvs && S<=4 && (g_absorb==1||(g_absorb<0&&S<=4)) && m->kv_start[layer]==0
        && D==6144 && H==64 && c->q_lora==2048 && c->kv_lora==512 && c->qk_nope==192
        && c->qk_rope==64 && vh==256 && l->kv_b.fmt==2
-       && l->q_a.fmt!=8 && l->q_b.fmt!=8 && l->kv_a.fmt!=8 && l->o.fmt!=8){
+       && metal_fused_fmt_ok(l->q_a.fmt) && metal_fused_fmt_ok(l->q_b.fmt)
+       && metal_fused_fmt_ok(l->kv_a.fmt) && metal_fused_fmt_ok(l->o.fmt)){
         int sel_active = m->has_dsa && layer<c->n_layers && c->idx_type[layer] && (pos_base+S) > c->index_topk;
         if(!sel_active){
             if(m->has_dsa && layer<c->n_layers && c->idx_type[layer]){   /* index keys for future selection */
@@ -5169,23 +5198,28 @@ static void layer_forward_rows(Model *m, Layer *l, int li, float *x, int S, int 
      * Fallback: qualsiasi condizione mancante -> percorso CPU intero qui sotto.
      * !kvs: ragged mux rows (per-row KV/position) are not expressible in this kernel's
      * single Lc/Rc + pos_base contract — see the matching guard in attention_rows.
-     * fmt!=8 guards (q_a/q_b/kv_a/o/sh_gate/sh_up/sh_down): same fail-closed discipline
-     * as attention_rows, extended to the shared-expert MLP this fused kernel also
-     * covers. STALE-COMMENT FIX -- the mm_gemv shader these bind_gemv calls dispatch
-     * through DOES have a real fmt==8 branch (this PR's own Metal kernel commit); the
-     * actual gap is the WP_() macro below, which picks q8 only for fmt==1 and q4
-     * (NULL/unallocated for fmt=8) otherwise, so none of these seven bind_gemv-routed
-     * tensors can safely carry fmt=8 through this fused path yet -- CPU below
-     * dispatches fmt=8 correctly via matmul_qt_ex/matmul_fp8. Fixing WP_() and wiring
-     * fmt=8 through bind_gemv is the same deferred follow-up noted in attention_rows,
-     * not done in this round. */
+     * metal_fused_fmt_ok(q_a/q_b/kv_a/o/sh_gate/sh_up/sh_down): POSITIVE allowlist
+     * (fmt 1/2/4), same fail-closed discipline as attention_rows, extended to the
+     * shared-expert MLP this fused kernel also covers. The mm_gemv shader these
+     * bind_gemv calls dispatch through has a real fmt==8 branch (this PR's own
+     * Metal kernel commit), but the WP_() macro below picks q8 only for fmt==1
+     * and q4 (NULL/unallocated for fmt=8) otherwise, so none of these seven
+     * bind_gemv-routed tensors can safely carry fmt=8 through this fused path
+     * yet -- and a fmt=5/6 tensor's REAL q4 bytes would be silently misread by
+     * the shader's terminal f32 fallback (see the predicate's comment). CPU
+     * below dispatches every format correctly, incl. fmt=8 via
+     * matmul_qt_ex/matmul_fp8. Fixing WP_() and wiring fmt=8 through bind_gemv
+     * is the same deferred follow-up noted in attention_rows, not done in this
+     * round. */
     if(g_metal_enabled && !kvs && S<=4 && li<c->n_layers && l->sparse
        && (g_absorb==1||(g_absorb<0&&S<=4)) && m->kv_start[li]==0
        && D==6144 && c->n_heads==64 && c->q_lora==2048 && c->kv_lora==512
        && c->qk_nope==192 && c->qk_rope==64 && c->v_head==256 && l->kv_b.fmt==2
        && c->n_experts==256 && c->topk==8 && c->n_shared==1 && c->moe_inter==2048
-       && l->q_a.fmt!=8 && l->q_b.fmt!=8 && l->kv_a.fmt!=8 && l->o.fmt!=8
-       && l->sh_gate.fmt!=8 && l->sh_up.fmt!=8 && l->sh_down.fmt!=8){
+       && metal_fused_fmt_ok(l->q_a.fmt) && metal_fused_fmt_ok(l->q_b.fmt)
+       && metal_fused_fmt_ok(l->kv_a.fmt) && metal_fused_fmt_ok(l->o.fmt)
+       && metal_fused_fmt_ok(l->sh_gate.fmt) && metal_fused_fmt_ok(l->sh_up.fmt)
+       && metal_fused_fmt_ok(l->sh_down.fmt)){
         int sel_active = m->has_dsa && c->idx_type[li] && (pos_base+S) > c->index_topk;
         if(!sel_active){
             static float *linrm,*lnrm,*lsh,*lw; static int *lidx,*lkeff;

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -103,7 +103,11 @@ typedef struct {
  *   fmt=1 INT8  -> q8 (1 byte/param) + scala per riga
  *   fmt=2 INT4  -> q4 (2 valori per byte, impacchettati) + scala per riga
  * INT4 e' cio' che fa stare la densa residente nei 15 GB (0.5 byte/param). */
-/* fmt: 0 F32, 1 INT8, 2 INT4 (2/byte), 3 INT2 (4/byte), 4 INT4-GROUPED, 5 INT3-G64.
+/* fmt: 0 F32, 1 INT8, 2 INT4 (2/byte), 3 INT2 (4/byte), 4 INT4-GROUPED, 5 INT3-G64,
+ * 6 E8/IQ3 lattice, 7 FP8-E4M3 (native, passthrough -- see quant.h). fmt=7 is a
+ * PUBLIC ordinal, assigned by the maintainer on #524; it developed under the
+ * PRIVATE ORDINAL BLOCK convention below as fmt=100 and graduated out of that
+ * block into this list at the same time this comment was written.
  * q4 ospita int4/int2/int3 packed. fmt=4 (grouped int4, #242): per-row nibbles + one f32
  * scale per group of `gs` inputs (s has O*ceil(I/gs) entries).
  * fmt=6 (E8/IQ3 lattice, #452): 98B per 256 weights = 3.0625 bits/weight, grid
@@ -112,7 +116,53 @@ typedef struct {
  * fmt=5 (int3, per-GROUP scales, group=64, see quant.h I3_*): values in [-4,3] stored per
  * 64-input group as 24 bytes = 16B low plane (2 bits/val, int2 layout) + 8B high plane
  * (1 bit/val), plus ONE f32 scale PER GROUP (s has O*ceil(I/64) entries, not O). 3.5
- * bits/weight effective — the quality/size sweet spot measured in the #132 ablation. */
+ * bits/weight effective — the quality/size sweet spot measured in the #132 ablation.
+ * fmt=7 (native FP8-e4m3 passthrough, resident/quality-core tier -- see quant.h's
+ * FP8_BLOCK/e4m3_decode/matmul_fp8): q8 holds O*I raw e4m3 bytes, ONE byte per weight,
+ * byte-identical layout to fmt=1's weight bytes (q4 is unused/NULL, same as fmt=1) --
+ * disambiguated from fmt=1 (and, at small [O,I], from fmt=6 -- see below) purely by
+ * scale geometry, see qt_resolve_fmt's "THE DESIGN LANDMINE" comment further down.
+ * s holds ONE f32 scale PER 128x128 BLOCK, ceil(O/128)*ceil(I/128) entries total
+ * (row-major: block-row-major then block-col), NOT O and NOT O*ceil(I/gs) --
+ * qt_bytes()/qt_scale_bytes() below are the authoritative byte-count formulas. The
+ * scale ENCODING is itself a declared PROPERTY of this format, not a hardcoded
+ * constant -- f32 (4 bytes/block, what's above) is the value THIS build
+ * implements; qt_resolve_fmt's "SCALE ENCODING IS A DECLARED PROPERTY" comment
+ * documents why (a DeepSeek-V4 checkpoint ships this identical weight geometry
+ * with a UE8M0 scale encoding instead) and how an unimplemented encoding is
+ * recognized and refused by name rather than silently misread.
+ * gs is unused (0) for fmt=7, same as fmt 1/2/3. */
+/* ---- PRIVATE ORDINAL BLOCK CONVENTION ------------------------------------
+ * fmt values 0-7 are upstream-assigned, public, stable ordinals -- do not
+ * reuse or renumber them (fmt=7 is the newest member: assigned by the
+ * maintainer on #524, after developing under this block as fmt=100 -- see
+ * "graduated" above). fmt values 100+ remain this repo's PRIVATE/EXPERIMENTAL
+ * block for any OTHER in-flight format proposal: ordinals a branch mints for
+ * itself during development so it can't collide with a number upstream claims
+ * out from under it -- exactly what happened to fmt=7's OWN earlier private
+ * number, fmt=6, when #465's E8/IQ3 proposal claimed that ordinal upstream
+ * while this branch was still developing against it, forcing a re-mint to
+ * fmt=100 (see upstream_contribution/FORMATS_registry_draft.md for the
+ * incident that prompted the rule).
+ *
+ * A PRIVATE-BLOCK ordinal is an internal enum value only -- qt_resolve_fmt
+ * (below) infers format purely from byte arithmetic; the container on disk
+ * carries no format ordinal at all. (A self-describing container stamp that
+ * would persist a format's NAME, not its ordinal, is a follow-up proposal --
+ * see qt_resolve_fmt's own note on where that plumbing would attach -- not
+ * present in this build.) Nothing outside this binary's own compiled code
+ * ever observes a 100+ number, so renumbering one later (e.g. when a format
+ * is upstreamed and assigned a real public ordinal at merge, as just happened
+ * for fmt=7) is a pure find-and-replace with zero on-disk or cross-version
+ * compatibility impact.
+ *
+ * Rule for adding a new format to this branch or a future one: claim the next
+ * unused 100+ integer, never a number already claimed upstream (check dev
+ * before picking one -- this is exactly the mistake that forced fmt=7's own
+ * proposal to renumber away from fmt=6) or by another in-flight private
+ * format. Never ship a 100+ ordinal as a public default/committed-upstream
+ * value -- the real ordinal is assigned by the maintainer at merge time,
+ * exactly as fmt=7's was. */
 typedef struct {
     int fmt; float *qf; int8_t *q8; uint8_t *q4; float *s; int O, I, gs;  /* gs=group size (0=per-row, 128=grouped) */
 #ifdef COLI_CUDA
@@ -137,7 +187,51 @@ static int64_t qt_bytes(const QT *t){    /* byte residenti del tensore */
         return (int64_t)t->O*ng*24 + (int64_t)t->O*ng*4; }
     if(t->fmt==6)  /* E8/IQ3: 98B per 256 weights, scales in-block, .qs is a 4-byte tag */
         return (int64_t)t->O*(((int64_t)t->I+255)/256)*98 + 4;
+    if(t->fmt==7){ /* fp8-e4m3 passthrough: O*I raw e4m3 bytes (n, byte-identical layout
+                    * to fmt=1's weight bytes) + one f32 scale per 128x128 block
+                    * (FP8_BLOCK in quant.h, included below qt_bytes -- keep the
+                    * arithmetic literal here, same discipline as fmt=5's comment
+                    * above). Missing this branch would fall through to the fmt=2
+                    * default below (packed-nibble formula, ~half the real weight
+                    * bytes) and undercount a resident fp8 tensor's byte footprint --
+                    * feeds AUTOPIN/RAM-budget math, so this branch is load-bearing
+                    * from day one, not a later fix (contrast fmt=6 above, upstream's
+                    * own #452 review round 1 caught this exact bug shape for E8). */
+        int64_t nblkO=((int64_t)t->O+127)/128, nblkI=((int64_t)t->I+127)/128;
+        return n + nblkO*nblkI*4; }
     return (int64_t)t->O*((t->I+1)/2) + (int64_t)t->O*4;  /* fmt=2 int4 per-row */
+}
+/* scale-array byte count only, format-aware -- split out of qt_bytes() because
+ * qt_wire_mmap/qt_unwire_mmap mlock the weight and scale ranges as TWO SEPARATE
+ * regions (separate allocations, not one contiguous buffer: qt_from_disk always
+ * qalloc's t->q8/t->q4 and t->s independently) and need the scale byte count on
+ * its own to split qt_bytes(t) into a weight half and a scale half. The two call
+ * sites used to hardcode scale_b=O*4 -- i.e. assume PER-ROW scale for every
+ * format -- which is right for fmt 0/1/2/3 but wrong for fmt=4 (grouped,
+ * O*ceil(I/gs) scales), fmt=5 (int3-g64, O*ceil(I/64) scales), and fmt=7
+ * (per-128x128-block, ceil(O/128)*ceil(I/128) scales): any tensor in one of
+ * those three formats reaching qt_wire_mmap/qt_unwire_mmap would mlock/munlock
+ * the wrong byte ranges on BOTH halves (weight_b = qt_bytes(t)-scale_b shifts
+ * too). fmt=6 (E8) is deliberately NOT covered here: its .qs is a fixed 4-byte
+ * tag with no wire-mmap-relevant weight/scale split of its own (matches
+ * qt_bytes' `+4` literal above), and t->fmt==6 tensors never reach
+ * qt_wire_mmap/qt_unwire_mmap's mlock path in this build (int3-g64/E8 stay
+ * CPU-side, see qt_cuda_upload -- MMAP wiring is a CUDA/Metal-adjacent memory
+ * concern this build doesn't extend to them). fixed generically since the same
+ * bug shape applies to fmt=4/5, not just the format that surfaced it -- fmt=4
+ * is the routed-expert "int4-g64" format (qt_resolve_fmt assigns it to ESlot
+ * g/u/d the same as any other tensor, see expert_load_impl), so this is not
+ * purely a dormant fmt=7-only fix: any COLI_MMAP + mem_should_wire() session
+ * pinning fmt=4 experts was already mlocking the wrong ranges before this
+ * branch existed. UNVERIFIED at runtime (no model run performed -- static/
+ * arithmetic fix only, see the report). */
+static int64_t qt_scale_bytes(const QT *t){
+    if(t->fmt==4){ int ng=(t->I+t->gs-1)/t->gs; return (int64_t)t->O*ng*4; }
+    if(t->fmt==5){ int64_t ng=((int64_t)t->I+63)/64; return (int64_t)t->O*ng*4; }
+    if(t->fmt==7){ int64_t nblkO=((int64_t)t->O+127)/128, nblkI=((int64_t)t->I+127)/128; return nblkO*nblkI*4; }
+    return (int64_t)t->O*4;   /* fmt 0 (t->s NULL, guarded by callers)/1/2/3/6: per-row (or, for
+                              * fmt=6, the 4-byte tag -- callers of this function never see fmt=6,
+                              * see the comment above; the fallback is harmless dead code for it). */
 }
 
 typedef struct {
@@ -407,6 +501,14 @@ static int vk_matmul_pair_qt(QT *a, float *ya, QT *b, float *yb, const float *x,
 static int qt_cuda_upload(QT *t){
     if(t->fmt==5) return 0;   /* int3-g64: no CUDA kernel yet — tensor stays CPU-side */
     if(t->fmt==6 && !g_cuda_e8_ready) return 0;   /* E8 without its codebook would decode garbage */
+    if(t->fmt==7) return 0;   /* fp8-e4m3 passthrough: no CUDA kernel yet either (matches the
+                               * fmt=5/6 idiom above; matmul_qt_ex's own caller-side fmt exclusion
+                               * already keeps this from being reached with cuda_eligible tensors
+                               * in the exact-kernel path, but row_bytes()/weight_at() in
+                               * backend_cuda.cu have no fmt=7 case either -- explicit early-
+                               * return here so a future caller doesn't have to rediscover that by
+                               * tracing through to the CUDA source. UNVERIFIED at runtime: no CUDA
+                               * toolchain on this macOS build host to compile-check. */
     const void *weights = t->fmt==0 ? (const void*)t->qf
                         : t->fmt==1 ? (const void*)t->q8 : (const void*)t->q4;
     if(t->fmt==4)   /* grouped int4 (#334): scales are [O, ceil(I/gs)] — the plain
@@ -684,13 +786,26 @@ static void matmul_i4_grouped_pair(float *yg, float *yu, const float *x,
  * (~+12% perplexity), measured. Every other prefill matmul keeps IDOT as before. */
 static void matmul_qt_ex(float *y, const float *x, QT *w, int S, int allow_idot){
 #ifdef COLI_METAL
+    /* fmt=7 (fp8 passthrough) deliberately absent from this allowlist, same as fmt=5/6:
+     * the S>=g_metal_gemm_min batched prefill GEMM path (coli_metal_gemm) only knows
+     * fmt 1/2/4 in this build, so it fails CLOSED to the CPU branch below (matmul_fp8)
+     * rather than being silently misread. coli_metal_gemm() also carries its own
+     * internal fmt!=1&&fmt!=2&&fmt!=4 guard, so this is belt-and-braces. */
     if(g_metal_enabled && S>=g_metal_gemm_min && !spec_pinned() && (w->fmt==1||w->fmt==2||w->fmt==4) && !omp_in_parallel()){
         const void *wp = w->fmt==1 ? (const void*)w->q8 : (const void*)w->q4;
         if(coli_metal_gemm(y,x,wp,w->s,w->fmt,S,w->I,w->O,w->gs)) return;
     }
 #endif
 #ifdef COLI_CUDA
-    if(g_cuda_enabled && w->cuda_eligible && !w->cuda_failed && w->fmt!=5 && !omp_in_parallel()){
+    /* fmt=7 excluded exactly like fmt=5/6: the CUDA backend's row_bytes()/weight_at()
+     * (backend_cuda.cu) have no case for it and fall through to `return 0` / undefined
+     * weight_at() behavior. row_bytes()==0 already makes coli_cuda_tensor_upload_g
+     * refuse (defensive fail-closed), but that path is reached only after paying an
+     * upload attempt and printing a "disabled after an error" message every load;
+     * excluding it here up front is the same fmt=5/6 idiom, silent and immediate.
+     * UNVERIFIED on this build (no CUDA toolchain on macOS to compile-check; traced
+     * from backend_cuda.cu source only). */
+    if(g_cuda_enabled && w->cuda_eligible && !w->cuda_failed && w->fmt!=5 && w->fmt!=7 && !omp_in_parallel()){
         const void *weights = w->fmt==0 ? (const void*)w->qf
                             : w->fmt==1 ? (const void*)w->q8 : (const void*)w->q4;
         if(coli_cuda_matmul(&w->cuda,y,x,weights,w->s,w->fmt,S,w->I,w->O,w->cuda_device,w->gs)) return;
@@ -716,6 +831,7 @@ static void matmul_qt_ex(float *y, const float *x, QT *w, int S, int allow_idot)
     if(w->fmt==1) matmul_q(y,x,w->q8,w->s,S,w->I,w->O);
     else if(w->fmt==3) matmul_i2(y,x,w->q4,w->s,S,w->I,w->O);
     else if(w->fmt==5) matmul_i3(y,x,w->q4,w->s,S,w->I,w->O);
+    else if(w->fmt==7) matmul_fp8(y,x,(const uint8_t*)w->q8,w->s,S,w->I,w->O);
     else matmul_i4(y,x,w->q4,w->s,S,w->I,w->O);
 }
 
@@ -1138,26 +1254,135 @@ static int detect_group_size(int O, int I, int64_t ns){
  * diventava un int2 valido e il matmul leggeva oltre il buffer (O*I nibble a
  * 4/byte). Qui i byte del peso devono corrispondere a un layout noto e i byte
  * della scala alla cardinalita' attesa (O per-row, O*ng per-gruppo) — altrimenti
- * si termina invece di sforare. Ritorna fmt (1/2/3/4/5) e scrive *gs. */
+ * si termina invece di sforare. Ritorna fmt (1/2/3/4/5/6/7) e scrive *gs.
+ * No container-level format stamp is consulted here: a self-describing
+ * __metadata__ stamp that could resolve a genuine byte-collision below
+ * (instead of refusing it unconditionally) is a follow-up proposal, not
+ * present in this build -- every ambiguous shape this function can see
+ * refuses, full stop. */
 static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns, int *gs){
     int64_t exp_i8=(int64_t)O*I, exp_i4=(int64_t)O*((I+1)/2), exp_i2=(int64_t)O*((I+3)/4);
     int64_t exp_i3=(int64_t)O*i3_rowbytes(I);   /* int3-g64 (fmt=5): 24B per 64-input group */
     /* fmt=6 (E8/IQ3, #452): scales live inside the 98B super-blocks, so the .qs
      * convention is kept with a single-float tag — ns==4 is the discriminator
-     * (every other format carries at least O floats of real scales). */
-    if(ns==4 && nb==(int64_t)O*e8_rowbytes(I)){ *gs=0; return 6; }
+     * (every other format carries at least O floats of real scales).
+     *
+     * SECOND DESIGN LANDMINE: e8_rowbytes(I) = ceil(I/256)*98 is the constant 98
+     * for every I in (0,256], so this check's nb==O*e8_rowbytes(I) collapses to
+     * nb==O*98 -- which is ALSO fp8-e4m3-b128's raw-byte weight count (O*I) at
+     * the ONE value of I where I itself equals 98 (solving 98k==I for I in
+     * ((k-1)*256,k*256] only admits k=1, I=98). At that same I=98 a handful of
+     * fp8 scale-array shapes ALSO carry exactly ns==4 bytes, same as this
+     * check's own tag, and each is a genuine collision candidate this block
+     * must catch before the unconditional `return 6` below:
+     *   - a SINGLE-BLOCK fp8 tensor (O<=128, fp8_nblk(O)*fp8_nblk(I)==1) with
+     *     f32 block scales: ns==1*4==4.
+     *   - a FOUR-BLOCK fp8 tensor (fp8_nblk(O)*fp8_nblk(I)==4, e.g. O in
+     *     (384,512] at this I) with UE8M0 (1 byte/block) scales: ns==4*1==4 --
+     *     the SAME arithmetic collision the fmt=1-vs-fmt=7 landmine below has
+     *     with UE8M0, just against fmt=6's tag instead of fmt=1's per-row
+     *     count; see that landmine's own comment for the general shape.
+     *   - at O==1 specifically, fmt=1's own per-row tag (O*4) is also 4.
+     * Refuse unconditionally when any of these coincide with the E8/IQ3 tag --
+     * this build has no stamp to break the tie (see the function's own header
+     * comment) -- rather than let dev's own unconditional `return 6` silently
+     * misread an fp8-e4m3-b128 (or, at O==1, plain int8) tensor as E8/IQ3-
+     * lattice-decoded garbage with no error. No real GLM tensor has these
+     * shapes; the discipline exists for untrusted containers. */
+    if(ns==4 && nb==(int64_t)O*e8_rowbytes(I)){
+        int fp8_blk_f32_also   = (nb==(int64_t)O*I) && (fp8_nblk(O)*fp8_nblk(I)==1);
+        int fp8_blk_ue8m0_also = (nb==(int64_t)O*I) && (fp8_nblk(O)*fp8_nblk(I)==4);
+        int i8_row_also        = (nb==(int64_t)O*I) && (O==1);   /* ns==O*4==4 iff O==1 */
+        if(fp8_blk_f32_also || fp8_blk_ue8m0_also || i8_row_also){
+            fprintf(stderr,"%s: [%d,%d] byte layout (nb=%lld ns=%lld) matches E8/IQ3 "
+                "(fmt=6, 4-byte tag)%s%s%s; refusing rather than guessing (untrusted "
+                "container, fmt=6 collision at I=98)\n",
+                name,O,I,(long long)nb,(long long)ns,
+                fp8_blk_f32_also   ? " AND per-128x128-block FP8 f32 scales (fmt=7, single block)" : "",
+                fp8_blk_ue8m0_also ? " AND per-128x128-block FP8 ue8m0 scales (fmt=7, 4 blocks, recognized-not-implemented)" : "",
+                i8_row_also        ? " AND plain int8 per-row (fmt=1, O=1)" : "");
+            exit(1);
+        }
+        *gs=0; return 6;
+    }
     /* Row formats take precedence: for tiny I the int3-g64 byte count can coincide with
      * a row layout (e.g. [O,48]: ceil(48/2)=24=1*24). For real tensor shapes the counts
      * are distinct, and the weight bytes — not the scale size — are the int3 tag, because
      * int3-g64 and grouped-int4-at-gs=64 carry the SAME scale cardinality O*ceil(I/64). */
     int fmt = (nb==exp_i8)?1 : (nb==exp_i4)?2 : (nb==exp_i2)?3 : (nb==exp_i3)?5 : 0;
     if(!fmt){
-        fprintf(stderr,"%s: quantized weight is %lld bytes — no int8/int4/int2/int3-g64 layout for [%d,%d], refusing (untrusted container)\n",
+        fprintf(stderr,"%s: quantized weight is %lld bytes — no int8/int4/int2/int3-g64/fp8 layout for [%d,%d], refusing (untrusted container)\n",
                 name,(long long)nb,O,I); exit(1); }
     *gs=0;
     if(fmt==2){ int g=detect_group_size(O,I,ns); if(g>0){ fmt=4; *gs=g; } }
+    /* fmt=1 vs fmt=7 (native FP8-e4m3 passthrough): THE DESIGN LANDMINE. Weight
+     * bytes are IDENTICAL (O*I raw bytes, both matched exp_i8 above) -- fmt=1
+     * and fmt=7 can only be told apart by the SCALE array's geometry: fmt=1 is
+     * per-row (ns==O*4 bytes); fmt=7 is per-128x128-BLOCK, ns==ceil(O/128)*
+     * ceil(I/128)*4 bytes for THIS build's implemented f32 scale encoding. For
+     * most real shapes these two byte counts are distinct and the match is
+     * unambiguous. But for small O (<=128) and/or small I, ceil(O/128)*
+     * ceil(I/128) can equal O exactly (e.g. O=1,I<=128 -> 1*1=1=O; O=2,I in
+     * [129,256] -> 1*2=2=O; O=256,I in (16256,16384] -> 2*128=256=O) -- a
+     * tensor whose scale array satisfies BOTH conventions at once. Guessing
+     * either way risks silently reading a genuine per-row-int8 tensor as
+     * block-scaled FP8 (or vice versa), which would corrupt every weight
+     * without any error. Refuse instead (same "untrusted container"
+     * discipline as the rest of this function).
+     *
+     * SCALE ENCODING IS A DECLARED PROPERTY, not a hardcoded constant: f32 (4
+     * bytes/block, above) is what THIS build implements, but it is not the
+     * only encoding real fp8-e4m3-b128 weight geometry ships with. DeepSeek-V4
+     * ships the SAME weight layout (FP8 E4M3, 128x128 blocks) with UE8M0
+     * scales instead -- one byte per block, a power-of-two exponent, dtype
+     * F8_E8M0 (maintainer finding, colibri #524) -- so a fp8-e4m3-b128
+     * container's scale sidecar can legitimately be ceil(O/128)*ceil(I/128)*1
+     * bytes, not *4. That byte count is a REAL, distinct signature (never
+     * equal to the f32 block-scale count above for any O,I>=1, since one is
+     * exactly 4x the other and 4n==n only at n==0) -- recognized here rather
+     * than silently misread as a truncated or corrupt f32 scale array. This
+     * build does not implement UE8M0 decode: recognizing the signature and
+     * refusing BY NAME (rather than falling through to the generic
+     * "wrong byte count" refusal below, or worse, matching it against the
+     * wrong candidate) is the whole point -- a future decoder lands into this
+     * seam rather than a near-duplicate format. Checked for collision against
+     * every OTHER format's ns arithmetic reachable from this nb==O*I branch
+     * (fmt=1 and fmt=7-f32, both above): the byte counts are realistically
+     * distinct (nblkO*nblkI is orders of magnitude smaller than O*4 for any
+     * real GLM-sized matrix), but NOT categorically distinct -- the same
+     * small-O regime that makes the fmt=1-vs-fmt=7-f32 collision above
+     * possible also makes a fmt=1-vs-fmt=7-ue8m0 collision possible (e.g.
+     * O=1, I in (384,512]: nblkO=1, nblkI=4, ue8m0 ns=4=O*4=fmt=1's own
+     * per-row count) -- handled below by refusing whenever the ue8m0
+     * signature matches, noting the row collision too when it also applies.
+     * No real GLM tensor has these shapes; see also the SECOND DESIGN
+     * LANDMINE above for the analogous ue8m0-vs-fmt=6 corner this same
+     * signature can hit. */
+    if(fmt==1){
+        int64_t nblkO=fp8_nblk(O), nblkI=fp8_nblk(I);
+        int64_t ns_row=(int64_t)O*4, ns_blk=nblkO*nblkI*4, ns_blk_ue8m0=nblkO*nblkI;
+        int is_row=(ns==ns_row), is_blk=(ns==ns_blk), is_blk_ue8m0=(ns==ns_blk_ue8m0);
+        if(is_row && is_blk){
+            fprintf(stderr,"%s: [%d,%d] scale array is %lld bytes — matches BOTH per-row "
+                "int8 (fmt=1) and per-128x128-block FP8 (fmt=7) scale geometry; refusing "
+                "rather than guessing (untrusted container, THE DESIGN LANDMINE)\n",
+                name,O,I,(long long)ns); exit(1);
+        }
+        if(is_blk_ue8m0){
+            fprintf(stderr,"%s: [%d,%d] fp8-e4m3-b128 with ue8m0 scales recognized but not "
+                "implemented; only f32 block scales are supported in this build (nb=%lld "
+                "bytes matches raw e4m3 weight bytes, ns=%lld bytes matches %lld blocks x "
+                "1 byte/block)%s\n",
+                name,O,I,(long long)nb,(long long)ns,(long long)(nblkO*nblkI),
+                is_row ? " -- scale array ALSO matches per-row int8 (fmt=1); refusing either way (untrusted container)" : "");
+            exit(1);
+        }
+        if(is_blk && !is_row) fmt=7;
+    }
     int64_t exp_scale = (fmt==4)? (int64_t)O*((I+*gs-1)/(*gs))
-                      : (fmt==5)? (int64_t)O*i3_groups(I) : (int64_t)O;   /* in FLOAT */
+                      : (fmt==5)? (int64_t)O*i3_groups(I)
+                      : (fmt==7)? fp8_nblk(O)*fp8_nblk(I)
+                      : (int64_t)O;   /* in FLOAT */
     if(ns != exp_scale*4){
         fprintf(stderr,"%s: scale array is %lld bytes — expected %lld for [%d,%d] fmt=%d, refusing (untrusted container)\n",
                 name,(long long)ns,(long long)(exp_scale*4),O,I,fmt); exit(1); }
@@ -1200,16 +1425,25 @@ static void qt_from_disk(Model *m, const char *name, int O, int I, int bits, int
         else if(fmt==6){   /* E8/IQ3: everything in-block, .qs is the 4-byte tag */
             if(t->fmt!=6||!t->q4){ t->fmt=6; t->O=O; t->I=I; t->gs=0; t->q4=qalloc(nb); t->s=qsalloc(1); }
             st_read_raw(&m->S,name,t->q4,drop); }
+        else if(fmt==7){ int64_t nblk=fp8_nblk(O)*fp8_nblk(I);   /* fp8-e4m3: raw bytes (q8, like fmt=1)
+            * + one f32 scale per 128x128 block. BOTH weights and scale via qalloc, not falloc,
+            * from day one -- the GPU-visibility lesson fmt=4 and fmt=5 each had to learn
+            * separately (see review round 1 audit history in the report). */
+            if(t->fmt!=7||!t->q8){ t->fmt=7; t->O=O; t->I=I; t->gs=0; t->q8=qalloc(nb); t->s=(float*)qalloc((size_t)nblk*sizeof(float)); }
+            st_read_raw(&m->S,name,t->q8,drop); }
         else      { if(t->fmt!=fmt||!t->q4){ t->fmt=fmt; t->O=O; t->I=I; t->gs=0; t->q4=qalloc(nb); t->s=qsalloc(O); } st_read_raw(&m->S,name,t->q4,drop); }
         /* cap MUST match the scale cardinality qt_resolve_fmt already validated and
          * the falloc above actually reserved, per format: grouped-int4 (fmt=4) keeps
-         * O*ceil(I/gs) scales and int3-g64 (fmt=5) keeps O*i3_groups(I); everything
-         * else is per-row O. Using the per-row bound for a grouped format would
-         * reject a legitimate container (fmt=5 regressed exactly that way). */
+         * O*ceil(I/gs) scales, int3-g64 (fmt=5) keeps O*i3_groups(I), E8/IQ3 (fmt=6)
+         * keeps the 1-float tag, and fp8-e4m3 (fmt=7) keeps ceil(O/128)*ceil(I/128)
+         * block scales; everything else is per-row O. Using the per-row bound for a
+         * grouped/blocked format would reject a legitimate container (fmt=5 regressed
+         * exactly that way). */
         st_read_f32_cap(&m->S,sn,t->s,
                         fmt==4 ? (int64_t)O*((I+gs-1)/gs) :
                         fmt==5 ? (int64_t)O*i3_groups(I)  :
-                        fmt==6 ? (int64_t)1               : (int64_t)O, drop);
+                        fmt==6 ? (int64_t)1               :
+                        fmt==7 ? fp8_nblk(O)*fp8_nblk(I) : (int64_t)O, drop);
     } else {
         if(!t->qf && !t->q8 && !t->q4) qt_alloc(t,O,I,bits);
         if(t->fmt==0) st_read_f32_cap(&m->S,name,t->qf,(int64_t)O*I,drop);
@@ -2598,10 +2832,19 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
      * (step_decode_batch) passes per-row kvs[]/positions[] with pos_base=0, so the kernel
      * would rope every row at position 0 and attend over a 1-token window of the wrong
      * cache -> greedy decode hits EOS at token 2 (mux answers truncated to 1 token).
-     * Ragged rows take the CPU absorb path below, which reads kvs[s]/positions[s]. */
+     * Ragged rows take the CPU absorb path below, which reads kvs[s]/positions[s].
+     * fmt!=7 guards (q_a/q_b/kv_a/o): coli_metal_attn_decode's WP_() macro and the
+     * mm_gemv shader it dispatches through (bind_gemv) have no fmt=7 case in this
+     * build -- an fp8-passthrough tensor reaching here would be silently misread as
+     * f32 by the shader's default branch. Fail closed to the CPU path below instead
+     * (matmul_qt_ex there dispatches fmt=7 correctly via matmul_fp8). kv_b is already
+     * pinned to fmt==2 above for an unrelated reason (its absorb kernel is int4-only);
+     * these four checks are the same discipline extended to the tensors that flow
+     * through the generic per-fmt shader. */
     if(g_metal_enabled && !kvs && S<=4 && (g_absorb==1||(g_absorb<0&&S<=4)) && m->kv_start[layer]==0
        && D==6144 && H==64 && c->q_lora==2048 && c->kv_lora==512 && c->qk_nope==192
-       && c->qk_rope==64 && vh==256 && l->kv_b.fmt==2){
+       && c->qk_rope==64 && vh==256 && l->kv_b.fmt==2
+       && l->q_a.fmt!=7 && l->q_b.fmt!=7 && l->kv_a.fmt!=7 && l->o.fmt!=7){
         int sel_active = m->has_dsa && layer<c->n_layers && c->idx_type[layer] && (pos_base+S) > c->index_topk;
         if(!sel_active){
             if(m->has_dsa && layer<c->n_layers && c->idx_type[layer]){   /* index keys for future selection */
@@ -4806,12 +5049,19 @@ static void layer_forward_rows(Model *m, Layer *l, int li, float *x, int S, int 
      * in un solo submit GPU; la CPU legge il routing e fa solo resolve/disk/expert-CB.
      * Fallback: qualsiasi condizione mancante -> percorso CPU intero qui sotto.
      * !kvs: ragged mux rows (per-row KV/position) are not expressible in this kernel's
-     * single Lc/Rc + pos_base contract — see the matching guard in attention_rows. */
+     * single Lc/Rc + pos_base contract — see the matching guard in attention_rows.
+     * fmt!=7 guards (q_a/q_b/kv_a/o/sh_gate/sh_up/sh_down): same fail-closed discipline
+     * as attention_rows, extended to the shared-expert MLP this fused kernel also
+     * covers -- none of these seven bind_gemv-routed tensors has fmt=7 support in this
+     * build's mm_gemv shader, so any of them carrying fmt=7 must skip the whole fused
+     * path (CPU below dispatches fmt=7 correctly via matmul_qt_ex/matmul_fp8). */
     if(g_metal_enabled && !kvs && S<=4 && li<c->n_layers && l->sparse
        && (g_absorb==1||(g_absorb<0&&S<=4)) && m->kv_start[li]==0
        && D==6144 && c->n_heads==64 && c->q_lora==2048 && c->kv_lora==512
        && c->qk_nope==192 && c->qk_rope==64 && c->v_head==256 && l->kv_b.fmt==2
-       && c->n_experts==256 && c->topk==8 && c->n_shared==1 && c->moe_inter==2048){
+       && c->n_experts==256 && c->topk==8 && c->n_shared==1 && c->moe_inter==2048
+       && l->q_a.fmt!=7 && l->q_b.fmt!=7 && l->kv_a.fmt!=7 && l->o.fmt!=7
+       && l->sh_gate.fmt!=7 && l->sh_up.fmt!=7 && l->sh_down.fmt!=7){
         int sel_active = m->has_dsa && c->idx_type[li] && (pos_base+S) > c->index_topk;
         if(!sel_active){
             static float *linrm,*lnrm,*lsh,*lw; static int *lidx,*lkeff;

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -2877,14 +2877,20 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
      * would rope every row at position 0 and attend over a 1-token window of the wrong
      * cache -> greedy decode hits EOS at token 2 (mux answers truncated to 1 token).
      * Ragged rows take the CPU absorb path below, which reads kvs[s]/positions[s].
-     * fmt!=7 guards (q_a/q_b/kv_a/o): coli_metal_attn_decode's WP_() macro and the
-     * mm_gemv shader it dispatches through (bind_gemv) have no fmt=7 case in this
-     * build -- an fp8-passthrough tensor reaching here would be silently misread as
-     * f32 by the shader's default branch. Fail closed to the CPU path below instead
-     * (matmul_qt_ex there dispatches fmt=7 correctly via matmul_fp8). kv_b is already
-     * pinned to fmt==2 above for an unrelated reason (its absorb kernel is int4-only);
-     * these four checks are the same discipline extended to the tensors that flow
-     * through the generic per-fmt shader. */
+     * fmt!=7 guards (q_a/q_b/kv_a/o): STALE-COMMENT FIX -- this PR's own mm_gemv
+     * Metal shader (backend_metal.mm) DOES have a real fmt==7 branch (fp8-e4m3
+     * decode + per-128x128-block scale); the shader is not the gap. The actual
+     * blocker is the WP_() macro two lines below: it picks q8 only for fmt==1,
+     * else q4 -- and q4 is NULL/unallocated for fmt=7 (same convention as fmt=1,
+     * see the QT struct comment), so an fmt=7 tensor reaching
+     * coli_metal_attn_decode would hand the kernel a NULL weight pointer, not a
+     * misread-as-f32 shader. Fail closed to the CPU path below instead
+     * (matmul_qt_ex there dispatches fmt=7 correctly via matmul_fp8); fixing
+     * WP_() and actually wiring fmt=7 through bind_gemv/coli_metal_attn_decode is
+     * a deferred follow-up (see this PR's GPU-path note), not done in this
+     * round. kv_b is already pinned to fmt==2 above for an unrelated reason (its
+     * absorb kernel is int4-only); these four checks are the same discipline
+     * extended to the tensors that flow through the shared per-fmt shader. */
     if(g_metal_enabled && !kvs && S<=4 && (g_absorb==1||(g_absorb<0&&S<=4)) && m->kv_start[layer]==0
        && D==6144 && H==64 && c->q_lora==2048 && c->kv_lora==512 && c->qk_nope==192
        && c->qk_rope==64 && vh==256 && l->kv_b.fmt==2
@@ -5096,9 +5102,14 @@ static void layer_forward_rows(Model *m, Layer *l, int li, float *x, int S, int 
      * single Lc/Rc + pos_base contract — see the matching guard in attention_rows.
      * fmt!=7 guards (q_a/q_b/kv_a/o/sh_gate/sh_up/sh_down): same fail-closed discipline
      * as attention_rows, extended to the shared-expert MLP this fused kernel also
-     * covers -- none of these seven bind_gemv-routed tensors has fmt=7 support in this
-     * build's mm_gemv shader, so any of them carrying fmt=7 must skip the whole fused
-     * path (CPU below dispatches fmt=7 correctly via matmul_qt_ex/matmul_fp8). */
+     * covers. STALE-COMMENT FIX -- the mm_gemv shader these bind_gemv calls dispatch
+     * through DOES have a real fmt==7 branch (this PR's own Metal kernel commit); the
+     * actual gap is the WP_() macro below, which picks q8 only for fmt==1 and q4
+     * (NULL/unallocated for fmt=7) otherwise, so none of these seven bind_gemv-routed
+     * tensors can safely carry fmt=7 through this fused path yet -- CPU below
+     * dispatches fmt=7 correctly via matmul_qt_ex/matmul_fp8. Fixing WP_() and wiring
+     * fmt=7 through bind_gemv is the same deferred follow-up noted in attention_rows,
+     * not done in this round. */
     if(g_metal_enabled && !kvs && S<=4 && li<c->n_layers && l->sparse
        && (g_absorb==1||(g_absorb<0&&S<=4)) && m->kv_start[li]==0
        && D==6144 && c->n_heads==64 && c->q_lora==2048 && c->kv_lora==512

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -205,9 +205,9 @@ static int64_t qt_bytes(const QT *t){    /* byte residenti del tensore */
  * qt_wire_mmap/qt_unwire_mmap mlock the weight and scale ranges as TWO SEPARATE
  * regions (separate allocations, not one contiguous buffer: qt_from_disk always
  * qalloc's t->q8/t->q4 and t->s independently) and need the scale byte count on
- * its own to split qt_bytes(t) into a weight half and a scale half. The two call
- * sites used to hardcode scale_b=O*4 -- i.e. assume PER-ROW scale for every
- * format -- which is right for fmt 0/1/2/3 but wrong for fmt=4 (grouped,
+ * its own to split qt_bytes(t) into a weight half and a scale half. Hardcoding
+ * scale_b=O*4 at those two call sites -- i.e. assuming PER-ROW scale for every
+ * format -- is right for fmt 0/1/2/3 but wrong for fmt=4 (grouped,
  * O*ceil(I/gs) scales), fmt=5 (int3-g64, O*ceil(I/64) scales), and fmt=7
  * (per-128x128-block, ceil(O/128)*ceil(I/128) scales): any tensor in one of
  * those three formats reaching qt_wire_mmap/qt_unwire_mmap would mlock/munlock
@@ -217,14 +217,21 @@ static int64_t qt_bytes(const QT *t){    /* byte residenti del tensore */
  * qt_bytes' `+4` literal above), and t->fmt==6 tensors never reach
  * qt_wire_mmap/qt_unwire_mmap's mlock path in this build (int3-g64/E8 stay
  * CPU-side, see qt_cuda_upload -- MMAP wiring is a CUDA/Metal-adjacent memory
- * concern this build doesn't extend to them). fixed generically since the same
- * bug shape applies to fmt=4/5, not just the format that surfaced it -- fmt=4
- * is the routed-expert "int4-g64" format (qt_resolve_fmt assigns it to ESlot
- * g/u/d the same as any other tensor, see expert_load_impl), so this is not
- * purely a dormant fmt=7-only fix: any COLI_MMAP + mem_should_wire() session
- * pinning fmt=4 experts was already mlocking the wrong ranges before this
- * branch existed. UNVERIFIED at runtime (no model run performed -- static/
- * arithmetic fix only, see the report). */
+ * concern this build doesn't extend to them). This is not purely a dormant
+ * fmt=7-only fix: fmt=4 is the routed-expert "int4-g64" format (qt_resolve_fmt
+ * assigns it to ESlot g/u/d the same as any other tensor, see
+ * expert_load_impl), so any COLI_MMAP + mem_should_wire() session pinning
+ * fmt=4 experts mlocks the wrong ranges without this. UNVERIFIED at runtime
+ * (no model run performed -- static/arithmetic fix only, see the report).
+ *
+ * REVIEW FINDING (maintainer, #528): this function existed correctly (the
+ * fmt=7 branch below is right) but neither qt_wire_mmap nor qt_unwire_mmap
+ * actually called it -- both independently hardcoded scale_b=(int64_t)t->O*4
+ * inline, so the "fix" this comment describes was never applied at either
+ * call site, and the resulting -Wunused-function warning on this then-dead
+ * function was suppressed by -Wno-unused-function in CFLAGS rather than
+ * caught. qt_wire_split() below is now the ONE place both call sites get
+ * weight_b/scale_b from -- see it and its call sites for the actual fix. */
 static int64_t qt_scale_bytes(const QT *t){
     if(t->fmt==4){ int ng=(t->I+t->gs-1)/t->gs; return (int64_t)t->O*ng*4; }
     if(t->fmt==5){ int64_t ng=((int64_t)t->I+63)/64; return (int64_t)t->O*ng*4; }
@@ -232,6 +239,16 @@ static int64_t qt_scale_bytes(const QT *t){
     return (int64_t)t->O*4;   /* fmt 0 (t->s NULL, guarded by callers)/1/2/3/6: per-row (or, for
                               * fmt=6, the 4-byte tag -- callers of this function never see fmt=6,
                               * see the comment above; the fallback is harmless dead code for it). */
+}
+/* qt_wire_mmap/qt_unwire_mmap's shared weight/scale byte-range split -- the ONE
+ * place that computes it, so the two sites can never independently drift back
+ * to a hardcoded per-row-only formula (that drift -- qt_scale_bytes() existing
+ * but unused at both sites -- was the maintainer's #528 finding, see the
+ * comment above qt_scale_bytes()). Directly unit-tested (test_fp8_load.c) so a
+ * regression here, not just at a call site, fails the suite. */
+static void qt_wire_split(const QT *t, int64_t *weight_b, int64_t *scale_b){
+    *scale_b = qt_scale_bytes(t);
+    *weight_b = qt_bytes(t) - *scale_b;
 }
 
 typedef struct {
@@ -7268,8 +7285,7 @@ static int mem_wire(void *addr, size_t len){
 static void qt_unwire_mmap(QT *t){
     if(!g_mmap || !mem_should_wire()) return;
     if(!t->q8 && !t->q4) return;
-    int64_t scale_b=(int64_t)t->O*4;
-    int64_t weight_b=qt_bytes(t)-scale_b;
+    int64_t weight_b, scale_b; qt_wire_split(t,&weight_b,&scale_b);
     void *wp=t->q8?(void*)t->q8:(void*)t->q4;
 #if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
     if(weight_b>0 && !munlock(wp,(size_t)weight_b)) g_mmap_wired-=weight_b;
@@ -7282,8 +7298,7 @@ static void qt_unwire_mmap(QT *t){
 static void qt_wire_mmap(QT *t, int64_t *wired, long *failed){
     if(!t->q8 && !t->q4) return;
     if(t->cuda_eligible) return;   /* resident in VRAM; host range is dead weight */
-    int64_t scale_b=(int64_t)t->O*4;
-    int64_t weight_b=qt_bytes(t)-scale_b;
+    int64_t weight_b, scale_b; qt_wire_split(t,&weight_b,&scale_b);
     void *wp=t->q8?(void*)t->q8:(void*)t->q4;
     if(weight_b>0){ if(mem_wire(wp,(size_t)weight_b)==0) *wired+=weight_b; else (*failed)++; }
     if(t->s && scale_b>0){ if(mem_wire(t->s,(size_t)scale_b)==0) *wired+=scale_b; else (*failed)++; }

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -2643,6 +2643,33 @@ static void qt_addrow(const QT *t, int row, float coef, float *acc){
             for(int k=0;k<n;k++){ unsigned u=((lo[k>>2]>>((k&3)*2))&3)|(((hi[k>>3]>>(k&7))&1)<<2);
                 acc[base+k]+=cg*(float)((int)u-4); } }
         return; }
+    /* GUARD (fix round 2, engine defect -- clean-room conformance trial found a real
+     * SIGSEGV, reproduced): fmt 0/4/5 already returned above; everything below this
+     * point assumes a PER-ROW scale (t->s[row]) followed by fmt=1 (int8, explicit
+     * branch), fmt=2 (int4 packed, explicit branch), or the tail's own IMPLICIT fmt=3
+     * (int2 packed, the final unconditional block) -- there was no guard stopping any
+     * OTHER fmt from reaching here. fmt=6 (E8/IQ3): t->s is a FIXED 4-byte tag (ONE
+     * float total, qsalloc(1) in qt_from_disk), not O floats -- t->s[row] for row>0 is
+     * a heap OVERREAD, and the untouched fall-through then misreads t->q4's real E8
+     * lattice bytes as int2-packed data (same bug SHAPE as #298's CUDA absorb-kernel
+     * fix, and the same one this file's own fmt=4/5 branches above were added to
+     * dodge -- fmt=6 was simply missed). fmt=7 (fp8-e4m3-b128): t->s holds
+     * ceil(O/128)*ceil(I/128) per-block floats, not O -- t->s[row] overreads for
+     * row>=nblk (e.g. a [130,130] tensor has nblk=4, so every row past 3 already reads
+     * out of bounds), AND t->q4 is NULL for fmt=7 (raw bytes live in t->q8 instead,
+     * same convention as fmt=1 -- see the QT struct comment), so the fall-through's
+     * `t->q4+(int64_t)row*((I+3)/4)` dereferences NULL-plus-offset: SIGSEGV,
+     * reproduced (see the report's proof-of-bite transcript). Refuse loudly instead --
+     * this function has no byte-count context of its own to validate against (it only
+     * ever sees an already-resolved QT), so "unsupported fmt" is the only check
+     * available, same "refuse rather than misread" discipline qt_resolve_fmt applies
+     * at load time. */
+    if(t->fmt!=1 && t->fmt!=2 && t->fmt!=3){
+        fprintf(stderr,"qt_addrow: unsupported fmt=%d for the per-row-scale absorb path "
+            "(only fmt 1/2/3 reach this point; fmt 0/4/5 are handled above and return "
+            "before it) -- refusing rather than misread t->s[row]/t->q4\n", t->fmt);
+        exit(1);
+    }
     float c=coef*t->s[row];
     if(t->fmt==1){ const int8_t *w=t->q8+(int64_t)row*I; for(int i=0;i<I;i++) acc[i]+=c*(float)w[i]; return; }
     if(t->fmt==2){ const uint8_t *w=t->q4+(int64_t)row*((I+1)/2);
@@ -2689,8 +2716,21 @@ static void qt_matvec_rows(const QT *t, int r0, int n, const float *x, float *y)
                 for(int k=0;k<n;k++){ unsigned u=((lo[k>>2]>>((k&3)*2))&3)|(((hi[k>>3]>>(k&7))&1)<<2);
                     acc+=(float)((int)u-4)*x[base+k]; }
                 a+=(double)(acc*sr[g]); } }
-        else { const uint8_t *w=t->q4+(int64_t)row*((I+3)/4); float s=t->s[row]; float acc=0;
+        /* fmt=3 (int2 packed, per-row scale) is the only fmt this final arm legitimately
+         * handles -- fmt 0/4/5 matched above, fmt 1/2 have their own explicit branches
+         * above too. Same GUARD and same reasoning as qt_addrow's (fix round 2, engine
+         * defect): fmt=6's t->s is a fixed 4-byte tag (t->s[row] overreads for row>0),
+         * fmt=7's t->s holds per-128x128-block floats (t->s[row] overreads for
+         * row>=nblk) and t->q4 is NULL for fmt=7 -- both would have silently misread or
+         * crashed here exactly like qt_addrow did before its own fix; refuse instead. */
+        else if(t->fmt==3){ const uint8_t *w=t->q4+(int64_t)row*((I+3)/4); float s=t->s[row]; float acc=0;
             for(int i=0;i<I;i++){ uint8_t b=w[i>>2]; acc+=((int)((b>>((i&3)*2))&3)-2)*x[i]; } a=acc*s; }
+        else {
+            fprintf(stderr,"qt_matvec_rows: unsupported fmt=%d for the per-row-scale absorb "
+                "path (only fmt 0/1/2/3/4/5 are handled) -- refusing rather than misread "
+                "t->s[row]/t->q4\n", t->fmt);
+            exit(1);
+        }
         y[j]=(float)a;
     }
 }

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -208,21 +208,17 @@ static int64_t qt_bytes(const QT *t){    /* byte residenti del tensore */
  * its own to split qt_bytes(t) into a weight half and a scale half. Hardcoding
  * scale_b=O*4 at those two call sites -- i.e. assuming PER-ROW scale for every
  * format -- is right for fmt 0/1/2/3 but wrong for fmt=4 (grouped,
- * O*ceil(I/gs) scales), fmt=5 (int3-g64, O*ceil(I/64) scales), and fmt=7
- * (per-128x128-block, ceil(O/128)*ceil(I/128) scales): any tensor in one of
- * those three formats reaching qt_wire_mmap/qt_unwire_mmap would mlock/munlock
- * the wrong byte ranges on BOTH halves (weight_b = qt_bytes(t)-scale_b shifts
- * too). fmt=6 (E8) is deliberately NOT covered here: its .qs is a fixed 4-byte
- * tag with no wire-mmap-relevant weight/scale split of its own (matches
- * qt_bytes' `+4` literal above), and t->fmt==6 tensors never reach
- * qt_wire_mmap/qt_unwire_mmap's mlock path in this build (int3-g64/E8 stay
- * CPU-side, see qt_cuda_upload -- MMAP wiring is a CUDA/Metal-adjacent memory
- * concern this build doesn't extend to them). This is not purely a dormant
- * fmt=7-only fix: fmt=4 is the routed-expert "int4-g64" format (qt_resolve_fmt
- * assigns it to ESlot g/u/d the same as any other tensor, see
- * expert_load_impl), so any COLI_MMAP + mem_should_wire() session pinning
- * fmt=4 experts mlocks the wrong ranges without this. UNVERIFIED at runtime
- * (no model run performed -- static/arithmetic fix only, see the report).
+ * O*ceil(I/gs) scales), fmt=5 (int3-g64, O*ceil(I/64) scales), fmt=6 (E8/IQ3,
+ * a FIXED 4-byte tag, see below), and fmt=7 (per-128x128-block,
+ * ceil(O/128)*ceil(I/128) scales): any tensor in one of those four formats
+ * reaching qt_wire_mmap/qt_unwire_mmap would mlock/munlock the wrong byte
+ * ranges on BOTH halves (weight_b = qt_bytes(t)-scale_b shifts too). This is
+ * not purely a dormant fmt=7-only fix: fmt=4 is the routed-expert
+ * "int4-g64" format (qt_resolve_fmt assigns it to ESlot g/u/d the same as
+ * any other tensor, see expert_load_impl), so any COLI_MMAP +
+ * mem_should_wire() session pinning fmt=4 experts mlocks the wrong ranges
+ * without this. UNVERIFIED at runtime (no model run performed -- static/
+ * arithmetic fix only, see the report).
  *
  * REVIEW FINDING (maintainer, #528): this function existed correctly (the
  * fmt=7 branch below is right) but neither qt_wire_mmap nor qt_unwire_mmap
@@ -231,14 +227,40 @@ static int64_t qt_bytes(const QT *t){    /* byte residenti del tensore */
  * call site, and the resulting -Wunused-function warning on this then-dead
  * function was suppressed by -Wno-unused-function in CFLAGS rather than
  * caught. qt_wire_split() below is now the ONE place both call sites get
- * weight_b/scale_b from -- see it and its call sites for the actual fix. */
+ * weight_b/scale_b from -- see it and its call sites for the actual fix.
+ *
+ * FIX ROUND (audit finding, SHOULD-FIX): this comment used to ALSO claim
+ * fmt=6 (E8/IQ3) was "deliberately NOT covered" because "t->fmt==6 tensors
+ * never reach qt_wire_mmap/qt_unwire_mmap's mlock path in this build
+ * (int3-g64/E8 stay CPU-side, see qt_cuda_upload -- MMAP wiring is a
+ * CUDA/Metal-adjacent memory concern this build doesn't extend to them)" --
+ * that conflated two UNRELATED mechanisms: qt_cuda_upload decides GPU-VRAM
+ * upload eligibility (fmt=5/6 genuinely excluded there, no CUDA kernel for
+ * either -- see qt_cuda_upload's own `fmt==5||fmt==6` guard), while
+ * qt_wire_mmap/qt_unwire_mmap mlock HOST RAM pages under COLI_MMAP, an
+ * entirely CPU-side concern. Staying CPU-side (no CUDA kernel) is exactly
+ * what makes a tensor a CANDIDATE for RAM wiring, not exempt from it.
+ * expert_load_impl assigns fmt=6 to ESlot g/u/d exactly like fmt=4/5 (same
+ * qt_resolve_fmt call site, three lines above the fmt=4 comment), and
+ * pin_wire calls qt_wire_mmap/qt_unwire_mmap on every pinned ESlot's g/u/d
+ * unconditionally, with no format filter -- so a pinned E8/IQ3 expert under
+ * COLI_MMAP + mem_should_wire() DOES reach here. Before the fmt=6 branch
+ * below, the O*4 fallback would have returned a scale_b wildly larger than
+ * the tensor's real scale allocation (a FIXED 4 bytes, qsalloc(1) in
+ * qt_from_disk's fmt==6 branch -- confirmed against qt_bytes' own `+4`
+ * literal and qt_from_disk's st_read_f32_cap cardinality switch, both of
+ * which already treat fmt=6's scale as exactly 1 float, not O floats), then
+ * mlock/munlock'd that many bytes starting at t->s -- past the end of a
+ * 4-byte allocation. UNVERIFIED at runtime (same static/arithmetic-only
+ * caveat as the fmt=4/5/7 fix above -- no model run performed). */
 static int64_t qt_scale_bytes(const QT *t){
     if(t->fmt==4){ int ng=(t->I+t->gs-1)/t->gs; return (int64_t)t->O*ng*4; }
     if(t->fmt==5){ int64_t ng=((int64_t)t->I+63)/64; return (int64_t)t->O*ng*4; }
+    if(t->fmt==6) return 4;   /* E8/IQ3: FIXED 4-byte tag (qsalloc(1)), not O*4 -- see this
+                              * function's own header comment for why this is reachable and
+                              * load-bearing, not dead code. */
     if(t->fmt==7){ int64_t nblkO=((int64_t)t->O+127)/128, nblkI=((int64_t)t->I+127)/128; return nblkO*nblkI*4; }
-    return (int64_t)t->O*4;   /* fmt 0 (t->s NULL, guarded by callers)/1/2/3/6: per-row (or, for
-                              * fmt=6, the 4-byte tag -- callers of this function never see fmt=6,
-                              * see the comment above; the fallback is harmless dead code for it). */
+    return (int64_t)t->O*4;   /* fmt 0 (t->s NULL, guarded by callers)/1/2/3: per-row. */
 }
 /* qt_wire_mmap/qt_unwire_mmap's shared weight/scale byte-range split -- the ONE
  * place that computes it, so the two sites can never independently drift back

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -104,10 +104,13 @@ typedef struct {
  *   fmt=2 INT4  -> q4 (2 valori per byte, impacchettati) + scala per riga
  * INT4 e' cio' che fa stare la densa residente nei 15 GB (0.5 byte/param). */
 /* fmt: 0 F32, 1 INT8, 2 INT4 (2/byte), 3 INT2 (4/byte), 4 INT4-GROUPED, 5 INT3-G64,
- * 6 E8/IQ3 lattice, 7 FP8-E4M3 (native, passthrough -- see quant.h). fmt=7 is a
- * PUBLIC ordinal, assigned by the maintainer on #524; it developed under the
- * PRIVATE ORDINAL BLOCK convention below as fmt=100 and graduated out of that
- * block into this list at the same time this comment was written.
+ * 6 E8/IQ3 lattice, 8 FP8-E4M3 (native, passthrough -- see quant.h). fmt=7 is
+ * MXFP4 (Kimi K3 Vulkan tier, #676/#705, backend_vulkan.c) -- claimed upstream,
+ * never a QT format here, deliberately absent from this struct's dispatch.
+ * fmt=8 is a PUBLIC ordinal: it developed under the PRIVATE ORDINAL BLOCK
+ * convention below as fmt=100, graduated to fmt=7 when the maintainer assigned
+ * that ordinal on #524, and was renumbered to 8 after #705 merged claiming 7
+ * for MXFP4 while this PR was still open (see the convention comment below).
  * q4 ospita int4/int2/int3 packed. fmt=4 (grouped int4, #242): per-row nibbles + one f32
  * scale per group of `gs` inputs (s has O*ceil(I/gs) entries).
  * fmt=6 (E8/IQ3 lattice, #452): 98B per 256 weights = 3.0625 bits/weight, grid
@@ -117,7 +120,7 @@ typedef struct {
  * 64-input group as 24 bytes = 16B low plane (2 bits/val, int2 layout) + 8B high plane
  * (1 bit/val), plus ONE f32 scale PER GROUP (s has O*ceil(I/64) entries, not O). 3.5
  * bits/weight effective — the quality/size sweet spot measured in the #132 ablation.
- * fmt=7 (native FP8-e4m3 passthrough, resident/quality-core tier -- see quant.h's
+ * fmt=8 (native FP8-e4m3 passthrough, resident/quality-core tier -- see quant.h's
  * FP8_BLOCK/e4m3_decode/matmul_fp8): q8 holds O*I raw e4m3 bytes, ONE byte per weight,
  * byte-identical layout to fmt=1's weight bytes (q4 is unused/NULL, same as fmt=1) --
  * disambiguated from fmt=1 (and, at small [O,I], from fmt=6 -- see below) purely by
@@ -131,19 +134,23 @@ typedef struct {
  * documents why (a DeepSeek-V4 checkpoint ships this identical weight geometry
  * with a UE8M0 scale encoding instead) and how an unimplemented encoding is
  * recognized and refused by name rather than silently misread.
- * gs is unused (0) for fmt=7, same as fmt 1/2/3. */
+ * gs is unused (0) for fmt=8, same as fmt 1/2/3. */
 /* ---- PRIVATE ORDINAL BLOCK CONVENTION ------------------------------------
- * fmt values 0-7 are upstream-assigned, public, stable ordinals -- do not
- * reuse or renumber them (fmt=7 is the newest member: assigned by the
- * maintainer on #524, after developing under this block as fmt=100 -- see
- * "graduated" above). fmt values 100+ remain this repo's PRIVATE/EXPERIMENTAL
+ * fmt values 0-8 are upstream-assigned, public, stable ordinals -- do not
+ * reuse or renumber them (fmt=8 is the newest member -- see "renumbered"
+ * above). fmt values 100+ remain this repo's PRIVATE/EXPERIMENTAL
  * block for any OTHER in-flight format proposal: ordinals a branch mints for
  * itself during development so it can't collide with a number upstream claims
- * out from under it -- exactly what happened to fmt=7's OWN earlier private
- * number, fmt=6, when #465's E8/IQ3 proposal claimed that ordinal upstream
- * while this branch was still developing against it, forcing a re-mint to
- * fmt=100 (see upstream_contribution/FORMATS_registry_draft.md for the
- * incident that prompted the rule).
+ * out from under it. That collision has now bitten this SAME format twice:
+ * first when #465's E8/IQ3 proposal claimed its original private number,
+ * fmt=6, upstream while this branch was still developing against it (forcing
+ * the re-mint to fmt=100 -- see upstream_contribution/FORMATS_registry_draft.md
+ * for the incident that prompted the rule); and again when #705 merged MXFP4
+ * as fmt=7 while this PR sat open already holding the maintainer-assigned
+ * ordinal 7 from #524, forcing the 7 -> 8 renumber recorded here. Ordinals
+ * are only settled by MERGE into dev, not by assignment on an open PR --
+ * docs/FORMATS.md (PR 2 of this pair) is the registry meant to make the
+ * next claim visible before it lands.
  *
  * A PRIVATE-BLOCK ordinal is an internal enum value only -- qt_resolve_fmt
  * (below) infers format purely from byte arithmetic; the container on disk
@@ -152,17 +159,17 @@ typedef struct {
  * see qt_resolve_fmt's own note on where that plumbing would attach -- not
  * present in this build.) Nothing outside this binary's own compiled code
  * ever observes a 100+ number, so renumbering one later (e.g. when a format
- * is upstreamed and assigned a real public ordinal at merge, as just happened
- * for fmt=7) is a pure find-and-replace with zero on-disk or cross-version
+ * is upstreamed and assigned a real public ordinal, as has now happened twice
+ * for fmt=8) is a pure find-and-replace with zero on-disk or cross-version
  * compatibility impact.
  *
  * Rule for adding a new format to this branch or a future one: claim the next
- * unused 100+ integer, never a number already claimed upstream (check dev
- * before picking one -- this is exactly the mistake that forced fmt=7's own
- * proposal to renumber away from fmt=6) or by another in-flight private
- * format. Never ship a 100+ ordinal as a public default/committed-upstream
- * value -- the real ordinal is assigned by the maintainer at merge time,
- * exactly as fmt=7's was. */
+ * unused 100+ integer, never a number already claimed upstream (check dev AND
+ * open PRs before picking one -- dev alone was not enough to prevent either of
+ * fmt=8's two renumbers) or by another in-flight private format. Never ship a
+ * 100+ ordinal as a public default/committed-upstream value -- the real
+ * ordinal is only settled when the format MERGES into dev, exactly as fmt=8's
+ * two renumbers demonstrate. */
 typedef struct {
     int fmt; float *qf; int8_t *q8; uint8_t *q4; float *s; int O, I, gs;  /* gs=group size (0=per-row, 128=grouped) */
 #ifdef COLI_CUDA
@@ -187,7 +194,7 @@ static int64_t qt_bytes(const QT *t){    /* byte residenti del tensore */
         return (int64_t)t->O*ng*24 + (int64_t)t->O*ng*4; }
     if(t->fmt==6)  /* E8/IQ3: 98B per 256 weights, scales in-block, .qs is a 4-byte tag */
         return (int64_t)t->O*(((int64_t)t->I+255)/256)*98 + 4;
-    if(t->fmt==7){ /* fp8-e4m3 passthrough: O*I raw e4m3 bytes (n, byte-identical layout
+    if(t->fmt==8){ /* fp8-e4m3 passthrough: O*I raw e4m3 bytes (n, byte-identical layout
                     * to fmt=1's weight bytes) + one f32 scale per 128x128 block
                     * (FP8_BLOCK in quant.h, included below qt_bytes -- keep the
                     * arithmetic literal here, same discipline as fmt=5's comment
@@ -209,11 +216,11 @@ static int64_t qt_bytes(const QT *t){    /* byte residenti del tensore */
  * scale_b=O*4 at those two call sites -- i.e. assuming PER-ROW scale for every
  * format -- is right for fmt 0/1/2/3 but wrong for fmt=4 (grouped,
  * O*ceil(I/gs) scales), fmt=5 (int3-g64, O*ceil(I/64) scales), fmt=6 (E8/IQ3,
- * a FIXED 4-byte tag, see below), and fmt=7 (per-128x128-block,
+ * a FIXED 4-byte tag, see below), and fmt=8 (per-128x128-block,
  * ceil(O/128)*ceil(I/128) scales): any tensor in one of those four formats
  * reaching qt_wire_mmap/qt_unwire_mmap would mlock/munlock the wrong byte
  * ranges on BOTH halves (weight_b = qt_bytes(t)-scale_b shifts too). This is
- * not purely a dormant fmt=7-only fix: fmt=4 is the routed-expert
+ * not purely a dormant fmt=8-only fix: fmt=4 is the routed-expert
  * "int4-g64" format (qt_resolve_fmt assigns it to ESlot g/u/d the same as
  * any other tensor, see expert_load_impl), so any COLI_MMAP +
  * mem_should_wire() session pinning fmt=4 experts mlocks the wrong ranges
@@ -221,7 +228,7 @@ static int64_t qt_bytes(const QT *t){    /* byte residenti del tensore */
  * arithmetic fix only, see the report).
  *
  * REVIEW FINDING (maintainer, #528): this function existed correctly (the
- * fmt=7 branch below is right) but neither qt_wire_mmap nor qt_unwire_mmap
+ * fmt=8 branch below is right) but neither qt_wire_mmap nor qt_unwire_mmap
  * actually called it -- both independently hardcoded scale_b=(int64_t)t->O*4
  * inline, so the "fix" this comment describes was never applied at either
  * call site, and the resulting -Wunused-function warning on this then-dead
@@ -252,14 +259,14 @@ static int64_t qt_bytes(const QT *t){    /* byte residenti del tensore */
  * which already treat fmt=6's scale as exactly 1 float, not O floats), then
  * mlock/munlock'd that many bytes starting at t->s -- past the end of a
  * 4-byte allocation. UNVERIFIED at runtime (same static/arithmetic-only
- * caveat as the fmt=4/5/7 fix above -- no model run performed). */
+ * caveat as the fmt=4/5/8 fix above -- no model run performed). */
 static int64_t qt_scale_bytes(const QT *t){
     if(t->fmt==4){ int ng=(t->I+t->gs-1)/t->gs; return (int64_t)t->O*ng*4; }
     if(t->fmt==5){ int64_t ng=((int64_t)t->I+63)/64; return (int64_t)t->O*ng*4; }
     if(t->fmt==6) return 4;   /* E8/IQ3: FIXED 4-byte tag (qsalloc(1)), not O*4 -- see this
                               * function's own header comment for why this is reachable and
                               * load-bearing, not dead code. */
-    if(t->fmt==7){ int64_t nblkO=((int64_t)t->O+127)/128, nblkI=((int64_t)t->I+127)/128; return nblkO*nblkI*4; }
+    if(t->fmt==8){ int64_t nblkO=((int64_t)t->O+127)/128, nblkI=((int64_t)t->I+127)/128; return nblkO*nblkI*4; }
     return (int64_t)t->O*4;   /* fmt 0 (t->s NULL, guarded by callers)/1/2/3: per-row. */
 }
 /* qt_wire_mmap/qt_unwire_mmap's shared weight/scale byte-range split -- the ONE
@@ -540,11 +547,11 @@ static int vk_matmul_pair_qt(QT *a, float *ya, QT *b, float *yb, const float *x,
 static int qt_cuda_upload(QT *t){
     if(t->fmt==5) return 0;   /* int3-g64: no CUDA kernel yet — tensor stays CPU-side */
     if(t->fmt==6 && !g_cuda_e8_ready) return 0;   /* E8 without its codebook would decode garbage */
-    if(t->fmt==7) return 0;   /* fp8-e4m3 passthrough: no CUDA kernel yet either (matches the
+    if(t->fmt==8) return 0;   /* fp8-e4m3 passthrough: no CUDA kernel yet either (matches the
                                * fmt=5/6 idiom above; matmul_qt_ex's own caller-side fmt exclusion
                                * already keeps this from being reached with cuda_eligible tensors
                                * in the exact-kernel path, but row_bytes()/weight_at() in
-                               * backend_cuda.cu have no fmt=7 case either -- explicit early-
+                               * backend_cuda.cu have no fmt=8 case either -- explicit early-
                                * return here so a future caller doesn't have to rediscover that by
                                * tracing through to the CUDA source. UNVERIFIED at runtime: no CUDA
                                * toolchain on this macOS build host to compile-check. */
@@ -825,7 +832,7 @@ static void matmul_i4_grouped_pair(float *yg, float *yu, const float *x,
  * (~+12% perplexity), measured. Every other prefill matmul keeps IDOT as before. */
 static void matmul_qt_ex(float *y, const float *x, QT *w, int S, int allow_idot){
 #ifdef COLI_METAL
-    /* fmt=7 (fp8 passthrough) deliberately absent from this allowlist, same as fmt=5/6:
+    /* fmt=8 (fp8 passthrough) deliberately absent from this allowlist, same as fmt=5/6:
      * the S>=g_metal_gemm_min batched prefill GEMM path (coli_metal_gemm) only knows
      * fmt 1/2/4 in this build, so it fails CLOSED to the CPU branch below (matmul_fp8)
      * rather than being silently misread. coli_metal_gemm() also carries its own
@@ -836,7 +843,7 @@ static void matmul_qt_ex(float *y, const float *x, QT *w, int S, int allow_idot)
     }
 #endif
 #ifdef COLI_CUDA
-    /* fmt=7 excluded exactly like fmt=5/6: the CUDA backend's row_bytes()/weight_at()
+    /* fmt=8 excluded exactly like fmt=5/6: the CUDA backend's row_bytes()/weight_at()
      * (backend_cuda.cu) have no case for it and fall through to `return 0` / undefined
      * weight_at() behavior. row_bytes()==0 already makes coli_cuda_tensor_upload_g
      * refuse (defensive fail-closed), but that path is reached only after paying an
@@ -844,7 +851,7 @@ static void matmul_qt_ex(float *y, const float *x, QT *w, int S, int allow_idot)
      * excluding it here up front is the same fmt=5/6 idiom, silent and immediate.
      * UNVERIFIED on this build (no CUDA toolchain on macOS to compile-check; traced
      * from backend_cuda.cu source only). */
-    if(g_cuda_enabled && w->cuda_eligible && !w->cuda_failed && w->fmt!=5 && w->fmt!=7 && !omp_in_parallel()){
+    if(g_cuda_enabled && w->cuda_eligible && !w->cuda_failed && w->fmt!=5 && w->fmt!=8 && !omp_in_parallel()){
         const void *weights = w->fmt==0 ? (const void*)w->qf
                             : w->fmt==1 ? (const void*)w->q8 : (const void*)w->q4;
         if(coli_cuda_matmul(&w->cuda,y,x,weights,w->s,w->fmt,S,w->I,w->O,w->cuda_device,w->gs)) return;
@@ -870,7 +877,7 @@ static void matmul_qt_ex(float *y, const float *x, QT *w, int S, int allow_idot)
     if(w->fmt==1) matmul_q(y,x,w->q8,w->s,S,w->I,w->O);
     else if(w->fmt==3) matmul_i2(y,x,w->q4,w->s,S,w->I,w->O);
     else if(w->fmt==5) matmul_i3(y,x,w->q4,w->s,S,w->I,w->O);
-    else if(w->fmt==7) matmul_fp8(y,x,(const uint8_t*)w->q8,w->s,S,w->I,w->O);
+    else if(w->fmt==8) matmul_fp8(y,x,(const uint8_t*)w->q8,w->s,S,w->I,w->O);
     else matmul_i4(y,x,w->q4,w->s,S,w->I,w->O);
 }
 
@@ -1293,7 +1300,7 @@ static int detect_group_size(int O, int I, int64_t ns){
  * diventava un int2 valido e il matmul leggeva oltre il buffer (O*I nibble a
  * 4/byte). Qui i byte del peso devono corrispondere a un layout noto e i byte
  * della scala alla cardinalita' attesa (O per-row, O*ng per-gruppo) — altrimenti
- * si termina invece di sforare. Ritorna fmt (1/2/3/4/5/6/7) e scrive *gs.
+ * si termina invece di sforare. Ritorna fmt (1/2/3/4/5/6/8) e scrive *gs.
  * No container-level format stamp is consulted here: a self-describing
  * __metadata__ stamp that could resolve a genuine byte-collision below
  * (instead of refusing it unconditionally) is a follow-up proposal, not
@@ -1318,7 +1325,7 @@ static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns
      *     f32 block scales: ns==1*4==4.
      *   - a FOUR-BLOCK fp8 tensor (fp8_nblk(O)*fp8_nblk(I)==4, e.g. O in
      *     (384,512] at this I) with UE8M0 (1 byte/block) scales: ns==4*1==4 --
-     *     the SAME arithmetic collision the fmt=1-vs-fmt=7 landmine below has
+     *     the SAME arithmetic collision the fmt=1-vs-fmt=8 landmine below has
      *     with UE8M0, just against fmt=6's tag instead of fmt=1's per-row
      *     count; see that landmine's own comment for the general shape.
      *   - at O==1 specifically, fmt=1's own per-row tag (O*4) is also 4.
@@ -1337,8 +1344,8 @@ static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns
                 "(fmt=6, 4-byte tag)%s%s%s; refusing rather than guessing (untrusted "
                 "container, fmt=6 collision at I=98)\n",
                 name,O,I,(long long)nb,(long long)ns,
-                fp8_blk_f32_also   ? " AND per-128x128-block FP8 f32 scales (fmt=7, single block)" : "",
-                fp8_blk_ue8m0_also ? " AND per-128x128-block FP8 ue8m0 scales (fmt=7, 4 blocks, recognized-not-implemented)" : "",
+                fp8_blk_f32_also   ? " AND per-128x128-block FP8 f32 scales (fmt=8, single block)" : "",
+                fp8_blk_ue8m0_also ? " AND per-128x128-block FP8 ue8m0 scales (fmt=8, 4 blocks, recognized-not-implemented)" : "",
                 i8_row_also        ? " AND plain int8 per-row (fmt=1, O=1)" : "");
             exit(1);
         }
@@ -1354,10 +1361,10 @@ static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns
                 name,(long long)nb,O,I); exit(1); }
     *gs=0;
     if(fmt==2){ int g=detect_group_size(O,I,ns); if(g>0){ fmt=4; *gs=g; } }
-    /* fmt=1 vs fmt=7 (native FP8-e4m3 passthrough): THE DESIGN LANDMINE. Weight
+    /* fmt=1 vs fmt=8 (native FP8-e4m3 passthrough): THE DESIGN LANDMINE. Weight
      * bytes are IDENTICAL (O*I raw bytes, both matched exp_i8 above) -- fmt=1
-     * and fmt=7 can only be told apart by the SCALE array's geometry: fmt=1 is
-     * per-row (ns==O*4 bytes); fmt=7 is per-128x128-BLOCK, ns==ceil(O/128)*
+     * and fmt=8 can only be told apart by the SCALE array's geometry: fmt=1 is
+     * per-row (ns==O*4 bytes); fmt=8 is per-128x128-BLOCK, ns==ceil(O/128)*
      * ceil(I/128)*4 bytes for THIS build's implemented f32 scale encoding. For
      * most real shapes these two byte counts are distinct and the match is
      * unambiguous. But for small O (<=128) and/or small I, ceil(O/128)*
@@ -1381,12 +1388,12 @@ static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns
      * INVERSION: an ambiguous shape resolves to fmt=1 -- the incumbent,
      * already-on-disk, decodable format -- instead of refusing. This is sound
      * because the WRITER side (tools/repack_fp8_passthrough.py's
-     * _check_geometry) now refuses to EMIT an fmt=7 container at any shape
-     * satisfying this same collision predicate: no genuine fmt=7 tensor this
+     * _check_geometry) now refuses to EMIT an fmt=8 container at any shape
+     * satisfying this same collision predicate: no genuine fmt=8 tensor this
      * engine's own tooling can produce will ever reach this branch, so
-     * resolving to fmt=1 here is not a guess against a live fmt=7 candidate --
+     * resolving to fmt=1 here is not a guess against a live fmt=8 candidate --
      * it is the only remaining candidate for an UNSTAMPED container. A
-     * self-describing __metadata__ stamp that lets a THIRD-PARTY fmt=7
+     * self-describing __metadata__ stamp that lets a THIRD-PARTY fmt=8
      * container resolve at this same colliding shape is a separate mechanism
      * (see qt_verify_fmt_stamp / the stamped build of this function) -- this
      * (unstamped) function has no stamp to consult and always commits to the
@@ -1409,11 +1416,11 @@ static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns
      * wrong candidate) is the whole point -- a future decoder lands into this
      * seam rather than a near-duplicate format. Checked for collision against
      * every OTHER format's ns arithmetic reachable from this nb==O*I branch
-     * (fmt=1 and fmt=7-f32, both above): the byte counts are realistically
+     * (fmt=1 and fmt=8-f32, both above): the byte counts are realistically
      * distinct (nblkO*nblkI is orders of magnitude smaller than O*4 for any
      * real GLM-sized matrix), but NOT categorically distinct -- the same
-     * small-O regime that makes the fmt=1-vs-fmt=7-f32 collision above
-     * possible also makes a fmt=1-vs-fmt=7-ue8m0 collision possible (e.g.
+     * small-O regime that makes the fmt=1-vs-fmt=8-f32 collision above
+     * possible also makes a fmt=1-vs-fmt=8-ue8m0 collision possible (e.g.
      * O=1, I in (384,512]: nblkO=1, nblkI=4, ue8m0 ns=4=O*4=fmt=1's own
      * per-row count) -- handled below by refusing whenever the ue8m0
      * signature matches, noting the row collision too when it also applies.
@@ -1443,11 +1450,11 @@ static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns
                 is_row ? " -- scale array ALSO matches per-row int8 (fmt=1); refusing either way (untrusted container)" : "");
             exit(1);
         }
-        if(is_blk && !is_row) fmt=7;
+        if(is_blk && !is_row) fmt=8;
     }
     int64_t exp_scale = (fmt==4)? (int64_t)O*((I+*gs-1)/(*gs))
                       : (fmt==5)? (int64_t)O*i3_groups(I)
-                      : (fmt==7)? fp8_nblk(O)*fp8_nblk(I)
+                      : (fmt==8)? fp8_nblk(O)*fp8_nblk(I)
                       : (int64_t)O;   /* in FLOAT */
     if(ns != exp_scale*4){
         fprintf(stderr,"%s: scale array is %lld bytes — expected %lld for [%d,%d] fmt=%d, refusing (untrusted container)\n",
@@ -1491,17 +1498,17 @@ static void qt_from_disk(Model *m, const char *name, int O, int I, int bits, int
         else if(fmt==6){   /* E8/IQ3: everything in-block, .qs is the 4-byte tag */
             if(t->fmt!=6||!t->q4){ t->fmt=6; t->O=O; t->I=I; t->gs=0; t->q4=qalloc(nb); t->s=qsalloc(1); }
             st_read_raw(&m->S,name,t->q4,drop); }
-        else if(fmt==7){ int64_t nblk=fp8_nblk(O)*fp8_nblk(I);   /* fp8-e4m3: raw bytes (q8, like fmt=1)
+        else if(fmt==8){ int64_t nblk=fp8_nblk(O)*fp8_nblk(I);   /* fp8-e4m3: raw bytes (q8, like fmt=1)
             * + one f32 scale per 128x128 block. BOTH weights and scale via qalloc, not falloc,
             * from day one -- the GPU-visibility lesson fmt=4 and fmt=5 each had to learn
             * separately (see review round 1 audit history in the report). */
-            if(t->fmt!=7||!t->q8){ t->fmt=7; t->O=O; t->I=I; t->gs=0; t->q8=qalloc(nb); t->s=(float*)qalloc((size_t)nblk*sizeof(float)); }
+            if(t->fmt!=8||!t->q8){ t->fmt=8; t->O=O; t->I=I; t->gs=0; t->q8=qalloc(nb); t->s=(float*)qalloc((size_t)nblk*sizeof(float)); }
             st_read_raw(&m->S,name,t->q8,drop); }
         else      { if(t->fmt!=fmt||!t->q4){ t->fmt=fmt; t->O=O; t->I=I; t->gs=0; t->q4=qalloc(nb); t->s=qsalloc(O); } st_read_raw(&m->S,name,t->q4,drop); }
         /* cap MUST match the scale cardinality qt_resolve_fmt already validated and
          * the falloc above actually reserved, per format: grouped-int4 (fmt=4) keeps
          * O*ceil(I/gs) scales, int3-g64 (fmt=5) keeps O*i3_groups(I), E8/IQ3 (fmt=6)
-         * keeps the 1-float tag, and fp8-e4m3 (fmt=7) keeps ceil(O/128)*ceil(I/128)
+         * keeps the 1-float tag, and fp8-e4m3 (fmt=8) keeps ceil(O/128)*ceil(I/128)
          * block scales; everything else is per-row O. Using the per-row bound for a
          * grouped/blocked format would reject a legitimate container (fmt=5 regressed
          * exactly that way). */
@@ -1509,7 +1516,7 @@ static void qt_from_disk(Model *m, const char *name, int O, int I, int bits, int
                         fmt==4 ? (int64_t)O*((I+gs-1)/gs) :
                         fmt==5 ? (int64_t)O*i3_groups(I)  :
                         fmt==6 ? (int64_t)1               :
-                        fmt==7 ? fp8_nblk(O)*fp8_nblk(I) : (int64_t)O, drop);
+                        fmt==8 ? fp8_nblk(O)*fp8_nblk(I) : (int64_t)O, drop);
     } else {
         if(!t->qf && !t->q8 && !t->q4) qt_alloc(t,O,I,bits);
         if(t->fmt==0) st_read_f32_cap(&m->S,name,t->qf,(int64_t)O*I,drop);
@@ -2653,10 +2660,10 @@ static void qt_addrow(const QT *t, int row, float coef, float *acc){
      * a heap OVERREAD, and the untouched fall-through then misreads t->q4's real E8
      * lattice bytes as int2-packed data (same bug SHAPE as #298's CUDA absorb-kernel
      * fix, and the same one this file's own fmt=4/5 branches above were added to
-     * dodge -- fmt=6 was simply missed). fmt=7 (fp8-e4m3-b128): t->s holds
+     * dodge -- fmt=6 was simply missed). fmt=8 (fp8-e4m3-b128): t->s holds
      * ceil(O/128)*ceil(I/128) per-block floats, not O -- t->s[row] overreads for
      * row>=nblk (e.g. a [130,130] tensor has nblk=4, so every row past 3 already reads
-     * out of bounds), AND t->q4 is NULL for fmt=7 (raw bytes live in t->q8 instead,
+     * out of bounds), AND t->q4 is NULL for fmt=8 (raw bytes live in t->q8 instead,
      * same convention as fmt=1 -- see the QT struct comment), so the fall-through's
      * `t->q4+(int64_t)row*((I+3)/4)` dereferences NULL-plus-offset: SIGSEGV,
      * reproduced (see the report's proof-of-bite transcript). Refuse loudly instead --
@@ -2720,8 +2727,8 @@ static void qt_matvec_rows(const QT *t, int r0, int n, const float *x, float *y)
          * handles -- fmt 0/4/5 matched above, fmt 1/2 have their own explicit branches
          * above too. Same GUARD and same reasoning as qt_addrow's (fix round 2, engine
          * defect): fmt=6's t->s is a fixed 4-byte tag (t->s[row] overreads for row>0),
-         * fmt=7's t->s holds per-128x128-block floats (t->s[row] overreads for
-         * row>=nblk) and t->q4 is NULL for fmt=7 -- both would have silently misread or
+         * fmt=8's t->s holds per-128x128-block floats (t->s[row] overreads for
+         * row>=nblk) and t->q4 is NULL for fmt=8 -- both would have silently misread or
          * crashed here exactly like qt_addrow did before its own fix; refuse instead. */
         else if(t->fmt==3){ const uint8_t *w=t->q4+(int64_t)row*((I+3)/4); float s=t->s[row]; float acc=0;
             for(int i=0;i<I;i++){ uint8_t b=w[i>>2]; acc+=((int)((b>>((i&3)*2))&3)-2)*x[i]; } a=acc*s; }
@@ -2939,16 +2946,16 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
      * would rope every row at position 0 and attend over a 1-token window of the wrong
      * cache -> greedy decode hits EOS at token 2 (mux answers truncated to 1 token).
      * Ragged rows take the CPU absorb path below, which reads kvs[s]/positions[s].
-     * fmt!=7 guards (q_a/q_b/kv_a/o): STALE-COMMENT FIX -- this PR's own mm_gemv
-     * Metal shader (backend_metal.mm) DOES have a real fmt==7 branch (fp8-e4m3
+     * fmt!=8 guards (q_a/q_b/kv_a/o): STALE-COMMENT FIX -- this PR's own mm_gemv
+     * Metal shader (backend_metal.mm) DOES have a real fmt==8 branch (fp8-e4m3
      * decode + per-128x128-block scale); the shader is not the gap. The actual
      * blocker is the WP_() macro two lines below: it picks q8 only for fmt==1,
-     * else q4 -- and q4 is NULL/unallocated for fmt=7 (same convention as fmt=1,
-     * see the QT struct comment), so an fmt=7 tensor reaching
+     * else q4 -- and q4 is NULL/unallocated for fmt=8 (same convention as fmt=1,
+     * see the QT struct comment), so an fmt=8 tensor reaching
      * coli_metal_attn_decode would hand the kernel a NULL weight pointer, not a
      * misread-as-f32 shader. Fail closed to the CPU path below instead
-     * (matmul_qt_ex there dispatches fmt=7 correctly via matmul_fp8); fixing
-     * WP_() and actually wiring fmt=7 through bind_gemv/coli_metal_attn_decode is
+     * (matmul_qt_ex there dispatches fmt=8 correctly via matmul_fp8); fixing
+     * WP_() and actually wiring fmt=8 through bind_gemv/coli_metal_attn_decode is
      * a deferred follow-up (see this PR's GPU-path note), not done in this
      * round. kv_b is already pinned to fmt==2 above for an unrelated reason (its
      * absorb kernel is int4-only); these four checks are the same discipline
@@ -2956,7 +2963,7 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
     if(g_metal_enabled && !kvs && S<=4 && (g_absorb==1||(g_absorb<0&&S<=4)) && m->kv_start[layer]==0
        && D==6144 && H==64 && c->q_lora==2048 && c->kv_lora==512 && c->qk_nope==192
        && c->qk_rope==64 && vh==256 && l->kv_b.fmt==2
-       && l->q_a.fmt!=7 && l->q_b.fmt!=7 && l->kv_a.fmt!=7 && l->o.fmt!=7){
+       && l->q_a.fmt!=8 && l->q_b.fmt!=8 && l->kv_a.fmt!=8 && l->o.fmt!=8){
         int sel_active = m->has_dsa && layer<c->n_layers && c->idx_type[layer] && (pos_base+S) > c->index_topk;
         if(!sel_active){
             if(m->has_dsa && layer<c->n_layers && c->idx_type[layer]){   /* index keys for future selection */
@@ -5162,23 +5169,23 @@ static void layer_forward_rows(Model *m, Layer *l, int li, float *x, int S, int 
      * Fallback: qualsiasi condizione mancante -> percorso CPU intero qui sotto.
      * !kvs: ragged mux rows (per-row KV/position) are not expressible in this kernel's
      * single Lc/Rc + pos_base contract — see the matching guard in attention_rows.
-     * fmt!=7 guards (q_a/q_b/kv_a/o/sh_gate/sh_up/sh_down): same fail-closed discipline
+     * fmt!=8 guards (q_a/q_b/kv_a/o/sh_gate/sh_up/sh_down): same fail-closed discipline
      * as attention_rows, extended to the shared-expert MLP this fused kernel also
      * covers. STALE-COMMENT FIX -- the mm_gemv shader these bind_gemv calls dispatch
-     * through DOES have a real fmt==7 branch (this PR's own Metal kernel commit); the
+     * through DOES have a real fmt==8 branch (this PR's own Metal kernel commit); the
      * actual gap is the WP_() macro below, which picks q8 only for fmt==1 and q4
-     * (NULL/unallocated for fmt=7) otherwise, so none of these seven bind_gemv-routed
-     * tensors can safely carry fmt=7 through this fused path yet -- CPU below
-     * dispatches fmt=7 correctly via matmul_qt_ex/matmul_fp8. Fixing WP_() and wiring
-     * fmt=7 through bind_gemv is the same deferred follow-up noted in attention_rows,
+     * (NULL/unallocated for fmt=8) otherwise, so none of these seven bind_gemv-routed
+     * tensors can safely carry fmt=8 through this fused path yet -- CPU below
+     * dispatches fmt=8 correctly via matmul_qt_ex/matmul_fp8. Fixing WP_() and wiring
+     * fmt=8 through bind_gemv is the same deferred follow-up noted in attention_rows,
      * not done in this round. */
     if(g_metal_enabled && !kvs && S<=4 && li<c->n_layers && l->sparse
        && (g_absorb==1||(g_absorb<0&&S<=4)) && m->kv_start[li]==0
        && D==6144 && c->n_heads==64 && c->q_lora==2048 && c->kv_lora==512
        && c->qk_nope==192 && c->qk_rope==64 && c->v_head==256 && l->kv_b.fmt==2
        && c->n_experts==256 && c->topk==8 && c->n_shared==1 && c->moe_inter==2048
-       && l->q_a.fmt!=7 && l->q_b.fmt!=7 && l->kv_a.fmt!=7 && l->o.fmt!=7
-       && l->sh_gate.fmt!=7 && l->sh_up.fmt!=7 && l->sh_down.fmt!=7){
+       && l->q_a.fmt!=8 && l->q_b.fmt!=8 && l->kv_a.fmt!=8 && l->o.fmt!=8
+       && l->sh_gate.fmt!=8 && l->sh_up.fmt!=8 && l->sh_down.fmt!=8){
         int sel_active = m->has_dsa && c->idx_type[li] && (pos_base+S) > c->index_topk;
         if(!sel_active){
             static float *linrm,*lnrm,*lsh,*lw; static int *lidx,*lkeff;

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -1324,11 +1324,34 @@ static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns
      * unambiguous. But for small O (<=128) and/or small I, ceil(O/128)*
      * ceil(I/128) can equal O exactly (e.g. O=1,I<=128 -> 1*1=1=O; O=2,I in
      * [129,256] -> 1*2=2=O; O=256,I in (16256,16384] -> 2*128=256=O) -- a
-     * tensor whose scale array satisfies BOTH conventions at once. Guessing
-     * either way risks silently reading a genuine per-row-int8 tensor as
-     * block-scaled FP8 (or vice versa), which would corrupt every weight
-     * without any error. Refuse instead (same "untrusted container"
-     * discipline as the rest of this function).
+     * tensor whose scale array satisfies BOTH conventions at once.
+     *
+     * REVIEW FINDING (maintainer, #528): this collision is not a theoretical
+     * corner case. GLM-5.2's own self_attn.o_proj.weight loads as
+     * [D,H*v_head] = [6144,16384]: nblkO=ceil(6144/128)=48,
+     * nblkI=ceil(16384/128)=128, nblkO*nblkI=6144==O -- a real, pre-existing,
+     * VALID int8-row o_proj tensor hits this exact byte-count collision on
+     * every GLM-5.2 checkpoint this engine has ever loaded. The general
+     * family is any int8 tensor where O==ceil(O/128)*ceil(I/128) (see the
+     * CENSUS SCAN, tools/fp8_collision_census.py, for the complete
+     * enumerated set over this repo's own containers). An earlier revision
+     * of this function refused unconditionally here -- exit(1) at load time
+     * on an ordinary, already-shipping, valid model -- which is a strictly
+     * worse failure mode than the misread it was guarding against.
+     *
+     * INVERSION: an ambiguous shape resolves to fmt=1 -- the incumbent,
+     * already-on-disk, decodable format -- instead of refusing. This is sound
+     * because the WRITER side (tools/repack_fp8_passthrough.py's
+     * _check_geometry) now refuses to EMIT an fmt=7 container at any shape
+     * satisfying this same collision predicate: no genuine fmt=7 tensor this
+     * engine's own tooling can produce will ever reach this branch, so
+     * resolving to fmt=1 here is not a guess against a live fmt=7 candidate --
+     * it is the only remaining candidate for an UNSTAMPED container. A
+     * self-describing __metadata__ stamp that lets a THIRD-PARTY fmt=7
+     * container resolve at this same colliding shape is a separate mechanism
+     * (see qt_verify_fmt_stamp / the stamped build of this function) -- this
+     * (unstamped) function has no stamp to consult and always commits to the
+     * incumbent format.
      *
      * SCALE ENCODING IS A DECLARED PROPERTY, not a hardcoded constant: f32 (4
      * bytes/block, above) is what THIS build implements, but it is not the
@@ -1362,12 +1385,16 @@ static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns
         int64_t nblkO=fp8_nblk(O), nblkI=fp8_nblk(I);
         int64_t ns_row=(int64_t)O*4, ns_blk=nblkO*nblkI*4, ns_blk_ue8m0=nblkO*nblkI;
         int is_row=(ns==ns_row), is_blk=(ns==ns_blk), is_blk_ue8m0=(ns==ns_blk_ue8m0);
-        if(is_row && is_blk){
-            fprintf(stderr,"%s: [%d,%d] scale array is %lld bytes — matches BOTH per-row "
-                "int8 (fmt=1) and per-128x128-block FP8 (fmt=7) scale geometry; refusing "
-                "rather than guessing (untrusted container, THE DESIGN LANDMINE)\n",
-                name,O,I,(long long)ns); exit(1);
-        }
+        /* THE DESIGN LANDMINE, INVERTED (maintainer review, #528): is_row&&is_blk
+         * used to exit(1) here unconditionally -- see the comment above this
+         * function's "REVIEW FINDING"/"INVERSION" paragraphs for why that was
+         * wrong. No explicit branch is needed to resolve it to fmt=1: `fmt` is
+         * already 1 at this point (this whole `if(fmt==1)` block only runs when
+         * nb==exp_i8, which is what set fmt=1 above), and the `is_blk && !is_row`
+         * check further down evaluates false whenever is_row is true -- so an
+         * is_row&&is_blk shape simply falls through unchanged to fmt=1. This
+         * comment exists so a future reader doesn't mistake the missing branch
+         * for an oversight. */
         if(is_blk_ue8m0){
             fprintf(stderr,"%s: [%d,%d] fp8-e4m3-b128 with ue8m0 scales recognized but not "
                 "implemented; only f32 block scales are supported in this build (nb=%lld "

--- a/c/quant.h
+++ b/c/quant.h
@@ -402,6 +402,111 @@ static void matmul_i3(float *y, const float *x, const uint8_t *q3, const float *
     }
 }
 
+/* ---- fmt=7: native FP8-e4m3 passthrough (Z.ai GLM-5.2-FP8 read path) ------
+ * PUBLIC ordinal, assigned by the maintainer on #524. This format was minted
+ * fmt=6 during original development, then re-tagged fmt=100 (PRIVATE ORDINAL
+ * BLOCK, see colibri.c's QT struct comment) after #465 (E8/IQ3, above) claimed
+ * ordinal 6 upstream out from under it; fmt=7 is the number it graduated to at
+ * merge, per the private-block convention's own "find-and-replace, zero
+ * on-disk impact" promise. See qt_resolve_fmt in colibri.c ("THE DESIGN
+ * LANDMINE") for the disambiguation this needs against BOTH fmt=1 (int8) and
+ * fmt=6 (E8/IQ3).
+ *
+ * fmt=7 weight bytes are O*I raw e4m3 bytes -- byte-identical to int8 (fmt=1).
+ * What makes this a DIFFERENT format is the scale: one f32 per 128x128 BLOCK of
+ * the [O,I] weight matrix (shape [ceil(O/128),ceil(I/128)]), not one f32 per
+ * output row. Dequant is w[o,i] = e4m3_decode(byte) * scale[o/128, i/128]
+ * (MULTIPLY, not divide) -- mirrors tools/convert_fp8_to_int4.py's dequant()
+ * exactly, which is the authoritative reference for how Z.ai's checkpoints read
+ * on the source side. This f32 encoding is a declared PROPERTY of the format,
+ * not the only one it can carry -- DeepSeek-V4 ships this identical weight
+ * geometry with UE8M0 (1-byte, power-of-two) block scales instead; qt_resolve_fmt
+ * recognizes that byte signature and refuses it BY NAME rather than
+ * misreading it as f32 (UE8M0 decode itself is not implemented in this build).
+ *
+ * 256-entry decode LUT, cross-checked byte-for-byte against PyTorch's
+ * torch.float8_e4m3fn (the exact dtype safetensors reports for these shards):
+ * sign(1) exp(4,bias=7) mant(3), subnormal at exp==0, and the OCP E4M3-FN
+ * convention that exp==0xF is NOT reserved for infinity -- only mant==0x7 at
+ * exp==0xF is NaN (max finite is exp=0xF,mant=0x6 -> 448). A static compile-time
+ * table (not a lazily-initialized one) is used deliberately: matmul_fp8 below
+ * runs inside #pragma omp parallel for, and a lazy-init global would race under
+ * concurrent first use.
+ *
+ * NaN POLICY (decided, documented per the build spec): a NaN byte (0x7F/0xFF)
+ * decodes to a real IEEE NaN and is left to propagate through the dot product,
+ * exactly like any other source of a NaN weight (fmt=0/f32 tensors are never
+ * scrubbed either). The engine already has a dedicated, TESTED safety net for
+ * NaN reaching the sampler (argmax_v/dist_build, see tests/test_logit_nan.c:
+ * "degrade + diagnose, never silently corrupt") -- fmt=7 relies on that existing
+ * downstream net rather than adding a second, redundant weight-level scrub. */
+static const float E4M3_LUT[256] = {
+    0x0.0p+0f,0x1.0000000000000p-9f,0x1.0000000000000p-8f,0x1.8000000000000p-8f,0x1.0000000000000p-7f,0x1.4000000000000p-7f,0x1.8000000000000p-7f,0x1.c000000000000p-7f,
+    0x1.0000000000000p-6f,0x1.2000000000000p-6f,0x1.4000000000000p-6f,0x1.6000000000000p-6f,0x1.8000000000000p-6f,0x1.a000000000000p-6f,0x1.c000000000000p-6f,0x1.e000000000000p-6f,
+    0x1.0000000000000p-5f,0x1.2000000000000p-5f,0x1.4000000000000p-5f,0x1.6000000000000p-5f,0x1.8000000000000p-5f,0x1.a000000000000p-5f,0x1.c000000000000p-5f,0x1.e000000000000p-5f,
+    0x1.0000000000000p-4f,0x1.2000000000000p-4f,0x1.4000000000000p-4f,0x1.6000000000000p-4f,0x1.8000000000000p-4f,0x1.a000000000000p-4f,0x1.c000000000000p-4f,0x1.e000000000000p-4f,
+    0x1.0000000000000p-3f,0x1.2000000000000p-3f,0x1.4000000000000p-3f,0x1.6000000000000p-3f,0x1.8000000000000p-3f,0x1.a000000000000p-3f,0x1.c000000000000p-3f,0x1.e000000000000p-3f,
+    0x1.0000000000000p-2f,0x1.2000000000000p-2f,0x1.4000000000000p-2f,0x1.6000000000000p-2f,0x1.8000000000000p-2f,0x1.a000000000000p-2f,0x1.c000000000000p-2f,0x1.e000000000000p-2f,
+    0x1.0000000000000p-1f,0x1.2000000000000p-1f,0x1.4000000000000p-1f,0x1.6000000000000p-1f,0x1.8000000000000p-1f,0x1.a000000000000p-1f,0x1.c000000000000p-1f,0x1.e000000000000p-1f,
+    0x1.0000000000000p+0f,0x1.2000000000000p+0f,0x1.4000000000000p+0f,0x1.6000000000000p+0f,0x1.8000000000000p+0f,0x1.a000000000000p+0f,0x1.c000000000000p+0f,0x1.e000000000000p+0f,
+    0x1.0000000000000p+1f,0x1.2000000000000p+1f,0x1.4000000000000p+1f,0x1.6000000000000p+1f,0x1.8000000000000p+1f,0x1.a000000000000p+1f,0x1.c000000000000p+1f,0x1.e000000000000p+1f,
+    0x1.0000000000000p+2f,0x1.2000000000000p+2f,0x1.4000000000000p+2f,0x1.6000000000000p+2f,0x1.8000000000000p+2f,0x1.a000000000000p+2f,0x1.c000000000000p+2f,0x1.e000000000000p+2f,
+    0x1.0000000000000p+3f,0x1.2000000000000p+3f,0x1.4000000000000p+3f,0x1.6000000000000p+3f,0x1.8000000000000p+3f,0x1.a000000000000p+3f,0x1.c000000000000p+3f,0x1.e000000000000p+3f,
+    0x1.0000000000000p+4f,0x1.2000000000000p+4f,0x1.4000000000000p+4f,0x1.6000000000000p+4f,0x1.8000000000000p+4f,0x1.a000000000000p+4f,0x1.c000000000000p+4f,0x1.e000000000000p+4f,
+    0x1.0000000000000p+5f,0x1.2000000000000p+5f,0x1.4000000000000p+5f,0x1.6000000000000p+5f,0x1.8000000000000p+5f,0x1.a000000000000p+5f,0x1.c000000000000p+5f,0x1.e000000000000p+5f,
+    0x1.0000000000000p+6f,0x1.2000000000000p+6f,0x1.4000000000000p+6f,0x1.6000000000000p+6f,0x1.8000000000000p+6f,0x1.a000000000000p+6f,0x1.c000000000000p+6f,0x1.e000000000000p+6f,
+    0x1.0000000000000p+7f,0x1.2000000000000p+7f,0x1.4000000000000p+7f,0x1.6000000000000p+7f,0x1.8000000000000p+7f,0x1.a000000000000p+7f,0x1.c000000000000p+7f,0x1.e000000000000p+7f,
+    0x1.0000000000000p+8f,0x1.2000000000000p+8f,0x1.4000000000000p+8f,0x1.6000000000000p+8f,0x1.8000000000000p+8f,0x1.a000000000000p+8f,0x1.c000000000000p+8f,       NAN,
+     -0x0.0p+0f,-0x1.0000000000000p-9f,-0x1.0000000000000p-8f,-0x1.8000000000000p-8f,-0x1.0000000000000p-7f,-0x1.4000000000000p-7f,-0x1.8000000000000p-7f,-0x1.c000000000000p-7f,
+    -0x1.0000000000000p-6f,-0x1.2000000000000p-6f,-0x1.4000000000000p-6f,-0x1.6000000000000p-6f,-0x1.8000000000000p-6f,-0x1.a000000000000p-6f,-0x1.c000000000000p-6f,-0x1.e000000000000p-6f,
+    -0x1.0000000000000p-5f,-0x1.2000000000000p-5f,-0x1.4000000000000p-5f,-0x1.6000000000000p-5f,-0x1.8000000000000p-5f,-0x1.a000000000000p-5f,-0x1.c000000000000p-5f,-0x1.e000000000000p-5f,
+    -0x1.0000000000000p-4f,-0x1.2000000000000p-4f,-0x1.4000000000000p-4f,-0x1.6000000000000p-4f,-0x1.8000000000000p-4f,-0x1.a000000000000p-4f,-0x1.c000000000000p-4f,-0x1.e000000000000p-4f,
+    -0x1.0000000000000p-3f,-0x1.2000000000000p-3f,-0x1.4000000000000p-3f,-0x1.6000000000000p-3f,-0x1.8000000000000p-3f,-0x1.a000000000000p-3f,-0x1.c000000000000p-3f,-0x1.e000000000000p-3f,
+    -0x1.0000000000000p-2f,-0x1.2000000000000p-2f,-0x1.4000000000000p-2f,-0x1.6000000000000p-2f,-0x1.8000000000000p-2f,-0x1.a000000000000p-2f,-0x1.c000000000000p-2f,-0x1.e000000000000p-2f,
+    -0x1.0000000000000p-1f,-0x1.2000000000000p-1f,-0x1.4000000000000p-1f,-0x1.6000000000000p-1f,-0x1.8000000000000p-1f,-0x1.a000000000000p-1f,-0x1.c000000000000p-1f,-0x1.e000000000000p-1f,
+    -0x1.0000000000000p+0f,-0x1.2000000000000p+0f,-0x1.4000000000000p+0f,-0x1.6000000000000p+0f,-0x1.8000000000000p+0f,-0x1.a000000000000p+0f,-0x1.c000000000000p+0f,-0x1.e000000000000p+0f,
+    -0x1.0000000000000p+1f,-0x1.2000000000000p+1f,-0x1.4000000000000p+1f,-0x1.6000000000000p+1f,-0x1.8000000000000p+1f,-0x1.a000000000000p+1f,-0x1.c000000000000p+1f,-0x1.e000000000000p+1f,
+    -0x1.0000000000000p+2f,-0x1.2000000000000p+2f,-0x1.4000000000000p+2f,-0x1.6000000000000p+2f,-0x1.8000000000000p+2f,-0x1.a000000000000p+2f,-0x1.c000000000000p+2f,-0x1.e000000000000p+2f,
+    -0x1.0000000000000p+3f,-0x1.2000000000000p+3f,-0x1.4000000000000p+3f,-0x1.6000000000000p+3f,-0x1.8000000000000p+3f,-0x1.a000000000000p+3f,-0x1.c000000000000p+3f,-0x1.e000000000000p+3f,
+    -0x1.0000000000000p+4f,-0x1.2000000000000p+4f,-0x1.4000000000000p+4f,-0x1.6000000000000p+4f,-0x1.8000000000000p+4f,-0x1.a000000000000p+4f,-0x1.c000000000000p+4f,-0x1.e000000000000p+4f,
+    -0x1.0000000000000p+5f,-0x1.2000000000000p+5f,-0x1.4000000000000p+5f,-0x1.6000000000000p+5f,-0x1.8000000000000p+5f,-0x1.a000000000000p+5f,-0x1.c000000000000p+5f,-0x1.e000000000000p+5f,
+    -0x1.0000000000000p+6f,-0x1.2000000000000p+6f,-0x1.4000000000000p+6f,-0x1.6000000000000p+6f,-0x1.8000000000000p+6f,-0x1.a000000000000p+6f,-0x1.c000000000000p+6f,-0x1.e000000000000p+6f,
+    -0x1.0000000000000p+7f,-0x1.2000000000000p+7f,-0x1.4000000000000p+7f,-0x1.6000000000000p+7f,-0x1.8000000000000p+7f,-0x1.a000000000000p+7f,-0x1.c000000000000p+7f,-0x1.e000000000000p+7f,
+    -0x1.0000000000000p+8f,-0x1.2000000000000p+8f,-0x1.4000000000000p+8f,-0x1.6000000000000p+8f,-0x1.8000000000000p+8f,-0x1.a000000000000p+8f,-0x1.c000000000000p+8f,       NAN,
+};
+static inline float e4m3_decode(uint8_t b){ return E4M3_LUT[b]; }
+
+#define FP8_BLOCK 128
+static inline int64_t fp8_nblk(int n){ return ((int64_t)n + FP8_BLOCK - 1) / FP8_BLOCK; }
+
+/* y[S,O] = x[S,I] @ W^T, W raw e4m3 bytes (byte-identical layout to fmt=1) +
+ * per-128x128-BLOCK f32 scale [ceil(O/128),ceil(I/128)]. Scalar reference path
+ * (no SIMD in v1 -- BW-bound like the Metal kernel, and this format's hot path
+ * is the GPU one; a vectorized CPU kernel is future work if measured needed).
+ * Mirrors matmul_i3's double-accumulate-across-groups / float-within-group
+ * convention so cross-block cancellation doesn't cost precision unfairly. */
+static void matmul_fp8(float *y, const float *x, const uint8_t *q8, const float *bscale,
+                       int S, int I, int O){
+    int64_t nblkI = fp8_nblk(I);
+    #pragma omp parallel for schedule(static)
+    for(int o=0;o<O;o++){
+        const uint8_t *w = q8 + (int64_t)o*I;
+        int64_t blkO = o / FP8_BLOCK;
+        const float *scl = bscale + blkO*nblkI;
+        for(int s=0;s<S;s++){
+            const float *xs = x + (int64_t)s*I;
+            double a=0;
+            for(int64_t bi=0; bi*FP8_BLOCK<I; bi++){
+                int base=(int)(bi*FP8_BLOCK); int blen=FP8_BLOCK; if(base+blen>I) blen=I-base;
+                float sc=scl[bi]; float acc=0;
+                for(int i=base;i<base+blen;i++) acc += e4m3_decode(w[i])*xs[i];
+                a += (double)acc*sc;
+            }
+            y[(int64_t)s*O+o]=(float)a;
+        }
+    }
+}
+
 /* ---- IDOT: integer dot kernels (int8-quantized activations) --------------- */
 #if defined(__AVX512VNNI__) && defined(__AVX512BW__)
 #define IDOT_KERNEL "avx512-vnni"

--- a/c/quant.h
+++ b/c/quant.h
@@ -402,17 +402,20 @@ static void matmul_i3(float *y, const float *x, const uint8_t *q3, const float *
     }
 }
 
-/* ---- fmt=7: native FP8-e4m3 passthrough (Z.ai GLM-5.2-FP8 read path) ------
- * PUBLIC ordinal, assigned by the maintainer on #524. This format was minted
- * fmt=6 during original development, then re-tagged fmt=100 (PRIVATE ORDINAL
- * BLOCK, see colibri.c's QT struct comment) after #465 (E8/IQ3, above) claimed
- * ordinal 6 upstream out from under it; fmt=7 is the number it graduated to at
- * merge, per the private-block convention's own "find-and-replace, zero
- * on-disk impact" promise. See qt_resolve_fmt in colibri.c ("THE DESIGN
+/* ---- fmt=8: native FP8-e4m3 passthrough (Z.ai GLM-5.2-FP8 read path) ------
+ * PUBLIC ordinal. This format was minted fmt=6 during original development,
+ * then re-tagged fmt=100 (PRIVATE ORDINAL BLOCK, see colibri.c's QT struct
+ * comment) after #465 (E8/IQ3, above) claimed ordinal 6 upstream out from
+ * under it; graduated to fmt=7 when the maintainer assigned that ordinal on
+ * #524; renumbered a second time to fmt=8 after #705 merged into dev claiming
+ * fmt=7 for MXFP4 (Kimi K3 Vulkan tier, backend_vulkan.c) while this PR was
+ * still open. Both renumbers were pure retags, per the private-block
+ * convention's own "find-and-replace, zero on-disk impact" promise: nothing
+ * on disk carries the ordinal. See qt_resolve_fmt in colibri.c ("THE DESIGN
  * LANDMINE") for the disambiguation this needs against BOTH fmt=1 (int8) and
  * fmt=6 (E8/IQ3).
  *
- * fmt=7 weight bytes are O*I raw e4m3 bytes -- byte-identical to int8 (fmt=1).
+ * fmt=8 weight bytes are O*I raw e4m3 bytes -- byte-identical to int8 (fmt=1).
  * What makes this a DIFFERENT format is the scale: one f32 per 128x128 BLOCK of
  * the [O,I] weight matrix (shape [ceil(O/128),ceil(I/128)]), not one f32 per
  * output row. Dequant is w[o,i] = e4m3_decode(byte) * scale[o/128, i/128]
@@ -438,7 +441,7 @@ static void matmul_i3(float *y, const float *x, const uint8_t *q3, const float *
  * exactly like any other source of a NaN weight (fmt=0/f32 tensors are never
  * scrubbed either). The engine already has a dedicated, TESTED safety net for
  * NaN reaching the sampler (argmax_v/dist_build, see tests/test_logit_nan.c:
- * "degrade + diagnose, never silently corrupt") -- fmt=7 relies on that existing
+ * "degrade + diagnose, never silently corrupt") -- fmt=8 relies on that existing
  * downstream net rather than adding a second, redundant weight-level scrub. */
 static const float E4M3_LUT[256] = {
     0x0.0p+0f,0x1.0000000000000p-9f,0x1.0000000000000p-8f,0x1.8000000000000p-8f,0x1.0000000000000p-7f,0x1.4000000000000p-7f,0x1.8000000000000p-7f,0x1.c000000000000p-7f,

--- a/c/tests/test_backend_metal.mm
+++ b/c/tests/test_backend_metal.mm
@@ -10,7 +10,7 @@
 #include <cmath>
 #include <vector>
 
-enum { F32=0, I8=1, I4=2, I2=3, I4G=4 };
+enum { F32=0, I8=1, I4=2, I2=3, I4G=4, FP8=7 };
 
 static void cpu_ref(int fmt, const void *W, const float *s, const float *x,
                     float *y, int S, int I, int O) {
@@ -80,6 +80,41 @@ static void cpu_ref_grouped(const uint8_t *q4, const float *scale, const float *
   }
 }
 
+// ---- fmt=7 (native FP8-e4m3 passthrough -- see colibri.c): own CPU reference +
+// harness --------------------------------------------------------------------------
+// Independent reference decode (bit manipulation, NOT quant.h's E4M3_LUT -- this file
+// stays self-contained like the rest of its CPU references) for OCP E4M3-FN: exp==0 is
+// subnormal, exp==0xF&&mant==0x7 is the only NaN code (both signs), else normal with
+// bias 7. Must match quant.h's e4m3_decode AND the mm_gemv fmt==7 branch's in-kernel
+// bit manipulation exactly -- see run_fp8_lut() below for the exhaustive 256-code check
+// that proves the GPU kernel agrees with this reference (and by transitivity with the
+// CPU LUT, which was cross-checked byte-for-byte against torch.float8_e4m3fn offline).
+static float ref_e4m3(uint8_t b) {
+  unsigned sign=(b>>7)&1, exp=(b>>3)&0xF, mant=b&0x7;
+  if (exp==0xF && mant==0x7) return NAN;
+  float val = (exp==0) ? (float)mant*(1.0f/8.0f)*powf(2.0f,1.0f-7.0f)
+                       : (1.0f+(float)mant*(1.0f/8.0f))*powf(2.0f,(float)exp-7.0f);
+  return sign ? -val : val;
+}
+static int fp8_nblk(int n){ return (n+127)/128; }
+
+static void cpu_ref_fp8(const uint8_t *q8, const float *bscale, const float *x,
+                        double *y, double *mag, int S, int I, int O) {
+  int nblkI = fp8_nblk(I);
+  for (int o=0;o<O;o++){
+    const uint8_t *w = q8 + (size_t)o*I;
+    const float *scl = bscale + (size_t)(o/128)*nblkI;
+    for (int s=0;s<S;s++){
+      const float *xs = x + (size_t)s*I; double a=0, m=0;
+      for (int i=0;i<I;i++){
+        double term = (double)ref_e4m3(w[i]) * (double)xs[i] * (double)scl[i/128];
+        a += term; m += fabs(term);
+      }
+      y[(size_t)s*O+o] = a; mag[(size_t)s*O+o] = m;
+    }
+  }
+}
+
 // Tolerance: magnitude-relative (error / sum of |terms|), NOT the ymax-relative-max-
 // abs-error convention run() above uses. Reason: a dot product over many groups can
 // land near zero from signed-term cancellation, and a fixed-point-ish absolute GPU/CPU
@@ -130,6 +165,107 @@ static int run_grouped(int O, int I, int gs, int S, int outlier, const char *nam
   int ok = (bad == 0);
   printf("  %-34s worst_rel=%.2e (I=%d gs=%d ng=%d S=%d)  %s\n", name, worst, I, gs, ng, S, ok?"ok":"*** MISMATCH");
   coli_metal_tensor_free(t);
+  return ok?0:1;
+}
+
+// Tolerance/oracle convention identical to run_grouped() above (magnitude-relative for
+// the block-scale accumulation, avoiding cancellation-noise false positives on
+// near-zero results).
+static int run_fp8(int O, int I, int S, const char *name) {
+  int nblkO=fp8_nblk(O), nblkI=fp8_nblk(I), nblk=nblkO*nblkI;
+  std::vector<uint8_t> W((size_t)O*I);
+  std::vector<float> scale((size_t)nblk), x((size_t)S*I), yg((size_t)S*O);
+  std::vector<double> yr((size_t)S*O), mag((size_t)S*O);
+  srand(5150 + I*7 + O*3 + S*13);
+  for (auto &b : W) { do { b = (uint8_t)(rand()&0xFF); } while (b==0x7F || b==0xFF); }  // exclude NaN codes
+  // distinct, easily-distinguishable scale per block (stride-audit idiom, same as
+  // test_fp8_passthrough.c's CPU version): a swapped o/128 vs i/128 stride, or a wrong
+  // nblkI in the shader's indexing, lands on a DIFFERENT block's scale and shows up as
+  // a loud numeric mismatch rather than passing by luck.
+  for (int b=0;b<nblk;b++) scale[b] = (float)(b+1)*0.01f*((b&1)?-1.f:1.f);
+  for (auto &v : x) v = ((rand()%2000)-1000)/1000.0f;
+  cpu_ref_fp8(W.data(), scale.data(), x.data(), yr.data(), mag.data(), S, I, O);
+  ColiMetalTensor *t=nullptr;
+  if (!coli_metal_matmul(&t, yg.data(), x.data(), W.data(), scale.data(), FP8, S, I, O, 0)) {
+    printf("  %-42s FAIL (matmul returned 0)\n", name); return 1; }
+  double worst=0; int bad=0;
+  for (size_t i=0; i<(size_t)S*O; i++) {
+    double d = fabs((double)yg[i] - yr[i]);
+    double rel = mag[i] > 1e-30 ? d/mag[i] : d;
+    if (rel > worst) worst = rel;
+    if (rel > 1e-4) bad++;
+  }
+  int ok = (bad == 0);
+  printf("  %-42s worst_rel=%.2e (I=%d O=%d nblkO=%d nblkI=%d S=%d)  %s\n",
+         name, worst, I, O, nblkO, nblkI, S, ok?"ok":"*** MISMATCH");
+  coli_metal_tensor_free(t);
+  return ok?0:1;
+}
+
+// Exhaustive LUT-exactness check run THROUGH the actual GPU kernel: O=256,I=1 means
+// each of the 256 output rows has exactly ONE weight byte, set to that row's own index
+// (0..255) -- so row o's dequant is exactly e4m3_decode(o). x=[1.0] and both blocks'
+// scale=1.0 isolate the decode from the block-scale/accumulation logic entirely. This
+// mirrors test_fp8_passthrough.c's CPU LUT-exactness test (test_lut), but exercised
+// through mm_gemv's in-kernel bit manipulation instead of quant.h's table -- proving
+// the two independently-written decoders agree on all 256 codes, including both NaN
+// codes and the sign of zero.
+static int run_fp8_lut(const char *name) {
+  enum { O=256, I=1 };
+  std::vector<uint8_t> W(O*I); for (int b=0;b<O;b++) W[b]=(uint8_t)b;
+  std::vector<float> scale(fp8_nblk(O)*fp8_nblk(I), 1.0f);   // nblkO=2,nblkI=1 -> both blocks scale=1
+  std::vector<float> x(I, 1.0f), yg(O);
+  ColiMetalTensor *t=nullptr;
+  if (!coli_metal_matmul(&t, yg.data(), x.data(), W.data(), scale.data(), FP8, 1, I, O, 0)) {
+    printf("  %-42s FAIL (matmul returned 0)\n", name); return 1; }
+  int bad=0;
+  for (int b=0;b<O;b++) {
+    float ref = ref_e4m3((uint8_t)b);
+    if (b==0x7F || b==0xFF) { if (!std::isnan(yg[b])) bad++; continue; }
+    if (yg[b] != ref) bad++;
+  }
+  int ok = (bad==0);
+  printf("  %-42s %d/256 mismatches  %s\n", name, bad, ok?"ok":"*** MISMATCH");
+  coli_metal_tensor_free(t);
+  return ok?0:1;
+}
+
+// Confirms the documented "GEMM path optional this build" claim is actually true, not
+// just asserted in a comment: coli_metal_gemm must refuse fmt=7 (return 0, the CPU-
+// fallback signal) so matmul_qt_ex's caller-side allowlist exclusion is backed by a
+// second, independent gate inside the Metal backend itself.
+static int run_fp8_gemm_gate(const char *name) {
+  uint8_t w[8]={0}; float s[1]={1.0f}, x[8]={0}, y[1]={0};
+  int rc = coli_metal_gemm(y, x, w, s, FP8, 1, 8, 1, 0);
+  int ok = (rc == 0);
+  printf("  %-42s rc=%d (expect 0/CPU-fallback)  %s\n", name, rc, ok?"ok":"*** MISMATCH (should have refused)");
+  return ok?0:1;
+}
+
+// colibri.c's moe() has a THIRD fmt=7-adjacent Metal entry point besides the two
+// guarded above (bind_gemv's attn/layer-decode shaders and coli_metal_gemm) -- the
+// batched routed-expert dispatch via coli_metal_moe_block[_begin] (colibri.c's
+// MB_BUILD macro). MB_BUILD's own pointer-selection ternary does NOT special-case
+// fmt=7: if a layer's shared expert is fmt=7 and MB_BUILD's TRY_SH path picks it
+// up with no routed expert already fixing `mfmt`, it would submit the WRONG pointer
+// (q4, NULL/stale for an fmt=7 tensor whose weights live in q8) tagged as fmt=7.
+// This is safe ANYWAY, but only incidentally: moe_submit() (backend_metal.mm) gates
+// `fmt != 1 && fmt != 2` as its very FIRST statement, before any of g/u/d/gs/us/ds is
+// dereferenced or even resolve()'d -- so an fmt=7 submission is refused before the
+// bad pointer would ever be read, no matter what garbage MB_BUILD packed into it. This
+// test uses deliberately-invalid weight/scale pointers (never dereferenced if the gate
+// holds) to prove the fence BY TEST rather than leaving it an artifact of moe_submit's
+// fmt allowlist happening not to include 7 (yet) -- same discipline
+// run_fp8_gemm_gate above applies to coli_metal_gemm's analogous exclusion.
+static int run_fp8_moe_gate(const char *name) {
+  const void *bad = (const void*)(uintptr_t)0xdeadbeef;   // must NEVER be dereferenced
+  const void *g[1] = {bad}, *u[1] = {bad}, *d[1] = {bad};
+  const float *gs[1] = {(const float*)bad}, *us[1] = {(const float*)bad}, *ds[1] = {(const float*)bad};
+  float xg[8]={0}, out[8]={0}, rw[1]={1.0f};
+  int xoff[1]={0}, nr[1]={1}, rows[1]={0};
+  int rc = coli_metal_moe_block(1, 8, 8, FP8, g, u, d, gs, us, ds, xg, xoff, nr, rows, rw, out, 1);
+  int ok = (rc == 0);
+  printf("  %-42s rc=%d (expect 0/CPU-fallback)  %s\n", name, rc, ok?"ok":"*** MISMATCH (should have refused)");
   return ok?0:1;
 }
 
@@ -463,6 +599,22 @@ int main(void) {
   // tail-clipping regime grouped scales exist for), verified end-to-end through the GPU.
   fail |= run_grouped(5,   512, 64,3,1, "grouped I=512(mult64) outlier-heavy S=3");
   fail |= run_grouped(5,   201, 64,2,1, "grouped I=201(non-mult-64) outlier-heavy S=2");
+  printf("Metal fmt=7 native FP8-e4m3 passthrough tests:\n");
+  fail |= run_fp8_lut("fp8 LUT exactness (256/256 codes via GPU kernel)");
+  fail |= run_fp8(2048,6144,1, "fp8 gate/up-shaped O=2048 I=6144 (spec example) S=1");
+  fail |= run_fp8(6144,2048,1, "fp8 down-shaped O=6144 I=2048 S=1");
+  fail |= run_fp8(2048,6144,4, "fp8 gate/up-shaped O=2048 I=6144 S=4");
+  // block edges: O,I not multiples of 128 (the partial-tile clamp)
+  fail |= run_fp8(130, 200, 2, "fp8 block edges: O,I both non-mult-128");
+  fail |= run_fp8(129, 128, 1, "fp8 block edges: O just over 128, I exact");
+  fail |= run_fp8(128, 129, 1, "fp8 block edges: O exact, I just over 128");
+  fail |= run_fp8(1,   1,   1, "fp8 degenerate 1x1 (single sub-block)");
+  // non-square block grid (nblkO=3 != nblkI=48) with a distinct scale per block: a
+  // swapped o/128 vs i/128 index, or a wrong nblkI stride, lands on the wrong block's
+  // scale and this shape/scale choice makes that numerically loud.
+  fail |= run_fp8(384, 6144, 3, "fp8 non-square block grid nblkO=3 nblkI=48 (stride audit)");
+  fail |= run_fp8_gemm_gate("fp8 GEMM entry explicitly gated off (coli_metal_gemm refuses)");
+  fail |= run_fp8_moe_gate("fp8 MB_BUILD/moe_submit entry gated off (shared-expert fmt=7 hazard)");
   printf("Metal batched moe_block tests:\n");
   fail |= run_moe({1,1,1,1,1,1,1,1}, "moe decode nb=8");
   fail |= run_moe({3,1,4,2,1,5},     "moe ragged nb=6");

--- a/c/tests/test_backend_metal.mm
+++ b/c/tests/test_backend_metal.mm
@@ -10,7 +10,7 @@
 #include <cmath>
 #include <vector>
 
-enum { F32=0, I8=1, I4=2, I2=3, I4G=4, FP8=7 };
+enum { F32=0, I8=1, I4=2, I2=3, I4G=4, FP8=8 };
 
 static void cpu_ref(int fmt, const void *W, const float *s, const float *x,
                     float *y, int S, int I, int O) {
@@ -80,12 +80,12 @@ static void cpu_ref_grouped(const uint8_t *q4, const float *scale, const float *
   }
 }
 
-// ---- fmt=7 (native FP8-e4m3 passthrough -- see colibri.c): own CPU reference +
+// ---- fmt=8 (native FP8-e4m3 passthrough -- see colibri.c): own CPU reference +
 // harness --------------------------------------------------------------------------
 // Independent reference decode (bit manipulation, NOT quant.h's E4M3_LUT -- this file
 // stays self-contained like the rest of its CPU references) for OCP E4M3-FN: exp==0 is
 // subnormal, exp==0xF&&mant==0x7 is the only NaN code (both signs), else normal with
-// bias 7. Must match quant.h's e4m3_decode AND the mm_gemv fmt==7 branch's in-kernel
+// bias 7. Must match quant.h's e4m3_decode AND the mm_gemv fmt==8 branch's in-kernel
 // bit manipulation exactly -- see run_fp8_lut() below for the exhaustive 256-code check
 // that proves the GPU kernel agrees with this reference (and by transitivity with the
 // CPU LUT, which was cross-checked byte-for-byte against torch.float8_e4m3fn offline).
@@ -231,7 +231,7 @@ static int run_fp8_lut(const char *name) {
 }
 
 // Confirms the documented "GEMM path optional this build" claim is actually true, not
-// just asserted in a comment: coli_metal_gemm must refuse fmt=7 (return 0, the CPU-
+// just asserted in a comment: coli_metal_gemm must refuse fmt=8 (return 0, the CPU-
 // fallback signal) so matmul_qt_ex's caller-side allowlist exclusion is backed by a
 // second, independent gate inside the Metal backend itself.
 static int run_fp8_gemm_gate(const char *name) {
@@ -242,20 +242,20 @@ static int run_fp8_gemm_gate(const char *name) {
   return ok?0:1;
 }
 
-// colibri.c's moe() has a THIRD fmt=7-adjacent Metal entry point besides the two
+// colibri.c's moe() has a THIRD fmt=8-adjacent Metal entry point besides the two
 // guarded above (bind_gemv's attn/layer-decode shaders and coli_metal_gemm) -- the
 // batched routed-expert dispatch via coli_metal_moe_block[_begin] (colibri.c's
 // MB_BUILD macro). MB_BUILD's own pointer-selection ternary does NOT special-case
-// fmt=7: if a layer's shared expert is fmt=7 and MB_BUILD's TRY_SH path picks it
+// fmt=8: if a layer's shared expert is fmt=8 and MB_BUILD's TRY_SH path picks it
 // up with no routed expert already fixing `mfmt`, it would submit the WRONG pointer
-// (q4, NULL/stale for an fmt=7 tensor whose weights live in q8) tagged as fmt=7.
+// (q4, NULL/stale for an fmt=8 tensor whose weights live in q8) tagged as fmt=8.
 // This is safe ANYWAY, but only incidentally: moe_submit() (backend_metal.mm) gates
 // `fmt != 1 && fmt != 2` as its very FIRST statement, before any of g/u/d/gs/us/ds is
-// dereferenced or even resolve()'d -- so an fmt=7 submission is refused before the
+// dereferenced or even resolve()'d -- so an fmt=8 submission is refused before the
 // bad pointer would ever be read, no matter what garbage MB_BUILD packed into it. This
 // test uses deliberately-invalid weight/scale pointers (never dereferenced if the gate
 // holds) to prove the fence BY TEST rather than leaving it an artifact of moe_submit's
-// fmt allowlist happening not to include 7 (yet) -- same discipline
+// fmt allowlist happening not to include 8 (yet) -- same discipline
 // run_fp8_gemm_gate above applies to coli_metal_gemm's analogous exclusion.
 static int run_fp8_moe_gate(const char *name) {
   const void *bad = (const void*)(uintptr_t)0xdeadbeef;   // must NEVER be dereferenced
@@ -599,7 +599,7 @@ int main(void) {
   // tail-clipping regime grouped scales exist for), verified end-to-end through the GPU.
   fail |= run_grouped(5,   512, 64,3,1, "grouped I=512(mult64) outlier-heavy S=3");
   fail |= run_grouped(5,   201, 64,2,1, "grouped I=201(non-mult-64) outlier-heavy S=2");
-  printf("Metal fmt=7 native FP8-e4m3 passthrough tests:\n");
+  printf("Metal fmt=8 native FP8-e4m3 passthrough tests:\n");
   fail |= run_fp8_lut("fp8 LUT exactness (256/256 codes via GPU kernel)");
   fail |= run_fp8(2048,6144,1, "fp8 gate/up-shaped O=2048 I=6144 (spec example) S=1");
   fail |= run_fp8(6144,2048,1, "fp8 down-shaped O=6144 I=2048 S=1");
@@ -614,7 +614,7 @@ int main(void) {
   // scale and this shape/scale choice makes that numerically loud.
   fail |= run_fp8(384, 6144, 3, "fp8 non-square block grid nblkO=3 nblkI=48 (stride audit)");
   fail |= run_fp8_gemm_gate("fp8 GEMM entry explicitly gated off (coli_metal_gemm refuses)");
-  fail |= run_fp8_moe_gate("fp8 MB_BUILD/moe_submit entry gated off (shared-expert fmt=7 hazard)");
+  fail |= run_fp8_moe_gate("fp8 MB_BUILD/moe_submit entry gated off (shared-expert fmt=8 hazard)");
   printf("Metal batched moe_block tests:\n");
   fail |= run_moe({1,1,1,1,1,1,1,1}, "moe decode nb=8");
   fail |= run_moe({3,1,4,2,1,5},     "moe ragged nb=6");

--- a/c/tests/test_fp8_e2e_loader.c
+++ b/c/tests/test_fp8_e2e_loader.c
@@ -1,0 +1,86 @@
+/* fp8 passthrough END-TO-END loader harness.
+ *
+ * Neither test_fp8_load.c (hand-built wire-format C fixtures -- proves the
+ * LOADER's own disambiguation logic in isolation, but the container bytes
+ * are hand-authored, not tool-produced) nor test_fp8_repack.py (proves the
+ * WRITER's Python-side output shape -- never invokes the C loader at all)
+ * exercises the REAL round trip: a container the REAL
+ * tools/repack_fp8_passthrough.py actually produced, fed into the REAL
+ * st_init/qt_from_disk. This binary is the C-side half of that round trip;
+ * tests/test_fp8_e2e_repack_load.py drives it end to end (builds a synthetic
+ * FP8 checkpoint via tools/glm_fp8_emit.py, repacks it with the real tool
+ * via subprocess -- the actual CLI, not a reimplementation -- then invokes
+ * this binary against the real output directory).
+ *
+ * Usage: test_fp8_e2e_loader <container_dir> [name O I]...
+ * For every (name,O,I) triple, calls the REAL qt_from_disk (the identical
+ * function every model load uses) and asserts:
+ *   (a) fmt==7 resolved (native fp8-e4m3-passthrough, via byte-arithmetic
+ *       inference alone -- this PR's repack tool writes no container
+ *       metadata stamp, see repack_fp8_passthrough.py's module docstring);
+ *   (b) the weight (q8) and scale (s) buffers are non-NULL;
+ *   (c) every dequantized value (e4m3_decode(byte) * block scale) is finite
+ *       -- catches a decode-table or block-index bug a pure byte-count
+ *       check wouldn't. */
+#define main coli_glm_main_unused
+#include "../colibri.c"
+#undef main
+
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv){
+    if(argc < 2){ fprintf(stderr,"usage: %s <dir> [name O I]...\n", argv[0]); return 2; }
+    if((argc-2) % 3 != 0){
+        fprintf(stderr,"args after <dir> must come in (name,O,I) triples (got %d)\n", argc-2);
+        return 2;
+    }
+    const char *dir = argv[1];
+    int ntensors = (argc-2)/3;
+    if(ntensors == 0){ fprintf(stderr,"no (name,O,I) triples given -- nothing to check\n"); return 2; }
+
+    static Model gm; memset(&gm,0,sizeof gm);
+    st_init(&gm.S, dir);
+
+    int fails = 0;
+    for(int i=0;i<ntensors;i++){
+        const char *name = argv[2+i*3];
+        int O = atoi(argv[3+i*3]);
+        int I = atoi(argv[4+i*3]);
+
+        QT t; memset(&t,0,sizeof t);
+        qt_from_disk(&gm, name, O, I, 8, 0, &t);   /* THE REAL LOADER PATH -- not mocked */
+
+        if(t.fmt != 7){
+            printf("FAIL %s: fmt=%d, expected 7 (native fp8-e4m3 passthrough)\n", name, t.fmt);
+            fails++; continue;
+        }
+        if(!t.q8 || !t.s){
+            printf("FAIL %s: fmt=7 but q8=%p s=%p (expected both non-NULL)\n",
+                   name, (void*)t.q8, (void*)t.s);
+            fails++; continue;
+        }
+        int64_t nblkI = fp8_nblk(I);
+        int64_t bad = -1;
+        for(int64_t o=0; o<O && bad<0; o++){
+            int64_t blkO = o/FP8_BLOCK;
+            const float *scl = t.s + blkO*nblkI;
+            for(int64_t ii=0; ii<I; ii++){
+                int64_t bi = ii/FP8_BLOCK;
+                float v = e4m3_decode(t.q8[o*(int64_t)I+ii]) * scl[bi];
+                if(!isfinite(v)){ bad = o*(int64_t)I+ii; break; }
+            }
+        }
+        if(bad >= 0){
+            printf("FAIL %s: non-finite dequantized value at flat index %lld\n", name, (long long)bad);
+            fails++; continue;
+        }
+        printf("ok %s: fmt=7 O=%d I=%d, weights+scale loaded through the real loader, all-finite\n",
+               name, O, I);
+    }
+    if(fails){ printf("fp8 e2e repack->load: %d/%d tensor(s) FAILED\n", fails, ntensors); return 1; }
+    printf("fp8 e2e repack->load: ok (%d tensor(s))\n", ntensors);
+    return 0;
+}

--- a/c/tests/test_fp8_e2e_loader.c
+++ b/c/tests/test_fp8_e2e_loader.c
@@ -15,7 +15,7 @@
  * Usage: test_fp8_e2e_loader <container_dir> [name O I]...
  * For every (name,O,I) triple, calls the REAL qt_from_disk (the identical
  * function every model load uses) and asserts:
- *   (a) fmt==7 resolved (native fp8-e4m3-passthrough, via byte-arithmetic
+ *   (a) fmt==8 resolved (native fp8-e4m3-passthrough, via byte-arithmetic
  *       inference alone -- this PR's repack tool writes no container
  *       metadata stamp, see repack_fp8_passthrough.py's module docstring);
  *   (b) the weight (q8) and scale (s) buffers are non-NULL;
@@ -53,12 +53,12 @@ int main(int argc, char **argv){
         QT t; memset(&t,0,sizeof t);
         qt_from_disk(&gm, name, O, I, 8, 0, &t);   /* THE REAL LOADER PATH -- not mocked */
 
-        if(t.fmt != 7){
-            printf("FAIL %s: fmt=%d, expected 7 (native fp8-e4m3 passthrough)\n", name, t.fmt);
+        if(t.fmt != 8){
+            printf("FAIL %s: fmt=%d, expected 8 (native fp8-e4m3 passthrough)\n", name, t.fmt);
             fails++; continue;
         }
         if(!t.q8 || !t.s){
-            printf("FAIL %s: fmt=7 but q8=%p s=%p (expected both non-NULL)\n",
+            printf("FAIL %s: fmt=8 but q8=%p s=%p (expected both non-NULL)\n",
                    name, (void*)t.q8, (void*)t.s);
             fails++; continue;
         }
@@ -77,7 +77,7 @@ int main(int argc, char **argv){
             printf("FAIL %s: non-finite dequantized value at flat index %lld\n", name, (long long)bad);
             fails++; continue;
         }
-        printf("ok %s: fmt=7 O=%d I=%d, weights+scale loaded through the real loader, all-finite\n",
+        printf("ok %s: fmt=8 O=%d I=%d, weights+scale loaded through the real loader, all-finite\n",
                name, O, I);
     }
     if(fails){ printf("fp8 e2e repack->load: %d/%d tensor(s) FAILED\n", fails, ntensors); return 1; }

--- a/c/tests/test_fp8_e2e_repack_load.py
+++ b/c/tests/test_fp8_e2e_repack_load.py
@@ -18,7 +18,7 @@ test does, end to end:
      Makefile's own CFLAGS, asserted to produce zero warnings -- into a
      temp binary;
   4. run that binary against the REAL repacked output directory, asserting
-     every selected tensor loads fmt=7 through the real qt_from_disk with
+     every selected tensor loads fmt=8 through the real qt_from_disk with
      finite dequantized values (byte-arithmetic inference alone -- this PR's
      repack tool writes no container metadata stamp).
 

--- a/c/tests/test_fp8_e2e_repack_load.py
+++ b/c/tests/test_fp8_e2e_repack_load.py
@@ -1,0 +1,160 @@
+"""End-to-end: REAL tools/repack_fp8_passthrough.py output fed into the REAL
+C loader (st_init/qt_from_disk in colibri.c) via a small C harness.
+
+Neither test_fp8_load.c (hand-built wire-format C fixtures -- proves the C
+loader's OWN logic, but the container bytes are hand-authored, not
+tool-produced) nor test_fp8_repack.py (proves the Python tool's OUTPUT
+shape, but never invokes the C loader at all) covers this round trip. This
+test does, end to end:
+
+  1. build a synthetic FP8 checkpoint with tools/glm_fp8_emit.py (the same
+     fixture-generation helper test_fp8_repack.py uses -- not reimplemented
+     here, imported directly);
+  2. repack it with the REAL tools/repack_fp8_passthrough.py, invoked as a
+     subprocess exactly as a user would run it from the command line (not
+     imported and called as a library, so the CLI entry point is exercised
+     too, not just the importable functions);
+  3. compile tests/test_fp8_e2e_loader.c -- production flags mirroring the
+     Makefile's own CFLAGS, asserted to produce zero warnings -- into a
+     temp binary;
+  4. run that binary against the REAL repacked output directory, asserting
+     every selected tensor loads fmt=7 through the real qt_from_disk with
+     finite dequantized values (byte-arithmetic inference alone -- this PR's
+     repack tool writes no container metadata stamp).
+
+Hermetic: everything (checkpoint, repacked output, compiled harness binary)
+lives under one TemporaryDirectory; nothing is left behind.
+"""
+import glob, json, os, shutil, struct, subprocess, sys, tempfile, unittest
+
+try:
+    import torch
+except ImportError as e:
+    raise unittest.SkipTest(f"torch not installed: {e}")
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+C_DIR = os.path.normpath(os.path.join(HERE, ".."))
+sys.path.insert(0, os.path.join(C_DIR, "tools"))
+from glm_fp8_emit import save_fp8_safetensors  # reuse: real fp8 block-quantize, not reimplemented
+
+
+def _cc_flags():
+    """Mirror the Makefile's CFLAGS closely enough to compile colibri.c
+    cleanly: -O3 + the same warning flags, plus libomp on macOS if present
+    (falls back to single-threaded -- exactly like the Makefile's own
+    OMPDIR probe -- if it's not, rather than failing the build). Returns
+    (cc, cflags, ldflags) or (None, None, None) if no compiler is found."""
+    cc = shutil.which("cc") or shutil.which("clang") or shutil.which("gcc")
+    if not cc:
+        return None, None, None
+    cflags = ["-O3", "-Wall", "-Wextra", "-Wno-unused-parameter",
+              "-Wno-misleading-indentation", "-Wno-unused-function"]
+    ldflags = ["-lm"]
+    if sys.platform == "darwin":
+        try:
+            prefix = subprocess.run(["brew", "--prefix", "libomp"], capture_output=True,
+                                    text=True, timeout=10).stdout.strip()
+        except (OSError, subprocess.TimeoutExpired, FileNotFoundError):
+            prefix = ""
+        inc, lib = os.path.join(prefix, "include"), os.path.join(prefix, "lib")
+        if prefix and os.path.exists(os.path.join(inc, "omp.h")):
+            cflags += ["-Xclang", "-fopenmp", "-I", inc]
+            ldflags += ["-L", lib, "-lomp"]
+    return cc, cflags, ldflags
+
+
+class Fp8RepackLoadE2ETest(unittest.TestCase):
+    """The real tools/repack_fp8_passthrough.py -> the real C loader, once."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.indir = os.path.join(self.tmp.name, "fp8src")
+        os.makedirs(self.indir)
+        self.outdir = os.path.join(self.tmp.name, "out")
+        self.shard = os.path.join(self.indir, "model-00001-of-00001.safetensors")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_real_repack_output_loads_through_real_c_loader(self):
+        D, I_ = 256, 384   # non-degenerate shapes: nblkO*nblkI never coincides with O (no
+                            # THE DESIGN LANDMINE ambiguity here -- that boundary is
+                            # test_fp8_load.c's job, this test's job is the round trip)
+        torch.manual_seed(7)
+        sd = {
+            "model.layers.0.self_attn.o_proj.weight": torch.randn(D, D) * 0.02,
+            "model.layers.0.self_attn.q_a_proj.weight": torch.randn(D, D) * 0.02,
+            "model.layers.0.mlp.shared_experts.gate_proj.weight": torch.randn(D, I_) * 0.02,
+            "model.layers.0.mlp.gate_proj.weight": torch.randn(D, I_) * 0.02,
+            # routed expert: must NOT be selected (stays int4-g64 path) -- included
+            # as a negative control so this test also proves the real tool's selection
+            # logic held on the real round trip, not just in test_fp8_repack.py's own suite.
+            "model.layers.0.mlp.experts.0.gate_proj.weight": torch.randn(I_, D) * 0.02,
+            "model.layers.0.input_layernorm.weight": torch.randn(D),   # f32: must NOT be selected
+        }
+        # (O, I) exactly as the engine/repack tool see them -- known here because this
+        # test authored the checkpoint; the real C loader never gets told this by us,
+        # only by the container it reads (st_init parses shape from the file itself;
+        # O/I are qt_from_disk's own [O,I] contract, same as every real model load).
+        shapes = {
+            "model.layers.0.self_attn.o_proj.weight": (D, D),
+            "model.layers.0.self_attn.q_a_proj.weight": (D, D),
+            "model.layers.0.mlp.shared_experts.gate_proj.weight": (D, I_),
+            "model.layers.0.mlp.gate_proj.weight": (D, I_),
+        }
+        save_fp8_safetensors(sd, self.shard)
+
+        tool = os.path.join(C_DIR, "tools", "repack_fp8_passthrough.py")
+        rc = subprocess.run([sys.executable, tool, "--indir", self.indir,
+                            "--outdir", self.outdir, "--n-layers", "5"],
+                           capture_output=True, text=True)
+        self.assertEqual(rc.returncode, 0, f"real repack tool failed:\nSTDOUT:\n{rc.stdout}\nSTDERR:\n{rc.stderr}")
+
+        outs = glob.glob(os.path.join(self.outdir, "out-fp8pass-*.safetensors"))
+        self.assertEqual(len(outs), 1, "expected exactly one repacked output shard")
+
+        # Sanity-check the real tool's own selection BEFORE asking the C harness to load
+        # it: if this fails, the bug is in the tool, not the loader, and running the
+        # harness anyway would only muddy which side broke. This PR's repack tool writes
+        # NO container metadata stamp (that's a separate, follow-up PR -- see the tool's
+        # own module docstring), so selection is checked by tensor presence instead of a
+        # stamp's tensor-name set, and the stamp's ABSENCE is itself asserted below: a
+        # regression guard that this PR's tool really stays out of that scope.
+        with open(outs[0], "rb") as f:
+            hlen = struct.unpack("<Q", f.read(8))[0]
+            hdr = json.loads(f.read(hlen))
+        for name in shapes:
+            self.assertIn(name, hdr, f"{name}: expected tensor missing from repacked output")
+            self.assertIn(name + ".qs", hdr, f"{name}.qs: expected scale sidecar missing")
+        self.assertNotIn("model.layers.0.mlp.experts.0.gate_proj.weight", hdr)
+        self.assertNotIn("model.layers.0.input_layernorm.weight", hdr)
+        self.assertNotIn("__metadata__", hdr,
+                         "this PR's repack tool must not write a container metadata stamp "
+                         "(stamp writer is a separate, follow-up PR)")
+
+        cc, cflags, ldflags = _cc_flags()
+        if not cc:
+            raise unittest.SkipTest("no C compiler found on PATH")
+
+        harness_src = os.path.join(HERE, "test_fp8_e2e_loader.c")
+        harness_bin = os.path.join(self.tmp.name, "test_fp8_e2e_loader")
+        build = subprocess.run([cc] + cflags + [harness_src, "-o", harness_bin] + ldflags,
+                               capture_output=True, text=True, cwd=C_DIR)
+        self.assertEqual(build.returncode, 0, f"e2e harness build failed:\n{build.stderr}")
+        self.assertEqual(build.stderr.strip(), "",
+                         f"e2e harness build produced warnings (production flags require zero):\n{build.stderr}")
+
+        args = [harness_bin, self.outdir]
+        for name, (O, I) in shapes.items():
+            args += [name, str(O), str(I)]
+        run = subprocess.run(args, capture_output=True, text=True)
+        self.assertEqual(run.returncode, 0,
+                         f"e2e harness (real loader) failed:\nSTDOUT:\n{run.stdout}\nSTDERR:\n{run.stderr}")
+        self.assertNotIn("FAIL", run.stdout)
+        for name in shapes:
+            self.assertIn(f"ok {name}:", run.stdout)
+        self.assertIn("fp8 e2e repack->load: ok", run.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tests/test_fp8_load.c
+++ b/c/tests/test_fp8_load.c
@@ -481,8 +481,10 @@ static void check_fp8_bytes(int O, int I, const char *tag){
  * -Wno-unused-function suppressed the warning that should have caught it) --
  * fails here. Covers every format qt_wire_split's callers can see in practice
  * (fmt=1 per-row unaffected; fmt=4/5 grouped-scale formats qt_scale_bytes'
- * own comment names as previously-broken too; fmt=7 nblk>O, the shape this
- * review round is about). */
+ * own comment names as previously-broken too; fmt=6 (E8/IQ3, FIX ROUND,
+ * audit finding: a FIXED 4-byte tag, not O*4 -- see qt_scale_bytes' own
+ * comment for why this is reachable, not dead code); fmt=7 nblk>O, the
+ * shape this review round is about). */
 static void check_wire_split(int fmt, int O, int I, int gs, const char *tag){
     QT t; memset(&t,0,sizeof t); t.fmt=fmt; t.O=O; t.I=I; t.gs=gs;
     int64_t want_scale = qt_scale_bytes(&t);
@@ -497,12 +499,17 @@ static void check_wire_split(int fmt, int O, int I, int gs, const char *tag){
     CHECK(got_weight == want_weight);
     /* the regression this test exists to catch: a per-row-only scale_b==O*4
      * must NOT be what qt_wire_split returns for a format whose real scale
-     * cardinality differs from O (fmt=4/5/7 here) -- confirm the value has
+     * cardinality differs from O (fmt=4/5/6/7 here) -- confirm the value has
      * actually moved off that old constant, not just matched qt_scale_bytes()
      * by coincidence at a degenerate shape. */
     int64_t old_wrong_scale = (int64_t)O*4;
-    if((fmt==4 || fmt==5 || fmt==7) && want_scale != old_wrong_scale)
+    if((fmt==4 || fmt==5 || fmt==6 || fmt==7) && want_scale != old_wrong_scale)
         CHECK(got_scale != old_wrong_scale);
+    /* fmt=6's scale is a FIXED 4 bytes regardless of [O,I] -- assert the
+     * literal value directly too, not just "moved off O*4", since a future
+     * regression that made it O-dependent in some OTHER wrong way would
+     * still pass the generic check above. */
+    if(fmt==6) CHECK(want_scale == 4);
 }
 
 /* ---- Site-level wire regression (FIX ROUND, validator finding: mutation-
@@ -600,6 +607,8 @@ int main(void){
     check_wire_split(1, 4096,4096, 0,  "qt_wire_split fmt=1 plain int8 (per-row scale, unaffected by the fix)");
     check_wire_split(4, 2048,6144, 64, "qt_wire_split fmt=4 grouped int4 (O*ceil(I/gs) scale, not O*4)");
     check_wire_split(5, 2048,6144, 0,  "qt_wire_split fmt=5 int3-g64 (O*ceil(I/64) scale, not O*4)");
+    check_wire_split(6, 2048,6144, 0,  "qt_wire_split fmt=6 E8/IQ3 (FIXED 4-byte tag, not O*4=8192B)");
+    check_wire_split(6, 1,1,       0,  "qt_wire_split fmt=6 E8/IQ3 degenerate O=1 (O*4 would coincidentally also be 4 -- exercises the literal-4 assert, not just the moved-off-O*4 one)");
     check_wire_split(7, 2,16384, 0,    "qt_wire_split fmt=7 nblk(128) >> O(2): scale=512B, NOT O*4=8B");
     check_wire_split(7, 2048,6144, 0,  "qt_wire_split fmt=7 spec example: scale=3072B, NOT O*4=8192B");
     test_wire_site_regression();

--- a/c/tests/test_fp8_load.c
+++ b/c/tests/test_fp8_load.c
@@ -1,18 +1,19 @@
-/* fmt=7 (native FP8-e4m3 passthrough) loader-seam tests.
+/* fmt=8 (native FP8-e4m3 passthrough) loader-seam tests.
  *
- * fmt=7, PUBLIC ordinal assigned by the maintainer on #524: this format was
- * minted fmt=6 during original development of this branch, before dev's own
- * #465 (E8/IQ3) claimed that ordinal upstream and merged it into dev as a
- * REAL fmt=6 (see quant.h's E8 constants and e8_ helper functions, and
- * qt_resolve_fmt's ns==4-tag early check); re-tagged fmt=100 (PRIVATE ORDINAL
- * BLOCK, see colibri.c's QT struct comment) from that point forward -- there
- * was never a build in this branch's history where this format was reachable
- * as fmt=6 -- and graduated to fmt=7 at merge.
+ * fmt=8, PUBLIC ordinal: this format was minted fmt=6 during original
+ * development of this branch, before dev's own #465 (E8/IQ3) claimed that
+ * ordinal upstream and merged it into dev as a REAL fmt=6 (see quant.h's E8
+ * constants and e8_ helper functions, and qt_resolve_fmt's ns==4-tag early
+ * check); re-tagged fmt=100 (PRIVATE ORDINAL BLOCK, see colibri.c's QT struct
+ * comment) from that point forward -- there was never a build in this branch's
+ * history where this format was reachable as fmt=6 -- graduated to fmt=7 when
+ * the maintainer assigned that ordinal on #524, and renumbered to fmt=8 after
+ * #705 merged claiming 7 for MXFP4 (see colibri.c's QT comment).
  *
- * Part A: qt_resolve_fmt disambiguation suite -- THE DESIGN LANDMINE. fmt=7
+ * Part A: qt_resolve_fmt disambiguation suite -- THE DESIGN LANDMINE. fmt=8
  * weight bytes are byte-identical to fmt=1 (int8): both are O*I raw bytes.
  * The two are told apart ONLY by the scale array's byte count (per-row O*4 for
- * fmt=1, per-128x128-block ceil(O/128)*ceil(I/128)*4 for fmt=7, THIS build's
+ * fmt=1, per-128x128-block ceil(O/128)*ceil(I/128)*4 for fmt=8, THIS build's
  * implemented f32 scale encoding). For some shapes those two counts coincide
  * exactly -- INVERSION (maintainer review, #528): qt_resolve_fmt used to
  * REFUSE (exit(1)) this ambiguous case; it now resolves to fmt=1 (the
@@ -20,8 +21,8 @@
  * collision is not hypothetical (GLM-5.2's own self_attn.o_proj.weight hits
  * it, see qt_resolve_fmt's own "REVIEW FINDING"/"INVERSION" comment) and the
  * writer side (repack_fp8_passthrough.py's _check_geometry) now refuses to
- * ever EMIT an fmt=7 container at this same shape, so an unstamped ambiguous
- * tensor reaching this function is never a genuine fmt=7 candidate. The
+ * ever EMIT an fmt=8 container at this same shape, so an unstamped ambiguous
+ * tensor reaching this function is never a genuine fmt=8 candidate. The
  * former refusal-testing convention (fork()+waitpid(), mirroring
  * tests/test_st_pread.c's exit(1)-path idiom) is kept for the OTHER
  * refusing cases below (Part A2's fmt=6 collision, Part A3's UE8M0
@@ -29,11 +30,11 @@
  * refusal) -- only the is_row&&is_blk collision in this Part flipped from
  * expect_refuse to expect_fmt(...,1,...).
  *
- * Part A2: fmt=6 (E8/IQ3, upstream #465) vs fmt=7 collision at [O<=128 or
+ * Part A2: fmt=6 (E8/IQ3, upstream #465) vs fmt=8 collision at [O<=128 or
  * O in a 128-block-count range, I=98] -- SECOND DESIGN LANDMINE. Unchanged by
  * the #528 inversion above (a different collision predicate, still refused).
  *
- * Part A3: fmt=7's scale ENCODING is a declared property, not a hardcoded
+ * Part A3: fmt=8's scale ENCODING is a declared property, not a hardcoded
  * constant -- f32 (Part A/A2 above) is what this build implements. A UE8M0
  * (1 byte/block) encoding is a REAL, distinct byte signature (the DeepSeek-V4
  * checkpoint format for this identical weight geometry) this build recognizes
@@ -42,13 +43,13 @@
  * doesn't have -- see qt_resolve_fmt's own comment).
  *
  * Part B: qt_from_disk loader-seam -- writes a real single-shard .safetensors
- * file containing an fmt=7 tensor (U8 weight + per-block F32 .qs) next to an
+ * file containing an fmt=8 tensor (U8 weight + per-block F32 .qs) next to an
  * int8 control tensor of a DIFFERENT, non-colliding shape, loads both through
- * qt_from_disk, and checks the byte-count/.qs-size inference picks fmt=7 vs
+ * qt_from_disk, and checks the byte-count/.qs-size inference picks fmt=8 vs
  * fmt=1 correctly and the loaded weights dequantize identically to a reference.
  * Mirrors tests/test_int3_load.c's structure for fmt=5.
  *
- * Part C: qt_bytes()/qt_scale_bytes() byte-accounting for fmt=7, plus
+ * Part C: qt_bytes()/qt_scale_bytes() byte-accounting for fmt=8, plus
  * qt_wire_split() -- the shared weight/scale byte-range split qt_wire_mmap
  * and qt_unwire_mmap both now call (maintainer review, #528: qt_scale_bytes()
  * existed correctly but neither call site actually used it, a defect only
@@ -212,8 +213,8 @@ static void test_disambiguation(void){
     /* --- non-degenerate golden paths (unambiguous either way) --- */
     CHECK(expect_fmt(4096,4096,(int64_t)4096*4096,4096*4,1,"plain int8 4096x4096"));
     /* spec's own worked example: [2048,6144] expert -> block scale [16,48] */
-    CHECK(expect_fmt(2048,6144,(int64_t)2048*6144,16LL*48*4,7,"fp8 2048x6144 (spec example)"));
-    CHECK(expect_fmt(384,6144,(int64_t)384*6144,3LL*48*4,7,"fp8 384x6144 non-square block grid"));
+    CHECK(expect_fmt(2048,6144,(int64_t)2048*6144,16LL*48*4,8,"fp8 2048x6144 (spec example)"));
+    CHECK(expect_fmt(384,6144,(int64_t)384*6144,3LL*48*4,8,"fp8 384x6144 non-square block grid"));
 
     /* --- REGRESSION (maintainer review, #528): GLM-5.2's own
      * self_attn.o_proj.weight, [D,H*v_head]=[6144,16384]. nblkO=ceil(6144/128)=48,
@@ -259,17 +260,17 @@ static void test_disambiguation(void){
     /* --- boundary-ADJACENT non-degenerate cases: one step past each
      * degenerate case above, both interpretations now legitimately resolve. --- */
     CHECK(expect_fmt(1,129, 129,   4, 1, "adjacent O=1 I=129 as fmt=1 (ns=row)"));
-    CHECK(expect_fmt(1,129, 129,   8, 7, "adjacent O=1 I=129 as fmt=7 (ns=block, nblkI=2)"));
+    CHECK(expect_fmt(1,129, 129,   8, 8, "adjacent O=1 I=129 as fmt=8 (ns=block, nblkI=2)"));
     CHECK(expect_fmt(2,257, 2LL*257, 8,  1, "adjacent O=2 I=257 as fmt=1 (ns=row)"));
-    CHECK(expect_fmt(2,257, 2LL*257, 12, 7, "adjacent O=2 I=257 as fmt=7 (ns=block, nblkI=3)"));
+    CHECK(expect_fmt(2,257, 2LL*257, 12, 8, "adjacent O=2 I=257 as fmt=8 (ns=block, nblkI=3)"));
 
     /* --- neither interpretation matches: garbage .qs size, must still refuse
-     * (the pre-existing generic-mismatch path, exercised through the fmt=7-aware
+     * (the pre-existing generic-mismatch path, exercised through the fmt=8-aware
      * function to confirm the new code didn't disturb it). --- */
     CHECK(expect_refuse(10,10, 100, 999, "garbage ns matches neither row nor block layout"));
 }
 
-/* ---- Part A2: fmt=6 (E8/IQ3, upstream #465, merged into dev) vs fmt=7
+/* ---- Part A2: fmt=6 (E8/IQ3, upstream #465, merged into dev) vs fmt=8
  * (this branch's fp8-e4m3-b128) collision -- SECOND DESIGN LANDMINE, see the
  * derivation in qt_resolve_fmt's own comment. e8_rowbytes(I) is the constant
  * 98 for every I in (0,256], so dev's fmt=6 tag check (ns==4 &&
@@ -280,31 +281,31 @@ static void test_disambiguation(void){
  * same as the E8 tag. An unstamped [I=98] fp8-e4m3-b128 tensor at either of
  * those shapes is therefore byte-for-byte indistinguishable from a genuine
  * fmt=6 tensor: nb AND ns both coincide, not just ns (contrast the fmt=1/
- * fmt=7 collision in Part A, where only ns ever coincides). O==1 stacks a
+ * fmt=8 collision in Part A, where only ns ever coincides). O==1 stacks a
  * THIRD candidate: fmt=1's per-row ns (O*4) is also 4 there. This build has
  * no stamp to resolve any of these -- every one refuses. */
 static void test_fmt6_fp8_collision(void){
-    /* O=64, I=98: nblkO=nblkI=1 (fmt=7, single block, f32 scales) -> ns=4;
+    /* O=64, I=98: nblkO=nblkI=1 (fmt=8, single block, f32 scales) -> ns=4;
      * e8_blocks(98)=1 -> nb=O*98=6272 for BOTH interpretations, and fmt=6's
      * .qs tag is always exactly one f32 -> ns=4 too. Must refuse. */
     int64_t nb64=(int64_t)64*98;
-    CHECK(expect_refuse(64,98, nb64, 4, "fmt=6/fmt=7(f32) collision O=64 I=98"));
-    /* boundary O=128 variant: still nblkO=1 for fmt=7 (128<=128), same collision. */
+    CHECK(expect_refuse(64,98, nb64, 4, "fmt=6/fmt=8(f32) collision O=64 I=98"));
+    /* boundary O=128 variant: still nblkO=1 for fmt=8 (128<=128), same collision. */
     int64_t nb128=(int64_t)128*98;
-    CHECK(expect_refuse(128,98, nb128, 4, "fmt=6/fmt=7(f32) collision O=128 I=98"));
+    CHECK(expect_refuse(128,98, nb128, 4, "fmt=6/fmt=8(f32) collision O=128 I=98"));
 
     /* O=1, I=98: a THIRD candidate stacks on (fmt=1 plain int8 per-row, ns==O*4==4
      * too) -- a genuine three-way ambiguity. Must refuse. */
     int64_t nb1=(int64_t)1*98;
-    CHECK(expect_refuse(1,98, nb1, 4, "fmt=1/fmt=6/fmt=7(f32) THREE-way collision O=1 I=98"));
+    CHECK(expect_refuse(1,98, nb1, 4, "fmt=1/fmt=6/fmt=8(f32) THREE-way collision O=1 I=98"));
 
-    /* O in (384,512], I=98: nblkO=4, nblkI=1, product=4 -- a fmt=7 tensor with
+    /* O in (384,512], I=98: nblkO=4, nblkI=1, product=4 -- a fmt=8 tensor with
      * UE8M0 (1 byte/block) scales also lands at ns==4*1==4 here, the SAME tag
      * fmt=6 uses. Must refuse (and, since this build doesn't implement ue8m0
      * decode at all, would refuse on that basis alone even without the fmt=6
      * collision -- this case exercises the OUTER fmt=6 guard specifically). */
     int64_t nb400=(int64_t)400*98;
-    CHECK(expect_refuse(400,98, nb400, 4, "fmt=6/fmt=7(ue8m0, 4-block) collision O=400 I=98"));
+    CHECK(expect_refuse(400,98, nb400, 4, "fmt=6/fmt=8(ue8m0, 4-block) collision O=400 I=98"));
 
     /* regression guard: a GENUINE (non-colliding) fmt=6 fixture -- I!=98, so
      * e8_rowbytes(I)==98 does NOT equal O*I -- must keep resolving to fmt=6.
@@ -317,10 +318,10 @@ static void test_fmt6_fp8_collision(void){
         "genuine fmt=6 (non-colliding) O=64 I=256 (I!=98, no collision) -> fmt=6"));
 }
 
-/* ---- Part A3: fmt=7's scale ENCODING is a declared property -- UE8M0
+/* ---- Part A3: fmt=8's scale ENCODING is a declared property -- UE8M0
  * recognized, refused by name (not implemented in this build). ---- */
 static void test_ue8m0_scale_refusal(void){
-    /* [2048,6144] (spec example shape, same as Part A's fmt=7/f32 golden
+    /* [2048,6144] (spec example shape, same as Part A's fmt=8/f32 golden
      * path): nblkO=16, nblkI=48, product=768 blocks. A UE8M0 sidecar is
      * exactly 1 byte/block -> ns=768, distinct from BOTH fmt=1's per-row
      * count (O*4=8192) and this build's f32 block-scale count (768*4=3072).
@@ -342,7 +343,7 @@ static void test_ue8m0_scale_refusal(void){
 
 /* ---- Part B: qt_from_disk loader-seam (real safetensors file) ---- */
 
-static void deq_fmt7(const QT *t, float *dq){
+static void deq_fmt8(const QT *t, float *dq){
     int64_t nblkI = fp8_nblk(t->I);
     for(int o=0;o<t->O;o++){
         int64_t blkO = o/FP8_BLOCK; const float *scl = t->s + blkO*nblkI;
@@ -410,12 +411,12 @@ static void test_loader_seam(void){
 
     QT t7; memset(&t7,0,sizeof t7);
     qt_from_disk(&gm,"w7",O7,I7,8,0,&t7);
-    CHECK(t7.fmt==7);
+    CHECK(t7.fmt==8);
     CHECK(t7.q8!=NULL && t7.s!=NULL);            /* both weight and scale allocated (qalloc, not falloc) */
     static float dq_load[O7*I7], dq_ref[O7*I7];
-    deq_fmt7(&t7,dq_load);
-    QT tr7={.fmt=7,.q8=(int8_t*)q7,.s=s7,.O=O7,.I=I7};
-    deq_fmt7(&tr7,dq_ref);
+    deq_fmt8(&t7,dq_load);
+    QT tr7={.fmt=8,.q8=(int8_t*)q7,.s=s7,.O=O7,.I=I7};
+    deq_fmt8(&tr7,dq_ref);
     CHECK(memcmp(dq_load,dq_ref,sizeof dq_ref)==0);
 
     QT t1; memset(&t1,0,sizeof t1);
@@ -430,13 +431,13 @@ static void test_loader_seam(void){
     unlink(path); rmdir(dir);
 }
 
-/* ---- Part C: qt_bytes()/qt_scale_bytes() byte-accounting for fmt=7 ----
+/* ---- Part C: qt_bytes()/qt_scale_bytes() byte-accounting for fmt=8 ----
  *
  * qt_bytes() must not fall through to the fmt=2 (packed int4, O*ceil(I/2)+O*4)
  * default -- for a real fp8 tensor that would undercount the resident byte
  * count by roughly half (an AUTOPIN/RAM-budget-feeding hazard). qt_wire_mmap/
  * qt_unwire_mmap must not hardcode scale_b=O*4 (per-row) either -- wrong for
- * fmt=7's per-128x128-block scale array -- hence the dedicated
+ * fmt=8's per-128x128-block scale array -- hence the dedicated
  * qt_scale_bytes() helper shared by qt_bytes() and both wire functions so
  * there is exactly one place that knows each format's scale geometry. This
  * test exercises the arithmetic directly (no qt_from_disk/disk I/O, no mlock
@@ -445,7 +446,7 @@ static void test_loader_seam(void){
  * the shapes already used elsewhere in this file plus a block-edge
  * (non-128-multiple) case. */
 static void check_fp8_bytes(int O, int I, const char *tag){
-    QT t; memset(&t,0,sizeof t); t.fmt=7; t.O=O; t.I=I; t.gs=0;
+    QT t; memset(&t,0,sizeof t); t.fmt=8; t.O=O; t.I=I; t.gs=0;
     int64_t nblkO=fp8_nblk(O), nblkI=fp8_nblk(I), nblk=nblkO*nblkI;
     int64_t want_total = (int64_t)O*I + nblk*4;
     int64_t want_scale = nblk*4;
@@ -461,9 +462,9 @@ static void check_fp8_bytes(int O, int I, const char *tag){
      * O*I raw-byte weight region -- not short (partial mlock) or long (mlock past the
      * allocation, undefined behavior) by even one byte. */
     CHECK(got_total - got_scale == (int64_t)O*I);
-    /* regression guard: the fmt=2 (packed-nibble) formula must NOT be what fmt=7
+    /* regression guard: the fmt=2 (packed-nibble) formula must NOT be what fmt=8
      * returns -- confirm the value has actually MOVED off it (catches a silent
-     * revert of the fmt==7 branch order/placement, not just a formula typo). For
+     * revert of the fmt==8 branch order/placement, not just a formula typo). For
      * O=1,I=1 the two formulas coincide by coincidence (both give 1+4=5), so that
      * shape is skipped for this particular guard -- the other three shapes below are
      * chosen to avoid the coincidence. */
@@ -483,9 +484,19 @@ static void check_fp8_bytes(int O, int I, const char *tag){
  * (fmt=1 per-row unaffected; fmt=4/5 grouped-scale formats qt_scale_bytes'
  * own comment names as previously-broken too; fmt=6 (E8/IQ3, FIX ROUND,
  * audit finding: a FIXED 4-byte tag, not O*4 -- see qt_scale_bytes' own
- * comment for why this is reachable, not dead code); fmt=7 nblk>O, the
+ * comment for why this is reachable, not dead code); fmt=8 nblk>O, the
  * shape this review round is about). */
 static void check_wire_split(int fmt, int O, int I, int gs, const char *tag){
+    /* self-guard (fix round 1, reviewer finding): the fmt ARGUMENT is the
+     * load-bearing input here, and a label that says fmt=8 with the argument
+     * left at a stale ordinal turns every assertion below into a tautology
+     * (want and got both fall to the same per-row default together). Pin the
+     * argument to the supported set so label/argument drift dies loudly at
+     * the call site instead. */
+    if(fmt!=1 && fmt!=4 && fmt!=5 && fmt!=6 && fmt!=8){
+        printf("FAIL %s: check_wire_split fmt=%d not in supported set {1,4,5,6,8} -- stale call site?\n", tag, fmt);
+        CHECK(0); return;
+    }
     QT t; memset(&t,0,sizeof t); t.fmt=fmt; t.O=O; t.I=I; t.gs=gs;
     int64_t want_scale = qt_scale_bytes(&t);
     int64_t want_weight = qt_bytes(&t) - want_scale;
@@ -499,17 +510,30 @@ static void check_wire_split(int fmt, int O, int I, int gs, const char *tag){
     CHECK(got_weight == want_weight);
     /* the regression this test exists to catch: a per-row-only scale_b==O*4
      * must NOT be what qt_wire_split returns for a format whose real scale
-     * cardinality differs from O (fmt=4/5/6/7 here) -- confirm the value has
+     * cardinality differs from O (fmt=4/5/6/8 here) -- confirm the value has
      * actually moved off that old constant, not just matched qt_scale_bytes()
      * by coincidence at a degenerate shape. */
     int64_t old_wrong_scale = (int64_t)O*4;
-    if((fmt==4 || fmt==5 || fmt==6 || fmt==7) && want_scale != old_wrong_scale)
+    if((fmt==4 || fmt==5 || fmt==6 || fmt==8) && want_scale != old_wrong_scale)
         CHECK(got_scale != old_wrong_scale);
     /* fmt=6's scale is a FIXED 4 bytes regardless of [O,I] -- assert the
      * literal value directly too, not just "moved off O*4", since a future
      * regression that made it O-dependent in some OTHER wrong way would
      * still pass the generic check above. */
     if(fmt==6) CHECK(want_scale == 4);
+    /* fmt=8: same independent-pin discipline as the fmt==6 literal above.
+     * want and got BOTH flow through the engine's qt_scale_bytes() (the test
+     * computes want from it, and qt_wire_split() calls it), so a reverted or
+     * deleted fmt==8 branch would move both sides to O*4 TOGETHER: the
+     * got==want checks stay green and the moved-off-O*4 check self-disables
+     * (its want_scale != O*4 guard goes false). Recomputing the expected
+     * block-grid value here, independently of the engine, is what makes a
+     * regression of that branch actually FAIL this test (mutation-proven,
+     * fix round 1). */
+    if(fmt==8){
+        int64_t nblk = (((int64_t)O+127)/128) * (((int64_t)I+127)/128);
+        CHECK(want_scale == nblk*4);
+    }
 }
 
 /* ---- Site-level wire regression (FIX ROUND, validator finding: mutation-
@@ -544,7 +568,7 @@ static void test_wire_site_regression(void){
     for(int i=0;i<NBLK;i++) s7[i]=0.01f+0.001f*(float)i;
 
     QT t; memset(&t,0,sizeof t);
-    t.fmt=7; t.O=O; t.I=I; t.gs=0; t.q8=(int8_t*)q7; t.s=s7;
+    t.fmt=8; t.O=O; t.I=I; t.gs=0; t.q8=(int8_t*)q7; t.s=s7;
 
     int64_t want_scale = qt_scale_bytes(&t);
     int64_t want_weight = qt_bytes(&t) - want_scale;
@@ -600,17 +624,17 @@ int main(void){
     test_fmt6_fp8_collision();
     test_ue8m0_scale_refusal();
     test_loader_seam();
-    check_fp8_bytes(2048,6144, "qt_bytes fmt=7 gate/up-shaped O=2048 I=6144 (spec example)");
-    check_fp8_bytes(6144,2048, "qt_bytes fmt=7 down-shaped O=6144 I=2048");
-    check_fp8_bytes(130,200,   "qt_bytes fmt=7 block edges O,I both non-mult-128");
-    check_fp8_bytes(1,1,       "qt_bytes fmt=7 degenerate 1x1");
+    check_fp8_bytes(2048,6144, "qt_bytes fmt=8 gate/up-shaped O=2048 I=6144 (spec example)");
+    check_fp8_bytes(6144,2048, "qt_bytes fmt=8 down-shaped O=6144 I=2048");
+    check_fp8_bytes(130,200,   "qt_bytes fmt=8 block edges O,I both non-mult-128");
+    check_fp8_bytes(1,1,       "qt_bytes fmt=8 degenerate 1x1");
     check_wire_split(1, 4096,4096, 0,  "qt_wire_split fmt=1 plain int8 (per-row scale, unaffected by the fix)");
     check_wire_split(4, 2048,6144, 64, "qt_wire_split fmt=4 grouped int4 (O*ceil(I/gs) scale, not O*4)");
     check_wire_split(5, 2048,6144, 0,  "qt_wire_split fmt=5 int3-g64 (O*ceil(I/64) scale, not O*4)");
     check_wire_split(6, 2048,6144, 0,  "qt_wire_split fmt=6 E8/IQ3 (FIXED 4-byte tag, not O*4=8192B)");
     check_wire_split(6, 1,1,       0,  "qt_wire_split fmt=6 E8/IQ3 degenerate O=1 (O*4 would coincidentally also be 4 -- exercises the literal-4 assert, not just the moved-off-O*4 one)");
-    check_wire_split(7, 2,16384, 0,    "qt_wire_split fmt=7 nblk(128) >> O(2): scale=512B, NOT O*4=8B");
-    check_wire_split(7, 2048,6144, 0,  "qt_wire_split fmt=7 spec example: scale=3072B, NOT O*4=8192B");
+    check_wire_split(8, 2,16384, 0,    "qt_wire_split fmt=8 nblk(128) >> O(2): scale=512B, NOT O*4=8B");
+    check_wire_split(8, 2048,6144, 0,  "qt_wire_split fmt=8 spec example: scale=3072B, NOT O*4=8192B");
     test_wire_site_regression();
     if(fails){ printf("fp8 loader-seam tests: %d FAILED\n", fails); return 1; }
     printf("fp8 loader-seam tests: ok\n");

--- a/c/tests/test_fp8_load.c
+++ b/c/tests/test_fp8_load.c
@@ -52,7 +52,15 @@
  * qt_wire_split() -- the shared weight/scale byte-range split qt_wire_mmap
  * and qt_unwire_mmap both now call (maintainer review, #528: qt_scale_bytes()
  * existed correctly but neither call site actually used it, a defect only
- * -Wno-unused-function's suppression let compile clean).
+ * -Wno-unused-function's suppression let compile clean). check_wire_split()
+ * exercises qt_wire_split() itself directly; test_wire_site_regression()
+ * (FIX ROUND, validator finding) additionally exercises the real
+ * qt_wire_mmap()/qt_unwire_mmap() call sites through a mem_wire()/munlock()
+ * observer seam (defined right below the #include below) -- a mutation that
+ * reverts ONLY those two call sites back to the old scale_b=(int64_t)t->O*4
+ * hardcode, leaving qt_wire_split() itself untouched, is invisible to
+ * check_wire_split() but fails test_wire_site_regression() (proven by
+ * actually running that exact mutation -- see the report).
  *
  * This build has NO container metadata stamp (see qt_resolve_fmt's own header
  * comment) -- every ambiguous/unimplemented-encoding shape below EXCEPT the
@@ -60,9 +68,41 @@
  * unconditionally; stamp-resolves-ambiguity behavior for the OTHER
  * collisions is a separate, follow-up PR (registry + metadata stamp), not
  * exercised here. */
+/* WIRE-SITE REGRESSION SEAM (FIX ROUND, validator finding). First attempt
+ * (superseded, kept as a note): renaming mem_wire() itself via macro does
+ * NOT work as an observer seam -- mem_wire is a real, internally-defined
+ * static function, so the SAME rename that frees up the name "mem_wire"
+ * for a shadow ALSO renames every CALL SITE (qt_wire_mmap's) to the new
+ * name, meaning qt_wire_mmap ends up calling the renamed-but-still-real
+ * function directly, bypassing any shadow defined under the old name
+ * entirely (confirmed by inspecting the preprocessed output -- caught
+ * before it could hide a broken test). The seam that actually works is one
+ * level lower: mlock()/munlock() themselves are EXTERNAL POSIX library
+ * functions with no body anywhere in this translation unit (only a
+ * declaration, via <sys/mman.h>, plus mem_wire's/qt_unwire_mmap's own call
+ * sites) -- renaming them redirects those call sites to a name THIS FILE
+ * provides its own (self-contained) definition for, with no real
+ * implementation being shadowed out of existence. This observes the EXACT
+ * (addr,len) qt_wire_mmap (via mem_wire) and qt_unwire_mmap actually pass
+ * down to the platform lock/unlock call -- not a reimplementation of what
+ * they SHOULD pass, and immune to a future mem_wire refactor since the
+ * seam sits at the syscall boundary, not the wrapper. #ifndef _WIN32:
+ * mlock/munlock are only called on this `#if defined(__APPLE__) ||
+ * defined(__linux__) || defined(__FreeBSD__)` arm; Windows uses
+ * compat_mlock/compat_munlock instead (untouched here, matching this
+ * file's existing POSIX-only test-seam convention -- the fork/pipe/waitpid
+ * refusal tests below skip analogously on Windows). */
+#ifndef _WIN32
+#define mlock test_mlock_seam
+#define munlock test_munlock_seam
+#endif
 #define main coli_glm_main_unused
 #include "../colibri.c"
 #undef main
+#ifndef _WIN32
+#undef mlock
+#undef munlock
+#endif
 
 #include <stdio.h>
 #include <string.h>
@@ -70,6 +110,38 @@
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/wait.h>
+#endif
+
+/* Shadow definitions for the seam above -- must come after the #include so
+ * mem_wire's (unmodified, real) call to mlock() and qt_unwire_mmap's
+ * (unmodified, real) call to munlock() have already been renamed to these
+ * names by the #define above. Neither mlock() nor munlock() has a body
+ * anywhere in this translation unit (both are declared only, via
+ * <sys/mman.h>) -- these are the ONLY definitions the renamed call sites
+ * can resolve to, both self-contained: returning 0 (success) without
+ * actually locking/unlocking anything is fine for this test, since the
+ * buffer under test is never really mlocked in the first place (mirrors
+ * check_fp8_bytes'/check_wire_split's own stated reasoning that the real
+ * RLIMIT_MEMLOCK-gated syscall's success is environment-dependent and not
+ * what any of these tests need to prove). Non-static: both must match the
+ * extern linkage of the (renamed) declarations <sys/mman.h> already left in
+ * this translation unit -- a static definition here would conflict with
+ * that non-static declaration ("static declaration follows non-static
+ * declaration"). g_seam_wire_* observes mem_wire's (hence qt_wire_mmap's)
+ * calls; g_seam_unwire_* observes qt_unwire_mmap's direct calls. */
+#ifndef _WIN32
+static void *g_seam_wire_addr[4]; static size_t g_seam_wire_len[4]; static int g_seam_wire_n;
+int test_mlock_seam(const void *addr, size_t len){
+    if(g_seam_wire_n < 4){ g_seam_wire_addr[g_seam_wire_n]=(void*)addr; g_seam_wire_len[g_seam_wire_n]=len; }
+    g_seam_wire_n++;
+    return 0;
+}
+static void *g_seam_unwire_addr[4]; static size_t g_seam_unwire_len[4]; static int g_seam_unwire_n;
+int test_munlock_seam(const void *addr, size_t len){
+    if(g_seam_unwire_n < 4){ g_seam_unwire_addr[g_seam_unwire_n]=(void*)addr; g_seam_unwire_len[g_seam_unwire_n]=len; }
+    g_seam_unwire_n++;
+    return 0;
+}
 #endif
 
 static int fails = 0;
@@ -433,6 +505,89 @@ static void check_wire_split(int fmt, int O, int I, int gs, const char *tag){
         CHECK(got_scale != old_wrong_scale);
 }
 
+/* ---- Site-level wire regression (FIX ROUND, validator finding: mutation-
+ * proven gap). check_wire_split() above calls qt_wire_split() directly --
+ * it would NOT notice a mutation that reverts ONLY qt_wire_mmap's and
+ * qt_unwire_mmap's call sites back to the old inline
+ * `scale_b=(int64_t)t->O*4` hardcode, leaving qt_wire_split() itself
+ * intact (the two sites would simply stop CALLING the now-orphaned-again
+ * helper). This test calls the real qt_wire_mmap()/qt_unwire_mmap()
+ * functions and asserts, through the mlock()/munlock() observer seam
+ * defined above (right after the #include), that the (addr,len) each site
+ * ACTUALLY passed down to the platform lock call matches
+ * qt_scale_bytes()/qt_bytes() -- i.e. it observes the call sites' own
+ * behavior, not a reimplementation of it. Shape chosen so a reverted site
+ * is unmistakably wrong, not coincidentally right: O=2, I=16384 ->
+ * nblkO=1, nblkI=128, nblk=128, scale_b=512B; the old hardcode would
+ * compute O*4=8B instead, a 64x difference. Proven to bite: see the
+ * report's mutation output (the exact single-line revert, applied and
+ * reverted, with the resulting FAIL line pasted in). POSIX-only (like this
+ * file's fork-based refusal tests): the observer seam only intercepts the
+ * `#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)`
+ * arm both qt_wire_mmap (via mem_wire) and qt_unwire_mmap take -- Windows
+ * takes a different call (compat_mlock/compat_munlock) not intercepted
+ * here. */
+static void test_wire_site_regression(void){
+#ifndef _WIN32
+    g_seam_wire_n = 0; g_seam_unwire_n = 0;
+    enum { O=2, I=16384 };
+    enum { NBLKO = CDIV(O,128), NBLKI = CDIV(I,128), NBLK = NBLKO*NBLKI };
+    static uint8_t q7[O*I]; static float s7[NBLK];
+    for(int i=0;i<O*I;i++) q7[i]=rndbyte_nonan();
+    for(int i=0;i<NBLK;i++) s7[i]=0.01f+0.001f*(float)i;
+
+    QT t; memset(&t,0,sizeof t);
+    t.fmt=7; t.O=O; t.I=I; t.gs=0; t.q8=(int8_t*)q7; t.s=s7;
+
+    int64_t want_scale = qt_scale_bytes(&t);
+    int64_t want_weight = qt_bytes(&t) - want_scale;
+    /* sanity: this shape must actually distinguish the fix from the old bug,
+     * or the test below would pass either way and prove nothing. */
+    CHECK(want_scale != (int64_t)O*4);
+
+    /* qt_wire_mmap doesn't itself gate on g_mmap/mem_should_wire (its
+     * caller, pin_wire, does) -- calling it directly always attempts to
+     * wire, which is exactly what this test wants. */
+    int64_t wired=0; long failed=0;
+    qt_wire_mmap(&t, &wired, &failed);
+    if(g_seam_wire_n != 2)
+        printf("FAIL wire-site regression: qt_wire_mmap called mlock() %d times, expected 2\n", g_seam_wire_n);
+    CHECK(g_seam_wire_n == 2);
+    if(g_seam_wire_n >= 1 && (int64_t)g_seam_wire_len[0] != want_weight)
+        printf("FAIL wire-site regression: qt_wire_mmap's WEIGHT mlock() call got len=%lld want=%lld\n",
+               (long long)g_seam_wire_len[0], (long long)want_weight);
+    CHECK(g_seam_wire_n>=1 && (int64_t)g_seam_wire_len[0]==want_weight);
+    if(g_seam_wire_n >= 2 && (int64_t)g_seam_wire_len[1] != want_scale)
+        printf("FAIL wire-site regression: qt_wire_mmap's SCALE mlock() call got len=%lld want=%lld "
+               "(this is exactly what a reverted scale_b=O*4 hardcode breaks)\n",
+               (long long)g_seam_wire_len[1], (long long)want_scale);
+    CHECK(g_seam_wire_n>=2 && (int64_t)g_seam_wire_len[1]==want_scale);
+
+    /* qt_unwire_mmap early-returns unless g_mmap && mem_should_wire() are
+     * both true -- force both on for this call, then restore, so this test
+     * doesn't change global state for any test that runs after it. */
+    int saved_g_mmap = g_mmap, saved_g_mlock = g_mlock;
+    g_mmap = 1; g_mlock = 1;
+    qt_unwire_mmap(&t);
+    g_mmap = saved_g_mmap; g_mlock = saved_g_mlock;
+
+    if(g_seam_unwire_n != 2)
+        printf("FAIL wire-site regression: qt_unwire_mmap called munlock() %d times, expected 2\n", g_seam_unwire_n);
+    CHECK(g_seam_unwire_n == 2);
+    if(g_seam_unwire_n >= 1 && (int64_t)g_seam_unwire_len[0] != want_weight)
+        printf("FAIL wire-site regression: qt_unwire_mmap's WEIGHT munlock() call got len=%lld want=%lld\n",
+               (long long)g_seam_unwire_len[0], (long long)want_weight);
+    CHECK(g_seam_unwire_n>=1 && (int64_t)g_seam_unwire_len[0]==want_weight);
+    if(g_seam_unwire_n >= 2 && (int64_t)g_seam_unwire_len[1] != want_scale)
+        printf("FAIL wire-site regression: qt_unwire_mmap's SCALE munlock() call got len=%lld want=%lld "
+               "(this is exactly what a reverted scale_b=O*4 hardcode breaks)\n",
+               (long long)g_seam_unwire_len[1], (long long)want_scale);
+    CHECK(g_seam_unwire_n>=2 && (int64_t)g_seam_unwire_len[1]==want_scale);
+#else
+    printf("skipped on Windows (no mlock/munlock observer seam): wire-site regression\n");
+#endif
+}
+
 int main(void){
     test_disambiguation();
     test_fmt6_fp8_collision();
@@ -447,6 +602,7 @@ int main(void){
     check_wire_split(5, 2048,6144, 0,  "qt_wire_split fmt=5 int3-g64 (O*ceil(I/64) scale, not O*4)");
     check_wire_split(7, 2,16384, 0,    "qt_wire_split fmt=7 nblk(128) >> O(2): scale=512B, NOT O*4=8B");
     check_wire_split(7, 2048,6144, 0,  "qt_wire_split fmt=7 spec example: scale=3072B, NOT O*4=8192B");
+    test_wire_site_regression();
     if(fails){ printf("fp8 loader-seam tests: %d FAILED\n", fails); return 1; }
     printf("fp8 loader-seam tests: ok\n");
     return 0;

--- a/c/tests/test_fp8_load.c
+++ b/c/tests/test_fp8_load.c
@@ -111,6 +111,7 @@
 #ifndef _WIN32
 #include <unistd.h>
 #include <sys/wait.h>
+#include <fcntl.h>      /* open(/dev/null) in Part G's sweep probe */
 #endif
 
 /* Shadow definitions for the seam above -- must come after the #include so
@@ -619,6 +620,135 @@ static void test_wire_site_regression(void){
 #endif
 }
 
+/* ---- Part F (micro-round 2): Metal fused-path POSITIVE allowlist ----
+ * The two fused-decode gates (attention_rows / layer_forward_rows) are only
+ * reachable at model scale (GLM-5.2 dims + a live Metal context), so the
+ * honest toy-scale decomposition is: (1) unit-test the predicate's truth
+ * table -- metal_fused_fmt_ok is defined unconditionally in colibri.c for
+ * exactly this reason -- and (2) pin, by reading colibri.c's own source,
+ * that BOTH gate sites actually consult the predicate on every fused-path
+ * tensor and that the old fail-open `l-><t>.fmt!=8` idiom is gone. The pin
+ * is a source-text assertion, disclosed as such: it proves wiring, not
+ * runtime routing; the truth table proves the routing decision itself. */
+static void test_metal_fused_allowlist(void){
+    /* (1) truth table: admits EXACTLY the shader's explicit integer-format
+     * set {1,2,3,4} (fmt=3 was legal-and-correct on the fused path before
+     * the allowlist existed; fmt=0 never actually fused -- WP_ hands the
+     * shader a NULL q4 for it). A negative-guard regression (e.g.
+     * `return fmt!=8;`) admits 5/6 -- the silent-f32-misread hazard -- and
+     * fails here. */
+    for(int fmt=-1; fmt<=9; fmt++){
+        int want = (fmt==1 || fmt==2 || fmt==3 || fmt==4);
+        if(metal_fused_fmt_ok(fmt) != want)
+            printf("FAIL metal_fused_fmt_ok(%d)=%d, want %d\n", fmt, metal_fused_fmt_ok(fmt), want);
+        CHECK(metal_fused_fmt_ok(fmt) == want);
+    }
+    CHECK(!metal_fused_fmt_ok(100));   /* private-block ordinals stay out too */
+    /* (2) grep-pin: run_tests.py runs us with cwd=c/ (Part B's fixtures rely
+     * on the same fact). 11 per-tensor call sites = 4 (attention_rows:
+     * q_a/q_b/kv_a/o) + 7 (layer_forward_rows: those + sh_gate/sh_up/sh_down). */
+    FILE *f = fopen("colibri.c", "r");
+    if(!f){ printf("FAIL Part F grep-pin: cannot open colibri.c (cwd not c/?)\n"); CHECK(0); return; }
+    static char src[16*1024*1024];
+    size_t n = fread(src, 1, sizeof(src)-1, f); src[n]=0; fclose(f);
+    CHECK(n > 100000);                      /* sanity: we read the real file */
+    int calls=0; const char *p=src;
+    while((p=strstr(p,"metal_fused_fmt_ok(l->"))!=NULL){ calls++; p++; }
+    if(calls!=11) printf("FAIL Part F grep-pin: %d metal_fused_fmt_ok(l->...) call sites, want 11\n", calls);
+    CHECK(calls==11);
+    /* the old fail-open idiom must be gone from the gate sites (the CUDA
+     * eligibility guard's `w->fmt!=8` is a different site and untouched). */
+    CHECK(strstr(src,"l->q_a.fmt!=8")==NULL);
+    CHECK(strstr(src,"l->sh_gate.fmt!=8")==NULL);
+}
+
+/* ---- Part G (micro-round 2): fmt=7 is unreachable as a qt_resolve_fmt
+ * return value -- property sweep. The fmt=7 ordinal belongs to dev's MXFP4
+ * (Vulkan tier, never a QT format); matmul_qt_ex's int4 tail is therefore
+ * unreachable for it, and this sweep is the RAN half of that argument (the
+ * other half is the producer enumeration in the PR verification matrix:
+ * every QT.fmt producer is qt_resolve_fmt, qt_alloc's 0/1/2/3/5 ladder, or
+ * a literal 1..6/8 assignment). Sweep a representative + adversarial
+ * (O, I, nb, ns) grid across every byte-count class the resolver knows
+ * (row formats, grouped, int3-g64, E8/IQ3, fp8 f32/ue8m0, collision-family
+ * members, degenerate dims) and assert every non-refusing resolution is in
+ * {1,2,3,4,5,6,8} -- never 7, never anything else. */
+static int resolved_fmt_probe(int O, int I, int64_t nb, int64_t ns){
+#ifndef _WIN32
+    fflush(stdout);   /* a refusing child exits via exit(1), which flushes
+                       * inherited stdio -- don't let it replay our buffer */
+    int pipefd[2]; if(pipe(pipefd)!=0) return -2;
+    pid_t pid = fork();
+    if(pid < 0) return -2;
+    if(pid == 0){
+        int devnull = open("/dev/null", O_WRONLY);
+        if(devnull>=0) dup2(devnull,2);                 /* silence refusal chatter */
+        close(pipefd[0]);
+        int gs=0;
+        int fmt = qt_resolve_fmt("sweep", O, I, nb, ns, &gs);
+        unsigned char b = (unsigned char)fmt;
+        ssize_t wr = write(pipefd[1], &b, 1); (void)wr;
+        _exit(0);
+    }
+    close(pipefd[1]);
+    unsigned char b=0; ssize_t got = read(pipefd[0], &b, 1);
+    close(pipefd[0]);
+    int status=0; waitpid(pid,&status,0);
+    if(WIFEXITED(status) && WEXITSTATUS(status)==0 && got==1) return (int)b;
+    if(WIFEXITED(status) && WEXITSTATUS(status)==1) return -1;   /* refused */
+    return -2;                                                    /* crash/protocol: always a failure */
+#else
+    (void)O;(void)I;(void)nb;(void)ns;
+    return -3;                                                    /* sweep skipped on Windows */
+#endif
+}
+static void test_fmt7_unreachable_sweep(void){
+#ifndef _WIN32
+    static const int Os[] = {1,2,3,24,32,33,64,98,127,128,129,130,384,400,576,2048};
+    static const int Is[] = {1,64,98,128,129,200,256,257,384,400,512,1024,6144,16384,33000};
+    int probes=0, resolved=0, refused=0;
+    for(size_t oi=0; oi<sizeof(Os)/sizeof(Os[0]); oi++){
+        for(size_t ii=0; ii<sizeof(Is)/sizeof(Is[0]); ii++){
+            int O=Os[oi], I=Is[ii];
+            int64_t nblk = fp8_nblk(O)*fp8_nblk(I);
+            /* every (nb, ns) class the resolver's ladder can see, incl. the
+             * adversarial cross-wired ones (row-shaped ns on block-shaped nb
+             * and vice versa): */
+            const int64_t cand[][2] = {
+                { (int64_t)O*I,              (int64_t)O*4 },        /* int8-row shaped   */
+                { (int64_t)O*I,              nblk*4       },        /* fp8 f32 block     */
+                { (int64_t)O*I,              nblk         },        /* fp8 ue8m0 block   */
+                { (int64_t)O*((I+1)/2),      (int64_t)O*4 },        /* int4-row          */
+                { (int64_t)O*((I+3)/4),      (int64_t)O*4 },        /* int2-row          */
+                { (int64_t)O*((I+1)/2),      (int64_t)O*((I+63)/64)*4 }, /* int4-grouped g64 */
+                { (int64_t)O*i3_rowbytes(I), (int64_t)O*i3_groups(I)*4 },/* int3-g64      */
+                { (int64_t)O*e8_rowbytes(I), 4 },                   /* E8/IQ3 tag        */
+                { (int64_t)O*I,              4 },                   /* cross-wired tag   */
+                { (int64_t)O*I,              0 },                   /* degenerate ns     */
+                { 0,                          (int64_t)O*4 },       /* degenerate nb     */
+            };
+            for(size_t c=0; c<sizeof(cand)/sizeof(cand[0]); c++){
+                int f = resolved_fmt_probe(O, I, cand[c][0], cand[c][1]);
+                probes++;
+                if(f==-2){ printf("FAIL sweep O=%d I=%d nb=%lld ns=%lld: crash/protocol error\n",
+                                  O,I,(long long)cand[c][0],(long long)cand[c][1]); CHECK(0); continue; }
+                if(f==-1){ refused++; continue; }
+                resolved++;
+                int ok = (f==1||f==2||f==3||f==4||f==5||f==6||f==8);
+                if(!ok) printf("FAIL sweep O=%d I=%d nb=%lld ns=%lld: resolved to fmt=%d (outside {1,2,3,4,5,6,8})\n",
+                               O,I,(long long)cand[c][0],(long long)cand[c][1],f);
+                CHECK(ok);
+                CHECK(f != 7);
+            }
+        }
+    }
+    /* the sweep must have actually exercised both arms, or it proved nothing. */
+    CHECK(probes >= 2000 && resolved >= 100 && refused >= 100);
+#else
+    printf("skipped on Windows (no fork): fmt=7 unreachability sweep\n");
+#endif
+}
+
 int main(void){
     test_disambiguation();
     test_fmt6_fp8_collision();
@@ -636,6 +766,8 @@ int main(void){
     check_wire_split(8, 2,16384, 0,    "qt_wire_split fmt=8 nblk(128) >> O(2): scale=512B, NOT O*4=8B");
     check_wire_split(8, 2048,6144, 0,  "qt_wire_split fmt=8 spec example: scale=3072B, NOT O*4=8192B");
     test_wire_site_regression();
+    test_metal_fused_allowlist();
+    test_fmt7_unreachable_sweep();
     if(fails){ printf("fp8 loader-seam tests: %d FAILED\n", fails); return 1; }
     printf("fp8 loader-seam tests: ok\n");
     return 0;

--- a/c/tests/test_fp8_load.c
+++ b/c/tests/test_fp8_load.c
@@ -1,0 +1,369 @@
+/* fmt=7 (native FP8-e4m3 passthrough) loader-seam tests.
+ *
+ * fmt=7, PUBLIC ordinal assigned by the maintainer on #524: this format was
+ * minted fmt=6 during original development of this branch, before dev's own
+ * #465 (E8/IQ3) claimed that ordinal upstream and merged it into dev as a
+ * REAL fmt=6 (see quant.h's E8 constants and e8_ helper functions, and
+ * qt_resolve_fmt's ns==4-tag early check); re-tagged fmt=100 (PRIVATE ORDINAL
+ * BLOCK, see colibri.c's QT struct comment) from that point forward -- there
+ * was never a build in this branch's history where this format was reachable
+ * as fmt=6 -- and graduated to fmt=7 at merge.
+ *
+ * Part A: qt_resolve_fmt disambiguation suite -- THE DESIGN LANDMINE. fmt=7
+ * weight bytes are byte-identical to fmt=1 (int8): both are O*I raw bytes.
+ * The two are told apart ONLY by the scale array's byte count (per-row O*4 for
+ * fmt=1, per-128x128-block ceil(O/128)*ceil(I/128)*4 for fmt=7, THIS build's
+ * implemented f32 scale encoding). For some shapes those two counts coincide
+ * exactly -- qt_resolve_fmt must REFUSE (exit(1)) rather than guess. Refusal
+ * is tested via fork()+waitpid(), mirroring tests/test_st_pread.c's
+ * established convention for exit(1)-terminated paths.
+ *
+ * Part A2: fmt=6 (E8/IQ3, upstream #465) vs fmt=7 collision at [O<=128 or
+ * O in a 128-block-count range, I=98] -- SECOND DESIGN LANDMINE.
+ *
+ * Part A3: fmt=7's scale ENCODING is a declared property, not a hardcoded
+ * constant -- f32 (Part A/A2 above) is what this build implements. A UE8M0
+ * (1 byte/block) encoding is a REAL, distinct byte signature (the DeepSeek-V4
+ * checkpoint format for this identical weight geometry) this build recognizes
+ * and refuses BY NAME rather than misreading.
+ *
+ * Part B: qt_from_disk loader-seam -- writes a real single-shard .safetensors
+ * file containing an fmt=7 tensor (U8 weight + per-block F32 .qs) next to an
+ * int8 control tensor of a DIFFERENT, non-colliding shape, loads both through
+ * qt_from_disk, and checks the byte-count/.qs-size inference picks fmt=7 vs
+ * fmt=1 correctly and the loaded weights dequantize identically to a reference.
+ * Mirrors tests/test_int3_load.c's structure for fmt=5.
+ *
+ * Part C: qt_bytes()/qt_scale_bytes() byte-accounting for fmt=7.
+ *
+ * This build has NO container metadata stamp (see qt_resolve_fmt's own header
+ * comment) -- every ambiguous/unimplemented-encoding shape below refuses
+ * unconditionally; stamp-resolves-ambiguity behavior is a separate, follow-up
+ * PR (registry + metadata stamp), not exercised here. */
+#define main coli_glm_main_unused
+#include "../colibri.c"
+#undef main
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#ifndef _WIN32
+#include <unistd.h>
+#include <sys/wait.h>
+#endif
+
+static int fails = 0;
+#define CHECK(c) do{ if(!(c)){ printf("FAIL %s:%d: %s\n", __FILE__, __LINE__, #c); fails++; } }while(0)
+
+static uint64_t rng = 0xFEEDFACE0DDBA11ull;
+static float rndf(void){ rng ^= rng << 13; rng ^= rng >> 7; rng ^= rng << 17;
+    return ((int64_t)(rng & 0xFFFFF) - 0x80000) / (float)0x80000; }
+static uint8_t rndbyte_nonan(void){
+    for(;;){ rng ^= rng << 13; rng ^= rng >> 7; rng ^= rng << 17;
+        uint8_t b = (uint8_t)(rng & 0xFF);
+        if(b != 0x7F && b != 0xFF) return b; }
+}
+
+/* ---- Part A: qt_resolve_fmt disambiguation (in-process for non-refusing
+ * cases, fork+waitpid for refusing ones -- qt_resolve_fmt exit(1)s in place,
+ * it does not return an error code). ---- */
+
+static int expect_fmt(int O, int I, int64_t nb, int64_t ns, int expect_fmt_val, const char *tag){
+    int gs=0;
+    int fmt = qt_resolve_fmt(tag, O, I, nb, ns, &gs);
+    if(fmt != expect_fmt_val){
+        printf("FAIL %s: got fmt=%d, expected fmt=%d (O=%d I=%d nb=%lld ns=%lld)\n",
+               tag, fmt, expect_fmt_val, O, I, (long long)nb, (long long)ns);
+        return 0;
+    }
+    return 1;
+}
+
+static int expect_refuse(int O, int I, int64_t nb, int64_t ns, const char *tag){
+#ifndef _WIN32
+    int pipefd[2]; if(pipe(pipefd)!=0) return 0;
+    pid_t pid = fork();
+    if(pid < 0) return 0;
+    if(pid == 0){
+        dup2(pipefd[1],2); close(pipefd[0]); close(pipefd[1]);
+        int gs=0;
+        qt_resolve_fmt(tag, O, I, nb, ns, &gs);   /* must exit(1) inside; must NOT return */
+        _exit(42);                                  /* reaching here is the bug */
+    }
+    close(pipefd[1]);
+    char err[1024]={0}; ssize_t n=read(pipefd[0],err,sizeof(err)-1); (void)n;
+    close(pipefd[0]);
+    int status=0; waitpid(pid,&status,0);
+    int ok = WIFEXITED(status) && WEXITSTATUS(status)==1;
+    if(!ok){
+        printf("FAIL %s: expected exit(1) refusal, got status=%d, stderr=%.200s\n", tag, status, err);
+        return 0;
+    }
+    if(!strstr(err,"refus")){
+        printf("FAIL %s: exited(1) but message lacked a refusal explanation: %.200s\n", tag, err);
+        return 0;
+    }
+    return 1;
+#else
+    /* fork/pipe/waitpid are POSIX -- mirrors tests/test_st_pread.c's own
+     * Windows arm: skip the exit(1) subprocess check, print an explicit
+     * (never silent) skip line per case, count it as passing rather than
+     * failing. Every non-refusing case in this file (expect_fmt and its
+     * callers) still runs and asserts for real on Windows. */
+    printf("skipped on Windows (no fork): %s\n", tag);
+    (void)O; (void)I; (void)nb; (void)ns;
+    return 1;
+#endif
+}
+
+static void test_disambiguation(void){
+    /* --- non-degenerate golden paths (unambiguous either way) --- */
+    CHECK(expect_fmt(4096,4096,(int64_t)4096*4096,4096*4,1,"plain int8 4096x4096"));
+    /* spec's own worked example: [2048,6144] expert -> block scale [16,48] */
+    CHECK(expect_fmt(2048,6144,(int64_t)2048*6144,16LL*48*4,7,"fp8 2048x6144 (spec example)"));
+    CHECK(expect_fmt(384,6144,(int64_t)384*6144,3LL*48*4,7,"fp8 384x6144 non-square block grid"));
+
+    /* --- degenerate shapes: O<=128 makes nblkO==1, so ns_blk==nblkI*4 can
+     * equal ns_row==O*4 whenever nblkI==O. Exhaustive-in-spirit sweep of the
+     * boundary the design landmine describes. --- */
+    CHECK(expect_refuse(1,1,      1,        4,  "degenerate O=1 I=1 (nblkI=1=O)"));
+    CHECK(expect_refuse(1,128,    128,      4,  "degenerate O=1 I=128 (nblkI=1=O, I at block edge)"));
+    CHECK(expect_refuse(2,256,    2LL*256,  8,  "degenerate O=2 I=256 (nblkI=2=O)"));
+    CHECK(expect_refuse(6,768,    6LL*768,  24, "degenerate O=6 I=768 (nblkI=6=O)"));
+    CHECK(expect_refuse(128,16384,128LL*16384, 512, "degenerate O=128 I=16384 (nblkO=1,nblkI=128=O)"));
+    /* O>128 degenerate case: nblkO=2, need nblkI=O/2 -- O=256,I=16384 -> nblkI=128, 2*128=256=O */
+    CHECK(expect_refuse(256,16384,256LL*16384, 1024, "degenerate O=256 I=16384 (nblkO=2,nblkI=128, product=O)"));
+    /* k=3: the ambiguity isn't a one-off O=256 coincidence -- it's structural for ANY
+     * O that's a multiple of 128 (nblkO=k), since nblkI==128 (I in (16256,16384]) always
+     * makes nblkO*nblkI == k*128 == O. One more multiple (O=384=3*128) confirms the
+     * condition generalizes past the k=2 worked example, not just a re-derivation. */
+    CHECK(expect_refuse(384,16384,384LL*16384, 1536, "degenerate O=384 I=16384 (nblkO=3,nblkI=128, k=3, product=O)"));
+
+    /* --- boundary-ADJACENT non-degenerate cases: one step past each
+     * degenerate case above, both interpretations now legitimately resolve. --- */
+    CHECK(expect_fmt(1,129, 129,   4, 1, "adjacent O=1 I=129 as fmt=1 (ns=row)"));
+    CHECK(expect_fmt(1,129, 129,   8, 7, "adjacent O=1 I=129 as fmt=7 (ns=block, nblkI=2)"));
+    CHECK(expect_fmt(2,257, 2LL*257, 8,  1, "adjacent O=2 I=257 as fmt=1 (ns=row)"));
+    CHECK(expect_fmt(2,257, 2LL*257, 12, 7, "adjacent O=2 I=257 as fmt=7 (ns=block, nblkI=3)"));
+
+    /* --- neither interpretation matches: garbage .qs size, must still refuse
+     * (the pre-existing generic-mismatch path, exercised through the fmt=7-aware
+     * function to confirm the new code didn't disturb it). --- */
+    CHECK(expect_refuse(10,10, 100, 999, "garbage ns matches neither row nor block layout"));
+}
+
+/* ---- Part A2: fmt=6 (E8/IQ3, upstream #465, merged into dev) vs fmt=7
+ * (this branch's fp8-e4m3-b128) collision -- SECOND DESIGN LANDMINE, see the
+ * derivation in qt_resolve_fmt's own comment. e8_rowbytes(I) is the constant
+ * 98 for every I in (0,256], so dev's fmt=6 tag check (ns==4 &&
+ * nb==O*e8_rowbytes(I)) collapses to nb==O*98 -- which coincides with
+ * fp8-e4m3-b128's raw weight bytes (O*I) at the ONE value I==98, where a
+ * SINGLE-BLOCK (O<=128) fp8 tensor with f32 block scales, OR a FOUR-BLOCK
+ * fp8 tensor with ue8m0 (1 byte/block) scales, ALSO carries exactly ns==4,
+ * same as the E8 tag. An unstamped [I=98] fp8-e4m3-b128 tensor at either of
+ * those shapes is therefore byte-for-byte indistinguishable from a genuine
+ * fmt=6 tensor: nb AND ns both coincide, not just ns (contrast the fmt=1/
+ * fmt=7 collision in Part A, where only ns ever coincides). O==1 stacks a
+ * THIRD candidate: fmt=1's per-row ns (O*4) is also 4 there. This build has
+ * no stamp to resolve any of these -- every one refuses. */
+static void test_fmt6_fp8_collision(void){
+    /* O=64, I=98: nblkO=nblkI=1 (fmt=7, single block, f32 scales) -> ns=4;
+     * e8_blocks(98)=1 -> nb=O*98=6272 for BOTH interpretations, and fmt=6's
+     * .qs tag is always exactly one f32 -> ns=4 too. Must refuse. */
+    int64_t nb64=(int64_t)64*98;
+    CHECK(expect_refuse(64,98, nb64, 4, "fmt=6/fmt=7(f32) collision O=64 I=98"));
+    /* boundary O=128 variant: still nblkO=1 for fmt=7 (128<=128), same collision. */
+    int64_t nb128=(int64_t)128*98;
+    CHECK(expect_refuse(128,98, nb128, 4, "fmt=6/fmt=7(f32) collision O=128 I=98"));
+
+    /* O=1, I=98: a THIRD candidate stacks on (fmt=1 plain int8 per-row, ns==O*4==4
+     * too) -- a genuine three-way ambiguity. Must refuse. */
+    int64_t nb1=(int64_t)1*98;
+    CHECK(expect_refuse(1,98, nb1, 4, "fmt=1/fmt=6/fmt=7(f32) THREE-way collision O=1 I=98"));
+
+    /* O in (384,512], I=98: nblkO=4, nblkI=1, product=4 -- a fmt=7 tensor with
+     * UE8M0 (1 byte/block) scales also lands at ns==4*1==4 here, the SAME tag
+     * fmt=6 uses. Must refuse (and, since this build doesn't implement ue8m0
+     * decode at all, would refuse on that basis alone even without the fmt=6
+     * collision -- this case exercises the OUTER fmt=6 guard specifically). */
+    int64_t nb400=(int64_t)400*98;
+    CHECK(expect_refuse(400,98, nb400, 4, "fmt=6/fmt=7(ue8m0, 4-block) collision O=400 I=98"));
+
+    /* regression guard: a GENUINE (non-colliding) fmt=6 fixture -- I!=98, so
+     * e8_rowbytes(I)==98 does NOT equal O*I -- must keep resolving to fmt=6.
+     * Mirrors test_e8_kernel.c's own O=24,I=512 shape and a small
+     * single-super-block shape (I=256, inside the (0,256] range where
+     * e8_rowbytes(I)==98 but I!=98, so still non-colliding). */
+    CHECK(expect_fmt(24,512, (int64_t)24*e8_rowbytes(512), 4, 6,
+        "genuine fmt=6 (non-colliding) O=24 I=512 -> still resolves to fmt=6"));
+    CHECK(expect_fmt(64,256, (int64_t)64*e8_rowbytes(256), 4, 6,
+        "genuine fmt=6 (non-colliding) O=64 I=256 (I!=98, no collision) -> fmt=6"));
+}
+
+/* ---- Part A3: fmt=7's scale ENCODING is a declared property -- UE8M0
+ * recognized, refused by name (not implemented in this build). ---- */
+static void test_ue8m0_scale_refusal(void){
+    /* [2048,6144] (spec example shape, same as Part A's fmt=7/f32 golden
+     * path): nblkO=16, nblkI=48, product=768 blocks. A UE8M0 sidecar is
+     * exactly 1 byte/block -> ns=768, distinct from BOTH fmt=1's per-row
+     * count (O*4=8192) and this build's f32 block-scale count (768*4=3072).
+     * Clean, unambiguous UE8M0 signature -- must name-refuse, not silently
+     * treat it as a truncated/corrupt f32 array or match it to fmt=1. */
+    int64_t nb=(int64_t)2048*6144;
+    CHECK(expect_refuse(2048,6144, nb, 768,
+        "fp8-e4m3-b128 with ue8m0 scales (spec-shaped, non-degenerate) -> recognized, refused by name"));
+
+    /* O=1, I=400: nblkO=1, nblkI=ceil(400/128)=4, product=4 -- a UE8M0 sidecar
+     * here is ns=4*1=4, which ALSO equals fmt=1's per-row count (O*4=4): the
+     * same small-O regime that produces the f32-vs-fmt=1 collision in Part A
+     * produces a ue8m0-vs-fmt=1 collision too. Must still refuse (combined
+     * message), not silently pick fmt=1. */
+    int64_t nb1=(int64_t)1*400;
+    CHECK(expect_refuse(1,400, nb1, 4,
+        "fp8-e4m3-b128 with ue8m0 scales, ALSO colliding with fmt=1 per-row (O=1) -> refused"));
+}
+
+/* ---- Part B: qt_from_disk loader-seam (real safetensors file) ---- */
+
+static void deq_fmt7(const QT *t, float *dq){
+    int64_t nblkI = fp8_nblk(t->I);
+    for(int o=0;o<t->O;o++){
+        int64_t blkO = o/FP8_BLOCK; const float *scl = t->s + blkO*nblkI;
+        for(int i=0;i<t->I;i++){
+            int64_t bi = i/FP8_BLOCK;
+            dq[(int64_t)o*t->I+i] = e4m3_decode(t->q8[(int64_t)o*t->I+i]) * scl[bi];
+        }
+    }
+}
+static void deq_fmt1(const QT *t, float *dq){
+    for(int o=0;o<t->O;o++){ float s=t->s[o];
+        for(int i=0;i<t->I;i++) dq[(int64_t)o*t->I+i]=(float)t->q8[(int64_t)o*t->I+i]*s; }
+}
+
+#define CDIV(n,d) (((n)+(d)-1)/(d))
+
+static void test_loader_seam(void){
+    enum { O7=8, I7=256 };                        /* nblkO=1, nblkI=2 -> 2 block scales total */
+    enum { O1=5, I1=64 };                        /* DIFFERENT shape from the fp8 tensor: O1*I1=320
+                                                   * bytes, ns=O1*4=20 -- neither collides with the
+                                                   * fp8 tensor's own byte counts (kept deliberately
+                                                   * distinct so this is a plain, non-degenerate
+                                                   * negative control, not another landmine case). */
+    enum { NBLK7 = CDIV(O7,128) * CDIV(I7,128) };  /* must be a compile-time constant expression for
+                                                     * the static array below -- fp8_nblk() is a real
+                                                     * function (runtime, not constexpr), so it can't
+                                                     * size a `static` array even with literal inputs. */
+    static uint8_t q7[O7*I7]; static float s7[NBLK7];
+    for(int i=0;i<O7*I7;i++) q7[i]=rndbyte_nonan();
+    for(int i=0;i<(int)(sizeof s7/sizeof *s7);i++) s7[i]=0.01f+0.001f*(float)i;
+
+    static int8_t q1[O1*I1]; static float s1[O1];
+    for(int i=0;i<O1*I1;i++) q1[i]=(int8_t)(rndbyte_nonan()-128);
+    for(int i=0;i<O1;i++) s1[i]=0.02f+0.001f*(float)i;
+
+    const char *dir="tests/tmp_fp8_snap";
+#ifdef _WIN32
+    mkdir(dir);
+#else
+    mkdir(dir,0755);
+#endif
+    char path[300]; snprintf(path,sizeof path,"%s/model.safetensors",dir);
+    int64_t nb7=(int64_t)O7*I7, ns7=(int64_t)(sizeof s7);
+    int64_t nb1=(int64_t)O1*I1, ns1=(int64_t)O1*4;
+    char hdr[1024];
+    int hl=snprintf(hdr,sizeof hdr,
+        "{\"w7\":{\"dtype\":\"U8\",\"shape\":[%lld],\"data_offsets\":[0,%lld]},"
+        "\"w7.qs\":{\"dtype\":\"F32\",\"shape\":[%lld],\"data_offsets\":[%lld,%lld]},"
+        "\"w1\":{\"dtype\":\"U8\",\"shape\":[%lld],\"data_offsets\":[%lld,%lld]},"
+        "\"w1.qs\":{\"dtype\":\"F32\",\"shape\":[%lld],\"data_offsets\":[%lld,%lld]}}",
+        (long long)nb7,(long long)nb7,
+        (long long)(ns7/4),(long long)nb7,(long long)(nb7+ns7),
+        (long long)nb1,(long long)(nb7+ns7),(long long)(nb7+ns7+nb1),
+        (long long)O1,(long long)(nb7+ns7+nb1),(long long)(nb7+ns7+nb1+ns1));
+    FILE *f=fopen(path,"wb");
+    if(!f){ printf("FAIL: cannot create %s (run from c/, like tools/run_tests.py does)\n", path); fails++; return; }
+    uint64_t hlen=(uint64_t)hl;
+    fwrite(&hlen,8,1,f); fwrite(hdr,1,hl,f);
+    fwrite(q7,1,(size_t)nb7,f); fwrite(s7,1,(size_t)ns7,f);
+    fwrite(q1,1,(size_t)nb1,f); fwrite(s1,1,(size_t)ns1,f);
+    fclose(f);
+
+    static Model gm;                             /* only gm.S is used by qt_from_disk */
+    st_init(&gm.S, dir);
+
+    QT t7; memset(&t7,0,sizeof t7);
+    qt_from_disk(&gm,"w7",O7,I7,8,0,&t7);
+    CHECK(t7.fmt==7);
+    CHECK(t7.q8!=NULL && t7.s!=NULL);            /* both weight and scale allocated (qalloc, not falloc) */
+    static float dq_load[O7*I7], dq_ref[O7*I7];
+    deq_fmt7(&t7,dq_load);
+    QT tr7={.fmt=7,.q8=(int8_t*)q7,.s=s7,.O=O7,.I=I7};
+    deq_fmt7(&tr7,dq_ref);
+    CHECK(memcmp(dq_load,dq_ref,sizeof dq_ref)==0);
+
+    QT t1; memset(&t1,0,sizeof t1);
+    qt_from_disk(&gm,"w1",O1,I1,8,0,&t1);
+    CHECK(t1.fmt==1);                            /* negative control: plain int8 still resolves as fmt=1 */
+    static float dq_load1[O1*I1], dq_ref1[O1*I1];
+    deq_fmt1(&t1,dq_load1);
+    QT tr1={.fmt=1,.q8=q1,.s=s1,.O=O1,.I=I1};
+    deq_fmt1(&tr1,dq_ref1);
+    CHECK(memcmp(dq_load1,dq_ref1,sizeof dq_ref1)==0);
+
+    unlink(path); rmdir(dir);
+}
+
+/* ---- Part C: qt_bytes()/qt_scale_bytes() byte-accounting for fmt=7 ----
+ *
+ * qt_bytes() must not fall through to the fmt=2 (packed int4, O*ceil(I/2)+O*4)
+ * default -- for a real fp8 tensor that would undercount the resident byte
+ * count by roughly half (an AUTOPIN/RAM-budget-feeding hazard). qt_wire_mmap/
+ * qt_unwire_mmap must not hardcode scale_b=O*4 (per-row) either -- wrong for
+ * fmt=7's per-128x128-block scale array -- hence the dedicated
+ * qt_scale_bytes() helper shared by qt_bytes() and both wire functions so
+ * there is exactly one place that knows each format's scale geometry. This
+ * test exercises the arithmetic directly (no qt_from_disk/disk I/O, no mlock
+ * syscall -- qt_wire_mmap's actual mem_wire() call is environment-dependent
+ * (RLIMIT_MEMLOCK) and not what changed; the byte-count formula is) across
+ * the shapes already used elsewhere in this file plus a block-edge
+ * (non-128-multiple) case. */
+static void check_fp8_bytes(int O, int I, const char *tag){
+    QT t; memset(&t,0,sizeof t); t.fmt=7; t.O=O; t.I=I; t.gs=0;
+    int64_t nblkO=fp8_nblk(O), nblkI=fp8_nblk(I), nblk=nblkO*nblkI;
+    int64_t want_total = (int64_t)O*I + nblk*4;
+    int64_t want_scale = nblk*4;
+    int64_t got_total = qt_bytes(&t);
+    int64_t got_scale = qt_scale_bytes(&t);
+    if(got_total != want_total)
+        printf("FAIL %s: qt_bytes=%lld want=%lld\n", tag, (long long)got_total, (long long)want_total);
+    CHECK(got_total == want_total);
+    if(got_scale != want_scale)
+        printf("FAIL %s: qt_scale_bytes=%lld want=%lld\n", tag, (long long)got_scale, (long long)want_scale);
+    CHECK(got_scale == want_scale);
+    /* weight_b, as qt_wire_mmap/qt_unwire_mmap now compute it, must land on the exact
+     * O*I raw-byte weight region -- not short (partial mlock) or long (mlock past the
+     * allocation, undefined behavior) by even one byte. */
+    CHECK(got_total - got_scale == (int64_t)O*I);
+    /* regression guard: the fmt=2 (packed-nibble) formula must NOT be what fmt=7
+     * returns -- confirm the value has actually MOVED off it (catches a silent
+     * revert of the fmt==7 branch order/placement, not just a formula typo). For
+     * O=1,I=1 the two formulas coincide by coincidence (both give 1+4=5), so that
+     * shape is skipped for this particular guard -- the other three shapes below are
+     * chosen to avoid the coincidence. */
+    int64_t old_wrong = (int64_t)O*((I+1)/2) + (int64_t)O*4;
+    if(!(O==1 && I==1)) CHECK(got_total != old_wrong);
+}
+
+int main(void){
+    test_disambiguation();
+    test_fmt6_fp8_collision();
+    test_ue8m0_scale_refusal();
+    test_loader_seam();
+    check_fp8_bytes(2048,6144, "qt_bytes fmt=7 gate/up-shaped O=2048 I=6144 (spec example)");
+    check_fp8_bytes(6144,2048, "qt_bytes fmt=7 down-shaped O=6144 I=2048");
+    check_fp8_bytes(130,200,   "qt_bytes fmt=7 block edges O,I both non-mult-128");
+    check_fp8_bytes(1,1,       "qt_bytes fmt=7 degenerate 1x1");
+    if(fails){ printf("fp8 loader-seam tests: %d FAILED\n", fails); return 1; }
+    printf("fp8 loader-seam tests: ok\n");
+    return 0;
+}

--- a/c/tests/test_fp8_load.c
+++ b/c/tests/test_fp8_load.c
@@ -14,18 +14,32 @@
  * The two are told apart ONLY by the scale array's byte count (per-row O*4 for
  * fmt=1, per-128x128-block ceil(O/128)*ceil(I/128)*4 for fmt=7, THIS build's
  * implemented f32 scale encoding). For some shapes those two counts coincide
- * exactly -- qt_resolve_fmt must REFUSE (exit(1)) rather than guess. Refusal
- * is tested via fork()+waitpid(), mirroring tests/test_st_pread.c's
- * established convention for exit(1)-terminated paths.
+ * exactly -- INVERSION (maintainer review, #528): qt_resolve_fmt used to
+ * REFUSE (exit(1)) this ambiguous case; it now resolves to fmt=1 (the
+ * incumbent, already-on-disk, decodable format) instead, because the
+ * collision is not hypothetical (GLM-5.2's own self_attn.o_proj.weight hits
+ * it, see qt_resolve_fmt's own "REVIEW FINDING"/"INVERSION" comment) and the
+ * writer side (repack_fp8_passthrough.py's _check_geometry) now refuses to
+ * ever EMIT an fmt=7 container at this same shape, so an unstamped ambiguous
+ * tensor reaching this function is never a genuine fmt=7 candidate. The
+ * former refusal-testing convention (fork()+waitpid(), mirroring
+ * tests/test_st_pread.c's exit(1)-path idiom) is kept for the OTHER
+ * refusing cases below (Part A2's fmt=6 collision, Part A3's UE8M0
+ * recognized-not-implemented refusal, and the generic garbage-byte-count
+ * refusal) -- only the is_row&&is_blk collision in this Part flipped from
+ * expect_refuse to expect_fmt(...,1,...).
  *
  * Part A2: fmt=6 (E8/IQ3, upstream #465) vs fmt=7 collision at [O<=128 or
- * O in a 128-block-count range, I=98] -- SECOND DESIGN LANDMINE.
+ * O in a 128-block-count range, I=98] -- SECOND DESIGN LANDMINE. Unchanged by
+ * the #528 inversion above (a different collision predicate, still refused).
  *
  * Part A3: fmt=7's scale ENCODING is a declared property, not a hardcoded
  * constant -- f32 (Part A/A2 above) is what this build implements. A UE8M0
  * (1 byte/block) encoding is a REAL, distinct byte signature (the DeepSeek-V4
  * checkpoint format for this identical weight geometry) this build recognizes
- * and refuses BY NAME rather than misreading.
+ * and refuses BY NAME rather than misreading. Unchanged by the #528
+ * inversion (a stamp confirms the WEIGHT format, never a decoder this build
+ * doesn't have -- see qt_resolve_fmt's own comment).
  *
  * Part B: qt_from_disk loader-seam -- writes a real single-shard .safetensors
  * file containing an fmt=7 tensor (U8 weight + per-block F32 .qs) next to an
@@ -34,12 +48,18 @@
  * fmt=1 correctly and the loaded weights dequantize identically to a reference.
  * Mirrors tests/test_int3_load.c's structure for fmt=5.
  *
- * Part C: qt_bytes()/qt_scale_bytes() byte-accounting for fmt=7.
+ * Part C: qt_bytes()/qt_scale_bytes() byte-accounting for fmt=7, plus
+ * qt_wire_split() -- the shared weight/scale byte-range split qt_wire_mmap
+ * and qt_unwire_mmap both now call (maintainer review, #528: qt_scale_bytes()
+ * existed correctly but neither call site actually used it, a defect only
+ * -Wno-unused-function's suppression let compile clean).
  *
  * This build has NO container metadata stamp (see qt_resolve_fmt's own header
- * comment) -- every ambiguous/unimplemented-encoding shape below refuses
- * unconditionally; stamp-resolves-ambiguity behavior is a separate, follow-up
- * PR (registry + metadata stamp), not exercised here. */
+ * comment) -- every ambiguous/unimplemented-encoding shape below EXCEPT the
+ * is_row&&is_blk collision (now resolved to fmt=1, see Part A above) refuses
+ * unconditionally; stamp-resolves-ambiguity behavior for the OTHER
+ * collisions is a separate, follow-up PR (registry + metadata stamp), not
+ * exercised here. */
 #define main coli_glm_main_unused
 #include "../colibri.c"
 #undef main
@@ -123,21 +143,46 @@ static void test_disambiguation(void){
     CHECK(expect_fmt(2048,6144,(int64_t)2048*6144,16LL*48*4,7,"fp8 2048x6144 (spec example)"));
     CHECK(expect_fmt(384,6144,(int64_t)384*6144,3LL*48*4,7,"fp8 384x6144 non-square block grid"));
 
+    /* --- REGRESSION (maintainer review, #528): GLM-5.2's own
+     * self_attn.o_proj.weight, [D,H*v_head]=[6144,16384]. nblkO=ceil(6144/128)=48,
+     * nblkI=ceil(16384/128)=128, product=6144==O -- this shape hits the
+     * is_row&&is_blk collision below on every GLM-5.2 checkpoint, and is a
+     * REAL, pre-existing, valid int8-row tensor, not a hypothetical. Confirmed
+     * against this repo's own v1 container header (o_proj weight U8
+     * 100,663,296 B == 6144*16384; .qs scale blob 24,576 B == 6144*4 ==
+     * 48*128*4, both at once) -- see the CENSUS SCAN
+     * (tools/fp8_collision_census.py) for the full enumerated family. An
+     * earlier revision of qt_resolve_fmt refused this shape unconditionally
+     * (exit(1) at load time on an ordinary model); the INVERSION resolves it
+     * to fmt=1 instead -- this is that non-refusal, asserted directly. */
+    CHECK(expect_fmt(6144,16384,(int64_t)6144*16384,6144LL*4,1,
+        "GLM-5.2 o_proj shape [6144,16384]: valid int8-row, ambiguous-by-byte-count, resolves fmt=1 (NOT a refusal)"));
+
     /* --- degenerate shapes: O<=128 makes nblkO==1, so ns_blk==nblkI*4 can
      * equal ns_row==O*4 whenever nblkI==O. Exhaustive-in-spirit sweep of the
-     * boundary the design landmine describes. --- */
-    CHECK(expect_refuse(1,1,      1,        4,  "degenerate O=1 I=1 (nblkI=1=O)"));
-    CHECK(expect_refuse(1,128,    128,      4,  "degenerate O=1 I=128 (nblkI=1=O, I at block edge)"));
-    CHECK(expect_refuse(2,256,    2LL*256,  8,  "degenerate O=2 I=256 (nblkI=2=O)"));
-    CHECK(expect_refuse(6,768,    6LL*768,  24, "degenerate O=6 I=768 (nblkI=6=O)"));
-    CHECK(expect_refuse(128,16384,128LL*16384, 512, "degenerate O=128 I=16384 (nblkO=1,nblkI=128=O)"));
+     * boundary the design landmine describes. INVERSION (maintainer review,
+     * #528): every one of these used to be an expect_refuse (exit(1)) -- the
+     * general family this collision predicate describes (any int8 tensor
+     * where O==ceil(O/128)*ceil(I/128)) includes real, valid, pre-existing
+     * tensors (see the o_proj case just above), so refusing was the wrong
+     * call across the board, not just for the three shapes the maintainer's
+     * review named explicitly ([128,16384],[256,16384],[384,16384] below) --
+     * every case in this sweep hits the exact same is_row&&is_blk branch and
+     * is flipped here for the same reason. --- */
+    CHECK(expect_fmt(1,1,      1,        4,  1, "degenerate O=1 I=1 (nblkI=1=O) -> fmt=1, was refuse"));
+    CHECK(expect_fmt(1,128,    128,      4,  1, "degenerate O=1 I=128 (nblkI=1=O, I at block edge) -> fmt=1, was refuse"));
+    CHECK(expect_fmt(2,256,    2LL*256,  8,  1, "degenerate O=2 I=256 (nblkI=2=O) -> fmt=1, was refuse"));
+    CHECK(expect_fmt(6,768,    6LL*768,  24, 1, "degenerate O=6 I=768 (nblkI=6=O) -> fmt=1, was refuse"));
+    /* the three shapes the maintainer's review named explicitly (his exact expect_refuse
+     * calls, O=128/256/384 at I=16384) -- FLIPPED to assert fmt=1. */
+    CHECK(expect_fmt(128,16384,128LL*16384, 512, 1, "degenerate O=128 I=16384 (nblkO=1,nblkI=128=O) -> fmt=1, was refuse"));
     /* O>128 degenerate case: nblkO=2, need nblkI=O/2 -- O=256,I=16384 -> nblkI=128, 2*128=256=O */
-    CHECK(expect_refuse(256,16384,256LL*16384, 1024, "degenerate O=256 I=16384 (nblkO=2,nblkI=128, product=O)"));
+    CHECK(expect_fmt(256,16384,256LL*16384, 1024, 1, "degenerate O=256 I=16384 (nblkO=2,nblkI=128, product=O) -> fmt=1, was refuse"));
     /* k=3: the ambiguity isn't a one-off O=256 coincidence -- it's structural for ANY
      * O that's a multiple of 128 (nblkO=k), since nblkI==128 (I in (16256,16384]) always
      * makes nblkO*nblkI == k*128 == O. One more multiple (O=384=3*128) confirms the
      * condition generalizes past the k=2 worked example, not just a re-derivation. */
-    CHECK(expect_refuse(384,16384,384LL*16384, 1536, "degenerate O=384 I=16384 (nblkO=3,nblkI=128, k=3, product=O)"));
+    CHECK(expect_fmt(384,16384,384LL*16384, 1536, 1, "degenerate O=384 I=16384 (nblkO=3,nblkI=128, k=3, product=O) -> fmt=1, was refuse"));
 
     /* --- boundary-ADJACENT non-degenerate cases: one step past each
      * degenerate case above, both interpretations now legitimately resolve. --- */

--- a/c/tests/test_fp8_load.c
+++ b/c/tests/test_fp8_load.c
@@ -183,7 +183,7 @@ static int expect_refuse(int O, int I, int64_t nb, int64_t ns, const char *tag){
         _exit(42);                                  /* reaching here is the bug */
     }
     close(pipefd[1]);
-    char err[1024]={0}; ssize_t n=read(pipefd[0],err,sizeof(err)-1); (void)n;
+    char err[1024]={0}; size_t eoff=0; ssize_t n; /* drain to EOF: a single read() can return SHORT on Linux pipes (glibc unbuffered stderr arrives in chunks) -- truncated the refusal message past the marker, CI-caught */ while(eoff<sizeof(err)-1 && (n=read(pipefd[0],err+eoff,sizeof(err)-1-eoff))>0) eoff+=(size_t)n;
     close(pipefd[0]);
     int status=0; waitpid(pid,&status,0);
     int ok = WIFEXITED(status) && WEXITSTATUS(status)==1;

--- a/c/tests/test_fp8_load.c
+++ b/c/tests/test_fp8_load.c
@@ -399,6 +399,40 @@ static void check_fp8_bytes(int O, int I, const char *tag){
     if(!(O==1 && I==1)) CHECK(got_total != old_wrong);
 }
 
+/* qt_wire_mmap()/qt_unwire_mmap() (colibri.c) both compute weight_b/scale_b via
+ * qt_wire_split(t,&weight_b,&scale_b) -- this calls that EXACT shared function
+ * directly (no mlock syscall: same reasoning as check_fp8_bytes above, mem_wire's
+ * actual RLIMIT_MEMLOCK behavior is environment-dependent and not what changed)
+ * so a regression at qt_wire_split() itself -- e.g. reverting to the
+ * scale_b=(int64_t)t->O*4 hardcode the maintainer's #528 review found dead-coded
+ * behind an unused qt_scale_bytes() (compiling clean only because
+ * -Wno-unused-function suppressed the warning that should have caught it) --
+ * fails here. Covers every format qt_wire_split's callers can see in practice
+ * (fmt=1 per-row unaffected; fmt=4/5 grouped-scale formats qt_scale_bytes'
+ * own comment names as previously-broken too; fmt=7 nblk>O, the shape this
+ * review round is about). */
+static void check_wire_split(int fmt, int O, int I, int gs, const char *tag){
+    QT t; memset(&t,0,sizeof t); t.fmt=fmt; t.O=O; t.I=I; t.gs=gs;
+    int64_t want_scale = qt_scale_bytes(&t);
+    int64_t want_weight = qt_bytes(&t) - want_scale;
+    int64_t got_weight=-1, got_scale=-1;
+    qt_wire_split(&t,&got_weight,&got_scale);
+    if(got_scale != want_scale)
+        printf("FAIL %s: qt_wire_split scale_b=%lld want=%lld\n", tag, (long long)got_scale, (long long)want_scale);
+    CHECK(got_scale == want_scale);
+    if(got_weight != want_weight)
+        printf("FAIL %s: qt_wire_split weight_b=%lld want=%lld\n", tag, (long long)got_weight, (long long)want_weight);
+    CHECK(got_weight == want_weight);
+    /* the regression this test exists to catch: a per-row-only scale_b==O*4
+     * must NOT be what qt_wire_split returns for a format whose real scale
+     * cardinality differs from O (fmt=4/5/7 here) -- confirm the value has
+     * actually moved off that old constant, not just matched qt_scale_bytes()
+     * by coincidence at a degenerate shape. */
+    int64_t old_wrong_scale = (int64_t)O*4;
+    if((fmt==4 || fmt==5 || fmt==7) && want_scale != old_wrong_scale)
+        CHECK(got_scale != old_wrong_scale);
+}
+
 int main(void){
     test_disambiguation();
     test_fmt6_fp8_collision();
@@ -408,6 +442,11 @@ int main(void){
     check_fp8_bytes(6144,2048, "qt_bytes fmt=7 down-shaped O=6144 I=2048");
     check_fp8_bytes(130,200,   "qt_bytes fmt=7 block edges O,I both non-mult-128");
     check_fp8_bytes(1,1,       "qt_bytes fmt=7 degenerate 1x1");
+    check_wire_split(1, 4096,4096, 0,  "qt_wire_split fmt=1 plain int8 (per-row scale, unaffected by the fix)");
+    check_wire_split(4, 2048,6144, 64, "qt_wire_split fmt=4 grouped int4 (O*ceil(I/gs) scale, not O*4)");
+    check_wire_split(5, 2048,6144, 0,  "qt_wire_split fmt=5 int3-g64 (O*ceil(I/64) scale, not O*4)");
+    check_wire_split(7, 2,16384, 0,    "qt_wire_split fmt=7 nblk(128) >> O(2): scale=512B, NOT O*4=8B");
+    check_wire_split(7, 2048,6144, 0,  "qt_wire_split fmt=7 spec example: scale=3072B, NOT O*4=8192B");
     if(fails){ printf("fp8 loader-seam tests: %d FAILED\n", fails); return 1; }
     printf("fp8 loader-seam tests: ok\n");
     return 0;

--- a/c/tests/test_fp8_passthrough.c
+++ b/c/tests/test_fp8_passthrough.c
@@ -1,4 +1,4 @@
-/* fmt=7 (native FP8-e4m3 passthrough) CPU kernel tests: LUT exactness (all 256
+/* fmt=8 (native FP8-e4m3 passthrough) CPU kernel tests: LUT exactness (all 256
  * byte codes, incl. +-0, subnormals, NaN), matmul_fp8 vs a double-precision
  * block-scale reference on block-edge (non-128-multiple O/I) shapes, a
  * non-square-block-grid case with a distinct scale per block (catches a
@@ -10,12 +10,14 @@
  * compute" header comment) -- the loader-seam (qt_resolve_fmt disambiguation,
  * qt_from_disk) is covered separately in test_fp8_load.c.
  *
- * fmt=7, PUBLIC ordinal assigned by the maintainer on #524: this format was
- * minted fmt=6 during original development of this branch, before dev's own
- * #465 (E8/IQ3) claimed that ordinal upstream; re-tagged fmt=100 (PRIVATE
- * ORDINAL BLOCK, see colibri.c's QT struct comment) from that point forward --
- * there was never a build in this branch's history where this format was
- * reachable as fmt=6 -- and graduated to fmt=7 at merge. */
+ * fmt=8, PUBLIC ordinal: this format was minted fmt=6 during original
+ * development of this branch, before dev's own #465 (E8/IQ3) claimed that
+ * ordinal upstream; re-tagged fmt=100 (PRIVATE ORDINAL BLOCK, see colibri.c's
+ * QT struct comment) from that point forward -- there was never a build in
+ * this branch's history where this format was reachable as fmt=6 -- graduated
+ * to fmt=7 when the maintainer assigned that ordinal on #524, and renumbered
+ * to fmt=8 after #705 merged claiming 7 for MXFP4 (see colibri.c's QT
+ * comment). */
 #include "../quant.h"
 #include <stdio.h>
 #include <string.h>
@@ -92,7 +94,7 @@ static void ref_matmul_fp8(double *y, double *mag, const float *x, const uint8_t
 }
 
 /* magnitude-relative Sigma|terms| oracle (the convention test_backend_metal.mm's
- * cpu_ref_grouped/run_grouped established for fmt=4 and reuses for fmt=7 on the
+ * cpu_ref_grouped/run_grouped established for fmt=4 and reuses for fmt=8 on the
  * GPU side): compare error against the sum of |terms|, not the (possibly
  * near-zero, cancellation-prone) result itself. */
 static int check_close(const float *got, const double *ref, const double *mag, int n, double tol, const char *tag){

--- a/c/tests/test_fp8_passthrough.c
+++ b/c/tests/test_fp8_passthrough.c
@@ -1,0 +1,165 @@
+/* fmt=7 (native FP8-e4m3 passthrough) CPU kernel tests: LUT exactness (all 256
+ * byte codes, incl. +-0, subnormals, NaN), matmul_fp8 vs a double-precision
+ * block-scale reference on block-edge (non-128-multiple O/I) shapes, a
+ * non-square-block-grid case with a distinct scale per block (catches a
+ * transposed/swapped block-index stride the same way test_backend_metal.mm's
+ * "stride-audit" case does for the GPU kernel), and the NaN-propagation policy
+ * (decode -> real IEEE NaN -> flows through the dot product; see quant.h's
+ * e4m3_decode/E4M3_LUT comment for the documented policy + rationale).
+ * Pure quant.h test: no Model/QT/disk dependency (see quant.h's own "pure
+ * compute" header comment) -- the loader-seam (qt_resolve_fmt disambiguation,
+ * qt_from_disk) is covered separately in test_fp8_load.c.
+ *
+ * fmt=7, PUBLIC ordinal assigned by the maintainer on #524: this format was
+ * minted fmt=6 during original development of this branch, before dev's own
+ * #465 (E8/IQ3) claimed that ordinal upstream; re-tagged fmt=100 (PRIVATE
+ * ORDINAL BLOCK, see colibri.c's QT struct comment) from that point forward --
+ * there was never a build in this branch's history where this format was
+ * reachable as fmt=6 -- and graduated to fmt=7 at merge. */
+#include "../quant.h"
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+static int fails = 0;
+#define CHECK(c) do{ if(!(c)){ printf("FAIL %s:%d: %s\n", __FILE__, __LINE__, #c); fails++; } }while(0)
+
+static uint64_t rng = 0xC0FFEE1234567ull;
+static float rndf(void){ rng ^= rng << 13; rng ^= rng >> 7; rng ^= rng << 17;
+    return ((int64_t)(rng & 0xFFFFF) - 0x80000) / (float)0x80000; }
+/* random byte EXCLUDING the two NaN codes (0x7F/0xFF) -- used by the accuracy/
+ * magnitude tests below so a stray NaN term doesn't turn `rel>tol` trivially
+ * false (NaN compares false against everything) and mask a real kernel bug.
+ * NaN handling itself is checked separately, deliberately, below. */
+static uint8_t rndbyte_nonan(void){
+    for(;;){ rng ^= rng << 13; rng ^= rng >> 7; rng ^= rng << 17;
+        uint8_t b = (uint8_t)(rng & 0xFF);
+        if(b != 0x7F && b != 0xFF) return b; }
+}
+
+/* independent reference decode (bit manipulation, not the LUT under test) --
+ * cross-checked offline against torch.float8_e4m3fn byte-for-byte (256/256
+ * match, RAN evidence, see the build report). Kept here so a transcription
+ * bug in E4M3_LUT's 256 hex-float literals is still caught by this test even
+ * though both were derived from the same formula. */
+static float ref_e4m3(uint8_t b){
+    unsigned sign=(b>>7)&1, exp=(b>>3)&0xF, mant=b&0x7;
+    if(exp==0xF && mant==0x7) return NAN;
+    float val;
+    if(exp==0) val = (float)mant * (1.0f/8.0f) * powf(2.0f, 1.0f-7.0f);
+    else       val = (1.0f + (float)mant*(1.0f/8.0f)) * powf(2.0f, (float)exp-7.0f);
+    return sign ? -val : val;
+}
+
+static void test_lut(void){
+    int nan_codes=0;
+    for(int b=0;b<256;b++){
+        float got = e4m3_decode((uint8_t)b);
+        float ref = ref_e4m3((uint8_t)b);
+        if(isnan(ref)){ CHECK(isnan(got)); nan_codes++; continue; }
+        CHECK(got == ref);
+        if(got==0.f) CHECK(signbit(got)==signbit(ref));   /* +-0 must keep its sign bit */
+    }
+    CHECK(nan_codes==2);                        /* exactly 0x7F and 0xFF */
+    CHECK(isnan(e4m3_decode(0x7F)) && isnan(e4m3_decode(0xFF)));
+    CHECK(e4m3_decode(0x7E)==448.0f && e4m3_decode(0xFE)==-448.0f);   /* max finite, OCP E4M3FN */
+    CHECK(e4m3_decode(0x01)==0x1.0p-9f);          /* min positive subnormal = 2^-9 */
+    CHECK(e4m3_decode(0x00)==0.0f && !signbit(e4m3_decode(0x00)));
+    CHECK(e4m3_decode(0x80)==0.0f && signbit(e4m3_decode(0x80)));    /* -0.0 */
+}
+
+/* double-precision block-scale reference: mirrors matmul_fp8's formula exactly
+ * (w[o,i] = e4m3_decode(byte) * scale[o/128,i/128]) but every intermediate is
+ * double so it can serve as ground truth for matmul_fp8's own float/double mix. */
+static void ref_matmul_fp8(double *y, double *mag, const float *x, const uint8_t *q8,
+                           const float *bscale, int S, int I, int O){
+    int64_t nblkI = fp8_nblk(I);
+    for(int o=0;o<O;o++){
+        const uint8_t *w = q8 + (int64_t)o*I;
+        int64_t blkO = o / FP8_BLOCK;
+        const float *scl = bscale + blkO*nblkI;
+        for(int s=0;s<S;s++){
+            const float *xs = x + (int64_t)s*I;
+            double a=0, m=0;
+            for(int i=0;i<I;i++){
+                int64_t bi = i/FP8_BLOCK;
+                double term = (double)e4m3_decode(w[i]) * (double)xs[i] * (double)scl[bi];
+                a += term; m += fabs(term);
+            }
+            y[(int64_t)s*O+o]=a; mag[(int64_t)s*O+o]=m;
+        }
+    }
+}
+
+/* magnitude-relative Sigma|terms| oracle (the convention test_backend_metal.mm's
+ * cpu_ref_grouped/run_grouped established for fmt=4 and reuses for fmt=7 on the
+ * GPU side): compare error against the sum of |terms|, not the (possibly
+ * near-zero, cancellation-prone) result itself. */
+static int check_close(const float *got, const double *ref, const double *mag, int n, double tol, const char *tag){
+    double worst=0; int bad=0;
+    for(int i=0;i<n;i++){
+        double d = fabs((double)got[i]-ref[i]);
+        double rel = mag[i]>1e-30 ? d/mag[i] : d;
+        if(rel>worst) worst=rel;
+        if(rel>tol) bad++;
+    }
+    if(bad) printf("  %-40s worst_rel=%.3e FAIL (%d/%d over tol)\n", tag, worst, bad, n);
+    return bad==0;
+}
+
+static void run_block_case(int O, int I, const char *tag){
+    int64_t nblkO=fp8_nblk(O), nblkI=fp8_nblk(I), nblk=nblkO*nblkI;
+    uint8_t *q8 = malloc((size_t)O*I);
+    float *bscale = malloc((size_t)nblk*sizeof(float));
+    float *x = malloc((size_t)3*I*sizeof(float));
+    float *y = malloc((size_t)3*O*sizeof(float));
+    double *yr = malloc((size_t)3*O*sizeof(double));
+    double *mag = malloc((size_t)3*O*sizeof(double));
+    for(int64_t i=0;i<(int64_t)O*I;i++) q8[i]=rndbyte_nonan();
+    /* distinct, easily-distinguishable scale per block (b+1)*0.01 with alternating
+     * sign and a random jitter -- a swapped blkO/blkI stride or a wrong nblkI in the
+     * indexing picks up the WRONG block's scale, which this makes numerically loud
+     * rather than "close enough to pass by luck" (same idea as the GPU stride-audit
+     * case, applied here to the CPU kernel). */
+    for(int64_t b=0;b<nblk;b++) bscale[b] = (float)(b+1)*0.01f*((b&1)?-1.f:1.f) + rndf()*0.001f;
+    for(int i=0;i<3*I;i++) x[i]=rndf();
+    ref_matmul_fp8(yr, mag, x, q8, bscale, 3, I, O);
+    matmul_fp8(y, x, q8, bscale, 3, I, O);
+    CHECK(check_close(y, yr, mag, 3*O, 1e-5, tag));
+    free(q8); free(bscale); free(x); free(y); free(yr); free(mag);
+}
+
+static void test_nan_propagation(void){
+    /* one NaN byte in an otherwise-normal tensor -> that OUTPUT ROW is NaN (the
+     * documented policy: propagate, rely on the existing argmax_v/dist_build net
+     * downstream -- see quant.h's e4m3_decode comment). Rows that never touch the
+     * NaN byte stay finite: NaN contamination is per-dot-product, not global.
+     * O=3<=128 -> nblkO=1, so all three rows share the SAME nblkI=2-entry scale
+     * block-row (bscale[0..1]); q8 is the only thing that differs per row. */
+    enum { O=3, I=200 };
+    static uint8_t q8[O*I];
+    static float bscale[2];                    /* nblkO(1)*nblkI(2) */
+    for(int i=0;i<O*I;i++) q8[i]=rndbyte_nonan();
+    q8[1*I + 37] = 0x7F;                        /* row 1 only, one NaN byte */
+    bscale[0]=0.1f; bscale[1]=0.11f;
+    static float x[I], y[O];
+    for(int i=0;i<I;i++) x[i]=rndf();
+    matmul_fp8(y, x, q8, bscale, 1, I, O);
+    CHECK(!isnan(y[0]) && !isnan(y[2]));       /* untouched rows stay finite */
+    CHECK(isnan(y[1]));                        /* contaminated row propagates NaN */
+}
+
+int main(void){
+    test_lut();
+    run_block_case(2048, 6144, "block gate/up-shaped O=2048 I=6144 (spec example)");
+    run_block_case(6144, 2048, "block down-shaped O=6144 I=2048");
+    run_block_case(130, 200,   "block edges: O,I both non-mult-128");
+    run_block_case(129, 128,   "block edges: O just over 128, I exact");
+    run_block_case(128, 129,   "block edges: O exact, I just over 128");
+    run_block_case(1, 1,       "degenerate 1x1 (single sub-block)");
+    run_block_case(384, 6144,  "non-square block grid nblkO=3 nblkI=48 (stride audit)");
+    test_nan_propagation();
+    if(fails){ printf("fp8 passthrough CPU tests: %d FAILED\n", fails); return 1; }
+    printf("fp8 passthrough CPU tests: ok\n");
+    return 0;
+}

--- a/c/tests/test_fp8_repack.py
+++ b/c/tests/test_fp8_repack.py
@@ -1,0 +1,210 @@
+"""tools/repack_fp8_passthrough.py: fmt=7 repack tool tests.
+
+fmt=7 is a PUBLIC ordinal, assigned by the maintainer on #524: see
+repack_fp8_passthrough.py's module docstring for the fmt=6 -> fmt=100 ->
+fmt=7 history (dev's own #465 merged a REAL fmt=6, E8/IQ3, so this tool's
+format moved to the PRIVATE ORDINAL BLOCK as fmt=100 during development
+before graduating to fmt=7 at merge).
+
+Synthetic fixtures ONLY (tools/glm_fp8_emit.py, the exact real-checkpoint FP8
+layout that convert_fp8_to_int4.py's dequant() reads) -- no real Z.ai shard is
+read or written by this suite, per the build's hard constraint. Covers:
+selection (resident kinds byte-preserved, routed experts / io / f32 excluded),
+byte-for-byte preservation of the fp8 weight and the .qs scale rename, the
+scale-geometry refusal path (THE DESIGN LANDMINE's write-side twin: a
+malformed source shard must be refused, not silently repacked into a
+container the engine's qt_resolve_fmt would then misread), --dry-run writing
+nothing, and the #383-class resume/params-guard behavior.
+"""
+import glob, json, os, struct, sys, tempfile, unittest
+
+try:
+    import torch
+    from safetensors import safe_open
+    from safetensors.torch import save_file
+except ImportError as e:
+    raise unittest.SkipTest(f"torch/safetensors not installed: {e}")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+from glm_fp8_emit import save_fp8_safetensors
+import repack_fp8_passthrough as rp
+
+
+def _read_header(path):
+    with open(path, "rb") as f:
+        hlen = struct.unpack("<Q", f.read(8))[0]
+        return json.loads(f.read(hlen))
+
+
+def _make_fixture(path, D=256, I_=384, E=4):
+    """One synthetic shard covering every selection case: SELECTED resident
+    kinds (attn/o/sh/dmlp), the EXCLUDED resident kind kvb (kv_b_proj -- valid
+    per convert_fp8_to_int4.classify(), but the engine's CPU/CUDA MLA-absorb
+    paths have no fmt=7 case yet, so this tool must not select it -- see the
+    module docstring), routed experts (must be excluded), the router and a
+    norm (f32-kept, never fp8), and embed_tokens (io kind -- excluded by kind
+    even though glm_fp8_emit's simpler keep_f32() happens to FP8-quantize it,
+    since it doesn't know the full classify() taxonomy; that mismatch is
+    itself a useful case: is_repack_target must exclude by KIND, not by
+    guessing at source dtype conventions)."""
+    torch.manual_seed(0)
+    sd = {
+        "model.layers.0.self_attn.o_proj.weight": torch.randn(D, D) * 0.02,
+        "model.layers.0.self_attn.q_a_proj.weight": torch.randn(D, D) * 0.02,
+        "model.layers.0.self_attn.kv_b_proj.weight": torch.randn(D, D) * 0.02,
+        "model.layers.0.mlp.shared_experts.gate_proj.weight": torch.randn(D, I_) * 0.02,
+        "model.layers.0.mlp.gate_proj.weight": torch.randn(D, I_) * 0.02,       # dmlp
+        "model.layers.0.mlp.experts.0.gate_proj.weight": torch.randn(I_, D) * 0.02,  # routed: EXCLUDE
+        "model.layers.0.mlp.experts.1.up_proj.weight": torch.randn(I_, D) * 0.02,    # routed: EXCLUDE
+        "model.layers.0.input_layernorm.weight": torch.randn(D),                # f32: EXCLUDE
+        "model.layers.0.mlp.gate.weight": torch.randn(E, D),                    # router f32: EXCLUDE
+        "model.embed_tokens.weight": torch.randn(64, D),                        # io: EXCLUDE
+    }
+    n_fp8, n_tot = save_fp8_safetensors(sd, path)
+    return sd, n_fp8, n_tot
+
+
+class SelectionTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.indir = os.path.join(self.tmp.name, "fp8src")
+        os.makedirs(self.indir)
+        self.shard = os.path.join(self.indir, "model-00001-of-00001.safetensors")
+        self.sd, self.n_fp8, self.n_tot = _make_fixture(self.shard)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_dry_run_selection_and_no_writes(self):
+        inv = rp.shard_inventory(self.shard, n_layers=5)
+        names = {it["name"] for it in inv}
+        self.assertEqual(names, {
+            "model.layers.0.self_attn.o_proj.weight",
+            "model.layers.0.self_attn.q_a_proj.weight",
+            "model.layers.0.mlp.shared_experts.gate_proj.weight",
+            "model.layers.0.mlp.gate_proj.weight",
+        })
+        kinds = {it["name"]: it["kind"] for it in inv}
+        self.assertEqual(kinds["model.layers.0.self_attn.o_proj.weight"], "o")
+        self.assertEqual(kinds["model.layers.0.self_attn.q_a_proj.weight"], "attn")
+        self.assertEqual(kinds["model.layers.0.mlp.shared_experts.gate_proj.weight"], "sh")
+        self.assertEqual(kinds["model.layers.0.mlp.gate_proj.weight"], "dmlp")
+        # --dry-run through the CLI must not create the outdir at all
+        outdir = os.path.join(self.tmp.name, "out_dry")
+        rc = os.system(
+            f'{sys.executable} "{os.path.join(os.path.dirname(__file__), "..", "tools", "repack_fp8_passthrough.py")}" '
+            f'--indir "{self.indir}" --outdir "{outdir}" --n-layers 5 --dry-run')
+        self.assertEqual(rc, 0)
+        self.assertFalse(os.path.exists(outdir), "--dry-run must not write anything")
+
+    def test_routed_experts_excluded(self):
+        inv = rp.shard_inventory(self.shard, n_layers=5)
+        names = {it["name"] for it in inv}
+        self.assertNotIn("model.layers.0.mlp.experts.0.gate_proj.weight", names)
+        self.assertNotIn("model.layers.0.mlp.experts.1.up_proj.weight", names)
+
+    def test_kv_b_proj_excluded(self):
+        """Regression guard for a gap found in self-review: kv_b_proj is a valid
+        resident kind per classify(), but colibri.c's CPU absorb path
+        (qt_addrow/qt_matvec_rows) and the CUDA absorb kernels have no fmt=7
+        case -- selecting it here would produce a container the engine
+        silently misreads as int2. Must stay excluded until that path gains
+        fmt=7 support (separate follow-up work)."""
+        inv = rp.shard_inventory(self.shard, n_layers=5)
+        names = {it["name"] for it in inv}
+        self.assertNotIn("model.layers.0.self_attn.kv_b_proj.weight", names)
+        self.assertNotIn("kvb", rp.RESIDENT_KINDS)
+
+    def test_io_and_f32_excluded(self):
+        inv = rp.shard_inventory(self.shard, n_layers=5)
+        names = {it["name"] for it in inv}
+        self.assertNotIn("model.embed_tokens.weight", names)          # io kind
+        self.assertNotIn("model.layers.0.input_layernorm.weight", names)   # f32 (also not FP8 dtype)
+        self.assertNotIn("model.layers.0.mlp.gate.weight", names)     # router, f32 kind
+
+    def test_byte_preservation_and_qs_rename(self):
+        out, inv = rp.repack_shard(self.shard, n_layers=5)
+        self.assertEqual(len(inv), 4)
+        with safe_open(self.shard, framework="pt") as f:
+            for it in inv:
+                name = it["name"]
+                w_src = f.get_tensor(name).view(torch.uint8)
+                sc_src = f.get_tensor(name + "_scale_inv").reshape(-1)
+                self.assertTrue(torch.equal(out[name], w_src), f"{name}: weight bytes not preserved")
+                self.assertEqual(out[name].dtype, torch.uint8)
+                self.assertTrue(torch.equal(out[name + ".qs"], sc_src), f"{name}: scale not preserved")
+                O, I_ = w_src.shape
+                nblkO, nblkI = (O + 127) // 128, (I_ + 127) // 128
+                self.assertEqual(out[name + ".qs"].numel(), nblkO * nblkI)
+
+    def test_geometry_refusal_on_malformed_scale(self):
+        """A shard whose _scale_inv shape doesn't match ceil(O/128)xceil(I/128) for
+        its weight must be REFUSED (write-side twin of qt_resolve_fmt's read-side
+        refusal for the same landmine) rather than silently repacked."""
+        bad_path = os.path.join(self.tmp.name, "bad.safetensors")
+        D = 300
+        w = torch.randn(D, D).to(torch.float8_e4m3fn)
+        bad_scale = torch.ones(1, 1, dtype=torch.float32)   # wrong: should be [3,3] for D=300
+        # o_proj.weight is a resident "o"-kind name -> is_repack_target will select it
+        save_file({"model.layers.0.self_attn.o_proj.weight": w,
+                  "model.layers.0.self_attn.o_proj.weight_scale_inv": bad_scale}, bad_path)
+        with self.assertRaises(ValueError):
+            rp.repack_shard(bad_path, n_layers=5)
+        with self.assertRaises(ValueError):
+            rp.shard_inventory(bad_path, n_layers=5)
+
+
+class ResumeAndParamsGuardTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.indir = os.path.join(self.tmp.name, "fp8src")
+        os.makedirs(self.indir)
+        self.shard = os.path.join(self.indir, "model-00001-of-00001.safetensors")
+        _make_fixture(self.shard)
+        self.outdir = os.path.join(self.tmp.name, "out")
+        self.tool = os.path.join(os.path.dirname(__file__), "..", "tools", "repack_fp8_passthrough.py")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _run(self, n_layers):
+        return os.system(f'{sys.executable} "{self.tool}" --indir "{self.indir}" '
+                         f'--outdir "{self.outdir}" --n-layers {n_layers} >/dev/null 2>&1')
+
+    def test_output_container_geometry(self):
+        self.assertEqual(self._run(5), 0)
+        outs = glob.glob(os.path.join(self.outdir, "out-fp8pass-*.safetensors"))
+        self.assertEqual(len(outs), 1)
+        hdr = _read_header(outs[0])
+        # o_proj is [256,256] -> nblkO=nblkI=2 -> 4 block scales
+        qs = hdr["model.layers.0.self_attn.o_proj.weight.qs"]
+        self.assertEqual(qs["dtype"], "F32")
+        self.assertEqual(qs["shape"], [4])
+        w = hdr["model.layers.0.self_attn.o_proj.weight"]
+        self.assertEqual(w["dtype"], "U8")
+        self.assertEqual(w["shape"], [256, 256])
+        # experts / io / f32 / kv_b_proj must be absent from the output container entirely
+        self.assertNotIn("model.layers.0.mlp.experts.0.gate_proj.weight", hdr)
+        self.assertNotIn("model.embed_tokens.weight", hdr)
+        self.assertNotIn("model.layers.0.input_layernorm.weight", hdr)
+        self.assertNotIn("model.layers.0.self_attn.kv_b_proj.weight", hdr)
+
+    def test_resume_skips_completed_shard(self):
+        self.assertEqual(self._run(5), 0)
+        mtime1 = os.path.getmtime(glob.glob(os.path.join(self.outdir, "out-fp8pass-*.safetensors"))[0])
+        self.assertEqual(self._run(5), 0)                 # rerun, same params
+        outs = glob.glob(os.path.join(self.outdir, "out-fp8pass-*.safetensors"))
+        self.assertEqual(len(outs), 1, "resume must not duplicate output shards")
+        self.assertEqual(os.path.getmtime(outs[0]), mtime1, "resume must not rewrite a completed shard")
+
+    def test_params_mismatch_refused(self):
+        self.assertEqual(self._run(5), 0)
+        rc = self._run(78)                                 # different n_layers, same outdir
+        self.assertNotEqual(rc, 0, "a params mismatch on the same outdir must be refused")
+        # and the FIRST run's output must be untouched by the refused second run
+        outs = glob.glob(os.path.join(self.outdir, "out-fp8pass-*.safetensors"))
+        self.assertEqual(len(outs), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tests/test_fp8_repack.py
+++ b/c/tests/test_fp8_repack.py
@@ -18,9 +18,14 @@ shape (nblkO*nblkI==O, where this tensor's block-scale byte count would
 coincide with a per-row int8 scale byte count) must ALSO be refused
 (maintainer review, #528: this is not hypothetical, GLM-5.2's own
 self_attn.o_proj.weight is a real instance) -- --dry-run writing nothing, and
-the #383-class resume/params-guard behavior.
+the #383-class resume/params-guard behavior. FIX ROUND 2 (clean-room
+conformance trial, spec I6): a real (non-dry-run) run that selects ZERO
+repack-target tensors across --indir must refuse loudly (nonzero exit,
+stderr naming the condition), not exit 0 having emitted nothing -- an empty
+"container" nobody asked for; --dry-run's own "0 selected" report is
+unaffected (that IS the loud, honest answer dry-run exists to give).
 """
-import glob, json, os, struct, sys, tempfile, unittest
+import glob, json, os, struct, subprocess, sys, tempfile, unittest
 
 try:
     import torch
@@ -236,6 +241,59 @@ class ResumeAndParamsGuardTest(unittest.TestCase):
         # and the FIRST run's output must be untouched by the refused second run
         outs = glob.glob(os.path.join(self.outdir, "out-fp8pass-*.safetensors"))
         self.assertEqual(len(outs), 1)
+
+
+def _make_zero_target_fixture(path, D=256, I_=384):
+    """A shard with real FP8 tensors, but NONE matching a repack-target kind --
+    mirrors the trial's own scenario (a non-resident-named FP8 tensor selects
+    nothing): one routed expert (kind "x", explicitly excluded) and one f32
+    norm (never a repack candidate at all)."""
+    torch.manual_seed(2)
+    sd = {
+        "model.layers.0.mlp.experts.0.gate_proj.weight": torch.randn(I_, D) * 0.02,  # routed: EXCLUDE
+        "model.layers.0.input_layernorm.weight": torch.randn(D),                     # f32: EXCLUDE
+    }
+    save_fp8_safetensors(sd, path)
+
+
+class ZeroTargetRefusalTest(unittest.TestCase):
+    """FIX ROUND 2, item 3 (clean-room conformance trial, spec I6): a real
+    (non-dry-run) run whose --indir has FP8 tensors but none matching a
+    repack-target kind must refuse loudly, not exit 0 having written nothing."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.indir = os.path.join(self.tmp.name, "fp8src")
+        os.makedirs(self.indir)
+        self.shard = os.path.join(self.indir, "model-00001-of-00001.safetensors")
+        _make_zero_target_fixture(self.shard)
+        self.outdir = os.path.join(self.tmp.name, "out")
+        self.tool = os.path.join(os.path.dirname(__file__), "..", "tools", "repack_fp8_passthrough.py")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _run(self, extra_args=()):
+        return subprocess.run(
+            [sys.executable, self.tool, "--indir", self.indir, "--outdir", self.outdir,
+             "--n-layers", "5", *extra_args],
+            capture_output=True, text=True)
+
+    def test_zero_targets_refuses_loudly(self):
+        proc = self._run()
+        self.assertNotEqual(proc.returncode, 0, "zero repack-target tensors must refuse, not exit 0")
+        self.assertIn("no repack-target tensors", proc.stderr)
+        self.assertIn(self.indir, proc.stderr, "the refusal must name the --indir condition")
+        # confirmed empty: no output container was (or should be) produced
+        self.assertEqual(glob.glob(os.path.join(self.outdir, "out-fp8pass-*.safetensors")), [])
+
+    def test_zero_targets_dry_run_unaffected(self):
+        """--dry-run's own "0 tensor(s) selected" report is the loud, honest
+        answer dry-run exists to give -- not a silent no-op -- so it must NOT
+        be turned into a refusal by this fix."""
+        proc = self._run(["--dry-run"])
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn("0 tensor(s) selected", proc.stdout)
 
 
 if __name__ == "__main__":

--- a/c/tests/test_fp8_repack.py
+++ b/c/tests/test_fp8_repack.py
@@ -1,10 +1,11 @@
-"""tools/repack_fp8_passthrough.py: fmt=7 repack tool tests.
+"""tools/repack_fp8_passthrough.py: fmt=8 repack tool tests.
 
-fmt=7 is a PUBLIC ordinal, assigned by the maintainer on #524: see
-repack_fp8_passthrough.py's module docstring for the fmt=6 -> fmt=100 ->
-fmt=7 history (dev's own #465 merged a REAL fmt=6, E8/IQ3, so this tool's
-format moved to the PRIVATE ORDINAL BLOCK as fmt=100 during development
-before graduating to fmt=7 at merge).
+fmt=8 is a PUBLIC ordinal: see repack_fp8_passthrough.py's module docstring
+for the fmt=6 -> fmt=100 -> fmt=7 -> fmt=8 history (dev's own #465 merged a
+REAL fmt=6, E8/IQ3, so this tool's format moved to the PRIVATE ORDINAL BLOCK
+as fmt=100 during development; the maintainer assigned fmt=7 on #524; #705
+then merged MXFP4 as fmt=7 while this PR was open, forcing the renumber
+to fmt=8).
 
 Synthetic fixtures ONLY (tools/glm_fp8_emit.py, the exact real-checkpoint FP8
 layout that convert_fp8_to_int4.py's dequant() reads) -- no real Z.ai shard is
@@ -49,7 +50,7 @@ def _make_fixture(path, D=256, I_=384, E=4):
     """One synthetic shard covering every selection case: SELECTED resident
     kinds (attn/o/sh/dmlp), the EXCLUDED resident kind kvb (kv_b_proj -- valid
     per convert_fp8_to_int4.classify(), but the engine's CPU/CUDA MLA-absorb
-    paths have no fmt=7 case yet, so this tool must not select it -- see the
+    paths have no fmt=8 case yet, so this tool must not select it -- see the
     module docstring), routed experts (must be excluded), the router and a
     norm (f32-kept, never fp8), and embed_tokens (io kind -- excluded by kind
     even though glm_fp8_emit's simpler keep_f32() happens to FP8-quantize it,
@@ -115,10 +116,10 @@ class SelectionTest(unittest.TestCase):
     def test_kv_b_proj_excluded(self):
         """Regression guard for a gap found in self-review: kv_b_proj is a valid
         resident kind per classify(), but colibri.c's CPU absorb path
-        (qt_addrow/qt_matvec_rows) and the CUDA absorb kernels have no fmt=7
+        (qt_addrow/qt_matvec_rows) and the CUDA absorb kernels have no fmt=8
         case -- selecting it here would produce a container the engine
         silently misreads as int2. Must stay excluded until that path gains
-        fmt=7 support (separate follow-up work)."""
+        fmt=8 support (separate follow-up work)."""
         inv = rp.shard_inventory(self.shard, n_layers=5)
         names = {it["name"] for it in inv}
         self.assertNotIn("model.layers.0.self_attn.kv_b_proj.weight", names)
@@ -174,8 +175,8 @@ class SelectionTest(unittest.TestCase):
         shape family c/tests/test_fp8_load.c's test_disambiguation() sweeps. The
         engine's qt_resolve_fmt reader resolves an unstamped collision at this
         shape to fmt=1 (int8-row) rather than refusing (see colibri.c's
-        INVERSION) -- so this tool refusing to ever EMIT an fmt=7 container here
-        is what keeps that reader-side resolution correct: an fmt=7 tensor this
+        INVERSION) -- so this tool refusing to ever EMIT an fmt=8 container here
+        is what keeps that reader-side resolution correct: an fmt=8 tensor this
         tool produced at this shape would be silently read back as plain int8."""
         amb_path = os.path.join(self.tmp.name, "ambiguous.safetensors")
         O, I_ = 2, 256

--- a/c/tests/test_fp8_repack.py
+++ b/c/tests/test_fp8_repack.py
@@ -11,10 +11,14 @@ layout that convert_fp8_to_int4.py's dequant() reads) -- no real Z.ai shard is
 read or written by this suite, per the build's hard constraint. Covers:
 selection (resident kinds byte-preserved, routed experts / io / f32 excluded),
 byte-for-byte preservation of the fp8 weight and the .qs scale rename, the
-scale-geometry refusal path (THE DESIGN LANDMINE's write-side twin: a
-malformed source shard must be refused, not silently repacked into a
-container the engine's qt_resolve_fmt would then misread), --dry-run writing
-nothing, and the #383-class resume/params-guard behavior.
+scale-geometry refusal path in TWO forms (THE DESIGN LANDMINE's write-side
+twin) -- a malformed source shard (.qs shape doesn't match ceil(O/128)x
+ceil(I/128) for its weight) must be refused, AND a well-formed-but-AMBIGUOUS
+shape (nblkO*nblkI==O, where this tensor's block-scale byte count would
+coincide with a per-row int8 scale byte count) must ALSO be refused
+(maintainer review, #528: this is not hypothetical, GLM-5.2's own
+self_attn.o_proj.weight is a real instance) -- --dry-run writing nothing, and
+the #383-class resume/params-guard behavior.
 """
 import glob, json, os, struct, sys, tempfile, unittest
 
@@ -152,6 +156,34 @@ class SelectionTest(unittest.TestCase):
             rp.repack_shard(bad_path, n_layers=5)
         with self.assertRaises(ValueError):
             rp.shard_inventory(bad_path, n_layers=5)
+
+    def test_geometry_refusal_on_ambiguous_shape(self):
+        """WRITER-SIDE REFUSAL (maintainer review, #528): a WELL-FORMED .qs sidecar
+        (correct nblkOxnblkI shape for [O,I], unlike the malformed case above) must
+        still be refused when nblkO*nblkI==O -- the exact shape where this tensor's
+        block-scale byte count (nblkO*nblkI*4) would coincide with a per-row int8
+        scale byte count (O*4). Not hypothetical: GLM-5.2's own
+        self_attn.o_proj.weight ([6144,16384], nblkO=48 nblkI=128 product=6144==O)
+        is a real instance of this exact family; O=2,I=256 here is the smallest
+        realistic analog (nblkO=1, nblkI=2, product=2==O), the same degenerate
+        shape family c/tests/test_fp8_load.c's test_disambiguation() sweeps. The
+        engine's qt_resolve_fmt reader resolves an unstamped collision at this
+        shape to fmt=1 (int8-row) rather than refusing (see colibri.c's
+        INVERSION) -- so this tool refusing to ever EMIT an fmt=7 container here
+        is what keeps that reader-side resolution correct: an fmt=7 tensor this
+        tool produced at this shape would be silently read back as plain int8."""
+        amb_path = os.path.join(self.tmp.name, "ambiguous.safetensors")
+        O, I_ = 2, 256
+        w = torch.randn(O, I_).to(torch.float8_e4m3fn)
+        nblkO, nblkI = (O + 127) // 128, (I_ + 127) // 128
+        self.assertEqual(nblkO * nblkI, O, "fixture must actually hit the collision")
+        scale = torch.ones(nblkO, nblkI, dtype=torch.float32)   # WELL-FORMED for [O,I] -- passes the first check
+        save_file({"model.layers.0.self_attn.o_proj.weight": w,
+                  "model.layers.0.self_attn.o_proj.weight_scale_inv": scale}, amb_path)
+        with self.assertRaises(ValueError):
+            rp.repack_shard(amb_path, n_layers=5)
+        with self.assertRaises(ValueError):
+            rp.shard_inventory(amb_path, n_layers=5)
 
 
 class ResumeAndParamsGuardTest(unittest.TestCase):

--- a/c/tests/test_qt_addrow.c
+++ b/c/tests/test_qt_addrow.c
@@ -4,8 +4,8 @@
  * fmt 0/4/5 explicitly, then fall through assuming a PER-ROW scale (t->s[row]) followed by
  * fmt=1/2/3 (qt_addrow) or fmt=0/1/2/3/4/5 (qt_matvec_rows, via an if/else-if chain ending
  * in a bare `else`) -- nothing stopped fmt=6 (E8/IQ3, t->s is a FIXED 4-byte tag, not O
- * floats) or fmt=7 (fp8-e4m3-b128, t->s holds per-128x128-block floats, not O; t->q4 is
- * NULL) from reaching that fall-through. For fmt=7 specifically this SIGSEGVs: t->s[row]
+ * floats) or fmt=8 (fp8-e4m3-b128, t->s holds per-128x128-block floats, not O; t->q4 is
+ * NULL) from reaching that fall-through. For fmt=8 specifically this SIGSEGVs: t->s[row]
  * overreads (silently, usually not fatal on its own), then the untouched tail computes
  * `t->q4+(int64_t)row*((I+3)/4)` on a NULL t->q4 and dereferences it. For fmt=6 it silently
  * misreads the real E8/IQ3 lattice bytes as int2-packed data (same bug SHAPE as #298's CUDA
@@ -14,7 +14,7 @@
  * any fmt they don't explicitly handle, matching qt_resolve_fmt's own "refuse rather than
  * misread" discipline.
  *
- * This file: (1) proves the refusal fires for fmt=6 and fmt=7 through BOTH functions
+ * This file: (1) proves the refusal fires for fmt=6 and fmt=8 through BOTH functions
  * (fork+pipe+waitpid, this suite's established house pattern for exit(1)-terminated paths --
  * see tests/test_fp8_load.c's expect_refuse/expect_stamp_refuse); (2) proves every format
  * BOTH functions still legitimately handle (0/1/2/3/4/5) produces byte-identical results
@@ -24,10 +24,10 @@
  * would show up here, not just tautologically re-run the same code). Reachability note (not
  * a scope excuse, just context): both functions serve ONLY the kv_b absorb path
  * (attention_rows/decode call sites), and tools/repack_fp8_passthrough.py deliberately
- * excludes kv_b_proj from fmt=7 repacking -- so this fires only via a hand-slotted or
+ * excludes kv_b_proj from fmt=8 repacking -- so this fires only via a hand-slotted or
  * ambiguous-collision container, not this repo's own tooling's own output. Crash-instead-of-
  * refuse is still a real defect (spec I6: loud failure, every refusal names its condition),
- * and the fmt=7 QT surface these functions can now be handed is one this same PR pair
+ * and the fmt=8 QT surface these functions can now be handed is one this same PR pair
  * created. */
 #define main coli_glm_main_unused
 #include "../colibri.c"
@@ -191,13 +191,13 @@ static void test_byte_identity_all_formats(void){
  * expect_refuse/expect_stamp_refuse) -- must exit(1) with a "refus"-containing message,
  * never reach the caller's continuation, never crash with a signal. ---- */
 typedef void (*absorb_fn)(void);
-static void call_addrow_fmt7(void){
+static void call_addrow_fmt8(void){
     QT t; memset(&t,0,sizeof t);
     enum { O=130, I=130 };   /* the coordinator's own repro shape: nblkO=nblkI=2, nblk=4 */
     static uint8_t q8[O*I]; static float s[4];
     for(int i=0;i<O*I;i++) q8[i]=rndbyte();
     for(int i=0;i<4;i++) s[i]=0.01f;
-    t.fmt=7; t.O=O; t.I=I; t.gs=0; t.q8=(int8_t*)q8; t.s=s;
+    t.fmt=8; t.O=O; t.I=I; t.gs=0; t.q8=(int8_t*)q8; t.s=s;
     float acc[I]; memset(acc,0,sizeof acc);
     qt_addrow(&t,0,1.f,acc);   /* must exit(1) inside; must NOT return */
 }
@@ -211,13 +211,13 @@ static void call_addrow_fmt6(void){
     float acc[I]; memset(acc,0,sizeof acc);
     qt_addrow(&t,0,1.f,acc);
 }
-static void call_matvec_fmt7(void){
+static void call_matvec_fmt8(void){
     QT t; memset(&t,0,sizeof t);
     enum { O=130, I=130 };
     static uint8_t q8[O*I]; static float s[4];
     for(int i=0;i<O*I;i++) q8[i]=rndbyte();
     for(int i=0;i<4;i++) s[i]=0.01f;
-    t.fmt=7; t.O=O; t.I=I; t.gs=0; t.q8=(int8_t*)q8; t.s=s;
+    t.fmt=8; t.O=O; t.I=I; t.gs=0; t.q8=(int8_t*)q8; t.s=s;
     static float x[I]; for(int i=0;i<I;i++) x[i]=rndsmallf();
     float y=0.f;
     qt_matvec_rows(&t,0,1,x,&y);
@@ -271,9 +271,9 @@ static int expect_refuse_call(absorb_fn fn, const char *tag){
 }
 
 static void test_refusals(void){
-    CHECK(expect_refuse_call(call_addrow_fmt7,  "qt_addrow refuses fmt=7 (was SIGSEGV)"));
+    CHECK(expect_refuse_call(call_addrow_fmt8,  "qt_addrow refuses fmt=8 (was SIGSEGV)"));
     CHECK(expect_refuse_call(call_addrow_fmt6,  "qt_addrow refuses fmt=6"));
-    CHECK(expect_refuse_call(call_matvec_fmt7,  "qt_matvec_rows refuses fmt=7"));
+    CHECK(expect_refuse_call(call_matvec_fmt8,  "qt_matvec_rows refuses fmt=8"));
     CHECK(expect_refuse_call(call_matvec_fmt6,  "qt_matvec_rows refuses fmt=6"));
 }
 

--- a/c/tests/test_qt_addrow.c
+++ b/c/tests/test_qt_addrow.c
@@ -245,7 +245,7 @@ static int expect_refuse_call(absorb_fn fn, const char *tag){
         _exit(42);   /* reaching here (surviving the call without exit(1)) is the bug */
     }
     close(pipefd[1]);
-    char err[1024]={0}; ssize_t n=read(pipefd[0],err,sizeof(err)-1); (void)n;
+    char err[1024]={0}; size_t eoff=0; ssize_t n; /* drain to EOF: a single read() can return SHORT on Linux pipes (glibc unbuffered stderr arrives in chunks) -- truncated the refusal message past the marker, CI-caught */ while(eoff<sizeof(err)-1 && (n=read(pipefd[0],err+eoff,sizeof(err)-1-eoff))>0) eoff+=(size_t)n;
     close(pipefd[0]);
     int status=0; waitpid(pid,&status,0);
     if(WIFSIGNALED(status)){

--- a/c/tests/test_qt_addrow.c
+++ b/c/tests/test_qt_addrow.c
@@ -1,0 +1,286 @@
+/* qt_addrow()/qt_matvec_rows() (colibri.c) -- per-row absorb helpers used only by the
+ * kv_b MLA-absorption CPU path (l->kv_b, see attention_rows/decode). FIX ROUND 2, engine
+ * defect (clean-room conformance trial finding, mutation-proven): both functions dispatch
+ * fmt 0/4/5 explicitly, then fall through assuming a PER-ROW scale (t->s[row]) followed by
+ * fmt=1/2/3 (qt_addrow) or fmt=0/1/2/3/4/5 (qt_matvec_rows, via an if/else-if chain ending
+ * in a bare `else`) -- nothing stopped fmt=6 (E8/IQ3, t->s is a FIXED 4-byte tag, not O
+ * floats) or fmt=7 (fp8-e4m3-b128, t->s holds per-128x128-block floats, not O; t->q4 is
+ * NULL) from reaching that fall-through. For fmt=7 specifically this SIGSEGVs: t->s[row]
+ * overreads (silently, usually not fatal on its own), then the untouched tail computes
+ * `t->q4+(int64_t)row*((I+3)/4)` on a NULL t->q4 and dereferences it. For fmt=6 it silently
+ * misreads the real E8/IQ3 lattice bytes as int2-packed data (same bug SHAPE as #298's CUDA
+ * absorb-kernel fix, which is why this file's own fmt=4/5 branches exist -- fmt=6 was simply
+ * missed). Both functions now refuse loudly (exit(1), naming the function and the fmt) for
+ * any fmt they don't explicitly handle, matching qt_resolve_fmt's own "refuse rather than
+ * misread" discipline.
+ *
+ * This file: (1) proves the refusal fires for fmt=6 and fmt=7 through BOTH functions
+ * (fork+pipe+waitpid, this suite's established house pattern for exit(1)-terminated paths --
+ * see tests/test_fp8_load.c's expect_refuse/expect_stamp_refuse); (2) proves every format
+ * BOTH functions still legitimately handle (0/1/2/3/4/5) produces byte-identical results
+ * against an independently-written reference dequantizer (qt_dequant_row_ref below -- NOT
+ * copy-pasted from qt_addrow/qt_matvec_rows, restructured as a single per-element loop per
+ * format, so a real regression in either the guard's placement or the untouched per-fmt math
+ * would show up here, not just tautologically re-run the same code). Reachability note (not
+ * a scope excuse, just context): both functions serve ONLY the kv_b absorb path
+ * (attention_rows/decode call sites), and tools/repack_fp8_passthrough.py deliberately
+ * excludes kv_b_proj from fmt=7 repacking -- so this fires only via a hand-slotted or
+ * ambiguous-collision container, not this repo's own tooling's own output. Crash-instead-of-
+ * refuse is still a real defect (spec I6: loud failure, every refusal names its condition),
+ * and the fmt=7 QT surface these functions can now be handed is one this same PR pair
+ * created. */
+#define main coli_glm_main_unused
+#include "../colibri.c"
+#undef main
+
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+#ifndef _WIN32
+#include <unistd.h>
+#include <sys/wait.h>
+#endif
+
+static int fails = 0;
+#define CHECK(c) do{ if(!(c)){ printf("FAIL %s:%d: %s\n", __FILE__, __LINE__, #c); fails++; } }while(0)
+
+static uint64_t rng = 0xA11CE5EEDF00Dull;
+static uint8_t rndbyte(void){ rng ^= rng << 13; rng ^= rng >> 7; rng ^= rng << 17; return (uint8_t)(rng & 0xFF); }
+static float rndsmallf(void){ rng ^= rng << 13; rng ^= rng >> 7; rng ^= rng << 17;
+    return ((int64_t)(rng & 0xFFF) - 0x800) / (float)0x800; }   /* [-1,1)-ish, small magnitude */
+
+/* ---- independent reference dequantizer: W[row,:] as floats, one element per loop
+ * iteration -- deliberately NOT the same code shape as qt_addrow/qt_matvec_rows (those
+ * unroll pairs for fmt=2/3, split low/high planes for fmt=5) so this genuinely
+ * cross-checks the production math, not just the production code running twice. ---- */
+static void qt_dequant_row_ref(const QT *t, int row, float *out){
+    int I=t->I;
+    if(t->fmt==0){ const float *w=t->qf+(int64_t)row*I; for(int i=0;i<I;i++) out[i]=w[i]; return; }
+    if(t->fmt==4){
+        const uint8_t *w=t->q4+(int64_t)row*((I+1)/2); int gs=t->gs, ng=(I+gs-1)/gs;
+        const float *scl=t->s+(int64_t)row*ng;
+        for(int i=0;i<I;i++){ uint8_t b=w[i>>1]; int nib=(i&1)?(b>>4):(b&0xF);
+            out[i]=((int)nib-8)*scl[i/gs]; }
+        return; }
+    if(t->fmt==5){
+        const uint8_t *w=t->q4+(int64_t)row*i3_rowbytes(I);
+        const float *sr=t->s+(int64_t)row*i3_groups(I);
+        for(int i=0;i<I;i++){ int64_t g=i/I3_GROUP; const uint8_t *lo=w+g*I3_GBYTES, *hi=lo+16;
+            int k=i-(int)(g*I3_GROUP);
+            unsigned u=((lo[k>>2]>>((k&3)*2))&3)|(((hi[k>>3]>>(k&7))&1)<<2);
+            out[i]=((int)u-4)*sr[g]; }
+        return; }
+    float s=t->s[row];
+    if(t->fmt==1){ const int8_t *w=t->q8+(int64_t)row*I; for(int i=0;i<I;i++) out[i]=(float)w[i]*s; return; }
+    if(t->fmt==2){
+        const uint8_t *w=t->q4+(int64_t)row*((I+1)/2);
+        for(int i=0;i<I;i++){ uint8_t b=w[i>>1]; int nib=(i&1)?(b>>4):(b&0xF); out[i]=((int)nib-8)*s; }
+        return; }
+    /* fmt==3 */
+    { const uint8_t *w=t->q4+(int64_t)row*((I+3)/4);
+      for(int i=0;i<I;i++){ uint8_t b=w[i>>2]; int v=(b>>((i&3)*2))&3; out[i]=((int)v-2)*s; } }
+}
+
+/* ---- fixture builders: one per format, deterministic pseudo-random payload ---- */
+static void fill_fmt0(QT *t, int O, int I){
+    t->fmt=0; t->O=O; t->I=I; t->gs=0;
+    t->qf=(float*)malloc((size_t)O*I*sizeof(float));
+    for(int i=0;i<O*I;i++) t->qf[i]=rndsmallf();
+}
+static void fill_fmt1(QT *t, int O, int I){
+    t->fmt=1; t->O=O; t->I=I; t->gs=0;
+    t->q8=(int8_t*)malloc((size_t)O*I);
+    t->s=(float*)malloc((size_t)O*sizeof(float));
+    for(int i=0;i<O*I;i++) t->q8[i]=(int8_t)(rndbyte()-128);
+    for(int i=0;i<O;i++) t->s[i]=0.01f+0.001f*(float)i;
+}
+static void fill_fmt2(QT *t, int O, int I){
+    t->fmt=2; t->O=O; t->I=I; t->gs=0;
+    int rb=(I+1)/2;
+    t->q4=(uint8_t*)malloc((size_t)O*rb);
+    t->s=(float*)malloc((size_t)O*sizeof(float));
+    for(int i=0;i<O*rb;i++) t->q4[i]=rndbyte();
+    for(int i=0;i<O;i++) t->s[i]=0.02f+0.001f*(float)i;
+}
+static void fill_fmt3(QT *t, int O, int I){
+    t->fmt=3; t->O=O; t->I=I; t->gs=0;
+    int rb=(I+3)/4;
+    t->q4=(uint8_t*)malloc((size_t)O*rb);
+    t->s=(float*)malloc((size_t)O*sizeof(float));
+    for(int i=0;i<O*rb;i++) t->q4[i]=rndbyte();
+    for(int i=0;i<O;i++) t->s[i]=0.03f+0.001f*(float)i;
+}
+static void fill_fmt4(QT *t, int O, int I, int gs){
+    t->fmt=4; t->O=O; t->I=I; t->gs=gs;
+    int rb=(I+1)/2, ng=(I+gs-1)/gs;
+    t->q4=(uint8_t*)malloc((size_t)O*rb);
+    t->s=(float*)malloc((size_t)O*ng*sizeof(float));
+    for(int i=0;i<O*rb;i++) t->q4[i]=rndbyte();
+    for(int i=0;i<O*ng;i++) t->s[i]=0.015f+0.0007f*(float)i;
+}
+static void fill_fmt5(QT *t, int O, int I){
+    t->fmt=5; t->O=O; t->I=I; t->gs=0;
+    int64_t ng=i3_groups(I), rb=i3_rowbytes(I);
+    t->q4=(uint8_t*)malloc((size_t)O*rb);
+    t->s=(float*)malloc((size_t)(O*ng)*sizeof(float));
+    for(int i=0;i<O*rb;i++) t->q4[i]=rndbyte();
+    for(int i=0;i<O*ng;i++) t->s[i]=0.025f+0.0003f*(float)i;
+}
+static void free_qt(QT *t){ free(t->qf); free(t->q8); free(t->q4); free(t->s); memset(t,0,sizeof *t); }
+
+/* ---- byte-identity: qt_addrow / qt_matvec_rows vs the independent reference, every
+ * format both functions still legitimately handle ---- */
+/* Epsilon, not bit-exact: qt_addrow precomputes c=coef*scale ONCE, then c*w[i]
+ * ((coef*scale)*w[i]); the reference below multiplies coef*(scale*w[i]) --
+ * mathematically identical, but floating-point multiplication isn't
+ * associative, so the two can differ in the last ULP for some inputs. This
+ * is expected float-reassociation noise, not a regression -- confirmed by
+ * inspecting actual failures at bit-exact comparison (all last-digit-of-
+ * mantissa only, no shape/format-decode errors) before relaxing to epsilon,
+ * matching this suite's own established practice for reduction-order-
+ * sensitive checks (e.g. the metal-test suite's worst_rel comparisons). */
+static void check_addrow_identity(QT *t, const char *tag){
+    int I=t->I; float *ref=(float*)malloc((size_t)I*sizeof(float));
+    float *acc=(float*)malloc((size_t)I*sizeof(float));
+    float coef=1.7f;   /* != 1, so a coef-scaling bug can't hide */
+    for(int row=0; row<t->O; row++){
+        qt_dequant_row_ref(t,row,ref);
+        memset(acc,0,(size_t)I*sizeof(float));
+        qt_addrow(t,row,coef,acc);
+        for(int i=0;i<I;i++){
+            float want=coef*ref[i];
+            float ae=fabsf(acc[i]-want);
+            float rel = fabsf(want)>1e-6f ? ae/fabsf(want) : ae;
+            if(rel > 1e-5f){
+                printf("FAIL %s: qt_addrow row=%d i=%d got=%.9g want=%.9g rel=%.3g\n",tag,row,i,(double)acc[i],(double)want,(double)rel);
+                fails++;
+            }
+        }
+    }
+    free(ref); free(acc);
+}
+static void check_matvec_identity(QT *t, const char *tag){
+    int I=t->I; float *ref=(float*)malloc((size_t)I*sizeof(float));
+    float *x=(float*)malloc((size_t)I*sizeof(float));
+    for(int i=0;i<I;i++) x[i]=rndsmallf();
+    for(int row=0; row<t->O; row++){
+        qt_dequant_row_ref(t,row,ref);
+        double want=0; for(int i=0;i<I;i++) want+=(double)ref[i]*x[i];
+        float y=0.f;
+        qt_matvec_rows(t,row,1,x,&y);
+        double relerr = fabs(want)>1e-6 ? fabs((double)y-want)/fabs(want) : fabs((double)y-want);
+        if(relerr > 1e-4){
+            printf("FAIL %s: qt_matvec_rows row=%d got=%.9g want=%.9g relerr=%.3g\n",tag,row,(double)y,want,relerr);
+            fails++;
+        }
+    }
+    free(ref); free(x);
+}
+
+static void test_byte_identity_all_formats(void){
+    QT t;
+    memset(&t,0,sizeof t); fill_fmt0(&t,4,17);   check_addrow_identity(&t,"fmt=0"); check_matvec_identity(&t,"fmt=0"); free_qt(&t);
+    memset(&t,0,sizeof t); fill_fmt1(&t,4,17);   check_addrow_identity(&t,"fmt=1"); check_matvec_identity(&t,"fmt=1"); free_qt(&t);
+    memset(&t,0,sizeof t); fill_fmt2(&t,4,17);   check_addrow_identity(&t,"fmt=2"); check_matvec_identity(&t,"fmt=2"); free_qt(&t);
+    memset(&t,0,sizeof t); fill_fmt3(&t,4,17);   check_addrow_identity(&t,"fmt=3"); check_matvec_identity(&t,"fmt=3"); free_qt(&t);
+    memset(&t,0,sizeof t); fill_fmt4(&t,4,40,16);check_addrow_identity(&t,"fmt=4"); check_matvec_identity(&t,"fmt=4"); free_qt(&t);
+    memset(&t,0,sizeof t); fill_fmt5(&t,4,130);  check_addrow_identity(&t,"fmt=5"); check_matvec_identity(&t,"fmt=5"); free_qt(&t);
+}
+
+/* ---- refusal: fork+pipe+waitpid, this suite's house pattern (see test_fp8_load.c's
+ * expect_refuse/expect_stamp_refuse) -- must exit(1) with a "refus"-containing message,
+ * never reach the caller's continuation, never crash with a signal. ---- */
+typedef void (*absorb_fn)(void);
+static void call_addrow_fmt7(void){
+    QT t; memset(&t,0,sizeof t);
+    enum { O=130, I=130 };   /* the coordinator's own repro shape: nblkO=nblkI=2, nblk=4 */
+    static uint8_t q8[O*I]; static float s[4];
+    for(int i=0;i<O*I;i++) q8[i]=rndbyte();
+    for(int i=0;i<4;i++) s[i]=0.01f;
+    t.fmt=7; t.O=O; t.I=I; t.gs=0; t.q8=(int8_t*)q8; t.s=s;
+    float acc[I]; memset(acc,0,sizeof acc);
+    qt_addrow(&t,0,1.f,acc);   /* must exit(1) inside; must NOT return */
+}
+static void call_addrow_fmt6(void){
+    QT t; memset(&t,0,sizeof t);
+    enum { O=4, I=98 };
+    static uint8_t q4[O*98]; static float s[1];
+    for(int i=0;i<O*98;i++) q4[i]=rndbyte();
+    s[0]=0.01f;
+    t.fmt=6; t.O=O; t.I=I; t.gs=0; t.q4=q4; t.s=s;
+    float acc[I]; memset(acc,0,sizeof acc);
+    qt_addrow(&t,0,1.f,acc);
+}
+static void call_matvec_fmt7(void){
+    QT t; memset(&t,0,sizeof t);
+    enum { O=130, I=130 };
+    static uint8_t q8[O*I]; static float s[4];
+    for(int i=0;i<O*I;i++) q8[i]=rndbyte();
+    for(int i=0;i<4;i++) s[i]=0.01f;
+    t.fmt=7; t.O=O; t.I=I; t.gs=0; t.q8=(int8_t*)q8; t.s=s;
+    static float x[I]; for(int i=0;i<I;i++) x[i]=rndsmallf();
+    float y=0.f;
+    qt_matvec_rows(&t,0,1,x,&y);
+}
+static void call_matvec_fmt6(void){
+    QT t; memset(&t,0,sizeof t);
+    enum { O=4, I=98 };
+    static uint8_t q4[O*98]; static float s[1];
+    for(int i=0;i<O*98;i++) q4[i]=rndbyte();
+    s[0]=0.01f;
+    t.fmt=6; t.O=O; t.I=I; t.gs=0; t.q4=q4; t.s=s;
+    static float x[I]; for(int i=0;i<I;i++) x[i]=rndsmallf();
+    float y=0.f;
+    qt_matvec_rows(&t,0,1,x,&y);
+}
+
+static int expect_refuse_call(absorb_fn fn, const char *tag){
+#ifndef _WIN32
+    int pipefd[2]; if(pipe(pipefd)!=0) return 0;
+    pid_t pid = fork();
+    if(pid < 0) return 0;
+    if(pid == 0){
+        dup2(pipefd[1],2); close(pipefd[0]); close(pipefd[1]);
+        fn();
+        _exit(42);   /* reaching here (surviving the call without exit(1)) is the bug */
+    }
+    close(pipefd[1]);
+    char err[1024]={0}; ssize_t n=read(pipefd[0],err,sizeof(err)-1); (void)n;
+    close(pipefd[0]);
+    int status=0; waitpid(pid,&status,0);
+    if(WIFSIGNALED(status)){
+        printf("FAIL %s: crashed with signal %d instead of refusing (exit(1)) -- this IS the "
+               "engine defect this test exists to catch\n", tag, WTERMSIG(status));
+        return 0;
+    }
+    int ok = WIFEXITED(status) && WEXITSTATUS(status)==1;
+    if(!ok){
+        printf("FAIL %s: expected exit(1) refusal, got status=%d, stderr=%.200s\n", tag, status, err);
+        return 0;
+    }
+    if(!strstr(err,"refus")){
+        printf("FAIL %s: exited(1) but message lacked a refusal explanation: %.200s\n", tag, err);
+        return 0;
+    }
+    return 1;
+#else
+    printf("skipped on Windows (no fork): %s\n", tag);
+    (void)fn;
+    return 1;
+#endif
+}
+
+static void test_refusals(void){
+    CHECK(expect_refuse_call(call_addrow_fmt7,  "qt_addrow refuses fmt=7 (was SIGSEGV)"));
+    CHECK(expect_refuse_call(call_addrow_fmt6,  "qt_addrow refuses fmt=6"));
+    CHECK(expect_refuse_call(call_matvec_fmt7,  "qt_matvec_rows refuses fmt=7"));
+    CHECK(expect_refuse_call(call_matvec_fmt6,  "qt_matvec_rows refuses fmt=6"));
+}
+
+int main(void){
+    test_byte_identity_all_formats();
+    test_refusals();
+    if(fails){ printf("qt_addrow/qt_matvec_rows tests: %d FAILED\n", fails); return 1; }
+    printf("qt_addrow/qt_matvec_rows tests: ok\n");
+    return 0;
+}

--- a/c/tools/README.md
+++ b/c/tools/README.md
@@ -4,6 +4,8 @@ These scripts support model preparation and offline engineering work. They are
 not runtime dependencies of the C engine.
 
 - `convert_fp8_to_int4.py`, `download_glm52.py`: model preparation
+- `repack_fp8_passthrough.py`: fmt=7 repack (byte-preserved FP8, resident kinds only;
+  see the module docstring -- synthetic-fixture-tested only, no real-shard runs yet)
 - `make_glm_oracle.py`, `make_glm_bench_model.py`: deterministic fixtures
 - `benchmark_cuda_fixture.py`, `eval_glm.py`, `fetch_benchmarks.py`: benchmarks
 - `gen_unicode.py`: tokenizer table generation

--- a/c/tools/README.md
+++ b/c/tools/README.md
@@ -4,7 +4,7 @@ These scripts support model preparation and offline engineering work. They are
 not runtime dependencies of the C engine.
 
 - `convert_fp8_to_int4.py`, `download_glm52.py`: model preparation
-- `repack_fp8_passthrough.py`: fmt=7 repack (byte-preserved FP8, resident kinds only;
+- `repack_fp8_passthrough.py`: fmt=8 repack (byte-preserved FP8, resident kinds only;
   see the module docstring -- synthetic-fixture-tested only, no real-shard runs yet)
 - `make_glm_oracle.py`, `make_glm_bench_model.py`: deterministic fixtures
 - `benchmark_cuda_fixture.py`, `eval_glm.py`, `fetch_benchmarks.py`: benchmarks

--- a/c/tools/fp8_collision_census.py
+++ b/c/tools/fp8_collision_census.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""fp8_collision_census.py: enumerate every RESIDENT-role tensor shape in a
+safetensors container (JSON header parse ONLY -- no tensor data read, no
+torch/safetensors import, no model load) and evaluate THE DESIGN LANDMINE's
+collision predicate (qt_resolve_fmt in colibri.c): O == ceil(O/128)*ceil(I/128),
+the shape family where an int8-row tensor's per-row scale byte count (O*4)
+exactly equals a per-128x128-block fp8 scale byte count
+(ceil(O/128)*ceil(I/128)*4) for the SAME [O,I].
+
+Maintainer review, #528: this is not a hypothetical corner case. GLM-5.2's own
+self_attn.o_proj.weight ([D,H*v_head] = [6144,16384]) hits it on every
+checkpoint this engine has loaded. This script is the "enumerated, not
+sampled" evidence for that finding, run against this repo's own containers.
+
+WHY config.json, not just the safetensors header: a container's on-disk
+weight tensor is stored FLATTENED (one dimension: O*I raw bytes for int8-row,
+O*ceil(I/2) for int4-packed, etc. -- see colibri.c's qt_bytes()) -- the header
+alone cannot recover O and I separately for [O,I]. This script instead
+computes each tensor's [O,I] from the model's config.json (hidden_size,
+q_lora_rank, kv_lora_rank, num_attention_heads, qk_rope_head_dim,
+qk_nope_head_dim, v_head_dim, intermediate_size, moe_intermediate_size -- the
+same dimensions colibri.c's own Cfg struct reads at load time and passes into
+qt_resolve_fmt as O,I), for every tensor NAME the header actually contains
+that this script's role table recognizes, then cross-checks the computed
+byte count against the header's own raw byte count (int8-row: O*I; int4-
+packed: O*ceil(I/2)) as a sanity check -- reported, not silently trusted.
+
+Scope: RESIDENT-kind tensor roles only (o_proj, q_a/q_b_proj,
+kv_a_proj_with_mqa, kv_b_proj, dense-MLP gate/up/down, shared-expert
+gate/up/down) plus routed-expert gate/up/down for completeness -- these are
+the only roles tools/repack_fp8_passthrough.py's RESIDENT_KINDS classify()
+taxonomy could ever select for fmt=7 repacking (routed experts are excluded
+by that tool's own design and stay on int4-g64/E8, but are included here
+anyway since the collision predicate is a pure function of [O,I], independent
+of current on-disk format). f32/norm/router/embed/lm_head tensors are not
+quantized (no U8 weight) and are skipped.
+
+Usage:
+  python3 tools/fp8_collision_census.py <container_dir> [<container_dir> ...]
+"""
+import glob, json, os, struct, sys
+
+BLOCK = 128
+
+
+def _nblk(n):
+    return (n + BLOCK - 1) // BLOCK
+
+
+def is_ambiguous(O, I):
+    """THE DESIGN LANDMINE's collision predicate (colibri.c qt_resolve_fmt):
+    an int8-row tensor at this [O,I] has per-row scale bytes O*4 that exactly
+    equal per-128x128-block fp8 scale bytes ceil(O/128)*ceil(I/128)*4."""
+    return _nblk(O) * _nblk(I) == O
+
+
+def read_header(path):
+    """Header-only read: 8-byte little-endian length prefix + that many bytes
+    of JSON. Never reads a single byte of actual tensor data."""
+    with open(path, "rb") as f:
+        hlen = struct.unpack("<Q", f.read(8))[0]
+        return json.loads(f.read(hlen).decode("utf-8"))
+
+
+def scan_tensor_headers(container_dir):
+    """Union of every non-metadata tensor key -> header entry, across every
+    shard in the container. Header (JSON) only, see read_header above."""
+    entries = {}
+    for path in sorted(glob.glob(os.path.join(container_dir, "*.safetensors"))):
+        hdr = read_header(path)
+        for k, v in hdr.items():
+            if k == "__metadata__":
+                continue
+            entries[k] = v
+    return entries
+
+
+def classify_shape(name, cfg):
+    """Returns (kind, O, I) for a tensor name this census can size from
+    config.json alone, or None if `name` isn't a role this script recognizes
+    (norms/router/embed/lm_head/MTP-head-only tensors -- none of these carry
+    a resident [O,I] weight this predicate applies to)."""
+    D = cfg["hidden_size"]
+    H = cfg["num_attention_heads"]
+    q_lora = cfg["q_lora_rank"]
+    kv_lora = cfg["kv_lora_rank"]
+    qk_rope = cfg["qk_rope_head_dim"]
+    qk_nope = cfg["qk_nope_head_dim"]
+    v_head = cfg["v_head_dim"]
+    inter = cfg["intermediate_size"]
+    moe_inter = cfg["moe_intermediate_size"]
+    qk_head = qk_nope + qk_rope
+
+    if name.endswith("self_attn.o_proj.weight"):
+        return ("self_attn.o_proj", D, H * v_head)
+    if name.endswith("self_attn.q_a_proj.weight"):
+        return ("self_attn.q_a_proj", q_lora, D)
+    if name.endswith("self_attn.q_b_proj.weight"):
+        return ("self_attn.q_b_proj", H * qk_head, q_lora)
+    if name.endswith("self_attn.kv_a_proj_with_mqa.weight"):
+        return ("self_attn.kv_a_proj_with_mqa", kv_lora + qk_rope, D)
+    if name.endswith("self_attn.kv_b_proj.weight"):
+        return ("self_attn.kv_b_proj (kvb -- excluded from fmt=7 repack, see tool docstring)",
+                 H * (qk_nope + v_head), kv_lora)
+    if ".mlp.experts." in name and name.endswith("gate_proj.weight"):
+        return ("mlp.experts.*.gate_proj (routed -- excluded from fmt=7 repack)", moe_inter, D)
+    if ".mlp.experts." in name and name.endswith("up_proj.weight"):
+        return ("mlp.experts.*.up_proj (routed -- excluded from fmt=7 repack)", moe_inter, D)
+    if ".mlp.experts." in name and name.endswith("down_proj.weight"):
+        return ("mlp.experts.*.down_proj (routed -- excluded from fmt=7 repack)", D, moe_inter)
+    if "shared_experts" in name and name.endswith("gate_proj.weight"):
+        return ("mlp.shared_experts.gate_proj", moe_inter, D)
+    if "shared_experts" in name and name.endswith("up_proj.weight"):
+        return ("mlp.shared_experts.up_proj", moe_inter, D)
+    if "shared_experts" in name and name.endswith("down_proj.weight"):
+        return ("mlp.shared_experts.down_proj", D, moe_inter)
+    if name.endswith("mlp.gate_proj.weight") and ".experts." not in name:
+        return ("mlp.gate_proj (dense)", inter, D)
+    if name.endswith("mlp.up_proj.weight") and ".experts." not in name:
+        return ("mlp.up_proj (dense)", inter, D)
+    if name.endswith("mlp.down_proj.weight") and ".experts." not in name:
+        return ("mlp.down_proj (dense)", D, inter)
+    return None
+
+
+def _byte_check(nb_actual, O, I):
+    if nb_actual == O * I:
+        return "int8-row (nb=O*I)"
+    if nb_actual == O * ((I + 1) // 2):
+        return "int4-packed (nb=O*ceil(I/2))"
+    return f"UNVERIFIED (nb={nb_actual}, neither O*I={O*I} nor O*ceil(I/2)={O*((I+1)//2)} -- " \
+           f"likely int3-g64/E8-lattice, expected for routed experts in some containers)"
+
+
+def census(container_dir):
+    cfg_path = os.path.join(container_dir, "config.json")
+    with open(cfg_path) as f:
+        cfg = json.load(f)
+    entries = scan_tensor_headers(container_dir)
+    by_pattern = {}
+    unresolved = []
+    for name, entry in entries.items():
+        if name.endswith(".qs") or name.endswith("_scale_inv"):
+            continue
+        if entry.get("dtype") != "U8":
+            continue
+        cls = classify_shape(name, cfg)
+        if cls is None:
+            unresolved.append(name)
+            continue
+        kind, O, I = cls
+        shp = entry.get("shape", [])
+        nb_actual = 1
+        for d in shp:
+            nb_actual *= d
+        key = (kind, O, I)
+        rec = by_pattern.setdefault(key, {"kind": kind, "O": O, "I": I, "count": 0,
+                                          "ambiguous": is_ambiguous(O, I),
+                                          "byte_encodings": set()})
+        rec["count"] += 1
+        rec["byte_encodings"].add(_byte_check(nb_actual, O, I))
+    return cfg, by_pattern, unresolved
+
+
+def main():
+    dirs = sys.argv[1:]
+    if not dirs:
+        print("usage: fp8_collision_census.py <container_dir> [<container_dir> ...]", file=sys.stderr)
+        sys.exit(1)
+    any_ambig = False
+    for d in dirs:
+        base = os.path.basename(os.path.normpath(d))
+        cfg, by_pattern, unresolved = census(d)
+        print(f"=== {base} ({d}) ===")
+        print(f"{'tensor name pattern':70s} {'O':>8s} {'I':>8s} {'nblkO*nblkI':>12s} {'count':>6s}  ambiguous?  on-disk encoding(s)")
+        for (kind, O, I), rec in sorted(by_pattern.items()):
+            nblk_prod = _nblk(O) * _nblk(I)
+            flag = "AMBIGUOUS <---" if rec["ambiguous"] else "-"
+            if rec["ambiguous"]:
+                any_ambig = True
+            enc = ", ".join(sorted(rec["byte_encodings"]))
+            print(f"{kind:70s} {O:8d} {I:8d} {nblk_prod:12d} {rec['count']:6d}  {flag:15s} {enc}")
+        if unresolved:
+            print(f"  ({len(unresolved)} U8 tensor(s) in {base} not classified by this script's role "
+                  f"table -- inspect if unexpected: {sorted(unresolved)[:5]}{'...' if len(unresolved)>5 else ''})")
+        print()
+    print("RESULT:", "AMBIGUOUS family found (see table above)" if any_ambig else "no ambiguous family found")
+
+
+if __name__ == "__main__":
+    main()

--- a/c/tools/fp8_collision_census.py
+++ b/c/tools/fp8_collision_census.py
@@ -29,7 +29,7 @@ Scope: RESIDENT-kind tensor roles only (o_proj, q_a/q_b_proj,
 kv_a_proj_with_mqa, kv_b_proj, dense-MLP gate/up/down, shared-expert
 gate/up/down) plus routed-expert gate/up/down for completeness -- these are
 the only roles tools/repack_fp8_passthrough.py's RESIDENT_KINDS classify()
-taxonomy could ever select for fmt=7 repacking (routed experts are excluded
+taxonomy could ever select for fmt=8 repacking (routed experts are excluded
 by that tool's own design and stay on int4-g64/E8, but are included here
 anyway since the collision predicate is a pure function of [O,I], independent
 of current on-disk format). f32/norm/router/embed/lm_head tensors are not
@@ -100,14 +100,14 @@ def classify_shape(name, cfg):
     if name.endswith("self_attn.kv_a_proj_with_mqa.weight"):
         return ("self_attn.kv_a_proj_with_mqa", kv_lora + qk_rope, D)
     if name.endswith("self_attn.kv_b_proj.weight"):
-        return ("self_attn.kv_b_proj (kvb -- excluded from fmt=7 repack, see tool docstring)",
+        return ("self_attn.kv_b_proj (kvb -- excluded from fmt=8 repack, see tool docstring)",
                  H * (qk_nope + v_head), kv_lora)
     if ".mlp.experts." in name and name.endswith("gate_proj.weight"):
-        return ("mlp.experts.*.gate_proj (routed -- excluded from fmt=7 repack)", moe_inter, D)
+        return ("mlp.experts.*.gate_proj (routed -- excluded from fmt=8 repack)", moe_inter, D)
     if ".mlp.experts." in name and name.endswith("up_proj.weight"):
-        return ("mlp.experts.*.up_proj (routed -- excluded from fmt=7 repack)", moe_inter, D)
+        return ("mlp.experts.*.up_proj (routed -- excluded from fmt=8 repack)", moe_inter, D)
     if ".mlp.experts." in name and name.endswith("down_proj.weight"):
-        return ("mlp.experts.*.down_proj (routed -- excluded from fmt=7 repack)", D, moe_inter)
+        return ("mlp.experts.*.down_proj (routed -- excluded from fmt=8 repack)", D, moe_inter)
     if "shared_experts" in name and name.endswith("gate_proj.weight"):
         return ("mlp.shared_experts.gate_proj", moe_inter, D)
     if "shared_experts" in name and name.endswith("up_proj.weight"):

--- a/c/tools/rans_format.py
+++ b/c/tools/rans_format.py
@@ -20,7 +20,7 @@ FORMAT SUMMARY (docs/int4-rans256-g0.md is the full specification):
     the format NAME "int4-rans256-g0". THE STAMP IS MANDATORY: entropy-coded
     sizes are data-dependent, so no byte-arithmetic inference exists for this
     format — the stamp is the ONLY signal a U8 tensor is entropy-coded, not a
-    cross-check on an inference (unlike fmt=7's optional stamp).
+    cross-check on an inference (unlike fmt=8's optional stamp).
 
 Table construction is the standard largest-remainder frequency quantization
 (FSE/rANS convention): scale an empirical histogram to sum exactly to
@@ -42,7 +42,7 @@ N_STREAMS = 256
 SCALE_BITS = 14                # M = 16384; generous for a 16-symbol alphabet
 M = 1 << SCALE_BITS
 TABLE_ID = "g0"                # shared-global-table generation 0
-METADATA_KEY = "colibri.fmt"   # same key/shape as the fmt=7 stamp convention
+METADATA_KEY = "colibri.fmt"   # same key/shape as the fmt=8 stamp convention
 TABLE_KEY = "colibri.int4-rans256-g0.table"
 RANS_L = 1 << 23
 SLACK = 64                     # readable bytes past a record buffer (SIMD contract)

--- a/c/tools/repack_fp8_passthrough.py
+++ b/c/tools/repack_fp8_passthrough.py
@@ -58,11 +58,20 @@ kv_b_proj (kind "kvb") is ALSO deliberately excluded, despite being a resident
 tensor classify() would otherwise select: colibri.c's MLA-absorption CPU path
 (qt_addrow/qt_matvec_rows, called only on l->kv_b -- the always-available
 fallback whenever the Metal fused decode kernel isn't used) has no fmt==7
-case and would silently misread fp8 bytes as int2-packed data; the CUDA
-absorb kernels (coli_cuda_attention_absorb/_kvdev in backend_cuda.cu) are
-similarly int4-specific. Repacking kv_b_proj to fmt=7 needs that CPU+CUDA
-absorb-path work first -- out of scope for this build, so this tool refuses
-to produce a container the engine cannot safely read.
+support. FIX ROUND 2 update: an fmt=7 (or fmt=6) tensor reaching either
+function now refuses loudly (exit(1), naming the function and the fmt) --
+before that fix it was worse than "misread as int2": qt_addrow SIGSEGV'd
+outright (t->q4 is NULL for fmt=7; the untouched int2 fall-through
+dereferenced it), and only fmt=6 (t->q4 non-NULL, wrong per-row scale
+geometry) actually produced silently-wrong values. Either way, this tool
+still does not select kv_b_proj: refusing loudly at the absorb call site is
+not the same as SUPPORTING fmt=7 there (no dequant path exists, whether it
+now trips a controlled refusal or, before the fix, undefined behavior). The
+CUDA absorb kernels (coli_cuda_attention_absorb/_kvdev in backend_cuda.cu)
+are similarly int4-specific and unaffected by that fix. Repacking kv_b_proj
+to fmt=7 needs real fmt=7 CPU+CUDA absorb-path support first -- out of scope
+for this build, so this tool refuses to produce a container the engine
+cannot safely read.
 
 This tool does NOT write a container metadata stamp: __metadata__-based
 self-description (writer + qt_verify_fmt_stamp reader + docs/FORMATS.md
@@ -295,6 +304,21 @@ def main():
         print(f"[RESUME] {skipped} shard(s) already done in {a.outdir}, skipped")
     print(f"[REPACK] {fresh} new output shard(s) written")
     _print_inventory_summary(all_inv, dry_run=False)
+    # FIX ROUND 2 (clean-room conformance trial, spec I6 -- loud failure, every
+    # refusal names its condition): a run that selects ZERO repack-target tensors
+    # across every shard under --indir (present run AND any prior resumed run --
+    # `done` has one entry per shard, "" meaning that shard has NEVER produced an
+    # output) used to exit 0 having emitted nothing -- a silent trap: an empty
+    # "container" (just the resume/params sidecars, no actual .safetensors output)
+    # that nobody asked for and no caller-side check would catch. Refuse loudly
+    # instead. --dry-run is NOT covered here: reporting "0 tensors selected" IS
+    # the loud, honest answer dry-run exists to give, not a silent no-op -- see
+    # the early `return` above, before any of this resume/write bookkeeping.
+    if all(v == "" for v in done.values()):
+        print(f"ERROR: no repack-target tensors found under {a.indir} (checked "
+              f"{len(shards)} shard(s), 0 selected) -- nothing emitted; refusing "
+              f"to exit 0 for an empty container nobody asked for", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/c/tools/repack_fp8_passthrough.py
+++ b/c/tools/repack_fp8_passthrough.py
@@ -19,13 +19,23 @@ comment): the engine tells fmt=7 (this tool's output) apart from fmt=1 (plain
 int8) ONLY by scale-array geometry -- per-row for fmt=1, per-128x128-block for
 fmt=7. This tool must therefore emit .qs sidecars whose byte count is EXACTLY
 ceil(O/128)*ceil(I/128)*4, never anything that could coincide with O*4 by
-accident for the shapes it targets (see _check_geometry below, which refuses
-rather than silently emitting a container the engine might misread). At I=98
-specifically, a single-block fp8 tensor's raw weight-byte count ALSO coincides
-with a genuine fmt=6 (E8/IQ3) tensor's -- see qt_resolve_fmt's "SECOND DESIGN
-LANDMINE" comment; this tool does not target I=98 shapes in practice (Z.ai's
-real projections don't land there), but the engine's read-side refusal covers
-it regardless.
+accident for the shapes it targets -- ENFORCED, not just asserted, by
+_check_geometry below (maintainer review, #528): it refuses to repack any
+[O,I] where nblkO*nblkI==O, the exact shape where this tool's own block-scale
+byte count would coincide with a per-row int8 scale byte count. This is not
+hypothetical: GLM-5.2's own self_attn.o_proj.weight ([6144,16384]) is a real
+instance (nblkO=48, nblkI=128, product=6144==O). It matters more now than it
+used to, because the engine's UNSTAMPED read-side collision policy resolves an
+ambiguous shape to fmt=1 rather than refusing (see qt_resolve_fmt's
+INVERSION) -- so an fmt=7 container this tool emitted at such a shape would be
+silently read back as plain int8, not caught by a read-side refusal. Avoiding
+the collision at write time is therefore load-bearing, not a redundant
+belt-and-braces check. At I=98 specifically, a single-block fp8 tensor's raw
+weight-byte count ALSO coincides with a genuine fmt=6 (E8/IQ3) tensor's -- see
+qt_resolve_fmt's "SECOND DESIGN LANDMINE" comment; this tool does not target
+I=98 shapes in practice (Z.ai's real projections don't land there), and that
+narrower collision is unchanged by this PR (still an unconditional read-side
+refusal), so _check_geometry does not additionally guard against it here.
 
 SCALE ENCODING: this tool always emits f32 block scales (4 bytes/block, the
 `.to(torch.float32)` below) -- the ENCODING this build implements. It never
@@ -112,13 +122,32 @@ def _check_geometry(name, O, I, nblkO, nblkI):
     doesn't match what qt_resolve_fmt expects for [O,I] -- the same "untrusted
     container" discipline the C side applies on read, applied here on write so a
     malformed source checkpoint is caught at repack time, not at load time three
-    steps later with a confusing engine-side refusal."""
+    steps later with a confusing engine-side refusal.
+
+    WRITER-SIDE REFUSAL (maintainer review, #528): also refuses at the AMBIGUOUS
+    shape THE DESIGN LANDMINE describes (qt_resolve_fmt in colibri.c) -- where
+    O == ceil(O/128)*ceil(I/128), i.e. this tensor's block-scale byte count
+    (nblkO*nblkI*4) exactly equals a per-row int8 scale byte count (O*4). GLM-5.2's
+    own self_attn.o_proj.weight ([6144,16384]) is a REAL, non-hypothetical instance
+    of this shape. The engine's reader now resolves an unstamped collision to fmt=1
+    (the incumbent, decodable format) rather than refusing -- which makes it load
+    bearing that THIS tool never emits an fmt=7 container at such a shape: this
+    docstring's own opening promise ("never anything that could coincide with O*4
+    by accident") is enforced here, not just asserted."""
     exp_nblkO, exp_nblkI = _nblk(O), _nblk(I)
     if (nblkO, nblkI) != (exp_nblkO, exp_nblkI):
         raise ValueError(
             f"{name}: scale_inv block shape ({nblkO},{nblkI}) != expected "
             f"({exp_nblkO},{exp_nblkI}) for [{O},{I}] -- refusing to repack a shape "
             f"the engine's qt_resolve_fmt would either refuse or (worse) misread")
+    if nblkO * nblkI == O:
+        raise ValueError(
+            f"{name}: [{O},{I}] is an AMBIGUOUS fp8-e4m3-b128 shape -- its "
+            f"block-scale byte count (nblkO*nblkI*4={nblkO*nblkI*4}) exactly "
+            f"coincides with a per-row int8 scale byte count (O*4={O*4}) for the "
+            f"same [O,I]; refusing to emit an fmt=7 container the engine's "
+            f"qt_resolve_fmt collision policy would resolve to fmt=1 (int8-row), "
+            f"not fmt=7, on an unstamped read (THE DESIGN LANDMINE, colibri.c)")
 
 
 def shard_inventory(path, n_layers):

--- a/c/tools/repack_fp8_passthrough.py
+++ b/c/tools/repack_fp8_passthrough.py
@@ -1,0 +1,272 @@
+"""fmt=7 repack tool: Z.ai GLM-5.2-FP8 shards -> the engine's native-FP8-passthrough
+container (byte-preserved, no dequant/requant).
+
+fmt=7 is a PUBLIC ordinal, assigned by the maintainer on #524. This tool's
+output format was minted fmt=6 during this branch's original development,
+before dev's own #465 (E8/IQ3) claimed that ordinal upstream and merged it
+into dev as a REAL fmt=6 (colibri.c's qt_resolve_fmt, quant.h's E8
+constants); re-tagged fmt=100 (PRIVATE ORDINAL BLOCK, see colibri.c's QT
+struct comment) from that point forward -- this tool has never emitted a
+container claiming ordinal 6 -- and graduated to fmt=7 at merge.
+
+Unlike convert_fp8_to_int4.py (which DEQUANTIZES fp8 -> f32 -> REQUANTIZES to a
+different, lossy format), this tool copies the fp8 weight bytes AS-IS and only
+renames/reshapes the scale sidecar to the engine's `.qs` convention. Same 8
+bits/weight streaming cost as the source, zero additional quantization loss.
+
+THE DESIGN LANDMINE (see qt_resolve_fmt in colibri.c, c/quant.h's E4M3_LUT
+comment): the engine tells fmt=7 (this tool's output) apart from fmt=1 (plain
+int8) ONLY by scale-array geometry -- per-row for fmt=1, per-128x128-block for
+fmt=7. This tool must therefore emit .qs sidecars whose byte count is EXACTLY
+ceil(O/128)*ceil(I/128)*4, never anything that could coincide with O*4 by
+accident for the shapes it targets (see _check_geometry below, which refuses
+rather than silently emitting a container the engine might misread). At I=98
+specifically, a single-block fp8 tensor's raw weight-byte count ALSO coincides
+with a genuine fmt=6 (E8/IQ3) tensor's -- see qt_resolve_fmt's "SECOND DESIGN
+LANDMINE" comment; this tool does not target I=98 shapes in practice (Z.ai's
+real projections don't land there), but the engine's read-side refusal covers
+it regardless.
+
+SCALE ENCODING: this tool always emits f32 block scales (4 bytes/block, the
+`.to(torch.float32)` below) -- the ENCODING this build implements. It never
+reads or emits a UE8M0 (1 byte/block) sidecar: Z.ai's GLM-5.2-FP8 checkpoints
+ship f32 `weight_scale_inv`, so there is no source data this tool would need
+to convert from. A DeepSeek-V4-shaped source (same weight geometry, UE8M0
+scales) is out of scope for this tool as written; the read side (qt_resolve_fmt)
+recognizes and refuses that byte signature by name rather than misread it,
+should a container carrying it ever reach the engine some other way.
+
+SELECTED kinds only: "resident" tensors (shared expert, o_proj, other
+attention projections, dense-MLP first layers, and the generic resident
+fallback) -- routed experts (kind "x" in convert_fp8_to_int4.classify) are
+EXCLUDED and stay on the existing int4-g64 streaming path; routers/norms/bias
+(kind "f32") and embed/lm_head (kind "io", BF16 in source, never FP8) are
+untouched by this tool -- carrying those into a mixed fmt=7+int4 loadout
+directory is separate, deferred "loadout index-rewrite blending" work.
+
+kv_b_proj (kind "kvb") is ALSO deliberately excluded, despite being a resident
+tensor classify() would otherwise select: colibri.c's MLA-absorption CPU path
+(qt_addrow/qt_matvec_rows, called only on l->kv_b -- the always-available
+fallback whenever the Metal fused decode kernel isn't used) has no fmt==7
+case and would silently misread fp8 bytes as int2-packed data; the CUDA
+absorb kernels (coli_cuda_attention_absorb/_kvdev in backend_cuda.cu) are
+similarly int4-specific. Repacking kv_b_proj to fmt=7 needs that CPU+CUDA
+absorb-path work first -- out of scope for this build, so this tool refuses
+to produce a container the engine cannot safely read.
+
+This tool does NOT write a container metadata stamp: __metadata__-based
+self-description (writer + qt_verify_fmt_stamp reader + docs/FORMATS.md
+registry) is a separate, follow-up PR, per the maintainer's #524 scoping.
+This PR's collision/refusal logic (qt_resolve_fmt) therefore refuses
+UNCONDITIONALLY at every ambiguous shape this tool could produce -- there is
+no stamp to break a tie.
+
+HARD CONSTRAINT for this build: unit-tested on synthetic fixtures ONLY (see
+tests/test_fp8_repack.py, built with tools/glm_fp8_emit.py's exact real-
+checkpoint layout) plus --dry-run inventory mode against those same fixtures.
+NO read of any real Z.ai shard, NO full or partial repack of a real checkpoint
+-- that is later, user-GO'd work once this build's plumbing has been reviewed.
+
+Usage (synthetic fixtures / local testing only):
+  python3 tools/repack_fp8_passthrough.py --indir <fp8_dir> --outdir <out> --dry-run
+  python3 tools/repack_fp8_passthrough.py --indir <fp8_dir> --outdir <out> --n-layers 78
+"""
+import argparse, glob, json, os, sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from convert_fp8_to_int4 import classify, check_or_record_params  # reuse: same taxonomy,
+                                                                    # same #383-class params guard
+
+# Kinds classify() can return that this tool targets: resident weights, NOT routed
+# experts ("x"), NOT the always-F32 set ("f32"), NOT embed/lm_head ("io" -- BF16 in
+# source, never FP8), NOT sidecars/skips ("consumed"/"skip"). "kvb" (kv_b_proj) is
+# ALSO excluded -- see the module docstring: the CPU absorb path (qt_addrow/
+# qt_matvec_rows) and the CUDA absorb kernels have no fmt=7 case yet.
+RESIDENT_KINDS = frozenset({"sh", "o", "attn", "dmlp", "q"})
+
+BLOCK = 128
+
+
+def _nblk(n):
+    return (n + BLOCK - 1) // BLOCK
+
+
+def is_repack_target(name, dtype, keys, n_layers):
+    """True if `name` is a resident-kind FP8 tensor this tool should byte-preserve
+    into the fmt=7 container. `keys` is the full set of tensor names in the shard
+    (needed to confirm the `_scale_inv` sidecar is actually present -- classify()
+    alone can't tell FP8 tensors from any other dtype a resident-kind name might
+    carry in a non-FP8 checkpoint variant)."""
+    if name.endswith("_scale_inv"):
+        return False                       # sidecar, handled together with its weight
+    kind = classify(name, n_layers)
+    if kind not in RESIDENT_KINDS:
+        return False
+    if dtype not in ("F8_E4M3", "float8_e4m3fn"):
+        return False
+    return (name + "_scale_inv") in keys
+
+
+def _check_geometry(name, O, I, nblkO, nblkI):
+    """Refuse (loud, ValueError) rather than silently emit a .qs whose geometry
+    doesn't match what qt_resolve_fmt expects for [O,I] -- the same "untrusted
+    container" discipline the C side applies on read, applied here on write so a
+    malformed source checkpoint is caught at repack time, not at load time three
+    steps later with a confusing engine-side refusal."""
+    exp_nblkO, exp_nblkI = _nblk(O), _nblk(I)
+    if (nblkO, nblkI) != (exp_nblkO, exp_nblkI):
+        raise ValueError(
+            f"{name}: scale_inv block shape ({nblkO},{nblkI}) != expected "
+            f"({exp_nblkO},{exp_nblkI}) for [{O},{I}] -- refusing to repack a shape "
+            f"the engine's qt_resolve_fmt would either refuse or (worse) misread")
+
+
+def shard_inventory(path, n_layers):
+    """--dry-run: scan one shard's header only (get_slice, no tensor data pulled)
+    and return the list of tensors that WOULD be repacked, without writing
+    anything. Cheap: safe to run over an entire real checkpoint's headers."""
+    from safetensors import safe_open
+    inv = []
+    with safe_open(path, framework="pt") as f:
+        keys = set(f.keys())
+        for name in f.keys():
+            sl = f.get_slice(name)
+            dt = sl.get_dtype()
+            if not is_repack_target(name, dt, keys, n_layers):
+                continue
+            O, I = sl.get_shape()
+            sc_slice = f.get_slice(name + "_scale_inv")
+            nblkO, nblkI = sc_slice.get_shape()
+            _check_geometry(name, O, I, nblkO, nblkI)
+            inv.append({"name": name, "kind": classify(name, n_layers),
+                       "O": O, "I": I, "nblkO": nblkO, "nblkI": nblkI,
+                       "weight_bytes": O * I, "scale_bytes": nblkO * nblkI * 4})
+    return inv
+
+
+def repack_shard(path, n_layers):
+    """Real mode: byte-preserve every selected tensor's weight bytes (raw e4m3,
+    no dequant/requant -- `.view(torch.uint8)` is a pure bit-reinterpret, verified
+    byte-identical against torch.float8_e4m3fn's own storage) and rename/flatten
+    the `_scale_inv` sidecar to the engine's `name.qs` convention (flat F32,
+    nblkO*nblkI elements, row-major [blkO,blkI] -- matching
+    scale[(o/128)*nblkI+i/128] on the read side). Returns (out_dict, inventory)."""
+    import torch
+    from safetensors import safe_open
+    out = {}
+    inv = []
+    with safe_open(path, framework="pt") as f:
+        keys = set(f.keys())
+        for name in f.keys():
+            sl = f.get_slice(name)
+            dt = sl.get_dtype()
+            if not is_repack_target(name, dt, keys, n_layers):
+                continue
+            w = f.get_tensor(name)                       # torch.float8_e4m3fn [O,I]
+            sc = f.get_tensor(name + "_scale_inv")        # torch.float32 [nblkO,nblkI]
+            O, I = w.shape
+            nblkO, nblkI = sc.shape
+            _check_geometry(name, O, I, nblkO, nblkI)
+            out[name] = w.view(torch.uint8).contiguous()              # BYTE-PRESERVED
+            out[name + ".qs"] = sc.to(torch.float32).reshape(-1).contiguous()
+            inv.append({"name": name, "kind": classify(name, n_layers),
+                       "O": O, "I": I, "nblkO": nblkO, "nblkI": nblkI,
+                       "weight_bytes": O * I, "scale_bytes": nblkO * nblkI * 4})
+    return out, inv
+
+
+def _print_inventory_summary(all_inv, dry_run):
+    by_kind = {}
+    tot_w = tot_s = 0
+    for it in all_inv:
+        by_kind.setdefault(it["kind"], []).append(it)
+        tot_w += it["weight_bytes"]; tot_s += it["scale_bytes"]
+    tag = "[DRY-RUN]" if dry_run else "[REPACK]"
+    print(f"{tag} {len(all_inv)} tensor(s) selected across all shards "
+         f"({tot_w/1e9:.3f} GB weights, {tot_s/1e6:.3f} MB scales)")
+    for kind in sorted(by_kind):
+        items = by_kind[kind]
+        w = sum(it["weight_bytes"] for it in items)
+        print(f"{tag}   kind={kind:5s} {len(items):5d} tensor(s)  {w/1e9:.3f} GB")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--indir", required=True, help="directory of Z.ai FP8 *.safetensors shards")
+    ap.add_argument("--outdir", required=True, help="destination for repacked fmt=7 container shards")
+    ap.add_argument("--n-layers", type=int, default=78)
+    ap.add_argument("--dry-run", action="store_true",
+                    help="inventory only: scan headers, print selection counts, write nothing")
+    a = ap.parse_args()
+
+    shards = sorted(glob.glob(os.path.join(a.indir, "*.safetensors")))
+    if not shards:
+        print(f"ERROR: no *.safetensors files in {a.indir}"); sys.exit(1)
+
+    if a.dry_run:
+        all_inv = []
+        for sp in shards:
+            all_inv.extend(shard_inventory(sp, a.n_layers))
+        _print_inventory_summary(all_inv, dry_run=True)
+        return
+
+    os.makedirs(a.outdir, exist_ok=True)
+    # #383-class guard, reused (not reimplemented): refuses a resumed run whose
+    # params differ from what's already partially in this outdir (the #355 failure
+    # mode -- a second pass with different flags silently mixing containers).
+    # Owns its own sidecar (.fp8pass-params.json), separate from the shard-progress
+    # manifest below, exactly like the --repo mtp/indexer loops in
+    # convert_fp8_to_int4.py use it.
+    params = {"mode": "fp8-passthrough", "n_layers": a.n_layers}
+    if not check_or_record_params(a.outdir, "fp8pass-", params):
+        sys.exit(1)
+
+    # RESUME (same #383-class manifest idiom as convert_fp8_to_int4.py's --indir path):
+    # a sidecar records input-shard -> output-shard-name-or-"" (shards with no
+    # resident-FP8 tensors emit no file), written atomically so an interrupted run
+    # never leaves a half-written manifest for the next invocation to trust. The
+    # params guard above already owns "don't mix conversions" -- this manifest is
+    # purely which shards are done.
+    prog_path = os.path.join(a.outdir, ".fp8pass-progress.json")
+    prog = {}
+    if os.path.exists(prog_path):
+        try:
+            prog = json.loads(open(prog_path).read())
+        except (OSError, ValueError):
+            prog = {}
+    done = prog.setdefault("shards", {})
+
+    from safetensors.torch import save_file
+    all_inv = []
+    n = fresh = skipped = 0
+    for sp in shards:
+        key = os.path.basename(sp)
+        prev = done.get(key)
+        if prev is not None and (prev == "" or os.path.exists(os.path.join(a.outdir, prev))):
+            if prev:
+                n += 1
+            skipped += 1
+            continue
+        out, inv = repack_shard(sp, a.n_layers)
+        all_inv.extend(inv)
+        if not out:
+            done[key] = ""
+        else:
+            name = f"out-fp8pass-{n:05d}.safetensors"
+            save_file(out, os.path.join(a.outdir, name))
+            done[key] = name
+            n += 1
+            fresh += 1
+        tmp = prog_path + ".tmp"
+        with open(tmp, "w") as fh:
+            json.dump(prog, fh, indent=1)
+        os.replace(tmp, prog_path)
+    if skipped:
+        print(f"[RESUME] {skipped} shard(s) already done in {a.outdir}, skipped")
+    print(f"[REPACK] {fresh} new output shard(s) written")
+    _print_inventory_summary(all_inv, dry_run=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/c/tools/repack_fp8_passthrough.py
+++ b/c/tools/repack_fp8_passthrough.py
@@ -1,13 +1,15 @@
-"""fmt=7 repack tool: Z.ai GLM-5.2-FP8 shards -> the engine's native-FP8-passthrough
+"""fmt=8 repack tool: Z.ai GLM-5.2-FP8 shards -> the engine's native-FP8-passthrough
 container (byte-preserved, no dequant/requant).
 
-fmt=7 is a PUBLIC ordinal, assigned by the maintainer on #524. This tool's
-output format was minted fmt=6 during this branch's original development,
-before dev's own #465 (E8/IQ3) claimed that ordinal upstream and merged it
-into dev as a REAL fmt=6 (colibri.c's qt_resolve_fmt, quant.h's E8
-constants); re-tagged fmt=100 (PRIVATE ORDINAL BLOCK, see colibri.c's QT
-struct comment) from that point forward -- this tool has never emitted a
-container claiming ordinal 6 -- and graduated to fmt=7 at merge.
+fmt=8 is a PUBLIC ordinal. This tool's output format was minted fmt=6 during
+this branch's original development, before dev's own #465 (E8/IQ3) claimed
+that ordinal upstream and merged it into dev as a REAL fmt=6 (colibri.c's
+qt_resolve_fmt, quant.h's E8 constants); re-tagged fmt=100 (PRIVATE ORDINAL
+BLOCK, see colibri.c's QT struct comment) from that point forward -- this
+tool has never emitted a container claiming ordinal 6 -- graduated to fmt=7
+when the maintainer assigned that ordinal on #524, and renumbered to fmt=8
+after #705 merged MXFP4 as fmt=7 while this PR was open. Nothing this tool
+writes carries the ordinal, so neither renumber changed its output bytes.
 
 Unlike convert_fp8_to_int4.py (which DEQUANTIZES fp8 -> f32 -> REQUANTIZES to a
 different, lossy format), this tool copies the fp8 weight bytes AS-IS and only
@@ -15,9 +17,9 @@ renames/reshapes the scale sidecar to the engine's `.qs` convention. Same 8
 bits/weight streaming cost as the source, zero additional quantization loss.
 
 THE DESIGN LANDMINE (see qt_resolve_fmt in colibri.c, c/quant.h's E4M3_LUT
-comment): the engine tells fmt=7 (this tool's output) apart from fmt=1 (plain
+comment): the engine tells fmt=8 (this tool's output) apart from fmt=1 (plain
 int8) ONLY by scale-array geometry -- per-row for fmt=1, per-128x128-block for
-fmt=7. This tool must therefore emit .qs sidecars whose byte count is EXACTLY
+fmt=8. This tool must therefore emit .qs sidecars whose byte count is EXACTLY
 ceil(O/128)*ceil(I/128)*4, never anything that could coincide with O*4 by
 accident for the shapes it targets -- ENFORCED, not just asserted, by
 _check_geometry below (maintainer review, #528): it refuses to repack any
@@ -27,7 +29,7 @@ hypothetical: GLM-5.2's own self_attn.o_proj.weight ([6144,16384]) is a real
 instance (nblkO=48, nblkI=128, product=6144==O). It matters more now than it
 used to, because the engine's UNSTAMPED read-side collision policy resolves an
 ambiguous shape to fmt=1 rather than refusing (see qt_resolve_fmt's
-INVERSION) -- so an fmt=7 container this tool emitted at such a shape would be
+INVERSION) -- so an fmt=8 container this tool emitted at such a shape would be
 silently read back as plain int8, not caught by a read-side refusal. Avoiding
 the collision at write time is therefore load-bearing, not a redundant
 belt-and-braces check. At I=98 specifically, a single-block fp8 tensor's raw
@@ -51,25 +53,25 @@ attention projections, dense-MLP first layers, and the generic resident
 fallback) -- routed experts (kind "x" in convert_fp8_to_int4.classify) are
 EXCLUDED and stay on the existing int4-g64 streaming path; routers/norms/bias
 (kind "f32") and embed/lm_head (kind "io", BF16 in source, never FP8) are
-untouched by this tool -- carrying those into a mixed fmt=7+int4 loadout
+untouched by this tool -- carrying those into a mixed fmt=8+int4 loadout
 directory is separate, deferred "loadout index-rewrite blending" work.
 
 kv_b_proj (kind "kvb") is ALSO deliberately excluded, despite being a resident
 tensor classify() would otherwise select: colibri.c's MLA-absorption CPU path
 (qt_addrow/qt_matvec_rows, called only on l->kv_b -- the always-available
-fallback whenever the Metal fused decode kernel isn't used) has no fmt==7
-support. FIX ROUND 2 update: an fmt=7 (or fmt=6) tensor reaching either
+fallback whenever the Metal fused decode kernel isn't used) has no fmt==8
+support. FIX ROUND 2 update: an fmt=8 (or fmt=6) tensor reaching either
 function now refuses loudly (exit(1), naming the function and the fmt) --
 before that fix it was worse than "misread as int2": qt_addrow SIGSEGV'd
-outright (t->q4 is NULL for fmt=7; the untouched int2 fall-through
+outright (t->q4 is NULL for fmt=8; the untouched int2 fall-through
 dereferenced it), and only fmt=6 (t->q4 non-NULL, wrong per-row scale
 geometry) actually produced silently-wrong values. Either way, this tool
 still does not select kv_b_proj: refusing loudly at the absorb call site is
-not the same as SUPPORTING fmt=7 there (no dequant path exists, whether it
+not the same as SUPPORTING fmt=8 there (no dequant path exists, whether it
 now trips a controlled refusal or, before the fix, undefined behavior). The
 CUDA absorb kernels (coli_cuda_attention_absorb/_kvdev in backend_cuda.cu)
 are similarly int4-specific and unaffected by that fix. Repacking kv_b_proj
-to fmt=7 needs real fmt=7 CPU+CUDA absorb-path support first -- out of scope
+to fmt=8 needs real fmt=8 CPU+CUDA absorb-path support first -- out of scope
 for this build, so this tool refuses to produce a container the engine
 cannot safely read.
 
@@ -100,7 +102,7 @@ from convert_fp8_to_int4 import classify, check_or_record_params  # reuse: same 
 # experts ("x"), NOT the always-F32 set ("f32"), NOT embed/lm_head ("io" -- BF16 in
 # source, never FP8), NOT sidecars/skips ("consumed"/"skip"). "kvb" (kv_b_proj) is
 # ALSO excluded -- see the module docstring: the CPU absorb path (qt_addrow/
-# qt_matvec_rows) and the CUDA absorb kernels have no fmt=7 case yet.
+# qt_matvec_rows) and the CUDA absorb kernels have no fmt=8 case yet.
 RESIDENT_KINDS = frozenset({"sh", "o", "attn", "dmlp", "q"})
 
 BLOCK = 128
@@ -112,7 +114,7 @@ def _nblk(n):
 
 def is_repack_target(name, dtype, keys, n_layers):
     """True if `name` is a resident-kind FP8 tensor this tool should byte-preserve
-    into the fmt=7 container. `keys` is the full set of tensor names in the shard
+    into the fmt=8 container. `keys` is the full set of tensor names in the shard
     (needed to confirm the `_scale_inv` sidecar is actually present -- classify()
     alone can't tell FP8 tensors from any other dtype a resident-kind name might
     carry in a non-FP8 checkpoint variant)."""
@@ -140,7 +142,7 @@ def _check_geometry(name, O, I, nblkO, nblkI):
     own self_attn.o_proj.weight ([6144,16384]) is a REAL, non-hypothetical instance
     of this shape. The engine's reader now resolves an unstamped collision to fmt=1
     (the incumbent, decodable format) rather than refusing -- which makes it load
-    bearing that THIS tool never emits an fmt=7 container at such a shape: this
+    bearing that THIS tool never emits an fmt=8 container at such a shape: this
     docstring's own opening promise ("never anything that could coincide with O*4
     by accident") is enforced here, not just asserted."""
     exp_nblkO, exp_nblkI = _nblk(O), _nblk(I)
@@ -154,9 +156,9 @@ def _check_geometry(name, O, I, nblkO, nblkI):
             f"{name}: [{O},{I}] is an AMBIGUOUS fp8-e4m3-b128 shape -- its "
             f"block-scale byte count (nblkO*nblkI*4={nblkO*nblkI*4}) exactly "
             f"coincides with a per-row int8 scale byte count (O*4={O*4}) for the "
-            f"same [O,I]; refusing to emit an fmt=7 container the engine's "
+            f"same [O,I]; refusing to emit an fmt=8 container the engine's "
             f"qt_resolve_fmt collision policy would resolve to fmt=1 (int8-row), "
-            f"not fmt=7, on an unstamped read (THE DESIGN LANDMINE, colibri.c)")
+            f"not fmt=8, on an unstamped read (THE DESIGN LANDMINE, colibri.c)")
 
 
 def shard_inventory(path, n_layers):
@@ -232,7 +234,7 @@ def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--indir", required=True, help="directory of Z.ai FP8 *.safetensors shards")
-    ap.add_argument("--outdir", required=True, help="destination for repacked fmt=7 container shards")
+    ap.add_argument("--outdir", required=True, help="destination for repacked fmt=8 container shards")
     ap.add_argument("--n-layers", type=int, default=78)
     ap.add_argument("--dry-run", action="store_true",
                     help="inventory only: scan headers, print selection counts, write nothing")

--- a/docs/int4-rans256-g0.md
+++ b/docs/int4-rans256-g0.md
@@ -153,7 +153,7 @@ lets tooling confirm two shards used the identical table without diffing
 the base64 blob. `table_id` is provenance metadata (a retuned future table
 would ship as `g1`); readers never resolve it externally.
 
-## THE STAMP IS MANDATORY (the load-bearing difference from fmt=7)
+## THE STAMP IS MANDATORY (the load-bearing difference from fmt=8)
 
 `__metadata__["colibri.fmt"]` maps each entropy-coded **weight** tensor
 name (never `.qs`) to the string `int4-rans256-g0`, JSON-encoded with


### PR DESCRIPTION
*Authored by Fable 5 in Claude Code (We/our), analysis in partnership with @monotophic (me/my).*

Revised per review (2026-07-23): collision policy inverted; see the comment of this date for the full revision + evidence.

# fmt=7: native FP8-e4m3 passthrough — CPU path, Metal kernel, repack tool

Branch: `fmt7/fp8-passthrough`. Base: dev `9baae9b`. Closes the FP8-passthrough
Feature Request; implements the format the maintainer assigned `fmt=7` on
#524. Companion PR (`fmt7/stamp-registry`, stacked on this one) adds the
container metadata stamp and the `docs/FORMATS.md` registry — split out per
the maintainer's own scoping request, so this PR is CPU path + repack tool +
collision/refusal logic + the Metal kernel only.

## What / why

Z.ai ships GLM-5.2's release-native checkpoint in FP8-e4m3
(`zai-org/GLM-5.2-FP8`) — to our knowledge there is no public bf16/fp16
upstream of it. Every existing path into this engine from that checkpoint
first **dequantizes to f32 and requantizes** to a lossy format (int4/int3),
paying a real second quantization error on top of whatever the FP8 already
cost. This PR adds a different path for tensors where the extra fidelity is
worth the extra 8 bits/weight over int4: **repack, not requantize**. The
repack tool copies the fp8 weight bytes AS-IS (`.view(torch.uint8)`, a pure
bit-reinterpret, verified byte-identical against `torch.float8_e4m3fn`'s own
storage) and only renames/reshapes the `weight_scale_inv` sidecar to the
engine's `.qs` convention. Same 8 bits/weight streaming cost as the FP8
source, **zero additional quantization loss** — a resident/quality-core tier
sitting above int4/int3 in fidelity, below f32 in size.

## Selection: which tensor roles get fmt=7

`tools/repack_fp8_passthrough.py` reuses `convert_fp8_to_int4.classify()` —
the engine's existing tensor-role taxonomy — rather than inventing a new one:

| role (`classify()` kind) | selected for fmt=7? | why |
|---|---|---|
| shared expert (`sh`) | yes | resident, always-active — fidelity matters every token |
| `o_proj` (`o`) | yes | resident attention output projection |
| other attention projections (`attn`, incl. `q_a_proj`) | yes | resident |
| dense-MLP first layers (`dmlp`) | yes | resident |
| generic resident fallback (`q`) | yes | catches anything else resident-shaped |
| `kv_b_proj` (`kvb`) | **no** | resident, but no fmt=7 case in the CPU/CUDA MLA-absorb path — see below |
| routed experts (`x`) | no | stays on the existing int4-g64 streaming path (58k+ tensors — the streaming-cost tradeoff is different for a per-token top-K subset) |
| routers/norms/biases (`f32`) | no | never FP8 in the source, always f32 |
| embed/lm_head (`io`) | no | BF16 in source, never FP8 |

Blending selected fmt=7 residents with int4-g64 routed experts in the same
loadout directory is separate, deferred "loadout index-rewrite blending"
work — out of scope here; the tool only ever emits a `fmt=7` container for
the roles in the table.

## Design

**Decode LUT** (`quant.h`'s `E4M3_LUT`, 256 entries): a static compile-time
table, cross-checked byte-for-byte against `torch.float8_e4m3fn` for all 256
codes including both signs of zero, subnormals, and the OCP E4M3-FN NaN
encoding (`exp==0xF && mant==0x7` only — `exp==0xF` is NOT reserved for
infinity in this format). Static rather than lazily initialized because
`matmul_fp8` runs inside `#pragma omp parallel for` and a lazy-init global
would race under concurrent first use. The Metal `mm_gemv` shader's `fmt==7`
branch does the identical bit-decode in-kernel (no LUT texture — BW-bound
kernel, decode ALU is free) and is verified to byte-match the CPU LUT via an
exhaustive 256/256-code GPU test (see Metal validation below).

**Block scales**: one `f32` per 128×128 block of the `[O,I]` weight matrix
(`ceil(O/128)*ceil(I/128)` entries, row-major block order), not one per
output row. Dequant is `w[o,i] = e4m3_decode(byte) * scale[o/128, i/128]`
(multiply, not divide) — matches `tools/convert_fp8_to_int4.py`'s own
`dequant()`, the authoritative reference for how Z.ai's checkpoints read.

**Scale encoding is a declared property of the format, not a hardcoded
constant.** This was an open design question we'd have gotten wrong by
defaulting to "f32, full stop" — the maintainer's own finding, surfaced on
#524, is what settled it: **DeepSeek-V4 ships this identical weight geometry
(FP8 E4M3, 128×128 blocks) with UE8M0 scales instead of f32** — one byte per
block, a power-of-two exponent, dtype `F8_E8M0`. Concretely, in this PR:

- fmt=7's scale encoding is named explicitly in the QT struct comment and
  `qt_resolve_fmt`'s own documentation; **f32 is the implemented value**
  (what Z.ai's GLM-5.2-FP8 checkpoints ship, and what this PR's CPU kernel,
  Metal kernel, and repack tool all read/write).
- The resolver **recognizes the UE8M0 byte signature and refuses by name**
  rather than misreading it: the two encodings differ cleanly in
  scale-sidecar arithmetic (`ceil(O/128)*ceil(I/128)*4` bytes for f32 vs
  `*1` for UE8M0), a real, distinct discriminator (never coincidentally
  equal for any `O,I >= 1`, since one is exactly 4× the other). An
  unstamped container with a 1-byte-per-block sidecar gets *"fp8-e4m3-b128
  with ue8m0 scales recognized but not implemented; only f32 block scales
  are supported in this build"* instead of garbage.
- UE8M0 decode itself is invited follow-up work, same posture this project
  already applies to the CUDA tier: whoever reaches DeepSeek-V4 first (that
  may be us, later) lands it into a seam that already exists rather than a
  near-duplicate format. The MXFP4 routed-expert question (E2M1 + UE8M0 g32)
  raised alongside this finding is a separate format and a separate
  conversation — but the same scale-encoding-as-property mechanism serves
  it too.

## The collision/refusal analysis

`qt_resolve_fmt` infers a tensor's format from byte arithmetic alone — the
container carries no format ordinal. fmt=7's weight bytes are
byte-identical to fmt=1 (int8): `O*I` raw bytes either way. That creates
**three** genuine byte-collision shapes this PR's resolver must catch and
refuse rather than silently misread:

1. **fmt=1 vs fmt=7 (THE DESIGN LANDMINE).** For small `O` (≤128) and/or
   small `I`, `ceil(O/128)*ceil(I/128)` can equal `O` exactly (e.g. `O=1,
   I≤128`; `O=2, I∈[129,256]`; `O=256, I∈(16256,16384]`) — a scale array
   that satisfies BOTH fmt=1's per-row convention (`O*4` bytes) and fmt=7's
   per-block convention (`ceil(O/128)*ceil(I/128)*4` bytes) at once.
   Guessing either way silently corrupts every weight. Refused.
2. **fmt=6 vs fmt=7 at I=98 (SECOND DESIGN LANDMINE).** Upstream's own
   fmt=6 (E8/IQ3, #465) tags itself with `ns==4 && nb==O*e8_rowbytes(I)`,
   checked unconditionally before any fmt=7-aware logic runs.
   `e8_rowbytes(I) = ceil(I/256)*98` is the constant 98 for every `I` in
   `(0,256]`, so that check collapses to `nb==O*98` — which is ALSO fp8's
   raw weight-byte count (`O*I`) at exactly `I=98`. At that same `I=98`, a
   single-block fp8 tensor (`O≤128`, f32 scales) carries exactly one
   `f32` block scale (`ns==4`, the same tag fmt=6 uses); a **four-block**
   fp8 tensor (`O∈(384,512]`, UE8M0 scales) also lands at `ns==4` (4
   blocks × 1 byte/block). A straight, un-reconciled rebase onto post-#465
   dev would silently misread either as E8/IQ3-lattice-decoded garbage —
   demonstrated fail-before during development (a standalone probe at
   `O=64, I=98` returned `fmt=6` with no error before the fix). Refused
   after the fix, for both the f32-scaled and UE8M0-scaled variants.
3. **`O==1` triple collision.** At `O=1, I=98`, fmt=1's own per-row tag
   (`O*4`) is ALSO 4 — a genuine three-way ambiguity (fmt=1 / fmt=6 /
   fmt=7) at one shape. Refused.

**This PR's refusal posture is unconditional**: it carries no container
metadata stamp (that's the companion PR), so every one of these three
collisions refuses regardless of the tensor's true identity — "nothing real
is lost: no real checkpoint tensor has these shapes" (the maintainer's own
framing, #524). The companion PR's stamp is the only thing that can turn a
refusal into a resolution, and even then only for the f32-scaled candidates
— a stamp can confirm a WEIGHT format, it can't grant a decoder this build
doesn't have, so the UE8M0 corners of collisions 2 and 3 stay refused even
under a (correct) stamp.

Test coverage: `tests/test_fp8_load.c`'s Part A (15 cases: golden paths, 6
degenerate collisions, 4 boundary-adjacent non-collisions) + Part A2 (the
fmt=6 collision at `I=98`, both boundary shapes, the three-way `O=1`
case, plus 2 non-colliding fmt=6 regression fixtures proving dev's own
E8/IQ3 inference stays unbroken) + Part A3 (2 UE8M0-signature refusal
cases, including the small-O collision variant).

## `kv_b_proj` exclusion

`kv_b_proj` (kind `kvb`) is a valid resident tensor `classify()` would
otherwise select, and it's deliberately excluded anyway: colibri.c's
MLA-absorption CPU path (`qt_addrow`/`qt_matvec_rows`, the always-available
fallback whenever the Metal fused decode kernel isn't used) has no fmt=7
case and would silently misread fp8 bytes as int2-packed data; the CUDA
absorb kernels (`coli_cuda_attention_absorb`/`_kvdev` in `backend_cuda.cu`)
are similarly int4-specific. Repacking `kv_b_proj` to fmt=7 needs that
CPU+CUDA absorb-path work first — out of scope for this PR, so the tool
refuses to produce a container the engine cannot safely read
(`tests/test_fp8_repack.py::test_kv_b_proj_excluded` is the regression
guard).

## Metal validation record

**This is the evidence we'd ask you to merge on, absent Apple hardware on
your side** — every fmt=7 code path exercised on real M-series Metal, not
just described:

- **LUT-through-GPU exactness: 256/256 byte codes**, run through the
  ACTUAL compiled `mm_gemv` shader (not a CPU-only spot check) — proves the
  in-kernel bit-decode agrees with `quant.h`'s reference LUT for every
  possible byte value, including both zeros, all subnormals, and the NaN
  encoding.
- **Adversarial shape suite**: block edges (`O,I` both non-multiples of
  128), degenerate 1×1 (single sub-block), a non-square block grid
  (`nblkO=3, nblkI=48` — a stride-audit case that would surface a
  transposed or swapped block index), worst observed relative error
  `3.0e-8` to `7.0e-8` across all cases (tolerance `1e-4`).
- **`S>1` gate test**: the spec-shaped `[2048,6144]` case run at `S=4`
  (batched decode), not just `S=1`.
- **Two independent negative-gate tests**: `coli_metal_gemm` explicitly
  refuses fmt=7 (`rc=0`, CPU-fallback signal) — the large-batch sync GEMM
  path was never in scope for this format. `coli_metal_moe_block`/
  `moe_submit`'s existing `fmt != 1 && fmt != 2` allowlist already refuses
  fmt=7 before any pointer is dereferenced — proven BY TEST with
  deliberately-invalid `0xdeadbeef` weight/scale pointers that must never
  be read, not left as an artifact of the allowlist happening not to
  include 7 (yet).
- **Both `COLI_METAL_RESSET` states**: `make metal-test` full green under
  `COLI_METAL_RESSET=0` AND `COLI_METAL_RESSET=1` (residency-set path
  confirmed active via `"[METAL] residency-set: on"`), all 11 fp8 GPU
  lines identical in both.

Full case-by-case output (RESSET=0; RESSET=1 is line-identical apart from
the residency-set banner):

```
Metal fmt=7 native FP8-e4m3 passthrough tests:
  fp8 LUT exactness (256/256 codes via GPU kernel) 0/256 mismatches  ok
  fp8 gate/up-shaped O=2048 I=6144 (spec example) S=1 worst_rel=3.01e-08 (I=6144 O=2048 nblkO=16 nblkI=48 S=1)  ok
  fp8 down-shaped O=6144 I=2048 S=1          worst_rel=3.63e-08 (I=2048 O=6144 nblkO=48 nblkI=16 S=1)  ok
  fp8 gate/up-shaped O=2048 I=6144 S=4       worst_rel=4.05e-08 (I=6144 O=2048 nblkO=16 nblkI=48 S=4)  ok
  fp8 block edges: O,I both non-mult-128     worst_rel=5.95e-08 (I=200 O=130 nblkO=2 nblkI=2 S=2)  ok
  fp8 block edges: O just over 128, I exact  worst_rel=4.65e-08 (I=128 O=129 nblkO=2 nblkI=1 S=1)  ok
  fp8 block edges: O exact, I just over 128  worst_rel=6.93e-08 (I=129 O=128 nblkO=1 nblkI=2 S=1)  ok
  fp8 degenerate 1x1 (single sub-block)      worst_rel=5.87e-08 (I=1 O=1 nblkO=1 nblkI=1 S=1)  ok
  fp8 non-square block grid nblkO=3 nblkI=48 (stride audit) worst_rel=3.33e-08 (I=6144 O=384 nblkO=3 nblkI=48 S=3)  ok
  fp8 GEMM entry explicitly gated off (coli_metal_gemm refuses) rc=0 (expect 0/CPU-fallback)  ok
  fp8 MB_BUILD/moe_submit entry gated off (shared-expert fmt=7 hazard) rc=0 (expect 0/CPU-fallback)  ok
```

Every pre-existing Metal case (int8/int4/int2/f32, moe_block, gemm S=64,
fused attention, top-8 select) unaffected, in the same run.

## Durable vs. current-state (review map)

Per this project's own convention for delineating what's structural from
what has a foreseeable resolution:

| | claim | durable / current-state | revisit trigger |
|---|---|---|---|
| 1 | fmt=7 weight-byte layout (`O*I` raw e4m3), E4M3 decode LUT, block-scale indexing | **durable** | none — fixed by the OCP E4M3-FN spec and this format's own definition |
| 2 | fmt=1-vs-fmt=7 and fmt=6-vs-fmt=7 collision/refusal logic | **durable** | none — the ambiguous shapes are structural (byte-arithmetic facts), not tunable |
| 3 | UE8M0 scale encoding: recognized, refused, not decoded | **current-state** | a UE8M0 CPU+Metal decoder landing into this seam (`qt_resolve_fmt`'s fmt=1 candidate branch + a new dispatch case) — invited follow-up, may be us |
| 4 | `kv_b_proj` excluded from fmt=7 selection | **current-state** | CPU (`qt_addrow`/`qt_matvec_rows`) + CUDA MLA-absorb kernels gaining an fmt=7 case |
| 5 | "refuse unconditionally" at all three collision shapes (no stamp) | **current-state**, resolved by the companion PR | `fmt7/stamp-registry` merging — a stamped, unambiguous container resolves instead of refusing (except the UE8M0 corners, which stay current-state per row 3) |
| 6 | Metal validation record below | checkable coordinates | measured 2026-07-22, macOS 26.5.2 (build 25F84), Apple M5 Max (MacBook Pro, Mac17,7), engine base dev `9baae9b` |

## Behavioral contract

This PR was revised against a written contract; every invariant below is a
registered claim (stated before the revision was built), each with its
decisive evidence:

| Invariant | Capstone evidence |
|---|---|
| Every container that loads on dev loads identically here (resolutions, notices, output) | Differential matrix vs. current dev: **byte-identical temp-0 generated text** on the stock int8-MTP container and an int8-resident mint |
| No byte pattern readable today changes meaning; ambiguity favors the incumbent | `[6144,16384]` int8-row (GLM-5.2's real `o_proj`): refused by the previous head (`exit 1`, quoted in-thread), **loads as fmt=1 here** |
| The writer can never emit what the reader would mis-resolve | Repack refusal demonstrated at a real ambiguous shape (`[2048,16384]`); round-trip load verified on non-ambiguous output |
| fmt=7 decode is exact OCP E4M3-FN — passthrough, no approximation | Independently derived oracle (from the OFP8 spec text): **bit-exact at all 16,900 positions** of a partial-block (130×130) tensor |
| Failure is loud: every refusal names its condition | New: `qt_addrow`/`qt_matvec_rows` refuse unhandled formats by name (previously: SIGSEGV for fmt=7, silent misread for fmt=6 — found by the acceptance suite, fixed here) |
| Collision family is enumerated, not sampled | In-tree census over every real tensor shape: `o_proj` is the **only** ambiguous family (79 instances/container) |

<details>
<summary>Full evidence matrix (instruments and results per requirement)</summary>

- **Compatibility (I1)**: old-binary/new-binary differential over both real
  containers, per-run usage-state control, telemetry-excised output
  comparison; plus same-binary control run proving the method's
  discrimination. Result: identical loads, per-tensor resolutions, notices,
  and generated text, all four comparisons.
- **Collision policy (E4/I2)**: reader inversion verified at source and
  behaviorally (collision-family fixtures at 4 real shapes + 1
  non-collision control resolve fmt=1); the three previously-refusing test
  shapes plus four degenerate cases now assert fmt=1; census tool
  regenerable upstream (`c/tools/fp8_collision_census.py`).
- **Exact decode (I4)**: spec-blind acceptance suite with an independently
  derived E4M3-FN oracle (derivation caught an internal contradiction in
  the OFP8 spec's own bias statement, resolved via its worked examples);
  bit-exact on NaN-free data; NaN weights verified to poison their row
  through the dot product (IEEE-correct propagation, 130/130 rows).
- **Wire-path sizing**: `qt_scale_bytes()` wired via shared
  `qt_wire_split()`; seam test intercepts actual `mlock`/`munlock` calls —
  a sites-only regression to `O*4` fails 4 named assertions; fmt=6's
  4-byte-tag case corrected while making the helper authoritative.
- **Loud failure (I6)**: refusal tests for fmt=6/7 through both absorb-path
  functions (previously crash/silent); repack tool refuses on zero
  repack-target tensors (previously silent success).
- **Gates**: `make check`; METAL=1 zero warnings; `metal-test` under both
  `COLI_METAL_RESSET` states; per-commit bisect builds; suppression-
  stripped `-Wunused-function` build; POSIX-construct check (Windows CI
  pattern) on all new tests.

Deeper artifacts (specific transcripts, census tables, suite design)
available on request.
</details>

## Commits in this PR

1. `fp8: CPU read path + matmul_fp8, as fmt=7 (public ordinal, #524)` —
   quant.h's LUT/decode/kernel, colibri.c's byte-accounting and THE DESIGN
   LANDMINE refusal, the UE8M0 recognition seam, `qt_resolve_fmt` in its
   plain 6-argument (no stamp) form.
2. `fp8: Metal mm_gemv kernel for fmt=7 native FP8-e4m3 passthrough` — the
   GPU kernel and its full adversarial test suite, including the
   `moe_submit` gate regression test.
3. `fp8: repack tool (Z.ai FP8 shards -> byte-preserved fmt=7 container)` —
   the writer side, no metadata stamp.
4. `fp8: end-to-end test, real repack tool -> real C loader` — the real
   round trip, closing the last coverage gap.
