### PR TITLE
perf: balance causal attention prefill scheduling

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -2579,7 +2579,8 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
         }
 #endif
         if(!cuda_core){
-        #pragma omp parallel for collapse(2) schedule(static)
+        /* Causal rows grow with s; round-robin pairs keep that work balanced. */
+        #pragma omp parallel for collapse(2) schedule(static,1)
         for(int s=0;s<S;s++) for(int h=0;h<H;h++){
             KVState *ks=kvs?kvs[s]:m->kv;
             int pos=positions?positions[s]:pos_base+s;
@@ -2662,7 +2663,8 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
     int64_t sc_cap = Tk - stL;
     float *sc_all = falloc((int64_t)omp_get_max_threads()*sc_cap);
     double tac=now_s();
-    #pragma omp parallel for collapse(2) schedule(static)
+    /* Causal rows grow with s; round-robin pairs keep that work balanced. */
+    #pragma omp parallel for collapse(2) schedule(static,1)
     for(int s=0;s<S;s++) for(int h=0;h<H;h++){
         int pos=pos_base+s;
         const float *qp=Q+(int64_t)s*H*qh+(int64_t)h*qh;          /* [qk_nope | qk_rope] */


### PR DESCRIPTION
## Summary

- round-robin collapsed `(s, h)` attention work with `schedule(static,1)`
- apply the same scheduling fix to both the MLA-absorb and reconstructed-K/V causal attention paths
- keep every pair's output and per-thread score-buffer ownership unchanged

This implements the diagnosis and proposed fix from #554. Thanks to
@RDouglasSharp for identifying and measuring the causal-row imbalance.

## Why

With `collapse(2) schedule(static)`, each thread receives a contiguous range of
`(s, h)` pairs. Causal row cost grows with `s`, so early threads finish cheap
rows first while later threads retain the expensive tail. A chunk size of one
round-robins those pairs across threads and mixes cheap and expensive rows
without introducing dynamic scheduler coordination.

The gain depends on how much of a host's prefill is spent in CPU attention. It
is expected to be small on expert/GPU-dominated configurations and to grow with
sequence length.

## Verification

`make check` on the patched current `dev` tree:

- 142 tests passed
- 10 platform-specific tests skipped

Native Windows A/B benchmark:

- upstream base: `e4b5bf3db113aef6798a538290e49fb3a3ca0f21`
- Windows 11, Ryzen 9 7845HX, 12 OpenMP threads, MSYS2 UCRT64 GCC 16.1.0
- GLM-5.2 int4, CPU backend, 32 GB RAM tier, `CTX=8192`
- `PIPE=1`, `DIRECT=1`, `PILOT_REAL=1`, `KVSAVE=0`
- fresh engine for every measurement; one deterministic completion token
- baseline SHA-256: `8cd3d80f9904469d6dd1e22e2ae1bb82209a0f5734eafaa60f06c3d141100472`
- patched SHA-256: `1ea710ec1834053691bf113747441abb5ab1341f506c1e12423c4afe78d2eff9`

| Prompt | Runs/build | `static` | `static,1` | Wall reduction |
|---:|---:|---:|---:|---:|
| 512 tokens | 1 | 166.7 s | 159.4 s | 4.4% |
| 1,024 tokens | 3 | 365.3 s median | 330.5 s median | 9.5% |
| 2,048 tokens | 1 | 1,005.2 s | 813.7 s | 19.1% |

At 1,024 tokens, run-time CV was 1.5% for the baseline and 0.6% for the patch.
Median average logical-CPU utilization increased from 29.2% to 34.7%. At 2,048
tokens it increased from 29.6% to 39.3%. All five paired comparisons emitted
the same completion token across builds.

Closes #554.
