### PR TITLE
install: ship version.py + make the launcher survive its absence (#575)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -512,7 +512,7 @@ install: colibri$(EXE) olmoe$(EXE)
 	$(INSTALL) -m 755 coli $(DESTDIR)$(BINDIR)/coli
 	$(INSTALL) -m 755 colibri$(EXE) $(DESTDIR)$(LIBEXECDIR)/colibri$(EXE)
 	$(INSTALL) -m 755 olmoe$(EXE) $(DESTDIR)$(LIBEXECDIR)/olmoe$(EXE)
-	$(INSTALL) -m 644 resource_plan.py doctor.py openai_server.py $(DESTDIR)$(LIBEXECDIR)/
+	$(INSTALL) -m 644 resource_plan.py doctor.py openai_server.py version.py $(DESTDIR)$(LIBEXECDIR)/
 	$(INSTALL) -m 644 tools/*.py $(DESTDIR)$(LIBEXECDIR)/tools/
 
 uninstall:

--- a/c/coli
+++ b/c/coli
@@ -44,7 +44,18 @@ if sys.platform == "win32":
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)
-from version import __version__ as _version
+# version.py sits next to this script in a source checkout, but an installed
+# layout puts the launcher in $(PREFIX)/bin while the support modules live in
+# $(PREFIX)/libexec/colibri — and a packager may strip it entirely (#575,
+# FreeBSD port). The launcher must never crash over a version string.
+try:
+    from version import __version__ as _version
+except ModuleNotFoundError:
+    sys.path.insert(0, os.path.join(os.path.dirname(HERE), "libexec", "colibri"))
+    try:
+        from version import __version__ as _version
+    except ModuleNotFoundError:
+        _version = "unknown"
 
 # Run-in-place (source checkout, "cd c && ./coli ..."): the engine, the
 # support modules (resource_plan.py, doctor.py, openai_server.py) and


### PR DESCRIPTION
Fixes #575.

## Root cause

Two halves, both real:

1. **`make install` never ships `version.py`.** The install target copies `resource_plan.py doctor.py openai_server.py` to `$(LIBEXECDIR)` but not `version.py`, so no installed layout has the module anywhere.
2. **The launcher only looks next to itself.** `c/coli` inserts `HERE` (= `$(PREFIX)/bin` when installed) into `sys.path` and does a bare `from version import __version__` — an unconditional crash on every installed layout, before any subcommand runs. @yurivict hit this packaging the FreeBSD port; every `make install` user hits it too.

## Fix

- `Makefile`: add `version.py` to the libexec install list.
- `c/coli`: try `HERE` first (source checkout, unchanged), then `../libexec/colibri` (installed layout), and fall back to `"unknown"` instead of crashing — a packager stripping the file entirely gets a working launcher with `colibri unknown`, not a traceback.

## Verified

Simulated both layouts locally:

```
$ bin/coli --version          # no version.py anywhere (stripped package)
colibri unknown
$ bin/coli --version          # version.py in ../libexec/colibri (make install layout)
colibri 1.1.1
```

Source-checkout behavior (`cd c && ./coli`) is unchanged — `HERE` still wins.