### PR TITLE
inkling: serve mode + openai_server gateway support

### DIFF
--- a/c/inkling.c
+++ b/c/inkling.c
@@ -29,6 +29,7 @@
 #include <time.h>
 #if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
 #include <sys/resource.h>
+#include <sys/select.h>                              /* serve-loop stdin poll (POSIX); inkling serves on Linux */
 #endif
 #include "st.h"
 #include "tok.h"
@@ -1132,6 +1133,239 @@ static void generate_stream(Model *m, Tok *T, const char *prompt, int n_new) {
     free(ids);
 }
 
+/* ---------- serve mode: openai_server.py engine protocol ----------
+ * stdin:  SUBMIT <id> <slot> <len> <max_tokens> <temp> <top_p>\n<payload>\n
+ *         CANCEL <id>\n
+ * stdout: READY sentinel once loaded, then per request a stream of
+ *         DATA <id> <size>\n<bytes>\n frames and a final
+ *         DONE <id> STAT <tok> <tps> <hit%> <rss> <prompt_tok> <len_limited>\n
+ * Byte-identical to colibri.c's serve protocol so the shared openai_server.py
+ * gateway drives inkling unchanged (v1: one request at a time; the KV slot arg
+ * is accepted but every request re-prefills). */
+
+static uint64_t g_rng = 0x9E3779B97F4A7C15ull;
+static double rng_next(void) {
+    g_rng ^= g_rng << 13; g_rng ^= g_rng >> 7; g_rng ^= g_rng << 17;
+    return (double)(g_rng >> 11) / 9007199254740992.0;
+}
+
+/* temperature + top-p nucleus sampling; temp<=0 = greedy (the oracle path) */
+typedef struct { float p; int i; } PI;
+static int pi_desc(const void *a, const void *b) {
+    float d = ((const PI*)b)->p - ((const PI*)a)->p;
+    return d > 0 ? 1 : d < 0 ? -1 : 0;
+}
+static int sample_logits(const float *logit, int n, float temp, float top_p) {
+    int best = 0;
+    for (int i = 1; i < n; i++) if (logit[i] > logit[best]) best = i;
+    if (temp <= 0.f) return best;
+    PI *c = malloc((size_t)n * sizeof(PI));
+    double sum = 0;
+    for (int i = 0; i < n; i++) {
+        c[i].p = expf((logit[i] - logit[best]) / temp);
+        c[i].i = i; sum += c[i].p;
+    }
+    qsort(c, n, sizeof(PI), pi_desc);
+    double cut = (top_p > 0.f && top_p < 1.f) ? top_p * sum : sum;
+    double acc = 0; int k = 0;
+    while (k < n && acc < cut) acc += c[k++].p;
+    double r = rng_next() * acc, run = 0;
+    int pick = c[0].i;
+    for (int i = 0; i < k; i++) { run += c[i].p; if (run >= r) { pick = c[i].i; break; } }
+    free(c);
+    return pick;
+}
+
+/* light repeat guard: recently emitted tokens get their logit divided by pen>1 */
+static void apply_rep_penalty(float *logit, int n, const int *hist, int nhist, float pen) {
+    if (pen <= 1.f) return;
+    for (int i = 0; i < nhist; i++) {
+        int t = hist[i];
+        if (t < 0 || t >= n) continue;
+        logit[t] = logit[t] > 0 ? logit[t] / pen : logit[t] * pen;
+    }
+}
+
+/* reject a prompt that would overrun the served KV bound (CTX_MAX, default 8192) */
+static const char *prompt_reject(int np, int want) {
+    const char *cm = getenv("CTX_MAX");
+    int ctx_max = cm ? atoi(cm) : 8192;
+    if (np + want > ctx_max) return "context exceeds CTX_MAX";
+    return NULL;
+}
+
+typedef struct { char id[64]; int max_tok; float temp, top_p; char *payload; int plen; } SReq;
+#define SRV_QMAX 16
+static SReq g_q[SRV_QMAX]; static int g_qn = 0;
+
+static int stdin_readable(void) {
+    fd_set r; struct timeval tv = {0, 0};
+    FD_ZERO(&r); FD_SET(0, &r);
+    return select(1, &r, NULL, NULL, &tv) > 0;
+}
+
+/* read one control line (+ payload for SUBMIT). cur_id: request in flight;
+ * returns 1 if that request was cancelled, 0 otherwise, -1 on stdin EOF. */
+static int serve_read_cmd(const char *cur_id) {
+    char ln[512];
+    if (!fgets(ln, sizeof(ln), stdin)) return -1;
+    char cmd[16], id[64];
+    if (sscanf(ln, "%15s %63s", cmd, id) < 2) return 0;
+    if (!strcmp(cmd, "CANCEL")) return cur_id && !strcmp(id, cur_id);
+    if (!strcmp(cmd, "SUBMIT")) {
+        int slot, plen, max_tok; float temp, top_p;
+        if (sscanf(ln, "%*s %*s %d %d %d %f %f", &slot, &plen, &max_tok, &temp, &top_p) != 5 ||
+            plen < 0 || plen > (1<<22)) { printf("ERROR %s bad submit header\n", id); fflush(stdout); return 0; }
+        (void)slot;
+        char *pl = malloc((size_t)plen + 1);
+        if (fread(pl, 1, (size_t)plen, stdin) != (size_t)plen) { free(pl); return -1; }
+        int nl = fgetc(stdin); (void)nl;
+        pl[plen] = 0;
+        if (g_qn < SRV_QMAX) {
+            SReq *q = &g_q[g_qn++];
+            snprintf(q->id, sizeof(q->id), "%s", id);
+            q->max_tok = max_tok; q->temp = temp; q->top_p = top_p;
+            q->payload = pl; q->plen = plen;
+        } else { printf("ERROR %s queue full\n", id); fflush(stdout); free(pl); }
+    }
+    return 0;
+}
+
+static void serve_one(Model *m, Tok *T, SReq *q) {
+    Cfg *c = &m->c;
+    int cap = q->plen + 16;
+    int *ids = malloc((size_t)cap * sizeof(int));
+    int np = tok_encode(T, q->payload, q->plen, ids, cap);
+    if (np <= 0) { printf("ERROR %s empty prompt\n", q->id); fflush(stdout); free(ids); return; }
+    const char *bad = prompt_reject(np, q->max_tok);
+    if (bad) { printf("ERROR %s %s\n", q->id, bad); fflush(stdout); free(ids); return; }
+    state_reset(m);
+    kv_alloc(m, np + q->max_tok + 8);
+    double t0 = now_s();
+    uint64_t h0 = m->hits, m0 = m->miss;
+    /* per-turn phase snapshot for the PROF line (timers accumulate globally) */
+    double f0 = m->t_fill, e0 = m->t_expert, s0 = m->t_shared, a0 = m->t_attn;
+    float *logit = step(m, ids, np, 0, NULL);
+    int len = np, gen = 0, limited = 1, cancelled = 0;
+    char buf[512];
+    /* repetition-penalty history: prompt tail + emitted tokens, ring of 128 */
+    float rep = getenv("REP_PEN") ? atof(getenv("REP_PEN")) : 1.1f;
+    int hist[128], nhist = 0;
+    for (int i = (np > 128 ? np - 128 : 0); i < np; i++) hist[nhist++] = ids[i];
+    for (int s = 0; s < q->max_tok && !cancelled; s++) {
+        apply_rep_penalty(logit, c->unpad_vocab, hist, nhist, rep);
+        int tk = sample_logits(logit, c->unpad_vocab, q->temp, q->top_p);
+        free(logit); logit = NULL;
+        if (tk == c->eos) { limited = 0; break; }
+        if (nhist < 128) hist[nhist++] = tk;
+        else { memmove(hist, hist+1, 127*sizeof(int)); hist[127] = tk; }
+        int nb = tok_decode(T, &tk, 1, buf, sizeof(buf)-1);
+        printf("DATA %s %d\n", q->id, nb);
+        fwrite(buf, 1, (size_t)nb, stdout);
+        fputc('\n', stdout); fflush(stdout);
+        gen++; len++;
+        while (stdin_readable()) {
+            int r = serve_read_cmd(q->id);
+            if (r < 0) { free(ids); return; }
+            if (r > 0) { cancelled = 1; limited = 0; }
+        }
+        if (cancelled || s == q->max_tok - 1) break;
+        logit = step(m, &tk, 1, len - 1, NULL);
+    }
+    free(logit);
+    double dt = now_s() - t0;
+    double tot = (double)(m->hits - h0 + m->miss - m0);
+    printf("DONE %s STAT %d %.3f %.1f %.2f %d %d\n", q->id, gen,
+           dt > 0 ? gen/dt : 0.0, tot ? 100.0*(m->hits-h0)/tot : 0.0, rss_gb(), np, limited);
+    /* PROF: per-turn phase timings for the dashboard (gateway schema — we map
+     * expert_wait -> shared-expert compute, lm_head folded into 0). */
+    printf("PROF %.3f %d %d %.3f %.3f %.3f %.3f %.3f %d\n", dt, np, gen,
+           m->t_fill - f0, m->t_shared - s0, m->t_expert - e0, m->t_attn - a0, 0.0, gen + 1);
+    fflush(stdout);
+    free(ids);
+}
+
+/* ---------- dashboard protocol (HWINFO / TIERS / EMAP) ----------
+ * Same stdout lines colibri.c emits for the web dashboard; the gateway parses
+ * them and the Brain/Profiling pages render live expert-tier state. */
+static void serve_hwinfo(Model *m) {
+    char cpu[256] = ""; int cores = 0; double rt = 0, ra = 0;
+    FILE *ci = fopen("/proc/cpuinfo", "r");
+    if (ci) { char ln[256];
+        while (fgets(ln, sizeof(ln), ci)) if (!strncmp(ln, "model name", 10)) {
+            char *p = strchr(ln, ':'); if (p) { p++; while (*p == ' ') p++;
+            int n = (int)strlen(p); if (n > 0 && p[n-1] == '\n') p[--n] = 0;
+            snprintf(cpu, sizeof(cpu), "%s", p); } break; }
+        fclose(ci); }
+#ifdef _SC_NPROCESSORS_ONLN
+    cores = (int)sysconf(_SC_NPROCESSORS_ONLN);
+#endif
+    FILE *mi = fopen("/proc/meminfo", "r");
+    if (mi) { char ln[256]; double v = 0;
+        while (fgets(ln, sizeof(ln), mi)) {
+            if (sscanf(ln, "MemTotal: %lf", &v) == 1) rt = v/1e6;
+            if (sscanf(ln, "MemAvailable: %lf", &v) == 1) ra = v/1e6;
+        } fclose(mi); }
+    int ngpu = 0; double vram = 0;
+    const char *gpu = "";
+#ifdef COLI_CUDA
+    if (g_cuda) { ngpu = 1; vram = ink_cuda_free_bytes()/1e9; gpu = "CUDA device"; }
+#endif
+    (void)m;
+    printf("HWINFO %d %.1f %.1f %d %.1f %s|%s\n", cores, rt, ra, ngpu, vram, cpu[0]?cpu:"unknown", gpu);
+    fflush(stdout);
+}
+
+static void serve_tiers_emap(Model *m) {
+    Cfg *c = &m->c; int E = c->n_experts;
+    int nsp = 0, filled = 0;
+    for (int i = 0; i < c->n_layers; i++) if (c->sparse[i]) { nsp++; filled += m->cache[i].n; }
+    int64_t I = c->moe_inter, D = c->hidden;
+    int64_t slotb = m->xq ? m->rb13*2*I + m->rb2*D + (2*I+D)*4
+                  : m->quant_bits ? 3*I*D + (2*I+D)*4 : 3*I*D*4;
+    printf("TIERS 0 %d %d 0.00 %.2f\n", filled, nsp*E - filled, filled*(double)slotb/1e9);
+    /* EMAP: 1 byte/expert hex — tier(2b: 0=disk 1=RAM)<<6 | heat(6b: log2 usage) */
+    char *hex = malloc((size_t)nsp*E*2 + 1); int w = 0;
+    for (int i = 0; i < c->n_layers; i++) {
+        if (!c->sparse[i]) continue;
+        LCache *lc = &m->cache[i];
+        for (int e = 0; e < E; e++) {
+            int tier = 0;
+            for (int z = 0; z < lc->n; z++) if (lc->slots[z].eid == e && lc->slots[z].filled) { tier = 1; break; }
+            uint32_t u = m->eusage[i] ? m->eusage[i][e] : 0;
+            int heat = 0; while (u) { heat++; u >>= 1; } if (heat > 63) heat = 63;
+            int b = (tier << 6) | heat;
+            hex[w++] = "0123456789abcdef"[b >> 4];
+            hex[w++] = "0123456789abcdef"[b & 15];
+        }
+    }
+    hex[w] = 0;
+    printf("EMAP %d %d %s\n", nsp, E, hex);
+    fflush(stdout); free(hex);
+}
+
+static void serve_loop(Model *m, Tok *T) {
+    setvbuf(stdin, NULL, _IONBF, 0);
+    const char *sd = getenv("SEED");
+    if (sd) g_rng ^= (uint64_t)strtoull(sd, NULL, 10);
+    else g_rng ^= (uint64_t)time(NULL) * 2654435761u;
+    /* the gateway reads a STAT line right after the READY sentinel (colibri
+     * reports its load stats there) — match the handshake */
+    fputs("\x01\x01READY\x01\x01\n", stdout);
+    printf("STAT 0 0.0 0.0 %.2f 0 0\n", rss_gb());
+    fflush(stdout);
+    serve_hwinfo(m);
+    serve_tiers_emap(m);
+    for (;;) {
+        while (!g_qn) if (serve_read_cmd(NULL) < 0) return;   /* blocks on stdin */
+        SReq q = g_q[0];
+        memmove(g_q, g_q+1, (size_t)(--g_qn) * sizeof(SReq));
+        serve_one(m, T, &q);
+        serve_tiers_emap(m);
+        free(q.payload);
+    }
+}
+
 /* ---------- ref_inkling.json harness ---------- */
 static int *read_int_array(jval *o, const char *key, int *n_out) {
     jval *a = json_get(o, key);
@@ -1177,6 +1411,18 @@ int main(int argc, char **argv) {
     }
     if (cap < 0) cap = (prompt || pfile) ? 0 : 16;   /* generate mode defaults to RAM-sized auto cap */
     if (bits && (bits < 2 || bits > 8)) { fprintf(stderr, "quant_bits must be 0 (f32) or 2..8\n"); return 1; }
+
+    /* SERVE=1: the openai_server.py gateway drives the engine over stdin/stdout
+     * (READY handshake, SUBMIT/CANCEL, DATA/DONE frames) — same protocol colibri. */
+    if (getenv("SERVE") && getenv("SERVE")[0] == '1') {
+        Model m; model_init(&m, snap, cap, bits);
+        pins_load(&m, snap);
+        char tkp[2048]; snprintf(tkp, sizeof(tkp), "%s/tokenizer.json", snap);
+        Tok T; tok_load(&T, tkp);
+        serve_loop(&m, &T);
+        usage_save(&m, snap);
+        return 0;
+    }
 
     if (prompt || pfile) {
         Model m; model_init(&m, snap, cap, bits);

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -357,6 +357,8 @@ def parse_tool_calls(reply, tools=None):
     text = _BOX_RE.sub("", reply)
     if tail is not None:                       # drop the recovered tail from the visible content
         text = text[:text.rindex(BOX_START)]
+    if ARCH == "inkling":
+        text = strip_inkling_markers(text)   # thinking is reasoning, not answer
     if THINK_CLOSE in text:
         text = text.split(THINK_CLOSE, 1)[1]
     text = text.replace(THINK_OPEN, "").replace(THINK_CLOSE, "")
@@ -369,6 +371,150 @@ def parse_tool_calls(reply, tools=None):
                             (" -> " + ", ".join(salvaged)) if dm else ""))
         sys.stderr.flush()
     return text.strip(), calls
