### PR TITLE
docs: remove google redirect from links

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -52,11 +52,11 @@ Additionally: a **fast SSD** is essential. Colibrì uses the disk as additional 
 
 ### Software
 
-* **Docker Desktop** (Windows, Mac, Linux) — [download here](https://www.google.com/search?q=https://www.docker.com/products/docker-desktop/)
+* **Docker Desktop** (Windows, Mac, Linux) — [download here](https://www.docker.com/products/docker-desktop/)
 * **Python** (only if you want to download the model yourself)
-* Windows: [python.org](https://www.google.com/search?q=https://www.python.org) or Microsoft Store
+* Windows: [python.org](https://www.python.org) or Microsoft Store
 * Linux: `apt-get install python3 python3-pip`
-* Mac: [python.org](https://www.google.com/search?q=https://www.python.org) or Homebrew
+* Mac: [python.org](https://www.python.org) or Homebrew
 
 No build environment is needed. Everything happens inside the Docker container.
 
@@ -90,14 +90,14 @@ hf_download mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp --local-dir .
 
 If you are on Windows and cannot get it to work with Python:
 
-* Download manually from [Hugging Face](https://www.google.com/search?q=https://huggingface.co/mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp)
+* Download manually from [Hugging Face](https://huggingface.co/mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp)
 * Unzip into a folder (e.g., `C:\LLM\models\glm-5.2`)
 
 ---
 
 ### Step 2: Download the Colibrì Dockerfile
 
-1. Go to: [https://github.com/JustVugg/colibri/blob/main/docker/Dockerfile](https://www.google.com/search?q=https://github.com/JustVugg/colibri/blob/main/docker/Dockerfile)
+1. Go to: [https://github.com/JustVugg/colibri/blob/main/docker/Dockerfile](https://github.com/JustVugg/colibri/blob/main/docker/Dockerfile)
 2. Click the **Download** button (⬇️ icon) in the top right
 3. Save the file in a folder (e.g., `C:\LLM\Colibrì`)
 
@@ -229,7 +229,7 @@ Now you are inside Linux. Type `exit` to leave.
 
 **Solution**:
 
-1. Reinstall [Docker Desktop](https://www.google.com/search?q=https://www.docker.com/products/docker-desktop/)
+1. Reinstall [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 2. Restart your computer
 3. Open a new terminal and try again
 
@@ -371,7 +371,7 @@ Then retry the `hf_download` command.
 **Solution**:
 
 1. Wait and retry the `hf_download` command
-2. If it continues, download manually from [here](https://www.google.com/search?q=https://huggingface.co/mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp)
+2. If it continues, download manually from [here](https://huggingface.co/mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp)
 3. Unzip the ZIP file into the desired folder
 
 ---
@@ -392,7 +392,7 @@ If your disk is slow, the answers will be very slow even with a lot of RAM.
 
 ### Recommended default configuration for WLS on Windows
 
-If you have **exactly 32 GB of RAM** and are using Windows, it is very likely that WLS by default is set to consume no more than 16 GB of RAM. We need to increase this limit [Troubleshooting](https://www.google.com/search?q=#troubleshooting) . In my case I adopted this configuration:
+If you have **exactly 32 GB of RAM** and are using Windows, it is very likely that WLS by default is set to consume no more than 16 GB of RAM. We need to increase this limit [Troubleshooting](#troubleshooting) . In my case I adopted this configuration:
 
 ```ini
 [wsl2]


### PR DESCRIPTION
## Summary

This change follows up on c5b9d5a.
(https://github.com/JustVugg/colibri/pull/504)

It removes an unnecessary `https://www.google.com/search?q=` from links in `docker/README.md`. This fixes one more anchor (on line 395), outside the TOC anchors addressed in PR 504. And even for external links it seems better to just point directly at the relevant page rather than a Google result.

## Validation

Doc-only change

