### PR TITLE
fix(windows): enable direct I/O for mirror shards

### DIFF
--- a/c/st.h
+++ b/c/st.h
@@ -169,7 +169,7 @@ static int st_mirror_init(shards *S, const char *dir) {
         S->mfds[i] = mfd;
 #ifdef O_DIRECT
         S->mdfds[i] = open(mp, COMPAT_O_RDONLY | O_DIRECT);
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(_WIN32)
         S->mdfds[i] = compat_open_direct(mp);
 #endif
         S->nmirror++;

--- a/c/tests/test_st_mirror.c
+++ b/c/tests/test_st_mirror.c
@@ -83,6 +83,9 @@ int main(void) {
     CHECK(st_mirror_init(&S, DIR_B) == 1);
     int mfd = st_fd_rep(&S, t->fd, 1);
     CHECK(mfd >= 0 && mfd != t->fd);
+#ifdef _WIN32
+    CHECK(st_direct_fd_rep(&S, t->fd, 1) >= 0);
+#endif
     float a[8], b[8];
     CHECK(pread(t->fd, a, t->nbytes, t->off) == t->nbytes);
     CHECK(pread(mfd, b, t->nbytes, t->off) == t->nbytes);


### PR DESCRIPTION
## Summary

- Open Windows mirror replicas with the existing `compat_open_direct()` path, matching primary shard behavior.
- Keep the buffered mirror descriptor for metadata and fallback reads; only the direct-read replica descriptor changes.
- Add a Windows regression assertion that an accepted mirror registers a direct descriptor.

## Root cause

`st_open_fd()` already uses `compat_open_direct()` for primary shards on Windows, but `st_mirror_init()` only created direct mirror descriptors for platforms with `O_DIRECT` or for Apple. On Windows, every `mdfds[]` entry therefore remained `-1`: `DIRECT=1` bypassed the page cache for primary-shard reads but not mirror reads, and the mirror probe warned that it could measure cached I/O.

The fix extends the existing Apple compatibility branch to `_WIN32`; it does not add a new I/O implementation or alter non-Windows behavior.

## Validation

- [x] `make -C c check`
  - Linux: all native tests passed; Python `167 passed, 13 skipped`.
  - Windows 11 / MSYS2 GCC: all native tests passed, including `compat direct tests: ok` and the new mirror assertion; Python `166 passed, 30 skipped`.
- [x] Tiny-model token-exact oracle:
  - `SNAP=./glm_tiny TF=1 ./colibri 64 16 16` -> `32/32 positions`
  - `SNAP=./glm_tiny ./colibri 64 16 16` -> `20/20` matching tokens
- [x] Two clean patched Windows builds were byte-identical:
  - SHA-256 `cfc4634521ebd75d54c0dd19d92d5eb04505c68431ebc6e498ba61dc200aaf15`
- [x] CUDA validation is not applicable; no CUDA code changed.
- [x] Performance claims include hardware, commands, and repeatable measurements.

The Windows compiler emitted the same pre-existing `colibri.c` format-truncation and unused-variable warnings in baseline and patched builds; the changed files introduced no warnings.

### Windows mirror A/B benchmark

- Baseline: `11cd1c6456db34da6c3faf5d6472aec54e45c85b`
- Patched: `926dde9af3b2f19faa1cb7d1e608de0ee8f44417`
- Host: Windows 11 Pro, AMD Ryzen 9 7845HX
- Storage: Samsung PM9A1 NVMe 2 TB and WD_BLACK SN850X 1 TB; the `SNAP` manifest links 72 shards to `C:` and 72 shards to mounted `D:`, while `COLI_MODEL_MIRROR` provides the 72 complementary `C:` replicas
- Model: GLM-5.2 int4
- Run policy: A-B-B-A, 16 generated tokens per run, fixed prompt/seed, the same `.coli_usage` snapshot restored before every run, no warm-up run discarded
- Settings: `RAM_GB=32`, `CTX=8192`, `DIRECT=1`, `PIPE=1`, `PIPE_WORKERS=8`, `PILOT=1`, `PILOT_REAL=0`, `DRAFT=0`, `KVSAVE=0`, `REPIN=0`, `COLI_TEMP=0`, `OMP_NUM_THREADS=12`
- Invocation for each baseline/patched binary: `colibri-<variant>.exe 8`

| Median metric (2 runs/variant) | Baseline | Patched | Change |
|---|---:|---:|---:|
| Direct mirror coverage | 78.64% | 99.41% | +20.77 pp |
| Prefill | 15.275 s | 13.360 s | -12.54% |
| Decode | 36.750 s | 33.950 s | -7.62% |
| I/O felt wait | 27.012 s | 24.317 s | -9.98% |
| I/O throughput | 3.845 GB/s | 4.160 GB/s | +8.19% |
| Forward p50 | 2420.1 ms | 2256.1 ms | -6.78% |
| End-to-end elapsed | 62.076 s | 59.110 s | -4.78% |

All four runs produced the same generated-token SHA-256:
`e9404802f30b6629f99388a588e3c7eb35bdee496060a114c9780e93ac3b7936`.
The baseline printed the buffered-mirror warning and selected a roughly 61/39 primary/mirror split; patched runs printed no warning and selected 48/52 and 49/51.

## Compatibility

- [x] The default CPU build remains dependency-free.
- [x] No model files, generated binaries, or benchmark artifacts are included.