+
+
+ARCH = "glm"   # set in main(): "glm" | "inkling" (auto-detected from the model's config.json)
+
+INK_THINK, INK_TEXT = "<|content_thinking|>", "<|content_text|>"
+
+
+class InklingStreamSplit:
+    """Strips Inkling's content markers from the visible stream and withholds
+    <|content_thinking|> sections from `content` (they are reasoning, not
+    answer). Buffers partial markers across chunk boundaries so a marker split
+    between two DATA frames never leaks."""
+
+    def __init__(self, on_content, on_reasoning=None):
+        self.on_content = on_content
+        self.on_reasoning = on_reasoning
+        self.mode = "content"
+        self.buf = ""
+
+    def feed(self, piece):
+        self.buf += piece
+        while True:
+            hits = [(i, m) for i, m in ((self.buf.find(INK_THINK), INK_THINK),
+                                        (self.buf.find(INK_TEXT), INK_TEXT)) if i >= 0]
+            if not hits:
+                hold = self._tail_hold()
+                out = self.buf[:len(self.buf) - hold] if hold else self.buf
+                self.buf = self.buf[len(self.buf) - hold:] if hold else ""
+                self._emit(out)
+                return
+            i, m = min(hits)
+            self._emit(self.buf[:i])
+            self.mode = "reasoning" if m == INK_THINK else "content"
+            self.buf = self.buf[i + len(m):]
+
+    def _tail_hold(self):
+        for k in range(min(len(self.buf), 24), 0, -1):
+            if INK_THINK.startswith(self.buf[-k:]) or INK_TEXT.startswith(self.buf[-k:]):
+                return k
+        return 0
+
+    def _emit(self, text):
+        if not text:
+            return
+        text = _INK_MARKER.sub("", text)
+        if not text:
+            return
+        if self.mode == "content":
+            self.on_content(text)
+        elif self.on_reasoning:
+            self.on_reasoning(text)
+
+    def close(self):
+        self._emit(self.buf)
+        self.buf = ""
+
+
+import re as _re
+_INK_MARKER = _re.compile(r"<\|(?:content_\w+|end_message|message_\w+|audio_end|unused_\d+)\|>")
+
+def strip_inkling_markers(text):
+    """Remove <|content_thinking|>…<|content_text|> sections, then any stray
+    control markers (end_message, role/content tokens) the model emits."""
+    while INK_THINK in text:
+        pre, _, rest = text.partition(INK_THINK)
+        _, _, after = rest.partition(INK_TEXT)
+        text = pre + after
+    return _INK_MARKER.sub("", text)
+
+
+def split_inkling(text):
+    """Split raw Inkling output into (content, reasoning). Thinking blocks
+    (<|content_thinking|>…<|content_text|>) become reasoning — including an
+    UNTERMINATED trailing block (budget ran out mid-thought), which partitions
+    to everything after the opener — so a think-only generation surfaces its
+    reasoning instead of collapsing to an empty answer."""
+    reasoning = []
+    while INK_THINK in text:
+        pre, _, rest = text.partition(INK_THINK)
+        think, _, after = rest.partition(INK_TEXT)
+        reasoning.append(think)
+        text = pre + after
+    return _INK_MARKER.sub("", text), _INK_MARKER.sub("", "".join(reasoning))
+
+
+def render_chat_inkling(messages, enable_thinking=False, reasoning_effort=None, tools=None,
+                        tool_choice=None):
+    """Text-only subset of Inkling's chat_template.jinja: role tokens with
+    <|content_text|> parts and <|end_message|> terminators, an assistant
+    <|content_model_end_sampling|> after each prior model turn, the
+    thinking-effort hint appended after the messages (the template's fallback
+    branch), then <|message_model|> as the generation prompt."""
+    if not isinstance(messages, list) or not messages:
+        raise APIError(400, "`messages` must be a non-empty array.", "messages")
+    if tools or (tool_choice not in (None, "none")):
+        raise APIError(400, "Tool use is not wired up for the Inkling engine yet.",
+                       "tools", "unsupported_parameter")
+    role_token = {"user": "<|message_user|>", "system": "<|message_system|>",
+                  "developer": "<|message_system|>", "assistant": "<|message_model|>",
+                  "tool": "<|message_tool|>"}
+    # Thinking effort — template default is 0.9, but at single-machine decode
+    # speeds unrequested reasoning burns the whole token budget before the answer
+    # starts, so we default it OFF unless the client asks.
+    effort_map = {"none": 0.0, "minimal": 0.1, "low": 0.2, "medium": 0.7,
+                  "high": 0.9, "max": 0.99}
+    if reasoning_effort in effort_map:
+        eff = effort_map[reasoning_effort]
+    else:
+        eff = 0.9 if enable_thinking else 0.0
+    effort_str = ("<|message_system|><|content_text|>Thinking effort level: "
+                  f"{0 if eff == 0.0 else eff}<|end_message|>")
+
+    prompt = []
+    effort_emitted = False
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict):
+            raise APIError(400, "Each message must be an object.", f"messages.{index}")
+        role = message.get("role")
+        rtok = role_token.get(role)
+        if rtok is None:
+            raise APIError(400, f"Unsupported role {role!r}.", f"messages.{index}.role")
+        # the template emits the effort hint inline, right before the first
+        # non-system message — not at the end. Position matters: it changes the
+        # exact token sequence the model was trained on.
+        if not effort_emitted and role not in ("system", "developer"):
+            prompt.append(effort_str)
+            effort_emitted = True
+        raw = message.get("content")
+        text = content_text(raw, f"messages.{index}.content") if raw is not None else ""
+        prompt.append(f"{rtok}<|content_text|>{text}<|end_message|>")
+        if role == "assistant":
+            prompt.append("<|content_model_end_sampling|>")
+    if not effort_emitted:                       # all-system edge case: fallback
+        prompt.append(effort_str)
+    prompt.append("<|message_model|>")           # add_generation_prompt
+    # Thinking off: prefill the content channel. Without this the model can still
+    # sample <|content_thinking|> as its first token (the effort hint is only a
+    # soft signal), open a reasoning block, and burn the whole token budget before
+    # reaching <|content_text|> — which the splitter then strips to an empty
+    # answer. Ending the prompt at <|message_model|><|content_text|> forces content
+    # mode; it is exactly the sequence every non-thinking turn is trained on.
+    if eff == 0.0:
+        prompt.append("<|content_text|>")
+    return "".join(prompt)
 
 
 def render_chat(messages, enable_thinking=False, reasoning_effort=None, tools=None,
@@ -1222,6 +1368,11 @@ class APIHandler(BaseHTTPRequestHandler):
             sys.stderr.write(f"\n===== PROMPT [{request_id}] =====\n{prompt}\n===== OUTPUT [{request_id}] =====\n")
             sys.stderr.flush()
         maximum, temperature, top_p, grammar = generation_options(body, self.server.max_tokens)
+        if grammar is not None and ARCH == "inkling":
+            # inkling.c's serve loop speaks the 6-field SUBMIT header only; sending the
+            # grammar payload extension would desync its stdin framing.
+            raise APIError(400, "`response_format` grammars are not supported by the Inkling "
+                                "engine yet.", "response_format", "unsupported_parameter")
         # tools and tool_choice come from chat_completion() already processed/filtered
         if chat and tool_choice == "none":
             tools = None          # client forbade tools: never surface tool_calls
@@ -1252,17 +1403,25 @@ class APIHandler(BaseHTTPRequestHandler):
                     prompt, maximum, temperature, top_p, output.append, cache_slot,
                     self.client_disconnected, grammar=grammar)
                 text = "".join(output)
