### PR TITLE
feat: add dense MLP activation sharding

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,32 @@ the right experts get. It works because routing has measurable structure (see
 the [expert atlas](https://github.com/JustVugg/colibri/issues/175)) — and
 structure is cacheable.
 
-The engine is a single C file (`c/glm.c`) plus small headers. No BLAS, no Python
-at runtime, no GPU required.
+The engine is a single C file (`c/colibri.c`) plus small headers. No BLAS, no
+Python at runtime, no GPU required.
+
+### Dense MLP activation sharding
+
+The first local-cluster seam can move contiguous dense MLP layers to another
+machine. Attention, KV state, routing, and token generation remain on the
+coordinator; the worker owns only the selected gate/up/down tensors and
+returns the activation result over a small TCP protocol.
+
+Start a worker with the same converted model:
+
+```bash
+./coli cluster dense-worker --model /nvme/glm52_i4 \
+  --port 9200 --first 0 --last 2
+```
+
+Point the coordinator at that range:
+
+```bash
+./coli serve --model /nvme/glm52_i4 \
+  --dense-shards WORKER_IP:9200:0:2
+```
+
+This is intentionally a narrow activation pipeline. Full attention/KV
+ownership and tensor-parallel sharding are separate follow-up designs.
 
 ## How it works
 

--- a/c/Makefile
+++ b/c/Makefile
@@ -199,7 +199,7 @@ else
 PYTHON    ?= python3
 endif
 CUDA_OBJ  =
-TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_st_mirror$(EXE) tests/test_st_pread$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_grouped$(EXE) tests/test_stops$(EXE) tests/test_topp$(EXE) tests/test_sample_nan$(EXE) tests/test_temp_env$(EXE) tests/test_tok_o200k$(EXE) tests/test_kv_alloc$(EXE) tests/test_int3$(EXE) tests/test_int3_load$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE) tests/test_dsa_select$(EXE) tests/test_logit_nan$(EXE) tests/test_pipe_block$(EXE) tests/test_e8_kernel$(EXE)
+TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_st_mirror$(EXE) tests/test_st_pread$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_grouped$(EXE) tests/test_stops$(EXE) tests/test_topp$(EXE) tests/test_sample_nan$(EXE) tests/test_temp_env$(EXE) tests/test_tok_o200k$(EXE) tests/test_kv_alloc$(EXE) tests/test_int3$(EXE) tests/test_int3_load$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE) tests/test_dsa_select$(EXE) tests/test_logit_nan$(EXE) tests/test_pipe_block$(EXE) tests/test_e8_kernel$(EXE) tests/test_dense_protocol$(EXE)
 ifneq (,$(LINUX))
 TEST_BINS += tests/test_uring$(EXE)
 endif
@@ -463,6 +463,9 @@ tests/test_uring$(EXE): tests/test_uring.c colibri.c st.h uring.h json.h tok.h t
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_pipe_block$(EXE): tests/test_pipe_block.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+tests/test_dense_protocol$(EXE): tests/test_dense_protocol.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 test-c: $(TEST_BINS)

--- a/c/coli
+++ b/c/coli
@@ -215,6 +215,7 @@ def env_for(a):
     if a.ngen: e["NGEN"]=str(a.ngen)
     if a.topp: e["TOPP"]=str(a.topp)
     if a.topk: e["TOPK"]=str(a.topk)
+    if getattr(a, "dense_shards", None): e["DENSE_SHARDS"]=a.dense_shards
     if a.temp is not None: e["COLI_TEMP"]=str(a.temp)   # 0 = greedy; default motore: 1.0 + nucleus 0.95
                                                         # COLI_TEMP, non TEMP: ROCm e Windows leggono $TEMP come dir temporanea (#509)
     if a.repin: e["REPIN"]=str(a.repin)
@@ -836,6 +837,16 @@ def cmd_serve(a):
         try: os.unlink(serve_pidfile(a.port))
         except OSError: pass
 
