### PR TITLE
metal: two-phase prefill attention for arbitrary sequence lengths

### DIFF
--- a/c/backend_metal.mm
+++ b/c/backend_metal.mm
@@ -593,15 +593,27 @@ extern "C" int coli_metal_matmul(ColiMetalTensor **tp, float *y, const float *x,
 // ---- fused decode attention scratch (GLM-5.2 dims) ----
 enum { AH=6144, AHEADS=64, AQLORA=2048, AKVL=512, AROPE=64, AVH=256, AQH=256, ANOPE=192, AROWSH=448, AHQH=AHEADS*AQH, AHVH=AHEADS*AVH, AMAXS=4 };
 static id<MTLBuffer> ax_,aqr_,aqf_,acomp_,aqabs_,ascore_,aclat_,actx_,aout_,aqaln_,akvaln_; static size_t ascore_cap;
-static id<MTLBuffer> axr_,anrm_,ash1_,ash2_,ashout_,asig_,aidx_,aw_,akeff_;   // full-layer tail
+static size_t ax_cap,aqr_cap,aqf_cap,acomp_cap,aqabs_cap,aclat_cap,actx_cap,aout_cap;
+static id<MTLBuffer> axr_,anrm_,ash1_,ash2_,ashout_,asig_,aidx_,aw_,akeff_;   // full-layer tail (AMAXS-sized)
 static void attn_scratch_init(){
   if(ax_) return;
   auto L=[&](size_t n){ return [g_dev newBufferWithLength:n*AMAXS options:g_res_opts]; };
-  ax_=L(AH*4); aqr_=L(AQLORA*4); aqf_=L(AHQH*4); acomp_=L((AKVL+AROPE)*4);
-  aqabs_=L((size_t)AHEADS*AKVL*4); aclat_=L((size_t)AHEADS*AKVL*4); actx_=L(AHVH*4); aout_=L(AH*4);
-  aqaln_=L(AQLORA*4/AMAXS); akvaln_=L(AKVL*4/AMAXS);   // norm weights are per-tensor, not per-row
   axr_=L(AH*4); anrm_=L(AH*4); ash1_=L(2048*4); ash2_=L(2048*4); ashout_=L(AH*4);
   asig_=L(256*4); aidx_=L(8*4); aw_=L(8*4); akeff_=L(4);
+  aqaln_=[g_dev newBufferWithLength:AQLORA*4 options:g_res_opts];
+  akvaln_=[g_dev newBufferWithLength:AKVL*4 options:g_res_opts];
+}
+static void attn_scratch_reserve(int S, int T){
+  attn_scratch_init();
+  ax_=ensure(ax_,&ax_cap,(size_t)S*AH*4);
+  aqr_=ensure(aqr_,&aqr_cap,(size_t)S*AQLORA*4);
+  aqf_=ensure(aqf_,&aqf_cap,(size_t)S*AHQH*4);
+  acomp_=ensure(acomp_,&acomp_cap,(size_t)S*(AKVL+AROPE)*4);
+  aqabs_=ensure(aqabs_,&aqabs_cap,(size_t)S*AHEADS*AKVL*4);
+  ascore_=ensure(ascore_,&ascore_cap,(size_t)S*AHEADS*T*4);
+  aclat_=ensure(aclat_,&aclat_cap,(size_t)S*AHEADS*AKVL*4);
+  actx_=ensure(actx_,&actx_cap,(size_t)S*AHVH*4);
+  aout_=ensure(aout_,&aout_cap,(size_t)S*AH*4);
 }
 // y[S,O] = quantized-weight(w) applied to xin[S,I]. Weights are registered (page-aligned,
 // zero-copy) at model load; resolve to (buffer,offset). Returns false to fall back to CPU.
@@ -631,13 +643,13 @@ typedef struct {
   const void *o_w;  const float *o_s;  int o_fmt;
 } AttnW;
 
-// Encode the fused attention chain into encoder e. Input: ax_ holds the NORMED x [S,AH].
-// Output: aout_ holds attention output [S,AH]. Returns false on unresolved weights.
-static bool encode_attention(id<MTLComputeCommandEncoder> e, const AttnW *W,
+// Phase 1: projections (qa, kva, qb, RMS, RoPE, qabs) for all S rows.
+// Reads ax_[S*AH], writes aqr_[S*AQLORA], acomp_[S*(AKVL+AROPE)], aqf_[S*AHQH], aqabs_[S*AHEADS*AKVL].
+// Also writes Lc (keys) and Rc (rope keys) into the KV cache at pos_base.
+static bool encode_attn_projections(id<MTLComputeCommandEncoder> e, const AttnW *W,
                              id<MTLBuffer> Lb, size_t loff, id<MTLBuffer> Rb, size_t roff,
                              id<MTLBuffer> kvbW, size_t kvbwoff, id<MTLBuffer> kvbS, size_t kvbsoff,
-                             int S, int pos_base, float eps, float theta, float ascale) {
-    int T=pos_base+S;
+                             int S, int pos_base, float eps, float theta) {
     memcpy([aqaln_ contents],W->qa_ln,AQLORA*4); memcpy([akvaln_ contents],W->kva_ln,AKVL*4);
     size_t Loff=loff+(size_t)pos_base*AKVL*4, Roff=roff+(size_t)pos_base*AROPE*4;
     auto BAR=[&]{ [e memoryBarrierWithScope:MTLBarrierScopeBuffers]; };
@@ -658,15 +670,41 @@ static bool encode_attention(id<MTLComputeCommandEncoder> e, const AttnW *W,
     rope(aqf_,0,ANOPE,AHQH,AQH,AHEADS); BAR();
     [e setComputePipelineState:g_a_qabs]; [e setBuffer:kvbW offset:kvbwoff atIndex:0]; [e setBuffer:kvbS offset:kvbsoff atIndex:1]; [e setBuffer:aqf_ offset:0 atIndex:2]; [e setBuffer:aqabs_ offset:0 atIndex:3];
     [e dispatchThreads:MTLSizeMake((size_t)S*AHEADS*AKVL,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; BAR();
-    [e setComputePipelineState:g_a_score]; [e setBuffer:aqabs_ offset:0 atIndex:0]; [e setBuffer:Lb offset:loff atIndex:1]; [e setBuffer:Rb offset:roff atIndex:2]; [e setBuffer:aqf_ offset:0 atIndex:3]; [e setBuffer:ascore_ offset:0 atIndex:4];
-    [e setBytes:&T length:4 atIndex:5]; [e setBytes:&ascale length:4 atIndex:6]; [e setBytes:&pos_base length:4 atIndex:7];
-    [e dispatchThreads:MTLSizeMake((size_t)S*AHEADS*T,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; BAR();
+    return true;
+}
+// Phase 2: chunked attention core for one chunk of ch rows (starting at r0 within the S-row batch).
+// Reads aqabs_[r0*AHEADS*AKVL], aqf_[r0*AHQH], Lb, Rb, kvbW, kvbS.
+// Writes actx_[r0*AHVH] (accumulated into the S-row ctx buffer).
+// Intermediate: ascore_[ch*AHEADS*T], aclat_[ch*AHEADS*AKVL] (per chunk, ephemeral).
+// T = total keys in the KV cache (pos_base_global + S_total). pos_base here = pos_base_global + r0
+// so that the score kernel's per-row causal length (pos - t + 1) is correct for this chunk.
+static bool encode_attn_core_chunk(id<MTLComputeCommandEncoder> e,
+                             id<MTLBuffer> Lb, size_t loff, id<MTLBuffer> Rb, size_t roff,
+                             id<MTLBuffer> kvbW, size_t kvbwoff, id<MTLBuffer> kvbS, size_t kvbsoff,
+                             int r0, int ch, int T, int pos_base, float ascale) {
+    size_t qabs_off=(size_t)r0*AHEADS*AKVL*4, qf_off=(size_t)r0*AHQH*4, ctx_off=(size_t)r0*AHVH*4;
+    int PB=pos_base;
+    auto BAR=[&]{ [e memoryBarrierWithScope:MTLBarrierScopeBuffers]; };
+    [e setComputePipelineState:g_a_score]; [e setBuffer:aqabs_ offset:qabs_off atIndex:0];
+    [e setBuffer:Lb offset:loff atIndex:1]; [e setBuffer:Rb offset:roff atIndex:2]; [e setBuffer:aqf_ offset:qf_off atIndex:3];
+    [e setBuffer:ascore_ offset:0 atIndex:4]; [e setBytes:&T length:4 atIndex:5]; [e setBytes:&ascale length:4 atIndex:6]; [e setBytes:&PB length:4 atIndex:7];
+    [e dispatchThreads:MTLSizeMake((size_t)ch*AHEADS*T,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; BAR();
     [e setComputePipelineState:g_a_smax]; [e setBuffer:ascore_ offset:0 atIndex:0]; [e setBytes:&T length:4 atIndex:1];
-    [e dispatchThreadgroups:MTLSizeMake((size_t)S*AHEADS,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; BAR();
+    [e dispatchThreadgroups:MTLSizeMake((size_t)ch*AHEADS,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; BAR();
     [e setComputePipelineState:g_a_clat]; [e setBuffer:ascore_ offset:0 atIndex:0]; [e setBuffer:Lb offset:loff atIndex:1]; [e setBuffer:aclat_ offset:0 atIndex:2]; [e setBytes:&T length:4 atIndex:3];
-    [e dispatchThreads:MTLSizeMake((size_t)S*AHEADS*AKVL,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; BAR();
-    [e setComputePipelineState:g_a_ctx]; [e setBuffer:kvbW offset:kvbwoff atIndex:0]; [e setBuffer:kvbS offset:kvbsoff atIndex:1]; [e setBuffer:aclat_ offset:0 atIndex:2]; [e setBuffer:actx_ offset:0 atIndex:3];
-    [e dispatchThreads:MTLSizeMake((size_t)S*AHEADS*AVH,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; BAR();
+    [e dispatchThreads:MTLSizeMake((size_t)ch*AHEADS*AKVL,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; BAR();
+    [e setComputePipelineState:g_a_ctx]; [e setBuffer:kvbW offset:kvbwoff atIndex:0]; [e setBuffer:kvbS offset:kvbsoff atIndex:1]; [e setBuffer:aclat_ offset:0 atIndex:2]; [e setBuffer:actx_ offset:ctx_off atIndex:3];
+    [e dispatchThreads:MTLSizeMake((size_t)ch*AHEADS*AVH,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; BAR();
+    return true;
+}
+// Old monolithic encode_attention: projections + core + output GEMV in one call.
+// Used by the S<=4 decode path and as a building block for larger S.
+static bool encode_attention(id<MTLComputeCommandEncoder> e, const AttnW *W,
+                             id<MTLBuffer> Lb, size_t loff, id<MTLBuffer> Rb, size_t roff,
+                             id<MTLBuffer> kvbW, size_t kvbwoff, id<MTLBuffer> kvbS, size_t kvbsoff,
+                             int S, int T, int pos_base, float eps, float theta, float ascale) {
+    if(!encode_attn_projections(e,W,Lb,loff,Rb,roff,kvbW,kvbwoff,kvbS,kvbsoff,S,pos_base,eps,theta)) return false;
+    if(!encode_attn_core_chunk(e,Lb,loff,Rb,roff,kvbW,kvbwoff,kvbS,kvbsoff,0,S,T,pos_base,ascale)) return false;
     bind_gemv(e,W->o_w,W->o_s,W->o_fmt,AHVH,AH,actx_,aout_,S);
     return true;
 }
@@ -692,25 +730,72 @@ extern "C" int coli_metal_attn_decode(const float* x,
     const void* o_w,const float* o_s,int o_fmt,
     float* Lc,float* Rc,int S,int pos_base,int st0,float eps,float theta,float ascale,float* out){
   if(!g_dev) return 0;
-  if(st0!=0 || S<1 || S>AMAXS) return 0;     // partial-KV / S>4 -> CPU
+  if(st0!=0 || S<1) return 0;     // partial-KV -> CPU (S no longer capped)
   int T=pos_base+S;
   @autoreleasepool {
-    attn_scratch_init();
     AttnW W={qa_w,qa_s,qa_fmt,qa_ln,qb_w,qb_s,qb_fmt,kva_w,kva_s,kva_fmt,kva_ln,kvb_w,kvb_s,kvb_fmt,o_w,o_s,o_fmt};
     id<MTLBuffer> Lb,Rb,kvbW,kvbS; size_t loff,roff,kvbwoff,kvbsoff;
     if(!resolve_attn(&W,Lc,Rc,&Lb,&loff,&Rb,&roff,&kvbW,&kvbwoff,&kvbS,&kvbsoff)) return 0;
-    ascore_=ensure(ascore_,&ascore_cap,(size_t)S*AHEADS*T*4);
-    memcpy([ax_ contents],x,(size_t)S*AH*4);
-    id<MTLCommandBuffer> cb=[g_queue commandBuffer]; id<MTLComputeCommandEncoder> e=[cb computeCommandEncoder];
-    [e useResource:Lb usage:MTLResourceUsageRead|MTLResourceUsageWrite]; [e useResource:Rb usage:MTLResourceUsageRead|MTLResourceUsageWrite];
-    [e useResource:kvbW usage:MTLResourceUsageRead]; [e useResource:kvbS usage:MTLResourceUsageRead];
-    if(!encode_attention(e,&W,Lb,loff,Rb,roff,kvbW,kvbwoff,kvbS,kvbsoff,S,pos_base,eps,theta,ascale)) return 0;
-    double tc=mnow();
-    [e endEncoding]; [cb commit]; [cb waitUntilCompleted];
-    if(cb.status==MTLCommandBufferStatusError){ fprintf(stderr,"[metal] attn cmdbuf error: %s\n", cb.error?[[cb.error localizedDescription]UTF8String]:"?"); return 0; }
-    g_attn_ok++; g_attn_wall += mnow()-tc; g_attn_kernel += [cb GPUEndTime]-[cb GPUStartTime];
-    g_attn_sched += [cb GPUStartTime]-[cb kernelStartTime]; g_attn_ksched += [cb kernelStartTime]-tc;
-    memcpy(out,[aout_ contents],(size_t)S*AH*4);
+
+    if(S<=AMAXS){
+      // Monolithic path (S<=4): single command buffer, backward compatible.
+      attn_scratch_reserve(S,T);
+      memcpy([ax_ contents],x,(size_t)S*AH*4);
+      id<MTLCommandBuffer> cb=[g_queue commandBuffer]; id<MTLComputeCommandEncoder> e=[cb computeCommandEncoder];
+      [e useResource:Lb usage:MTLResourceUsageRead|MTLResourceUsageWrite]; [e useResource:Rb usage:MTLResourceUsageRead|MTLResourceUsageWrite];
+      [e useResource:kvbW usage:MTLResourceUsageRead]; [e useResource:kvbS usage:MTLResourceUsageRead];
+      if(!encode_attention(e,&W,Lb,loff,Rb,roff,kvbW,kvbwoff,kvbS,kvbsoff,S,T,pos_base,eps,theta,ascale)) return 0;
+      double tc=mnow();
+      [e endEncoding]; [cb commit]; [cb waitUntilCompleted];
+      if(cb.status==MTLCommandBufferStatusError){ fprintf(stderr,"[metal] attn cmdbuf error: %s\n", cb.error?[[cb.error localizedDescription]UTF8String]:"?"); return 0; }
+      g_attn_ok++; g_attn_wall += mnow()-tc; g_attn_kernel += [cb GPUEndTime]-[cb GPUStartTime];
+      g_attn_sched += [cb GPUStartTime]-[cb kernelStartTime]; g_attn_ksched += [cb kernelStartTime]-tc;
+      memcpy(out,[aout_ contents],(size_t)S*AH*4);
+    } else {
+      // Two-phase prefill path (S>4): projections once, attention core in chunks, output GEMV once.
+      attn_scratch_reserve(S,T);
+      memcpy([ax_ contents],x,(size_t)S*AH*4);
+
+      // Phase 1: projections for all S rows.
+      {
+        id<MTLCommandBuffer> cb=[g_queue commandBuffer]; id<MTLComputeCommandEncoder> e=[cb computeCommandEncoder];
+        [e useResource:Lb usage:MTLResourceUsageRead|MTLResourceUsageWrite]; [e useResource:Rb usage:MTLResourceUsageRead|MTLResourceUsageWrite];
+        [e useResource:kvbW usage:MTLResourceUsageRead]; [e useResource:kvbS usage:MTLResourceUsageRead];
+        if(!encode_attn_projections(e,&W,Lb,loff,Rb,roff,kvbW,kvbwoff,kvbS,kvbsoff,S,pos_base,eps,theta)) return 0;
+        [e endEncoding]; [cb commit]; [cb waitUntilCompleted];
+        if(cb.status==MTLCommandBufferStatusError){ fprintf(stderr,"[metal] attn proj cmdbuf error\n"); return 0; }
+      }
+
+      // Phase 2: chunked attention core over rows. Chunk size caps a_score threads at ~1B.
+      int CH=(int)((1LL<<30)/((int64_t)AHEADS*T));
+      if(CH<1) CH=1; if(CH>S) CH=S;
+      for(int r0=0;r0<S;r0+=CH){
+        int ch=(S-r0<CH)?(S-r0):CH;
+        id<MTLCommandBuffer> cb=[g_queue commandBuffer]; id<MTLComputeCommandEncoder> e=[cb computeCommandEncoder];
+        [e useResource:Lb usage:MTLResourceUsageRead|MTLResourceUsageWrite]; [e useResource:Rb usage:MTLResourceUsageRead|MTLResourceUsageWrite];
+        [e useResource:kvbW usage:MTLResourceUsageRead]; [e useResource:kvbS usage:MTLResourceUsageRead];
+        if(!encode_attn_core_chunk(e,Lb,loff,Rb,roff,kvbW,kvbwoff,kvbS,kvbsoff,r0,ch,T,pos_base+r0,ascale)) return 0;
+        double tc=mnow();
+        [e endEncoding]; [cb commit]; [cb waitUntilCompleted];
+        if(cb.status==MTLCommandBufferStatusError){ fprintf(stderr,"[metal] attn core cmdbuf error (r0=%d)\n",r0); return 0; }
+        g_attn_kernel += [cb GPUEndTime]-[cb GPUStartTime];
+        g_attn_sched += [cb GPUStartTime]-[cb kernelStartTime]; g_attn_ksched += [cb kernelStartTime]-tc;
+      }
+      g_attn_ok++;
+
+      // Phase 3: output projection GEMV on accumulated actx_.
+      {
+        id<MTLCommandBuffer> cb=[g_queue commandBuffer]; id<MTLComputeCommandEncoder> e=[cb computeCommandEncoder];
+        [e useResource:kvbW usage:MTLResourceUsageRead]; [e useResource:kvbS usage:MTLResourceUsageRead];
+        bind_gemv(e,W->o_w,W->o_s,W->o_fmt,AHVH,AH,actx_,aout_,S);
+        double tc=mnow();
+        [e endEncoding]; [cb commit]; [cb waitUntilCompleted];
+        if(cb.status==MTLCommandBufferStatusError){ fprintf(stderr,"[metal] attn oproj cmdbuf error\n"); return 0; }
+        g_attn_kernel += [cb GPUEndTime]-[cb GPUStartTime];
+        g_attn_sched += [cb GPUStartTime]-[cb kernelStartTime]; g_attn_ksched += [cb kernelStartTime]-tc;
+      }
+      memcpy(out,[aout_ contents],(size_t)S*AH*4);
+    }
   }
   return 1;
 }
@@ -771,7 +856,7 @@ extern "C" int coli_metal_layer_decode(float *x,
     // 1) in_ln: ax_ = rmsnorm(x)
     copyrow(axr_,ax_,AH); BAR(); rmsw(ax_,inB,inoff,AH,S); BAR();
     // 2) attention (ax_ -> aout_)
-    if(!encode_attention(e,&W,Lb,loff,Rb,roff,kvbW,kvbwoff,kvbS,kvbsoff,S,pos_base,eps,theta,ascale)) return 0;
+    if(!encode_attention(e,&W,Lb,loff,Rb,roff,kvbW,kvbwoff,kvbS,kvbsoff,S,T,pos_base,eps,theta,ascale)) return 0;
     BAR();
     // 3) residual: axr_ += aout_ ; then nrm = post_ln(x_new)
     [e setComputePipelineState:g_a_add]; [e setBuffer:axr_ offset:0 atIndex:0]; [e setBuffer:aout_ offset:0 atIndex:1];

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -2361,7 +2361,7 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
      * would rope every row at position 0 and attend over a 1-token window of the wrong
      * cache -> greedy decode hits EOS at token 2 (mux answers truncated to 1 token).
      * Ragged rows take the CPU absorb path below, which reads kvs[s]/positions[s]. */
-    if(g_metal_enabled && !kvs && S<=4 && (g_absorb==1||(g_absorb<0&&S<=4)) && m->kv_start[layer]==0
+    if(g_metal_enabled && !kvs && g_absorb!=0 && m->kv_start[layer]==0
        && D==6144 && H==64 && c->q_lora==2048 && c->kv_lora==512 && c->qk_nope==192
        && c->qk_rope==64 && vh==256 && l->kv_b.fmt==2){
         int sel_active = m->has_dsa && layer<c->n_layers && c->idx_type[layer] && (pos_base+S) > c->index_topk;
@@ -4287,11 +4287,12 @@ static void layers_forward_rows(Model *m, float *x, int S, int pos_base,
     int pipe2 = g_cuda_pipe>=2 && !kvs && S>=pipe_s_min && g_cuda_enabled && c->kv_lora<=512 &&
                 !(m->has_dsa && pos_base+S>c->index_topk);
 #endif
+    double tl0=now_s();
     for(int i=0;i<c->n_layers;i++){
         /* progresso su stderr per i batch grossi (prefill): il primo byte di risposta
          * puo' arrivare dopo MINUTI di streaming — al buio sembra un blocco. */
         if(S>=8 && (i%4==0 || i==c->n_layers-1))
-            fprintf(stderr,"[prefill] layer %d/%d · %d token\n", i+1, c->n_layers, S);
+            fprintf(stderr,"[prefill] layer %d/%d · %d token · +%.2fs\n", i+1, c->n_layers, S, now_s()-tl0);
 #ifdef COLI_CUDA
         Layer *l=&m->L[i];
         if(pipe2 && l->sparse && i<c->n_layers &&


### PR DESCRIPTION
Split the fused Metal attention encoder into three phases:

1. **encode_attn_projections** — RMS norm, Qa/KVa/Qb projections, RoPE, Q→abs once for all S rows
2. **encode_attn_core_chunk** — score/softmax/clat/ctx over a row chunk, respecting Metal's ~1B thread limit
3. **Output projection GEMV** — once on the accumulated ctx buffer

Removes the AMAXS=4 cap from `coli_metal_attn_decode`. Scratch buffers are now reserved dynamically via `attn_scratch_reserve(S,T)`. The S≤4 decode path is unchanged (backward compatible — same monolithic command buffer). The S>4 path uses 1 projections buffer + N core chunks + 1 output buffer.

Also lifts the S≤4 gate in `colibri.c:attention_rows` — the absorb path now delegates to Metal for any S when `g_absorb!=0`.

### Key changes
- `c/backend_metal.mm`: +119 / -33 — split + reserve + two-phase dispatch
- `c/colibri.c`: +5 / -10 — gate lift + cumulative timer in prefill progress

Needs `JustVugg/colibri#587` (host-side _gs params) if routed-expert fmt=4 decode is also wanted, but this PR is independent.