### PR TITLE
serve: COLI_SERVE_ALL_STOPS re-arms the full stop set for non-tool-call use (#549)

### DIFF
--- a/c/sample.h
+++ b/c/sample.h
@@ -119,8 +119,14 @@ static void stops_arm_tok(const Cfg *c, int tok_eos, Tok *T){
     /* #401: in serve mode keep ONLY <|endoftext|>. Role markers <|user|>/<|observation|>
      * (config stops + tokenizer special set) are boundaries the Python server owns; as
      * hard stops they cut generation the moment the model opens a <tool_call> block,
-     * because int4 argmax noise picks a stop-token ID over the correct '<' token. */
-    if (getenv("SERVE") && tok_eos >= 0) {
+     * because int4 argmax noise picks a stop-token ID over the correct '<' token.
+     *
+     * #549: on some quantized containers (notably int4-gs64) an end-of-turn special
+     * OTHER than <|endoftext|> wins the final-token margin, so serve mode never stops and
+     * runs into hallucinated turns. COLI_SERVE_ALL_STOPS=1 re-arms the full stop set for
+     * users who are NOT doing tool calls (or whose client owns the tool boundary), at the
+     * cost of the #401 tool-call safety. Default off — filter unchanged. */
+    if (getenv("SERVE") && tok_eos >= 0 && !getenv("COLI_SERVE_ALL_STOPS")) {
         int kept = 0;
         for (int i = 0; i < g_nstop; i++) if (g_stop[i] == tok_eos) g_stop[kept++] = g_stop[i];
         if (kept < g_nstop) fprintf(stderr, "[stop] serve mode: filtered %d non-EOS stop tokens (tool-call safety, #401)\n", g_nstop - kept);


### PR DESCRIPTION
Fixes the concrete case in #549 (output never terminating on an int4-gs64 container in `coli serve`), building on @ZacharyZcR's diagnosis there.

**Root cause (verified in `sample.h:123`):** serve mode keeps **only** `<|endoftext|>` and filters the other end-of-turn specials for tool-call safety (#401). GLM-5.2 has a family of near-tied end-of-turn specials; on some quantized containers (gs64 in the report) the final-token margin is won by a *filtered* sibling, so serve never stops.

**Fix:** `COLI_SERVE_ALL_STOPS=1` re-arms the full stop set. One-line gate — default off, so the #401 filter and every existing serve deployment are byte-for-byte unchanged. It's opt-in for users who aren't doing tool calls (or whose client owns the tool boundary), trading the #401 safety for reliable termination.

Not a substitute for the deeper fix (context-aware stops that fire on end-of-turn but not inside a `<tool_call>` block) — but it unblocks @weber-software today without touching the default path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)