+                reasoning = ""
+                if ARCH == "inkling":
+                    text, reasoning = split_inkling(text)
                 length_finish = "length" if stats["length_limited"] else "stop"
                 if chat and tools:
                     content, calls = parse_tool_calls(text, tools)
                     message = {"role": "assistant", "content": content or None, "refusal": None}
+                    if reasoning:
+                        message["reasoning_content"] = reasoning
                     if calls:
                         message["tool_calls"] = calls
                     finish = "tool_calls" if calls else length_finish
                     choice = {"index": 0, "message": message, "logprobs": None, "finish_reason": finish}
                 else:
-                    choice = ({"index": 0, "message": {"role": "assistant", "content": text,
-                               "refusal": None}, "logprobs": None, "finish_reason": length_finish} if chat else
+                    _msg = {"role": "assistant", "content": text, "refusal": None}
+                    if reasoning:
+                        _msg["reasoning_content"] = reasoning
+                    choice = ({"index": 0, "message": _msg,
+                               "logprobs": None, "finish_reason": length_finish} if chat else
                               {"index": 0, "text": text, "logprobs": None, "finish_reason": length_finish})
                 self.send_json(200, {"id": completion_id, "object": object_name, "created": created,
                     "model": self.server.model_id, "choices": [choice], "usage": self.usage(stats)},
@@ -1328,6 +1487,13 @@ class APIHandler(BaseHTTPRequestHandler):
                           {"index": 0, "text": text, "logprobs": None, "finish_reason": None})
                 event([choice])
 
+            def emit_reasoning(text):     # thinking → reasoning_content deltas (chat only)
+                event([{"index": 0, "delta": {"reasoning_content": text},
+                        "logprobs": None, "finish_reason": None}])
+
+            splitter = (InklingStreamSplit(emit, emit_reasoning if chat else None)
+                        if ARCH == "inkling" else None)
+
             ka_thread = threading.Thread(target=_keepalive, daemon=True)
             ka_thread.start()
             if chat and tools:
@@ -1371,10 +1537,12 @@ class APIHandler(BaseHTTPRequestHandler):
                 def emit_plain(chunk):
                     if dbg_echo:
                         sys.stderr.write(chunk); sys.stderr.flush()
-                    emit(chunk)
+                    (splitter.feed if splitter else emit)(chunk)
                 stats = self.server.engine.generate(
                     prompt, maximum, temperature, top_p, emit_plain, cache_slot,
                     lambda: not connected, grammar=grammar)
+                if splitter:
+                    splitter.close()
                 finish = "length" if stats["length_limited"] else "stop"
             ka_stop.set()                          # generation done: stop the keepalive pump
             ka_thread.join(timeout=2)
@@ -1427,8 +1595,9 @@ class APIHandler(BaseHTTPRequestHandler):
             raise APIError(400, "`enable_thinking` must be a boolean.", "enable_thinking")
         tools = body.get("tools") or body.get("functions") or None
         tool_choice = body.get("tool_choice")
-        prompt = render_chat(body.get("messages"), enable_thinking, reasoning_effort, tools,
-                             tool_choice)
+        renderer = render_chat_inkling if ARCH == "inkling" else render_chat
+        prompt = renderer(body.get("messages"), enable_thinking, reasoning_effort, tools,
+                          tool_choice)
         self.generation(body, prompt, request_id, True, tools, tool_choice)
 
     # ---- Anthropic /v1/messages (#343) ----------------------------------------------------
@@ -1673,9 +1842,11 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model", default=os.environ.get("COLI_MODEL"), required=not os.environ.get("COLI_MODEL"))
     parser.add_argument("--engine", default=str(default_engine()))
+    parser.add_argument("--arch", choices=("auto", "glm", "inkling"), default="auto",
+                        help="chat-template family; auto reads model_type from the model's config.json")
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
-    parser.add_argument("--model-id", default=os.environ.get("COLI_MODEL_ID", "glm-5.2-colibri"))
+    parser.add_argument("--model-id", default=os.environ.get("COLI_MODEL_ID"))
     parser.add_argument("--api-key", default=os.environ.get("COLI_API_KEY"))
     parser.add_argument("--cors-origin", action="append", default=None,
                         help="allowed browser origin; repeat as needed (use '*' for any origin)")
@@ -1686,6 +1857,16 @@ def main():
                         default=float(os.environ.get("COLI_QUEUE_TIMEOUT", "300")))
     parser.add_argument("--kv-slots", type=int, default=int(os.environ.get("COLI_KV_SLOTS", "1")))
     args = parser.parse_args()
