### PR TITLE
cuda: fuse silu into the dual hidden kernels' epilogue (bit-identical)

### DIFF
--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -319,7 +319,13 @@ __global__ static void grouped_hidden_w4_dual(float *gate,float *up,const float 
         int i=b*2;ga+=xs[i]*g0;ua+=xs[i]*u0;if(i+1<D){ga+=xs[i+1]*g1;ua+=xs[i+1]*u1;}}
     __shared__ float gp[256],upv[256];gp[threadIdx.x]=ga;upv[threadIdx.x]=ua;__syncthreads();
     for(int n=128;n;n>>=1){if(threadIdx.x<n){gp[threadIdx.x]+=gp[threadIdx.x+n];upv[threadIdx.x]+=upv[threadIdx.x+n];}__syncthreads();}
-    if(!threadIdx.x){size_t z=(size_t)(d.offset+s)*I+o;gate[z]=gp[0]*d.gs[o];up[z]=upv[0]*d.us[o];}
+    /* Fused epilogue: silu(gate)*up lands here instead of a third kernel —
+     * the exact silu_mul expression on the exact same inputs, so bit-identical,
+     * and the up[] round-trip through global memory disappears. up stays a
+     * param so the launch sites keep their signature. */
+    if(!threadIdx.x){size_t z=(size_t)(d.offset+s)*I+o;
+        float g=gp[0]*d.gs[o],u=upv[0]*d.us[o];
+        gate[z]=(g/(1.0f+expf(-g)))*u;(void)up;}
 }
 
 __global__ static void grouped_down_w4(float *y,const float *x,const GroupDesc *desc,int D,int I){
@@ -353,7 +359,11 @@ __global__ static void grouped_hidden_g4_dual(float *gate,float *up,const float 
         if(i+1<D){ga+=xs[i+1]*g1*gv;ua+=xs[i+1]*u1*uv;}}
     __shared__ float gp[256],upv[256];gp[threadIdx.x]=ga;upv[threadIdx.x]=ua;__syncthreads();
     for(int n=128;n;n>>=1){if(threadIdx.x<n){gp[threadIdx.x]+=gp[threadIdx.x+n];upv[threadIdx.x]+=upv[threadIdx.x+n];}__syncthreads();}
-    if(!threadIdx.x){size_t z=(size_t)(d.offset+s)*I+o;gate[z]=gp[0];up[z]=upv[0];}
+    /* same epilogue fusion as the w4 dual above (per-group scales already
+     * applied inside the accumulation, so silu runs on the raw sums) */
+    if(!threadIdx.x){size_t z=(size_t)(d.offset+s)*I+o;
+        float g=gp[0],u=upv[0];
+        gate[z]=(g/(1.0f+expf(-g)))*u;(void)up;}
 }
 __global__ static void grouped_down_g4(float *y,const float *x,const GroupDesc *desc,int D,int I){
     int o=blockIdx.x,s=blockIdx.y,c=blockIdx.z;GroupDesc d=desc[c];if(s>=d.rows)return;
@@ -879,18 +889,17 @@ extern "C" int coli_cuda_expert_group(ColiCudaTensor *const *gates,
         dim3 hg((unsigned)I,(unsigned)max_rows,(unsigned)count),og((unsigned)D,(unsigned)max_rows,(unsigned)count);
         int dual=!getenv("COLI_CUDA_DUAL_PROJ")||atoi(getenv("COLI_CUDA_DUAL_PROJ"));
         if(dual)grouped_hidden_w4_dual<<<hg,256,0,ctx->stream>>>(ctx->gate,ctx->up,ctx->x,dev,I,D);
-        else{
+        else{   /* non-dual path has no fused epilogue: silu stays a kernel here */
             grouped_hidden_w4<<<hg,256,0,ctx->stream>>>(ctx->gate,ctx->x,dev,I,D,0);
             grouped_hidden_w4<<<hg,256,0,ctx->stream>>>(ctx->up,ctx->x,dev,I,D,1);
+            silu_mul<<<(unsigned)(((size_t)total*I+255)/256),256,0,ctx->stream>>>(ctx->gate,ctx->up,(size_t)total*I);
         }
-        silu_mul<<<(unsigned)(((size_t)total*I+255)/256),256,0,ctx->stream>>>(ctx->gate,ctx->up,(size_t)total*I);
         grouped_down_w4<<<og,256,0,ctx->stream>>>(ctx->y,ctx->gate,dev,D,I);
     }else if(all_q4&&any_g4){
         /* grouped-int4 (fmt=4) present: per-group scales (#334). fmt=2 members
-         * ride along as the ng=1 special case. */
+         * ride along as the ng=1 special case. silu fused in the dual epilogue. */
         dim3 hg((unsigned)I,(unsigned)max_rows,(unsigned)count),og((unsigned)D,(unsigned)max_rows,(unsigned)count);
         grouped_hidden_g4_dual<<<hg,256,0,ctx->stream>>>(ctx->gate,ctx->up,ctx->x,dev,I,D);
-        silu_mul<<<(unsigned)(((size_t)total*I+255)/256),256,0,ctx->stream>>>(ctx->gate,ctx->up,(size_t)total*I);
         grouped_down_g4<<<og,256,0,ctx->stream>>>(ctx->y,ctx->gate,dev,D,I);
     }else{
         /* generic path decodes fmt 0/1/2/3 only — a fmt=4 group that slipped the
@@ -1438,8 +1447,7 @@ extern "C" int coli_cuda_expert_group_resident_issue(ColiCudaTensor *const *gate
     bcast_row<<<64,256,0,ctx->stream>>>(ctx->x,ctx->x,count,D);   /* row 0 -> rows 1..count-1 (in-place safe: row 0 rewritten with itself) */
     GroupDesc *dev=(GroupDesc*)ctx->group_desc;
     dim3 hg((unsigned)I,1,(unsigned)count),og((unsigned)D,1,(unsigned)count);
-    grouped_hidden_w4_dual<<<hg,256,0,ctx->stream>>>(ctx->gate,ctx->up,ctx->x,dev,I,D);
-    silu_mul<<<(unsigned)(((size_t)count*I+255)/256),256,0,ctx->stream>>>(ctx->gate,ctx->up,(size_t)count*I);
+    grouped_hidden_w4_dual<<<hg,256,0,ctx->stream>>>(ctx->gate,ctx->up,ctx->x,dev,I,D);  /* silu fused in epilogue */
     grouped_down_w4<<<og,256,0,ctx->stream>>>(ctx->y,ctx->gate,dev,D,I);
     weighted_sum_rows<<<48,256,0,ctx->stream>>>(partial_local,ctx->y,w_dev,count,D);
     if(!cuda_ok(cudaMemcpyPeerAsync(partial_slot_dev,home_device,partial_local,device,


### PR DESCRIPTION
## What

The grouped decode path launches `grouped_hidden_*_dual` (gate+up in one kernel) → `silu_mul` → `grouped_down_*`. The middle kernel exists only to apply `silu(gate)*up` element-wise over data the dual kernel just wrote. This PR moves that expression into the dual kernels' epilogue: the thread that owns output element `z` applies silu right after its block reduction, writes the fused product into `gate[z]`, and never writes `up[z]` at all.

Per group call this removes one kernel launch and a full `S*I` float round-trip through global memory (one write + two reads). Applied to `grouped_hidden_w4_dual`, `grouped_hidden_g4_dual`, and the resident-path launch site; the non-dual (`COLI_CUDA_DUAL_PROJ=0`) and generic fmt-0/1/2/3 paths keep their explicit `silu_mul`, since their hidden kernels write gate and up separately.

## Bit-identical, verified

The epilogue computes literally the same expression `silu_mul` did — `(g/(1.0f+expf(-g)))*u` — on literally the same two fp32 values (the scaled block-reduction results). No reassociation, no contraction opportunity, so the outputs are bit-identical.

A/B on the 6x RTX 5090 rig (GLM-5.2 int4, frozen `.coli_usage` snapshot per the near-tie discipline from #510, greedy, 128 tokens): fused vs `COLI_CUDA_DUAL_PROJ=0` (which exercises the old separate-silu route) — **generated text byte-identical**, decode 8.34 vs 8.27 tok/s (parity; launch count is not this box's wall, consistent with the #431 findings — the win is the removed memory traffic, which travels with the change to launch-taxed and HIP hosts for free).

Note for the frozen-snapshot discipline: without freezing `.coli_usage`, two runs of the *same* binary diverge at this prompt (placement drift → kernel-family near-ties), which is why the A/B pins the snapshot.