### PR TITLE
Metal: add _gs group-size plumbing for attention decode

### DIFF
--- a/c/backend_metal.h
+++ b/c/backend_metal.h
@@ -104,11 +104,11 @@ int coli_metal_rtop8(int par, const float *sig, const float *bias, int S, int E,
 void coli_metal_attn_counts(uint64_t *ok, double *wall, double *kernel);
 void coli_metal_attn_lat(double *ksched, double *gsched);
 int coli_metal_attn_decode(const float *x,
-    const void *qa_w, const float *qa_s, int qa_fmt, const float *qa_ln,
-    const void *qb_w, const float *qb_s, int qb_fmt,
-    const void *kva_w, const float *kva_s, int kva_fmt, const float *kva_ln,
-    const void *kvb_w, const float *kvb_s, int kvb_fmt,
-    const void *o_w, const float *o_s, int o_fmt,
+    const void *qa_w, const float *qa_s, int qa_fmt, int qa_gs, const float *qa_ln,
+    const void *qb_w, const float *qb_s, int qb_fmt, int qb_gs,
+    const void *kva_w, const float *kva_s, int kva_fmt, int kva_gs, const float *kva_ln,
+    const void *kvb_w, const float *kvb_s, int kvb_fmt, int kvb_gs,
+    const void *o_w, const float *o_s, int o_fmt, int o_gs,
     float *Lc, float *Rc, int S, int pos_base, int st0, float eps, float theta, float ascale, float *out);
 
 /* Diagnostics: GPU blocks executed, CPU-fallback blocks, experts run on GPU. */

--- a/c/backend_metal.mm
+++ b/c/backend_metal.mm
@@ -605,7 +605,7 @@ static void attn_scratch_init(){
 }
 // y[S,O] = quantized-weight(w) applied to xin[S,I]. Weights are registered (page-aligned,
 // zero-copy) at model load; resolve to (buffer,offset). Returns false to fall back to CPU.
-static bool bind_gemv(id<MTLComputeCommandEncoder> e, const void* w, const float* s, int fmt, int I, int O,
+static bool bind_gemv(id<MTLComputeCommandEncoder> e, const void* w, const float* s, int fmt, int gs, int I, int O,
                       id<MTLBuffer> xin, id<MTLBuffer> yout, int S){
   uint64_t wa=0,sa=0; id<MTLBuffer> wb=resolve(w,&wa); id<MTLBuffer> sb=resolve(s,&sa);
   if(!wb||!sb) return false;
@@ -616,7 +616,7 @@ static bool bind_gemv(id<MTLComputeCommandEncoder> e, const void* w, const float
   [e setBuffer:xin offset:0 atIndex:2]; [e setBuffer:yout offset:0 atIndex:3];
   int NT=S*O;
   [e setBytes:&S length:4 atIndex:4]; [e setBytes:&I length:4 atIndex:5]; [e setBytes:&O length:4 atIndex:6]; [e setBytes:&fmt length:4 atIndex:7];
-  [e setBytes:&NT length:4 atIndex:8];
+  [e setBytes:&NT length:4 atIndex:8]; [e setBytes:&gs length:4 atIndex:9];
   [e dispatchThreadgroups:MTLSizeMake(((size_t)NT+3)/4,1,1) threadsPerThreadgroup:MTLSizeMake(128,1,1)];
   return true;
 }
@@ -624,11 +624,11 @@ static bool bind_gemv(id<MTLComputeCommandEncoder> e, const void* w, const float
 // Weight-pointer bundle for one layer's attention (+optional layer tail). All pointers
 // must be inside registered allocations.
 typedef struct {
-  const void *qa_w; const float *qa_s; int qa_fmt; const float *qa_ln;
-  const void *qb_w; const float *qb_s; int qb_fmt;
-  const void *kva_w; const float *kva_s; int kva_fmt; const float *kva_ln;
-  const void *kvb_w; const float *kvb_s; int kvb_fmt;
-  const void *o_w;  const float *o_s;  int o_fmt;
+  const void *qa_w; const float *qa_s; int qa_fmt; int qa_gs; const float *qa_ln;
+  const void *qb_w; const float *qb_s; int qb_fmt; int qb_gs;
+  const void *kva_w; const float *kva_s; int kva_fmt; int kva_gs; const float *kva_ln;
+  const void *kvb_w; const float *kvb_s; int kvb_fmt; int kvb_gs;
+  const void *o_w;  const float *o_s;  int o_fmt; int o_gs;
 } AttnW;
 
 // Encode the fused attention chain into encoder e. Input: ax_ holds the NORMED x [S,AH].
@@ -651,12 +651,13 @@ static bool encode_attention(id<MTLComputeCommandEncoder> e, const AttnW *W,
       [e setBuffer:acomp_ offset:0 atIndex:0]; [e setBytes:&off length:4 atIndex:1]; [e setBytes:&ss length:4 atIndex:2];
       [e setBuffer:dst offset:doff atIndex:3]; [e setBytes:&n length:4 atIndex:4]; [e setBytes:&n length:4 atIndex:5];
       [e dispatchThreads:MTLSizeMake((size_t)S*n,1,1) threadsPerThreadgroup:MTLSizeMake(64,1,1)]; };
-    bind_gemv(e,W->qa_w,W->qa_s,W->qa_fmt,AH,AQLORA,ax_,aqr_,S);
-    bind_gemv(e,W->kva_w,W->kva_s,W->kva_fmt,AH,AKVL+AROPE,ax_,acomp_,S); BAR();
+    bind_gemv(e,W->qa_w,W->qa_s,W->qa_fmt,W->qa_gs,AH,AQLORA,ax_,aqr_,S);
+    bind_gemv(e,W->kva_w,W->kva_s,W->kva_fmt,W->kva_gs,AH,AKVL+AROPE,ax_,acomp_,S); BAR();
     rms(aqr_,0,aqaln_,AQLORA,S); cpy(0,Lb,Loff,AKVL); cpy(AKVL,Rb,Roff,AROPE); BAR();
-    bind_gemv(e,W->qb_w,W->qb_s,W->qb_fmt,AQLORA,AHQH,aqr_,aqf_,S); rms(Lb,Loff,akvaln_,AKVL,S); rope(Rb,Roff,0,AROPE,0,1); BAR();
+    bind_gemv(e,W->qb_w,W->qb_s,W->qb_fmt,W->qb_gs,AQLORA,AHQH,aqr_,aqf_,S); rms(Lb,Loff,akvaln_,AKVL,S); rope(Rb,Roff,0,AROPE,0,1); BAR();
     rope(aqf_,0,ANOPE,AHQH,AQH,AHEADS); BAR();
     [e setComputePipelineState:g_a_qabs]; [e setBuffer:kvbW offset:kvbwoff atIndex:0]; [e setBuffer:kvbS offset:kvbsoff atIndex:1]; [e setBuffer:aqf_ offset:0 atIndex:2]; [e setBuffer:aqabs_ offset:0 atIndex:3];
+    [e setBytes:&W->kvb_fmt length:4 atIndex:4]; [e setBytes:&W->kvb_gs length:4 atIndex:5];
     [e dispatchThreads:MTLSizeMake((size_t)S*AHEADS*AKVL,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; BAR();
     [e setComputePipelineState:g_a_score]; [e setBuffer:aqabs_ offset:0 atIndex:0]; [e setBuffer:Lb offset:loff atIndex:1]; [e setBuffer:Rb offset:roff atIndex:2]; [e setBuffer:aqf_ offset:0 atIndex:3]; [e setBuffer:ascore_ offset:0 atIndex:4];
     [e setBytes:&T length:4 atIndex:5]; [e setBytes:&ascale length:4 atIndex:6]; [e setBytes:&pos_base length:4 atIndex:7];
@@ -666,8 +667,9 @@ static bool encode_attention(id<MTLComputeCommandEncoder> e, const AttnW *W,
     [e setComputePipelineState:g_a_clat]; [e setBuffer:ascore_ offset:0 atIndex:0]; [e setBuffer:Lb offset:loff atIndex:1]; [e setBuffer:aclat_ offset:0 atIndex:2]; [e setBytes:&T length:4 atIndex:3];
     [e dispatchThreads:MTLSizeMake((size_t)S*AHEADS*AKVL,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; BAR();
     [e setComputePipelineState:g_a_ctx]; [e setBuffer:kvbW offset:kvbwoff atIndex:0]; [e setBuffer:kvbS offset:kvbsoff atIndex:1]; [e setBuffer:aclat_ offset:0 atIndex:2]; [e setBuffer:actx_ offset:0 atIndex:3];
+    [e setBytes:&W->kvb_fmt length:4 atIndex:4]; [e setBytes:&W->kvb_gs length:4 atIndex:5];
     [e dispatchThreads:MTLSizeMake((size_t)S*AHEADS*AVH,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; BAR();
-    bind_gemv(e,W->o_w,W->o_s,W->o_fmt,AHVH,AH,actx_,aout_,S);
+    bind_gemv(e,W->o_w,W->o_s,W->o_fmt,W->o_gs,AHVH,AH,actx_,aout_,S);
     return true;
 }
 // Resolve Lc/Rc + kv_b (+pre-check the projection weights). Returns false -> CPU fallback.
@@ -685,18 +687,18 @@ static bool resolve_attn(const AttnW *W, float *Lc, float *Rc,
 }
 
 extern "C" int coli_metal_attn_decode(const float* x,
-    const void* qa_w,const float* qa_s,int qa_fmt,const float* qa_ln,
-    const void* qb_w,const float* qb_s,int qb_fmt,
-    const void* kva_w,const float* kva_s,int kva_fmt,const float* kva_ln,
-    const void* kvb_w,const float* kvb_s,int kvb_fmt,
-    const void* o_w,const float* o_s,int o_fmt,
+    const void* qa_w,const float* qa_s,int qa_fmt,int qa_gs,const float* qa_ln,
+    const void* qb_w,const float* qb_s,int qb_fmt,int qb_gs,
+    const void* kva_w,const float* kva_s,int kva_fmt,int kva_gs,const float* kva_ln,
+    const void* kvb_w,const float* kvb_s,int kvb_fmt,int kvb_gs,
+    const void* o_w,const float* o_s,int o_fmt,int o_gs,
     float* Lc,float* Rc,int S,int pos_base,int st0,float eps,float theta,float ascale,float* out){
   if(!g_dev) return 0;
   if(st0!=0 || S<1 || S>AMAXS) return 0;     // partial-KV / S>4 -> CPU
   int T=pos_base+S;
   @autoreleasepool {
     attn_scratch_init();
-    AttnW W={qa_w,qa_s,qa_fmt,qa_ln,qb_w,qb_s,qb_fmt,kva_w,kva_s,kva_fmt,kva_ln,kvb_w,kvb_s,kvb_fmt,o_w,o_s,o_fmt};
+    AttnW W={qa_w,qa_s,qa_fmt,qa_gs,qa_ln,qb_w,qb_s,qb_fmt,qb_gs,kva_w,kva_s,kva_fmt,kva_gs,kva_ln,kvb_w,kvb_s,kvb_fmt,kvb_gs,o_w,o_s,o_fmt,o_gs};
     id<MTLBuffer> Lb,Rb,kvbW,kvbS; size_t loff,roff,kvbwoff,kvbsoff;
     if(!resolve_attn(&W,Lc,Rc,&Lb,&loff,&Rb,&roff,&kvbW,&kvbwoff,&kvbS,&kvbsoff)) return 0;
     ascore_=ensure(ascore_,&ascore_cap,(size_t)S*AHEADS*T*4);

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -2374,11 +2374,11 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
             }
             #define WP_(q) ((q).fmt==1?(const void*)(q).q8:(const void*)(q).q4)
             int ok = coli_metal_attn_decode(x,
-                WP_(l->q_a), l->q_a.s, l->q_a.fmt, l->q_a_ln,
-                WP_(l->q_b), l->q_b.s, l->q_b.fmt,
-                WP_(l->kv_a), l->kv_a.s, l->kv_a.fmt, l->kv_a_ln,
-                WP_(l->kv_b), l->kv_b.s, l->kv_b.fmt,
-                WP_(l->o), l->o.s, l->o.fmt,
+                WP_(l->q_a), l->q_a.s, l->q_a.fmt, l->q_a.gs, l->q_a_ln,
+                WP_(l->q_b), l->q_b.s, l->q_b.fmt, l->q_b.gs,
+                WP_(l->kv_a), l->kv_a.s, l->kv_a.fmt, l->kv_a.gs, l->kv_a_ln,
+                WP_(l->kv_b), l->kv_b.s, l->kv_b.fmt, l->kv_b.gs,
+                WP_(l->o), l->o.s, l->o.fmt, l->o.gs,
                 m->Lc[layer], m->Rc[layer], S, pos_base, m->kv_start[layer], c->eps, c->theta, c->attn_scale, out);
             #undef WP_
             if(ok){ m->t_attn += now_s()-ta0; return; }
@@ -5486,6 +5486,16 @@ static int mux_submit(Model *m, Tok *T, ServeCtx *ctx, ServeReq *req, GrDraft *g
     char *line=NULL; size_t cap=0; ssize_t nr=getline(&line,&cap,stdin);
     if(nr<0){ free(line); return -1; }
     if(nr && line[nr-1]=='\n') line[--nr]=0;
+    if(!strncmp(line,"STOP ",5)){
+        unsigned long long id=0; char tail;
+        if(sscanf(line+5,"%llu %c",&id,&tail)!=1 || id==0){
+            printf("ERROR 0 BAD_REQUEST\n"); fflush(stdout); free(line); return 0;
+        }
+        for(int i=0;i<nctx;i++) if(req[i].active && req[i].id==id){
+            mux_done(m,&ctx[i],&req[i]); free(line); return 0;
+        }
+        printf("ERROR %llu NOT_FOUND\n",id); fflush(stdout); free(line); return 0;
+    }
     if(!strncmp(line,"CANCEL ",7)){
         unsigned long long id=0; char tail;
         if(sscanf(line+7,"%llu %c",&id,&tail)!=1 || id==0){

--- a/c/tests/test_backend_metal.mm
+++ b/c/tests/test_backend_metal.mm
@@ -160,8 +160,8 @@ static int run_attn(int S, int pos_base, const char* name){
     t_gemv4(&ref[(size_t)s*TH],ctx.data(),o.w,o.s,TH,THH*TVH);
   }
   std::vector<float> got((size_t)S*TH);
-  int ok=coli_metal_attn_decode(x.data(), qa.w,qa.s,2,qaln.data(), qb.w,qb.s,2,
-        kva.w,kva.s,2,kvaln.data(), kvb.w,kvb.s,2, o.w,o.s,2,
+  int ok=coli_metal_attn_decode(x.data(), qa.w,qa.s,2,0,qaln.data(), qb.w,qb.s,2,0,
+        kva.w,kva.s,2,0,kvaln.data(), kvb.w,kvb.s,2,0, o.w,o.s,2,0,
         Lc,Rc,S,pos_base,0,eps,theta,ascale,got.data());
   double ma=0,ym=0; for(size_t i=0;i<ref.size();i++){ ma=fmax(ma,fabs(got[i]-ref[i])); ym=fmax(ym,fabs(ref[i])); }
   // also verify the cache write-back (Lc/Rc for the new positions)


### PR DESCRIPTION
Add per-weight group-size (gs) parameters to `coli_metal_attn_decode`, `bind_gemv`, `AttnW`, and `encode_attention`. Pass `kvb_fmt`/`kvb_gs` to the `a_qabs` and `a_ctx` kernel dispatches so those shaders can select the grouped-int4 scale layout (PR #587). Update the `colibri.c` call site and the metal-test suite.

Depends on the shader-side changes in PR #587 for correct operation at fmt=4.