+    global ARCH
+    ARCH = args.arch
+    if ARCH == "auto":
+        try:
+            with open(Path(args.model) / "config.json") as fh:
+                ARCH = "inkling" if "inkling" in (json.load(fh).get("model_type") or "") else "glm"
+        except OSError:
+            ARCH = "glm"
+    if args.model_id is None:
+        args.model_id = "inkling-colibri" if ARCH == "inkling" else "glm-5.2-colibri"
     serve(args.model, args.host, args.port, args.model_id, args.api_key,
           args.cap,args.max_tokens,args.engine,cors_origins=args.cors_origin,
           max_queue=args.max_queue,queue_timeout=args.queue_timeout,kv_slots=args.kv_slots)


### PR DESCRIPTION
## What

#312 landed the Inkling engine, but `inkling.c` only has `-p` streaming and the oracle harness — the shared `openai_server.py` gateway has nothing to drive. This adds the missing serve loop **and** the gateway support to actually serve it, both strictly additive.

**Engine (`inkling.c`, +246):** a `SERVE=1` loop **byte-identical to `colibri.c`'s protocol**, so the existing gateway drives it unchanged:
- READY sentinel + STAT handshake, then per request `SUBMIT <id> <slot> <len> <max_tok> <temp> <top_p>` → `DATA` frames → `DONE <id> STAT …` + `PROF` (per-turn phase timings). `CANCEL` honored between tokens; v1 runs one request at a time.
- temperature + top-p nucleus sampling (`sample_logits`; `temp<=0` = greedy, so the oracle path is untouched) + a light `REP_PEN` repeat guard.
- `HWINFO` / `TIERS` / `EMAP` dashboard lines (same as `colibri.c`) for the web Brain/Profiling pages.
- `prompt_reject` bounds the served context (`CTX_MAX`, default 8192).

