### PR TITLE
prefill: COLI_PREFILL_CHUNK=N — slice long prompts, bound activation memory to chunk size

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -4260,6 +4260,29 @@ static void kv_bind(Model *m, KVState *k){
 static void mtp_absorb(Model *m, const int *next_ids, const float *x, int S, int pos_base);
 static float *step(Model *m, const int *ids, int S, int pos_base){
     Cfg *c=&m->c; int D=c->hidden;
+    /* Chunked prefill (COLI_PREFILL_CHUNK=N): run a long prompt through the
+     * layers in N-token slices. KV rows are position-addressed, so a slice at
+     * pos_base+done is exactly the serve path's incremental suffix prefill —
+     * every S-scaled activation buffer here and inside attention/moe shrinks
+     * from prompt-sized to chunk-sized, and a serve scheduler gains a natural
+     * yield point between slices. Leading slices only write KV; logits come
+     * from the final slice's fall-through. Skipped under an active MTP draft:
+     * mtp_absorb consumes cross-position pairs a chunk boundary would split.
+     * Verified: 1,683-token prompt at N=256 produces byte-identical greedy
+     * output to the single-shot path. */
+    static int chunk=-1;
+    if(chunk<0) chunk=getenv("COLI_PREFILL_CHUNK")?atoi(getenv("COLI_PREFILL_CHUNK")):0;
+    if(chunk>0 && S>chunk && !(m->has_mtp && g_draft>0)){
+        int done=0;
+        while(S-done>chunk){
+            float *cx=falloc((int64_t)chunk*D);
+            for(int s=0;s<chunk;s++) embed_row(m, ids[done+s], cx+(int64_t)s*D);
+            layers_forward(m,cx,chunk,pos_base+done);
+            free(cx);
+            done+=chunk;
+        }
+        ids+=done; S-=done; pos_base+=done;
+    }
     float *x=falloc((int64_t)S*D);
     for(int s=0;s<S;s++) embed_row(m, ids[s], x+(int64_t)s*D);
     layers_forward(m,x,S,pos_base);


### PR DESCRIPTION
## What

vLLM-style chunked prefill, minimally: `COLI_PREFILL_CHUNK=N` makes `step()` run a long prompt through the layers in N-token slices instead of one prompt-sized batch. Leading slices only write KV; the final slice falls through the original path and produces the logits.

## Why it is safe

KV rows are position-addressed (`coli_kv_row(base, pos, width)`), and a slice at `pos_base+done` is *exactly* the incremental suffix prefill the serve path already performs on every follow-up turn (`step(m, hist+len, add, len)`); attention over prior slices' rows works because `Tk=pos_base+S` reconstructs over everything already written. Nothing writes rows out of order. Skipped under an active MTP draft (`m->has_mtp && g_draft>0`): `mtp_absorb` consumes cross-position hidden/id pairs that a chunk boundary would split.

## Measured (6x RTX 5090, GLM-5.2 int4, frozen usage snapshot, greedy)

1,683-token prompt, `NGEN=32`:

| | prefill | decode | output |
|---|---|---|---|
| single-shot | 141.8 s | 4.88 tok/s | — |
| `COLI_PREFILL_CHUNK=256` | 136.4 s | 5.04 tok/s | **byte-identical** |

Speed is parity (small win within noise); the point is what the slicing buys:

- **Bounded activation memory.** Every `falloc(S*…)` in `step`/`attention_rows`/`moe` (Q/ctx/comp buffers, router logits, group staging) scales with the slice, not the prompt. At 4k-16k contexts on small-RAM hosts this is the difference between fitting and not.
- **A scheduler yield point.** `run_serve_mux`'s prefill is serial and blocks decode for every active slot until the whole prompt is done (the SUBMIT handler comment says so explicitly). With slicing in place, making the mux resumable between slices — one slice per main-loop iteration, decode rows interleaved — becomes a small state-machine change instead of a forward-pass surgery. This PR deliberately ships only the mechanism; the mux integration can follow separately.

Default off (`COLI_PREFILL_CHUNK` unset): zero behavior change.