+def cmd_cluster_dense_worker(a):
+    need_model(a.model)
+    if a.first < 0 or a.last < a.first:
+        sys.exit(f"{C.yel}dense worker range must satisfy 0 <= --first <= --last{C.r}")
+    e=env_for(a)
+    e.update({"DENSE_WORKER":"1", "DENSE_WORKER_PORT":str(a.port),
+              "DENSE_WORKER_FIRST":str(a.first), "DENSE_WORKER_LAST":str(a.last)})
+    print(f"  {C.dim}[DENSE] worker · layers {a.first}-{a.last} · MLP activation pipeline{C.r}")
+    return subprocess.call([GLM,str(a.cap),str(a.ebits),str(a.dbits)],env=e)
+
 def cmd_stop(a):
     """Shut down a running `coli serve` AND its engine — one command, no pkill.
     The engine re-execs itself for OMP tuning, so its process is named `exe`,
@@ -963,6 +974,8 @@ def main():
     common.add_argument("--cap", type=int, default=8); common.add_argument("--ngen", type=int, default=1024)  # rete di sicurezza: la fine vera la decidono gli stop token
     common.add_argument("--topp", type=float, default=0); common.add_argument("--topk", type=int, default=0)
     common.add_argument("--temp", type=float, default=None)  # temperatura token (0=greedy, default 1.0+nucleus .95)
+    common.add_argument("--dense-shards", default=os.environ.get("DENSE_SHARDS"),
+                        help="static dense MLP shards: host:port:first:last,...")
     ap=argparse.ArgumentParser(prog="coli", parents=[common], description="colibri — run GLM-5.2 locally")
     ap.add_argument("--version", action="version", version=f"colibri {_version}")
     sub=ap.add_subparsers(dest="cmd")
@@ -988,6 +1001,14 @@ def main():
     ps.add_argument("--max-queue",type=int,default=int(os.environ.get("COLI_MAX_QUEUE","8")))
     ps.add_argument("--queue-timeout",type=float,default=float(os.environ.get("COLI_QUEUE_TIMEOUT","300")))
     ps.add_argument("--kv-slots",type=int,default=int(os.environ.get("COLI_KV_SLOTS","1")))
+    pcluster=sub.add_parser("cluster", help="run local dense-shard workers")
+    cluster_sub=pcluster.add_subparsers(dest="cluster_cmd")
+    pdense=cluster_sub.add_parser("dense-worker", parents=[common], help="serve sharded dense MLP layers")
+    pdense.add_argument("--port",type=int,default=9200)
+    pdense.add_argument("--first",type=int,required=True)
+    pdense.add_argument("--last",type=int,required=True)
+    pdense.add_argument("--ebits",type=int,default=8)
+    pdense.add_argument("--dbits",type=int,default=8)
     pst=sub.add_parser("stop", parents=[common], help="shut down a running coli serve and its engine")
     pst.add_argument("--port",type=int,default=8000); pst.add_argument("--dry-run",action="store_true")
     pw=sub.add_parser("web", parents=[common], help="serve + open the dashboard in a browser")
@@ -1015,6 +1036,8 @@ def main():
     handler={"build":cmd_build,"info":cmd_info,"plan":cmd_plan,"doctor":cmd_doctor,
              "run":cmd_run,"chat":cmd_chat,"serve":cmd_serve,"stop":cmd_stop,"bench":cmd_bench,
              "convert":cmd_convert,"web":cmd_web}.get(a.cmd)
+    if a.cmd=="cluster" and a.cluster_cmd=="dense-worker":
+        handler=cmd_cluster_dense_worker
     if handler: sys.exit(handler(a) or 0)
     banner(); print(__doc__)
 

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -30,6 +30,10 @@
 #include <unistd.h>
 #if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
 #include <sys/select.h>                             /* select() serve-loop polling (#68); not on native MinGW */
+#include <sys/socket.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
 #endif
 #if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
 #include <sys/resource.h>
@@ -75,6 +79,19 @@ static const float *g_pre_sh;
 /* routing precalcolata dalla GPU (Metal layer CB o device router CUDA, #431):
  * moe() la usa e salta la FASE A. NULL = router su CPU. */
 static const int *g_pre_idx; static const float *g_pre_w; static const int *g_pre_keff;
+#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
+typedef struct { int fd; char host[128]; int port, first, last; } DenseShard;
+static DenseShard g_dense_shards[16];
+static int g_dense_n;
+static int g_dense_worker;
+static int g_dense_worker_first, g_dense_worker_last;
+static int dense_owner(int layer);
+static int dense_worker_run(const char *snap, int port, int first, int last,
+                            int cap, int ebits, int dbits);
+#else
+static int g_dense_worker;
+static int g_dense_worker_first, g_dense_worker_last;
+#endif
 #ifdef __APPLE__
 #include <mach/mach.h>                            /* host_statistics64: MemAvailable di macOS */
 #endif
@@ -1088,6 +1105,70 @@ static void layer_cuda_shard_kvb(Layer *l,int H,int Q,int V){
 }
 #endif
 
+#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
+/* Dense-shard protocol. Headers use network-order u32 values; activations and
+ * outputs stay raw little-endian f32, matching the host engine's ABI. */
+#define COLI_DENSE_MAGIC "COLIDN01"
+static int dense_io(int fd, void *buf, size_t n, int write_mode){
+    char *p=(char*)buf;
+    while(n){
+        ssize_t r=write_mode?send(fd,p,n,0):recv(fd,p,n,MSG_WAITALL);
+        if(r<=0){ if(r<0&&errno==EINTR) continue; return -1; }
+        p+=r; n-=(size_t)r;
+    }
+    return 0;
+}
+static int dense_u32(int fd, uint32_t *v, int write_mode){
+    uint32_t x=write_mode?htonl(*v):0;
+    if(dense_io(fd,write_mode?(void*)&x:(void*)v,sizeof(x),write_mode)) return -1;
+    if(!write_mode) *v=ntohl(*v);
+    return 0;
+}
+static int dense_connect_one(const char *spec, DenseShard *out){
+    char copy[256]; strncpy(copy,spec,sizeof(copy)-1); copy[sizeof(copy)-1]=0;
+    char *colon=strrchr(copy,':'); if(!colon||colon==copy||!colon[1]) return -1;
+    *colon=0; int port=atoi(colon+1); if(port<1||port>65535) return -1;
+    char portbuf[16]; snprintf(portbuf,sizeof(portbuf),"%d",port);
+    struct addrinfo hint={0},*ai=NULL; hint.ai_socktype=SOCK_STREAM;
+    if(getaddrinfo(copy,portbuf,&hint,&ai)!=0) return -1;
+    int fd=-1;
+    for(struct addrinfo *p=ai;p;p=p->ai_next){
+        fd=socket(p->ai_family,p->ai_socktype,p->ai_protocol);
+        if(fd<0) continue;
+        if(connect(fd,p->ai_addr,p->ai_addrlen)==0) break;
+        close(fd); fd=-1;
+    }
+    freeaddrinfo(ai); if(fd<0) return -1;
+    out->fd=fd; strncpy(out->host,copy,sizeof(out->host)-1); out->host[sizeof(out->host)-1]=0;
+    out->port=port; return 0;
+}
+static int dense_owner(int layer){
+    for(int i=0;i<g_dense_n;i++)
+        if(layer>=g_dense_shards[i].first&&layer<=g_dense_shards[i].last) return i;
+    return -1;
+}
+static void dense_init(void){
+    const char *list=getenv("DENSE_SHARDS"); if(!list||!*list) return;
+    char *copy=strdup(list),*save=NULL;
+    for(char *tok=strtok_r(copy,",",&save);tok&&g_dense_n<16;tok=strtok_r(NULL,",",&save)){
+        char spec[256]; strncpy(spec,tok,sizeof(spec)-1); spec[sizeof(spec)-1]=0;
+        char *last=strrchr(spec,':'); if(!last) continue; int end=atoi(last+1); *last=0;
+        char *firstp=strrchr(spec,':'); if(!firstp) continue; int first=atoi(firstp+1); *firstp=0;
+        if(first<0||end<first) continue;
+        if(dense_connect_one(spec,&g_dense_shards[g_dense_n])) continue;
+        g_dense_shards[g_dense_n].first=first; g_dense_shards[g_dense_n].last=end;
+        g_dense_n++;
+    }
+    free(copy);
+    if(!g_dense_n){ fprintf(stderr,"[DENSE] no dense shard workers reachable\n"); exit(1); }
+    fprintf(stderr,"[DENSE] activation pipeline connected to %d shard(s)\n",g_dense_n);
+}
+static void dense_close(void){
+    for(int i=0;i<g_dense_n;i++) if(g_dense_shards[i].fd>=0) close(g_dense_shards[i].fd);
+    g_dense_n=0;
+}
+#endif
+
 static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits){
     memset(m,0,sizeof(*m)); m->ebits=ebits; m->dbits=dbits;
     load_cfg(&m->c,snap);
@@ -1097,9 +1178,11 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
     /* embed e lm_head sono il confine I/O: tenerli ad alta precisione (come i quant dynamic
      * reali). A bf16 ~1.9GB su GLM reale: trascurabile. dbits>=8 -> qui f32; piu' basso -> dbits. */
     int io_bits = dbits>=8 ? 16 : dbits;
-    m->embed   = qt_load(m,"model.embed_tokens.weight", c->vocab, D, io_bits);
-    m->lm_head = qt_load(m,"lm_head.weight", c->vocab, D, io_bits);
-    m->final_norm = ld(m,"model.norm.weight");
+    if(!g_dense_worker){
+        m->embed   = qt_load(m,"model.embed_tokens.weight", c->vocab, D, io_bits);
+        m->lm_head = qt_load(m,"lm_head.weight", c->vocab, D, io_bits);
+        m->final_norm = ld(m,"model.norm.weight");
+    }
     m->L=calloc(c->n_layers,sizeof(Layer));
     int NR=c->n_layers+1;                        /* +1: riga del layer MTP */
     m->ecap=cap; m->ecache=calloc(NR,sizeof(ESlot*)); m->ecn=calloc(NR,sizeof(int));
@@ -1114,6 +1197,16 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
     m->kv_start=m->kv->kv_start=calloc(NR,sizeof(int));
     for(int i=0;i<c->n_layers;i++){
         Layer *l=&m->L[i];
+        if(g_dense_worker){
+            if(i<g_dense_worker_first||i>g_dense_worker_last||i>=c->first_dense) continue;
+            l->sparse=0;
+            #define PW(s) (snprintf(nm,sizeof(nm),"model.layers.%d." s,i),nm)
+            l->gate_proj=qt_load(m,PW("mlp.gate_proj.weight"),c->dense_inter,D,dbits);
+            l->up_proj=qt_load(m,PW("mlp.up_proj.weight"),c->dense_inter,D,dbits);
+            l->down_proj=qt_load(m,PW("mlp.down_proj.weight"),D,c->dense_inter,dbits);
+            #undef PW
+            continue;
+        }
         #define P(s) (snprintf(nm,sizeof(nm),"model.layers.%d." s,i),nm)
         l->in_ln=ld(m,P("input_layernorm.weight"));
         l->post_ln=ld(m,P("post_attention_layernorm.weight"));
@@ -1133,7 +1226,11 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
             layer_cuda_shard_kvb(l,H,c->qk_nope,c->v_head);
 #endif
         l->sparse = (i >= c->first_dense);
-        if(!l->sparse){
+        if(!l->sparse
+#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
+           && dense_owner(i)<0
+#endif
+          ){
             l->gate_proj = qt_load(m,P("mlp.gate_proj.weight"), c->dense_inter, D, dbits);
             l->up_proj   = qt_load(m,P("mlp.up_proj.weight"),   c->dense_inter, D, dbits);
             l->down_proj = qt_load(m,P("mlp.down_proj.weight"), D, c->dense_inter, dbits);
@@ -1169,7 +1266,7 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
             "self_attn.kv_b_proj.weight","self_attn.o_proj.weight","mlp.gate.weight",
             "mlp.shared_experts.gate_proj.weight","mlp.shared_experts.down_proj.weight",
             "mlp.experts.0.gate_proj.weight"};
-        char mn[256]; m->has_mtp=1;
+        char mn[256]; m->has_mtp=g_dense_worker?0:1;
         for(unsigned q=0;q<sizeof(req)/sizeof(req[0]);q++){
             snprintf(mn,sizeof(mn),"model.layers.%d.%s",c->n_layers,req[q]);
             if(!st_has(&m->S,mn)){ m->has_mtp=0; break; }
@@ -1216,7 +1313,7 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
     /* DSA lightning indexer: attivo SOLO se i pesi (conversione --indexer) ci sono per
      * TUTTI i layer full. Auto-rilevamento come per MTP: niente flag, niente passi extra. */
     {
-        m->has_dsa = (c->index_topk>0 && c->index_nh>0 && c->index_hd>0 && c->index_hd<=256);
+        m->has_dsa = (!g_dense_worker && c->index_topk>0 && c->index_nh>0 && c->index_hd>0 && c->index_hd<=256);
         char inm[300];
         for(int i=0;i<c->n_layers && m->has_dsa;i++){
             if(!c->idx_type[i]) continue;
@@ -3542,6 +3639,65 @@ static void dense_mlp(Layer *l, float *x, int S, int D, int I, float *out){
     free(g); free(u);
 }
 
+#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
+static void dense_mlp_remote(Model *m,int layer,const float *input,int S,float *output){
+    int wi=dense_owner(layer);
+    if(wi<0){ fprintf(stderr,"[DENSE] no owner for layer %d\n",layer); exit(1); }
+    DenseShard *w=&g_dense_shards[wi]; uint32_t v;
+    int D=m->c.hidden,I=m->c.dense_inter;
+    if(dense_io(w->fd,(void*)COLI_DENSE_MAGIC,8,1)) goto fail;
+    v=1; if(dense_u32(w->fd,&v,1)) goto fail;
+    v=(uint32_t)layer; if(dense_u32(w->fd,&v,1)) goto fail;
+    v=(uint32_t)D; if(dense_u32(w->fd,&v,1)) goto fail;
+    v=(uint32_t)I; if(dense_u32(w->fd,&v,1)) goto fail;
+    v=(uint32_t)S; if(dense_u32(w->fd,&v,1)) goto fail;
+    if(dense_io(w->fd,(void*)input,(size_t)S*D*sizeof(float),1)) goto fail;
+    char magic[8];
+    if(dense_io(w->fd,magic,8,0)||memcmp(magic,COLI_DENSE_MAGIC,8)) goto fail;
+    if(dense_u32(w->fd,&v,0)||v!=1) goto fail;
+    if(dense_u32(w->fd,&v,0)||v!=0) goto fail;
+    if(dense_u32(w->fd,&v,0)||v!=(uint32_t)S) goto fail;
+    if(dense_io(w->fd,output,(size_t)S*D*sizeof(float),0)) goto fail;
+    return;
+fail:
+    fprintf(stderr,"[DENSE] shard %s:%d failed for layer %d\n",w->host,w->port,layer);
+    exit(1);
+}
+
+static int dense_worker_run(const char *snap,int port,int first,int last,int cap,int ebits,int dbits){
+    g_dense_worker=1; g_dense_worker_first=first; g_dense_worker_last=last;
+    Model m; double t0=now_s(); model_init(&m,snap,cap,ebits,dbits);
+    int fd=socket(AF_INET,SOCK_STREAM,0); if(fd<0){perror("dense worker socket");return 1;}
+    int yes=1; setsockopt(fd,SOL_SOCKET,SO_REUSEADDR,&yes,sizeof(yes));
+    struct sockaddr_in addr={0}; addr.sin_family=AF_INET; addr.sin_addr.s_addr=htonl(INADDR_ANY); addr.sin_port=htons((uint16_t)port);
+    if(bind(fd,(struct sockaddr*)&addr,sizeof(addr))||listen(fd,4)){perror("dense worker bind/listen");return 1;}
+    fprintf(stderr,"[DENSE] worker listening on 0.0.0.0:%d · layers %d-%d · loaded %.2f MB in %.2fs\n",
+            port,first,last,m.resident_bytes/(1024.0*1024.0),now_s()-t0);
+    for(;;){
+        int cfd=accept(fd,NULL,NULL); if(cfd<0){if(errno==EINTR)continue;break;}
+        for(;;){
+            char magic[8]; uint32_t v,layer,D,I,S;
+            if(dense_io(cfd,magic,8,0)) break;
+            if(memcmp(magic,COLI_DENSE_MAGIC,8)||dense_u32(cfd,&v,0)||v!=1||
+               dense_u32(cfd,&layer,0)||dense_u32(cfd,&D,0)||dense_u32(cfd,&I,0)||dense_u32(cfd,&S,0)||
+               layer>=(uint32_t)m.c.n_layers||layer<(uint32_t)first||layer>(uint32_t)last||layer>=(uint32_t)m.c.first_dense||
+               D!=(uint32_t)m.c.hidden||I!=(uint32_t)m.c.dense_inter||S<1||S>4096){
+                close(cfd); cfd=-1; break;
+            }
+            float *input=falloc((int64_t)S*D),*output=falloc((int64_t)S*D);
+            if(dense_io(cfd,input,(size_t)S*D*sizeof(float),0)){free(input);free(output);break;}
+            dense_mlp(&m.L[layer],input,S,D,I,output);
+            v=1; if(dense_io(cfd,(void*)COLI_DENSE_MAGIC,8,1)||dense_u32(cfd,&v,1)){free(input);free(output);break;}
+            v=0; if(dense_u32(cfd,&v,1)){free(input);free(output);break;}
+            v=S; if(dense_u32(cfd,&v,1)||dense_io(cfd,output,(size_t)S*D*sizeof(float),1)){free(input);free(output);break;}
+            free(input);free(output);
+        }
+        if(cfd>=0)close(cfd);
+    }
+    close(fd); return 0;
+}
+#endif
+
 /* LOOKA: predice il top-K del router del layer `target` dallo stato h (residual stream),
  * usando la STESSA pipeline del routing vero (post_ln -> router -> sigmoid+bias, top-K).
  * kind 0 = stesso layer saltando l'attention
@@ -4127,7 +4283,11 @@ static void layer_forward_rows(Model *m, Layer *l, int li, float *x, int S, int 
         la_predict(m,li+1,x,2);  /* two-step: shared-expert-corrected prediction */
     }
     for(int s=0;s<S;s++) rmsnorm(nrm+(int64_t)s*D, x+(int64_t)s*D, l->post_ln, D, c->eps);
-    if(l->sparse) moe(m,l,li,nrm,S,tmp,1); else dense_mlp(l,nrm,S,D,c->dense_inter,tmp);
+    if(l->sparse) moe(m,l,li,nrm,S,tmp,1);
+#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
+    else if(dense_owner(li)>=0) dense_mlp_remote(m,li,nrm,S,tmp);
+#endif
+    else dense_mlp(l,nrm,S,D,c->dense_inter,tmp);
     for(int64_t j=0;j<(int64_t)S*D;j++) x[j]+=tmp[j];
 }
 static void layer_forward(Model *m, Layer *l, int li, float *x, int S, int pos_base, float *nrm, float *tmp){
@@ -6531,8 +6691,29 @@ int main(int argc, char **argv){
         return 2;
     }
 #endif
+#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
+    if(getenv("DENSE_WORKER")){
+        int port=getenv("DENSE_WORKER_PORT")?atoi(getenv("DENSE_WORKER_PORT")):9200;
+        int first=getenv("DENSE_WORKER_FIRST")?atoi(getenv("DENSE_WORKER_FIRST")):-1;
+        int last=getenv("DENSE_WORKER_LAST")?atoi(getenv("DENSE_WORKER_LAST")):-1;
+        if(port<1||port>65535||first<0||last<first){
+            fprintf(stderr,"invalid dense worker port/range\n"); return 2;
+        }
+        return dense_worker_run(snap,port,first,last,cap,ebits,dbits);
+    }
+#else
+    if(getenv("DENSE_WORKER")){
+        fprintf(stderr,"[DENSE] dense workers are not supported on Windows yet\n"); return 2;
+    }
+#endif
     printf("== GLM C engine (glm_moe_dsa), cache=%d experts/layer | experts@%d-bit dense@%d-bit | idot: " IDOT_KERNEL " ==\n", cap, ebits, dbits);
     g_mem_avail_boot = mem_available_gb();
+#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
+    if(getenv("DENSE_SHARDS") && *getenv("DENSE_SHARDS")){
+        dense_init();
+        atexit(dense_close);
+    }
+#endif
     Model m; double t0=now_s(); model_init(&m,snap,cap,ebits,dbits);
     if(!g_direct_heat_explicit){                     /* COLI_DISKCLASS_WINDOW default, needs m.c (topk/n_layers) */
         /* CURRENT-STATE CALIBRATION: the "8" multiplier (recency window ~= the last 8

--- a/c/tests/test_dense_protocol.c
+++ b/c/tests/test_dense_protocol.c
@@ -1,0 +1,98 @@
+/* Dense shard wire contract: network-order headers, raw f32 activations, and
+ * one request/response over a persistent stream. No model fixture required. */
+#define main coli_engine_main_unused
+#include "../colibri.c"
+#undef main
+
+#include <assert.h>
+
+#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
+typedef struct { int fd; int failed; } DenseProtocolArgs;
+
+static void *dense_protocol_worker(void *opaque)
+{
+    DenseProtocolArgs *args = opaque;
+    char magic[8];
+    uint32_t version, layer, hidden, intermediate, rows;
+    float input[3], output[3];
+
+    if (dense_io(args->fd, magic, sizeof(magic), 0) || memcmp(magic, COLI_DENSE_MAGIC, 8) ||
+        dense_u32(args->fd, &version, 0) || version != 1 ||
+        dense_u32(args->fd, &layer, 0) || layer != 2 ||
+        dense_u32(args->fd, &hidden, 0) || hidden != 3 ||
+        dense_u32(args->fd, &intermediate, 0) || intermediate != 5 ||
+        dense_u32(args->fd, &rows, 0) || rows != 1 ||
+        dense_io(args->fd, input, sizeof(input), 0)) {
+        args->failed = 1;
+        return NULL;
+    }
+    for (int i = 0; i < 3; i++) output[i] = input[i] * 2.0f;
+    version = 1;
+    if (dense_io(args->fd, (void *)COLI_DENSE_MAGIC, 8, 1) ||
+        dense_u32(args->fd, &version, 1) ||
+        dense_u32(args->fd, &(uint32_t){0}, 1) ||
+        dense_u32(args->fd, &(uint32_t){1}, 1) ||
+        dense_io(args->fd, output, sizeof(output), 1))
+        args->failed = 1;
+    return NULL;
+}
+
+static void test_wire_round_trip(void)
+{
+    int sockets[2];
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    DenseProtocolArgs args = {sockets[1], 0};
+    pthread_t thread;
+    assert(pthread_create(&thread, NULL, dense_protocol_worker, &args) == 0);
+
+    uint32_t value;
+    float input[3] = {1.0f, -2.0f, 0.5f}, output[3] = {0};
+    assert(dense_io(sockets[0], (void *)COLI_DENSE_MAGIC, 8, 1) == 0);
+    value = 1; assert(dense_u32(sockets[0], &value, 1) == 0);
+    value = 2; assert(dense_u32(sockets[0], &value, 1) == 0);
+    value = 3; assert(dense_u32(sockets[0], &value, 1) == 0);
+    value = 5; assert(dense_u32(sockets[0], &value, 1) == 0);
+    value = 1; assert(dense_u32(sockets[0], &value, 1) == 0);
+    assert(dense_io(sockets[0], input, sizeof(input), 1) == 0);
+
+    char magic[8];
+    assert(dense_io(sockets[0], magic, 8, 0) == 0);
+    assert(memcmp(magic, COLI_DENSE_MAGIC, 8) == 0);
+    value = 0; assert(dense_u32(sockets[0], &value, 0) == 0 && value == 1);
+    value = 1; assert(dense_u32(sockets[0], &value, 0) == 0 && value == 0);
+    value = 0; assert(dense_u32(sockets[0], &value, 0) == 0 && value == 1);
+    assert(dense_io(sockets[0], output, sizeof(output), 0) == 0);
+    assert(output[0] == 2.0f && output[1] == -4.0f && output[2] == 1.0f);
+
+    assert(pthread_join(thread, NULL) == 0);
+    assert(args.failed == 0);
+    close(sockets[0]);
+    close(sockets[1]);
+}
+
+static void test_layer_ownership(void)
+{
+    memset(g_dense_shards, 0, sizeof(g_dense_shards));
+    g_dense_n = 2;
+    g_dense_shards[0].first = 0; g_dense_shards[0].last = 2;
+    g_dense_shards[1].first = 3; g_dense_shards[1].last = 5;
+    assert(dense_owner(0) == 0);
+    assert(dense_owner(2) == 0);
+    assert(dense_owner(3) == 1);
+    assert(dense_owner(5) == 1);
+    assert(dense_owner(6) == -1);
+    g_dense_n = 0;
+}
+#endif
+
+int main(void)
+{
+#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
+    test_wire_round_trip();
+    test_layer_ownership();
+    puts("dense protocol tests: ok");
+#else
+    puts("dense protocol tests: skipped on Windows");
+#endif
+    return 0;
+}

--- a/c/tests/test_dense_sharding.py
+++ b/c/tests/test_dense_sharding.py
@@ -1,0 +1,127 @@
+"""Token-exact correctness gate for the dense activation shard."""
+
+import os
+import re
+import socket
+import subprocess
+import time
+import unittest
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+C_DIR = HERE.parent
+ENGINE = C_DIR / "colibri"
+TINY = C_DIR / "glm_tiny"
+
+
+def _available() -> bool:
+    return ENGINE.exists() and (TINY / "config.json").exists()
+
+
+def _skip_reason() -> str:
+    if not ENGINE.exists():
+        return "colibri is not built (run: make colibri)"
+    return "glm_tiny fixture absent (run tools/make_glm_oracle.py)"
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _tf_signature(result: subprocess.CompletedProcess[str]):
+    match = re.search(
+        r"PREFILL \(teacher-forcing\).*:\s+(\d+)/(\d+) positions",
+        result.stdout,
+    )
+    mismatches = tuple(
+        line for line in result.stderr.splitlines() if line.startswith("[ORACLE] mismatch")
+    )
+    return (match.groups() if match else None, mismatches)
+
+
+@unittest.skipUnless(_available(), _skip_reason())
+class DenseShardingCorrectnessTest(unittest.TestCase):
+    """The remote dense path must preserve every teacher-forced token."""
+
+    def test_dense_shard_matches_local_cpu(self):
+        port = _free_port()
+        worker_env = {
+            **os.environ,
+            "SNAP": str(TINY),
+            "DENSE_WORKER": "1",
+            "DENSE_WORKER_PORT": str(port),
+            "DENSE_WORKER_FIRST": "0",
+            "DENSE_WORKER_LAST": "2",
+            "COLI_NO_OMP_TUNE": "1",
+        }
+        worker = subprocess.Popen(
+            [str(ENGINE), "64", "8", "8"],
+            cwd=C_DIR,
+            env=worker_env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                if worker.poll() is not None:
+                    stderr = worker.stderr.read() if worker.stderr else ""
+                    self.fail(f"dense worker exited early: {stderr}")
+                try:
+                    with socket.create_connection(("127.0.0.1", port), timeout=0.1):
+                        break
+                except OSError:
+                    time.sleep(0.05)
+            else:
+                self.fail("dense worker did not start listening")
+
+            common_env = {
+                **os.environ,
+                "SNAP": str(TINY),
+                "TF": "1",
+                "TEMP": "0",
+                "DRAFT": "0",
+                "COLI_NO_OMP_TUNE": "1",
+            }
+            baseline = subprocess.run(
+                [str(ENGINE), "64", "8", "8"],
+                cwd=C_DIR,
+                env=common_env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            delegated_env = {
+                **common_env,
+                "DENSE_SHARDS": f"127.0.0.1:{port}:0:2",
+            }
+            delegated = subprocess.run(
+                [str(ENGINE), "64", "8", "8"],
+                cwd=C_DIR,
+                env=delegated_env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(baseline.returncode, 0, baseline.stderr)
+            self.assertEqual(delegated.returncode, 0, delegated.stderr)
+            self.assertEqual(
+                _tf_signature(baseline),
+                _tf_signature(delegated),
+                "dense sharding changed teacher-forced token predictions",
+            )
+        finally:
+            worker.terminate()
+            try:
+                worker.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                worker.kill()
+                worker.wait()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a coordinator-to-worker TCP activation protocol for contiguous dense MLP layers
- add `coli cluster dense-worker` and `--dense-shards host:port:first:last`
- keep attention, KV cache, routing, and token generation on the coordinator
- load only the selected dense gate/up/down tensors on each worker
- add wire-level protocol/ownership tests and a token-exact CPU teacher-forcing gate

## Correctness gate

The optional `c/tests/test_dense_sharding.py` test starts a worker and compares the exact `TF=1` oracle mismatch signature between local CPU execution and delegated dense execution. It skips cleanly when the gitignored `glm_tiny` fixture is unavailable.

Native verification on macOS:

- `make colibri`
- `make test-c`
- `./tests/test_dense_protocol`
- dense sharding correctness test: skipped only because `glm_tiny` is not present locally

This is intentionally limited to dense MLP activation sharding. Expert-worker and WebGPU work remain separate PRs. The existing bundled PR #380 remains open while the work is split.
