### PR TITLE
perf: add AVX2 int8 dot-product path to olmoe's matmul_q

### DIFF
--- a/c/olmoe.c
+++ b/c/olmoe.c
@@ -149,9 +149,30 @@ static inline int32_t dot_i8_16(const int8_t *a, const int8_t *b) {
 #endif
     return vaddvq_s32(acc);
 }
+#define HAVE_FAST_DOT_I8 1
+#elif defined(__AVX2__)
+#include <immintrin.h>
+/* x86 counterpart of the NEON path above (was scalar-only here before —
+ * the only fast path was ARM, so x86 boxes silently used the scalar
+ * fallback even when AVX2 was available).
+ * Sign-extend both int8 vectors to int16 (exact, no precision loss) then
+ * madd+horizontal-sum in int32: pure integer arithmetic, so this is
+ * bit-for-bit identical to the scalar dot product, just vectorized. */
+static inline int32_t dot_i8_16(const int8_t *a, const int8_t *b) {
+    __m256i va16 = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)a));
+    __m256i vb16 = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)b));
+    __m256i prod = _mm256_madd_epi16(va16, vb16);           /* 8 x int32, adjacent pairs summed */
+    __m128i sum128 = _mm_add_epi32(_mm256_castsi256_si128(prod), _mm256_extracti128_si256(prod, 1));
+    __m128i hi64   = _mm_unpackhi_epi64(sum128, sum128);
+    __m128i sum64  = _mm_add_epi32(sum128, hi64);
+    __m128i hi32   = _mm_shuffle_epi32(sum64, _MM_SHUFFLE(2, 3, 0, 1));
+    __m128i sum32  = _mm_add_epi32(sum64, hi32);
+    return _mm_cvtsi128_si32(sum32);
+}
+#define HAVE_FAST_DOT_I8 1
 #endif
 static void matmul_q(float *y, const float *x, const int8_t *q, const float *scale, int I, int O) {
-#if defined(__ARM_NEON)
+#if defined(HAVE_FAST_DOT_I8)
     static int idot = -1;
     if (idot < 0) { const char *e = getenv("IDOT"); idot = !(e && *e == '0'); }
     if (idot && I % 16 == 0 && I <= 4096) {


### PR DESCRIPTION
## Summary

`matmul_q`'s fast dot-product path was ARM NEON only — every x86 build silently fell back to a scalar, byte-at-a-time loop even on CPUs with AVX2 available. Adds an AVX2 counterpart using the same block-quantized-activation scheme: sign-extend both int8 operands to int16, multiply+horizontal-pair-sum via `_mm256_madd_epi16`, reduce to a scalar. Pure integer arithmetic, so it's bit-for-bit identical to the scalar reference.

## Validation

- [x] `make -C c check` — portable CPU build and all C unit tests pass. One pre-existing, unrelated Python test (`test_resource_plan.py::test_auto_tune_mtp_off_when_disk_low_hit`) fails on my dev machine with "disk quota exceeded" writing its own test fixtures — reproduces identically on a clean `dev` checkout with no changes at all, so it's a local-disk-space issue on this box, not something this PR causes.
- [ ] CUDA changes were tested with `make -C c cuda-test` (if applicable) — N/A, no CUDA touched.
- [x] Performance claims include hardware, commands, and repeatable measurements — see below. Correctness (IDOT=0 vs IDOT=1 byte-identical output) is the main claim; the honest performance picture is noisier than I'd like:

Measured on an 8-core AMD Zen (Lucienne) CPU-only box, OLMoE-1B-7B-0125-Instruct int8, cache=64, same 100-token prompt:
```
SNAP=<olmoe_merged> IDOT=0 ./olmoe 64 8 ref.json   # scalar
SNAP=<olmoe_merged> IDOT=1 ./olmoe 64 8 ref.json   # AVX2 (default)
```
- IDOT=0: 1.90 / 2.37 / 2.73 / 2.84 tok/s (median 2.55, n=4)
- IDOT=1: 2.54 / 2.64 / 3.90 tok/s (median 2.64, n=3)

This machine was running a full kube-apiserver/etcd/kubelet stack, clickhouse-server, and several Chrome renderers throughout (load average ~4.0/8 cores) — that background noise dominates the ~4% median difference, so I'm **not** claiming a confirmed speedup here. This patch's value is x86/ARM parity and verified correctness; a clean throughput number needs a quieter or dedicated box.

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included
