### PR TITLE
Release v1.1.1 — Defender false positive was our bug: 107 KB of zeros in .data

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,6 +37,14 @@ jobs:
       - name: make check
         run: make -C c check
 
+      # The Windows engine as this branch builds it. Small, and it makes an
+      # antivirus false-positive report (#527) verifiable on a PR instead of
+      # only after a release is tagged and published.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: colibri-windows-exe
+          path: c/colibri.exe
+
   macos:
     # clang; libomp for the threaded path (Makefile falls back to
     # single-threaded automatically if it's ever missing).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG=${GITHUB_REF#refs/tags/}
+          # SHA256SUMS: lets anyone verify a download against what CI built. Named in
+          # the response to #527 (Defender ML false positive) — the checksums are the
+          # public, permanent form of the release-vs-artifact comparison done there.
+          (cd artifacts && sha256sum colibri-*) > artifacts/SHA256SUMS.txt
+          cat artifacts/SHA256SUMS.txt
           # Extract the latest version section from CHANGELOG
           NOTES=$(awk "/^## \\[${TAG#v}\\]/{found=1;next} /^## \\[/{if(found)exit} found{print}" CHANGELOG.md)
           if [ -z "$NOTES" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,54 @@
 All notable changes to colibrì are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.1.1] — 2026-07-23
