### PR TITLE
fix: Windows portability and security hardening in colibri.c and st.h

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -349,12 +349,29 @@ static int parse_cuda_devices(const char *list, int *out){
     return n;
 }
 #endif
-static double now_s(void){ struct timespec t; clock_gettime(CLOCK_MONOTONIC,&t); return t.tv_sec+t.tv_nsec*1e-9; }
-static double rss_gb(void){ struct rusage r; getrusage(RUSAGE_SELF,&r);
+static double now_s(void){
+#ifdef _WIN32
+    LARGE_INTEGER freq, count;
+    QueryPerformanceFrequency(&freq);
+    QueryPerformanceCounter(&count);
+    return (double)count.QuadPart / (double)freq.QuadPart;
+#else
+    struct timespec t; clock_gettime(CLOCK_MONOTONIC,&t); return t.tv_sec+t.tv_nsec*1e-9;
+#endif
+}
+static double rss_gb(void){
+#ifdef _WIN32
+    PROCESS_MEMORY_COUNTERS_EX pmc = {0}; pmc.cb = sizeof(pmc);
+    if(GetProcessMemoryInfo(GetCurrentProcess(), (PROCESS_MEMORY_COUNTERS*)&pmc, sizeof(pmc)))
+        return pmc.WorkingSetSize / (1024.0 * 1024.0 * 1024.0);
+    return 0;
+#else
+    struct rusage r; getrusage(RUSAGE_SELF,&r);
 #ifdef __APPLE__
     return r.ru_maxrss/(1024.0*1024.0*1024.0);   /* macOS: ru_maxrss in BYTE */
 #else
     return r.ru_maxrss/(1024.0*1024.0);          /* Linux: in KB */
+#endif
 #endif
 }
 /* ---- PROF=1: opt-in performance profile ----------------------------------

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -39,6 +39,12 @@
 #endif
 #include <sys/stat.h>                             /* fstat per mmap degli shard (COLI_MMAP) */
 #include <signal.h>                               /* SIGINT = stop morbido del turno in serve mode */
+#elif defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <psapi.h>                                /* Required for GetProcessMemoryInfo */
 #endif
 #ifdef __linux__
 #include <sys/vfs.h>                              /* statfs: real fs-type check for the 9p warning (below) */

--- a/c/st.h
+++ b/c/st.h
@@ -331,7 +331,12 @@ static void st_init_multi(shards *S, const char *snap_dir, const char *extra_dir
             if (bad_shape) {
                 fprintf(stderr, "%s: tensor '%s' shape overflows int64 — refusing (hostile or corrupt file)\n",
                         files[fi], name); exit(1); }
-            if (S->n == S->cap) { S->cap *= 2; S->t = realloc(S->t, S->cap*sizeof(st_tensor)); }
+            if (S->n == S->cap) {
+                S->cap *= 2;
+                st_tensor *nt = (st_tensor*)realloc(S->t, S->cap * sizeof(st_tensor));
+                if (!nt) { fprintf(stderr, "OOM reallocating shard tensor array\n"); exit(1); }
+                S->t = nt;
+            }
             st_tensor *t = &S->t[S->n++];
             t->name = strdup(name); t->fd = fd; t->off = data_start + a0;
             t->nbytes = b0 - a0; t->dtype = st_dtype_code(dt->str); t->numel = numel;

--- a/c/st.h
+++ b/c/st.h
@@ -467,7 +467,7 @@ static void st_read_slice_f32(shards *S, const char *name, int64_t elem_off, int
     st_tensor *t = st_find(S, name);
     if (!t) { fprintf(stderr, "missing tensor: %s\n", name); exit(1); }
     int esz = (t->dtype == 2) ? 4 : 2;
-    if (elem_off < 0 || n_elems < 0 || elem_off + n_elems > t->numel) {   /* keep the slice inside the tensor */
+    if (elem_off < 0 || n_elems < 0 || elem_off > t->numel || n_elems > t->numel - elem_off) {   /* keep the slice inside the tensor; subtraction avoids overflow (#1) */
         fprintf(stderr, "slice %s [%lld,+%lld) out of tensor bounds (numel %lld)\n",
                 name, (long long)elem_off, (long long)n_elems, (long long)t->numel); exit(1); }
     int64_t boff = t->off + elem_off * esz, nb = n_elems * esz;

--- a/c/st.h
+++ b/c/st.h
@@ -271,7 +271,7 @@ static void st_init_multi(shards *S, const char *snap_dir, const char *extra_dir
                 ndir, nf, snap_dir, c0);
     }
     for (int a = 0; a < nf; a++) for (int b = a+1; b < nf; b++)
-        if (strcmp(files[a], files[b]) > 0) { char tmp[1024]; strcpy(tmp, files[a]); strcpy(files[a], files[b]); strcpy(files[b], tmp); }
+        if (strcmp(files[a], files[b]) > 0) { char tmp[1024]; snprintf(tmp, sizeof(tmp), "%s", files[a]); snprintf(files[a], 1024, "%s", files[b]); snprintf(files[b], 1024, "%s", tmp); }
 
     for (int fi = 0; fi < nf; fi++) {
         int fd = st_open_fd(S, files[fi]);

--- a/c/st.h
+++ b/c/st.h
@@ -438,7 +438,7 @@ static int64_t st_read_f32(shards *S, const char *name, float *out, int drop) {
 static int64_t st_read_f32_cap(shards *S, const char *name, float *out, int64_t cap, int drop) {
     st_tensor *t = st_find(S, name);
     if (!t) { fprintf(stderr, "missing tensor: %s\n", name); exit(1); }
-    if (t->numel > cap) {
+    if (t->numel < 0 || t->numel > cap) {
         fprintf(stderr, "tensor %s: numel %lld exceeds destination capacity %lld\n",
                 name, (long long)t->numel, (long long)cap); exit(1); }
     return st_read_f32(S, name, out, drop);


### PR DESCRIPTION
## Summary
Improves Windows portability (MinGW-w64/MSYS2) and hardens safetensors tensor 
validation against malicious or corrupted inputs.

## Changes

### Windows Portability (colibri.c)
- Separates POSIX includes (`sys/stat.h`, `signal.h`) from Windows (`windows.h`, `psapi.h`) 
  using `#if/#elif`. Prevents MinGW-w64 from attempting to compile non-existent headers.
- Adds `QueryPerformanceCounter` fallback for `now_s()` on Windows.
- Implements `GetProcessMemoryInfo` for `rss_gb()` on Windows, matching 
  the Makefile's `-lpsapi` flag.

### Security — Defense in Depth (st.h)
- **Integer overflow fix** (`st_read_slice_f32`): Changes `elem_off + n_elems > t->numel` 
  to `elem_off > t->numel || n_elems > t->numel - elem_off`. Subtraction prevents `int64_t` 
  overflow with malicious safetensors files.
- **Negative `numel` validation** (`st_read_f32_cap`): Adds `t->numel < 0` as defense in depth.
- **Memory leak protection** (shard init): Guards `realloc` with a temporary variable 
  to prevent losing the original pointer if `realloc` returns `NULL`.
- **Buffer safety** (sort): Replaces `strcpy` with `snprintf` in a fixed 1024-byte 
  buffer during shard path sorting.

## Modified Files
- `c/colibri.c` — Windows portability + time/memory APIs
- `c/st.h` — integer overflow checks + memory leak fix + buffer safety

## Testing
- ✅ Compiled on Windows 11 with MSYS2 UCRT64 (`make colibri.exe ARCH=native`).
- ✅ Compiled on Linux (Docker/WSL) — no changes to conditional flags.
- Changes are platform-conditional (`#ifdef _WIN32`) and do not affect 
  behavior on Linux/macOS.

## Note for Reviewers
The security fixes in `st.h` (integer overflow in `st_read_slice_f32` and 
negative `numel` validation in `st_read_f32_cap`) act as defense in depth 
against malicious safetensors files. They require a careful review of the bounds checking 
logic, particularly the shift from addition to subtraction in `st_read_slice_f32`.

Closes #?? (maintainer will assign number)