### PR TITLE
formats: self-describing container stamp (TRUST-VERIFY-REFUSE) + FORMATS.md registry (#524)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -1341,14 +1341,19 @@ static const char *qt_name_by_fmt(int fmt){
  * 4/byte). Qui i byte del peso devono corrispondere a un layout noto e i byte
  * della scala alla cardinalita' attesa (O per-row, O*ng per-gruppo) — altrimenti
  * si termina invece di sforare. Ritorna fmt (1/2/3/4/5/6/8) e scrive *gs.
- * No container-level format stamp is consulted INSIDE this function yet in
- * this commit -- qt_verify_fmt_stamp (below) checks one AFTER the fact, a
- * pure post-hoc cross-check that cannot yet resolve a genuine byte-collision
- * below (every ambiguous shape this function can see still refuses
- * unconditionally here). A follow-up commit threads a `stamped_name`
- * parameter into this function itself so a stamp can resolve those
- * collisions instead of merely confirming an already-unambiguous result. */
-static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns, int *gs){
+ * `stamped_name`: the tensor's __metadata__ format-NAME stamp if the caller
+ * looked one up (st_fmt_stamp, st.h), else NULL -- used ONLY to break a
+ * genuine byte-count collision (see THE DESIGN LANDMINE and the SECOND
+ * DESIGN LANDMINE below); every other decision in this function is
+ * byte-arithmetic alone, unchanged by whether a stamp is present. A stamp
+ * can never grant this build a decoder it doesn't have: the UE8M0
+ * scale-encoding refusals below stay refusals even when a stamp names
+ * "fp8-e4m3-b128" correctly, because that name confirms the WEIGHT format,
+ * not a scale encoding this build can read. Routed-expert callers
+ * (expert_load_impl and friends) always pass NULL: this branch's repack
+ * tool never stamps routed experts, so there is nothing for those paths to
+ * consult. */
+static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns, int *gs, const char *stamped_name){
     int64_t exp_i8=(int64_t)O*I, exp_i4=(int64_t)O*((I+1)/2), exp_i2=(int64_t)O*((I+3)/4);
     int64_t exp_i3=(int64_t)O*i3_rowbytes(I);   /* int3-g64 (fmt=5): 24B per 64-input group */
     /* fmt=6 (E8/IQ3, #452): scales live inside the 98B super-blocks, so the .qs
@@ -1371,24 +1376,36 @@ static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns
      *     with UE8M0, just against fmt=6's tag instead of fmt=1's per-row
      *     count; see that landmine's own comment for the general shape.
      *   - at O==1 specifically, fmt=1's own per-row tag (O*4) is also 4.
-     * Refuse unconditionally when any of these coincide with the E8/IQ3 tag --
-     * this build has no stamp to break the tie (see the function's own header
-     * comment) -- rather than let dev's own unconditional `return 6` silently
-     * misread an fp8-e4m3-b128 (or, at O==1, plain int8) tensor as E8/IQ3-
-     * lattice-decoded garbage with no error. No real GLM tensor has these
-     * shapes; the discipline exists for untrusted containers. */
+     * A stamp naming exactly one live candidate resolves the ambiguity --
+     * EXCEPT a "fp8-e4m3-b128" stamp on the UE8M0-shaped candidate: the stamp
+     * confirms the WEIGHT format, not a scale encoding this build can decode,
+     * so that specific case still refuses (same "recognized but not
+     * implemented" discipline as the landmine below). Everything else
+     * (unstamped, or a stamp that doesn't resolve) refuses rather than let
+     * dev's own unconditional `return 6` silently misread an fp8-e4m3-b128
+     * (or, at O==1, plain int8) tensor as E8/IQ3-lattice-decoded garbage with
+     * no error. No real GLM tensor has these shapes; the discipline exists
+     * for untrusted containers. */
     if(ns==4 && nb==(int64_t)O*e8_rowbytes(I)){
         int fp8_blk_f32_also   = (nb==(int64_t)O*I) && (fp8_nblk(O)*fp8_nblk(I)==1);
         int fp8_blk_ue8m0_also = (nb==(int64_t)O*I) && (fp8_nblk(O)*fp8_nblk(I)==4);
         int i8_row_also        = (nb==(int64_t)O*I) && (O==1);   /* ns==O*4==4 iff O==1 */
         if(fp8_blk_f32_also || fp8_blk_ue8m0_also || i8_row_also){
+            int sf = stamped_name ? qt_fmt_by_name(stamped_name) : -1;
+            if(sf==6){ *gs=0; return 6; }
+            if(sf==8 && fp8_blk_f32_also){ *gs=0; return 8; }
+            if(sf==1 && i8_row_also){ *gs=0; return 1; }
+            /* sf==8 with only fp8_blk_ue8m0_also true falls through here too --
+             * see the comment above this block. */
             fprintf(stderr,"%s: [%d,%d] byte layout (nb=%lld ns=%lld) matches E8/IQ3 "
                 "(fmt=6, 4-byte tag)%s%s%s; refusing rather than guessing (untrusted "
-                "container, fmt=6 collision at I=98)\n",
+                "container, fmt=6 collision at I=98)%s\n",
                 name,O,I,(long long)nb,(long long)ns,
                 fp8_blk_f32_also   ? " AND per-128x128-block FP8 f32 scales (fmt=8, single block)" : "",
                 fp8_blk_ue8m0_also ? " AND per-128x128-block FP8 ue8m0 scales (fmt=8, 4 blocks, recognized-not-implemented)" : "",
-                i8_row_also        ? " AND plain int8 per-row (fmt=1, O=1)" : "");
+                i8_row_also        ? " AND plain int8 per-row (fmt=1, O=1)" : "",
+                stamped_name ? " -- metadata stamp present but names a format/encoding that doesn't resolve the ambiguity"
+                             : "");
             exit(1);
         }
         *gs=0; return 6;
@@ -1427,19 +1444,24 @@ static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns
      * on an ordinary, already-shipping, valid model -- which is a strictly
      * worse failure mode than the misread it was guarding against.
      *
-     * INVERSION: an ambiguous shape resolves to fmt=1 -- the incumbent,
-     * already-on-disk, decodable format -- instead of refusing. This is sound
-     * because the WRITER side (tools/repack_fp8_passthrough.py's
-     * _check_geometry) now refuses to EMIT an fmt=8 container at any shape
-     * satisfying this same collision predicate: no genuine fmt=8 tensor this
-     * engine's own tooling can produce will ever reach this branch, so
-     * resolving to fmt=1 here is not a guess against a live fmt=8 candidate --
-     * it is the only remaining candidate for an UNSTAMPED container. A
-     * self-describing __metadata__ stamp that lets a THIRD-PARTY fmt=8
-     * container resolve at this same colliding shape is a separate mechanism
-     * (see qt_verify_fmt_stamp / the stamped build of this function) -- this
-     * (unstamped) function has no stamp to consult and always commits to the
-     * incumbent format.
+     * INVERSION, governing the UNSTAMPED case: an ambiguous shape with no
+     * resolving stamp resolves to fmt=1 -- the incumbent, already-on-disk,
+     * decodable format -- instead of refusing. This is sound because the
+     * WRITER side (tools/repack_fp8_passthrough.py's _check_geometry) now
+     * refuses to EMIT an fmt=8 container at any shape satisfying this same
+     * collision predicate: no genuine fmt=8 tensor this engine's own tooling
+     * can produce will ever reach this branch unstamped, so resolving to
+     * fmt=1 here is not a guess against a live fmt=8 candidate -- it is the
+     * only remaining candidate. THE STAMPED CASE IS UNCHANGED by this
+     * inversion: a metadata stamp present and naming exactly one of the two
+     * colliding candidates (int8-row or fp8-e4m3-b128) still resolves via
+     * that stamp through the existing TRUST-VERIFY-REFUSE path below (the
+     * maintainer verified that path is sound on #524/#529) -- a THIRD-PARTY
+     * fmt=8 container can still declare itself at this same colliding shape
+     * and be believed, exactly as before. A stamp naming anything else
+     * (unrecognized, or a format that isn't one of the two candidates) does
+     * NOT resolve the ambiguity and refuses, same as it did before this
+     * inversion -- the inversion changes ONLY what an absent stamp does here.
      *
      * SCALE ENCODING IS A DECLARED PROPERTY, not a hardcoded constant: f32 (4
      * bytes/block, above) is what THIS build implements, but it is not the
@@ -1464,35 +1486,60 @@ static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns
      * small-O regime that makes the fmt=1-vs-fmt=8-f32 collision above
      * possible also makes a fmt=1-vs-fmt=8-ue8m0 collision possible (e.g.
      * O=1, I in (384,512]: nblkO=1, nblkI=4, ue8m0 ns=4=O*4=fmt=1's own
-     * per-row count) -- handled below by refusing whenever the ue8m0
-     * signature matches, noting the row collision too when it also applies.
-     * No real GLM tensor has these shapes; see also the SECOND DESIGN
-     * LANDMINE above for the analogous ue8m0-vs-fmt=6 corner this same
-     * signature can hit. */
+     * per-row count). A stamp naming "int8-row" resolves that specific
+     * corner to fmt=1 (the stamp confirms it really is plain int8, a format
+     * this build CAN decode); a stamp naming "fp8-e4m3-b128" does NOT resolve
+     * it, for the same "recognized but not implemented" reason the clean
+     * (non-colliding) ue8m0 case below refuses regardless of any stamp. No
+     * real GLM tensor has these shapes; see also the SECOND DESIGN LANDMINE
+     * above for the analogous ue8m0-vs-fmt=6 corner this same signature can
+     * hit. */
     if(fmt==1){
         int64_t nblkO=fp8_nblk(O), nblkI=fp8_nblk(I);
         int64_t ns_row=(int64_t)O*4, ns_blk=nblkO*nblkI*4, ns_blk_ue8m0=nblkO*nblkI;
         int is_row=(ns==ns_row), is_blk=(ns==ns_blk), is_blk_ue8m0=(ns==ns_blk_ue8m0);
-        /* THE DESIGN LANDMINE, INVERTED (maintainer review, #528): is_row&&is_blk
-         * used to exit(1) here unconditionally -- see the comment above this
-         * function's "REVIEW FINDING"/"INVERSION" paragraphs for why that was
-         * wrong. No explicit branch is needed to resolve it to fmt=1: `fmt` is
-         * already 1 at this point (this whole `if(fmt==1)` block only runs when
-         * nb==exp_i8, which is what set fmt=1 above), and the `is_blk && !is_row`
-         * check further down evaluates false whenever is_row is true -- so an
-         * is_row&&is_blk shape simply falls through unchanged to fmt=1. This
-         * comment exists so a future reader doesn't mistake the missing branch
-         * for an oversight. */
-        if(is_blk_ue8m0){
-            fprintf(stderr,"%s: [%d,%d] fp8-e4m3-b128 with ue8m0 scales recognized but not "
-                "implemented; only f32 block scales are supported in this build (nb=%lld "
-                "bytes matches raw e4m3 weight bytes, ns=%lld bytes matches %lld blocks x "
-                "1 byte/block)%s\n",
-                name,O,I,(long long)nb,(long long)ns,(long long)(nblkO*nblkI),
-                is_row ? " -- scale array ALSO matches per-row int8 (fmt=1); refusing either way (untrusted container)" : "");
-            exit(1);
-        }
-        if(is_blk && !is_row) fmt=8;
+        int sf = stamped_name ? qt_fmt_by_name(stamped_name) : -1;
+        /* THE DESIGN LANDMINE, INVERTED for the UNSTAMPED case (maintainer
+         * review, #528): is_row&&is_blk with no resolving stamp used to
+         * exit(1) unconditionally -- see this function's "REVIEW
+         * FINDING"/"INVERSION" comment above for why that was wrong. The
+         * STAMPED sub-case (sf==1 || sf==8) is untouched by the inversion:
+         * it already resolved via TRUST-VERIFY-REFUSE before this revision
+         * and still does. Only the "no stamp, or a stamp that names neither
+         * candidate" branch changes: it used to exit(1); it now falls
+         * through to fmt=1 (already the value coming into this block, so no
+         * explicit assignment is needed -- the `is_blk && !is_row` check
+         * further down evaluates false whenever is_row is true). A stamp
+         * that names some OTHER, unrelated format still refuses -- the
+         * inversion applies only to the genuinely stamp-less case. */
+        if(is_row && is_blk){
+            if(sf==1 || sf==8){
+                fmt = sf;
+            } else if(stamped_name){
+                fprintf(stderr,"%s: [%d,%d] scale array is %lld bytes — matches BOTH per-row "
+                    "int8 (fmt=1) and per-128x128-block FP8 (fmt=8) scale geometry; refusing "
+                    "rather than guessing (untrusted container, THE DESIGN LANDMINE) -- metadata "
+                    "stamp present but names a format that doesn't resolve the ambiguity\n",
+                    name,O,I,(long long)ns);
+                exit(1);
+            }
+            /* else (no stamp at all): falls through to fmt=1, the INVERSION. */
+        } else if(is_blk_ue8m0){
+            if(sf==1 && is_row){
+                fmt = 1;   /* stamp confirms this is genuinely plain int8, not an
+                            * unimplemented-encoding fp8 tensor -- safe to resolve. */
+            } else {
+                fprintf(stderr,"%s: [%d,%d] fp8-e4m3-b128 with ue8m0 scales recognized but not "
+                    "implemented; only f32 block scales are supported in this build (nb=%lld "
+                    "bytes matches raw e4m3 weight bytes, ns=%lld bytes matches %lld blocks x "
+                    "1 byte/block)%s%s\n",
+                    name,O,I,(long long)nb,(long long)ns,(long long)(nblkO*nblkI),
+                    is_row ? " -- scale array ALSO matches per-row int8 (fmt=1)" : "",
+                    stamped_name ? " -- a metadata stamp cannot grant this build a decoder it doesn't have"
+                                 : "");
+                exit(1);
+            }
+        } else if(is_blk && !is_row) fmt=8;
     }
     int64_t exp_scale = (fmt==4)? (int64_t)O*((I+*gs-1)/(*gs))
                       : (fmt==5)? (int64_t)O*i3_groups(I)
@@ -1558,8 +1605,8 @@ static void qt_from_disk(Model *m, const char *name, int O, int I, int bits, int
          * qt_resolve_fmt valida entrambi i conteggi contro [O,I] e termina se
          * non fidati (SEC). */
         int gs=0;
-        int fmt = qt_resolve_fmt(name,O,I,nb,ns,&gs);
         const char *stamped = st_fmt_stamp(&m->S,name);   /* NULL if unstamped */
+        int fmt = qt_resolve_fmt(name,O,I,nb,ns,&gs,stamped);
         qt_verify_fmt_stamp(name,stamped,fmt);   /* TRUST-VERIFY-REFUSE: no-op if unstamped */
         if(fmt==1){ if(t->fmt!=1||!t->q8){ t->fmt=1; t->O=O; t->I=I; t->gs=0; t->q8=qalloc(nb); t->s=qsalloc(O); } st_read_raw(&m->S,name,t->q8,drop); }
         else if(fmt==4){ int ng=(I+gs-1)/gs;
@@ -2121,7 +2168,7 @@ static int expert_load_impl(Model *m, int layer, int eid, ESlot *s, int fatal, i
             for(int k=0;k<3;k++){
                 int64_t nb=tw[k]->nbytes;
                 int gs=0;
-                int fmt=qt_resolve_fmt(tw[k]->name,OO[k],II[k],nb,tq[k]->nbytes,&gs);
+                int fmt=qt_resolve_fmt(tw[k]->name,OO[k],II[k],nb,tq[k]->nbytes,&gs,NULL);   /* routed expert: never stamped */
                 qt[k]->fmt=fmt; qt[k]->O=OO[k]; qt[k]->I=II[k]; qt[k]->gs=gs; qt[k]->qf=NULL;
                 qt[k]->q8=(int8_t*)((char*)bw[k]+tw[k]->off); qt[k]->q4=(uint8_t*)((char*)bw[k]+tw[k]->off);
                 qt[k]->s=(float*)((char*)bq[k]+tq[k]->off);
@@ -2290,7 +2337,7 @@ static int expert_load_impl(Model *m, int layer, int eid, ESlot *s, int fatal, i
     for(int k=0;k<3;k++){
         int64_t nb=tw[k]->nbytes;
         int gs=0;
-        int fmt=qt_resolve_fmt(tw[k]->name,OO[k],II[k],nb,tq[k]->nbytes,&gs);
+        int fmt=qt_resolve_fmt(tw[k]->name,OO[k],II[k],nb,tq[k]->nbytes,&gs,NULL);   /* routed expert: never stamped */
         qt[k]->fmt=fmt; qt[k]->O=OO[k]; qt[k]->I=II[k]; qt[k]->gs=gs; qt[k]->qf=NULL;
         qt[k]->q8=(int8_t*)(s->slab+pos[k]); qt[k]->q4=s->slab+pos[k]; qt[k]->s=fp[k];
     }
@@ -2484,7 +2531,7 @@ static int uring_finalize_load(UringBatch *b,int li,int publish_eid){
         /* qt_resolve_fmt like the other two expert paths: the raw ?1:?2:3 inference here
          * missed grouped int4 (fmt=4, gs never set) and would mis-tag int3-g64 as int2. */
         int gs=0;
-        int fmt=qt_resolve_fmt(l->tw[k]->name,OO[k],II[k],nb,l->tq[k]->nbytes,&gs);
+        int fmt=qt_resolve_fmt(l->tw[k]->name,OO[k],II[k],nb,l->tq[k]->nbytes,&gs,NULL);   /* routed expert: never stamped */
         qt[k]->fmt=fmt; qt[k]->O=OO[k]; qt[k]->I=II[k]; qt[k]->gs=gs; qt[k]->qf=NULL;
         qt[k]->q8=(int8_t*)(s->slab+l->pos[k]); qt[k]->q4=s->slab+l->pos[k]; qt[k]->s=fp[k];
     }

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -1294,6 +1294,46 @@ static int detect_group_size(int O, int I, int64_t ns){
     return 0;
 }
 
+/* FORMAT NAME <-> internal fmt-int table. The NAME is the public identity a
+ * container or a Feature Request advertises; the int on the right is this
+ * build's internal enum value (colibri.c's QT.fmt / qt_resolve_fmt's return
+ * value), never itself persisted to a container -- a container's __metadata__
+ * stamp (below) carries the NAME, never the number, matching docs/FORMATS.md's
+ * own registry. Covers every format qt_resolve_fmt can return, not just the
+ * one this branch's tool stamps: a single-entry table could only ever
+ * exercise the "unrecognized name" refusal path, never a genuine
+ * recognized-but-different-format mismatch. "e8-iq3-lattice" is this build's
+ * own placeholder name for upstream fmt=6 (#465 never stamped containers --
+ * dev has no metadata-stamp feature of its own) -- listed so
+ * qt_fmt_by_name/qt_name_by_fmt are total over every value qt_resolve_fmt can
+ * return, matching this comment's own claim; a real name for fmt=6 belongs to
+ * whoever upstreams a stamp for it. "fp8-e4m3-b128" (fmt=8) names the WEIGHT
+ * geometry only, not a specific scale encoding -- a tensor stamped
+ * "fp8-e4m3-b128" whose scale sidecar carries UE8M0 bytes still refuses (see
+ * qt_resolve_fmt's "SCALE ENCODING IS A DECLARED PROPERTY" comment): the stamp
+ * confirms the WEIGHT format, it does not grant this build a decoder it
+ * doesn't have. */
+static const struct { const char *name; int fmt; } FMT_NAMES[] = {
+    { "f32",           0 },
+    { "int8-row",      1 },
+    { "int4-row",      2 },
+    { "int2-row",      3 },
+    { "int4-grouped",  4 },
+    { "int3-g64",      5 },
+    { "e8-iq3-lattice", 6 },
+    { "fp8-e4m3-b128", 8 },
+};
+#define N_FMT_NAMES (int)(sizeof(FMT_NAMES)/sizeof(FMT_NAMES[0]))
+
+static int qt_fmt_by_name(const char *name){
+    for(int i=0;i<N_FMT_NAMES;i++) if(!strcmp(FMT_NAMES[i].name,name)) return FMT_NAMES[i].fmt;
+    return -1;   /* unrecognized name -- never a valid qt_resolve_fmt() return value */
+}
+static const char *qt_name_by_fmt(int fmt){
+    for(int i=0;i<N_FMT_NAMES;i++) if(FMT_NAMES[i].fmt==fmt) return FMT_NAMES[i].name;
+    return NULL; /* fmt has no registered public name yet (e.g. upstream 0-5) */
+}
+
 /* SEC: risolve e VALIDA il formato quantizzato di un tensore [O,I] letto da un
  * container non fidato (mirror). L'inferenza precedente (`?1:?2:3`) cadeva su
  * int2 per QUALSIASI conteggio byte non riconosciuto: un peso troppo corto
@@ -1301,11 +1341,13 @@ static int detect_group_size(int O, int I, int64_t ns){
  * 4/byte). Qui i byte del peso devono corrispondere a un layout noto e i byte
  * della scala alla cardinalita' attesa (O per-row, O*ng per-gruppo) — altrimenti
  * si termina invece di sforare. Ritorna fmt (1/2/3/4/5/6/8) e scrive *gs.
- * No container-level format stamp is consulted here: a self-describing
- * __metadata__ stamp that could resolve a genuine byte-collision below
- * (instead of refusing it unconditionally) is a follow-up proposal, not
- * present in this build -- every ambiguous shape this function can see
- * refuses, full stop. */
+ * No container-level format stamp is consulted INSIDE this function yet in
+ * this commit -- qt_verify_fmt_stamp (below) checks one AFTER the fact, a
+ * pure post-hoc cross-check that cannot yet resolve a genuine byte-collision
+ * below (every ambiguous shape this function can see still refuses
+ * unconditionally here). A follow-up commit threads a `stamped_name`
+ * parameter into this function itself so a stamp can resolve those
+ * collisions instead of merely confirming an already-unambiguous result. */
 static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns, int *gs){
     int64_t exp_i8=(int64_t)O*I, exp_i4=(int64_t)O*((I+1)/2), exp_i2=(int64_t)O*((I+3)/4);
     int64_t exp_i3=(int64_t)O*i3_rowbytes(I);   /* int3-g64 (fmt=5): 24B per 64-input group */
@@ -1461,6 +1503,48 @@ static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns
                 name,(long long)ns,(long long)(exp_scale*4),O,I,fmt); exit(1); }
     return fmt;
 }
+
+/* TRUST-VERIFY-REFUSE: if `stamped` (the tensor's __metadata__ format-NAME
+ * stamp, or NULL if none -- see st_fmt_stamp/st_fmt_stamp_ingest in st.h)
+ * is present, verify it agrees with `fmt` (qt_resolve_fmt's byte-arithmetic
+ * result) and refuse loudly on disagreement -- same "untrusted container"
+ * discipline qt_resolve_fmt applies throughout. A stamp naming a format this
+ * build doesn't recognize is ALSO a refusal: silently accepting an
+ * unrecognized name would be indistinguishable from missing a real mismatch,
+ * and "refuse rather than guess" is the whole point of this function's
+ * design. No stamp at all is NOT an error -- the container simply predates
+ * this feature (or was never stamped by a stamping tool), and byte-arithmetic
+ * inference alone decides, exactly as before this function existed: zero
+ * behavior change for unstamped containers.
+ *
+ * Called from qt_from_disk right after qt_resolve_fmt -- the resident-tensor
+ * load path this branch's repack tool actually stamps. Deliberately NOT
+ * threaded into the routed-expert loader paths (expert_load_impl and
+ * friends, which call qt_resolve_fmt separately for g/u/d slab layout): this
+ * branch's tools/repack_fp8_passthrough.py never stamps routed experts (kind
+ * "x" is explicitly excluded, see that tool's module docstring), so there is
+ * no stamp for those paths to verify yet -- adding the plumbing there now
+ * would be framework-building ahead of any container that needs it, which
+ * this reference implementation deliberately avoids. */
+static void qt_verify_fmt_stamp(const char *name, const char *stamped, int fmt){
+    if(!stamped) return;                       /* unstamped: infer exactly as today */
+    int stamped_fmt = qt_fmt_by_name(stamped);
+    if(stamped_fmt == fmt) return;              /* agree: silent pass-through, loads normally */
+    if(stamped_fmt < 0){
+        fprintf(stderr,
+            "%s: metadata stamp names format '%s', which this build does not recognize "
+            "(byte-arithmetic inference says fmt=%d) -- refusing (untrusted container, "
+            "unrecognized stamp name)\n", name, stamped, fmt);
+        exit(1);
+    }
+    const char *inferred_name = qt_name_by_fmt(fmt);
+    fprintf(stderr,
+        "%s: metadata stamp says format '%s' but byte-arithmetic inference says fmt=%d "
+        "(%s) -- refusing (untrusted container, stamp/inference mismatch)\n",
+        name, stamped, fmt, inferred_name ? inferred_name : "no registered name");
+    exit(1);
+}
+
 /* costruisce un QT [O,I] dal disco in `t` (buffer riusabili tra chiamate).
  *  - se esiste `name.qs`: pesi GIA' quantizzati nel container (U8 qdata + F32 scala) -> letti diretti
  *  - altrimenti: tensore pieno (f32/bf16) -> quantizzato a runtime a `bits` (oracolo tiny / pesi pieni)
@@ -1475,6 +1559,8 @@ static void qt_from_disk(Model *m, const char *name, int O, int I, int bits, int
          * non fidati (SEC). */
         int gs=0;
         int fmt = qt_resolve_fmt(name,O,I,nb,ns,&gs);
+        const char *stamped = st_fmt_stamp(&m->S,name);   /* NULL if unstamped */
+        qt_verify_fmt_stamp(name,stamped,fmt);   /* TRUST-VERIFY-REFUSE: no-op if unstamped */
         if(fmt==1){ if(t->fmt!=1||!t->q8){ t->fmt=1; t->O=O; t->I=I; t->gs=0; t->q8=qalloc(nb); t->s=qsalloc(O); } st_read_raw(&m->S,name,t->q8,drop); }
         else if(fmt==4){ int ng=(I+gs-1)/gs;
             /* METAL: t->s must be page-aligned + coli_metal_register'd like every other

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -1490,10 +1490,19 @@ static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns
      * corner to fmt=1 (the stamp confirms it really is plain int8, a format
      * this build CAN decode); a stamp naming "fp8-e4m3-b128" does NOT resolve
      * it, for the same "recognized but not implemented" reason the clean
-     * (non-colliding) ue8m0 case below refuses regardless of any stamp. No
-     * real GLM tensor has these shapes; see also the SECOND DESIGN LANDMINE
-     * above for the analogous ue8m0-vs-fmt=6 corner this same signature can
-     * hit. */
+     * (non-colliding) ue8m0 case below refuses regardless of any stamp.
+     * The colliding FAMILY is exactly: nb==O*I && ns==O*4 &&
+     * ceil(O/128)*ceil(I/128)==4*O (is_row && is_blk_ue8m0 below; is_blk can
+     * never co-hold since nblk==O and nblk==4*O are disjoint for O>=1).
+     * At I<=16384 (nblkI<=128) membership forces O<=32; every GLM-5.2
+     * resident/routed role has O>=576 (kv_a's kv_lora+qk_rope is the
+     * smallest -- tools/fp8_collision_census.py enumerates the roles, and
+     * the census over the real checkpoint was run in this PR's rev5 round),
+     * so no GLM-5.2 tensor is a member -- the discipline exists for
+     * untrusted containers. tests/test_fp8_load.c's Part A3b pins the
+     * family's polarity at member shapes [1,400], [2,1024], [129,33000].
+     * See also the SECOND DESIGN LANDMINE above for the analogous
+     * ue8m0-vs-fmt=6 corner this same signature can hit. */
     if(fmt==1){
         int64_t nblkO=fp8_nblk(O), nblkI=fp8_nblk(I);
         int64_t ns_row=(int64_t)O*4, ns_blk=nblkO*nblkI*4, ns_blk_ue8m0=nblkO*nblkI;
@@ -1532,7 +1541,8 @@ static int qt_resolve_fmt(const char *name, int O, int I, int64_t nb, int64_t ns
                 fprintf(stderr,"%s: [%d,%d] fp8-e4m3-b128 with ue8m0 scales recognized but not "
                     "implemented; only f32 block scales are supported in this build (nb=%lld "
                     "bytes matches raw e4m3 weight bytes, ns=%lld bytes matches %lld blocks x "
-                    "1 byte/block)%s%s\n",
+                    "1 byte/block)%s%s -- refusing rather than misreading the sidecar "
+                    "(untrusted container)\n",
                     name,O,I,(long long)nb,(long long)ns,(long long)(nblkO*nblkI),
                     is_row ? " -- scale array ALSO matches per-row int8 (fmt=1)" : "",
                     stamped_name ? " -- a metadata stamp cannot grant this build a decoder it doesn't have"

--- a/c/st.h
+++ b/c/st.h
@@ -49,6 +49,20 @@ typedef struct {
                            * (GLM: 256 expert x 78 layer x 3 x 2) la scansione lineare
                            * costava decine di secondi/token (misurato sul primo run reale) */
     int        hcap;
+    /* FORMAT METADATA STAMP (reference impl, see colibri.c's qt_verify_fmt_stamp):
+     * per-tensor {name -> format NAME string} pairs collected from every shard's
+     * __metadata__["colibri.fmt"] JSON blob (safetensors __metadata__ values are
+     * always strings, so colibri.fmt's value is itself JSON text, parsed a
+     * second time -- see st_init_multi below). Small in practice (only the
+     * tensors a stamping tool selected, a subset of S->t), so a flat array +
+     * linear st_fmt_stamp() lookup is fine; this is a reference implementation,
+     * not a framework -- no hash map for a handful-to-low-thousands of entries.
+     * Both arrays own strdup'd strings, intentionally leaked like the rest of
+     * st_init_multi's one-time startup parsing (see the json_parse callers
+     * below). */
+    char     **fmt_name;   /* stamped tensor name */
+    char     **fmt_val;    /* stamped format NAME string */
+    int        fmt_n, fmt_cap;
 } shards;
 #define ST_MAX_SHARDS 512
 
@@ -225,6 +239,60 @@ static void st_pread_full(int fd, void *buf, int64_t n, int64_t off, const char 
     }
 }
 
+/* Parses one shard's __metadata__["colibri.fmt"] value (a safetensors metadata
+ * value is always a plain string, so colibri.fmt's VALUE is itself JSON text --
+ * a flat {tensor_name: format_name} object -- parsed a second time here) and
+ * appends every entry to S->fmt_name/fmt_val. Absent __metadata__, or a
+ * __metadata__ without a colibri.fmt key, is NOT an error: that's simply an
+ * unstamped container, and byte-arithmetic inference alone decides, exactly as
+ * before this feature existed (see qt_verify_fmt_stamp in colibri.c). A
+ * colibri.fmt key that IS present but doesn't parse into that shape is refused
+ * loudly -- same "untrusted container" discipline qt_resolve_fmt applies
+ * elsewhere: a stamp the engine cannot make sense of must not be silently
+ * ignored (that would be indistinguishable from a real mismatch going
+ * unnoticed). */
+static void st_fmt_stamp_ingest(shards *S, jval *root, const char *shard_path) {
+    jval *meta = json_get(root, "__metadata__");
+    if (!meta || meta->t != J_OBJ) return;                /* no metadata object: unstamped, fine */
+    jval *stamp = json_get(meta, "colibri.fmt");
+    if (!stamp) return;                                    /* no stamp key: unstamped, fine */
+    if (stamp->t != J_STR) {
+        fprintf(stderr, "%s: __metadata__[\"colibri.fmt\"] is not a JSON string -- malformed stamp, refusing (untrusted container)\n",
+                shard_path); exit(1); }
+    char *arena2 = NULL;
+    jval *inner = json_parse(stamp->str, &arena2);
+    if (!inner || inner->t != J_OBJ) {
+        fprintf(stderr, "%s: __metadata__[\"colibri.fmt\"] does not parse as a JSON object -- malformed stamp, refusing (untrusted container)\n",
+                shard_path); exit(1); }
+    for (int i = 0; i < inner->len; i++) {
+        jval *v = inner->kids[i];
+        if (v->t != J_STR) {
+            fprintf(stderr, "%s: colibri.fmt entry '%s' is not a string -- malformed stamp, refusing (untrusted container)\n",
+                    shard_path, inner->keys[i]); exit(1); }
+        if (S->fmt_n == S->fmt_cap) {
+            S->fmt_cap = S->fmt_cap ? S->fmt_cap * 2 : 16;
+            S->fmt_name = realloc(S->fmt_name, S->fmt_cap * sizeof(char*));
+            S->fmt_val  = realloc(S->fmt_val,  S->fmt_cap * sizeof(char*));
+        }
+        S->fmt_name[S->fmt_n] = strdup(inner->keys[i]);
+        S->fmt_val[S->fmt_n]  = strdup(v->str);
+        S->fmt_n++;
+    }
+    free(arena2);  /* always NULL (json_parse never populates it -- see j_dup); the jval
+                    * tree itself is intentionally leaked, same one-time-startup convention
+                    * as st_init_multi's own root parse a few lines below. */
+}
+
+/* Stamped format NAME for `name`, or NULL if this tensor carries no stamp
+ * (either because no shard stamped it, or the container predates this
+ * feature). Linear scan: S->fmt_n is a subset of S->n (only stamped tensors),
+ * small in practice -- see the shards struct comment. */
+static const char *st_fmt_stamp(shards *S, const char *name) {
+    for (int i = 0; i < S->fmt_n; i++)
+        if (!strcmp(S->fmt_name[i], name)) return S->fmt_val[i];
+    return NULL;
+}
+
 /* Scan one directory for *.safetensors shards, appending to files[] (dedup by
  * basename, so a list of directories acts as a SEARCH PATH: the same shard
  * present on two drives is taken from the first-listed one only). *added
@@ -311,6 +379,7 @@ static void st_init_multi(shards *S, const char *snap_dir, const char *extra_dir
         jval *root = json_parse(hdr, &arena);
         if (!root || root->t != J_OBJ) {
             fprintf(stderr, "%s: safetensors header is not a JSON object\n", files[fi]); exit(1); }
+        st_fmt_stamp_ingest(S, root, files[fi]);
         for (int i = 0; i < root->len; i++) {
             const char *name = root->keys[i];
             if (!strcmp(name, "__metadata__")) continue;

--- a/c/st.h
+++ b/c/st.h
@@ -300,6 +300,34 @@ static void st_fmt_stamp_ingest(shards *S, jval *root, const char *shard_path) {
         if (v->t != J_STR) {
             fprintf(stderr, "%s: colibri.fmt entry '%s' is not a string -- malformed stamp, refusing (untrusted container)\n",
                     shard_path, inner->keys[i]); exit(1); }
+        /* DUPLICATE CLAIMS (user-ratified design, register D8): at most one
+         * DISTINCT format claim per tensor name, container-wide. An entry
+         * that repeats an already-ingested claim verbatim is tolerated and
+         * collapsed to one entry (idempotent -- a centralized-manifest
+         * writer may legally stamp the same map into every shard, and a
+         * shard may stamp tensors it does not itself contain; there is no
+         * locality constraint). An entry that CONTRADICTS an earlier claim
+         * refuses by name: a container that disagrees with itself about a
+         * tensor's format is corrupted or hostile, and the previous
+         * first-wins behavior made the outcome depend on shard enumeration
+         * order (st_scan_dir is raw readdir order, not sorted) while
+         * mis-diagnosing the real problem downstream as a stamp/inference
+         * mismatch -- or hiding it entirely when the enumeration happened
+         * to favor the agreeing claim. The refusal names the tensor and
+         * both format names; the EARLIER claim's shard file is not named
+         * (per-entry shard provenance isn't stored, and adding it just for
+         * this message would be new plumbing -- only the current shard's
+         * path is in scope here). Linear rescan per entry is O(n^2) worst
+         * case, bounded by ST_FMT_STAMP_MAX at one-time startup. */
+        int dup = -1;
+        for (int k = 0; k < S->fmt_n; k++)
+            if (!strcmp(S->fmt_name[k], inner->keys[i])) { dup = k; break; }
+        if (dup >= 0) {
+            if (!strcmp(S->fmt_val[dup], v->str)) continue;   /* agreeing duplicate: keep one */
+            fprintf(stderr, "%s: __metadata__[\"colibri.fmt\"] stamps tensor '%s' as '%s', but an "
+                    "earlier shard's map already stamped it '%s' -- conflicting format claims, "
+                    "refusing (untrusted container)\n",
+                    shard_path, inner->keys[i], v->str, S->fmt_val[dup]); exit(1); }
         if (S->fmt_n >= ST_FMT_STAMP_MAX) {
             fprintf(stderr, "%s: __metadata__[\"colibri.fmt\"] stamps more than %d tensor names across "
                     "this container's shards -- stamps are a resident-tensor convention (docs/FORMATS.md), "

--- a/c/st.h
+++ b/c/st.h
@@ -246,9 +246,13 @@ static void st_pread_full(int fd, void *buf, int64_t n, int64_t off, const char 
  * carries (tools/repack_fp8_passthrough.py never stamps routed experts). A
  * container whose combined __metadata__["colibri.fmt"] entries exceed this
  * cap is not using the convention as designed -- CAP, not a switch to a hash
- * table: refuse loudly rather than grow an unbounded array for an untrusted
- * container that might be trying to force a large ingest allocation during
- * header parsing, before any other validation has run. */
+ * table. Precisely what this bounds: the colibri.fmt blob is json_parse'd in
+ * FULL before the per-entry check below fires, so the parse allocation
+ * itself is bounded by ST_MAX_HEADER (the shard-header size cap), not by
+ * this constant -- what the cap bounds is the PERSISTENT fmt_name/fmt_val
+ * strdup arrays on `shards` (and every later st_fmt_stamp linear scan over
+ * them), which would otherwise grow with an adversarial map. Refuse loudly
+ * rather than carry an absurd stamp map forward. */
 #define ST_FMT_STAMP_MAX 4096
 
 /* Parses one shard's __metadata__["colibri.fmt"] value (a safetensors metadata

--- a/c/st.h
+++ b/c/st.h
@@ -239,6 +239,18 @@ static void st_pread_full(int fd, void *buf, int64_t n, int64_t off, const char 
     }
 }
 
+/* Stamps are a resident-tensor convention (see docs/FORMATS.md's "Stamp-map
+ * scan bound"): a handful to a few hundred entries per model
+ * (q_a/q_b/kv_a/kv_b_proj, o_proj, shared-expert and dense-MLP gate/up/down),
+ * NEVER the tens of thousands of routed-expert tensors a large MoE model
+ * carries (tools/repack_fp8_passthrough.py never stamps routed experts). A
+ * container whose combined __metadata__["colibri.fmt"] entries exceed this
+ * cap is not using the convention as designed -- CAP, not a switch to a hash
+ * table: refuse loudly rather than grow an unbounded array for an untrusted
+ * container that might be trying to force a large ingest allocation during
+ * header parsing, before any other validation has run. */
+#define ST_FMT_STAMP_MAX 4096
+
 /* Parses one shard's __metadata__["colibri.fmt"] value (a safetensors metadata
  * value is always a plain string, so colibri.fmt's VALUE is itself JSON text --
  * a flat {tensor_name: format_name} object -- parsed a second time here) and
@@ -250,7 +262,22 @@ static void st_pread_full(int fd, void *buf, int64_t n, int64_t off, const char 
  * loudly -- same "untrusted container" discipline qt_resolve_fmt applies
  * elsewhere: a stamp the engine cannot make sense of must not be silently
  * ignored (that would be indistinguishable from a real mismatch going
- * unnoticed). */
+ * unnoticed).
+ *
+ * DISCOVERY-TIME ABORT SURFACE: every exit(1) below (malformed stamp value,
+ * malformed entry, or the ST_FMT_STAMP_MAX cap) fires from inside
+ * st_init_multi's shard-header-parse loop -- i.e. at CONTAINER DISCOVERY
+ * time, while the engine is still building its tensor index, before it has
+ * resolved a single tensor against the model's architecture or read one byte
+ * of weight data. This is coarser-grained and EARLIER than
+ * qt_resolve_fmt/qt_verify_fmt_stamp's own per-tensor refusals in colibri.c
+ * (which fire much later, during weight load, once a specific tensor's
+ * [O,I] shape and stamp are both known): a malformed stamp anywhere in any
+ * shard aborts the ENTIRE model load immediately, before the user ever sees
+ * which layer or tensor was implicated -- these messages name a shard FILE,
+ * never a tensor, which is how to tell this abort surface apart from the
+ * later per-tensor one at a glance. See docs/FORMATS.md's own section on
+ * this. */
 static void st_fmt_stamp_ingest(shards *S, jval *root, const char *shard_path) {
     jval *meta = json_get(root, "__metadata__");
     if (!meta || meta->t != J_OBJ) return;                /* no metadata object: unstamped, fine */
@@ -269,6 +296,12 @@ static void st_fmt_stamp_ingest(shards *S, jval *root, const char *shard_path) {
         if (v->t != J_STR) {
             fprintf(stderr, "%s: colibri.fmt entry '%s' is not a string -- malformed stamp, refusing (untrusted container)\n",
                     shard_path, inner->keys[i]); exit(1); }
+        if (S->fmt_n >= ST_FMT_STAMP_MAX) {
+            fprintf(stderr, "%s: __metadata__[\"colibri.fmt\"] stamps more than %d tensor names across "
+                    "this container's shards -- stamps are a resident-tensor convention (docs/FORMATS.md), "
+                    "not a bulk migration path; a container stamping this many names is malformed, "
+                    "refusing (untrusted container)\n",
+                    shard_path, ST_FMT_STAMP_MAX); exit(1); }
         if (S->fmt_n == S->fmt_cap) {
             S->fmt_cap = S->fmt_cap ? S->fmt_cap * 2 : 16;
             S->fmt_name = realloc(S->fmt_name, S->fmt_cap * sizeof(char*));
@@ -286,7 +319,19 @@ static void st_fmt_stamp_ingest(shards *S, jval *root, const char *shard_path) {
 /* Stamped format NAME for `name`, or NULL if this tensor carries no stamp
  * (either because no shard stamped it, or the container predates this
  * feature). Linear scan: S->fmt_n is a subset of S->n (only stamped tensors),
- * small in practice -- see the shards struct comment. */
+ * small in practice -- see the shards struct comment.
+ *
+ * SCOPE: .qs-BACKED TENSORS ONLY. This function itself will happily look up
+ * ANY name that got stamped -- st_fmt_stamp_ingest doesn't know or check
+ * whether a stamped name belongs to a quantized (.qs-backed) tensor -- but
+ * qt_from_disk (colibri.c) only ever CALLS this inside its `st_has(name+
+ * ".qs")` branch, i.e. only for a tensor that already carries a quantized
+ * scale sidecar. A colibri.fmt entry naming a raw f32/bf16 weight, a norm, a
+ * router, or embed/lm_head is stored here like any other entry but never
+ * looked up: it is silently ignored BY DESIGN, not an oversight -- the
+ * convention exists to disambiguate a byte-count collision among quantized
+ * formats, and only a .qs-backed tensor can have one. See docs/FORMATS.md's
+ * "Scope: .qs-backed tensors only". */
 static const char *st_fmt_stamp(shards *S, const char *name) {
     for (int i = 0; i < S->fmt_n; i++)
         if (!strcmp(S->fmt_name[i], name)) return S->fmt_val[i];

--- a/c/tests/test_formats_registry.py
+++ b/c/tests/test_formats_registry.py
@@ -1,0 +1,96 @@
+"""docs/FORMATS.md <-> colibri.c FMT_NAMES parity (fix round 1, adopted
+review test-candidate).
+
+The registry's name column IS the canonical stamp string: a container's
+__metadata__["colibri.fmt"] entry is matched byte-for-byte against
+FMT_NAMES by qt_fmt_by_name(), and FORMATS.md is what a third-party tool
+author will read to learn the string to write. A divergence between the
+two (the class of defect this test pins: the registry shipped "e8-iq3"
+while FMT_NAMES said "e8-iq3-lattice") means a tool stamping the
+documented name produces containers the reader REFUSES as unrecognized.
+
+Mechanism: regex over the two authoritative TEXTS themselves (the C
+source and the markdown), not a generated header. Justification: a
+generated header is a third copy that can go stale exactly like the doc
+did, plus build machinery for one test; the C table's syntax is a
+trivially stable one-entry-per-line initializer and the doc's table is
+the reviewed artifact itself. Both parses assert plausibility floors so
+an anchor drifting (renamed array, retitled section) fails loudly as a
+parse error, never as a silent empty-vs-empty pass.
+
+Parity rules:
+  1. Every FMT_NAMES (name, fmt) entry must appear in the doc table as a
+     row whose ordinal matches and whose FIRST backticked token in the
+     name cell equals the C name exactly.
+  2. Every doc table row whose ordinal has NO FMT_NAMES entry must say so
+     explicitly ("no in-tree name string" -- the MXFP4 row's marker), so
+     a new registry row can't silently claim a name the reader won't
+     recognize.
+"""
+import os
+import re
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+C_DIR = os.path.normpath(os.path.join(HERE, ".."))
+COLIBRI_C = os.path.join(C_DIR, "colibri.c")
+FORMATS_MD = os.path.normpath(os.path.join(C_DIR, "..", "docs", "FORMATS.md"))
+
+
+def parse_fmt_names(path):
+    with open(path, encoding="utf-8") as f:
+        src = f.read()
+    m = re.search(r"FMT_NAMES\[\]\s*=\s*\{(.*?)\};", src, re.S)
+    if not m:
+        raise AssertionError("FMT_NAMES[] initializer not found in colibri.c "
+                             "(anchor drifted -- update this test's regex)")
+    entries = re.findall(r'\{\s*"([^"]+)"\s*,\s*(\d+)\s*\}', m.group(1))
+    return {int(fmt): name for name, fmt in entries}
+
+
+def parse_doc_rows(path):
+    rows = {}
+    with open(path, encoding="utf-8") as f:
+        lines = f.readlines()
+    for line in lines:
+        m = re.match(r"\|\s*\*{0,2}(\d+)\*{0,2}\s*\|\s*(.+)$", line)
+        if not m:
+            continue
+        ordinal = int(m.group(1))
+        name_cell = m.group(2).split("|")[0]
+        first_tick = re.search(r"`([^`]+)`", name_cell)
+        rows[ordinal] = (first_tick.group(1) if first_tick else None, name_cell)
+    return rows
+
+
+class RegistryParityTest(unittest.TestCase):
+    def setUp(self):
+        self.c_names = parse_fmt_names(COLIBRI_C)
+        self.doc_rows = parse_doc_rows(FORMATS_MD)
+        # plausibility floors: an anchor drift must fail HERE, loudly.
+        self.assertGreaterEqual(len(self.c_names), 8,
+                                "FMT_NAMES parse found suspiciously few entries")
+        self.assertGreaterEqual(len(self.doc_rows), 9,
+                                "FORMATS.md table parse found suspiciously few rows")
+
+    def test_every_c_name_matches_its_doc_row(self):
+        for fmt, name in sorted(self.c_names.items()):
+            self.assertIn(fmt, self.doc_rows,
+                          f"FMT_NAMES has fmt={fmt} ('{name}') but FORMATS.md has no row for it")
+            doc_name, cell = self.doc_rows[fmt]
+            self.assertEqual(doc_name, name,
+                             f"fmt={fmt}: FORMATS.md names '{doc_name}' but FMT_NAMES "
+                             f"(the string qt_fmt_by_name actually matches) says '{name}'")
+
+    def test_doc_rows_without_c_entry_are_marked(self):
+        for fmt, (doc_name, cell) in sorted(self.doc_rows.items()):
+            if fmt in self.c_names:
+                continue
+            self.assertIn("no in-tree name string", cell,
+                          f"FORMATS.md row fmt={fmt} ('{doc_name}') has no FMT_NAMES entry "
+                          f"and is not marked 'no in-tree name string' -- a tool stamping "
+                          f"this documented name would be refused as unrecognized")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tests/test_fp8_e2e_loader.c
+++ b/c/tests/test_fp8_e2e_loader.c
@@ -15,9 +15,9 @@
  * Usage: test_fp8_e2e_loader <container_dir> [name O I]...
  * For every (name,O,I) triple, calls the REAL qt_from_disk (the identical
  * function every model load uses) and asserts:
- *   (a) fmt==8 resolved (native fp8-e4m3-passthrough, via byte-arithmetic
- *       inference alone -- this PR's repack tool writes no container
- *       metadata stamp, see repack_fp8_passthrough.py's module docstring);
+ *   (a) fmt==8 resolved (native fp8-e4m3-passthrough -- byte-arithmetic
+ *       inference AND, since this tool stamps its output, metadata-stamp
+ *       agreement, both exercised for real here, neither mocked);
  *   (b) the weight (q8) and scale (s) buffers are non-NULL;
  *   (c) every dequantized value (e4m3_decode(byte) * block scale) is finite
  *       -- catches a decode-table or block-index bug a pure byte-count

--- a/c/tests/test_fp8_e2e_repack_load.py
+++ b/c/tests/test_fp8_e2e_repack_load.py
@@ -18,9 +18,8 @@ test does, end to end:
      Makefile's own CFLAGS, asserted to produce zero warnings -- into a
      temp binary;
   4. run that binary against the REAL repacked output directory, asserting
-     every selected tensor loads fmt=8 through the real qt_from_disk with
-     finite dequantized values (byte-arithmetic inference alone -- this PR's
-     repack tool writes no container metadata stamp).
+     every stamped tensor loads fmt=8 through the real qt_from_disk with
+     finite dequantized values.
 
 Hermetic: everything (checkpoint, repacked output, compiled harness binary)
 lives under one TemporaryDirectory; nothing is left behind.
@@ -86,7 +85,7 @@ class Fp8RepackLoadE2ETest(unittest.TestCase):
             "model.layers.0.self_attn.q_a_proj.weight": torch.randn(D, D) * 0.02,
             "model.layers.0.mlp.shared_experts.gate_proj.weight": torch.randn(D, I_) * 0.02,
             "model.layers.0.mlp.gate_proj.weight": torch.randn(D, I_) * 0.02,
-            # routed expert: must NOT be selected (stays int4-g64 path) -- included
+            # routed expert: must NOT be selected/stamped (stays int4-g64 path) -- included
             # as a negative control so this test also proves the real tool's selection
             # logic held on the real round trip, not just in test_fp8_repack.py's own suite.
             "model.layers.0.mlp.experts.0.gate_proj.weight": torch.randn(I_, D) * 0.02,
@@ -113,24 +112,19 @@ class Fp8RepackLoadE2ETest(unittest.TestCase):
         outs = glob.glob(os.path.join(self.outdir, "out-fp8pass-*.safetensors"))
         self.assertEqual(len(outs), 1, "expected exactly one repacked output shard")
 
-        # Sanity-check the real tool's own selection BEFORE asking the C harness to load
-        # it: if this fails, the bug is in the tool, not the loader, and running the
-        # harness anyway would only muddy which side broke. This PR's repack tool writes
-        # NO container metadata stamp (that's a separate, follow-up PR -- see the tool's
-        # own module docstring), so selection is checked by tensor presence instead of a
-        # stamp's tensor-name set, and the stamp's ABSENCE is itself asserted below: a
-        # regression guard that this PR's tool really stays out of that scope.
+        # Sanity-check the real tool's own selection/stamp BEFORE asking the C harness
+        # to load it: if this fails, the bug is in the tool, not the loader, and running
+        # the harness anyway would only muddy which side broke.
         with open(outs[0], "rb") as f:
             hlen = struct.unpack("<Q", f.read(8))[0]
             hdr = json.loads(f.read(hlen))
-        for name in shapes:
-            self.assertIn(name, hdr, f"{name}: expected tensor missing from repacked output")
-            self.assertIn(name + ".qs", hdr, f"{name}.qs: expected scale sidecar missing")
+        self.assertIn("__metadata__", hdr)
+        self.assertIn("colibri.fmt", hdr["__metadata__"])
+        stamp = json.loads(hdr["__metadata__"]["colibri.fmt"])
+        self.assertEqual(set(stamp.keys()), set(shapes.keys()),
+                         "real tool's selection must match exactly the resident-kind tensors")
         self.assertNotIn("model.layers.0.mlp.experts.0.gate_proj.weight", hdr)
         self.assertNotIn("model.layers.0.input_layernorm.weight", hdr)
-        self.assertNotIn("__metadata__", hdr,
-                         "this PR's repack tool must not write a container metadata stamp "
-                         "(stamp writer is a separate, follow-up PR)")
 
         cc, cflags, ldflags = _cc_flags()
         if not cc:

--- a/c/tests/test_fp8_load.c
+++ b/c/tests/test_fp8_load.c
@@ -997,6 +997,87 @@ static void test_stamp_absent(void){
     char p[300]; snprintf(p,sizeof p,"%s/model.safetensors",dir); unlink(p); rmdir(dir);
 }
 
+/* ---- Duplicate stamp claims (micro-round 2, user-ratified design D8) ----
+ * At most one DISTINCT format claim per tensor name, container-wide:
+ * conflicting claims refuse at ingest (naming the tensor and both format
+ * names); agreeing duplicates are tolerated (idempotent). There is no
+ * locality constraint -- shard 2 below stamps "w", a tensor it does NOT
+ * contain, which is legal by design (centralized-manifest writers) and is
+ * exactly what makes cross-shard conflicts possible in the first place. */
+
+/* Shard 1 = write_stamp_fixture's single-tensor fp8 shard ("w" + "w.qs"),
+ * renamed into a two-shard layout; shard 2 = one tiny aux f32 tensor of its
+ * own plus a colibri.fmt map stamping "w". */
+static void write_second_stamp_shard(const char *dir, const char *meta_json_string_literal){
+    char path[300]; snprintf(path,sizeof path,"%s/model-extra.safetensors",dir);
+    static float aux[4] = {1.f,2.f,3.f,4.f};
+    char hdr[1024]; int hl;
+    hl=snprintf(hdr,sizeof hdr,
+        "{\"__metadata__\":{\"colibri.fmt\":%s},"
+        "\"aux\":{\"dtype\":\"F32\",\"shape\":[4],\"data_offsets\":[0,16]}}",
+        meta_json_string_literal);
+    FILE *f=fopen(path,"wb");
+    if(!f){ printf("FAIL: cannot create %s\n", path); fails++; return; }
+    uint64_t hlen=(uint64_t)hl;
+    fwrite(&hlen,8,1,f); fwrite(hdr,1,hl,f); fwrite(aux,1,sizeof aux,f);
+    fclose(f);
+}
+static void rm_two_shard_fixture(const char *dir){
+    char p[300];
+    snprintf(p,sizeof p,"%s/model.safetensors",dir); unlink(p);
+    snprintf(p,sizeof p,"%s/model-extra.safetensors",dir); unlink(p);
+    rmdir(dir);
+}
+static void test_stamp_conflicting_duplicate(void){
+#ifndef _WIN32
+    const char *dir="tests/tmp_fp8_stamp_conflict";
+    write_stamp_fixture(dir, "\"{\\\"w\\\":\\\"fp8-e4m3-b128\\\"}\"");
+    write_second_stamp_shard(dir, "\"{\\\"w\\\":\\\"int8-row\\\"}\"");
+    /* refusal fires at DISCOVERY time (st_init's header-parse loop), before
+     * any tensor is resolved -- fork st_init alone and capture stderr. */
+    fflush(stdout);
+    int pipefd[2]; if(pipe(pipefd)!=0){ CHECK(0); return; }
+    pid_t pid = fork();
+    if(pid < 0){ CHECK(0); return; }
+    if(pid == 0){
+        dup2(pipefd[1],2); close(pipefd[0]); close(pipefd[1]);
+        static Model gm; memset(&gm,0,sizeof gm);
+        st_init(&gm.S, dir);                   /* must exit(1) inside the ingest */
+        _exit(42);                              /* surviving discovery is the bug */
+    }
+    close(pipefd[1]);
+    char err[2048]={0}; size_t eoff=0; ssize_t n;
+    while(eoff<sizeof(err)-1 && (n=read(pipefd[0],err+eoff,sizeof(err)-1-eoff))>0) eoff+=(size_t)n;
+    close(pipefd[0]);
+    int status=0; waitpid(pid,&status,0);
+    int ok = WIFEXITED(status) && WEXITSTATUS(status)==1;
+    if(!ok) printf("FAIL stamp-conflict: expected exit(1) at discovery, got status=%d, stderr=%.300s\n", status, err);
+    CHECK(ok);
+    /* the refusal must NAME the tensor and BOTH claims (either shard may be
+     * enumerated first -- readdir order -- so assert both names, not roles). */
+    CHECK(strstr(err,"conflicting format claims")!=NULL);
+    CHECK(strstr(err,"'w'")!=NULL);
+    CHECK(strstr(err,"fp8-e4m3-b128")!=NULL && strstr(err,"int8-row")!=NULL);
+    CHECK(strstr(err,"refus")!=NULL);
+    rm_two_shard_fixture(dir);
+#else
+    printf("skipped on Windows (no fork): stamp-conflict refusal\n");
+#endif
+}
+static void test_stamp_agreeing_duplicate(void){
+    const char *dir="tests/tmp_fp8_stamp_dupok";
+    write_stamp_fixture(dir, "\"{\\\"w\\\":\\\"fp8-e4m3-b128\\\"}\"");
+    write_second_stamp_shard(dir, "\"{\\\"w\\\":\\\"fp8-e4m3-b128\\\"}\"");
+    static Model gm; memset(&gm,0,sizeof gm);
+    st_init(&gm.S, dir);                        /* agreeing duplicate: no refusal */
+    CHECK(gm.S.fmt_n == 1);                     /* collapsed to ONE entry, not two */
+    QT t; memset(&t,0,sizeof t);
+    qt_from_disk(&gm,"w",8,256,8,0,&t);
+    CHECK(t.fmt==8);                            /* loads exactly as single-stamped */
+    CHECK(t.q8!=NULL && t.s!=NULL);
+    rm_two_shard_fixture(dir);
+}
+
 /* ---- Stamp-map scan bound (maintainer review, #529): st_fmt_stamp_ingest
  * (st.h) caps the number of stamped-tensor entries it will ingest across a
  * container's shards at ST_FMT_STAMP_MAX and refuses (exit(1)) past it --
@@ -1129,6 +1210,8 @@ int main(void){
     test_stamp_mismatching();
     test_stamp_unrecognized_name();
     test_stamp_absent();
+    test_stamp_conflicting_duplicate();
+    test_stamp_agreeing_duplicate();
     test_stamp_map_cap_boundary_ok();
     test_stamp_map_cap_exceeded();
     if(fails){ printf("fp8 loader-seam tests: %d FAILED\n", fails); return 1; }

--- a/c/tests/test_fp8_load.c
+++ b/c/tests/test_fp8_load.c
@@ -203,7 +203,16 @@ static int expect_refuse_stamped(int O, int I, int64_t nb, int64_t ns, const cha
         printf("FAIL %s: expected exit(1) refusal, got status=%d, stderr=%.200s\n", tag, status, err);
         return 0;
     }
-    if(!strstr(err,"refus")){
+    /* Search the ENGINE's message, not this test's own words: qt_resolve_fmt
+     * prints "%s: ..." with the caller-supplied name -- which is `tag` here --
+     * so a tag containing "refuses" would satisfy a naive strstr all by
+     * itself and turn this assertion into a tautology (fix round 1, found
+     * while pinning the ue8m0 family: the ue8m0 refusal message itself
+     * lacked any "refus" wording and the check never noticed). Skip the
+     * echoed tag prefix before searching. */
+    const char *msg = err; size_t tl = strlen(tag);
+    if(!strncmp(err, tag, tl)) msg = err + tl;
+    if(!strstr(msg,"refus")){
         printf("FAIL %s: exited(1) but message lacked a refusal explanation: %.200s\n", tag, err);
         return 0;
     }
@@ -402,6 +411,35 @@ static void test_ue8m0_scale_refusal(void){
         "ue8m0/fmt=1 collision O=1 I=400, stamped int8-row -> resolves to fmt=1 (real, decodable candidate)"));
     CHECK(expect_refuse_stamped(1,400, nb1, 4, "fp8-e4m3-b128",
         "ue8m0/fmt=1 collision O=1 I=400, stamped fp8-e4m3-b128 -> STILL refuses (no ue8m0 decoder)"));
+}
+
+/* ---- Part A3b (fix round 1): the ue8m0-vs-fmt=1 unstamped-refusal FAMILY,
+ * pinned at two more member shapes. Membership is exactly:
+ *     nb == O*I  &&  ns == O*4  &&  ceil(O/128)*ceil(I/128) == 4*O
+ * (qt_resolve_fmt's is_row && is_blk_ue8m0; is_blk can never co-hold, since
+ * nblk==O and nblk==4*O are disjoint for O>=1). The [1,400] case above is
+ * the O=1 member; these pin O=2 (nblkO=1) and O=129 (nblkO=2, past the
+ * block edge) so the family's O-dependence is exercised, not one corner.
+ * CURRENT POLARITY, pinned deliberately: an UNSTAMPED tensor whose bytes
+ * are genuine plain int8 at a member shape REFUSES here (the named ue8m0
+ * refusal, carrying its "ALSO matches per-row int8" clause), while a build
+ * without this PR's fp8 branches loads the same bytes as fmt=1 -- this is
+ * a knowing, disclosed strictness trade for untrusted containers, and the
+ * stamp ("int8-row") is the designed escape hatch, verified here too.
+ * No GLM-5.2 resident tensor is a member: at I<=16384 (nblkI<=128),
+ * membership forces O<=32, and every repack-eligible GLM-5.2 role has
+ * O>=576 (tools/fp8_collision_census.py enumerates the roles). */
+static void test_ue8m0_family_sweep(void){
+    /* [2,1024]: nblkO=1, nblkI=8 -> nblk=8 == 4*O. ns = O*4 = nblk = 8. */
+    CHECK(expect_refuse(2,1024, (int64_t)2*1024, 8,
+        "ue8m0 family [2,1024] (nblk=8==4*O), unstamped int8-shaped -> refuses (current polarity)"));
+    CHECK(expect_fmt_stamped(2,1024, (int64_t)2*1024, 8, "int8-row", 1,
+        "ue8m0 family [2,1024], stamped int8-row -> resolves to fmt=1 (the escape hatch)"));
+    /* [129,33000]: nblkO=2, nblkI=258 -> nblk=516 == 4*129. ns = 516. */
+    CHECK(expect_refuse(129,33000, (int64_t)129*33000, 516,
+        "ue8m0 family [129,33000] (nblk=516==4*O, nblkO=2), unstamped int8-shaped -> refuses (current polarity)"));
+    CHECK(expect_fmt_stamped(129,33000, (int64_t)129*33000, 516, "int8-row", 1,
+        "ue8m0 family [129,33000], stamped int8-row -> resolves to fmt=1"));
 }
 
 /* ---- Part B: qt_from_disk loader-seam (real safetensors file) ---- */
@@ -1071,6 +1109,7 @@ int main(void){
     test_disambiguation();
     test_fmt6_fp8_collision();
     test_ue8m0_scale_refusal();
+    test_ue8m0_family_sweep();
     test_loader_seam();
     check_fp8_bytes(2048,6144, "qt_bytes fmt=8 gate/up-shaped O=2048 I=6144 (spec example)");
     check_fp8_bytes(6144,2048, "qt_bytes fmt=8 down-shaped O=6144 I=2048");

--- a/c/tests/test_fp8_load.c
+++ b/c/tests/test_fp8_load.c
@@ -63,12 +63,19 @@
  * check_wire_split() but fails test_wire_site_regression() (proven by
  * actually running that exact mutation -- see the report).
  *
- * This build has NO container metadata stamp (see qt_resolve_fmt's own header
- * comment) -- every ambiguous/unimplemented-encoding shape below EXCEPT the
- * is_row&&is_blk collision (now resolved to fmt=1, see Part A above) refuses
- * unconditionally; stamp-resolves-ambiguity behavior for the OTHER
- * collisions is a separate, follow-up PR (registry + metadata stamp), not
- * exercised here. */
+ * Part D: metadata-stamp TRUST-VERIFY-REFUSE (qt_verify_fmt_stamp, colibri.c)
+ * and stamp-RESOLVES-ambiguity (qt_resolve_fmt's `stamped_name` parameter) --
+ * this PR (registry + metadata stamp) makes the stamp load-bearing: Parts A
+ * and A2's collision cases gain stamped variants below (a stamp naming
+ * exactly one live candidate resolves what an absent stamp still refuses --
+ * or, for Part A's is_row&&is_blk collision specifically, what an absent
+ * stamp now resolves to fmt=1 anyway, see the #528 INVERSION note above; the
+ * stamped sub-case there is UNCHANGED by that inversion, still
+ * TRUST-VERIFY-REFUSE), and Part D covers the four stamp outcomes on an
+ * otherwise-unambiguous tensor (agreeing/mismatching/unrecognized-name/
+ * absent). A stamp can never grant this build a decoder it doesn't have:
+ * Part A3's UE8M0 refusals stay refusals even when correctly stamped
+ * "fp8-e4m3-b128" (see test_ue8m0_scale_refusal's stamped cases). */
 /* WIRE-SITE REGRESSION SEAM (FIX ROUND, validator finding). First attempt
  * (superseded, kept as a note): renaming mem_wire() itself via macro does
  * NOT work as an observer seam -- mem_wire is a real, internally-defined
@@ -162,9 +169,9 @@ static uint8_t rndbyte_nonan(void){
  * cases, fork+waitpid for refusing ones -- qt_resolve_fmt exit(1)s in place,
  * it does not return an error code). ---- */
 
-static int expect_fmt(int O, int I, int64_t nb, int64_t ns, int expect_fmt_val, const char *tag){
+static int expect_fmt_stamped(int O, int I, int64_t nb, int64_t ns, const char *stamped_name, int expect_fmt_val, const char *tag){
     int gs=0;
-    int fmt = qt_resolve_fmt(tag, O, I, nb, ns, &gs);
+    int fmt = qt_resolve_fmt(tag, O, I, nb, ns, &gs, stamped_name);
     if(fmt != expect_fmt_val){
         printf("FAIL %s: got fmt=%d, expected fmt=%d (O=%d I=%d nb=%lld ns=%lld)\n",
                tag, fmt, expect_fmt_val, O, I, (long long)nb, (long long)ns);
@@ -172,8 +179,11 @@ static int expect_fmt(int O, int I, int64_t nb, int64_t ns, int expect_fmt_val, 
     }
     return 1;
 }
+static int expect_fmt(int O, int I, int64_t nb, int64_t ns, int expect_fmt_val, const char *tag){
+    return expect_fmt_stamped(O, I, nb, ns, NULL, expect_fmt_val, tag);
+}
 
-static int expect_refuse(int O, int I, int64_t nb, int64_t ns, const char *tag){
+static int expect_refuse_stamped(int O, int I, int64_t nb, int64_t ns, const char *stamped_name, const char *tag){
 #ifndef _WIN32
     int pipefd[2]; if(pipe(pipefd)!=0) return 0;
     pid_t pid = fork();
@@ -181,7 +191,7 @@ static int expect_refuse(int O, int I, int64_t nb, int64_t ns, const char *tag){
     if(pid == 0){
         dup2(pipefd[1],2); close(pipefd[0]); close(pipefd[1]);
         int gs=0;
-        qt_resolve_fmt(tag, O, I, nb, ns, &gs);   /* must exit(1) inside; must NOT return */
+        qt_resolve_fmt(tag, O, I, nb, ns, &gs, stamped_name);   /* must exit(1) inside; must NOT return */
         _exit(42);                                  /* reaching here is the bug */
     }
     close(pipefd[1]);
@@ -205,9 +215,12 @@ static int expect_refuse(int O, int I, int64_t nb, int64_t ns, const char *tag){
      * failing. Every non-refusing case in this file (expect_fmt and its
      * callers) still runs and asserts for real on Windows. */
     printf("skipped on Windows (no fork): %s\n", tag);
-    (void)O; (void)I; (void)nb; (void)ns;
+    (void)O; (void)I; (void)nb; (void)ns; (void)stamped_name;
     return 1;
 #endif
+}
+static int expect_refuse(int O, int I, int64_t nb, int64_t ns, const char *tag){
+    return expect_refuse_stamped(O, I, nb, ns, NULL, tag);
 }
 
 static void test_disambiguation(void){
@@ -283,44 +296,84 @@ static void test_disambiguation(void){
  * those shapes is therefore byte-for-byte indistinguishable from a genuine
  * fmt=6 tensor: nb AND ns both coincide, not just ns (contrast the fmt=1/
  * fmt=8 collision in Part A, where only ns ever coincides). O==1 stacks a
- * THIRD candidate: fmt=1's per-row ns (O*4) is also 4 there. This build has
- * no stamp to resolve any of these -- every one refuses. */
+ * THIRD candidate: fmt=1's per-row ns (O*4) is also 4 there. Unstamped, every
+ * one of these refuses; a stamp naming exactly one live candidate resolves
+ * it -- EXCEPT the ue8m0-scaled fp8 candidate, which stays refused even when
+ * correctly stamped "fp8-e4m3-b128" (a stamp cannot grant a decoder this
+ * build doesn't have). */
 static void test_fmt6_fp8_collision(void){
     /* O=64, I=98: nblkO=nblkI=1 (fmt=8, single block, f32 scales) -> ns=4;
      * e8_blocks(98)=1 -> nb=O*98=6272 for BOTH interpretations, and fmt=6's
-     * .qs tag is always exactly one f32 -> ns=4 too. Must refuse. */
+     * .qs tag is always exactly one f32 -> ns=4 too. Unstamped: must refuse. */
     int64_t nb64=(int64_t)64*98;
-    CHECK(expect_refuse(64,98, nb64, 4, "fmt=6/fmt=8(f32) collision O=64 I=98"));
+    CHECK(expect_refuse(64,98, nb64, 4, "fmt=6/fmt=8(f32) collision O=64 I=98 (unstamped)"));
     /* boundary O=128 variant: still nblkO=1 for fmt=8 (128<=128), same collision. */
     int64_t nb128=(int64_t)128*98;
-    CHECK(expect_refuse(128,98, nb128, 4, "fmt=6/fmt=8(f32) collision O=128 I=98"));
+    CHECK(expect_refuse(128,98, nb128, 4, "fmt=6/fmt=8(f32) collision O=128 I=98 (unstamped)"));
+
+    /* stamped: the ONLY way to break this collision. Both directions must resolve
+     * to the STAMPED format, not whichever the byte-arithmetic-only check would
+     * have unconditionally picked (fmt=6, since it runs first in the function). */
+    CHECK(expect_fmt_stamped(64,98, nb64, 4, "fp8-e4m3-b128", 8,
+        "fmt=6/fmt=8(f32) collision O=64 I=98, stamped fp8-e4m3-b128 -> resolves to fmt=8"));
+    CHECK(expect_fmt_stamped(64,98, nb64, 4, "e8-iq3-lattice", 6,
+        "fmt=6/fmt=8(f32) collision O=64 I=98, stamped e8-iq3-lattice -> resolves to fmt=6"));
+    CHECK(expect_fmt_stamped(128,98, nb128, 4, "fp8-e4m3-b128", 8,
+        "fmt=6/fmt=8(f32) collision O=128 I=98, stamped fp8-e4m3-b128 -> resolves to fmt=8"));
+    CHECK(expect_fmt_stamped(128,98, nb128, 4, "e8-iq3-lattice", 6,
+        "fmt=6/fmt=8(f32) collision O=128 I=98, stamped e8-iq3-lattice -> resolves to fmt=6"));
+
+    /* a stamp naming something else entirely does NOT resolve the ambiguity --
+     * same "refuse rather than guess" posture as an absent stamp. */
+    CHECK(expect_refuse_stamped(64,98, nb64, 4, "int4-row",
+        "fmt=6/fmt=8(f32) collision O=64 I=98, stamped with an UNRELATED format -> still refuses"));
 
     /* O=1, I=98: a THIRD candidate stacks on (fmt=1 plain int8 per-row, ns==O*4==4
-     * too) -- a genuine three-way ambiguity. Must refuse. */
+     * too) -- a genuine three-way ambiguity. Unstamped refuses; stamped resolves
+     * to whichever of the three the stamp names. */
     int64_t nb1=(int64_t)1*98;
-    CHECK(expect_refuse(1,98, nb1, 4, "fmt=1/fmt=6/fmt=8(f32) THREE-way collision O=1 I=98"));
+    CHECK(expect_refuse(1,98, nb1, 4, "fmt=1/fmt=6/fmt=8(f32) THREE-way collision O=1 I=98 (unstamped)"));
+    CHECK(expect_fmt_stamped(1,98, nb1, 4, "int8-row", 1,
+        "three-way collision O=1 I=98, stamped int8-row -> resolves to fmt=1"));
+    CHECK(expect_fmt_stamped(1,98, nb1, 4, "fp8-e4m3-b128", 8,
+        "three-way collision O=1 I=98, stamped fp8-e4m3-b128 -> resolves to fmt=8"));
+    CHECK(expect_fmt_stamped(1,98, nb1, 4, "e8-iq3-lattice", 6,
+        "three-way collision O=1 I=98, stamped e8-iq3-lattice -> resolves to fmt=6"));
 
     /* O in (384,512], I=98: nblkO=4, nblkI=1, product=4 -- a fmt=8 tensor with
      * UE8M0 (1 byte/block) scales also lands at ns==4*1==4 here, the SAME tag
-     * fmt=6 uses. Must refuse (and, since this build doesn't implement ue8m0
-     * decode at all, would refuse on that basis alone even without the fmt=6
-     * collision -- this case exercises the OUTER fmt=6 guard specifically). */
+     * fmt=6 uses. Unstamped: must refuse. Stamped "e8-iq3-lattice": resolves to
+     * fmt=6 (a real, decodable format). Stamped "fp8-e4m3-b128": still refuses
+     * -- the stamp confirms the WEIGHT format, but this build has no UE8M0
+     * decoder, so it cannot grant a resolution the byte layout itself can't
+     * support (contrast the [64,98]/[128,98] cases above, where the SAME stamp
+     * name resolves cleanly because those are the f32-scaled candidate). */
     int64_t nb400=(int64_t)400*98;
-    CHECK(expect_refuse(400,98, nb400, 4, "fmt=6/fmt=8(ue8m0, 4-block) collision O=400 I=98"));
+    CHECK(expect_refuse(400,98, nb400, 4, "fmt=6/fmt=8(ue8m0, 4-block) collision O=400 I=98 (unstamped)"));
+    CHECK(expect_fmt_stamped(400,98, nb400, 4, "e8-iq3-lattice", 6,
+        "fmt=6/fmt=8(ue8m0) collision O=400 I=98, stamped e8-iq3-lattice -> resolves to fmt=6"));
+    CHECK(expect_refuse_stamped(400,98, nb400, 4, "fp8-e4m3-b128",
+        "fmt=6/fmt=8(ue8m0) collision O=400 I=98, stamped fp8-e4m3-b128 -> STILL refuses (no ue8m0 decoder)"));
 
     /* regression guard: a GENUINE (non-colliding) fmt=6 fixture -- I!=98, so
-     * e8_rowbytes(I)==98 does NOT equal O*I -- must keep resolving to fmt=6.
-     * Mirrors test_e8_kernel.c's own O=24,I=512 shape and a small
-     * single-super-block shape (I=256, inside the (0,256] range where
+     * e8_rowbytes(I)==98 does NOT equal O*I -- must keep resolving to fmt=6 with
+     * NO stamp at all. Mirrors test_e8_kernel.c's own O=24,I=512 shape and a
+     * small single-super-block shape (I=256, inside the (0,256] range where
      * e8_rowbytes(I)==98 but I!=98, so still non-colliding). */
     CHECK(expect_fmt(24,512, (int64_t)24*e8_rowbytes(512), 4, 6,
-        "genuine fmt=6 (non-colliding) O=24 I=512 -> still resolves to fmt=6"));
+        "genuine fmt=6 (non-colliding) O=24 I=512, unstamped -> still resolves to fmt=6"));
     CHECK(expect_fmt(64,256, (int64_t)64*e8_rowbytes(256), 4, 6,
-        "genuine fmt=6 (non-colliding) O=64 I=256 (I!=98, no collision) -> fmt=6"));
+        "genuine fmt=6 (non-colliding) O=64 I=256 (I!=98, no collision), unstamped -> fmt=6"));
 }
 
 /* ---- Part A3: fmt=8's scale ENCODING is a declared property -- UE8M0
- * recognized, refused by name (not implemented in this build). ---- */
+ * recognized, refused by name (not implemented in this build). A stamp
+ * cannot resolve any of these: "fp8-e4m3-b128" confirms the WEIGHT format,
+ * not a scale encoding this build can decode, so the stamped cases below
+ * refuse exactly like their unstamped counterparts -- the one exception is
+ * the small-O collision, where a DIFFERENT stamp ("int8-row", naming the
+ * OTHER live candidate) legitimately resolves it, because that candidate
+ * really is decodable. ---- */
 static void test_ue8m0_scale_refusal(void){
     /* [2048,6144] (spec example shape, same as Part A's fmt=8/f32 golden
      * path): nblkO=16, nblkI=48, product=768 blocks. A UE8M0 sidecar is
@@ -330,16 +383,25 @@ static void test_ue8m0_scale_refusal(void){
      * treat it as a truncated/corrupt f32 array or match it to fmt=1. */
     int64_t nb=(int64_t)2048*6144;
     CHECK(expect_refuse(2048,6144, nb, 768,
-        "fp8-e4m3-b128 with ue8m0 scales (spec-shaped, non-degenerate) -> recognized, refused by name"));
+        "fp8-e4m3-b128 with ue8m0 scales (spec-shaped, non-degenerate), unstamped -> recognized, refused by name"));
+    CHECK(expect_refuse_stamped(2048,6144, nb, 768, "fp8-e4m3-b128",
+        "fp8-e4m3-b128 with ue8m0 scales, stamped fp8-e4m3-b128 -> STILL refuses (stamp names the weight format, not a decoder)"));
 
     /* O=1, I=400: nblkO=1, nblkI=ceil(400/128)=4, product=4 -- a UE8M0 sidecar
      * here is ns=4*1=4, which ALSO equals fmt=1's per-row count (O*4=4): the
      * same small-O regime that produces the f32-vs-fmt=1 collision in Part A
-     * produces a ue8m0-vs-fmt=1 collision too. Must still refuse (combined
-     * message), not silently pick fmt=1. */
+     * produces a ue8m0-vs-fmt=1 collision too. Unstamped: must still refuse
+     * (combined message), not silently pick fmt=1. Stamped "int8-row" DOES
+     * resolve it -- that candidate is real, decodable plain int8, and the
+     * stamp confirms it's the one on disk. Stamped "fp8-e4m3-b128" does NOT
+     * resolve it -- same "no decoder" refusal as the clean case above. */
     int64_t nb1=(int64_t)1*400;
     CHECK(expect_refuse(1,400, nb1, 4,
-        "fp8-e4m3-b128 with ue8m0 scales, ALSO colliding with fmt=1 per-row (O=1) -> refused"));
+        "fp8-e4m3-b128 with ue8m0 scales, ALSO colliding with fmt=1 per-row (O=1), unstamped -> refused"));
+    CHECK(expect_fmt_stamped(1,400, nb1, 4, "int8-row", 1,
+        "ue8m0/fmt=1 collision O=1 I=400, stamped int8-row -> resolves to fmt=1 (real, decodable candidate)"));
+    CHECK(expect_refuse_stamped(1,400, nb1, 4, "fp8-e4m3-b128",
+        "ue8m0/fmt=1 collision O=1 I=400, stamped fp8-e4m3-b128 -> STILL refuses (no ue8m0 decoder)"));
 }
 
 /* ---- Part B: qt_from_disk loader-seam (real safetensors file) ---- */
@@ -673,7 +735,7 @@ static void test_metal_fused_allowlist(void){
  * (row formats, grouped, int3-g64, E8/IQ3, fp8 f32/ue8m0, collision-family
  * members, degenerate dims) and assert every non-refusing resolution is in
  * {1,2,3,4,5,6,8} -- never 7, never anything else. */
-static int resolved_fmt_probe(int O, int I, int64_t nb, int64_t ns){
+static int resolved_fmt_probe(int O, int I, int64_t nb, int64_t ns, const char *stamped){
 #ifndef _WIN32
     fflush(stdout);   /* a refusing child exits via exit(1), which flushes
                        * inherited stdio -- don't let it replay our buffer */
@@ -685,7 +747,7 @@ static int resolved_fmt_probe(int O, int I, int64_t nb, int64_t ns){
         if(devnull>=0) dup2(devnull,2);                 /* silence refusal chatter */
         close(pipefd[0]);
         int gs=0;
-        int fmt = qt_resolve_fmt("sweep", O, I, nb, ns, &gs);
+        int fmt = qt_resolve_fmt("sweep", O, I, nb, ns, &gs, stamped);
         unsigned char b = (unsigned char)fmt;
         ssize_t wr = write(pipefd[1], &b, 1); (void)wr;
         _exit(0);
@@ -727,26 +789,174 @@ static void test_fmt7_unreachable_sweep(void){
                 { (int64_t)O*I,              0 },                   /* degenerate ns     */
                 { 0,                          (int64_t)O*4 },       /* degenerate nb     */
             };
-            for(size_t c=0; c<sizeof(cand)/sizeof(cand[0]); c++){
-                int f = resolved_fmt_probe(O, I, cand[c][0], cand[c][1]);
-                probes++;
-                if(f==-2){ printf("FAIL sweep O=%d I=%d nb=%lld ns=%lld: crash/protocol error\n",
-                                  O,I,(long long)cand[c][0],(long long)cand[c][1]); CHECK(0); continue; }
-                if(f==-1){ refused++; continue; }
-                resolved++;
-                int ok = (f==1||f==2||f==3||f==4||f==5||f==6||f==8);
-                if(!ok) printf("FAIL sweep O=%d I=%d nb=%lld ns=%lld: resolved to fmt=%d (outside {1,2,3,4,5,6,8})\n",
-                               O,I,(long long)cand[c][0],(long long)cand[c][1],f);
-                CHECK(ok);
-                CHECK(f != 7);
+            /* STAMPED arm (this commit threads stamped_name into
+             * qt_resolve_fmt): the same grid under every stamp class --
+             * agreeing/disagreeing recognized names, and an unrecognized
+             * one. A stamp can steer WHICH member of {1,2,3,4,5,6,8} wins
+             * (or force a refusal); it must never mint 7 or anything else. */
+            static const char *stamps[] = { NULL, "int8-row", "fp8-e4m3-b128",
+                                            "e8-iq3-lattice", "quantum-format-9000" };
+            for(size_t st=0; st<sizeof(stamps)/sizeof(stamps[0]); st++){
+                for(size_t c=0; c<sizeof(cand)/sizeof(cand[0]); c++){
+                    int f = resolved_fmt_probe(O, I, cand[c][0], cand[c][1], stamps[st]);
+                    probes++;
+                    if(f==-2){ printf("FAIL sweep O=%d I=%d nb=%lld ns=%lld stamp=%s: crash/protocol error\n",
+                                      O,I,(long long)cand[c][0],(long long)cand[c][1],
+                                      stamps[st]?stamps[st]:"(none)"); CHECK(0); continue; }
+                    if(f==-1){ refused++; continue; }
+                    resolved++;
+                    int ok = (f==1||f==2||f==3||f==4||f==5||f==6||f==8);
+                    if(!ok) printf("FAIL sweep O=%d I=%d nb=%lld ns=%lld stamp=%s: resolved to fmt=%d (outside {1,2,3,4,5,6,8})\n",
+                                   O,I,(long long)cand[c][0],(long long)cand[c][1],
+                                   stamps[st]?stamps[st]:"(none)",f);
+                    CHECK(ok);
+                    CHECK(f != 7);
+                }
             }
         }
     }
-    /* the sweep must have actually exercised both arms, or it proved nothing. */
-    CHECK(probes >= 2000 && resolved >= 100 && refused >= 100);
+    /* the sweep must have actually exercised both outcomes across both the
+     * stamped and unstamped arms, or it proved nothing. */
+    CHECK(probes >= 10000 && resolved >= 500 && refused >= 500);
 #else
     printf("skipped on Windows (no fork): fmt=7 unreachability sweep\n");
 #endif
+}
+
+/* ---- Part D: metadata-stamp TRUST-VERIFY-REFUSE (qt_verify_fmt_stamp, colibri.c) ----
+ * The stamp lives in the safetensors __metadata__["colibri.fmt"] value -- itself
+ * JSON text (a {tensor_name: format_name} map, matching what
+ * tools/repack_fp8_passthrough.py writes and st_fmt_stamp_ingest (st.h) parses).
+ * Three outcomes: an AGREEING stamp is a silent no-op (loads exactly as it would
+ * unstamped); a MISMATCHING stamp (a recognized name naming a DIFFERENT format,
+ * or a name this build doesn't recognize at all) refuses (exit(1)); an UNSTAMPED
+ * container (no __metadata__ block at all) infers exactly as before this
+ * feature existed -- already exercised incidentally by every Part B/C fixture
+ * above (none of them write __metadata__), but given an explicit case here too
+ * so all three outcomes live together, self-documenting. */
+
+/* Writes a single-tensor fp8 shard (O=8,I=256 -> nblkO=1,nblkI=2, the same
+ * non-degenerate shape Part B's w7 fixture uses) with an OPTIONAL __metadata__
+ * block. `meta_json_string_literal`, if non-NULL, must already be a quoted/
+ * escaped JSON STRING TOKEN placed verbatim after "colibri.fmt": in the header
+ * -- callers pass a C string literal like "\"{\\\"w\\\":\\\"fp8-e4m3-b128\\\"}\""
+ * so the raw header bytes end up with colibri.fmt's VALUE being the JSON text
+ * {"w":"fp8-e4m3-b128"} (double-JSON-encoded: a JSON string whose CONTENT is
+ * itself JSON -- exactly what safetensors.save_file(metadata=...) produces,
+ * since __metadata__ values must be plain strings). */
+static void write_stamp_fixture(const char *dir, const char *meta_json_string_literal){
+#ifdef _WIN32
+    mkdir(dir);
+#else
+    mkdir(dir,0755);
+#endif
+    enum { O=8, I=256 };
+    enum { NBLK = CDIV(O,128) * CDIV(I,128) };
+    static uint8_t q[O*I]; static float s[NBLK];
+    for(int i=0;i<O*I;i++) q[i]=rndbyte_nonan();
+    for(int i=0;i<NBLK;i++) s[i]=0.01f+0.001f*(float)i;
+    char path[300]; snprintf(path,sizeof path,"%s/model.safetensors",dir);
+    int64_t nb=(int64_t)O*I, ns=(int64_t)sizeof(s);
+    char hdr[2048]; int hl;
+    if(meta_json_string_literal)
+        hl=snprintf(hdr,sizeof hdr,
+            "{\"__metadata__\":{\"colibri.fmt\":%s},"
+            "\"w\":{\"dtype\":\"U8\",\"shape\":[%lld],\"data_offsets\":[0,%lld]},"
+            "\"w.qs\":{\"dtype\":\"F32\",\"shape\":[%lld],\"data_offsets\":[%lld,%lld]}}",
+            meta_json_string_literal,
+            (long long)nb,(long long)nb,
+            (long long)(ns/4),(long long)nb,(long long)(nb+ns));
+    else
+        hl=snprintf(hdr,sizeof hdr,
+            "{\"w\":{\"dtype\":\"U8\",\"shape\":[%lld],\"data_offsets\":[0,%lld]},"
+            "\"w.qs\":{\"dtype\":\"F32\",\"shape\":[%lld],\"data_offsets\":[%lld,%lld]}}",
+            (long long)nb,(long long)nb,
+            (long long)(ns/4),(long long)nb,(long long)(nb+ns));
+    FILE *f=fopen(path,"wb");
+    if(!f){ printf("FAIL: cannot create %s (run from c/, like tools/run_tests.py does)\n", path); fails++; return; }
+    uint64_t hlen=(uint64_t)hl;
+    fwrite(&hlen,8,1,f); fwrite(hdr,1,hl,f);
+    fwrite(q,1,(size_t)nb,f); fwrite(s,1,(size_t)ns,f);
+    fclose(f);
+}
+
+/* Fork+waitpid, mirroring expect_refuse above: st_init+qt_from_disk run in the
+ * child (isolating a parsed-and-possibly-poisoned `shards` struct from the
+ * rest of the suite) and must exit(1) with a "refus"-containing stderr message. */
+static int expect_stamp_refuse(const char *dir, const char *tag){
+#ifndef _WIN32
+    int pipefd[2]; if(pipe(pipefd)!=0) return 0;
+    pid_t pid = fork();
+    if(pid < 0) return 0;
+    if(pid == 0){
+        dup2(pipefd[1],2); close(pipefd[0]); close(pipefd[1]);
+        static Model gm; memset(&gm,0,sizeof gm);
+        st_init(&gm.S, dir);
+        QT t; memset(&t,0,sizeof t);
+        qt_from_disk(&gm,"w",8,256,8,0,&t);   /* must exit(1) inside qt_verify_fmt_stamp */
+        _exit(42);                             /* reaching here is the bug */
+    }
+    close(pipefd[1]);
+    char err[1024]={0}; ssize_t n=read(pipefd[0],err,sizeof(err)-1); (void)n;
+    close(pipefd[0]);
+    int status=0; waitpid(pid,&status,0);
+    int ok = WIFEXITED(status) && WEXITSTATUS(status)==1;
+    if(!ok){
+        printf("FAIL %s: expected exit(1) refusal, got status=%d, stderr=%.200s\n", tag, status, err);
+        return 0;
+    }
+    if(!strstr(err,"refus")){
+        printf("FAIL %s: exited(1) but message lacked a refusal explanation: %.200s\n", tag, err);
+        return 0;
+    }
+    return 1;
+#else
+    /* same Windows arm as expect_refuse_stamped above: no fork, visible skip. */
+    printf("skipped on Windows (no fork): %s\n", tag);
+    (void)dir;
+    return 1;
+#endif
+}
+
+static void test_stamp_agreeing(void){
+    const char *dir="tests/tmp_fp8_stamp_agree";
+    write_stamp_fixture(dir, "\"{\\\"w\\\":\\\"fp8-e4m3-b128\\\"}\"");
+    static Model gm; memset(&gm,0,sizeof gm);
+    st_init(&gm.S, dir);
+    QT t; memset(&t,0,sizeof t);
+    qt_from_disk(&gm,"w",8,256,8,0,&t);
+    CHECK(t.fmt==8);                   /* stamp agreed -- loads exactly as unstamped would */
+    CHECK(t.q8!=NULL && t.s!=NULL);
+    char p[300]; snprintf(p,sizeof p,"%s/model.safetensors",dir); unlink(p); rmdir(dir);
+}
+
+static void test_stamp_mismatching(void){
+    const char *dir="tests/tmp_fp8_stamp_mismatch";
+    /* byte-arithmetic says fmt=8 (fp8); the stamp names a REAL, recognized,
+     * but DIFFERENT format -- exercises "found but disagrees", not just "name
+     * not found at all" (see test_stamp_unrecognized_name below for that case). */
+    write_stamp_fixture(dir, "\"{\\\"w\\\":\\\"int8-row\\\"}\"");
+    CHECK(expect_stamp_refuse(dir, "stamped-mismatching: stamp says int8-row, bytes say fp8-e4m3-b128"));
+    char p[300]; snprintf(p,sizeof p,"%s/model.safetensors",dir); unlink(p); rmdir(dir);
+}
+
+static void test_stamp_unrecognized_name(void){
+    const char *dir="tests/tmp_fp8_stamp_unknown";
+    write_stamp_fixture(dir, "\"{\\\"w\\\":\\\"quantum-format-9000\\\"}\"");
+    CHECK(expect_stamp_refuse(dir, "stamped with a format name this build doesn't recognize"));
+    char p[300]; snprintf(p,sizeof p,"%s/model.safetensors",dir); unlink(p); rmdir(dir);
+}
+
+static void test_stamp_absent(void){
+    const char *dir="tests/tmp_fp8_stamp_absent";
+    write_stamp_fixture(dir, NULL);       /* no __metadata__ block at all */
+    static Model gm; memset(&gm,0,sizeof gm);
+    st_init(&gm.S, dir);
+    QT t; memset(&t,0,sizeof t);
+    qt_from_disk(&gm,"w",8,256,8,0,&t);
+    CHECK(t.fmt==8);                   /* unstamped: byte-arithmetic inference alone decides */
+    CHECK(t.q8!=NULL && t.s!=NULL);
+    char p[300]; snprintf(p,sizeof p,"%s/model.safetensors",dir); unlink(p); rmdir(dir);
 }
 
 int main(void){
@@ -768,6 +978,10 @@ int main(void){
     test_wire_site_regression();
     test_metal_fused_allowlist();
     test_fmt7_unreachable_sweep();
+    test_stamp_agreeing();
+    test_stamp_mismatching();
+    test_stamp_unrecognized_name();
+    test_stamp_absent();
     if(fails){ printf("fp8 loader-seam tests: %d FAILED\n", fails); return 1; }
     printf("fp8 loader-seam tests: ok\n");
     return 0;

--- a/c/tests/test_fp8_load.c
+++ b/c/tests/test_fp8_load.c
@@ -897,7 +897,7 @@ static int expect_stamp_refuse(const char *dir, const char *tag){
         _exit(42);                             /* reaching here is the bug */
     }
     close(pipefd[1]);
-    char err[1024]={0}; ssize_t n=read(pipefd[0],err,sizeof(err)-1); (void)n;
+    char err[1024]={0}; size_t eoff=0; ssize_t n; /* drain to EOF (Linux pipe short-reads; see expect_refuse) */ while(eoff<sizeof(err)-1 && (n=read(pipefd[0],err+eoff,sizeof(err)-1-eoff))>0) eoff+=(size_t)n;
     close(pipefd[0]);
     int status=0; waitpid(pid,&status,0);
     int ok = WIFEXITED(status) && WEXITSTATUS(status)==1;
@@ -1049,7 +1049,7 @@ static void test_stamp_map_cap_exceeded(void){
             _exit(42);              /* reaching here is the bug */
         } else if(pid > 0){
             close(pipefd[1]);
-            char err[1024]={0}; ssize_t n=read(pipefd[0],err,sizeof(err)-1); (void)n;
+            char err[1024]={0}; size_t eoff=0; ssize_t n; /* drain to EOF (Linux pipe short-reads; see expect_refuse) */ while(eoff<sizeof(err)-1 && (n=read(pipefd[0],err+eoff,sizeof(err)-1-eoff))>0) eoff+=(size_t)n;
             close(pipefd[0]);
             int status=0; waitpid(pid,&status,0);
             int ok = WIFEXITED(status) && WEXITSTATUS(status)==1;

--- a/c/tests/test_fp8_load.c
+++ b/c/tests/test_fp8_load.c
@@ -959,6 +959,114 @@ static void test_stamp_absent(void){
     char p[300]; snprintf(p,sizeof p,"%s/model.safetensors",dir); unlink(p); rmdir(dir);
 }
 
+/* ---- Stamp-map scan bound (maintainer review, #529): st_fmt_stamp_ingest
+ * (st.h) caps the number of stamped-tensor entries it will ingest across a
+ * container's shards at ST_FMT_STAMP_MAX and refuses (exit(1)) past it --
+ * see st.h's own comment and docs/FORMATS.md's "Stamp-map scan bound" for
+ * why (stamps are a resident-tensor convention, never a bulk migration path
+ * for the tens of thousands of routed-expert tensors a large MoE model
+ * carries). Writes a minimal ONE-tensor shard (the shard's actual tensor
+ * content is irrelevant to this check -- the cap fires during
+ * st_init_multi's header-parse loop, at CONTAINER DISCOVERY time, before any
+ * tensor is resolved against the model, see st_fmt_stamp_ingest's own
+ * "DISCOVERY-TIME ABORT SURFACE" comment) carrying an oversized
+ * __metadata__["colibri.fmt"] blob of N distinct, entirely fictitious tensor
+ * names -- st_fmt_stamp_ingest parses that blob independently of the
+ * shard's real tensor list, so the names never need to correspond to
+ * anything real for the cap to trigger. Tests BOTH sides of the boundary:
+ * exactly ST_FMT_STAMP_MAX entries must still load fine (no off-by-one
+ * false refusal), one more must refuse. */
+static void write_stamp_cap_fixture(const char *dir, int n_entries){
+#ifdef _WIN32
+    mkdir(dir);
+#else
+    mkdir(dir,0755);
+#endif
+    size_t inner_cap = (size_t)n_entries*40 + 64;
+    char *inner = malloc(inner_cap);
+    size_t p = 0; inner[p++]='{';
+    for(int i=0;i<n_entries;i++)
+        p += (size_t)snprintf(inner+p, inner_cap-p, "%s\"stamp_%d\":\"int8-row\"", i?",":"", i);
+    inner[p++]='}'; inner[p]=0;
+
+    /* JSON-escape `inner` into a quoted string literal for the OUTER header's
+     * colibri.fmt VALUE (double-JSON-encoding, same shape write_stamp_fixture's
+     * callers hand-escape for small fixtures -- built programmatically here
+     * since n_entries is too many to hand-escape). */
+    char *esc = malloc(p*2 + 4);
+    size_t q = 0; esc[q++]='"';
+    for(size_t i=0;i<p;i++){
+        char c = inner[i];
+        if(c=='"' || c=='\\') esc[q++]='\\';
+        esc[q++]=c;
+    }
+    esc[q++]='"'; esc[q]=0;
+    free(inner);
+
+    enum { O=1, I=1 };
+    static uint8_t q1[O*I]; static float s1[O];
+    q1[0]=1; s1[0]=0.01f;
+    char path[300]; snprintf(path,sizeof path,"%s/model.safetensors",dir);
+    int64_t nb=(int64_t)O*I, ns=(int64_t)O*4;
+    char *hdr = malloc(q + 512);
+    int hl = snprintf(hdr, q+512,
+        "{\"__metadata__\":{\"colibri.fmt\":%s},"
+        "\"w\":{\"dtype\":\"U8\",\"shape\":[%lld],\"data_offsets\":[0,%lld]},"
+        "\"w.qs\":{\"dtype\":\"F32\",\"shape\":[%lld],\"data_offsets\":[%lld,%lld]}}",
+        esc,
+        (long long)nb,(long long)nb,
+        (long long)(ns/4),(long long)nb,(long long)(nb+ns));
+    free(esc);
+    FILE *f=fopen(path,"wb");
+    if(!f){ printf("FAIL: cannot create %s (run from c/, like tools/run_tests.py does)\n", path); fails++; free(hdr); return; }
+    uint64_t hlen=(uint64_t)hl;
+    fwrite(&hlen,8,1,f); fwrite(hdr,1,(size_t)hl,f);
+    fwrite(q1,1,(size_t)nb,f); fwrite(s1,1,(size_t)ns,f);
+    fclose(f);
+    free(hdr);
+}
+
+static void test_stamp_map_cap_boundary_ok(void){
+    const char *dir="tests/tmp_fp8_stamp_cap_ok";
+    write_stamp_cap_fixture(dir, ST_FMT_STAMP_MAX);   /* exactly at the cap: must NOT refuse */
+    static Model gm; memset(&gm,0,sizeof gm);
+    st_init(&gm.S, dir);
+    CHECK(gm.S.fmt_n == ST_FMT_STAMP_MAX);
+    char p[300]; snprintf(p,sizeof p,"%s/model.safetensors",dir); unlink(p); rmdir(dir);
+}
+
+static void test_stamp_map_cap_exceeded(void){
+    const char *dir="tests/tmp_fp8_stamp_cap_over";
+    write_stamp_cap_fixture(dir, ST_FMT_STAMP_MAX+1);  /* one past the cap: must refuse */
+#ifndef _WIN32
+    int pipefd[2];
+    if(pipe(pipefd)==0){
+        pid_t pid = fork();
+        if(pid == 0){
+            dup2(pipefd[1],2); close(pipefd[0]); close(pipefd[1]);
+            static Model gm; memset(&gm,0,sizeof gm);
+            st_init(&gm.S, dir);   /* must exit(1) inside st_fmt_stamp_ingest's cap check */
+            _exit(42);              /* reaching here is the bug */
+        } else if(pid > 0){
+            close(pipefd[1]);
+            char err[1024]={0}; ssize_t n=read(pipefd[0],err,sizeof(err)-1); (void)n;
+            close(pipefd[0]);
+            int status=0; waitpid(pid,&status,0);
+            int ok = WIFEXITED(status) && WEXITSTATUS(status)==1;
+            if(!ok) printf("FAIL stamp-map cap exceeded: expected exit(1), got status=%d, stderr=%.200s\n", status, err);
+            CHECK(ok);
+            if(ok && !strstr(err,"refus")){
+                printf("FAIL stamp-map cap exceeded: exited(1) but message lacked a refusal explanation: %.200s\n", err);
+                fails++;
+            }
+        } else fails++;
+    } else fails++;
+#else
+    printf("skipped on Windows (no fork): stamp-map cap exceeded\n");
+#endif
+    char p[300]; snprintf(p,sizeof p,"%s/model.safetensors",dir); unlink(p); rmdir(dir);
+}
+
 int main(void){
     test_disambiguation();
     test_fmt6_fp8_collision();
@@ -982,6 +1090,8 @@ int main(void){
     test_stamp_mismatching();
     test_stamp_unrecognized_name();
     test_stamp_absent();
+    test_stamp_map_cap_boundary_ok();
+    test_stamp_map_cap_exceeded();
     if(fails){ printf("fp8 loader-seam tests: %d FAILED\n", fails); return 1; }
     printf("fp8 loader-seam tests: ok\n");
     return 0;

--- a/c/tests/test_fp8_repack.py
+++ b/c/tests/test_fp8_repack.py
@@ -133,7 +133,7 @@ class SelectionTest(unittest.TestCase):
         self.assertNotIn("model.layers.0.mlp.gate.weight", names)     # router, f32 kind
 
     def test_byte_preservation_and_qs_rename(self):
-        out, inv = rp.repack_shard(self.shard, n_layers=5)
+        out, inv, fmt_map = rp.repack_shard(self.shard, n_layers=5)
         self.assertEqual(len(inv), 4)
         with safe_open(self.shard, framework="pt") as f:
             for it in inv:
@@ -146,6 +146,19 @@ class SelectionTest(unittest.TestCase):
                 O, I_ = w_src.shape
                 nblkO, nblkI = (O + 127) // 128, (I_ + 127) // 128
                 self.assertEqual(out[name + ".qs"].numel(), nblkO * nblkI)
+
+    def test_fmt_map_covers_exactly_selected_weight_names(self):
+        """fmt_map (the METADATA STAMP payload) must cover exactly the selected
+        WEIGHT names -- never the ".qs" sidecars, never an excluded tensor -- and
+        every value must be FORMAT_NAME (the format's public NAME, not the
+        internal fmt=8 ordinal)."""
+        out, inv, fmt_map = rp.repack_shard(self.shard, n_layers=5)
+        selected_names = {it["name"] for it in inv}
+        self.assertEqual(set(fmt_map.keys()), selected_names)
+        for name in selected_names:
+            self.assertNotIn(name + ".qs", fmt_map)
+            self.assertEqual(fmt_map[name], rp.FORMAT_NAME)
+        self.assertEqual(rp.FORMAT_NAME, "fp8-e4m3-b128")
 
     def test_geometry_refusal_on_malformed_scale(self):
         """A shard whose _scale_inv shape doesn't match ceil(O/128)xceil(I/128) for
@@ -226,6 +239,27 @@ class ResumeAndParamsGuardTest(unittest.TestCase):
         self.assertNotIn("model.embed_tokens.weight", hdr)
         self.assertNotIn("model.layers.0.input_layernorm.weight", hdr)
         self.assertNotIn("model.layers.0.self_attn.kv_b_proj.weight", hdr)
+
+    def test_metadata_stamp_present_and_correct(self):
+        """End-to-end through the real CLI: __metadata__["colibri.fmt"] must be
+        present, parse as JSON, and name exactly the selected resident-kind
+        tensors -- the real round trip a unit-level rp.repack_shard() call
+        can't exercise (save_file's own metadata= handling)."""
+        self.assertEqual(self._run(5), 0)
+        outs = glob.glob(os.path.join(self.outdir, "out-fp8pass-*.safetensors"))
+        self.assertEqual(len(outs), 1)
+        hdr = _read_header(outs[0])
+        self.assertIn("__metadata__", hdr)
+        self.assertIn("colibri.fmt", hdr["__metadata__"])
+        stamp = json.loads(hdr["__metadata__"]["colibri.fmt"])
+        self.assertEqual(set(stamp.keys()), {
+            "model.layers.0.self_attn.o_proj.weight",
+            "model.layers.0.self_attn.q_a_proj.weight",
+            "model.layers.0.mlp.shared_experts.gate_proj.weight",
+            "model.layers.0.mlp.gate_proj.weight",
+        })
+        for name, fmt_name in stamp.items():
+            self.assertEqual(fmt_name, rp.FORMAT_NAME, f"{name}: stamped format name mismatch")
 
     def test_resume_skips_completed_shard(self):
         self.assertEqual(self._run(5), 0)

--- a/c/tests/test_int3.c
+++ b/c/tests/test_int3.c
@@ -109,16 +109,20 @@ int main(void){
          *    disambiguate: same scales, int4 weights -> fmt=4/gs=64; int3 weights -> fmt=5.
          *    Only well-posed for I > 256: below that, O row scales legitimately match a
          *    1-group grouped layout too (detect_group_size probes gs up to 256), so
-         *    per-row vs grouped is not distinguishable from byte counts alone. */
+         *    per-row vs grouped is not distinguishable from byte counts alone.
+         *    stamped_name=NULL throughout below: this suite predates and is orthogonal
+         *    to the fp8 metadata-stamp feature -- none of these calls touch the
+         *    fmt=1-vs-fmt=7 or fmt=6-vs-fmt=7 collisions the stamp parameter exists
+         *    to resolve, so a NULL stamp cannot change any of this suite's outcomes. */
         if(I>256){ int gs=-1;
           int64_t ns_g64=(int64_t)O*i3_groups(I)*4, ns_row=(int64_t)O*4;
-          CHECK(qt_resolve_fmt("t.i3", O, I, (int64_t)O*i3_rowbytes(I), ns_g64, &gs)==5);
+          CHECK(qt_resolve_fmt("t.i3", O, I, (int64_t)O*i3_rowbytes(I), ns_g64, &gs, NULL)==5);
           CHECK(gs==0);
-          CHECK(qt_resolve_fmt("t.i8", O, I, (int64_t)O*I, ns_row, &gs)==1);
-          CHECK(qt_resolve_fmt("t.i4", O, I, (int64_t)O*((I+1)/2), ns_row, &gs)==2);
-          CHECK(qt_resolve_fmt("t.i4g", O, I, (int64_t)O*((I+1)/2), ns_g64, &gs)==4);
+          CHECK(qt_resolve_fmt("t.i8", O, I, (int64_t)O*I, ns_row, &gs, NULL)==1);
+          CHECK(qt_resolve_fmt("t.i4", O, I, (int64_t)O*((I+1)/2), ns_row, &gs, NULL)==2);
+          CHECK(qt_resolve_fmt("t.i4g", O, I, (int64_t)O*((I+1)/2), ns_g64, &gs, NULL)==4);
           CHECK(gs==64);
-          CHECK(qt_resolve_fmt("t.i2", O, I, (int64_t)O*((I+3)/4), ns_row, &gs)==3); }
+          CHECK(qt_resolve_fmt("t.i2", O, I, (int64_t)O*((I+3)/4), ns_row, &gs, NULL)==3); }
         free(t.q4); free(t.s);
     }
 

--- a/c/tests/test_int3.c
+++ b/c/tests/test_int3.c
@@ -112,7 +112,7 @@ int main(void){
          *    per-row vs grouped is not distinguishable from byte counts alone.
          *    stamped_name=NULL throughout below: this suite predates and is orthogonal
          *    to the fp8 metadata-stamp feature -- none of these calls touch the
-         *    fmt=1-vs-fmt=7 or fmt=6-vs-fmt=7 collisions the stamp parameter exists
+         *    fmt=1-vs-fmt=8 or fmt=6-vs-fmt=8 collisions the stamp parameter exists
          *    to resolve, so a NULL stamp cannot change any of this suite's outcomes. */
         if(I>256){ int gs=-1;
           int64_t ns_g64=(int64_t)O*i3_groups(I)*4, ns_row=(int64_t)O*4;

--- a/c/tools/repack_fp8_passthrough.py
+++ b/c/tools/repack_fp8_passthrough.py
@@ -75,12 +75,23 @@ to fmt=8 needs real fmt=8 CPU+CUDA absorb-path support first -- out of scope
 for this build, so this tool refuses to produce a container the engine
 cannot safely read.
 
-This tool does NOT write a container metadata stamp: __metadata__-based
-self-description (writer + qt_verify_fmt_stamp reader + docs/FORMATS.md
-registry) is a separate, follow-up PR, per the maintainer's #524 scoping.
-This PR's collision/refusal logic (qt_resolve_fmt) therefore refuses
-UNCONDITIONALLY at every ambiguous shape this tool could produce -- there is
-no stamp to break a tie.
+METADATA STAMP (reference implementation of the FORMATS-registry FR -- see
+docs/FORMATS.md): every output shard's safetensors `__metadata__` carries a
+`colibri.fmt` key whose VALUE is itself a JSON-encoded object mapping each
+stamped tensor's exact name to its format NAME string (FORMAT_NAME below,
+"fp8-e4m3-b128" -- never the internal fmt=8 ordinal, which the container must
+never depend on, see colibri.c's QT struct comment). The reader
+(qt_from_disk's qt_verify_fmt_stamp, colibri.c) is TRUST-VERIFY-REFUSE: a
+stamp that agrees with the byte-arithmetic inference is a no-op (the tensor
+loads exactly as it would unstamped); a stamp that disagrees, or names a
+format this build doesn't recognize, is refused loudly (same "untrusted
+container" discipline as qt_resolve_fmt's own THE DESIGN LANDMINE refusal).
+As a bonus, a stamp can also RESOLVE a genuine byte-count collision (the
+fmt=1-vs-fmt=8 and fmt=6-vs-fmt=8 cases documented in qt_resolve_fmt) instead
+of the collision refusing unconditionally -- see qt_resolve_fmt's own
+documentation for the exact rule. Unstamped containers (any container from a
+tool that doesn't stamp) are unaffected: no stamp means inference alone
+decides, exactly as before this feature existed.
 
 HARD CONSTRAINT for this build: unit-tested on synthetic fixtures ONLY (see
 tests/test_fp8_repack.py, built with tools/glm_fp8_emit.py's exact real-
@@ -104,6 +115,18 @@ from convert_fp8_to_int4 import classify, check_or_record_params  # reuse: same 
 # ALSO excluded -- see the module docstring: the CPU absorb path (qt_addrow/
 # qt_matvec_rows) and the CUDA absorb kernels have no fmt=8 case yet.
 RESIDENT_KINDS = frozenset({"sh", "o", "attn", "dmlp", "q"})
+
+# The format's PUBLIC identity (what containers/FRs advertise) -- the internal
+# fmt=8 ordinal is a colibri.c-only enum value, never itself persisted (see
+# that file's QT struct comment). Must match the reader's FMT_NAMES table
+# (colibri.c, near qt_resolve_fmt) or every stamp this tool writes will be
+# refused as "unrecognized format name" on load.
+FORMAT_NAME = "fp8-e4m3-b128"
+
+# safetensors __metadata__ key this tool stamps: JSON-encoded {tensor_name:
+# format_name}. Kept as a module constant so the reader-side doc and any
+# future tooling can cite the exact string instead of re-typing it.
+METADATA_KEY = "colibri.fmt"
 
 BLOCK = 128
 
@@ -190,11 +213,17 @@ def repack_shard(path, n_layers):
     byte-identical against torch.float8_e4m3fn's own storage) and rename/flatten
     the `_scale_inv` sidecar to the engine's `name.qs` convention (flat F32,
     nblkO*nblkI elements, row-major [blkO,blkI] -- matching
-    scale[(o/128)*nblkI+i/128] on the read side). Returns (out_dict, inventory)."""
+    scale[(o/128)*nblkI+i/128] on the read side). Returns (out_dict, inventory,
+    fmt_map): fmt_map is {weight_tensor_name: FORMAT_NAME} for every selected
+    tensor -- the caller JSON-encodes it into the output shard's __metadata__
+    (see the module docstring's METADATA STAMP section). Keyed by the WEIGHT
+    name only (not the ".qs" sidecar) -- that's the name qt_resolve_fmt/
+    qt_verify_fmt_stamp look the stamp up by on the read side."""
     import torch
     from safetensors import safe_open
     out = {}
     inv = []
+    fmt_map = {}
     with safe_open(path, framework="pt") as f:
         keys = set(f.keys())
         for name in f.keys():
@@ -209,10 +238,11 @@ def repack_shard(path, n_layers):
             _check_geometry(name, O, I, nblkO, nblkI)
             out[name] = w.view(torch.uint8).contiguous()              # BYTE-PRESERVED
             out[name + ".qs"] = sc.to(torch.float32).reshape(-1).contiguous()
+            fmt_map[name] = FORMAT_NAME
             inv.append({"name": name, "kind": classify(name, n_layers),
                        "O": O, "I": I, "nblkO": nblkO, "nblkI": nblkI,
                        "weight_bytes": O * I, "scale_bytes": nblkO * nblkI * 4})
-    return out, inv
+    return out, inv, fmt_map
 
 
 def _print_inventory_summary(all_inv, dry_run):
@@ -288,13 +318,18 @@ def main():
                 n += 1
             skipped += 1
             continue
-        out, inv = repack_shard(sp, a.n_layers)
+        out, inv, fmt_map = repack_shard(sp, a.n_layers)
         all_inv.extend(inv)
         if not out:
             done[key] = ""
         else:
             name = f"out-fp8pass-{n:05d}.safetensors"
-            save_file(out, os.path.join(a.outdir, name))
+            # METADATA STAMP: __metadata__ values must be strings (safetensors
+            # constraint) -- colibri.fmt's VALUE is itself JSON text (a map of
+            # tensor name -> format NAME), not a nested object, for exactly
+            # that reason. sort_keys for a deterministic, diffable stamp.
+            meta = {METADATA_KEY: json.dumps(fmt_map, sort_keys=True)}
+            save_file(out, os.path.join(a.outdir, name), metadata=meta)
             done[key] = name
             n += 1
             fresh += 1

--- a/c/tools/repack_fp8_passthrough.py
+++ b/c/tools/repack_fp8_passthrough.py
@@ -86,12 +86,20 @@ stamp that agrees with the byte-arithmetic inference is a no-op (the tensor
 loads exactly as it would unstamped); a stamp that disagrees, or names a
 format this build doesn't recognize, is refused loudly (same "untrusted
 container" discipline as qt_resolve_fmt's own THE DESIGN LANDMINE refusal).
-As a bonus, a stamp can also RESOLVE a genuine byte-count collision (the
-fmt=1-vs-fmt=8 and fmt=6-vs-fmt=8 cases documented in qt_resolve_fmt) instead
-of the collision refusing unconditionally -- see qt_resolve_fmt's own
-documentation for the exact rule. Unstamped containers (any container from a
-tool that doesn't stamp) are unaffected: no stamp means inference alone
-decides, exactly as before this feature existed.
+What a stamp additionally lets resolve differs by collision (FIX ROUND 2:
+corrected a stale pre-INVERSION description here -- see qt_resolve_fmt's own
+documentation for the exact rule in both cases): for the fmt=6-vs-fmt=8
+collision, an unstamped tensor at that shape still refuses unconditionally --
+a stamp naming the correct candidate resolves it instead, as originally
+designed. For the fmt=1-vs-fmt=8 collision, the INVERSION (maintainer review,
+#528) means an unstamped tensor at that shape no longer refuses at all -- it
+resolves to int8-row by default -- so a stamp's role there is letting a
+genuinely-stamped fmt=8 tensor still be read as fmt=8 (overriding that
+default), not resolving a refusal that no longer happens. Unstamped
+containers (any container from a tool that doesn't stamp, including every
+container this tool itself has ever produced before this feature existed)
+are otherwise unaffected: no stamp means byte-arithmetic inference alone
+decides, exactly as it always has.
 
 HARD CONSTRAINT for this build: unit-tested on synthetic fixtures ONLY (see
 tests/test_fp8_repack.py, built with tools/glm_fp8_emit.py's exact real-

--- a/docs/FORMATS.md
+++ b/docs/FORMATS.md
@@ -265,6 +265,29 @@ anything is wrong with a container; it is the default, expected state for
 everything that predates this convention (which, as of this PR, is
 everything).
 
+### Duplicate claims, locality, coverage
+
+Three rules complete the stamp's container-wide semantics (user-ratified
+this revision):
+
+- **Conflicting claims refuse.** At most one DISTINCT format claim per
+  tensor name, container-wide. If two shards' `colibri.fmt` maps (or two
+  entries anywhere in the container) stamp the same tensor name with
+  DIFFERENT format names, ingest refuses loudly at discovery time, naming
+  the tensor and both claims — a container that disagrees with itself about
+  a tensor's format is corrupted or hostile. (The previous behavior was
+  first-wins, which made the outcome depend on shard enumeration order —
+  `st_scan_dir` is raw `readdir` order — and mis-diagnosed or hid the real
+  problem.)
+- **Agreeing duplicates are tolerated** (idempotent; collapsed to one
+  entry). A centralized-manifest writer may stamp the same map into every
+  shard. There is **no locality constraint**: a shard may stamp tensors it
+  does not itself contain.
+- **No coverage requirement at load.** Unstamped tensors — and wholly
+  unstamped containers — load exactly as before this feature existed;
+  completeness of a stamping tool's coverage is a writer-side guarantee
+  (a load-time coverage diagnostic is deferred, not implied).
+
 ### Stamp-map scan bound
 
 `st_fmt_stamp_ingest` (`c/st.h`) caps the total number of stamped-tensor

--- a/docs/FORMATS.md
+++ b/docs/FORMATS.md
@@ -17,11 +17,19 @@ coordination alone.
 
 This registry (and the metadata stamp it documents) is PR 2 of a two-PR pair:
 PR 1 (`fmt7/fp8-passthrough`) shipped the CPU read path, repack tool, Metal
-kernel, and collision/refusal logic for `fmt=7` — refusing UNCONDITIONALLY at
-every ambiguous shape, since it carries no stamp. This PR stacks on top of it
-and adds the stamp (writer + reader) that lets those same collisions resolve
-instead of refuse, plus this registry document, as their own reviewable unit
-per the maintainer's request on
+kernel, and collision/refusal logic for `fmt=7`. **Post-INVERSION** (the
+#528 review round's fix, folded into PR 1 before this PR stacked on it): an
+UNSTAMPED tensor at the fmt=1-vs-fmt=7 ambiguous shape (THE DESIGN LANDMINE)
+no longer refuses — it resolves to `int8-row`, the incumbent,
+already-on-disk, decodable format, and the writer (`repack_fp8_passthrough.py`)
+refuses to ever EMIT an `fmt=7` container at that same ambiguous shape, so an
+unstamped collision is never silently misread either way. This PR stacks on
+top of that and adds the stamp (writer + reader): a stamp's role here is
+letting a genuinely-STAMPED `fmt=7` tensor at an ambiguous shape still be
+read as `fmt=7` (overriding the unstamped-case default) — and, for every
+tensor generally, confirming a stamped identity agrees with byte-arithmetic
+inference (TRUST-VERIFY-REFUSE) — plus this registry document, as their own
+reviewable unit per the maintainer's request on
 [#524](https://github.com/JustVugg/colibri/issues/524) to keep the convention
 discussion separate from the CPU+Metal implementation.
 
@@ -98,9 +106,13 @@ Sources for all rows (`c/quant.h`/`c/colibri.c` line numbers, branch
   scale-array geometry, which is ambiguous for some small shapes) and the
   fmt=6 collision ("SECOND DESIGN LANDMINE") both live in `qt_resolve_fmt`
   (`c/colibri.c:1161`), which now also consults an optional `stamped_name`
-  parameter (this PR) to resolve them instead of refusing unconditionally
-  — see "The metadata stamp" below. FMT_NAMES table (name string <-> fmt
-  int): `c/colibri.c:1121`.
+  parameter (this PR): for the fmt=6 collision, a stamp resolves what an
+  absent stamp still refuses; for the fmt=1-vs-fmt=7 collision, an absent
+  stamp already resolves to `int8-row` since the #528 INVERSION, and a
+  stamp's role there is instead letting a genuinely-stamped `fmt=7` tensor
+  override that default — see "The metadata stamp" below for the exact
+  rule in both cases. FMT_NAMES table (name string <-> fmt int):
+  `c/colibri.c:1121`.
 
 ## Scale encoding is a declared property (fmt=7)
 
@@ -195,13 +207,21 @@ reference implementation of this proposal:
   this build doesn't recognize, is refused loudly — the tensor name and
   both identities (stamped vs. inferred) are printed and the process exits,
   matching `qt_resolve_fmt`'s existing "refuse rather than guess" posture
-  for untrusted containers. An absent stamp changes nothing: inference alone
+  for untrusted containers. An absent stamp changes nothing beyond what the
+  INVERSION already made the unstamped default (see above): inference alone
   decides, exactly as it does today for every container that predates this
-  feature. As a bonus, a stamp can also **resolve** a genuine byte-count
-  collision (the fmt=1-vs-fmt=7 and fmt=6-vs-fmt=7 cases above) instead of
-  the collision refusing unconditionally — see `qt_resolve_fmt`'s own
-  documentation for the exact rule, including the cases where even a
-  correct stamp still can't resolve one (the UE8M0 corners above).
+  feature. What a stamp adds differs by which collision it's breaking a tie
+  on: for the **fmt=6-vs-fmt=7** collision (SECOND DESIGN LANDMINE), an
+  unstamped tensor at that shape still refuses unconditionally — a stamp
+  naming the correct candidate **resolves** it instead, exactly as
+  originally designed. For the **fmt=1-vs-fmt=7** collision (THE DESIGN
+  LANDMINE), the INVERSION means an unstamped tensor at that shape no
+  longer refuses at all — a stamp's role there is letting a genuinely
+  stamped `fmt=7` tensor still be read as `fmt=7` (overriding the unstamped
+  default of `int8-row`), not resolving a refusal that no longer happens.
+  See `qt_resolve_fmt`'s own documentation for the exact rule in both
+  cases, including the cases where even a correct stamp still can't resolve
+  one (the UE8M0 corners above).
 
 ### Non-retroactivity
 

--- a/docs/FORMATS.md
+++ b/docs/FORMATS.md
@@ -27,12 +27,15 @@ discussion separate from the CPU+Metal implementation.
 
 ## Known formats
 
-Every row below is verified against branch `fmt7/stamp-registry` (base commit
-`9a1690e`, this document's own commit stacked directly on it), itself stacked
-on `fmt7/fp8-passthrough`, based on dev `9baae9b` (post-#465-merge, post-#526)
-— no cross-tree line-number mixing. The fmt=6 rows are upstream's own merged
-code (this branch's only fmt=6-adjacent change is the collision handling
-inside `qt_resolve_fmt`, `c/colibri.c`).
+Every row below is verified against branch `fmt7/stamp-registry-rev1` (base
+commit `696ce96`, this document's own commit stacked directly on it), itself
+restacked on the revised `fmt7/fp8-passthrough-rev1` (base `a77421d`, the
+#528 review round's INVERSION/qt_wire_split/stale-comment fixes), which is
+in turn based on dev `9baae9b` (post-#465-merge, post-#526) — no cross-tree
+line-number mixing. Every `c/colibri.c` line number in this document reflects
+that restack; re-verify them again if this branch is rebased further. The
+fmt=6 rows are upstream's own merged code (this branch's only fmt=6-adjacent
+change is the collision handling inside `qt_resolve_fmt`, `c/colibri.c`).
 
 `qt_resolve_fmt` (`c/colibri.c`) is the authoritative reader: it infers a
 tensor's format from byte arithmetic alone (weight-byte count + scale-byte
@@ -60,9 +63,9 @@ this document would naturally land there, but per the convention below it
 isn't claimed here; the maintainer assigns at merge.
 
 Sources for all rows (`c/quant.h`/`c/colibri.c` line numbers, branch
-`fmt7/stamp-registry` @ this commit, base dev `9baae9b`):
+`fmt7/stamp-registry-rev1` @ this commit, base dev `9baae9b`):
 
-- **fmt=0/1/2/3** — allocation policy: `qt_alloc`, `c/colibri.c:893`
+- **fmt=0/1/2/3** — allocation policy: `qt_alloc`, `c/colibri.c:910`
   (`bits>=16→fmt=0`, `bits>=5→fmt=1`, `bits>=4→fmt=2`, else `fmt=3`).
   Kernels: `matmul_q` (`quant.h:105`, fmt=1), `matmul_i4` (`quant.h:125`,
   fmt=2), `matmul_i2` (`quant.h:251`, fmt=3); pack/quantize helpers
@@ -71,12 +74,12 @@ Sources for all rows (`c/quant.h`/`c/colibri.c` line numbers, branch
 - **fmt=4** (`int4-grouped`) — kernel `matmul_i4_grouped`, `quant.h:168`;
   group size `gs` is per-tensor, not fixed at 64 (contrast fmt=5). Byte-count:
   `qt_bytes`'s `fmt==4` branch (inside `c/colibri.c:164`); scale-count split:
-  `qt_scale_bytes`, `c/colibri.c:216`.
+  `qt_scale_bytes`, `c/colibri.c:223`.
 - **fmt=5** (`int3-g64`) — group size is fixed (`I3_GROUP=64`,
   `quant.h:293`; `I3_GBYTES=24`, `quant.h:294`); helpers `i3_groups`
   (`quant.h:295`), `i3_rowbytes` (`quant.h:296`); kernel `matmul_i3`
   (`quant.h:302`); pack helper `pack_int3_g64` (`quant.h:899`). Allocation:
-  `qt_alloc`'s `bits==3` branch (inside `c/colibri.c:893`).
+  `qt_alloc`'s `bits==3` branch (inside `c/colibri.c:910`).
 - **fmt=6** (`e8-iq3`) — upstream's merged code: format section header
   precedes `quant.h:951`; constants `E8_QK=256` (`quant.h:951`),
   `E8_SUB=32` (`quant.h:952`), `E8_BBYTES=98` (`quant.h:953`); row-byte
@@ -84,7 +87,7 @@ Sources for all rows (`c/quant.h`/`c/colibri.c` line numbers, branch
   documented at `quant.h:1248` ("fmt=6 stores W@Q, so activations must be
   transformed before"). Loader discriminator, upstream form (dev, ns==4 tag
   check at the top of `qt_resolve_fmt`): this branch's SECOND DESIGN
-  LANDMINE comment (`qt_resolve_fmt`, `c/colibri.c:1144`) hardens that check
+  LANDMINE comment (`qt_resolve_fmt`, `c/colibri.c:1161`) hardens that check
   against the degenerate collisions below without changing any genuine-fmt=6
   outcome.
 - **fmt=7** (`fp8-e4m3-b128`, this branch) — decode table `E4M3_LUT`
@@ -94,10 +97,10 @@ Sources for all rows (`c/quant.h`/`c/colibri.c` line numbers, branch
   weight bytes are byte-identical and can only be told apart by
   scale-array geometry, which is ambiguous for some small shapes) and the
   fmt=6 collision ("SECOND DESIGN LANDMINE") both live in `qt_resolve_fmt`
-  (`c/colibri.c:1144`), which now also consults an optional `stamped_name`
+  (`c/colibri.c:1161`), which now also consults an optional `stamped_name`
   parameter (this PR) to resolve them instead of refusing unconditionally
   — see "The metadata stamp" below. FMT_NAMES table (name string <-> fmt
-  int): `c/colibri.c:1104`.
+  int): `c/colibri.c:1121`.
 
 ## Scale encoding is a declared property (fmt=7)
 

--- a/docs/FORMATS.md
+++ b/docs/FORMATS.md
@@ -62,8 +62,8 @@ the bytes alone say.
 | 3 | `int2-row` | `O*ceil(I/4)` bytes (`q4`, 4 packed 2-bit values/byte) | 1 `f32` per **row** (`O` entries) | stable, upstream | `1ae22a6` (initial commit) |
 | 4 | `int4-grouped` | `O*ceil(I/2)` bytes (`q4`, same packed layout as fmt=2) | 1 `f32` per **group** of `gs` inputs, `O*ceil(I/gs)` entries | stable, upstream | `498ab0c` / merged PR [#242](https://github.com/JustVugg/colibri/pull/242) |
 | 5 | `int3-g64` | `O*ceil(I/64)*24` bytes (`q4`; 24B/group = 16B low-plane + 8B high-plane, `I3_GROUP=64`/`I3_GBYTES=24`) | 1 `f32` per **64-input group**, `O*ceil(I/64)` entries | stable, upstream | `5e42e70` |
-| 6 | `e8-iq3` (E8/IQ3 lattice) | `O*ceil(I/256)*98` bytes (98-byte self-contained super-blocks: E8 lattice indices + parity signs + fp16 super-scales; `E8_QK=256`, `E8_BBYTES=98`) | none as a separate array — scales live **inside** the super-blocks; the `.qs` sidecar is a single-float tag (`ns==4` is the loader's discriminator). NOTE: stores `W@Q` (block-diagonal FWHT rotation) — activations must be rotated before the kernel | **stable, upstream** — [#465](https://github.com/JustVugg/colibri/pull/465) MERGED 2026-07-21 | dev `dce7012` |
-| 7 | `mxfp4` (no in-tree name string — dev has no stamp feature) | `O*ceil(I/2)` bytes (e2m1 nibbles, 2 packed values/byte — same nibble packing as fmt=2/4) | 1 `f32` per **group** of `gs` inputs (`gs=32` for Kimi K3; host gate requires `gs % 8 == 0`) | **stable, upstream** — Kimi K3 native routed-expert tier, **Vulkan backend only** (`c/backend_vulkan.c`, `c/shaders/qmatmul.comp`); NOT a CPU/`QT` format — `qt_resolve_fmt` never returns 7 and the Metal backend refuses it | merged [#676](https://github.com/JustVugg/colibri/issues/676)/[#705](https://github.com/JustVugg/colibri/pull/705) |
+| 6 | `e8-iq3-lattice` (E8/IQ3 lattice) | `O*ceil(I/256)*98` bytes (98-byte self-contained super-blocks: E8 lattice indices + parity signs + fp16 super-scales; `E8_QK=256`, `E8_BBYTES=98`) | none as a separate array — scales live **inside** the super-blocks; the `.qs` sidecar is a single-float tag (`ns==4` is the loader's discriminator). NOTE: stores `W@Q` (block-diagonal FWHT rotation) — activations must be rotated before the kernel | **stable, upstream** — [#465](https://github.com/JustVugg/colibri/pull/465) MERGED 2026-07-21 | dev `dce7012` |
+| 7 | `mxfp4` (no in-tree name string — dev has no stamp feature) | `O*ceil(I/2)` bytes (e2m1 nibbles, 2 packed values/byte — same nibble packing as fmt=2/4) | in the **container**: 1 **UE8M0** byte (u8 power-of-two exponent) per **group** of `gs=32` inputs; expanded to 1 `f32` per group at Vulkan upload (`c/kimi_k3.c`'s `mx4_scale` loop — the shader is float-only). Host gate: `gs >= 8 && gs % 8 == 0` (`c/backend_vulkan.c`) | **stable, upstream** — Kimi K3 native routed-expert tier, **Vulkan backend only** (`c/backend_vulkan.c`, `c/shaders/qmatmul.comp`); NOT a CPU/`QT` format — `qt_resolve_fmt` never returns 7 and the Metal backend refuses it | merged [#676](https://github.com/JustVugg/colibri/issues/676)/[#705](https://github.com/JustVugg/colibri/pull/705) |
 | **8** | `fp8-e4m3-b128` | `O*I` × 1 byte (`q8`, raw e4m3, byte-identical layout to fmt=1) | a **declared property**, not one fixed layout — see "Scale encoding is a declared property" below. **f32** (1 per 128×128 block, `ceil(O/128)*ceil(I/128)` entries) is IMPLEMENTED; **UE8M0** (1 byte/block, same block grid) is RECOGNIZED and refused by name, not yet implemented | **this PR pair** — CPU/Metal/repack/collision-refusal on `fmt7/fp8-passthrough`, this stamp+registry PR stacked on top; developed under the PRIVATE ORDINAL BLOCK as `fmt=100`; assigned fmt=7 by the maintainer on #524, renumbered to **fmt=8** after #705 merged claiming 7 for MXFP4 while this pair was open (see "ID assignment" below) | `fmt7/fp8-passthrough` (PR 1) |
 
 With fmt 0–8 all assigned, the next free public ordinal is **9** — per the
@@ -95,7 +95,7 @@ pair's current restack, base dev `292ed4c`):
   (`quant.h:295`), `i3_rowbytes` (`quant.h:296`); kernel `matmul_i3`
   (`quant.h:354`); pack helper `pack_int3_g64` (`quant.h:956`). Allocation:
   `qt_alloc`'s `bits==3` branch (inside `c/colibri.c:1105`).
-- **fmt=6** (`e8-iq3`) — upstream's merged code: format section header
+- **fmt=6** (`e8-iq3-lattice`) — upstream's merged code: format section header
   precedes `quant.h:1008`; constants `E8_QK=256` (`quant.h:1008`),
   `E8_SUB=32` (`quant.h:1009`), `E8_BBYTES=98` (`quant.h:1010`); row-byte
   helpers `e8_blocks`/`e8_rowbytes` (`quant.h:1011-1012`); rotation contract
@@ -109,9 +109,11 @@ pair's current restack, base dev `292ed4c`):
   branch `p.fmt == 4 || p.fmt == 7` in `c/shaders/qmatmul.comp` (e2m1 nibble
   decode, per-`gs`-group scale folded into the accumulation), host gate and
   sizing in `c/backend_vulkan.c` (`upload_tensor`'s `fmt == 4 || fmt == 7`
-  allow-list, `gs % 8 == 0`). Wired for Kimi K3's routed-expert tier
-  (`c/kimi_k3.c`); no CPU (`quant.h`) or Metal kernel exists for it, and
-  `qt_resolve_fmt` has no byte-arithmetic branch that returns 7.
+  allow-list, `gs >= 8 && gs % 8 == 0`). Wired for Kimi K3's routed-expert
+  tier (`c/kimi_k3.c`, which expands the container's per-32-group UE8M0 u8
+  exponents to the f32 group scales the shader consumes — `mx4_scale`); no
+  CPU (`quant.h`) or Metal kernel exists for it, and `qt_resolve_fmt` has
+  no byte-arithmetic branch that returns 7.
 - **fmt=8** (`fp8-e4m3-b128`, this branch) — decode table `E4M3_LUT`
   (`quant.h:446`) / `e4m3_decode` (`quant.h:480`), block size
   `FP8_BLOCK=128` (`quant.h:482`), kernel `matmul_fp8` (`quant.h:491`).
@@ -172,8 +174,14 @@ LANDMINE) also produces a UE8M0-vs-fmt=1 collision at different shapes (e.g.
 `O=1, I` in `(384,512]`), and the same small-shape corner of the fmt=6
 collision (SECOND DESIGN LANDMINE, `I=98`) has a UE8M0-scaled analogue at
 `O` in `(384,512]`. Both are handled explicitly in `qt_resolve_fmt` and
-covered by `tests/test_fp8_load.c`'s Part A3 suite. No real GLM tensor has
-these shapes; the discipline exists for untrusted containers.
+covered by `tests/test_fp8_load.c`'s Part A3/A3b suites. The
+UE8M0-vs-fmt=1 colliding family is exactly `nb == O*I && ns == O*4 &&
+ceil(O/128)*ceil(I/128) == 4*O`; at `I <= 16384` (`nblkI <= 128`)
+membership forces `O <= 32`, and every GLM-5.2 resident/routed role has
+`O >= 576` (`kv_a`'s `kv_lora+qk_rope` is the smallest — the role census
+in `c/tools/fp8_collision_census.py`, run against the real checkpoint in
+this PR's rev5 round), so no GLM-5.2 tensor is a member; the discipline
+exists for untrusted containers.
 
 ## PRIVATE ORDINAL BLOCK convention (this repo, pending upstream review)
 
@@ -269,11 +277,15 @@ handful to a few hundred tensors per model (`q_a`/`q_b`/`kv_a`/`kv_b_proj`,
 census in `c/tools/fp8_collision_census.py`), **never** the tens of
 thousands of routed-expert tensors a large MoE checkpoint carries. A
 container whose combined stamp map exceeds 4096 entries is not using this
-convention as it's designed to be used — most plausibly a malformed or
-adversarial container trying to force an unbounded ingest allocation during
-header parsing, before any size/shape validation has even run. Refusing
-loudly at that bound is the same "untrusted container, refuse rather than
-guess" discipline `qt_resolve_fmt` applies everywhere else in this feature.
+convention as it's designed to be used. To be precise about what the cap
+bounds: the `colibri.fmt` blob is JSON-parsed in full **before** the
+per-entry cap is checked, so the parse allocation itself is bounded by the
+shard-header size cap (`ST_MAX_HEADER`), not by this constant — what the
+cap bounds is the **persistent** per-tensor arrays (`fmt_name`/`fmt_val`
+strdups on `shards`) that would otherwise grow with an adversarial map,
+plus every later `st_fmt_stamp` linear scan over them. Refusing loudly at
+that bound is the same "untrusted container, refuse rather than guess"
+discipline `qt_resolve_fmt` applies everywhere else in this feature.
 
 ### Discovery-time abort surface
 

--- a/docs/FORMATS.md
+++ b/docs/FORMATS.md
@@ -1,0 +1,250 @@
+# FORMATS.md — a registry for colibrì's quantized weight formats
+
+*Authored by Fable 5 in Claude Code, analysis in partnership with @monotophic.*
+
+## Why this exists
+
+Two independent format proposals claimed the same internal ordinal in the same
+week: [#465](https://github.com/JustVugg/colibri/pull/465) (ZacharyZcR,
+E8/IQ3 container, step 3 of the #452 ladder) and this repo's FP8-e4m3
+passthrough branch both used `fmt=6`. Neither was wrong — nothing before now
+told either author that "6" was spoken for. That's a process gap, not a code
+bug: `QT.fmt` is a plain `int` with no enum declaration and no in-repo list of
+what's taken. This closes that gap with (1) a lightweight, in-repo registry
+(this file) and (2) an optional self-describing container stamp so a format's
+*identity* never has to depend on getting the *number* right by social
+coordination alone.
+
+This registry (and the metadata stamp it documents) is PR 2 of a two-PR pair:
+PR 1 (`fmt7/fp8-passthrough`) shipped the CPU read path, repack tool, Metal
+kernel, and collision/refusal logic for `fmt=7` — refusing UNCONDITIONALLY at
+every ambiguous shape, since it carries no stamp. This PR stacks on top of it
+and adds the stamp (writer + reader) that lets those same collisions resolve
+instead of refuse, plus this registry document, as their own reviewable unit
+per the maintainer's request on
+[#524](https://github.com/JustVugg/colibri/issues/524) to keep the convention
+discussion separate from the CPU+Metal implementation.
+
+## Known formats
+
+Every row below is verified against branch `fmt7/stamp-registry` (base commit
+`9a1690e`, this document's own commit stacked directly on it), itself stacked
+on `fmt7/fp8-passthrough`, based on dev `9baae9b` (post-#465-merge, post-#526)
+— no cross-tree line-number mixing. The fmt=6 rows are upstream's own merged
+code (this branch's only fmt=6-adjacent change is the collision handling
+inside `qt_resolve_fmt`, `c/colibri.c`).
+
+`qt_resolve_fmt` (`c/colibri.c`) is the authoritative reader: it infers a
+tensor's format from byte arithmetic alone (weight-byte count + scale-byte
+count against `[O,I]`) — **the container itself never carries a format
+ordinal**, which is exactly why ordinal collisions like #465-vs-this-branch
+are silent until someone notices at review time instead of at parse time. An
+optional `__metadata__` stamp (see "The metadata stamp" below, this PR) can
+additionally confirm — or, for the two known byte-collisions, resolve — what
+the bytes alone say.
+
+| ordinal | name | weight bytes | scale layout | status | since |
+|---|---|---|---|---|---|
+| 0 | `f32` | `O*I` × 4 bytes (`qf`, plain `float`) | none | stable, upstream | `1ae22a6` (initial commit) |
+| 1 | `int8-row` | `O*I` × 1 byte (`q8`, signed) | 1 `f32` per **row** (`O` entries) | stable, upstream | `1ae22a6` (initial commit) |
+| 2 | `int4-row` | `O*ceil(I/2)` bytes (`q4`, 2 packed nibbles/byte) | 1 `f32` per **row** (`O` entries) | stable, upstream | `1ae22a6` (initial commit) |
+| 3 | `int2-row` | `O*ceil(I/4)` bytes (`q4`, 4 packed 2-bit values/byte) | 1 `f32` per **row** (`O` entries) | stable, upstream | `1ae22a6` (initial commit) |
+| 4 | `int4-grouped` | `O*ceil(I/2)` bytes (`q4`, same packed layout as fmt=2) | 1 `f32` per **group** of `gs` inputs, `O*ceil(I/gs)` entries | stable, upstream | `498ab0c` / merged PR [#242](https://github.com/JustVugg/colibri/pull/242) |
+| 5 | `int3-g64` | `O*ceil(I/64)*24` bytes (`q4`; 24B/group = 16B low-plane + 8B high-plane, `I3_GROUP=64`/`I3_GBYTES=24`) | 1 `f32` per **64-input group**, `O*ceil(I/64)` entries | stable, upstream | `5e42e70` |
+| 6 | `e8-iq3` (E8/IQ3 lattice) | `O*ceil(I/256)*98` bytes (98-byte self-contained super-blocks: E8 lattice indices + parity signs + fp16 super-scales; `E8_QK=256`, `E8_BBYTES=98`) | none as a separate array — scales live **inside** the super-blocks; the `.qs` sidecar is a single-float tag (`ns==4` is the loader's discriminator). NOTE: stores `W@Q` (block-diagonal FWHT rotation) — activations must be rotated before the kernel | **stable, upstream** — [#465](https://github.com/JustVugg/colibri/pull/465) MERGED 2026-07-21 | dev `dce7012` |
+| **7** | `fp8-e4m3-b128` | `O*I` × 1 byte (`q8`, raw e4m3, byte-identical layout to fmt=1) | a **declared property**, not one fixed layout — see "Scale encoding is a declared property" below. **f32** (1 per 128×128 block, `ceil(O/128)*ceil(I/128)` entries) is IMPLEMENTED; **UE8M0** (1 byte/block, same block grid) is RECOGNIZED and refused by name, not yet implemented | **this PR pair** — CPU/Metal/repack/collision-refusal on `fmt7/fp8-passthrough`, this stamp+registry PR stacked on top; PUBLIC ordinal assigned by the maintainer on #524 (developed under the PRIVATE ORDINAL BLOCK as `fmt=100`) | `fmt7/fp8-passthrough` (PR 1) |
+
+With fmt=6 and fmt=7 both assigned, the next free public ordinal is **8** —
+the (separate, future) entropy-tier proposal mentioned in earlier drafts of
+this document would naturally land there, but per the convention below it
+isn't claimed here; the maintainer assigns at merge.
+
+Sources for all rows (`c/quant.h`/`c/colibri.c` line numbers, branch
+`fmt7/stamp-registry` @ this commit, base dev `9baae9b`):
+
+- **fmt=0/1/2/3** — allocation policy: `qt_alloc`, `c/colibri.c:893`
+  (`bits>=16→fmt=0`, `bits>=5→fmt=1`, `bits>=4→fmt=2`, else `fmt=3`).
+  Kernels: `matmul_q` (`quant.h:105`, fmt=1), `matmul_i4` (`quant.h:125`,
+  fmt=2), `matmul_i2` (`quant.h:251`, fmt=3); pack/quantize helpers
+  `quantize_rows` (`quant.h:871`, fmt=1) and `pack_int2` (`quant.h:923`,
+  fmt=3). Byte-count formulas: `qt_bytes`, `c/colibri.c:164`.
+- **fmt=4** (`int4-grouped`) — kernel `matmul_i4_grouped`, `quant.h:168`;
+  group size `gs` is per-tensor, not fixed at 64 (contrast fmt=5). Byte-count:
+  `qt_bytes`'s `fmt==4` branch (inside `c/colibri.c:164`); scale-count split:
+  `qt_scale_bytes`, `c/colibri.c:216`.
+- **fmt=5** (`int3-g64`) — group size is fixed (`I3_GROUP=64`,
+  `quant.h:293`; `I3_GBYTES=24`, `quant.h:294`); helpers `i3_groups`
+  (`quant.h:295`), `i3_rowbytes` (`quant.h:296`); kernel `matmul_i3`
+  (`quant.h:302`); pack helper `pack_int3_g64` (`quant.h:899`). Allocation:
+  `qt_alloc`'s `bits==3` branch (inside `c/colibri.c:893`).
+- **fmt=6** (`e8-iq3`) — upstream's merged code: format section header
+  precedes `quant.h:951`; constants `E8_QK=256` (`quant.h:951`),
+  `E8_SUB=32` (`quant.h:952`), `E8_BBYTES=98` (`quant.h:953`); row-byte
+  helpers `e8_blocks`/`e8_rowbytes` (`quant.h:954-955`); rotation contract
+  documented at `quant.h:1248` ("fmt=6 stores W@Q, so activations must be
+  transformed before"). Loader discriminator, upstream form (dev, ns==4 tag
+  check at the top of `qt_resolve_fmt`): this branch's SECOND DESIGN
+  LANDMINE comment (`qt_resolve_fmt`, `c/colibri.c:1144`) hardens that check
+  against the degenerate collisions below without changing any genuine-fmt=6
+  outcome.
+- **fmt=7** (`fp8-e4m3-b128`, this branch) — decode table `E4M3_LUT`
+  (`quant.h:389`) / `e4m3_decode` (`quant.h:423`), block size
+  `FP8_BLOCK=128` (`quant.h:425`), kernel `matmul_fp8` (`quant.h:434`).
+  Disambiguation from fmt=1 ("THE DESIGN LANDMINE" — the two formats'
+  weight bytes are byte-identical and can only be told apart by
+  scale-array geometry, which is ambiguous for some small shapes) and the
+  fmt=6 collision ("SECOND DESIGN LANDMINE") both live in `qt_resolve_fmt`
+  (`c/colibri.c:1144`), which now also consults an optional `stamped_name`
+  parameter (this PR) to resolve them instead of refusing unconditionally
+  — see "The metadata stamp" below. FMT_NAMES table (name string <-> fmt
+  int): `c/colibri.c:1104`.
+
+## Scale encoding is a declared property (fmt=7)
+
+fmt=7's byte layout for the WEIGHTS (`O*I` raw e4m3 bytes) is fixed. Its
+scale sidecar's ENCODING is not — it's a property of the format that a
+container can carry one of several ways, the same identity ("fp8-e4m3-b128",
+128×128-block scaling) admitting more than one physical byte layout for the
+scale array:
+
+- **f32** — 4 bytes/block, `ceil(O/128)*ceil(I/128)` `float`s. This is the
+  value **this PR pair implements**: Z.ai's GLM-5.2-FP8 checkpoints ship
+  `weight_scale_inv` this way, and `tools/repack_fp8_passthrough.py` /
+  `matmul_fp8` / the Metal `mm_gemv` fmt=7 branch all read and write it.
+- **UE8M0** — 1 byte/block, a power-of-two exponent (dtype `F8_E8M0`), same
+  `ceil(O/128)*ceil(I/128)` block grid. **DeepSeek-V4 ships this identical
+  weight geometry (FP8 E4M3, 128×128 blocks) with UE8M0 scales instead of
+  f32** — a finding the maintainer surfaced on #524. This PR pair
+  **recognizes but does not implement** it: `qt_resolve_fmt` detects the
+  distinct byte signature (`ns == ceil(O/128)*ceil(I/128)`, exactly 1/4 the
+  f32 byte count, never coincidentally equal to it for any `O,I >= 1`) and
+  refuses by name — *"fp8-e4m3-b128 with ue8m0 scales recognized but not
+  implemented; only f32 block scales are supported in this build"* — rather
+  than misreading the sidecar as truncated or corrupt f32 data. A future
+  UE8M0 decoder (CPU kernel + Metal kernel + this resolver's `fmt==1`
+  candidate branch) lands into this seam; it is explicitly invited follow-up
+  work, not blocked on anything in this PR pair. The MXFP4 routed-expert
+  question (E2M1 + ue8m0 g32) raised alongside this finding is a **separate**
+  format and a separate conversation — but this same scale-encoding-as-
+  property mechanism is designed to serve it too.
+- A metadata stamp naming `"fp8-e4m3-b128"` (below) confirms the WEIGHT
+  format only. It cannot grant this build a decoder it doesn't have: a
+  tensor whose scale sidecar is UE8M0-shaped still refuses even when
+  correctly stamped, in both places `qt_resolve_fmt` could otherwise resolve
+  an ambiguity (the fmt=1 collision and the fmt=6 collision) — see
+  `qt_resolve_fmt`'s own comments for the exact cases.
+
+Collision-checked against every other format's `ns` (scale-byte) arithmetic
+reachable from fmt=7's `nb==O*I` weight-byte branch: realistically distinct
+for GLM-sized shapes (`ceil(O/128)*ceil(I/128)` is orders of magnitude
+smaller than `O*4` for any real matrix), but not categorically distinct — the
+same small-`O` regime that produces the f32-vs-fmt=1 collision (THE DESIGN
+LANDMINE) also produces a UE8M0-vs-fmt=1 collision at different shapes (e.g.
+`O=1, I` in `(384,512]`), and the same small-shape corner of the fmt=6
+collision (SECOND DESIGN LANDMINE, `I=98`) has a UE8M0-scaled analogue at
+`O` in `(384,512]`. Both are handled explicitly in `qt_resolve_fmt` and
+covered by `tests/test_fp8_load.c`'s Part A3 suite. No real GLM tensor has
+these shapes; the discipline exists for untrusted containers.
+
+## PRIVATE ORDINAL BLOCK convention (this repo, pending upstream review)
+
+To avoid a repeat of the #465 collision, in-flight branches in this repo mint
+format ordinals from a **private block starting at 100**, never from the
+public 0-7 range, and never claim a specific public ordinal in a Feature
+Request. The convention (already applied twice: fmt=6's original proposal
+briefly held it before #465 claimed the number upstream, and this PR pair's
+own fmt=7 moved from the collided `fmt=6` to `fmt=100` and then graduated to
+the maintainer-assigned `fmt=7`):
+
+- **0-7 stays upstream's namespace.** A branch never assigns itself an
+  ordinal in that range, even provisionally.
+- **100+ is scratch space.** Any branch may claim the next unused 100+
+  integer for local development and testing. Since the ordinal is a
+  compiled-in `int` with no on-disk representation (see `qt_resolve_fmt`'s
+  byte-arithmetic inference above), renumbering it later is a pure
+  find-and-replace with zero on-disk or cross-version compatibility impact
+  — nothing outside the binary's own compiled code ever observes the
+  number, as this branch's own fmt=100 → fmt=7 renumbering demonstrated.
+- **A container never advertises a private ordinal.** What a container (or
+  a Feature Request) advertises is the format's **NAME** — a string like
+  `fp8-e4m3-b128` — never the integer. The real, public ordinal is assigned
+  by the maintainer at merge time, exactly as it always has been; this
+  convention only formalizes what a *branch* calls itself internally before
+  that point.
+
+## The metadata stamp (reference implementation, this PR)
+
+Because the container carries no ordinal today, and because a NAME-based
+convention only helps if something can actually check a NAME against the
+bytes, this PR implements a minimal, optional self-describing stamp as its
+reference implementation of this proposal:
+
+- **Writer** (`c/tools/repack_fp8_passthrough.py`): every tensor it repacks
+  into the fp8-e4m3-b128 container gets an entry in the output shard's
+  safetensors `__metadata__["colibri.fmt"]` — a JSON-encoded map of exact
+  tensor name → format NAME string (never the private ordinal, and never a
+  scale-encoding name either — the stamp names the WEIGHT format, not which
+  of that format's possible scale encodings is present; see "Scale encoding
+  is a declared property" above for why that distinction is load-bearing).
+- **Reader** (`qt_verify_fmt_stamp` + `qt_resolve_fmt`, `c/colibri.c`):
+  TRUST-VERIFY-REFUSE. A stamp that agrees with the byte-arithmetic
+  inference is a silent no-op. A stamp that disagrees, or names a format
+  this build doesn't recognize, is refused loudly — the tensor name and
+  both identities (stamped vs. inferred) are printed and the process exits,
+  matching `qt_resolve_fmt`'s existing "refuse rather than guess" posture
+  for untrusted containers. An absent stamp changes nothing: inference alone
+  decides, exactly as it does today for every container that predates this
+  feature. As a bonus, a stamp can also **resolve** a genuine byte-count
+  collision (the fmt=1-vs-fmt=7 and fmt=6-vs-fmt=7 cases above) instead of
+  the collision refusing unconditionally — see `qt_resolve_fmt`'s own
+  documentation for the exact rule, including the cases where even a
+  correct stamp still can't resolve one (the UE8M0 corners above).
+
+This is offered as a **reference implementation**, not a mandate: a future
+public format registry could standardize the metadata key and stamp shape
+(`colibri.fmt` and its JSON-map-of-name convention are this PR's proposal,
+open to revision) so any tool, not just this one, can write a self-describing
+container that any reader can verify without needing a side-channel ordinal
+assignment at all.
+
+## How to add a format
+
+1. **Claim a NAME**, not a number, via a Feature Request. Describe the
+   weight-byte layout and scale layout precisely (see the table above for
+   the level of detail expected) so the maintainer and reviewers can check
+   it against `qt_resolve_fmt`'s existing disambiguation logic for
+   collisions with formats already in the table. If the format's scale (or
+   any other secondary array) can legitimately carry more than one physical
+   encoding — as fmt=7's now can — say so explicitly and declare which
+   encoding(s) the implementation actually reads and writes, so a future
+   encoder for the same format NAME doesn't have to guess or fork off a new
+   name unnecessarily.
+2. **Develop against a private 100+ ordinal** in your own branch (see the
+   PRIVATE ORDINAL BLOCK convention above). This lets you write, test, and
+   review real code without a numbering conversation blocking on it.
+3. **The maintainer assigns the real ordinal at merge time**, and the
+   branch's private 100+ number is find-and-replaced to it as part of
+   landing — a mechanical, zero-risk step precisely because nothing on disk
+   or in a released container ever depended on the private number, exactly
+   as fmt=7's `fmt=100 → fmt=7` renumbering was.
+4. **Stamp containers via `__metadata__`** (see "The metadata stamp" above)
+   so tooling that produces the format's containers can self-describe, and
+   readers can verify-or-refuse rather than trust byte arithmetic alone.
+5. **Update this registry** with the new row once the format lands.
+
+## Open questions for maintainer review
+
+- Is `100+` an acceptable private-block convention, or would the project
+  prefer a different reserved range (e.g. negative values, or a separate
+  `fmt_ext` field) for in-flight private ordinals?
+- Should `colibri.fmt` (this PR's metadata key) become the project's
+  standard stamp key, or is a different shape preferred (e.g. one key per
+  tensor instead of one JSON blob) if this pattern is adopted project-wide?
+- ~~How should #465 and this branch's FP8 proposal be sequenced?~~ Resolved
+  by events: #465 merged 2026-07-21 as fmt=6, fmt=7 assigned to this
+  proposal 2026-07-22 on #524.
+- ~~Should scale encoding be a hardcoded constant or a declared,
+  per-container property?~~ Decided by the maintainer on #524, prompted by
+  the DeepSeek-V4 datapoint above: it's a declared property. f32 is this PR
+  pair's implemented value; UE8M0 is recognized and refused by name, an
+  invited follow-up rather than a blocking requirement.

--- a/docs/FORMATS.md
+++ b/docs/FORMATS.md
@@ -17,16 +17,16 @@ coordination alone.
 
 This registry (and the metadata stamp it documents) is PR 2 of a two-PR pair:
 PR 1 (`fmt7/fp8-passthrough`) shipped the CPU read path, repack tool, Metal
-kernel, and collision/refusal logic for `fmt=7`. **Post-INVERSION** (the
+kernel, and collision/refusal logic for `fmt=8`. **Post-INVERSION** (the
 #528 review round's fix, folded into PR 1 before this PR stacked on it): an
-UNSTAMPED tensor at the fmt=1-vs-fmt=7 ambiguous shape (THE DESIGN LANDMINE)
+UNSTAMPED tensor at the fmt=1-vs-fmt=8 ambiguous shape (THE DESIGN LANDMINE)
 no longer refuses — it resolves to `int8-row`, the incumbent,
 already-on-disk, decodable format, and the writer (`repack_fp8_passthrough.py`)
-refuses to ever EMIT an `fmt=7` container at that same ambiguous shape, so an
+refuses to ever EMIT an `fmt=8` container at that same ambiguous shape, so an
 unstamped collision is never silently misread either way. This PR stacks on
 top of that and adds the stamp (writer + reader): a stamp's role here is
-letting a genuinely-STAMPED `fmt=7` tensor at an ambiguous shape still be
-read as `fmt=7` (overriding the unstamped-case default) — and, for every
+letting a genuinely-STAMPED `fmt=8` tensor at an ambiguous shape still be
+read as `fmt=8` (overriding the unstamped-case default) — and, for every
 tensor generally, confirming a stamped identity agrees with byte-arithmetic
 inference (TRUST-VERIFY-REFUSE) — plus this registry document, as their own
 reviewable unit per the maintainer's request on
@@ -35,15 +35,15 @@ discussion separate from the CPU+Metal implementation.
 
 ## Known formats
 
-Every row below is verified against branch `fmt7/stamp-registry-rev1` (base
-commit `696ce96`, this document's own commit stacked directly on it), itself
-restacked on the revised `fmt7/fp8-passthrough-rev1` (base `a77421d`, the
-#528 review round's INVERSION/qt_wire_split/stale-comment fixes), which is
-in turn based on dev `9baae9b` (post-#465-merge, post-#526) — no cross-tree
-line-number mixing. Every `c/colibri.c` line number in this document reflects
-that restack; re-verify them again if this branch is rebased further. The
-fmt=6 rows are upstream's own merged code (this branch's only fmt=6-adjacent
-change is the collision handling inside `qt_resolve_fmt`, `c/colibri.c`).
+Every row below is verified against this PR pair's current restack: the
+stamp+registry series (#529) stacked directly on the fp8-passthrough series
+(#528), which is in turn based on dev `292ed4c` (post-#465, post-#457
+Metal grouped-GEMV merge, post-#705 Vulkan/Kimi-K3 MXFP4 merge) — no
+cross-tree line-number mixing. Every `c/colibri.c`/`c/quant.h` line number
+in this document reflects that restack; re-verify them again if this branch
+is rebased further. The fmt=6 and fmt=7 rows are upstream's own merged code
+(this branch's only fmt=6-adjacent change is the collision handling inside
+`qt_resolve_fmt`, `c/colibri.c`; it does not touch fmt=7/MXFP4 at all).
 
 `qt_resolve_fmt` (`c/colibri.c`) is the authoritative reader: it infers a
 tensor's format from byte arithmetic alone (weight-byte count + scale-byte
@@ -63,60 +63,74 @@ the bytes alone say.
 | 4 | `int4-grouped` | `O*ceil(I/2)` bytes (`q4`, same packed layout as fmt=2) | 1 `f32` per **group** of `gs` inputs, `O*ceil(I/gs)` entries | stable, upstream | `498ab0c` / merged PR [#242](https://github.com/JustVugg/colibri/pull/242) |
 | 5 | `int3-g64` | `O*ceil(I/64)*24` bytes (`q4`; 24B/group = 16B low-plane + 8B high-plane, `I3_GROUP=64`/`I3_GBYTES=24`) | 1 `f32` per **64-input group**, `O*ceil(I/64)` entries | stable, upstream | `5e42e70` |
 | 6 | `e8-iq3` (E8/IQ3 lattice) | `O*ceil(I/256)*98` bytes (98-byte self-contained super-blocks: E8 lattice indices + parity signs + fp16 super-scales; `E8_QK=256`, `E8_BBYTES=98`) | none as a separate array — scales live **inside** the super-blocks; the `.qs` sidecar is a single-float tag (`ns==4` is the loader's discriminator). NOTE: stores `W@Q` (block-diagonal FWHT rotation) — activations must be rotated before the kernel | **stable, upstream** — [#465](https://github.com/JustVugg/colibri/pull/465) MERGED 2026-07-21 | dev `dce7012` |
-| **7** | `fp8-e4m3-b128` | `O*I` × 1 byte (`q8`, raw e4m3, byte-identical layout to fmt=1) | a **declared property**, not one fixed layout — see "Scale encoding is a declared property" below. **f32** (1 per 128×128 block, `ceil(O/128)*ceil(I/128)` entries) is IMPLEMENTED; **UE8M0** (1 byte/block, same block grid) is RECOGNIZED and refused by name, not yet implemented | **this PR pair** — CPU/Metal/repack/collision-refusal on `fmt7/fp8-passthrough`, this stamp+registry PR stacked on top; PUBLIC ordinal assigned by the maintainer on #524 (developed under the PRIVATE ORDINAL BLOCK as `fmt=100`) | `fmt7/fp8-passthrough` (PR 1) |
+| 7 | `mxfp4` (no in-tree name string — dev has no stamp feature) | `O*ceil(I/2)` bytes (e2m1 nibbles, 2 packed values/byte — same nibble packing as fmt=2/4) | 1 `f32` per **group** of `gs` inputs (`gs=32` for Kimi K3; host gate requires `gs % 8 == 0`) | **stable, upstream** — Kimi K3 native routed-expert tier, **Vulkan backend only** (`c/backend_vulkan.c`, `c/shaders/qmatmul.comp`); NOT a CPU/`QT` format — `qt_resolve_fmt` never returns 7 and the Metal backend refuses it | merged [#676](https://github.com/JustVugg/colibri/issues/676)/[#705](https://github.com/JustVugg/colibri/pull/705) |
+| **8** | `fp8-e4m3-b128` | `O*I` × 1 byte (`q8`, raw e4m3, byte-identical layout to fmt=1) | a **declared property**, not one fixed layout — see "Scale encoding is a declared property" below. **f32** (1 per 128×128 block, `ceil(O/128)*ceil(I/128)` entries) is IMPLEMENTED; **UE8M0** (1 byte/block, same block grid) is RECOGNIZED and refused by name, not yet implemented | **this PR pair** — CPU/Metal/repack/collision-refusal on `fmt7/fp8-passthrough`, this stamp+registry PR stacked on top; developed under the PRIVATE ORDINAL BLOCK as `fmt=100`; assigned fmt=7 by the maintainer on #524, renumbered to **fmt=8** after #705 merged claiming 7 for MXFP4 while this pair was open (see "ID assignment" below) | `fmt7/fp8-passthrough` (PR 1) |
 
-With fmt=6 and fmt=7 both assigned, the next free public ordinal is **8** —
-the (separate, future) entropy-tier proposal mentioned in earlier drafts of
-this document would naturally land there, but per the convention below it
-isn't claimed here; the maintainer assigns at merge.
+With fmt 0–8 all assigned, the next free public ordinal is **9** — per the
+convention below it isn't claimed here; an ID is only settled at merge.
 
-Sources for all rows (`c/quant.h`/`c/colibri.c` line numbers, branch
-`fmt7/stamp-registry-rev1` @ this commit, base dev `9baae9b`):
+**ID assignment.** An ordinal is claimed by the first merge into dev that
+ships it — there is no reservation mechanism, and an assignment made on an
+open PR or issue thread does not survive a competing merge (this pair's own
+format was assigned 7 on #524, then #705 merged MXFP4 as fmt=7 first, and
+this format moved to 8). Before picking an ordinal — or relying on one —
+proposers must scan both dev and the open PRs. This registry is the
+coordination point: a row lands here when the format lands in dev.
 
-- **fmt=0/1/2/3** — allocation policy: `qt_alloc`, `c/colibri.c:910`
+Sources for all rows (`c/quant.h`/`c/colibri.c` line numbers at this PR
+pair's current restack, base dev `292ed4c`):
+
+- **fmt=0/1/2/3** — allocation policy: `qt_alloc`, `c/colibri.c:1105`
   (`bits>=16→fmt=0`, `bits>=5→fmt=1`, `bits>=4→fmt=2`, else `fmt=3`).
   Kernels: `matmul_q` (`quant.h:105`, fmt=1), `matmul_i4` (`quant.h:125`,
   fmt=2), `matmul_i2` (`quant.h:251`, fmt=3); pack/quantize helpers
-  `quantize_rows` (`quant.h:871`, fmt=1) and `pack_int2` (`quant.h:923`,
-  fmt=3). Byte-count formulas: `qt_bytes`, `c/colibri.c:164`.
+  `quantize_rows` (`quant.h:928`, fmt=1) and `pack_int2` (`quant.h:980`,
+  fmt=3). Byte-count formulas: `qt_bytes`, `c/colibri.c:183`.
 - **fmt=4** (`int4-grouped`) — kernel `matmul_i4_grouped`, `quant.h:168`;
   group size `gs` is per-tensor, not fixed at 64 (contrast fmt=5). Byte-count:
-  `qt_bytes`'s `fmt==4` branch (inside `c/colibri.c:164`); scale-count split:
-  `qt_scale_bytes`, `c/colibri.c:223`.
+  `qt_bytes`'s `fmt==4` branch (inside `c/colibri.c:183`); scale-count split:
+  `qt_scale_bytes`, `c/colibri.c:263`.
 - **fmt=5** (`int3-g64`) — group size is fixed (`I3_GROUP=64`,
   `quant.h:293`; `I3_GBYTES=24`, `quant.h:294`); helpers `i3_groups`
   (`quant.h:295`), `i3_rowbytes` (`quant.h:296`); kernel `matmul_i3`
-  (`quant.h:302`); pack helper `pack_int3_g64` (`quant.h:899`). Allocation:
-  `qt_alloc`'s `bits==3` branch (inside `c/colibri.c:910`).
+  (`quant.h:354`); pack helper `pack_int3_g64` (`quant.h:956`). Allocation:
+  `qt_alloc`'s `bits==3` branch (inside `c/colibri.c:1105`).
 - **fmt=6** (`e8-iq3`) — upstream's merged code: format section header
-  precedes `quant.h:951`; constants `E8_QK=256` (`quant.h:951`),
-  `E8_SUB=32` (`quant.h:952`), `E8_BBYTES=98` (`quant.h:953`); row-byte
-  helpers `e8_blocks`/`e8_rowbytes` (`quant.h:954-955`); rotation contract
-  documented at `quant.h:1248` ("fmt=6 stores W@Q, so activations must be
+  precedes `quant.h:1008`; constants `E8_QK=256` (`quant.h:1008`),
+  `E8_SUB=32` (`quant.h:1009`), `E8_BBYTES=98` (`quant.h:1010`); row-byte
+  helpers `e8_blocks`/`e8_rowbytes` (`quant.h:1011-1012`); rotation contract
+  documented at `quant.h:1305` ("fmt=6 stores W@Q, so activations must be
   transformed before"). Loader discriminator, upstream form (dev, ns==4 tag
   check at the top of `qt_resolve_fmt`): this branch's SECOND DESIGN
-  LANDMINE comment (`qt_resolve_fmt`, `c/colibri.c:1161`) hardens that check
+  LANDMINE comment (`qt_resolve_fmt`, `c/colibri.c:1356`) hardens that check
   against the degenerate collisions below without changing any genuine-fmt=6
   outcome.
-- **fmt=7** (`fp8-e4m3-b128`, this branch) — decode table `E4M3_LUT`
-  (`quant.h:389`) / `e4m3_decode` (`quant.h:423`), block size
-  `FP8_BLOCK=128` (`quant.h:425`), kernel `matmul_fp8` (`quant.h:434`).
+- **fmt=7** (`mxfp4`, upstream's merged code) — Vulkan-only decode: shader
+  branch `p.fmt == 4 || p.fmt == 7` in `c/shaders/qmatmul.comp` (e2m1 nibble
+  decode, per-`gs`-group scale folded into the accumulation), host gate and
+  sizing in `c/backend_vulkan.c` (`upload_tensor`'s `fmt == 4 || fmt == 7`
+  allow-list, `gs % 8 == 0`). Wired for Kimi K3's routed-expert tier
+  (`c/kimi_k3.c`); no CPU (`quant.h`) or Metal kernel exists for it, and
+  `qt_resolve_fmt` has no byte-arithmetic branch that returns 7.
+- **fmt=8** (`fp8-e4m3-b128`, this branch) — decode table `E4M3_LUT`
+  (`quant.h:446`) / `e4m3_decode` (`quant.h:480`), block size
+  `FP8_BLOCK=128` (`quant.h:482`), kernel `matmul_fp8` (`quant.h:491`).
   Disambiguation from fmt=1 ("THE DESIGN LANDMINE" — the two formats'
   weight bytes are byte-identical and can only be told apart by
   scale-array geometry, which is ambiguous for some small shapes) and the
   fmt=6 collision ("SECOND DESIGN LANDMINE") both live in `qt_resolve_fmt`
-  (`c/colibri.c:1161`), which now also consults an optional `stamped_name`
+  (`c/colibri.c:1356`), which now also consults an optional `stamped_name`
   parameter (this PR): for the fmt=6 collision, a stamp resolves what an
-  absent stamp still refuses; for the fmt=1-vs-fmt=7 collision, an absent
+  absent stamp still refuses; for the fmt=1-vs-fmt=8 collision, an absent
   stamp already resolves to `int8-row` since the #528 INVERSION, and a
-  stamp's role there is instead letting a genuinely-stamped `fmt=7` tensor
+  stamp's role there is instead letting a genuinely-stamped `fmt=8` tensor
   override that default — see "The metadata stamp" below for the exact
   rule in both cases. FMT_NAMES table (name string <-> fmt int):
-  `c/colibri.c:1121`.
+  `c/colibri.c:1316`.
 
-## Scale encoding is a declared property (fmt=7)
+## Scale encoding is a declared property (fmt=8)
 
-fmt=7's byte layout for the WEIGHTS (`O*I` raw e4m3 bytes) is fixed. Its
+fmt=8's byte layout for the WEIGHTS (`O*I` raw e4m3 bytes) is fixed. Its
 scale sidecar's ENCODING is not — it's a property of the format that a
 container can carry one of several ways, the same identity ("fp8-e4m3-b128",
 128×128-block scaling) admitting more than one physical byte layout for the
@@ -125,7 +139,7 @@ scale array:
 - **f32** — 4 bytes/block, `ceil(O/128)*ceil(I/128)` `float`s. This is the
   value **this PR pair implements**: Z.ai's GLM-5.2-FP8 checkpoints ship
   `weight_scale_inv` this way, and `tools/repack_fp8_passthrough.py` /
-  `matmul_fp8` / the Metal `mm_gemv` fmt=7 branch all read and write it.
+  `matmul_fp8` / the Metal `mm_gemv` fmt=8 branch all read and write it.
 - **UE8M0** — 1 byte/block, a power-of-two exponent (dtype `F8_E8M0`), same
   `ceil(O/128)*ceil(I/128)` block grid. **DeepSeek-V4 ships this identical
   weight geometry (FP8 E4M3, 128×128 blocks) with UE8M0 scales instead of
@@ -150,7 +164,7 @@ scale array:
   `qt_resolve_fmt`'s own comments for the exact cases.
 
 Collision-checked against every other format's `ns` (scale-byte) arithmetic
-reachable from fmt=7's `nb==O*I` weight-byte branch: realistically distinct
+reachable from fmt=8's `nb==O*I` weight-byte branch: realistically distinct
 for GLM-sized shapes (`ceil(O/128)*ceil(I/128)` is orders of magnitude
 smaller than `O*4` for any real matrix), but not categorically distinct — the
 same small-`O` regime that produces the f32-vs-fmt=1 collision (THE DESIGN
@@ -165,13 +179,14 @@ these shapes; the discipline exists for untrusted containers.
 
 To avoid a repeat of the #465 collision, in-flight branches in this repo mint
 format ordinals from a **private block starting at 100**, never from the
-public 0-7 range, and never claim a specific public ordinal in a Feature
-Request. The convention (already applied twice: fmt=6's original proposal
-briefly held it before #465 claimed the number upstream, and this PR pair's
-own fmt=7 moved from the collided `fmt=6` to `fmt=100` and then graduated to
-the maintainer-assigned `fmt=7`):
+public 0-8 range, and never claim a specific public ordinal in a Feature
+Request. The convention (already applied twice — both times to this same
+format: its original proposal briefly held `fmt=6` before #465 claimed that
+number upstream, so it moved to `fmt=100`; it graduated to the
+maintainer-assigned `fmt=7` on #524, and then #705 merged MXFP4 as fmt=7
+first, moving it again to `fmt=8`):
 
-- **0-7 stays upstream's namespace.** A branch never assigns itself an
+- **0-8 stays upstream's namespace.** A branch never assigns itself an
   ordinal in that range, even provisionally.
 - **100+ is scratch space.** Any branch may claim the next unused 100+
   integer for local development and testing. Since the ordinal is a
@@ -179,7 +194,7 @@ the maintainer-assigned `fmt=7`):
   byte-arithmetic inference above), renumbering it later is a pure
   find-and-replace with zero on-disk or cross-version compatibility impact
   — nothing outside the binary's own compiled code ever observes the
-  number, as this branch's own fmt=100 → fmt=7 renumbering demonstrated.
+  number, as this branch's own fmt=100 → fmt=7 → fmt=8 renumberings demonstrated.
 - **A container never advertises a private ordinal.** What a container (or
   a Feature Request) advertises is the format's **NAME** — a string like
   `fp8-e4m3-b128` — never the integer. The real, public ordinal is assigned
@@ -211,13 +226,13 @@ reference implementation of this proposal:
   INVERSION already made the unstamped default (see above): inference alone
   decides, exactly as it does today for every container that predates this
   feature. What a stamp adds differs by which collision it's breaking a tie
-  on: for the **fmt=6-vs-fmt=7** collision (SECOND DESIGN LANDMINE), an
+  on: for the **fmt=6-vs-fmt=8** collision (SECOND DESIGN LANDMINE), an
   unstamped tensor at that shape still refuses unconditionally — a stamp
   naming the correct candidate **resolves** it instead, exactly as
-  originally designed. For the **fmt=1-vs-fmt=7** collision (THE DESIGN
+  originally designed. For the **fmt=1-vs-fmt=8** collision (THE DESIGN
   LANDMINE), the INVERSION means an unstamped tensor at that shape no
   longer refuses at all — a stamp's role there is letting a genuinely
-  stamped `fmt=7` tensor still be read as `fmt=7` (overriding the unstamped
+  stamped `fmt=8` tensor still be read as `fmt=8` (overriding the unstamped
   default of `int8-row`), not resolving a refusal that no longer happens.
   See `qt_resolve_fmt`'s own documentation for the exact rule in both
   cases, including the cases where even a correct stamp still can't resolve
@@ -312,7 +327,7 @@ assignment at all.
    it against `qt_resolve_fmt`'s existing disambiguation logic for
    collisions with formats already in the table. If the format's scale (or
    any other secondary array) can legitimately carry more than one physical
-   encoding — as fmt=7's now can — say so explicitly and declare which
+   encoding — as fmt=8's now can — say so explicitly and declare which
    encoding(s) the implementation actually reads and writes, so a future
    encoder for the same format NAME doesn't have to guess or fork off a new
    name unnecessarily.
@@ -323,7 +338,9 @@ assignment at all.
    branch's private 100+ number is find-and-replaced to it as part of
    landing — a mechanical, zero-risk step precisely because nothing on disk
    or in a released container ever depended on the private number, exactly
-   as fmt=7's `fmt=100 → fmt=7` renumbering was.
+   as this format's own `fmt=100 → fmt=7 → fmt=8` renumberings were. Note
+   that even a maintainer-assigned ordinal on an open PR is not settled
+   until MERGE (see "ID assignment" above).
 4. **Stamp containers via `__metadata__`** (see "The metadata stamp" above)
    so tooling that produces the format's containers can self-describe, and
    readers can verify-or-refuse rather than trust byte arithmetic alone.
@@ -338,8 +355,10 @@ assignment at all.
   standard stamp key, or is a different shape preferred (e.g. one key per
   tensor instead of one JSON blob) if this pattern is adopted project-wide?
 - ~~How should #465 and this branch's FP8 proposal be sequenced?~~ Resolved
-  by events: #465 merged 2026-07-21 as fmt=6, fmt=7 assigned to this
-  proposal 2026-07-22 on #524.
+  by events: #465 merged 2026-07-21 as fmt=6; fmt=7 assigned to this
+  proposal 2026-07-22 on #524, then claimed by #705's MXFP4 merge while
+  this pair was open — this proposal now lands as fmt=8 (see "ID
+  assignment" above).
 - ~~Should scale encoding be a hardcoded constant or a declared,
   per-container property?~~ Decided by the maintainer on #524, prompted by
   the DeepSeek-V4 datapoint above: it's a declared property. f32 is this PR

--- a/docs/FORMATS.md
+++ b/docs/FORMATS.md
@@ -203,6 +203,80 @@ reference implementation of this proposal:
   documentation for the exact rule, including the cases where even a
   correct stamp still can't resolve one (the UE8M0 corners above).
 
+### Non-retroactivity
+
+The stamp is a **forward convention**, not a migration path. It describes
+containers written *going forward* by a tool that has been updated to write
+`__metadata__["colibri.fmt"]` — it says nothing about, and does nothing to,
+containers that already exist. A pre-convention container (anything written
+before this feature existed — including every container this repo's own
+tooling has produced to date, and every upstream Z.ai/DeepSeek checkpoint)
+is simply **unstamped**: `st_fmt_stamp` returns `NULL` for every tensor in
+it, `qt_verify_fmt_stamp` is a no-op, and `qt_resolve_fmt` resolves it by
+byte arithmetic alone, exactly as it did before this PR. There is no
+in-place upgrade path, no "adopt the stamp on an existing container"
+tooling, and none is implied by anything in this document — the only way a
+container gains a stamp is to be produced (or re-produced) by a tool that
+writes one. An absent stamp is therefore never itself a signal that
+anything is wrong with a container; it is the default, expected state for
+everything that predates this convention (which, as of this PR, is
+everything).
+
+### Stamp-map scan bound
+
+`st_fmt_stamp_ingest` (`c/st.h`) caps the total number of stamped-tensor
+entries it will ingest across a container's shards at `ST_FMT_STAMP_MAX`
+(4096) and refuses loudly (`exit(1)`) if a container's combined
+`__metadata__["colibri.fmt"]` entries exceed it. This is a **cap, not a
+switch to a hash table**: stamps are a resident-tensor convention — a
+handful to a few hundred tensors per model (`q_a`/`q_b`/`kv_a`/`kv_b_proj`,
+`o_proj`, shared-expert and dense-MLP gate/up/down; see the resident-role
+census in `c/tools/fp8_collision_census.py`), **never** the tens of
+thousands of routed-expert tensors a large MoE checkpoint carries. A
+container whose combined stamp map exceeds 4096 entries is not using this
+convention as it's designed to be used — most plausibly a malformed or
+adversarial container trying to force an unbounded ingest allocation during
+header parsing, before any size/shape validation has even run. Refusing
+loudly at that bound is the same "untrusted container, refuse rather than
+guess" discipline `qt_resolve_fmt` applies everywhere else in this feature.
+
+### Discovery-time abort surface
+
+`st_fmt_stamp_ingest`'s `exit(1)` calls (a `colibri.fmt` value that isn't a
+JSON string, one that doesn't parse to a JSON object, an entry whose value
+isn't a string, or the 4096-entry cap above) all fire from inside
+`st_init_multi`'s shard-header-parse loop — i.e. at **container discovery
+time**, while the engine is still building its tensor index, before it has
+resolved a single tensor against the model's architecture or read one byte
+of weight data. This is a coarser-grained, EARLIER abort surface than
+`qt_resolve_fmt`/`qt_verify_fmt_stamp`'s own per-tensor refusals (which fire
+much later, once a *specific* tensor's `[O,I]` shape and stamp are both
+known during weight load): a malformed stamp anywhere in any shard aborts
+the *entire* model load immediately, before the user ever sees which layer
+or tensor was implicated. Operationally, a stamp-related `exit(1)` whose
+message names a *file* (shard path) rather than a *tensor* is this
+discovery-time surface; one that names a tensor is the later, per-tensor
+one.
+
+### Scope: `.qs`-backed tensors only
+
+The stamp lookup (`st_fmt_stamp`, called from `qt_from_disk`) is consulted
+**only** inside `qt_from_disk`'s `st_has(&m->S, name+".qs")` branch — i.e.
+only for a tensor that already carries a quantized `.qs` scale sidecar. A
+`colibri.fmt` entry naming some *other* tensor (a raw f32/bf16 weight, a
+norm, a router, embed/lm_head) is parsed and stored exactly like any other
+entry — `st_fmt_stamp_ingest` has no way to know, and does not check,
+whether the name it's ingesting belongs to a `.qs`-backed tensor — but it is
+then **silently ignored by design**: `qt_from_disk`'s plain f32/bf16 read
+path never calls `st_fmt_stamp` for it, so nothing ever consults that entry.
+This is intentional, not an oversight this document is patching over: the
+whole point of the stamp is to disambiguate a *byte-count* collision among
+quantized formats, and only a `.qs`-backed tensor can have one — stamping
+anything else has no failure mode to guard against, so the convention simply
+doesn't extend its verification there. A future stamping tool that writes
+`colibri.fmt` entries for non-`.qs` tensors would not break anything, but
+those entries would have no effect.
+
 This is offered as a **reference implementation**, not a mandate: a future
 public format registry could standardize the metadata key and stamp shape
 (`colibri.fmt` and its JSON-map-of-name convention are this PR's proposal,


### PR DESCRIPTION
*Authored by Fable 5 in Claude Code (We/our), analysis in partnership with @monotophic (me/my).*

Revised per review (2026-07-23): restacked on [#528](https://github.com/JustVugg/colibri/issues/528)'s inverted collision policy — see the comment of this date for the revision + evidence. Where this description says PR 1 "refuses unconditionally" at ambiguous shapes: that predates the inversion. Current behavior: unstamped fmt=1-vs-fmt=7 ambiguity resolves to the incumbent (fmt=1); the stamp lets a stamped fmt=7 at such a shape be read as fmt=7. The fmt=6-vs-fmt=7 (I=98) collision still refuses unstamped, and a stamp there still resolves it.

# fmt=7 registry + metadata stamp (TRUST-VERIFY-REFUSE)

Branch: `fmt7/stamp-registry`, stacked on `fmt7/fp8-passthrough` (PR 1 — CPU
path, repack tool, Metal kernel, collision/refusal logic; merge that one
first). This PR is the **convention discussion** the maintainer asked to keep
separate from the implementation: a self-describing container stamp, and the
in-repo format registry it's documented against. Nothing in PR 1's behavior
changes if this PR is never merged — PR 1 stands on its own: unstamped fmt=1-vs-fmt=7 ambiguity resolves to the incumbent, and the narrower fmt=6-vs-fmt=7 collision refuses. This PR's stamp confirms identity where arithmetic already decides, upgrades an ambiguous-shape fmt=7 from incumbent-resolution to its true format, and turns the remaining refusal into a resolution — it never turns a resolution into a refusal, and it never grants a decoder PR 1 doesn't have.

## Why a stamp, and why now

`QT.fmt` is a plain `int` with no enum declaration and no in-repo list of
what's taken — the process gap that let #465 (E8/IQ3) and this project's own
FP8 proposal both mint `fmt=6` independently, in the same week, with neither
author wrong. `docs/FORMATS.md` (this PR) is the lightweight fix for the
*ordinal* half of that gap: an in-repo table of what's assigned. The stamp is
the fix for the other half — a container's format *identity* shouldn't have
to depend on getting the *number* right by social coordination alone, and PR
1's own collision analysis shows byte arithmetic genuinely can't always
decide identity on its own (three structural ambiguities — one of them, 
fmt=1-vs-fmt=7, at a shape GLM-5.2 actually ships: o_proj [6144,16384], 
the very case the #528 review surfaced; the other two at shapes no real GLM 
tensor has.). A NAME-based stamp is the thing that can actually check a NAME 
against the bytes.

## TRUST-VERIFY-REFUSE

**Writer** (`tools/repack_fp8_passthrough.py`): every tensor it repacks
into the fp8-e4m3-b128 container gets an entry in the output shard's
safetensors `__metadata__["colibri.fmt"]` — a JSON-encoded map of exact
tensor name → format NAME string (`"fp8-e4m3-b128"`, never the internal
`fmt=7` ordinal, which stays a colibri.c-only enum value the container never
depends on). The stamp names the WEIGHT format only, deliberately — not a
scale encoding, since fmt=7 can legitimately carry more than one (see PR 1's
"scale encoding is a declared property"; more below).

**Reader** (`qt_verify_fmt_stamp` + `qt_resolve_fmt`'s new `stamped_name`
parameter, `colibri.c`):

- **Agree** → silent no-op. A stamped, unambiguous tensor loads exactly as
  it would unstamped.
- **Disagree**, or the stamp names a format this build doesn't recognize →
  refuse loudly (tensor name + both identities printed, `exit(1)`) — same
  "untrusted container" discipline `qt_resolve_fmt` already applies
  everywhere else.
- **Absent** → zero behavior change. Byte-arithmetic inference alone
  decides, exactly as before this feature existed — every container that
  predates this PR, or comes from a tool that doesn't stamp, is unaffected.
- **Resolves an ambiguity** (the bonus case): for PR 1's two collision
  points — fmt=1-vs-fmt=7 (THE DESIGN LANDMINE) and fmt=6-vs-fmt=7 at
  `I=98` (SECOND DESIGN LANDMINE) — a stamp naming exactly one live,
  *decodable* candidate resolves it directly instead of refusing. This is
  the one case where the stamp becomes load-bearing rather than a
  post-hoc cross-check: bytes alone are fundamentally ambiguous at these
  shapes, so the stamp is the only thing that CAN decide.

**What the stamp cannot do**: grant a decoder this build doesn't have. A
tensor whose scale sidecar is UE8M0-shaped still refuses even when
correctly stamped `"fp8-e4m3-b128"` — in the clean, non-colliding case (PR
1's straightforward "recognized but not implemented" refusal) and in both
places a stamp could otherwise resolve a collision (the small-`O`
fmt=1-vs-UE8M0 corner, and the `O∈(384,512], I=98` fmt=6-vs-UE8M0 corner).
The stamp confirms the WEIGHT format; the scale ENCODING is a separate,
declared property PR 1 only implements one value of. `qt_resolve_fmt`'s own
comments carry the exact case-by-case rule.

## The registry: `docs/FORMATS.md`

Adapted from the Feature Request draft already referenced on #524
(`upstream_contribution/FORMATS_registry_draft.md` on our side) into an
in-repo reference document:

- Every format 0–7 in one table: ordinal, name, weight-byte layout,
  scale-array layout, status, and the commit/PR it landed in.
- fmt=7's row status reads **"this PR pair"** — the ordinal is public and
  the implementation is what's under review, not a proposal anymore.
- A dedicated **"Scale encoding is a declared property (fmt=7)"** section
  documenting both values explicitly: f32 (implemented) and UE8M0
  (recognized, refused by name, not implemented — the DeepSeek-V4 finding
  credited to the maintainer's own #524 comment).
- The **PRIVATE ORDINAL BLOCK convention** (100+ scratch-ordinal range for
  in-flight branches) is kept intact, updated to cite fmt=7 itself as the
  convention's own worked example: minted `fmt=6` → collided with #465 →
  re-minted `fmt=100` → graduated to the maintainer-assigned `fmt=7`, a
  pure find-and-replace at every step, zero on-disk impact.
- **"How to add a format"** gains one bullet: a Feature Request should
  declare which scale/secondary-array *encoding(s)* it implements, not
  just its byte layout — the precedent this PR sets.
- **Open questions for maintainer review**, carried forward: is `100+` the
  right private-block convention (or would a different reserved range be
  preferred)? Should `colibri.fmt` become the project's standard stamp key,
  or is a different shape preferred? Two questions from earlier drafts are
  now resolved-by-events and marked as such (the #465 sequencing question;
  the scale-encoding-as-property question, decided by the maintainer on
  #524).

## Testing

`tests/test_fp8_load.c` Part D (four stamp outcomes: agreeing, mismatching,
unrecognized-name, absent — fork+waitpid for the two refusing cases) plus
stamped variants added to Part A2 (both collision directions resolve to the
stamped format; an unrelated stamp does NOT resolve; the UE8M0-scaled
corners of both collisions stay refused even when stamped
`"fp8-e4m3-b128"`) and Part A3 (the clean UE8M0 case stays refused when
stamped; the small-`O` UE8M0-vs-fmt=1 collision DOES resolve when stamped
`"int8-row"`, since that candidate is real and decodable).
`tests/test_fp8_repack.py` gains two cases (the stamp's tensor-name set
matches selection exactly; the real CLI's output carries a correct,
parseable stamp). `tests/test_fp8_e2e_repack_load.py` (inherited from PR 1)
now also asserts the real tool's stamp end-to-end against the real C loader.

- `make glm METAL=1` (clean rebuild): zero warnings, at both commits in
  this PR individually.
- `make test-c`: full C suite green, exit 0, at both commits — including
  the expanded `test_fp8_load` (Parts A–D) and `test_int3` (its 5
  `qt_resolve_fmt` call sites updated for the new `stamped_name`
  parameter, `NULL` throughout — this suite predates and is orthogonal to
  the stamp feature).
- `make test-python`: 154 tests, 10 skipped, 0 failures, exit 0.
- `make metal-test` under `COLI_METAL_RESSET=0` AND `=1`: both full
  green, exit 0 — unaffected by this PR (the stamp is a CPU-side,
  pre-Metal-dispatch concern; `qt_from_disk` resolves `fmt` before any
  Metal call, so the GPU kernel never sees a stamp either way).
- Per-commit gates verified in isolation, same discipline as PR 1.

## Durable vs. current-state (review map)

| | claim | durable / current-state | revisit trigger |
|---|---|---|---|
| 1 | TRUST-VERIFY-REFUSE discipline (agree=no-op, disagree=refuse, absent=unaffected) | **durable** | none — this is a correctness posture, not a calibration |
| 2 | A stamp resolves THE DESIGN LANDMINE and the SECOND DESIGN LANDMINE (f32-scaled candidates only) | **durable** | none — follows directly from PR 1's byte-arithmetic facts |
| 3 | `colibri.fmt` as the stamp's `__metadata__` key, JSON-map-of-name as its shape | **current-state / provisional** — explicitly flagged as this PR's proposal, open to revision, in `docs/FORMATS.md`'s own "Open questions" section | the maintainer (or a future project-wide stamp standard) choosing a different key/shape |
| 4 | `100+` PRIVATE ORDINAL BLOCK convention | **current-state / provisional** | maintainer endorsement, or a preferred alternative (negative values, a separate `fmt_ext` field) |
| 5 | A stamp cannot resolve any UE8M0-scaled collision (no decoder exists) | **current-state**, tied to PR 1's row 3 | the same UE8M0 decoder that would flip PR 1's refusal flips this PR's stamp-resolution too, once it exists |
| 6 | measurement coordinates | checkable | measured 2026-07-22, macOS 26.5.2 (build 25F84), Apple M5 Max (MacBook Pro, Mac17,7), engine base = PR 1 tip |

## Commits in this PR

1. `fp8: self-describing __metadata__ stamp, trust-verify-refuse reader` —
   `st.h`'s stamp ingest/lookup, `colibri.c`'s FMT_NAMES table and
   `qt_verify_fmt_stamp` (post-hoc verify only, not yet resolving), the
   repack tool's writer side, the two new `test_fp8_repack.py` cases.
2. `fp8: qt_resolve_fmt lets a metadata stamp resolve byte collisions` —
   threads `stamped_name` into `qt_resolve_fmt` itself, making both
   collision points stamp-resolvable (except the UE8M0 corners); updates
   the three routed-expert call sites and `test_int3.c`'s five direct
   calls for the new signature; `test_fp8_load.c` Parts A2/A3 gain
   stamped cases, new Part D.
3. `docs: add FORMATS.md, the quantized-format registry (fmt=6/fmt=7 +
   convention)` — this PR's own documentation, no code changes.
