### PR TITLE
loader: diagnose a missing core tensor instead of just naming it (#586)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -1075,7 +1075,7 @@ static QT qt_load(Model *m, const char *name, int O, int I, int bits){
     return t;
 }
 static float *ld(Model *m, const char *name){   /* tensore 1D f32 residente (norme/bias) */
-    int64_t n=st_numel(&m->S,name); if(n<0){fprintf(stderr,"missing %s\n",name);exit(1);}
+    int64_t n=st_numel(&m->S,name); if(n<0) st_die_missing(&m->S,name);
     float *p=(float*)qalloc((size_t)n*sizeof(float));   /* registrato per la GPU sotto METAL */
     st_read_f32(&m->S,name,p,0); return p;
 }
@@ -1485,7 +1485,8 @@ static int expert_load_impl(Model *m, int layer, int eid, ESlot *s, int fatal, i
     for(int k=0;k<3;k++){
         tw[k]=st_find(&m->S,nm[k]);
         snprintf(qn,sizeof(qn),"%s.qs",nm[k]); tq[k]=st_find(&m->S,qn);
-        if(!tw[k]||!tq[k]){ fprintf(stderr,"missing %s\n",nm[k]); if(fatal) exit(1); return -1; }
+        if(!tw[k]||!tq[k]){ if(fatal) st_die_missing(&m->S,nm[k]);   /* #586: diagnose, don't just name it */
+                            fprintf(stderr,"missing %s\n",nm[k]); return -1; }
     }
     if(g_disk_split){ /* split load/byte per tipo layer; atomici: expert_load gira anche su OMP/pipe/pilot */
         int64_t tb=0; for(int k=0;k<3;k++) tb+=tw[k]->nbytes+tq[k]->nbytes;

--- a/c/st.h
+++ b/c/st.h
@@ -377,6 +377,71 @@ static st_tensor *st_find(shards *S, const char *name) {
 }
 static int st_has(shards *S, const char *name) { return st_find(S, name) != NULL; }
 
+/* A missing CORE tensor is almost never an engine bug: the converter writes the final
+ * norm and lm_head into the LAST shards, so a transfer that stopped early indexes
+ * nearly everything and then dies on the first tensor from the gap. Bare "missing
+ * model.norm.weight" gave the user no way to tell that apart from a wrong --model or a
+ * real bug (#586, #583). Report what was actually found, and let the filenames say
+ * whether shards are absent: the HF layout declares the total in `-of-NNNNN`, the
+ * converter layout at least reveals a truncated tail. */
+static void st_die_missing(shards *S, const char *name) {
+    fprintf(stderr, "missing %s\n\n", name);
+    if (S->nfd == 0 || S->n == 0) {
+        fprintf(stderr, "  No safetensors tensors were indexed at all. --model must point AT the\n"
+                        "  container directory -- the one holding the *.safetensors shards.\n");
+        exit(1);
+    }
+    int lo = -1, hi = -1, declared = 0, numbered = 0;
+    for (int i = 0; i < S->nfd; i++) {
+        const char *b = strrchr(S->paths[i], '/');
+#ifdef _WIN32
+        const char *b2 = strrchr(S->paths[i], '\\');
+        if (b2 && (!b || b2 > b)) b = b2;
+#endif
+        b = b ? b + 1 : S->paths[i];
+        int idx, tot;
+        if (sscanf(b, "model-%d-of-%d", &idx, &tot) == 2) declared = tot;
+        else if (sscanf(b, "out-%d", &idx) != 1) continue;   /* out-mtp-* etc: not numbered */
+        numbered++;
+        if (lo < 0 || idx < lo) lo = idx;
+        if (idx > hi) hi = idx;
+    }
+    int complete = declared > 0 && numbered >= declared;
+    fprintf(stderr, "  indexed %d tensors from %d shard file(s)\n", S->n, S->nfd);
+    if (declared > 0 && numbered < declared)
+        fprintf(stderr, "  shard filenames declare %d shards, but only %d are here -- %d MISSING\n",
+                declared, numbered, declared - numbered);
+    else if (declared > 0)
+        fprintf(stderr, "  shard filenames declare %d shards and %d are here\n", declared, numbered);
+    else if (numbered > 0)
+        fprintf(stderr, "  shards numbered %05d..%05d, %d file(s)%s\n", lo, hi, numbered,
+                numbered == hi - lo + 1 ? " (contiguous: a gap would be at the tail)" : " (GAPS in the numbering)");
+    /* Follow the evidence: telling someone who already has every declared shard to
+     * re-download sends them round a loop that cannot help them. */
+    if (complete) {
+        fprintf(stderr,
+            "\n  '%s' is a core tensor the engine cannot run without, and every shard the\n"
+            "  filenames declare is present -- so this is NOT the usual truncated download.\n"
+            "  Either the container was built without this tensor, or the engine is looking\n"
+            "  for the wrong name. Please report it with this output.\n", name);
+        exit(1);
+    }
+    /* The final norm and lm_head sit at the END of the model, so an interrupted transfer
+     * loses them first -- worth saying, but only where it's true. */
+    if (strstr(name, "model.norm") || strstr(name, "lm_head"))
+        fprintf(stderr, "\n  '%s' is written into one of the LAST shards, so a container whose tail\n"
+                        "  never arrived indexes almost everything and then fails exactly here.\n", name);
+    else
+        fprintf(stderr, "\n  '%s' is a core tensor: the engine cannot run without it.\n", name);
+    fprintf(stderr,
+        "  An incomplete transfer is far more likely than a corrupt engine. Re-running the\n"
+        "  download resumes only the missing shards; the HF xet backend is known to stall\n"
+        "  mid-transfer (#452), so disable it:\n"
+        "      HF_HUB_DISABLE_XET=1 hf download <repo> --local-dir <model-dir>\n"
+        "  If your shard count is already complete, that IS a bug worth reporting.\n");
+    exit(1);
+}
+
 /* prefetch ASINCRONO: dice al kernel di iniziare a leggere le pagine del tensore in
  * background (readahead). Serve a sovrapporre l'I/O degli expert col calcolo: si
  * prefetcha tutto il set di expert di un layer, poi le pread sincrone trovano la cache


### PR DESCRIPTION
Picks up the gap you identified at the end of #586:

> we think the error message itself is the real gap here — "missing model.norm.weight" gives you no way to know the container is just incomplete. We're looking at making the engine say that explicitly (how many shards/tensors it found, which core ones are missing, "looks like an incomplete download").

That thread took three rounds to reach the answer, and the reasoning that got there is mechanical enough for the engine to do itself: the final norm and `lm_head` are written into the **last** shards, so a truncated transfer indexes nearly every tensor and then dies on the first one from the gap.

## What it prints now

`out-NNNNN` converter layout, truncated tail — @xbais's exact situation (125 files, `out-00000..out-00121`):

```
missing model.norm.weight

  indexed 4821 tensors from 125 shard file(s)
  shards numbered 00000..00121, 122 file(s) (contiguous: a gap would be at the tail)

  'model.norm.weight' is written into one of the LAST shards, so a container whose tail
  never arrived indexes almost everything and then fails exactly here.
  An incomplete transfer is far more likely than a corrupt engine. Re-running the
  download resumes only the missing shards; the HF xet backend is known to stall
  mid-transfer (#452), so disable it:
      HF_HUB_DISABLE_XET=1 hf download <repo> --local-dir <model-dir>
  If your shard count is already complete, that IS a bug worth reporting.
```

HF layout, where `-of-NNNNN` gives an authoritative total, so the gap is stated as a fact rather than an inference:

```
  indexed 4500 tensors from 122 shard file(s)
  shard filenames declare 144 shards, but only 122 are here -- 22 MISSING
```

**The conclusion follows the evidence.** With every declared shard present, advising a re-download would send the user round a loop that cannot help, so it flips:

```
  shard filenames declare 144 shards and 144 are here

  'model.norm.weight' is a core tensor the engine cannot run without, and every shard the
  filenames declare is present -- so this is NOT the usual truncated download.
  Either the container was built without this tensor, or the engine is looking
  for the wrong name. Please report it with this output.
```

Zero indexed tensors is a different failure wearing the same message, and is reported as one:

```
  No safetensors tensors were indexed at all. --model must point AT the
  container directory -- the one holding the *.safetensors shards.
```

Gaps in the middle print `(GAPS in the numbering)` rather than the tail inference, and a non-tail tensor name drops the "LAST shards" sentence, which would be false for an expert weight.

## Scope

`st_die_missing()` in `st.h`, wired into `ld()` and the **fatal** branch of the expert-tensor load. The non-fatal probe branch at `colibri.c:1488` keeps its one-line `missing` log on purpose — it runs per expert and must not flood. No loading behaviour changes; this only replaces `fprintf + exit(1)` on paths that were already fatal.

## Verification

`make -C c colibri ARCH=x86-64-v3` clean, `make check` **197 passed / 13 skipped**.

The five reporting branches were exercised directly, by building a throwaway harness that includes `st.h` and hand-populates a `shards` struct (paths/n/nfd) for each layout — truncated `out-*` tail, HF `-of-` gap, complete HF container, mid-numbering hole with an expert tensor name, and zero tensors. The outputs above are that harness's real output, not hand-written samples. The harness is not part of this PR since it would need a Makefile target of its own; happy to add it as a proper test if you'd rather have the branches locked down in CI.

Not reproduced against a genuinely truncated 372 GB container — I don't have one — so the shard-arithmetic is verified against synthesised layouts, not a real interrupted download.