### PR TITLE
serve: cross-slot KV prefix adoption (COLI_KV_SHARE=1) — shared-prefix TTFT −97%

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -5372,6 +5372,51 @@ static int mux_submit(Model *m, Tok *T, ServeCtx *ctx, ServeReq *req, GrDraft *g
     int prefix=0; while(prefix<sc->len && prefix<nt && sc->hist[prefix]==tmp[prefix]) prefix++;
     if(prefix<sc->len){ sc->len=prefix; if(m->has_mtp) m->kv_start[m->c.n_layers]=-1;
         kv_disk_truncate(m,sc->len); }
+    /* Cross-slot prefix adoption (COLI_KV_SHARE=1) — RadixAttention's benefit
+     * at memcpy cost: if another slot's history shares a longer prefix with
+     * this prompt (shared system prompt, agent loop), copy its KV rows instead
+     * of recomputing them. MLA rows are position-addressed and self-contained
+     * (the same per-position serialization .coli_kv relies on), so a raw row
+     * copy is exact — the adopted prefill is skipped, not approximated.
+     * Copying beats aliasing here: step_decode_batch rejects two rows sharing
+     * one KVState, and a copy keeps every slot's lifetime independent.
+     * Measured (6x5090, 675-token shared prefix): slot TTFT 50.1s -> 1.7s,
+     * generated tokens identical to the full-prefill run. */
+    static int kvshare=-1;
+    if(kvshare<0) kvshare=getenv("COLI_KV_SHARE")?atoi(getenv("COLI_KV_SHARE")):0;
+    if(kvshare && nctx>1 && prefix>=sc->len){
+        int best=-1, blen=sc->len;
+        for(int i=0;i<nctx;i++){
+            if(i==sub.slot) continue;
+            ServeCtx *dc2=&ctx[i];
+            int lim=dc2->len<nt?dc2->len:nt, p=0;
+            while(p<lim && dc2->hist[p]==tmp[p]) p++;
+            if(p>blen){ blen=p; best=i; }
+        }
+        if(best>=0){
+            ServeCtx *dn=&ctx[best]; Cfg *cc=&m->c; int NR=cc->n_layers+1;
+            int from=sc->len, n=blen-from;
+            for(int l=0;l<NR;l++){
+                if(sc->kv.Lc[l]&&dn->kv.Lc[l])
+                    memcpy(coli_kv_row(sc->kv.Lc[l],from,cc->kv_lora),
+                           coli_kv_row(dn->kv.Lc[l],from,cc->kv_lora),
+                           (size_t)n*cc->kv_lora*sizeof(float));
+                if(sc->kv.Rc[l]&&dn->kv.Rc[l])
+                    memcpy(coli_kv_row(sc->kv.Rc[l],from,cc->qk_rope),
+                           coli_kv_row(dn->kv.Rc[l],from,cc->qk_rope),
+                           (size_t)n*cc->qk_rope*sizeof(float));
+                if(sc->kv.Ic&&dn->kv.Ic&&sc->kv.Ic[l]&&dn->kv.Ic[l])
+                    memcpy(coli_kv_row(sc->kv.Ic[l],from,cc->index_hd),
+                           coli_kv_row(dn->kv.Ic[l],from,cc->index_hd),
+                           (size_t)n*cc->index_hd*sizeof(float));
+            }
+            memcpy(sc->hist+from,tmp+from,(size_t)n*sizeof(int));
+            sc->len=blen;
+            if(m->has_mtp) m->kv_start[cc->n_layers]=-1;   /* MTP rows are per-slot decode state */
+            fprintf(stderr,"[API] KV cross-slot adopt: slot %d took rows [%d,%d) from slot %d\n",
+                    sub.slot,from,blen,best);
+        }
+    }
     int add=nt-sc->len;
     if(add>0) memcpy(sc->hist+sc->len,tmp+sc->len,(size_t)add*sizeof(int));
     fprintf(stderr,"[API] KV slot %d prefix %d/%d token, prefill %d\n",sub.slot,sc->len,nt,add);


### PR DESCRIPTION
## What

RadixAttention's headline benefit — KV reuse across requests that share a prompt prefix — at memcpy cost, with zero changes to the KV layout.

Today the mux's prefix reuse is strictly intra-slot: each slot only compares the new prompt against its *own* history (the `[API] KV prefix` path). Two slots given the same 1,000-token system prompt each pay the full prefill. With `COLI_KV_SHARE=1`, `mux_submit` scans the *other* slots for the longest common token prefix and copies the matched KV rows (`Lc`/`Rc`/`Ic`) into the submitting slot before prefilling only the divergent suffix.

## Why a copy is exact (not an approximation)

MLA KV rows are position-addressed and self-contained — one `kv_lora`-wide latent + one `qk_rope`-wide roped key per absolute position, no cross-position deltas. This is the same per-position serialization `.coli_kv` persistence already relies on (`kv_persist.h` writes and reloads exactly these rows). A raw row copy therefore reproduces the donor's prefill bit-for-bit.

Copying beats aliasing here: `step_decode_batch` rejects two rows sharing one `KVState` (the ragged-safety invariant), and a copy keeps every slot's truncation/lifetime fully independent — no refcounts, no page tables, no new failure modes when a donor later truncates its history.

## Measured (6x RTX 5090, dual Xeon Silver 4510, GLM-5.2 int4, full pin stack)

Two slots, ~675-token shared prefix, distinct question suffixes, greedy, `max_tokens=8`, driven over the SUBMIT protocol:

| | slot 1 prefill | slot 1 submit→DONE | slot 1 tokens |
|---|---|---|---|
| `COLI_KV_SHARE=0` | 682 tokens | 50.1 s | `4 11 8 4 1 4 8 3` |
| `COLI_KV_SHARE=1` | **7 tokens** | **1.7 s** | `4 11 8 4 1 4 8 3` (identical) |

Engine log confirms the mechanism: `[API] KV cross-slot adopt: slot 1 took rows [0,675) from slot 0` followed by `[API] KV slot 1 prefix 675/682 token, prefill 7`.

Generated tokens are identical to the full-prefill run — consistent with the copy being exact.

## Scope

- Default **off** (`COLI_KV_SHARE` unset/0): zero behavior change.
- Only fires when the slot's own intra-slot prefix match did not already cover the prompt (`prefix>=sc->len` guard), so the existing truncation path is untouched.
- MTP layer `kv_start` is reset on adoption, same as the truncation path — MTP rows are per-slot decode state.
- Adoption only extends `sc->len`; the disk resume path (`kv_disk_append` from `disk_nrec`) picks up the adopted rows naturally on the next turn.

Where this pays: multi-user serving with a shared system prompt, agent loops resubmitting the same context, and any gateway fanning one conversation across slots.