**Gateway (`openai_server.py`, +193):** teach it to speak inkling — the glm path is byte-unchanged (`ARCH` defaults to `glm`):
- `--arch {auto,glm,inkling}`; `auto` reads `model_type` from the model's `config.json`, then picks the chat-template renderer and model-id.
- inkling's thinking is reasoning, not answer: split the `<|content_thinking|>` / `<|content_text|>` channels into `reasoning_content` on both the streaming (`InklingStreamSplit`) and non-streaming chat paths.
- `response_format` grammars are refused for inkling (its serve loop speaks the 6-field `SUBMIT` header only) with a clear 400.

## Validation

- **Oracle unchanged:** `make_tiny_inkling.py` + `./inkling 8 0 ref_inkling.json` still **36/36** teacher-forced argmax + **24/24** greedy. Serve mode is additive; `-Wall -Wextra` clean.
- **End-to-end serve smoke** against a tiny model: `SUBMIT` → 8 `DATA` frames → `DONE req1 STAT 8 … 2 1` → 9-field `PROF`. Sampling (temp/top_p) works; the `DONE`/`STAT`/`PROF` layout matches the gateway's `_stats` parser exactly.
- **51** `openai_server` tests pass (glm default path intact).

Follow-up worth doing: a serve-mode smoke wired into the `inkling-oracle` CI job (needs the tiny fixture to also emit a tokenizer). Happy to add it here or separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KLDCYJSyHxd39ChTr4T27
