### PR TITLE
engine: 107 KB of zeros were being shipped in .data — binary -22% (#527 lead)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,6 +37,14 @@ jobs:
       - name: make check
         run: make -C c check
 
+      # The Windows engine as this branch builds it. Small, and it makes an
+      # antivirus false-positive report (#527) verifiable on a PR instead of
+      # only after a release is tagged and published.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: colibri-windows-exe
+          path: c/colibri.exe
+
   macos:
     # clang; libomp for the threaded path (Makefile falls back to
     # single-threaded automatically if it's ever missing).

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -645,7 +645,13 @@ typedef struct {
     int on, armed, max;
     uint64_t prop, acc;
 } GrDraft;
-static GrDraft g_grd={.max=24};   /* process-level instance: PROMPT mode + run_serve keep using this */
+/* NO initializer: GrDraft is ~107 KB (Grammar's 1024 static rules + the walker), and any
+ * initializer — even `={.max=24}` — moves the whole struct from .bss into .data, writing
+ * 106,848 bytes of mostly zeros into every binary we ship (#527: the v1.1.0 Windows exe
+ * grew a 108 KB near-zero-entropy .data blob, which is also exactly the shape an antivirus
+ * ML heuristic reads as an unpacking buffer). Static storage is zero-initialized by the C
+ * standard; `max` is set in grammar_setup(), which runs before any read of it. */
+static GrDraft g_grd;             /* process-level instance: PROMPT mode + run_serve keep using this */
 static void couple_prefetch(Model *m, int layer, const int *idx, int Ke);
 static int g_looka=0;    /* LOOKA=1: misura (solo contatori, zero effetti) quanto il routing MoE
                           * e' predicibile IN ANTICIPO — la domanda che decide se un prefetch
@@ -4438,6 +4444,7 @@ static void grammar_teardown(GrDraft *g){
     int max=g->max; memset(g,0,sizeof(*g)); g->max=max;
 }
 static void grammar_setup(GrDraft *g, Tok *T){
+    g->max=24;                    /* was a static initializer; see g_grd's declaration (#527) */
     /* GRAMMAR=<file.gbnf> takes precedence; SCHEMA=<file.json> compiles a JSON-Schema
      * to GBNF. Both fail soft: the engine runs without a grammar, output unchanged. */
     const char *gf=getenv("GRAMMAR");


### PR DESCRIPTION
While triaging #527 (Defender flags the v1.1.0 Windows exe; v1.0.0 is clean **on the same definitions**, confirmed by the maintainer testing both tonight), I ran section forensics on the two published binaries:

| | v1.0.0 (clean) | v1.1.0 (flagged) |
|---|---|---|
| toolchain | GCC 16.1.0 Rev5 MSYS2 | identical |
| PE layout | 9 sections | identical |
| `.text` | 523,296 | 565,856 |
| **`.data`** | **1,840** | **108,752** |
| `.bss` | 959,856 | 853,232 |

`.bss` shrank by 106,624 and `.data` grew by 106,912 — one large object migrated between them. It is `g_grd`: `static GrDraft g_grd={.max=24};`. `GrDraft` is ~107 KB (Grammar's 1024 static rules + the PDA walker), and **any** initializer moves the whole struct from `.bss` into `.data`, writing 106,848 bytes of mostly zeros into every binary we ship. Measured entropy of that section: **0.083 bits/byte**.

Two consequences:

1. **It is waste on its own terms.** The Linux engine drops 474,904 → 368,016 bytes, **-22.5%**, with no behavioural change.
2. **It is a plausible AV trigger.** A large near-zero-entropy blob in a *writable* section is the classic shape of an unpacking buffer for a packed payload — the kind of feature PE ML classifiers weight heavily. Whether it is what tripped Defender is **not knowable from outside**; the model is a black box and file reputation (a hours-old unsigned binary) is likely also involved. This PR does not claim to fix #527 — it removes the strongest candidate and makes the hypothesis testable.

Fix: drop the initializer (static storage is zero-initialized by the C standard) and set `max` at the top of `grammar_setup()`, which both call sites run before any read — the only read is inside `if(g_grd.on)`.

`check.yml` now uploads the Windows exe as a CI artifact, so an antivirus report can be verified **on a PR** instead of only after a release is tagged and published. That is how we test this one: download the artifact from this PR's Windows job and scan it.

Verified: full C suite green; a grammar-loading run on `glm_tiny` is byte-identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)