### PR TITLE
convert: default to group-scaled int4 (gs64) — the #455 tracking item

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -936,7 +936,8 @@ def cmd_convert(a):
     venv_py = os.path.join(HERE, "mio_env", "Scripts" if sys.platform == "win32" else "bin", "python3")
     py = venv_py if os.path.exists(venv_py) else sys.executable
     base=[py, os.path.join(TOOLS,"convert_fp8_to_int4.py"),
-          "--repo", a.repo, "--outdir", a.model, "--ebits", str(a.ebits), "--io-bits", str(a.io_bits)]
+          "--repo", a.repo, "--outdir", a.model, "--ebits", str(a.ebits), "--io-bits", str(a.io_bits),
+          "--group-size", str(a.group_size)]
     if a.xbits: base+=["--xbits",str(a.xbits)]
     # passo 1: modello principale (78 layer). Resumabile: riparte dagli shard mancanti.
     print(f"  {C.dim}[1/2] model: {' '.join(base)}{C.r}")
@@ -1010,6 +1011,8 @@ def main():
     pb.add_argument("--data",default=_bench_cache)
     pc=sub.add_parser("convert", parents=[common]); pc.add_argument("--repo",default="zai-org/GLM-5.2-FP8")
     pc.add_argument("--ebits",type=int,default=4); pc.add_argument("--io-bits",type=int,default=8); pc.add_argument("--xbits",type=int,default=0)
+    pc.add_argument("--group-size",type=int,default=64,
+        help="int4 scale group size: 64 (default, group-scaled quality) or 0 (legacy per-row)")
     pc.add_argument("--no-mtp",action="store_true",help="skip the MTP head (no speculative drafts)")
     a=ap.parse_args()
     handler={"build":cmd_build,"info":cmd_info,"plan":cmd_plan,"doctor":cmd_doctor,

--- a/c/tools/convert_fp8_to_int4.py
+++ b/c/tools/convert_fp8_to_int4.py
@@ -353,8 +353,16 @@ def main():
         help="bits for other attention projections (q_a, q_b, kv_a). Default=ebits")
     ap.add_argument("--dmlp-bits", type=int, default=None,
         help="bits for dense MLP (first 3 layers). Default=ebits")
-    ap.add_argument("--group-size", type=int, default=0,  # 0 = per-row (backward compat); 128 = group-scaled
-        help="group size for int4 scales: 0=per-row (default), 128=one scale per 128 elements (much better quality)")
+    ap.add_argument("--group-size", type=int, default=64,
+        # gs64 is the community-validated default (#225 root cause, #455 5/5-clean
+        # verification, ablation #453: per-row int4 costs -9.3pp mean acc_norm vs
+        # -2.2..-3.4pp for group-scaled). Per-row remains available as an explicit
+        # opt-out; the resume manifest (check_or_record_params) refuses to mix the
+        # two in one outdir, so a resumed pre-default conversion aborts loudly
+        # instead of interleaving formats (#355-class).
+        help="group size for int4 scales: 64=one scale per 64 elements (default, "
+             "much better quality), 0=per-row (legacy; costs ~9pp on quality "
+             "benchmarks and is the #455 non-termination trigger)")
     # Per-projection bit overrides for routed experts (orthogonal to the type-level flags above).
     ap.add_argument("--up-bits", type=_bits, default=None,
         help="bits for up_proj in routed experts (e.g. 3 = int3-g64). Default=xbits")
@@ -389,7 +397,7 @@ def main():
         # EN: this way is repairable in place with tools/repair_mtp_int8.py.
         print(f"WARNING: --mtp with --ebits {a.ebits} and per-row scales ZEROES eh_proj's "
               "embedding half -> MTP acceptance ~0% (issue #8). Use the default --ebits 8, "
-              "or add --group-size 128 for group-scaled int4.")
+              "or drop --group-size 0 to get the group-scaled default.")
     if a.xbits is None: a.xbits = a.ebits
     for proj, val in (("gate_proj", a.gate_bits), ("up_proj", a.up_bits), ("down_proj", a.down_bits)):
         if val is not None: PROJ_BITS[proj] = val

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -120,11 +120,18 @@ You have two paths.
 
 ### Easiest — download a ready-made int4 container
 
