### PR TITLE
fix(metal): compile-time SDK floor for the residency-set path

### DIFF
--- a/c/backend_metal.mm
+++ b/c/backend_metal.mm
@@ -333,8 +333,20 @@ static std::mutex g_slab_mtx;   // expert_load registers slabs from parallel Ope
 // g_resset_obj is a bare `id` (holds id<MTLResidencySet>) so the global's declared type
 // carries no availability annotation -- the protocol name only appears inside
 // @available(macOS 15.0, *) guards below, keeping -Wunguarded-availability clean.
+// @available is a runtime guard only: the compiler still resolves MTLResidencySet and its
+// selectors against the SDK headers, which don't declare them before macOS 15 (#596).
+// COLI_HAS_RESSET is the compile-time floor (helpers become no-ops below it); the @available
+// guards stay on top so a macOS 15 SDK build still runs right on macOS 14. -DCOLI_HAS_RESSET=0
+// forces the fallback branch on a modern SDK.
+#ifndef COLI_HAS_RESSET
+#if defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 150000
+#define COLI_HAS_RESSET 1
+#else
+#define COLI_HAS_RESSET 0
+#endif
+#endif
 static id g_resset_obj;
-static bool g_resset_enabled;   // COLI_METAL_RESSET=1, macOS 15+, and creation succeeded
+static bool g_resset_enabled;   // COLI_METAL_RESSET=1, macOS 15 SDK+OS, and creation succeeded
 static bool g_resset_dirty;     // addAllocation: calls pending commit; g_resset_mtx-guarded
 // Set mutations + dirty flag get their OWN mutex, never held together with g_slab_mtx: no
 // live Metal call may run under the slab lock the parallel OMP loader threads contend on
@@ -355,8 +367,12 @@ static double g_t_resset_flush;   // sec committing pending adds in moe_submit (
 // no separate counter for the add/remove side.
 static void resset_add(id<MTLBuffer> b) {
   if (!g_resset_enabled) return;
+#if COLI_HAS_RESSET
   std::lock_guard<std::mutex> lk(g_resset_mtx);
   if (@available(macOS 15.0, *)) { [(id<MTLResidencySet>)g_resset_obj addAllocation:b]; g_resset_dirty = true; }
+#else
+  (void)b;
+#endif
 }
 // Remove + commit immediately, NOT deferred: the caller frees the underlying host memory
 // right after coli_metal_unregister returns, so the removal must be applied before that --
