### PR TITLE
nix: fix the flake build broken by the glm → colibri rename (#595)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
 
           buildPhase = ''
             runHook preBuild
-            make -C c glm ARCH="$ARCH"
+            make -C c colibri ARCH="$ARCH"
             runHook postBuild
           '';
 
@@ -68,7 +68,7 @@
             # modules it imports (openai_server.py, resource_plan.py,
             # doctor.py), and tools/ all sit next to each other.
             mkdir -p $out/lib/colibri/tools $out/bin
-            cp c/glm             $out/lib/colibri/glm
+            cp c/colibri         $out/lib/colibri/colibri
             cp c/coli            $out/lib/colibri/coli
             chmod +x $out/lib/colibri/coli
             cp c/openai_server.py c/resource_plan.py c/doctor.py c/version.py \
@@ -76,14 +76,14 @@
             cp -r c/tools/*      $out/lib/colibri/tools/
 
             # $out/bin holds the user-facing entry points.
-            ln -s ../lib/colibri/glm $out/bin/glm
+            ln -s ../lib/colibri/colibri $out/bin/colibri
 
             # Wrap coli: point it at the bundled engine (COLI_ENGINE) so it is
             # found by default, and at the module dir (PYTHONPATH) so
             # `import openai_server` / `resource_plan` / `doctor` resolve.
             makeWrapper ${pythonEnv}/bin/python $out/bin/coli \
               --add-flags "$out/lib/colibri/coli" \
-              --set-default COLI_ENGINE "$out/lib/colibri/glm" \
+              --set-default COLI_ENGINE "$out/lib/colibri/colibri" \
               --set PYTHONPATH "$out/lib/colibri:${pythonEnv}/${pkgs.python3.sitePackages}"
             runHook postInstall
           '';
@@ -117,9 +117,14 @@
             type = "app";
             program = pkgs.lib.getExe colibri;
           };
-          glm = {
+          # `nix run .#engine` runs the engine binary directly, skipping the
+          # coli launcher. Named "engine", not "colibri", so it doesn't shadow
+          # packages.colibri (whose mainProgram is coli). Replaces the old
+          # `.#glm`, which pointed at a share/colibri/ path the installPhase
+          # never produced (#595).
+          engine = {
             type = "app";
-            program = "${colibri}/share/colibri/glm";
+            program = "${colibri}/bin/colibri";
           };
         };
 
@@ -141,9 +146,9 @@
             echo "  gcc: $(gcc --version | head -1)"
             echo "  python: $(python3 --version)"
             echo ""
-            echo "Build the engine:   make -C c glm"
+            echo "Build the engine:   make -C c colibri"
             echo "Run the converter:  python c/coli convert --model /path/to/glm52_i4"
-            echo "Chat:               COLI_MODEL=/path/to/glm52_i4 ./c/glm ..."
+            echo "Chat:               COLI_MODEL=/path/to/glm52_i4 ./c/colibri ..."
           '';
         };
       }


### PR DESCRIPTION
Fixes #595 — both defects @jerome-benoit reported, which share one root cause: the `glm` → `colibri` binary rename updated every other reference but not `flake.nix`.

## A1 — `packages.default` fails in installPhase

`buildPhase` ran `make -C c glm`, but `c/Makefile:263` `glm: colibri$(EXE)` is a phony alias and the link rule emits `colibri$(EXE)`, so `cp c/glm` had nothing to copy.

Rather than just repointing the `cp` at `c/colibri` and keeping the installed name `glm`, this installs the engine under its **real** name. `c/coli`'s path resolution (`c/coli:69-86`) already prefers `HERE/colibri`, with `HERE/glm` only as a legacy fallback — so the bundled layout now matches what a source checkout looks like, and the `--set-default COLI_ENGINE` wrapper flag goes back to being a belt-and-braces override instead of the thing holding the layout together. `buildPhase` uses `make -C c colibri`, matching `ci.yml`, `release.yml` and `docker/Dockerfile.slim`.

## A2 — `apps.glm` points at a path that is never produced

`${colibri}/share/colibri/glm` — there is no `share/colibri/`. It becomes `apps.engine` → `$out/bin/colibri`. Deliberately *not* named `colibri`, so it doesn't shadow `packages.colibri` (whose `mainProgram` is `coli`, the launcher — the right default). Renaming rather than aliasing is safe here: A1 meant the package never built, so `nix run .#glm` has never resolved for anyone, and nothing in the repo or docs references it.

Also fixes the two `devShell` shellHook hints, which still printed `make -C c glm` and `./c/glm`.

## Verification — please read this before merging

**I do not have Nix installed, so I could not run `nix build` end to end.** What I did verify on Linux (x86-64-v3, gcc):

- `make -C c colibri ARCH=x86-64-v3` exits 0 and produces `c/colibri`; `c/glm` is never created, confirming the reported failure mode. (It prints `make: Circular colibri <- colibri dependency dropped.` where `$(EXE)` is empty — pre-existing noise on the target CI, release and Docker already use, not introduced here.)
- Replayed the new `installPhase` verbatim against that tree: every `cp` source resolves, and `$out/bin/colibri` is a working symlink.
- Against that simulated `$out`, with `COLI_ENGINE` **unset**, `python3 coli --version` prints `colibri 1.1.1` and engine auto-discovery resolves to `$out/lib/colibri/colibri` — i.e. the layout stands on its own.

That covers the logic but not the Nix evaluation. @jerome-benoit, since you have the real aarch64-darwin + `apple-sdk 14.4` setup that surfaced this, a `nix build` / `nix run .#engine` confirmation would be the missing piece.

The dependency-free default CPU path is untouched.