### PR TITLE
serve: emit finish_reason=length on real cap-hits, not just at admission (addresses a side-bug named in #455)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -5594,14 +5594,21 @@ static int mux_submit(Model *m, Tok *T, ServeCtx *ctx, ServeReq *req, GrDraft *g
     r->id=sub.id; r->maximum=sub.max_tokens; r->temp=sub.temperature; r->top_p=sub.top_p;
     r->prompt_tokens=nt; r->started=now_s(); r->hits0=m->hits; r->miss0=m->miss;
     prof_base(m,&r->pb);                 /* a few loads: cheap enough to always track */
-    int room=maxctx-sc->len-1; if(r->maximum>room){r->maximum=room; r->length_limited=1;}
+    /* Clamp to the KV room WITHOUT flagging: length_limited must mean "the
+     * limit is what stopped us", not "the request asked for more than the
+     * context could ever hold" — clients that default max_tokens to the
+     * context size would otherwise see finish_reason=length on every
+     * naturally-completed generation. The flag is set at the actual
+     * emitted>=maximum stops below instead. */
+    int room=maxctx-sc->len-1; if(r->maximum>room) r->maximum=room;
     g_temp=r->temp; g_nuc=r->top_p;
     int next=pick_tok(logit,m->c.vocab,-1); free(logit);
-    if(r->maximum<=0 || next==eos || is_stop(next)){ mux_done(m,sc,r); return 1; }
+    if(r->maximum<=0){ r->length_limited=1; mux_done(m,sc,r); return 1; }   /* no room at all */
+    if(next==eos || is_stop(next)){ mux_done(m,sc,r); return 1; }
     r->pending=next; r->emitted=1; r->active=1; sc->hist[sc->len]=next; m->n_emit++;
     if(grd[sub.slot].on){ grammar_reset(&grd[sub.slot]); gr_feed(&grd[sub.slot],next); }
     mux_data(T,r->id,next);
-    if(r->emitted>=r->maximum) mux_done(m,sc,r);
+    if(r->emitted>=r->maximum){ r->length_limited=1; mux_done(m,sc,r); }
     return 1;
 }
 
