### PR TITLE
cuda: DSA sparse decode on GPU via gather staging (COLI_DSA_GATHER=1) — first stone of KV tiering

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -2569,7 +2569,35 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
             for(int s=0;s<S&&cuda_core;s++){
                 KVState *ks=kvs?kvs[s]:m->kv;int pos=positions?positions[s]:pos_base+s;
                 int st0=ks->kv_start[layer],nt=pos+1-st0;
-                if(dnsel&&dnsel[s]>0){cuda_core=0;break;}
+                if(dnsel&&dnsel[s]>0){
+                    /* Sparse decode used to force the CPU path here: the CUDA
+                     * absorb kernel only scans contiguous rows and cannot take
+                     * the DSA gather list. COLI_DSA_GATHER=1: gather the
+                     * selected top-k rows into a compact staging pair and hand
+                     * the dense kernel that instead. Host KV stays canonical —
+                     * only ~index_topk rows cross PCIe per (layer, token), so
+                     * the device never needs the full context resident (the
+                     * first stone of KV tiering). Same row set as the CPU loop
+                     * below; results differ only by kernel-family FP order,
+                     * the same class of divergence the dense CUDA absorb
+                     * already has vs the CPU path (#510). Verified: with
+                     * DSA_FORCE=1 (identity selection) output is byte-identical
+                     * to the dense CUDA path. */
+                    static int dsag=-1;
+                    if(dsag<0) dsag=getenv("COLI_DSA_GATHER")?atoi(getenv("COLI_DSA_GATHER")):0;
+                    if(!dsag){cuda_core=0;break;}
+                    int ns=dnsel[s]; const int *tl=dsel+(int64_t)s*dtopk;
+                    float *gl=falloc((int64_t)ns*kvl), *gr=falloc((int64_t)ns*c->qk_rope);
+                    for(int jj=0;jj<ns;jj++){
+                        memcpy(gl+(int64_t)jj*kvl, coli_kv_row(ks->Lc[layer],tl[jj],kvl), (size_t)kvl*sizeof(float));
+                        memcpy(gr+(int64_t)jj*c->qk_rope, coli_kv_row(ks->Rc[layer],tl[jj],c->qk_rope), (size_t)c->qk_rope*sizeof(float));
+                    }
+                    cuda_core=coli_cuda_attention_absorb(l->kv_b.cuda,ctx+(int64_t)s*H*vh,
+                        Q+(int64_t)s*H*qh,gl,gr,H,c->qk_nope,c->qk_rope,vh,kvl,ns,c->attn_scale);
+                    free(gl);free(gr);
+                    if(!cuda_core)break;    /* CPU fallback recomputes every row: idempotent */
+                    continue;
+                }
                 cuda_core=0;
                 if(g_cuda_pipe&&ks==m->kv&&layer<c->n_layers&&kv_dev_sync(m,l,layer,pos+1))
                     cuda_core=coli_cuda_attention_absorb_kvdev(l->kv_b.cuda,ctx+(int64_t)s*H*vh,


### PR DESCRIPTION
## What

Past `index_topk` context, DSA sparse decode today forces the whole layer's attention onto the CPU: the CUDA absorb kernel only scans contiguous KV rows and cannot consume the selection list, so `attention_rows` bails (`if(dnsel[s]>0){cuda_core=0;break;}`) and long-context decode loses the GPU exactly when attention cost peaks.

`COLI_DSA_GATHER=1` closes that gap without touching the kernel: gather the DSA-selected top-k rows into a compact `[ns, kv_lora]` / `[ns, qk_rope]` staging pair on the host, and hand the existing dense `coli_cuda_attention_absorb` that. Scores, softmax, and the latent mix are position-free (RoPE is applied at KV-write time), so a dense scan over gathered rows computes the same attention the CPU gather loop does.

## Why this is the first stone of KV tiering

Host KV stays canonical; only `~index_topk` rows (≈4.7 MB at kv_lora=512) cross PCIe per (layer, token). The device never needs the full context resident — which is the read path of hot/cold KV tiering (the same shape SGLang has on its 2026 Q2 roadmap for NSA models: full KV in host memory, only the sparse top-k in device memory). The natural next steps stack on this seam: a device-side gather (index list into the kernel, feeding from a resident `kv_dev` shadow — zero PCIe), and pinned staging for true DMA.

## Correctness

- **Identity selection is byte-exact**: with `DSA_FORCE=1` at short context (selection = all positions, ascending), output is byte-identical to the dense CUDA absorb path — the staging and the call are exact.
- **Partial selection diverges only by kernel family**, which is the pre-existing contract, not a new behavior. Discrimination experiment at 2,943-token context (frozen usage snapshot, greedy): all-CPU attention, the current mixed path, and the gather path produce three *mutually different* fluent continuations — the first generated token after this near-tie-heavy prompt flips under any kernel-family change, exactly the #510 doctrine (bit-identity holds within a kernel family, not across).

## Measured (6x RTX 5090, GLM-5.2 int4, 2,943-token prompt, 32-token greedy decode)

| | decode |
|---|---|
| CPU sparse (today's fallback) | 4.08 tok/s |
| `COLI_DSA_GATHER=1` | 3.81 tok/s |

Parity-to-slightly-behind at 3k context on this box — the AVX-512 CPU sweep over 2,048 rows is already fast, and the gather pays a host memcpy + PCIe upload per layer. The value at this stage is architectural (device no longer needs full-context KV; CPU freed from the attention sweep on sparse layers) and it establishes the seam the device-side gather needs. Default off; zero behavior change unless `COLI_DSA_GATHER=1`.