@@ -364,22 +380,28 @@ static void resset_add(id<MTLBuffer> b) {
 // risk the GPU could act on. Also runs outside g_slab_mtx (see g_resset_mtx above).
 static void resset_remove(id<MTLBuffer> b) {
   if (!g_resset_enabled) return;
+#if COLI_HAS_RESSET
   std::lock_guard<std::mutex> lk(g_resset_mtx);
   if (@available(macOS 15.0, *)) {
     id<MTLResidencySet> rs = (id<MTLResidencySet>)g_resset_obj;
     [rs removeAllocation:b]; [rs commit];
   }
   g_resset_dirty = false;   // commit above also flushes any pending adds
+#else
+  (void)b;
+#endif
 }
 // Flush pending adds before moe_submit relies on the set alone for residency -- the only
 // caller that skips per-buffer useResource: (see moe_submit below). Takes g_resset_mtx
 // only, never g_slab_mtx; the happens-before argument lives at resset_add above.
 static void resset_flush() {
   if (!g_resset_enabled) return;
+#if COLI_HAS_RESSET
   std::lock_guard<std::mutex> lk(g_resset_mtx);
   if (!g_resset_dirty) return;
   if (@available(macOS 15.0, *)) { [(id<MTLResidencySet>)g_resset_obj commit]; }
   g_resset_dirty = false;
+#endif
 }
 // Harness visibility for the flush cost, which sits OUTSIDE the moe_times setup/gpu
 // breakdown (timed around resset_flush in moe_submit, before ts_start). Returns whether
@@ -455,6 +477,7 @@ extern "C" int coli_metal_init(void) {
       fprintf(stderr, "[metal] pipeline failed\n"); g_dev = nil; return 0; }
     // E5 experiment: COLI_METAL_RESSET=1 -- see g_resset_obj comment above.
     if (getenv("COLI_METAL_RESSET") && atoi(getenv("COLI_METAL_RESSET"))) {
+#if COLI_HAS_RESSET
       if (@available(macOS 15.0, *)) {
         MTLResidencySetDescriptor *rd = [MTLResidencySetDescriptor new];
         rd.initialCapacity = 4096;   // hint only (internal array presize), not a hard limit
@@ -471,6 +494,10 @@ extern "C" int coli_metal_init(void) {
       } else {
         fprintf(stderr, "[METAL] COLI_METAL_RESSET=1 requested but OS < macOS 15 -- stock per-CB residency path\n");
       }
+#else
+      fprintf(stderr, "[METAL] COLI_METAL_RESSET=1 requested but this binary was built against a "
+                      "macOS SDK < 15 (MTLResidencySet unavailable) -- stock per-CB residency path\n");
+#endif
     }
   }
   return 1;
@@ -543,9 +570,11 @@ extern "C" void coli_metal_spin_stop(void) { g_spin_run.store(false); }
 
 extern "C" void coli_metal_shutdown(void) {
   coli_metal_spin_stop();
+#if COLI_HAS_RESSET
   if (g_resset_enabled) {
     if (@available(macOS 15.0, *)) { [g_queue removeResidencySet:(id<MTLResidencySet>)g_resset_obj]; }
   }
+#endif
   g_resset_obj=nil; g_resset_enabled=false; g_resset_dirty=false;
   g_gemv=nil; g_queue=nil; g_dev=nil; g_tensor_count=g_tensor_bytes=0;
 }

--- a/docs/metal.md
+++ b/docs/metal.md
@@ -10,6 +10,8 @@ Token-exact vs the CPU path.
 ```bash
 cd c
 make colibri METAL=1          # macOS only; no Xcode needed (shader compiles at runtime)
+                              # any macOS SDK builds; the COLI_METAL_RESSET residency-set
+                              # path needs the macOS 15 SDK and is compiled out below it
 make metal-test           # standalone kernel/attention correctness vs CPU reference
 COLI_METAL=1 COLI_MODEL=/path/glm52_i4 ./coli chat --ram 96
 ```


### PR DESCRIPTION
Fixes #596. Written working with Claude, and I am not a Metal expert by training, so please read the diff with that in mind.

`@available(macOS 15.0, *)` is a runtime guard: the compiler still resolves `MTLResidencySet`, `MTLResidencySetDescriptor` and the residency-set selectors against the SDK headers, which do not declare them before macOS 15, so `METAL=1` fails to build on older SDKs exactly as reported. This adds `COLI_HAS_RESSET` (`__MAC_OS_X_VERSION_MAX_ALLOWED >= 150000`, overridable with `-DCOLI_HAS_RESSET=0`) around the five sites that touch the API, keeps the `@available` guards for the runtime side, has the init path print that the gate was compiled out instead of staying silent, and documents the SDK floor in `docs/metal.md`.

Verification, since I had no macOS 14 SDK on hand: I reconstructed one (Metal.framework from the 26.5 SDK with `MTLResidencySet.h` and the related declarations removed, sanity-checked with a plain `#import <Metal/Metal.h>` build). Stock `dev` fails against it with the 11 errors from the issue; this branch compiles clean with the gate at 0. The repro earned its keep, my first version missed the `removeResidencySet:` call in `coli_metal_shutdown`. With the gate on, the emitted object is byte identical to stock `dev`, so macOS 15+ SDK builds are unchanged.

On the exact tree of this PR (macOS 26.5, M5 Pro 48 GB): `make check` 167 tests pass, `make -C c colibri METAL=1` builds with no warnings, `make -C c metal-test` is green, oracle 32/32 teacher-forced and 20/20 greedy.

One oracle note that may be worth a line in CONTRIBUTING: `tools/make_glm_oracle.py` needs `transformers >= 5.11`, and on Python 3.9 pip silently caps at 4.57.6 via `requires-python`, which looks like the version does not exist. Python 3.12 resolves it fine.

It would be good if @jerome-benoit could confirm on the real `apple-sdk 14.4` Nix build, since my SDK 14 is a reconstruction.