@@ -5696,7 +5703,7 @@ static void run_serve_mux(Model *m, const char *snap){
                     r->pending=next; sc->hist[sc->len]=next; r->emitted++; m->n_emit++;
                     if(gd->on) gr_feed(gd,next);
                     mux_data(&T,r->id,next);
-                    if(r->emitted>=r->maximum){ mux_done(m,sc,r); done=1; break; }
+                    if(r->emitted>=r->maximum){ r->length_limited=1; mux_done(m,sc,r); done=1; break; }
                     if(j<k){
                         if(next!=draft[j]) break;    /* rejected: seq[j+1..] stale, overwritten next forward */
                         gd->acc++;
@@ -5720,7 +5727,7 @@ static void run_serve_mux(Model *m, const char *snap){
             r->pending=next; sc->hist[sc->len]=next; r->emitted++; m->n_emit++;
             if(grd[i].on) gr_feed(&grd[i],next);   /* walker stays in sync when not drafting */
             mux_data(&T,r->id,next);
-            if(r->emitted>=r->maximum) mux_done(m,sc,r);
+            if(r->emitted>=r->maximum){ r->length_limited=1; mux_done(m,sc,r); }
         }
         free(lo);
     }


### PR DESCRIPTION
## Problem

`coli serve` (the HTTP API) always dispatches through `run_serve_mux()` — `openai_server.py`'s `Engine.__init__` hardcodes `SERVE_BATCH="1"` in the child env unconditionally, and `main()` reads that to choose `run_serve_mux` over `run_serve` regardless of `--kv-slots`. So every HTTP client's `finish_reason` comes from exactly one source: `ServeReq.length_limited`, threaded through `mux_done()`'s `STAT` line (its last field) into `openai_server.py`'s `finish = "length" if stats["length_limited"] else "stop"`.

Today that flag is set in the wrong place and missing in the right ones:

- It's set at **admission time**, whenever the *requested* `max_tokens` exceeds available KV context room — even if the request finishes naturally (EOS) long before using that room. Naturally-completed generations can be mislabeled `"length"`.
- It is **not** set at any of the three places a request is actually cut off because `emitted` reached `maximum`: `mux_submit()`'s single-token path, the grammar-forced-draft verify loop, and the plain shared-batch decode loop. Genuine cap-hits are mislabeled `"stop"`.

## Traced against #455

#455's KV-resume paragraph reports: *"...the same request ran into a 'Wait' loop to the max_tokens cap with no post-think answer — and the cap-hit was reported as `finish_reason:"stop"` instead of `"length"`."*

Confirmed the causal chain end to end, deterministically:

`coli serve` → `SERVE_BATCH=1` (hardcoded) → `run_serve_mux()` → (no tool/grammar mode in that repro, so not the grammar-draft branch) → the shared-batch decode loop's `if(r->emitted>=r->maximum) mux_done(m,sc,r);` never sets the flag → `mux_done()`'s `STAT` line prints `length_limited=0` → `openai_server.py` emits `finish_reason:"stop"`.

That is exactly the reported symptom, at the exact field.

**Scope note:** this fixes only the `finish_reason` side-bug named in #455's "Notes / suspected causes" section. It does **not** address #455's actual root cause (per-row-scale int4 quantization eroding EOS logit margins — already resolved by the community via a published gs64 container, no code change needed) or its second formal "Ask" (loop/repetition protection — still unimplemented, separate scope). Not proposed as closing #455.

## Fix

`c/colibri.c`, `mux_submit()` and `run_serve_mux()` — 4 hunks:

1. The admission-time room clamp no longer sets `length_limited`. Clamping what a client *asked for* to available KV room isn't the same as the request actually being cut off by it.
2. `length_limited` is now set at all three sites where generation stops because `emitted` reached `maximum`: `mux_submit()`'s single-token path, the grammar-forced-draft verify loop, and the plain shared-batch decode loop (the site the #455 repro actually hits).
3. The `room<=0` immediate-reject path now explicitly sets `length_limited=1` (a genuine "no room at all" case), split out from the EOS/stop check it was previously OR'd together with.

## Scope / non-goals

- No change to sampling, token selection, or decode performance — this only changes which value gets written to `ServeReq.length_limited`. Not a perf-sensitive change; no tok/s measurement attached (nothing to measure).
- Does not touch `run_serve()` (the non-mux path) — `coli serve` always uses `run_serve_mux` today, so that's the only path a client can observe `finish_reason` through. `run_serve` was not audited for the same pattern and may warrant a separate look.
- Does not implement loop/repetition protection or the quantization-quality mitigation from #455 — both out of scope here.

## Test plan

Static:
- `gcc -fsyntax-only` clean on the modified file.
- Clean rebuild (`make colibri`, macOS arm64/clang): 0 warnings.

Regression, on the rebuilt binary:
- Oracle: `SNAP=./glm_tiny TF=1 ./colibri 64 16 16` → **32/32** teacher-forced positions match. `SNAP=./glm_tiny NGEN=20 TEMP=0 ./colibri 64 16 16` → **20/20** greedy tokens match. Both per CONTRIBUTING.md's merge bar; no change to forward-pass/sampling output.
- `python3 -m pytest c/tests/test_openai_server.py`: **51/51 passed**, unchanged. Confirms the existing `STAT`-parsing tests (they mock the `STAT` line and never exercised the C-side decision) still pass — this PR doesn't touch that contract, only what the engine writes into it.

**Live A/B against a real running `coli serve`, same prompts, only the binary differs** (this repo's own convention for isolating a variable, per e.g. #455's own capture-matrix methodology): built this fix's binary and, separately, an unpatched baseline from `upstream/dev` @ `5724dae` (current `dev` tip pre-this-PR) from the same source tree. Ran both against `glm_tiny` (the CONTRIBUTING.md oracle fixture; it ships no `tokenizer.json`, so I generated a minimal synthetic byte-level one — ASCII 32-126, one token per byte, no merges — purely to make `coli serve`'s HTTP layer testable; this is why completions below are gibberish, the fixture is untrained and was never meant to produce coherent text, and it also means the model never emits a real EOS, so this A/B isolates and confirms the cap-hit-mislabeling mechanism specifically, not the admission-time hunk — see caveat below). Identical requests (`POST /v1/chat/completions`, `{"content":"hi"}`, `temperature:0`) against each server:

| Request | Baseline (`upstream/dev` unpatched) | This PR |
|---|---|---|
| `max_tokens=200` (runs to cap, `completion_tokens=200`) | `finish_reason:"stop"` ❌ | `finish_reason:"length"` ✅ |
| `max_tokens=3` (runs to cap, `completion_tokens=3`) | `finish_reason:"stop"` ❌ | `finish_reason:"length"` ✅ |

Both baseline responses hit their exact token cap (`completion_tokens == max_tokens`, no EOS ever sampled — confirmed separately by the raw generated text never containing the tokenizer's `<|endoftext|>` byte) yet reported `"stop"` — that is #455's exact reported defect, reproduced live, not just traced through source. This PR's binary reports the correct `"length"` on the identical requests.

**Caveat, stated plainly:** this live test only exercises hunks 2-4 (the three real-cap-hit sites) end-to-end, because `glm_tiny` never emits a genuine EOS, so I couldn't drive a live "completes naturally, but `max_tokens` exceeds context room" case to empirically confirm hunk 1 (the admission-time declaw) the same way. Hunk 1 is verified by code-path reasoning only (see Fix section) plus the fact that removing it doesn't regress either oracle or the A/B above. Flagging this so a reviewer can judge whether that's sufficient or whether it's worth a targeted unit test before merge — see the still-open test-coverage gap below.

- **Known gap, not closed by this PR:** there is still no *repo* test exercising the C code path that sets `r->length_limited` (the live A/B above was done ad hoc for this PR, not added as a fixture-backed test). A `c/tests/test_serve_mux.c`-style test — or a `test_openai_server.py` addition that spins up a real (small) engine and asserts `finish_reason` for both a natural stop and a real cap-hit — would close it and would have caught this bug directly. Flagging for a maintainer/reviewer call on whether to require it before merge.