-A pre-converted **GLM-5.2 int4** model is on Hugging Face. **Use the version
-with the int8 MTP heads** (the plain int4 heads disable speculative decoding —
-see [#8](https://github.com/JustVugg/colibri/issues/8)):
+A pre-converted **GLM-5.2 int4** model is on Hugging Face. Use the
+**group-scaled (gs64)** container with the **int8 MTP head**:
 
-**https://huggingface.co/mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp**
+**https://huggingface.co/mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp**
+
+Group scales matter: the older per-row int4 containers
+(`mateogrgic/…-int4-with-int8-mtp`, `jlnsrk/…`) measure ~9pp worse on quality
+benchmarks and are the root cause of the think-mode loops and never-terminating
+generations in [#455](https://github.com/JustVugg/colibri/issues/455) — the
+gs64 container cured every failing case in that report. (The int8 MTP head is
+also required: plain int4 heads disable speculative decoding, see
+[#8](https://github.com/JustVugg/colibri/issues/8).)
 
 Download it into a folder on a fast disk, e.g. `/nvme/glm52_i4` (Linux/macOS) or
 `D:\glm52_i4` (Windows). It is about **372 GB**, so make sure you have the space.
@@ -138,8 +145,9 @@ never needs the full ~756 GB on disk at once:
 ./coli convert --model /nvme/glm52_i4
 ```
 
-This step uses Python and runs only once. Safe to interrupt and re-run — it
-resumes where it left off.
+This produces a group-scaled (gs64) container — the same quality-validated
+format as the recommended download. This step uses Python and runs only once.
+Safe to interrupt and re-run — it resumes where it left off.
 
 ---
 


### PR DESCRIPTION
First brick of the 1.2.0 "serve path from working to reliable" arc: stop handing new users the per-row quality trap by default.

## Why now

Per-row int4 is the most-reproduced failure source in the tracker: −9.3pp mean acc_norm in the ablation (#453), the root cause of the think-mode loops and EOS starvation in #455 (gs64 cured 5/5 capture-matrix cells), and the very first thing the newest field report (#549) tripped over — that user's first conversion was per-row, their "quality worse than Qwen" was exactly the measured per-row deficit, and #455 closed with "make the converter default to group scales" as tracking item (a). This PR is that item.

## Changes

1. **`convert_fp8_to_int4.py`: `--group-size` default `0` → `64`.** gs64 is the community-validated point (the #455-curing container, the #453 ablation arm at −2.2..−3.4pp vs fp16). Per-row stays available as an explicit `--group-size 0` opt-out.
2. **`coli convert`: `--group-size` passthrough** (default 64) so the launcher path is controllable without dropping to the tool.
3. **`docs/quickstart.md`: the "Easiest" recommendation now points at the gs64 container** (`mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp`) instead of the per-row one it recommended until now — the docs were steering every new user into the exact container class that #455 documented as broken. The per-row cards stay mentioned, labeled with what they cost.

## Safety

- **No silent mixing on resume**: `check_or_record_params` already records `group_size` in the outdir manifest, so a pre-default per-row conversion resumed under the new default refuses loudly with the existing "use a fresh --outdir" message (#355-class guard doing its job) rather than interleaving formats.
- **MTP head unaffected**: the int8 head path (`bits=8`) never enters the grouped-int4 branch, and `coli convert`'s step-2 re-invocation inherits the flag harmlessly.
- **Engine side is long since ready**: fmt=4/gs64 is the format the tracker's production containers already use (#298/#334/#451 line, all merged); the issue-#8 eh_proj warning text updated to match the new default.