### PR TITLE
feat: enable Metal GEMM for fmt=4 (grouped-int4) weights

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -547,7 +547,7 @@ static void matmul_i4_grouped_pair(float *yg, float *yu, const float *x,
  * (~+12% perplexity), measured. Every other prefill matmul keeps IDOT as before. */
 static void matmul_qt_ex(float *y, const float *x, QT *w, int S, int allow_idot){
 #ifdef COLI_METAL
-    if(g_metal_enabled && S>=g_metal_gemm_min && !spec_pinned() && (w->fmt==1||w->fmt==2) && !omp_in_parallel()){
+    if(g_metal_enabled && S>=g_metal_gemm_min && !spec_pinned() && (w->fmt==1||w->fmt==2||w->fmt==4) && !omp_in_parallel()){
         const void *wp = w->fmt==1 ? (const void*)w->q8 : (const void*)w->q4;
         if(coli_metal_gemm(y,x,wp,w->s,w->fmt,S,w->I,w->O)) return;
     }


### PR DESCRIPTION
Open the `matmul_qt_ex` Metal GEMM gate for fmt=4 alongside the existing fmt=1 and fmt=2. The Metal `mm_gemv` shader already handles grouped-int4 scale layout (PR #587); this only enables the C-side dispatch.