### PR TITLE
pipe2: download the resident residual before every exit from residency

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -4176,7 +4176,13 @@ static void layers_forward_rows(Model *m, float *x, int S, int pos_base,
            l->kv_a.cuda_device==l->kv_b.cuda_device&&l->o.cuda_device==l->kv_b.cuda_device){
             int dev=l->kv_b.cuda_device, ok=1;
             float *dst=coli_cuda_pipe_scratch(dev,15,xb);
-            if(dst){
+            /* Ogni uscita dalla residenza deve riportare il residuo su host PRIMA di
+             * lasciare il layer al percorso CPU: x host e' STALE finche' x_dev_on>=0,
+             * quindi scaricare e' l'unico modo di non calcolare su uno stato vecchio. */
+            if(!dst){
+                /* niente scratch su questo device: si cade sul percorso CPU qui sotto */
+                if(x_dev_on>=0){ coli_cuda_pipe_download(x_dev_on,x_dev,x,xb); x_dev_on=-1; }
+            } else {
                 if(x_dev_on<0) ok=coli_cuda_pipe_upload(dev,dst,x,xb);
                 else if(x_dev_on!=dev){
                     double tp=g_prof?now_s():0;
@@ -4191,7 +4197,14 @@ static void layers_forward_rows(Model *m, float *x, int S, int pos_base,
                     coli_cuda_pipe_peer_copy(dev,x_dev,dev,coli_cuda_pipe_scratch(dev,14,xb),xb);
                     coli_cuda_pipe_download(dev,x_dev,x,xb);
                     x_dev_on=-1;
-                }else x_dev_on=-1;
+                }else{
+                    /* upload o peer-copy fallita (P2P disabilitato, rifiuto del driver,
+                     * NVLink giu'). Se la residenza era attiva il dato autorevole e'
+                     * ancora sul device PRECEDENTE, non in dst: va scaricato da li'.
+                     * Con x_dev_on<0 ha fallito l'upload e x host e' gia' autorevole. */
+                    if(x_dev_on>=0) coli_cuda_pipe_download(x_dev_on,x_dev,x,xb);
+                    x_dev_on=-1;
+                }
             }
         } else if(x_dev_on>=0){                 /* layer fuori pipe: il residuo torna a casa */
             coli_cuda_pipe_download(x_dev_on,x_dev,x,xb);


### PR DESCRIPTION
Fixes #557.

`layers_forward_rows()` documents its own invariant: while the PIPE2 residual is device-resident, **host `x` is STALE**. Every exit from residency honours it except two, which drop residency without downloading — so the CPU fallback for that layer computes from a stale hidden state and every subsequent layer inherits it. Wrong tokens, no error, no crash.

- `coli_cuda_pipe_scratch()` returning NULL skipped the entire `if(dst)` body with no `else`, leaving `x_dev_on>=0` and falling through to `layer_forward_rows()`. The next pipe2 layer then peer-copied from `x_dev`, discarding this layer's CPU work outright.
- A failed upload/peer-copy set `x_dev_on=-1` while the authoritative residual was still on the **previous** device, never downloaded.

Both arms now download from `x_dev_on` before clearing it. The upload-failure case (`x_dev_on<0`) is deliberately unchanged — host `x` is already authoritative there.

### Validation

- `make check`: portable CPU build **0 warnings**, C unit tests pass. (One Python test, `test_auto_tune_mtp_off_when_disk_low_hit`, errors with `ENOSPC` on my machine — disk, not this change.)
- CUDA path is compile-checked only (`-fsyntax-only -DCOLI_CUDA`, 0 errors/warnings). **I have no CUDA host**, so this is not runtime-tested. The reproducer that would settle it: fault-inject a scratch-allocation failure and a peer-copy failure mid-stack on a multi-GPU host, and diff the greedy-decode token stream against a CPU-only run.

Left alone deliberately: `coli_cuda_pipe_download`'s return value is ignored at all call sites clearing residency, so a *failed* download has the same consequence as no download. Same defect class, but it needs an error policy decision that belongs to you, not a drive-by change.