+
+A same-day patch release. **Windows users on v1.1.0 should upgrade**: Microsoft
+Defender flags the v1.1.0 Windows binary, and the cause was ours.
+
+### Fixed
+
+- **107 KB of zeros were shipped inside every binary** (#527, #532) — and that is
+  what antivirus ML heuristics were reacting to. `static GrDraft g_grd={.max=24};`
+  looks harmless, but `GrDraft` is ~107 KB (the grammar's 1024 static rules plus the
+  PDA walker) and **any** initializer moves the whole struct out of `.bss` and into
+  `.data`, writing 106,848 bytes of near-zero-entropy data into the file — in a
+  *writable* section, which is the classic shape of an unpacking buffer for a packed
+  payload. Section forensics against v1.0.0 (clean on the same Defender definitions)
+  isolated it: identical toolchain, identical PE layout, `.data` 1,840 → 108,752
+  bytes. A Windows build with the fix scans clean where v1.1.0 does not. Every
+  platform's binary also gets smaller: the Linux engine drops 474,904 → 368,016
+  bytes, **-22.5%**.
+- **`python3 openai_server.py` was broken on a clean checkout** (#526) — the gateway
+  still looked for an engine named `glm` after the #391 rename. It resolves
+  `colibri`/`colibri.exe` first now, falling back to `glm` for older trees.
+  `coli serve` was unaffected. Spotted by @RDouglasSharp while debugging #488.
+
+### Added
+
+- **Anthropic Messages API** on `/v1/messages` (#343, #525) — clients that only speak
+  to Anthropic endpoints, Claude Code above all, now work against colibri with no
+  shim: same port, nothing to enable. It is a translation layer over the same
+  generation path, so tools, streaming and the KV cache behave exactly as on
+  `/v1/chat/completions`. Covers system prompts, `text`/`tool_use`/`tool_result`
+  blocks, `input_schema` tools, every `tool_choice` mode, the full named-event SSE
+  sequence with protocol `ping` keepalives, `stop_reason` mapping, extended thinking,
+  and `x-api-key` auth (`Bearer` still works). `stop_sequences`, `top_k` and non-text
+  blocks are refused explicitly rather than silently ignored.
+- **`SHA256SUMS.txt` published with every release** (#530) — verify a download is
+  exactly what CI built from the tagged source.
+- **The Windows engine is uploaded as a CI artifact** (#532) — an antivirus report can
+  now be verified on a pull request instead of only after a release is published.
+
+### Changed
+
+- **Docs: "Get started" now starts by getting the program** (#521). The README told
+  newcomers to download the 372 GB model *before* it told them how to obtain colibri —
+  and for Linux/macOS it never told them at all. New order: get colibri (prebuilt
+  archive or build from source) → get the model (372 GB stated up front) → run it.
+  The obsolete "rename the engine to `glm.exe`" step is gone; archives have shipped a
+  plainly-named `colibri.exe` since #508. Applied in all four languages.
+
 ## [1.1.0] — 2026-07-22
 
 A community release. 27 pull requests from more than 20 contributors, 216 commits since

--- a/c/cfse_pack.c
+++ b/c/cfse_pack.c
@@ -1,0 +1,167 @@
+/* cfse_pack — converte uno shard safetensors nel container entropy-coded CFSE
+ * (LOCALE, non pushato). E lo VERIFICA: --verify rilegge il convertito, lo
+ * decomprime e lo confronta byte-per-byte con l'originale.
+ *
+ * Formato d'uscita: safetensors normale, ma:
+ *   - __metadata__ contiene "cfse":"1"
+ *   - il payload di OGNI tensore e' un flusso CFS1 (fse_coli.h), col fallback
+ *     raw interno per i tensori incomprimibili
+ *   - data_offsets copre l'estensione COMPRESSA; la taglia raw resta
+ *     ricostruibile da shape x dtype (invariante safetensors) e dal campo
+ *     rawlen dentro CFS1 (doppio controllo in lettura)
+ *
+ * Uso:  cfse_pack in.safetensors out.safetensors        converte
+ *       cfse_pack --verify in.safetensors out.safetensors   certifica il convertito
+ *       cfse_pack --cert in.safetensors                     certificazione IN MEMORIA:
+ *         round-trip compress+decompress+memcmp di OGNI tensore, per-tensore via
+ *         fseek (RAM ~2x il tensore piu' grande, mai il file intero), ZERO scritture.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include "json.h"
+#include "fse_coli.h"
+
+static void *xmalloc(size_t n){ void *p=malloc(n?n:1); if(!p){fprintf(stderr,"OOM %zu\n",n);exit(1);} return p; }
+
+typedef struct { const char *name; const char *dtype; jval *shape; int64_t a,b; } TEnt;
+
+static int cmp_off(const void *x,const void *y){
+    const TEnt *A=x,*B=y; return (A->a>B->a)-(A->a<B->a);
+}
+
+static char *read_file(const char *path, size_t *n){
+    FILE *f=fopen(path,"rb"); if(!f){perror(path);exit(1);}
+    fseek(f,0,SEEK_END); long sz=ftell(f); fseek(f,0,SEEK_SET);
+    char *b=xmalloc((size_t)sz);
+    if(fread(b,1,(size_t)sz,f)!=(size_t)sz){perror("fread");exit(1);}
+    fclose(f); *n=(size_t)sz; return b;
+}
+
+static int parse_shard(char *buf, size_t n, jval **root_out, char **arena_out,
+                       TEnt **ents_out, int *nents_out, size_t *data_start_out){
+    if(n<8) return -1;
+    uint64_t hlen; memcpy(&hlen,buf,8);
+    if(hlen>n-8) return -1;
+    char *hdr=xmalloc(hlen+1); memcpy(hdr,buf+8,hlen); hdr[hlen]=0;
+    char *arena=NULL; jval *root=json_parse(hdr,&arena);
+    if(!root||root->t!=J_OBJ) return -1;
+    TEnt *ents=xmalloc(sizeof(TEnt)*(size_t)root->len); int ne=0;
+    for(int i=0;i<root->len;i++){
+        if(!strcmp(root->keys[i],"__metadata__")) continue;
+        jval *m=root->kids[i];
+        jval *dt=json_get(m,"dtype"), *off=json_get(m,"data_offsets"), *shp=json_get(m,"shape");
+        if(!dt||dt->t!=J_STR||!off||off->t!=J_ARR||off->len<2||!shp||shp->t!=J_ARR) return -1;
+        ents[ne].name=root->keys[i]; ents[ne].dtype=dt->str; ents[ne].shape=shp;
+        ents[ne].a=(int64_t)off->kids[0]->num; ents[ne].b=(int64_t)off->kids[1]->num; ne++;
+    }
+    qsort(ents,(size_t)ne,sizeof(TEnt),cmp_off);
+    *root_out=root; *arena_out=arena; *ents_out=ents; *nents_out=ne; *data_start_out=8+hlen;
+    (void)hdr;   /* le stringhe json puntano dentro hdr: resta vivo */
+    return 0;
+}
+
+static void emit_json_shape(FILE *o, jval *shp){
+    fputc('[',o);
+    for(int k=0;k<shp->len;k++) fprintf(o,"%s%lld",k?",":"",(long long)shp->kids[k]->num);
+    fputc(']',o);
+}
+
+static int do_cert(const char *inp){
+    FILE *f=fopen(inp,"rb"); if(!f){perror(inp);return 1;}
+    uint64_t hlen; if(fread(&hlen,8,1,f)!=1){fprintf(stderr,"%s: header\n",inp);return 1;}
+    char *hdr=xmalloc(hlen+1);
+    if(fread(hdr,1,hlen,f)!=hlen){fprintf(stderr,"%s: header troncato\n",inp);return 1;}
+    hdr[hlen]=0;
+    char *arena=NULL; jval *root=json_parse(hdr,&arena);
+    if(!root||root->t!=J_OBJ){fprintf(stderr,"%s: json\n",inp);return 1;}
+    size_t ds=8+hlen; int nt=0; int64_t rawtot=0,comptot=0;
+    for(int i=0;i<root->len;i++){
+        if(!strcmp(root->keys[i],"__metadata__")) continue;
+        jval *m=root->kids[i]; jval *off=json_get(m,"data_offsets");
+        if(!off||off->t!=J_ARR||off->len<2){fprintf(stderr,"%s: offsets %s\n",inp,root->keys[i]);return 1;}
+        size_t a=(size_t)off->kids[0]->num, b=(size_t)off->kids[1]->num, rn=b-a;
+        uint8_t *raw=xmalloc(rn?rn:1), *c=xmalloc(cfse_bound(rn)), *d=xmalloc(rn?rn:1);
+        if(fseek(f,(long)(ds+a),SEEK_SET)||fread(raw,1,rn,f)!=rn){fprintf(stderr,"%s: read %s\n",inp,root->keys[i]);return 1;}
+        size_t cs=cfse_compress(raw,rn,c,cfse_bound(rn)); size_t rl=0;
+        if(!cs||cfse_decompress(c,cs,d,rn,&rl)||rl!=rn||(rn&&memcmp(raw,d,rn))){
+            fprintf(stderr,"CERT FAIL: %s / %s\n",inp,root->keys[i]); return 1; }
+        free(raw);free(c);free(d); nt++; rawtot+=(int64_t)rn; comptot+=(int64_t)cs;
+    }
+    fclose(f);
+    printf("CERT OK %s: %d tensori | %.3fx\n",inp,nt,comptot?(double)rawtot/(double)comptot:1.0);
+    return 0;
+}
+
+int main(int argc,char**argv){
+    if(argc==3 && !strcmp(argv[1],"--cert")) return do_cert(argv[2]);
+    int verify = argc>1 && !strcmp(argv[1],"--verify");
+    if((verify&&argc!=4)||(!verify&&argc!=3)){
+        fprintf(stderr,"uso: %s in.st out.st | %s --verify in.st out.st\n",argv[0],argv[0]); return 2; }
+    const char *inp=argv[verify?2:1], *outp=argv[verify?3:2];
+
+    size_t inN; char *in=read_file(inp,&inN);
+    jval *root; char *arena; TEnt *E; int NE; size_t ds;
+    if(parse_shard(in,inN,&root,&arena,&E,&NE,&ds)){ fprintf(stderr,"%s: header non valido\n",inp); return 1; }
+
+    if(verify){
+        size_t oN; char *ob=read_file(outp,&oN);
+        jval *oroot; char *oarena; TEnt *OE; int ONE; size_t ods;
+        if(parse_shard(ob,oN,&oroot,&oarena,&OE,&ONE,&ods)){ fprintf(stderr,"%s: header non valido\n",outp); return 1; }
+        if(ONE!=NE){ fprintf(stderr,"VERIFY FAIL: %d vs %d tensori\n",NE,ONE); return 1; }
+        int64_t rawtot=0, comptot=0;
+        for(int i=0;i<NE;i++){
+            /* trova il gemello per nome (l'ordine per offset puo' differire) */
+            TEnt *o=NULL; for(int j=0;j<ONE;j++) if(!strcmp(OE[j].name,E[i].name)){o=&OE[j];break;}
+            if(!o){ fprintf(stderr,"VERIFY FAIL: manca %s\n",E[i].name); return 1; }
+            size_t rn=(size_t)(E[i].b-E[i].a), cn=(size_t)(o->b-o->a);
+            uint8_t *dec=xmalloc(rn); size_t rl=0;
+            if(cfse_decompress((uint8_t*)ob+ods+o->a,cn,dec,rn,&rl) || rl!=rn ||
+               memcmp(dec,in+ds+E[i].a,rn)){
+                fprintf(stderr,"VERIFY FAIL: %s non identico dopo il round-trip\n",E[i].name); return 1; }
+            free(dec); rawtot+=(int64_t)rn; comptot+=(int64_t)cn;
+        }
+        printf("VERIFY OK: %d tensori BIT-IDENTICI | %lld -> %lld byte (%.3fx)\n",
+               NE,(long long)rawtot,(long long)comptot,(double)rawtot/(double)comptot);
+        return 0;
+    }
+
+    /* --- conversione: comprimi ogni tensore, ricostruisci header con nuovi offset --- */
+    uint8_t **blob=xmalloc(sizeof(void*)*(size_t)NE); size_t *bn=xmalloc(sizeof(size_t)*(size_t)NE);
+    int64_t rawtot=0, comptot=0;
+    for(int i=0;i<NE;i++){
+        size_t rn=(size_t)(E[i].b-E[i].a);
+        blob[i]=xmalloc(cfse_bound(rn));
+        bn[i]=cfse_compress((uint8_t*)in+ds+E[i].a,rn,blob[i],cfse_bound(rn));
+        if(!bn[i]){ fprintf(stderr,"%s: compress fallita su %s\n",inp,E[i].name); return 1; }
+        /* paranoia in linea: round-trip IMMEDIATO prima di scrivere qualsiasi cosa */
+        uint8_t *chk=xmalloc(rn); size_t rl=0;
+        if(cfse_decompress(blob[i],bn[i],chk,rn,&rl)||rl!=rn||memcmp(chk,in+ds+E[i].a,rn)){
+            fprintf(stderr,"ABORT: self-check fallito su %s — nessun file scritto\n",E[i].name); return 1; }
+        free(chk); rawtot+=(int64_t)rn; comptot+=(int64_t)bn[i];
+    }
+
+    /* header JSON: __metadata__.cfse=1 + tensori con offset compressi (ordine originale) */
+    FILE *o=fopen(outp,"wb"); if(!o){perror(outp);return 1;}
+    fseek(o,8,SEEK_SET);                      /* hlen scritto alla fine */
+    long h0=ftell(o);
+    fprintf(o,"{\"__metadata__\":{\"cfse\":\"1\"}");
+    int64_t cur=0;
+    for(int i=0;i<NE;i++){
+        fprintf(o,",\"%s\":{\"dtype\":\"%s\",\"shape\":",E[i].name,E[i].dtype);
+        emit_json_shape(o,E[i].shape);
+        fprintf(o,",\"data_offsets\":[%lld,%lld]}",(long long)cur,(long long)(cur+(int64_t)bn[i]));
+        cur+=(int64_t)bn[i];
+    }
+    fputc('}',o);
+    long h1=ftell(o);
+    while((h1-h0)%8){ fputc(' ',o); h1++; }   /* padding a 8 per buona educazione */
+    uint64_t hlen=(uint64_t)(h1-h0);
+    for(int i=0;i<NE;i++) if(fwrite(blob[i],1,bn[i],o)!=bn[i]){perror("fwrite");return 1;}
+    fseek(o,0,SEEK_SET); fwrite(&hlen,8,1,o);
+    fclose(o);
+    printf("%s: %d tensori | %lld -> %lld byte (%.3fx)\n",
+           outp,NE,(long long)rawtot,(long long)comptot,(double)rawtot/(double)comptot);
+    return 0;
+}

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -645,7 +645,13 @@ typedef struct {
     int on, armed, max;
     uint64_t prop, acc;
 } GrDraft;
-static GrDraft g_grd={.max=24};   /* process-level instance: PROMPT mode + run_serve keep using this */
+/* NO initializer: GrDraft is ~107 KB (Grammar's 1024 static rules + the walker), and any
+ * initializer — even `={.max=24}` — moves the whole struct from .bss into .data, writing
+ * 106,848 bytes of mostly zeros into every binary we ship (#527: the v1.1.0 Windows exe
+ * grew a 108 KB near-zero-entropy .data blob, which is also exactly the shape an antivirus
+ * ML heuristic reads as an unpacking buffer). Static storage is zero-initialized by the C
+ * standard; `max` is set in grammar_setup(), which runs before any read of it. */
+static GrDraft g_grd;             /* process-level instance: PROMPT mode + run_serve keep using this */
 static void couple_prefetch(Model *m, int layer, const int *idx, int Ke);
 static int g_looka=0;    /* LOOKA=1: misura (solo contatori, zero effetti) quanto il routing MoE
                           * e' predicibile IN ANTICIPO — la domanda che decide se un prefetch
@@ -4438,6 +4444,7 @@ static void grammar_teardown(GrDraft *g){
     int max=g->max; memset(g,0,sizeof(*g)); g->max=max;
 }
 static void grammar_setup(GrDraft *g, Tok *T){
+    g->max=24;                    /* was a static initializer; see g_grd's declaration (#527) */
     /* GRAMMAR=<file.gbnf> takes precedence; SCHEMA=<file.json> compiles a JSON-Schema
      * to GBNF. Both fail soft: the engine runs without a grammar, output unchanged. */
     const char *gf=getenv("GRAMMAR");

--- a/c/fse_coli.h
+++ b/c/fse_coli.h
@@ -1,0 +1,173 @@
+/* fse_coli.h — entropy coder di casa per il container colibrì (LOCALE, non pushato).
+ *
+ * COSA: rANS statico ordine-0 sui NIBBLE (16 simboli), 2 stati interleaved,
+ * frequenze normalizzate a 4096 (12 bit), rinormalizzazione a byte.
+ * PERCHE' proprio questo: i pesi int4 sono statisticamente BIANCHI (misurato
+ * 2026-07-17: condizionali +0.000, MI tra tensori 0.0009-0.0018 bit), quindi
+ * l'ordine-0 e' GIA' ottimo — H=2.924 bit/peso, nessun modello di contesto puo'
+ * fare meglio, e' un teorema, non una scelta. Ratio atteso ~1.37x, verificato
+ * con zstd (stadio FSE) a 1.371x medio su expert reali.
+ *
+ * SICUREZZA (questo codice tocca i PESI: un bug qui corrompe l'output del
+ * modello in silenzio):
+ *  - il decoder NON legge mai oltre il buffer: ogni fetch e' bounds-checked;
+ *  - lo stato finale dei due rANS DEVE tornare a RANS_L: sigillo d'integrita'
+ *    che intercetta troncamenti e corruzioni (non e' un CRC, ma un flip nel
+ *    payload disallinea lo stato con probabilita' ~1-2^-46);
+ *  - la tabella delle frequenze deve sommare ESATTAMENTE a 4096 o si rifiuta;
+ *  - input incomprimibile -> modalita' raw (mai espandere oltre header);
+ *  - niente malloc: lavora nei buffer del chiamante.
+ *
+ * Formato: "CFS1" | mode u8 (0=raw 1=rans) | rawlen u32LE |
+ *          mode1: freq[16] u16LE | xA u32LE | xB u32LE | payload
+ *          (l'encoder scrive il payload ALL'INDIETRO: il decoder legge in avanti)
+ */
+#ifndef FSE_COLI_H
+#define FSE_COLI_H
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#define CFSE_PROB_BITS 12
+#define CFSE_PROB_SCALE (1u<<CFSE_PROB_BITS)
+#define CFSE_RANS_L (1u<<23)
+#define CFSE_HDR 9              /* magic4 + mode1 + rawlen4 */
+
+static inline size_t cfse_bound(size_t n){ return n + CFSE_HDR + 64; }
+
+/* conteggi -> frequenze che sommano ESATTAMENTE a 4096; ogni simbolo presente
+ * riceve almeno 1 (un simbolo con freq 0 presente nei dati = encode impossibile). */
+static int cfse_normalize(const uint64_t cnt[16], uint16_t freq[16]){
+    uint64_t tot=0; int used=0;
+    for(int i=0;i<16;i++){ tot+=cnt[i]; if(cnt[i]) used++; }
+    if(!tot) return -1;
+    uint32_t sum=0; int last=-1;
+    for(int i=0;i<16;i++){
+        if(!cnt[i]){ freq[i]=0; continue; }
+        uint64_t f=(cnt[i]*CFSE_PROB_SCALE)/tot; if(!f) f=1;
+        if(f>CFSE_PROB_SCALE-(unsigned)(used-1)) f=CFSE_PROB_SCALE-(used-1);
+        freq[i]=(uint16_t)f; sum+=(uint32_t)f; last=i;
+    }
+    /* aggiusta sul simbolo piu' frequente (mai sotto 1) */
+    int big=last; for(int i=0;i<16;i++) if(freq[i]>freq[big]) big=i;
+    int32_t diff=(int32_t)CFSE_PROB_SCALE-(int32_t)sum;
+    if((int32_t)freq[big]+diff<1) return -1;
+    freq[big]=(uint16_t)((int32_t)freq[big]+diff);
+    return 0;
+}
+
+/* comprime n byte (2n nibble). Ritorna i byte scritti, 0 = errore/cap corto. */
+static size_t cfse_compress(const uint8_t *in, size_t n, uint8_t *out, size_t cap){
+    if(cap<cfse_bound(n) || n>0xFFFFFFFFu) return 0;
+    memcpy(out,"CFS1",4); out[5]=(uint8_t)(n); out[6]=(uint8_t)(n>>8);
+    out[7]=(uint8_t)(n>>16); out[8]=(uint8_t)(n>>24);
+    if(n==0){ out[4]=0; return CFSE_HDR; }
+
+    uint64_t cnt[16]={0};
+    for(size_t i=0;i<n;i++){ cnt[in[i]&0xF]++; cnt[in[i]>>4]++; }
+    uint16_t freq[16]; uint32_t cum[17]={0};
+    if(cfse_normalize(cnt,freq)) goto raw;
+    for(int i=0;i<16;i++) cum[i+1]=cum[i]+freq[i];
+
+    {
+    /* encode all'indietro nel fondo di out; poi compattiamo dietro l'header */
+    uint8_t *base=out+CFSE_HDR+32;              /* header + tabella freq */
+    uint8_t *end=out+cap, *p=end;
+    uint32_t xA=CFSE_RANS_L, xB=CFSE_RANS_L;
+    size_t N=2*n;                                /* nibble totali */
+    for(size_t i=N; i-- > 0; ){                  /* i = N-1 .. 0 */
+        unsigned s = (i&1) ? (in[i>>1]>>4) : (in[i>>1]&0xF);
+        uint32_t *x = (i&1) ? &xB : &xA;         /* pari->A, dispari->B (specchio del decode) */
+        uint32_t f=freq[s];
+        uint32_t xmax=((CFSE_RANS_L>>CFSE_PROB_BITS)<<8)*f;
+        while(*x>=xmax){ if(p<=base) goto raw; *--p=(uint8_t)(*x&0xFF); *x>>=8; }
+        *x = ((*x/f)<<CFSE_PROB_BITS) + (*x%f) + cum[s];
+    }
+    /* flush: B poi A scrivendo all'indietro -> nel flusso in avanti arriva A poi B */
+    if(p-base<8) goto raw;
+    for(int k=3;k>=0;k--) *--p=(uint8_t)(xB>>(8*k));
+    for(int k=3;k>=0;k--) *--p=(uint8_t)(xA>>(8*k));
+    size_t payload=(size_t)(end-p);
+    if(CFSE_HDR+32+payload >= n+CFSE_HDR) goto raw;      /* non conviene */
+    out[4]=1;
+    for(int i=0;i<16;i++){ out[CFSE_HDR+2*i]=(uint8_t)freq[i]; out[CFSE_HDR+2*i+1]=(uint8_t)(freq[i]>>8); }
+    memmove(out+CFSE_HDR+32, p, payload);
+    return CFSE_HDR+32+payload;
+    }
+raw:
+    out[4]=0; memcpy(out+CFSE_HDR,in,n); return CFSE_HDR+n;
+}
+
+/* 0 = ok (rawlen scritto), -1 = input invalido/corrotto/troncato. MAI legge
+ * oltre in+nin ne' scrive oltre out+cap. */
+static int cfse_decompress(const uint8_t *in, size_t nin, uint8_t *out, size_t cap, size_t *rawlen){
+    if(nin<CFSE_HDR || memcmp(in,"CFS1",4)) return -1;
+    size_t n = (size_t)in[5] | ((size_t)in[6]<<8) | ((size_t)in[7]<<16) | ((size_t)in[8]<<24);
+    if(n>cap) return -1;
+    *rawlen=n;
+    if(in[4]==0){
+        if(nin != CFSE_HDR+n) return -1;
+        memcpy(out,in+CFSE_HDR,n); return 0;
+    }
+    if(in[4]!=1 || n==0 || nin<CFSE_HDR+32+8) return -1;
+
+    uint16_t freq[16]; uint32_t cum[17]={0}; uint32_t sum=0;
+    for(int i=0;i<16;i++){ freq[i]=(uint16_t)(in[CFSE_HDR+2*i] | (in[CFSE_HDR+2*i+1]<<8)); sum+=freq[i]; }
+    if(sum!=CFSE_PROB_SCALE) return -1;
+    for(int i=0;i<16;i++) cum[i+1]=cum[i]+freq[i];
+    /* tabella unica per slot: bias(12b)<<20 | freq(13b)<<7 | sym(4b) = 29 bit.
+     * ATTENZIONE al layout: freq puo' valere 4096 (caso un-solo-simbolo) e vuole
+     * 13 bit — messa a <<20 overflowava il uint32 e la batteria l'ha beccato.
+     * bias = slot - cum[sym]: il passo di decode diventa UNA lookup L1 (16 KB)
+     * invece di tre dipendenti (slot2sym -> freq[s] -> cum[s]). */
+    uint32_t tab[CFSE_PROB_SCALE];
+    for(int s=0;s<16;s++)
+        for(uint32_t slot=cum[s]; slot<cum[s+1]; slot++)
+            tab[slot] = ((slot-cum[s])<<20) | ((uint32_t)freq[s]<<7) | (uint32_t)s;
+
+    const uint8_t *p=in+CFSE_HDR+32, *end=in+nin;
+    /* gli stati sono nel flusso in LITTLE-endian (l'encoder li scrive
+     * all'indietro byte alto per primo -> in avanti escono LE) */
+    uint32_t xA=(uint32_t)p[0]|((uint32_t)p[1]<<8)|((uint32_t)p[2]<<16)|((uint32_t)p[3]<<24);
+    uint32_t xB=(uint32_t)p[4]|((uint32_t)p[5]<<8)|((uint32_t)p[6]<<16)|((uint32_t)p[7]<<24);
+    p+=8;
+    if(xA<CFSE_RANS_L || xB<CFSE_RANS_L) return -1;
+
+    /* Il ciclo caldo lavora a COPPIE (nibble pari->xA, dispari->xB) in registri.
+     * Ogni coppia consuma AL MASSIMO 4 byte di payload (2 per stato: da x>=2^11
+     * dopo il passo, due rinormalizzazioni a byte riportano sopra 2^23).
+     * Quindi: finche' restano >=4*coppie byte, si corre SENZA bounds-check per
+     * byte (la matematica lo garantisce, non la fortuna); la coda torna al
+     * percorso controllato byte-per-byte. Sicurezza invariata: stesso formato,
+     * stessi sigilli (p==end, stati==RANS_L), la batteria + ASAN lo certificano. */
+    uint32_t xa=xA, xb=xB;
+    size_t pairs=n, j=0;
+    while(j<pairs){
+        size_t safe = (size_t)(end-p)/4;             /* coppie garantite senza check */
+        size_t stop = j + (pairs-j < safe ? pairs-j : safe);
+        for(; j<stop; j++){
+            uint32_t ea = tab[xa & (CFSE_PROB_SCALE-1)];
+            xa = ((ea>>7)&0x1FFF)*(xa>>CFSE_PROB_BITS) + (ea>>20);
+            if(xa<CFSE_RANS_L){ xa=(xa<<8)|*p++; if(xa<CFSE_RANS_L) xa=(xa<<8)|*p++; }
+            uint32_t eb = tab[xb & (CFSE_PROB_SCALE-1)];
+            xb = ((eb>>7)&0x1FFF)*(xb>>CFSE_PROB_BITS) + (eb>>20);
+            if(xb<CFSE_RANS_L){ xb=(xb<<8)|*p++; if(xb<CFSE_RANS_L) xb=(xb<<8)|*p++; }
+            out[j] = (uint8_t)((ea&0xF) | ((eb&0xF)<<4));
+        }
+        if(j<pairs){                                  /* coda: percorso CONTROLLATO */
+            uint32_t ea = tab[xa & (CFSE_PROB_SCALE-1)];
+            xa = ((ea>>7)&0x1FFF)*(xa>>CFSE_PROB_BITS) + (ea>>20);
+            while(xa<CFSE_RANS_L){ if(p>=end) return -1; xa=(xa<<8)|*p++; }
+            uint32_t eb = tab[xb & (CFSE_PROB_SCALE-1)];
+            xb = ((eb>>7)&0x1FFF)*(xb>>CFSE_PROB_BITS) + (eb>>20);
+            while(xb<CFSE_RANS_L){ if(p>=end) return -1; xb=(xb<<8)|*p++; }
+            out[j] = (uint8_t)((ea&0xF) | ((eb&0xF)<<4));
+            j++;
+        }
+    }
+    xA=xa; xB=xb;                                    /* per i sigilli finali */
+    if(p!=end) return -1;                        /* byte avanzati = flusso non nostro */
+    if(xA!=CFSE_RANS_L || xB!=CFSE_RANS_L) return -1;  /* sigillo d'integrita' */
+    return 0;
+}
+#endif

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -437,6 +437,152 @@ def render_chat(messages, enable_thinking=False, reasoning_effort=None, tools=No
     return "".join(prompt)
 
 
+# ---- Anthropic Messages API (#343) --------------------------------------------------------
+# A translation layer, NOT a second engine path: /v1/messages rewrites an Anthropic-shaped
+# request into the exact OpenAI-shaped body the existing path already validates, so prompt
+# rendering, scheduling, generation and tool parsing stay single-sourced. Only the request
+# translation and the response/SSE shapes are new. Claude Code is the reference client.
+
+def _anthropic_block_text(blocks, param):
+    """Text out of an Anthropic content array (tool_result content is the same shape)."""
+    if isinstance(blocks, str):
+        return blocks
+    if not isinstance(blocks, list):
+        raise APIError(400, "Content must be a string or an array of blocks.", param)
+    parts = []
+    for index, block in enumerate(blocks):
+        if not isinstance(block, dict) or block.get("type") != "text":
+            raise APIError(400, "Colibri currently supports text blocks only here.",
+                           f"{param}.{index}", "unsupported_content_type")
+        if not isinstance(block.get("text"), str):
+            raise APIError(400, "Text blocks require a string `text` field.", f"{param}.{index}.text")
+        parts.append(block["text"])
+    return "".join(parts)
+
+
+def anthropic_to_openai(body):
+    """Anthropic request -> (messages, tools, tool_choice) in OpenAI shape."""
+    messages = []
+    system = body.get("system")
+    if isinstance(system, str):
+        if system:
+            messages.append({"role": "system", "content": system})
+    elif isinstance(system, list):
+        text = _anthropic_block_text(system, "system")
+        if text:
+            messages.append({"role": "system", "content": text})
+    elif system is not None:
+        raise APIError(400, "`system` must be a string or an array of text blocks.", "system")
+
+    raw = body.get("messages")
+    if not isinstance(raw, list) or not raw:
+        raise APIError(400, "`messages` must be a non-empty array.", "messages")
+    for index, message in enumerate(raw):
+        if not isinstance(message, dict):
+            raise APIError(400, "Each message must be an object.", f"messages.{index}")
+        role = message.get("role")
+        if role not in ("user", "assistant"):
+            raise APIError(400, f"Unsupported message role: {role!r}. Anthropic messages are "
+                           "`user` or `assistant`; a system prompt goes in the top-level `system`.",
+                           f"messages.{index}.role", "unsupported_role")
+        content = message.get("content")
+        if isinstance(content, str):
+            messages.append({"role": role, "content": content})
+            continue
+        if not isinstance(content, list):
+            raise APIError(400, "Message content must be a string or an array of blocks.",
+                           f"messages.{index}.content")
+        texts, calls, results = [], [], []
+        for j, block in enumerate(content):
+            where = f"messages.{index}.content.{j}"
+            if not isinstance(block, dict):
+                raise APIError(400, "Each content block must be an object.", where)
+            kind = block.get("type")
+            if kind == "text":
+                if not isinstance(block.get("text"), str):
+                    raise APIError(400, "Text blocks require a string `text` field.", f"{where}.text")
+                texts.append(block["text"])
+            elif kind == "tool_use":
+                name = block.get("name")
+                if not isinstance(name, str) or not name:
+                    raise APIError(400, "`tool_use` blocks require a string `name`.", f"{where}.name")
+                arguments = block.get("input")
+                if arguments is None:
+                    arguments = {}
+                if not isinstance(arguments, dict):
+                    raise APIError(400, "`tool_use.input` must be an object.", f"{where}.input")
+                calls.append({"id": block.get("id") or ("toolu_" + uuid.uuid4().hex[:24]),
+                              "type": "function",
+                              "function": {"name": name,
+                                           "arguments": json.dumps(arguments, ensure_ascii=False)}})
+            elif kind == "tool_result":
+                results.append({"role": "tool",
+                                "tool_call_id": block.get("tool_use_id") or "",
+                                "content": _anthropic_block_text(block.get("content", ""),
+                                                                 f"{where}.content")})
+            else:
+                raise APIError(400, "Colibri supports `text`, `tool_use` and `tool_result` "
+                               "content blocks only.", f"{where}.type", "unsupported_content_type")
+        # tool results precede the user's own text: they answer the previous assistant turn
+        messages.extend(results)
+        text = "".join(texts)
+        if role == "assistant":
+            if text or calls:
+                entry = {"role": "assistant", "content": text or None}
+                if calls:
+                    entry["tool_calls"] = calls
+                messages.append(entry)
+        elif text or not results:
+            messages.append({"role": "user", "content": text})
+    return messages
+
+
+def anthropic_tools(body):
+    """Anthropic tools/tool_choice -> OpenAI shape (validated downstream by generation_options)."""
+    raw = body.get("tools")
+    if raw is None:
+        tools = None
+    elif not isinstance(raw, list):
+        raise APIError(400, "`tools` must be an array.", "tools")
+    else:
+        tools = []
+        for index, tool in enumerate(raw):
+            if not isinstance(tool, dict):
+                raise APIError(400, "Each tool must be an object.", f"tools.{index}")
+            name = tool.get("name")
+            if not isinstance(name, str) or not name:
+                raise APIError(400, "Each tool requires a string `name`.", f"tools.{index}.name")
+            schema = tool.get("input_schema")
+            if schema is not None and not isinstance(schema, dict):
+                raise APIError(400, "`input_schema` must be an object.", f"tools.{index}.input_schema")
+            function = {"name": name, "parameters": schema or {"type": "object", "properties": {}}}
+            if isinstance(tool.get("description"), str):
+                function["description"] = tool["description"]
+            tools.append({"type": "function", "function": function})
+        tools = tools or None
+
+    choice = body.get("tool_choice")
+    if choice is None:
+        return tools, None
+    if not isinstance(choice, dict):
+        raise APIError(400, "`tool_choice` must be an object.", "tool_choice")
+    kind = choice.get("type")
+    if kind == "auto":
+        return tools, "auto"
+    if kind == "any":
+        return tools, "required"
+    if kind == "none":
+        return tools, "none"
+    if kind == "tool":
+        name = choice.get("name")
+        if not isinstance(name, str) or not name:
+            raise APIError(400, "`tool_choice.name` is required when type is `tool`.",
+                           "tool_choice.name")
+        return tools, {"type": "function", "function": {"name": name}}
+    raise APIError(400, "`tool_choice.type` must be auto, any, none, or tool.", "tool_choice.type",
+                   "unsupported_value")
+
+
 # Generic whitespace-tolerant JSON grammar for response_format {"type": "json_object"}.
 # Draft-source semantics: positions with one legal byte draft; jws points just keep
 # the walker alive through the model's own spacing (see docs/grammar-draft.md).
@@ -856,7 +1002,7 @@ class APIHandler(BaseHTTPRequestHandler):
             return
         self.send_header("Access-Control-Allow-Origin", "*" if "*" in self.server.cors_origins else origin)
         self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "Authorization, Content-Type")
+        self.send_header("Access-Control-Allow-Headers", "Authorization, Content-Type, x-api-key, anthropic-version")
         self.send_header("Access-Control-Expose-Headers",
                          "x-request-id, x-colibri-queue-wait-ms, Retry-After")
         self.send_header("Access-Control-Max-Age", "600")
@@ -866,12 +1012,16 @@ class APIHandler(BaseHTTPRequestHandler):
     LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1", ""}
 
     def _is_authed(self):
-        """True if no key is configured, or a correct Bearer key was presented."""
+        """True if no key is configured, or a correct key was presented. Anthropic clients
+        (Claude Code, the Anthropic SDKs) authenticate with `x-api-key`, not `Bearer` — both
+        are accepted, and both are compared in constant time."""
         if not self.server.api_key:
             return True
         import hmac
-        provided = self.headers.get("Authorization", "")
-        return hmac.compare_digest(provided, f"Bearer {self.server.api_key}")
+        if hmac.compare_digest(self.headers.get("Authorization", ""),
+                               f"Bearer {self.server.api_key}"):
+            return True
+        return hmac.compare_digest(self.headers.get("x-api-key", ""), self.server.api_key)
 
     def require_auth(self):
         if not self._is_authed():
@@ -1023,10 +1173,12 @@ class APIHandler(BaseHTTPRequestHandler):
                 self.chat_completion(body, request_id)
             elif path == "/v1/completions":
                 self.completion(body, request_id)
+            elif path == "/v1/messages":
+                self.anthropic_messages(body, request_id)
             else:
                 raise APIError(404, "Not found.", None, "not_found")
         except APIError as error:
-            self.send_json(error.status, error_object(error), request_id, error.headers)
+            self.send_json(error.status, self.error_body(error), request_id, error.headers)
         except ClientCancelled:
             pass
         except (BrokenPipeError, ConnectionResetError):
@@ -1036,9 +1188,15 @@ class APIHandler(BaseHTTPRequestHandler):
             api_error = APIError(500, "The colibri engine failed to process the request.",
                                  None, "engine_error", "server_error")
             try:
-                self.send_json(500, error_object(api_error), request_id)
+                self.send_json(500, self.error_body(api_error), request_id)
             except OSError:
                 pass
+
+    def error_body(self, error):
+        """Anthropic clients parse a different error envelope; the OpenAI one is unchanged."""
+        if urlsplit(self.path).path != "/v1/messages":
+            return error_object(error)
+        return {"type": "error", "error": {"type": error.error_type, "message": error.message}}
 
     def generation(self, body, prompt, request_id, chat, tools=None, tool_choice=None):
         # COLI_DEBUG tees the engine transaction to stderr: 1 = decoded output stream only,
@@ -1260,6 +1418,189 @@ class APIHandler(BaseHTTPRequestHandler):
         prompt = render_chat(body.get("messages"), enable_thinking, reasoning_effort, tools,
                              tool_choice)
         self.generation(body, prompt, request_id, True, tools, tool_choice)
+
+    # ---- Anthropic /v1/messages (#343) ----------------------------------------------------
+    ANTHROPIC_STOP = {"stop": "end_turn", "length": "max_tokens", "tool_calls": "tool_use"}
+
+    def anthropic_messages(self, body, request_id):
+        for unsupported, why in (("stop_sequences", "custom stop sequences"),
+                                 ("top_k", "top-k sampling")):
+            if body.get(unsupported) not in (None, [], ""):
+                raise APIError(400, f"Colibri does not support `{unsupported}` ({why}) yet.",
+                               unsupported, "unsupported_value")
+        messages = anthropic_to_openai(body)
+        tools, tool_choice = anthropic_tools(body)
+        thinking = body.get("thinking")
+        if thinking is not None and not isinstance(thinking, dict):
+            raise APIError(400, "`thinking` must be an object.", "thinking")
+        enable_thinking = bool(thinking and thinking.get("type") == "enabled")
+        if not enable_thinking and thinking is None and os.environ.get("COLI_THINK", "0") == "1":
+            enable_thinking = True
+        if body.get("max_tokens") is None:
+            raise APIError(400, "`max_tokens` is required.", "max_tokens")
+        # Reuse the OpenAI path's own validation by handing it an equivalent body.
+        translated = {"messages": messages, "max_tokens": body.get("max_tokens"),
+                      "temperature": body.get("temperature"), "top_p": body.get("top_p"),
+                      "stream": body.get("stream", False), "cache_slot": body.get("cache_slot")}
+        if tools:
+            translated["tools"] = tools
+        if tool_choice is not None:
+            translated["tool_choice"] = tool_choice
+        if tool_choice == "none":
+            tools = None
+        prompt = render_chat(messages, enable_thinking, "high" if enable_thinking else None,
+                             tools, tool_choice)
+        self.anthropic_generation(translated, prompt, request_id, tools)
+
+    def anthropic_generation(self, body, prompt, request_id, tools):
+        maximum, temperature, top_p, grammar = generation_options(body, self.server.max_tokens)
+        cache_slot = body.get("cache_slot")
+        if (cache_slot is not None and
+                (isinstance(cache_slot, bool) or not isinstance(cache_slot, int) or
+                 not 0 <= cache_slot < self.server.kv_slots)):
+            raise APIError(400, f"`cache_slot` must be an integer between 0 and {self.server.kv_slots - 1}.",
+                           "cache_slot")
+        stream = body.get("stream", False)
+        if not isinstance(stream, bool):
+            raise APIError(400, "`stream` must be a boolean.", "stream")
+        message_id = "msg_" + uuid.uuid4().hex[:24]
+
+        def blocks_and_stop(text, stats):
+            """Split a finished reply into Anthropic content blocks + stop_reason."""
+            calls = []
+            if tools:
+                text, calls = parse_tool_calls(text, tools)
+            content = []
+            if text:
+                content.append({"type": "text", "text": text})
+            for call in calls:
+                function = call["function"]
+                try:
+                    arguments = json.loads(function["arguments"])
+                except (json.JSONDecodeError, TypeError):
+                    arguments = {}
+                content.append({"type": "tool_use", "id": call["id"],
+                                "name": function["name"], "input": arguments})
+            reason = "tool_calls" if calls else ("length" if stats["length_limited"] else "stop")
+            return content, self.ANTHROPIC_STOP[reason]
+
+        with self.server.scheduler.admit(self.client_disconnected, cache_slot) as admission:
+            queue_wait, cache_slot = admission
+            queue_headers = {"x-colibri-queue-wait-ms": str(round(queue_wait * 1000))}
+            if not stream:
+                output = []
+                stats = self.server.engine.generate(
+                    prompt, maximum, temperature, top_p, output.append, cache_slot,
+                    self.client_disconnected, grammar=grammar)
+                content, stop_reason = blocks_and_stop("".join(output), stats)
+                self.send_json(200, {
+                    "id": message_id, "type": "message", "role": "assistant",
+                    "model": self.server.model_id, "content": content,
+                    "stop_reason": stop_reason, "stop_sequence": None,
+                    "usage": {"input_tokens": stats["prompt_tokens"],
+                              "output_tokens": stats["completion_tokens"]}},
+                    request_id, queue_headers)
+                return
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("X-Accel-Buffering", "no")
+            self.send_header("x-request-id", request_id)
+            for name, value in queue_headers.items():
+                self.send_header(name, value)
+            self.send_cors_headers()
+            self.end_headers()
+            connected = [True]
+            write_lock = threading.Lock()
+            last_write = [time.time()]
+            ka_stop = threading.Event()
+
+            def send_event(name, payload):
+                if not connected[0]:
+                    return
+                data = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+                with write_lock:
+                    try:
+                        self.wfile.write(f"event: {name}\ndata: {data}\n\n".encode())
+                        self.wfile.flush()
+                        last_write[0] = time.time()
+                    except OSError:
+                        connected[0] = False
+
+            # Anthropic has a first-class keepalive event, so the cold prefill (minutes) does
+            # not need the OpenAI path's reasoning-delta trick: `ping` is in the protocol.
+            def keepalive():
+                while not ka_stop.wait(1.0):
+                    if not connected[0]:
+                        return
+                    if time.time() - last_write[0] >= 10.0:
+                        send_event("ping", {"type": "ping"})
+
+            send_event("message_start", {"type": "message_start", "message": {
+                "id": message_id, "type": "message", "role": "assistant",
+                "model": self.server.model_id, "content": [], "stop_reason": None,
+                "stop_sequence": None, "usage": {"input_tokens": 0, "output_tokens": 0}}})
+            send_event("content_block_start", {"type": "content_block_start", "index": 0,
+                                               "content_block": {"type": "text", "text": ""}})
+            ka_thread = threading.Thread(target=keepalive, daemon=True)
+            ka_thread.start()
+
+            raw = []
+            state = {"buf": "", "in_tool": False}
+            hold = len(BOX_START) - 1
+
+            def on_text(chunk):
+                raw.append(chunk)
+                if not tools:
+                    send_event("content_block_delta", {"type": "content_block_delta", "index": 0,
+                        "delta": {"type": "text_delta", "text": chunk}})
+                    return
+                if state["in_tool"]:
+                    return                       # tool markers never reach the client as text
+                state["buf"] += chunk
+                cut = state["buf"].find(BOX_START)
+                if cut >= 0:
+                    if cut:
+                        send_event("content_block_delta", {"type": "content_block_delta", "index": 0,
+                            "delta": {"type": "text_delta", "text": state["buf"][:cut]}})
+                    state["buf"] = ""
+                    state["in_tool"] = True
+                    return
+                flush = max(0, len(state["buf"]) - hold)
+                if flush:
+                    send_event("content_block_delta", {"type": "content_block_delta", "index": 0,
+                        "delta": {"type": "text_delta", "text": state["buf"][:flush]}})
+                    state["buf"] = state["buf"][flush:]
+
+            stats = self.server.engine.generate(
+                prompt, maximum, temperature, top_p, on_text, cache_slot,
+                lambda: not connected[0], grammar=grammar)
+            if tools and not state["in_tool"] and state["buf"]:
+                send_event("content_block_delta", {"type": "content_block_delta", "index": 0,
+                    "delta": {"type": "text_delta", "text": state["buf"]}})
+            ka_stop.set()
+            ka_thread.join(timeout=2)
+            send_event("content_block_stop", {"type": "content_block_stop", "index": 0})
+
+            content, stop_reason = blocks_and_stop("".join(raw), stats)
+            index = 1
+            for block in content:
+                if block["type"] != "tool_use":
+                    continue                     # text already streamed as block 0
+                send_event("content_block_start", {"type": "content_block_start", "index": index,
+                    "content_block": {"type": "tool_use", "id": block["id"],
+                                      "name": block["name"], "input": {}}})
+                send_event("content_block_delta", {"type": "content_block_delta", "index": index,
+                    "delta": {"type": "input_json_delta",
+                              "partial_json": json.dumps(block["input"], ensure_ascii=False)}})
+                send_event("content_block_stop", {"type": "content_block_stop", "index": index})
+                index += 1
+            send_event("message_delta", {"type": "message_delta",
+                "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+                "usage": {"output_tokens": stats["completion_tokens"]}})
+            send_event("message_stop", {"type": "message_stop"})
+            self.close_connection = True
 
     def completion(self, body, request_id):
         prompt = body.get("prompt")

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -24,6 +24,18 @@ from urllib.parse import unquote, urlsplit
 
 
 HERE = Path(__file__).resolve().parent
+
+
+def default_engine():
+    """The engine next to this file. Since #391 it is built as `colibri`; `glm` stays as a
+    fallback so an old tree (or an old hand-built binary) still starts. Reported by
+    @RDouglasSharp in #488: the default still said `glm`, so `python3 openai_server.py`
+    on a clean checkout looked for a file the build no longer produces."""
+    for name in ("colibri", "colibri.exe", "glm", "glm.exe"):
+        candidate = HERE / name
+        if candidate.exists():
+            return candidate
+    return HERE / "colibri"
 END = b"\x01\x01END\x01\x01\n"
 READY = b"\x01\x01READY\x01\x01\n"
 MAX_BODY = 4 << 20
@@ -1612,8 +1624,10 @@ class APIHandler(BaseHTTPRequestHandler):
 
 
 def serve(model, host="127.0.0.1", port=8000, model_id="glm-5.2-colibri", api_key=None,
-          cap=8, max_tokens=1024, engine=HERE / "glm", env=None, cors_origins=None,
+          cap=8, max_tokens=1024, engine=None, env=None, cors_origins=None,
           max_queue=8, queue_timeout=300, kv_slots=1):
+    if engine is None:
+        engine = default_engine()
     if not 1 <= max_tokens:
         raise ValueError("max_tokens must be positive")
     if not 1 <= port <= 65535:
@@ -1658,7 +1672,7 @@ def serve(model, host="127.0.0.1", port=8000, model_id="glm-5.2-colibri", api_ke
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model", default=os.environ.get("COLI_MODEL"), required=not os.environ.get("COLI_MODEL"))
-    parser.add_argument("--engine", default=str(HERE / "glm"))
+    parser.add_argument("--engine", default=str(default_engine()))
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--model-id", default=os.environ.get("COLI_MODEL_ID", "glm-5.2-colibri"))

--- a/c/tests/test_anthropic_messages.py
+++ b/c/tests/test_anthropic_messages.py
@@ -1,0 +1,220 @@
+"""Anthropic Messages API (#343): /v1/messages as a translation layer over the same
+generation path the OpenAI endpoint uses.
+
+The point of these tests is the *contract a real Anthropic client depends on* — Claude Code
+is the reference client from the issue — not merely that the handler returns 200:
+  - request translation: system prompt, content blocks, tool_use/tool_result round trips;
+  - response shape: content blocks, stop_reason, usage with Anthropic's own field names;
+  - the SSE event sequence, in order, with named events (a client that keys off
+    `event:` names breaks on a data-only stream even if the JSON is right);
+  - `x-api-key` auth, which is how Anthropic clients authenticate — Bearer keeps working;
+  - the Anthropic error envelope, which is not the OpenAI one.
+"""
+import json
+import threading
+import unittest
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from openai_server import (APIServer, anthropic_to_openai, anthropic_tools, APIError)
+
+
+class FakeEngine:
+    """Emits whatever `script` says, so a test can drive tool syntax through the parser."""
+    def __init__(self, script=("Hé", "llo"), length_limited=False):
+        self.script = script
+        self.length_limited = length_limited
+        self.prompts = []
+
+    def generate(self, prompt, maximum, temperature, top_p, on_text, cache_slot=0,
+                 cancelled=None, grammar=None):
+        self.prompts.append(prompt)
+        for chunk in self.script:
+            on_text(chunk)
+        return {"prompt_tokens": 11, "completion_tokens": 3,
+                "length_limited": self.length_limited}
+
+
+class TranslationTest(unittest.TestCase):
+    def test_system_and_blocks_become_openai_messages(self):
+        messages = anthropic_to_openai({
+            "system": [{"type": "text", "text": "Be brief."}],
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}],
+        })
+        self.assertEqual(messages, [{"role": "system", "content": "Be brief."},
+                                    {"role": "user", "content": "Hi"}])
+
+    def test_tool_use_and_result_round_trip(self):
+        messages = anthropic_to_openai({"messages": [
+            {"role": "user", "content": "weather?"},
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "toolu_1", "name": "get_weather",
+                 "input": {"city": "Rome"}}]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_1", "content": "18C"},
+                {"type": "text", "text": "and tomorrow?"}]},
+        ]})
+        self.assertEqual(messages[1]["tool_calls"][0]["function"]["name"], "get_weather")
+        self.assertEqual(json.loads(messages[1]["tool_calls"][0]["function"]["arguments"]),
+                         {"city": "Rome"})
+        # the tool result must precede the user's new question, or the model reads the
+        # answer as arriving after a question it has not been asked yet
+        self.assertEqual([m["role"] for m in messages[2:]], ["tool", "user"])
+        self.assertEqual(messages[2]["content"], "18C")
+        self.assertEqual(messages[3]["content"], "and tomorrow?")
+
+    def test_tool_result_only_message_adds_no_empty_user_turn(self):
+        messages = anthropic_to_openai({"messages": [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "t1", "name": "f", "input": {}}]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": "done"}]},
+        ]})
+        self.assertEqual([m["role"] for m in messages], ["user", "assistant", "tool"])
+
+    def test_tools_and_choice_translate(self):
+        tools, choice = anthropic_tools({
+            "tools": [{"name": "f", "description": "d",
+                       "input_schema": {"type": "object", "properties": {"x": {"type": "string"}}}}],
+            "tool_choice": {"type": "tool", "name": "f"}})
+        self.assertEqual(tools[0]["type"], "function")
+        self.assertEqual(tools[0]["function"]["parameters"]["properties"], {"x": {"type": "string"}})
+        self.assertEqual(choice, {"type": "function", "function": {"name": "f"}})
+        self.assertEqual(anthropic_tools({"tool_choice": {"type": "any"}})[1], "required")
+        self.assertEqual(anthropic_tools({"tool_choice": {"type": "auto"}})[1], "auto")
+
+    def test_rejects_system_role_in_messages(self):
+        with self.assertRaises(APIError) as caught:
+            anthropic_to_openai({"messages": [{"role": "system", "content": "no"}]})
+        self.assertIn("system", caught.exception.message)
+
+
+class MessagesHTTPTest(unittest.TestCase):
+    def setUp(self):
+        self.engine = FakeEngine()
+        self.server = APIServer(("127.0.0.1", 0), self.engine, "test-model", "secret", 64,
+                                kv_slots=2)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base = f"http://127.0.0.1:{self.server.server_port}"
+
+    def tearDown(self):
+        self.server.scheduler.close()
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+
+    def post(self, body, headers=None, path="/v1/messages"):
+        head = {"Content-Type": "application/json", "x-api-key": "secret"}
+        head.update(headers or {})
+        return urlopen(Request(self.base + path, data=json.dumps(body).encode(), headers=head),
+                       timeout=3)
+
+    def base_body(self, **extra):
+        body = {"model": "test-model", "max_tokens": 32,
+                "messages": [{"role": "user", "content": "Hi"}]}
+        body.update(extra)
+        return body
+
+    def test_message_response_shape(self):
+        with self.post(self.base_body()) as response:
+            payload = json.load(response)
+        self.assertEqual(payload["type"], "message")
+        self.assertEqual(payload["role"], "assistant")
+        self.assertEqual(payload["content"], [{"type": "text", "text": "Héllo"}])
+        self.assertEqual(payload["stop_reason"], "end_turn")
+        self.assertIsNone(payload["stop_sequence"])
+        # Anthropic's usage field names, not OpenAI's prompt_tokens/completion_tokens
+        self.assertEqual(payload["usage"], {"input_tokens": 11, "output_tokens": 3})
+        self.assertTrue(payload["id"].startswith("msg_"))
+
+    def test_x_api_key_and_bearer_both_authenticate(self):
+        with self.post(self.base_body(), {"x-api-key": "secret"}) as response:
+            self.assertEqual(response.status, 200)
+        with self.post(self.base_body(), {"x-api-key": None and "" or "",
+                                          "Authorization": "Bearer secret"}) as response:
+            self.assertEqual(response.status, 200)
+        with self.assertRaises(HTTPError) as caught:
+            self.post(self.base_body(), {"x-api-key": "wrong"})
+        self.assertEqual(caught.exception.code, 401)
+
+    def test_error_envelope_is_anthropic_shaped(self):
+        with self.assertRaises(HTTPError) as caught:
+            self.post({"model": "test-model", "messages": [{"role": "user", "content": "x"}]})
+        payload = json.load(caught.exception)
+        self.assertEqual(payload["type"], "error")
+        self.assertEqual(payload["error"]["type"], "invalid_request_error")
+        self.assertIn("max_tokens", payload["error"]["message"])
+        self.assertNotIn("param", payload)          # OpenAI's envelope must not leak here
+
+    def test_max_tokens_maps_to_stop_reason(self):
+        self.engine.length_limited = True
+        with self.post(self.base_body()) as response:
+            self.assertEqual(json.load(response)["stop_reason"], "max_tokens")
+
+    def test_stream_emits_named_events_in_order(self):
+        with self.post(self.base_body(stream=True)) as response:
+            raw = response.read().decode()
+        names = [line[len("event: "):] for line in raw.splitlines() if line.startswith("event: ")]
+        self.assertEqual(names, ["message_start", "content_block_start", "content_block_delta",
+                                 "content_block_delta", "content_block_stop", "message_delta",
+                                 "message_stop"])
+        payloads = [json.loads(line[len("data: "):]) for line in raw.splitlines()
+                    if line.startswith("data: ")]
+        text = "".join(p["delta"]["text"] for p in payloads
+                       if p["type"] == "content_block_delta")
+        self.assertEqual(text, "Héllo")
+        self.assertEqual(payloads[-2]["delta"]["stop_reason"], "end_turn")
+        self.assertEqual(payloads[-2]["usage"]["output_tokens"], 3)
+
+    def test_tool_call_becomes_tool_use_block(self):
+        self.engine.script = ("Sure. <tool_call>get_weather<arg_key>city</arg_key>"
+                              "<arg_value>Rome</arg_value></tool_call>",)
+        body = self.base_body(tools=[{"name": "get_weather", "description": "w",
+                                      "input_schema": {"type": "object",
+                                                       "properties": {"city": {"type": "string"}},
+                                                       "required": ["city"]}}])
+        with self.post(body) as response:
+            payload = json.load(response)
+        self.assertEqual(payload["stop_reason"], "tool_use")
+        kinds = [block["type"] for block in payload["content"]]
+        self.assertEqual(kinds, ["text", "tool_use"])
+        call = payload["content"][1]
+        self.assertEqual(call["name"], "get_weather")
+        self.assertEqual(call["input"], {"city": "Rome"})
+        self.assertTrue(call["id"])
+        # the raw <tool_call> markup must never surface as visible text
+        self.assertNotIn("tool_call", payload["content"][0]["text"])
+
+    def test_streamed_tool_call_uses_input_json_delta(self):
+        self.engine.script = ("<tool_call>f<arg_key>x</arg_key><arg_value>1</arg_value></tool_call>",)
+        body = self.base_body(stream=True, tools=[{"name": "f", "input_schema": {
+            "type": "object", "properties": {"x": {"type": "string"}}}}])
+        with self.post(body) as response:
+            raw = response.read().decode()
+        self.assertIn('"type":"input_json_delta"', raw)
+        payloads = [json.loads(line[len("data: "):]) for line in raw.splitlines()
+                    if line.startswith("data: ")]
+        start = [p for p in payloads if p["type"] == "content_block_start"
+                 and p["content_block"]["type"] == "tool_use"]
+        self.assertEqual(len(start), 1)
+        self.assertEqual(start[0]["content_block"]["name"], "f")
+        self.assertEqual(start[0]["index"], 1)      # block 0 is the text block
+        self.assertEqual(payloads[-2]["delta"]["stop_reason"], "tool_use")
+
+    def test_thinking_enabled_renders_reasoning_prompt(self):
+        self.post(self.base_body(thinking={"type": "enabled"})).close()
+        self.assertIn("Reasoning Effort", self.engine.prompts[-1])
+        self.assertTrue(self.engine.prompts[-1].endswith("<|assistant|><think>"))
+
+    def test_unsupported_fields_refuse_loudly(self):
+        for field, value in (("stop_sequences", ["STOP"]), ("top_k", 40)):
+            with self.assertRaises(HTTPError) as caught:
+                self.post(self.base_body(**{field: value}))
+            self.assertEqual(caught.exception.code, 400)
+            self.assertIn(field, json.load(caught.exception)["error"]["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tests/test_fse.c
+++ b/c/tests/test_fse.c
@@ -1,0 +1,128 @@
+/* Batteria di test per fse_coli.h — scritta PRIMA che il codec tocchi glm.c.
+ *
+ * Questo codec decomprimera' PESI: un bug qui non crasha, corrompe l'output
+ * del modello in silenzio. Quindi: round-trip esatti, distribuzioni degeneri,
+ * fuzz di troncamento e corruzione (il decoder non deve MAI crashare, leggere
+ * oltre, o accettare in silenzio un flusso rotto), expert reale se disponibile
+ * (env EXPERT_RAW), ratio contro l'entropia misurata, velocita' di decode.
+ * Da compilare anche con -fsanitize=address,undefined: il fuzz sotto ASAN e'
+ * il vero certificato di bounds-safety. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "../fse_coli.h"
+
+static uint64_t rng=0x243F6A8885A308D3ull;
+static uint32_t xr(void){ rng^=rng<<13; rng^=rng>>7; rng^=rng<<17; return (uint32_t)(rng>>32); }
+
+static int roundtrip(const uint8_t *in, size_t n, const char *name, double *ratio){
+    size_t cap=cfse_bound(n);
+    uint8_t *c=malloc(cap?cap:1), *d=malloc(n?n:1);
+    size_t cs=cfse_compress(in,n,c,cap);
+    if(!cs){ printf("  FAIL %s: compress=0\n",name); return 1; }
+    size_t rl=0;
+    if(cfse_decompress(c,cs,d,n,&rl)){ printf("  FAIL %s: decompress rifiutato\n",name); return 1; }
+    if(rl!=n || (n && memcmp(in,d,n))){ printf("  FAIL %s: round-trip NON identico\n",name); return 1; }
+    if(ratio) *ratio = cs? (double)n/(double)cs : 0;
+    free(c); free(d); return 0;
+}
+
+int main(void){
+    int fail=0; double r;
+    printf("test_fse: rANS nibble per il container colibri'\n");
+
+    /* --- 1. vettori noti e casi limite --- */
+    { uint8_t v[]={0x00,0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99,0xAA,0xBB,0xCC,0xDD,0xEE,0xFF};
+      fail|=roundtrip(v,sizeof v,"16 byte tutti i nibble",NULL); }
+    fail|=roundtrip((const uint8_t*)"",0,"vuoto",NULL);
+    { uint8_t b=0x5A; fail|=roundtrip(&b,1,"un byte",NULL); }
+    { uint8_t v[3]={0xFF,0x00,0xFF}; fail|=roundtrip(v,3,"tre byte estremi",NULL); }
+    if(!fail) printf("  vettori noti + vuoto + 1 byte                    ok\n");
+
+    /* --- 2. degeneri: un solo simbolo, due simboli --- */
+    { uint8_t *v=malloc(100000); memset(v,0x88,100000);
+      fail|=roundtrip(v,100000,"tutto un simbolo",&r);
+      if(!fail) printf("  degenere un-simbolo: ratio %.0fx                 ok\n",r);
+      for(size_t i=0;i<100000;i++) v[i]=(xr()&1)?0x87:0x78;
+      fail|=roundtrip(v,100000,"due simboli",&r);
+      if(!fail) printf("  degenere due-simboli: ratio %.2fx                ok\n",r);
+      free(v); }
+
+    /* --- 3. uniforme (incomprimibile): DEVE cadere in raw, mai espandere --- */
+    { size_t n=1<<20; uint8_t *v=malloc(n);
+      for(size_t i=0;i<n;i++) v[i]=(uint8_t)xr();
+      size_t cap=cfse_bound(n); uint8_t *c=malloc(cap);
+      size_t cs=cfse_compress(v,n,c,cap);
+      if(!cs || cs>n+CFSE_HDR){ printf("  FAIL uniforme: espande (%zu > %zu)\n",cs,n+CFSE_HDR); fail=1; }
+      fail|=roundtrip(v,n,"uniforme 1MB",&r);
+      if(!fail) printf("  uniforme 1MB: ratio %.3fx (fallback raw)         ok\n",r);
+      free(v); free(c); }
+
+    /* --- 4. gaussiana tipo-pesi: il ratio deve avvicinare il previsto 1.37x --- */
+    { size_t n=4<<20; uint8_t *v=malloc(n);
+      for(size_t i=0;i<n;i++){
+          int a=((int)(xr()&15)+(int)(xr()&15)+(int)(xr()&15)+(int)(xr()&15))/4; /* ~gauss 0..15 */
+          int b=((int)(xr()&15)+(int)(xr()&15)+(int)(xr()&15)+(int)(xr()&15))/4;
+          v[i]=(uint8_t)(a|(b<<4)); }
+      fail|=roundtrip(v,n,"gaussiana 4MB",&r);
+      if(!fail) printf("  gaussiana 4MB: ratio %.3fx                       ok\n",r);
+      free(v); }
+
+    /* --- 5. taglie casuali: 400 round-trip di lunghezze 0..8191 --- */
+    { int bad=0;
+      for(int t=0;t<400;t++){ size_t n=xr()&8191; uint8_t *v=malloc(n?n:1);
+        for(size_t i=0;i<n;i++){ int a=((int)(xr()&15)+(int)(xr()&15))/2; v[i]=(uint8_t)(a|(((int)(xr()&7)+4)<<4)); }
+        bad|=roundtrip(v,n,"taglia casuale",NULL); free(v); }
+      fail|=bad; if(!bad) printf("  400 round-trip a taglie casuali                  ok\n"); }
+
+    /* --- 6. FUZZ troncamento: OGNI prefisso del compresso va rifiutato pulito --- */
+    { size_t n=65536; uint8_t *v=malloc(n);
+      for(size_t i=0;i<n;i++){ int a=((int)(xr()&15)+(int)(xr()&15))/2; v[i]=(uint8_t)(a|(a<<4)); }
+      size_t cap=cfse_bound(n); uint8_t *c=malloc(cap), *d=malloc(n);
+      size_t cs=cfse_compress(v,n,c,cap); size_t rl;
+      int accepted=0;
+      for(size_t L=0;L<cs;L++)                       /* TUTTI i troncamenti */
+          if(cfse_decompress(c,L,d,n,&rl)==0) accepted++;
+      if(accepted){ printf("  FAIL troncamento: %d prefissi accettati\n",accepted); fail=1; }
+      else printf("  troncamento: %zu prefissi, tutti rifiutati       ok\n",cs);
+
+    /* --- 7. FUZZ corruzione: flip di byte; mai crash, (quasi) mai accettato --- */
+      int acc=0, trials=2000;
+      for(int t=0;t<trials;t++){
+          size_t pos=xr()%cs; uint8_t old=c[pos];
+          c[pos]^=(uint8_t)(1+(xr()&0xFE));
+          if(cfse_decompress(c,cs,d,n,&rl)==0 && (rl!=n || memcmp(v,d,n))) acc++;
+          c[pos]=old; }
+      printf("  corruzione: %d flip, %d accettati con dati sbagliati %s\n",
+             trials,acc, acc<=2?"ok":"TROPPI");
+      if(acc>2) fail=1;                              /* sigillo: attesi ~0 */
+      free(v); free(c); free(d); }
+
+    /* --- 8. expert REALE (se disponibile) + velocita' --- */
+    const char *er=getenv("EXPERT_RAW");
+    if(er){
+        FILE *f=fopen(er,"rb");
+        if(f){ fseek(f,0,SEEK_END); size_t n=(size_t)ftell(f); fseek(f,0,SEEK_SET);
+            uint8_t *v=malloc(n); if(fread(v,1,n,f)!=n){printf("  FAIL lettura expert\n");return 1;} fclose(f);
+            size_t cap=cfse_bound(n); uint8_t *c=malloc(cap), *d=malloc(n);
+            size_t cs=cfse_compress(v,n,c,cap); size_t rl;
+            if(!cs||cfse_decompress(c,cs,d,n,&rl)||rl!=n||memcmp(v,d,n)){
+                printf("  FAIL expert reale: round-trip\n"); fail=1;
+            } else {
+                struct timespec t0,t1; double best=1e9;
+                for(int k=0;k<5;k++){ clock_gettime(CLOCK_MONOTONIC,&t0);
+                    cfse_decompress(c,cs,d,n,&rl);
+                    clock_gettime(CLOCK_MONOTONIC,&t1);
+                    double dt=(t1.tv_sec-t0.tv_sec)+(t1.tv_nsec-t0.tv_nsec)/1e9;
+                    if(dt<best) best=dt; }
+                printf("  EXPERT REALE (%zu byte): ratio %.3fx | decode %.0f ms = %.2f GB/s (1 core)\n",
+                       n,(double)n/cs,best*1000,n/best/1e9);
+            }
+            free(v);free(c);free(d);
+        } else printf("  (EXPERT_RAW non leggibile: salto)\n");
+    } else printf("  (EXPERT_RAW non impostato: salto il test su pesi reali)\n");
+
+    printf(fail? "test_fse: FAIL\n" : "test_fse: ok\n");
+    return fail;
+}

--- a/c/version.py
+++ b/c/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the colibri version number."""
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/docs/api.md
+++ b/docs/api.md
@@ -49,6 +49,46 @@ errors before streaming headers are sent. `GET /health` exposes
 active/queued/completed/rejected counters, and successful generation responses
 include `x-colibri-queue-wait-ms`.
 
+## Anthropic-protocol endpoint (`/v1/messages`)
+
+The same server also speaks the **Anthropic Messages API**, so clients that only talk
+to Anthropic endpoints — Claude Code, the Anthropic SDKs — work against colibri
+without a shim. Nothing to enable: `/v1/messages` is served alongside
+`/v1/chat/completions` on the same port.
+
+```bash
+curl http://127.0.0.1:8000/v1/messages \
+  -H 'x-api-key: local' -H 'content-type: application/json' \
+  -d '{"model":"glm-5.2-colibri","max_tokens":128,
+       "messages":[{"role":"user","content":"Hello"}]}'
+```
+
+For Claude Code, point it at the server and give it any non-empty key:
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=local            # only enforced if you set COLI_API_KEY
+export ANTHROPIC_MODEL=glm-5.2-colibri
+claude
+```
+
+Supported: system prompts (string or text blocks), multi-turn `user`/`assistant`
+messages, `text` / `tool_use` / `tool_result` content blocks, tools with
+`input_schema`, every `tool_choice` mode, streaming with the full named-event
+sequence (`message_start` → `content_block_*` → `message_delta` → `message_stop`,
+plus protocol `ping` keepalives during long prefills), `stop_reason`
+(`end_turn` / `max_tokens` / `tool_use`), Anthropic `usage` field names, and
+`x-api-key` authentication (`Authorization: Bearer` also works). Extended
+thinking is enabled with `{"thinking": {"type": "enabled"}}`.
+
+Not supported, and refused explicitly rather than ignored: `stop_sequences`,
+`top_k`, and non-text content blocks (images, documents). Errors use Anthropic's
+own `{"type":"error","error":{...}}` envelope on this path.
+
+> The prefill warning below applies here too, and applies *hardest* to Claude Code:
+> its system prompt and tool catalog are large, and on a disk-streaming CPU path
+> that is a long silent wait before the first token. Read it before you connect.
+
 ## Connect a coding CLI or editor
 
 The API is OpenAI-compatible, so most coding CLIs and editor extensions work by


### PR DESCRIPTION
Same-day patch. **v1.1.0's Windows binary trips Microsoft Defender, and the cause was ours** — every new Windows download hits that alert right now, so this should go out quickly.

**#532 — the actual bug.** `static GrDraft g_grd={.max=24};` looks harmless, but `GrDraft` is ~107 KB (the grammar's 1024 static rules plus the PDA walker) and **any** initializer moves the whole struct out of `.bss` into `.data`: 106,848 bytes of near-zero-entropy data written into every binary, in a *writable* section — the classic shape of an unpacking buffer for a packed payload, and a heavily-weighted feature for PE ML classifiers. Section forensics against v1.0.0 (clean on the same Defender definitions) isolated it: identical toolchain, identical PE layout, `.data` 1,840 → 108,752 bytes. **A Windows build with the fix scans clean where v1.1.0 does not.** Binaries also shrink: Linux engine 474,904 → 368,016 bytes, -22.5%.

Also shipping:

- **#526** — `python3 openai_server.py` was broken on a clean checkout (still looked for `glm` after the #391 rename). Spotted by @RDouglasSharp.
- **#525** — Anthropic Messages API on `/v1/messages`, closes #343: Claude Code and the Anthropic SDKs now work against colibri with no shim.
- **#530** — `SHA256SUMS.txt` published with every release.
- **#521** — README/quickstart rewritten so "Get started" starts by getting the *program*, not the 372 GB model.
- **#532** also uploads the Windows exe as a CI artifact, so an antivirus report can be verified on a PR instead of only after a release is published.

After merge: tag `v1.1.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)