### PR TITLE
fix: use qalloc (not falloc) for fmt=4 grouped-int4 scales

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -1039,7 +1039,7 @@ static void qt_from_disk(Model *m, const char *name, int O, int I, int bits, int
         int fmt = qt_resolve_fmt(name,O,I,nb,ns,&gs);
         if(fmt==1){ if(t->fmt!=1||!t->q8){ t->fmt=1; t->O=O; t->I=I; t->gs=0; t->q8=qalloc(nb); t->s=qsalloc(O); } st_read_raw(&m->S,name,t->q8,drop); }
         else if(fmt==4){ int ng=(I+gs-1)/gs;
-            if(t->fmt!=4||!t->q4){ t->fmt=4; t->O=O; t->I=I; t->gs=gs; t->q4=qalloc(nb); t->s=falloc((int64_t)O*ng); }
+            if(t->fmt!=4||!t->q4){ t->fmt=4; t->O=O; t->I=I; t->gs=gs; t->q4=qalloc(nb); t->s=qalloc((int64_t)O*ng); }
             st_read_raw(&m->S,name,t->q4,drop); }
         else if(fmt==5){ int64_t ng=i3_groups(I);   /* int3-g64: 24B/group weights + O*ng group scales */
             if(t->fmt!=5||!t->q4){ t->fmt=5; t->O=O; t->I=I; t->gs=0; t->q4=qalloc(nb); t->s=falloc((int64_t)O*ng); }


### PR DESCRIPTION
fmt=4 scales are Metal-registered at model load and must be allocated via `qalloc` (page-aligned with `coli_metal_register`) instead of `falloc`. Without this fix a fmt=4 model hits unresolved-buffer fallback at every attention projection and expert GEMV, silently degrading to CPU.