### PR TITLE
fix(chat): retain role stop tokens in private mode

### DIFF
--- a/c/sample.h
+++ b/c/sample.h
@@ -116,20 +116,23 @@ static void stops_arm_tok(const Cfg *c, int tok_eos, Tok *T){
     int nsp = 0;
     if (T) for (int id = 0; id < T->n_ids && g_nstop < 64; id++)
         if (T->id_special[id] && !is_stop(id)) { g_stop[g_nstop++] = id; nsp++; }
-    /* #401: in serve mode keep ONLY <|endoftext|>. Role markers <|user|>/<|observation|>
-     * (config stops + tokenizer special set) are boundaries the Python server owns; as
-     * hard stops they cut generation the moment the model opens a <tool_call> block,
-     * because int4 argmax noise picks a stop-token ID over the correct '<' token.
+    /* #401: in batched gateway mode keep ONLY <|endoftext|>. Role markers
+     * <|user|>/<|observation|> (config stops + tokenizer special set) are boundaries
+     * the Python server owns; as hard stops they cut generation the moment the model
+     * opens a <tool_call> block, because int4 argmax noise picks a stop-token ID over
+     * the correct '<' token. Private `coli chat` also sets SERVE=1 for the byte
+     * protocol, but has no Python StopFilter, so it must retain the full stop set.
      *
      * #549: on some quantized containers (notably int4-gs64) an end-of-turn special
      * OTHER than <|endoftext|> wins the final-token margin, so serve mode never stops and
      * runs into hallucinated turns. COLI_SERVE_ALL_STOPS=1 re-arms the full stop set for
      * users who are NOT doing tool calls (or whose client owns the tool boundary), at the
      * cost of the #401 tool-call safety. Default off — filter unchanged. */
-    if (getenv("SERVE") && tok_eos >= 0 && !getenv("COLI_SERVE_ALL_STOPS")) {
+    if (getenv("SERVE") && getenv("SERVE_BATCH") && atoi(getenv("SERVE_BATCH")) &&
+        tok_eos >= 0 && !getenv("COLI_SERVE_ALL_STOPS")) {
         int kept = 0;
         for (int i = 0; i < g_nstop; i++) if (g_stop[i] == tok_eos) g_stop[kept++] = g_stop[i];
-        if (kept < g_nstop) fprintf(stderr, "[stop] serve mode: filtered %d non-EOS stop tokens (tool-call safety, #401)\n", g_nstop - kept);
+        if (kept < g_nstop) fprintf(stderr, "[stop] batched serve mode: filtered %d non-EOS stop tokens (tool-call safety, #401)\n", g_nstop - kept);
         g_nstop = kept; nsp = 0;
     }
     fprintf(stderr, "[stop] %d stop tokens:", g_nstop);

--- a/c/tests/test_stops.c
+++ b/c/tests/test_stops.c
@@ -128,6 +128,28 @@ int main(void){
       fail|=expect("T=NULL: no tokenizer sweep",101,0);
       if(!fail) printf("  T=NULL -> config stops only (validation path untouched)   ok\n"); }
 
+    /* 6. Private chat uses SERVE=1 for the byte protocol but has no Python
+     *    StopFilter. Only the batched gateway may reduce the engine stop set. */
+    { Cfg c; memset(&c,0,sizeof c); c.stop_ids[0]=100; c.n_stop=1;
+      setenv("SERVE","1",1); unsetenv("SERVE_BATCH"); unsetenv("COLI_SERVE_ALL_STOPS");
+      stops_arm_tok(&c,100,&T);
+      fail|=expect("private chat keeps <|user|>",101,1);
+      fail|=expect("private chat keeps <|observation|>",102,1);
+      if(g_nstop!=5){ fprintf(stderr,"  FAIL private chat: expected 5 stops, got %d\n",g_nstop); fail=1; }
+
+      setenv("SERVE_BATCH","1",1);
+      stops_arm_tok(&c,100,&T);
+      fail|=expect("batched gateway keeps EOS",100,1);
+      fail|=expect("batched gateway filters <|user|>",101,0);
+      if(g_nstop!=1){ fprintf(stderr,"  FAIL batched gateway: expected 1 stop, got %d\n",g_nstop); fail=1; }
+
+      setenv("COLI_SERVE_ALL_STOPS","1",1);
+      stops_arm_tok(&c,100,&T);
+      fail|=expect("gateway override restores <|user|>",101,1);
+      if(g_nstop!=5){ fprintf(stderr,"  FAIL gateway override: expected 5 stops, got %d\n",g_nstop); fail=1; }
+      unsetenv("COLI_SERVE_ALL_STOPS"); unsetenv("SERVE_BATCH"); unsetenv("SERVE");
+      if(!fail) printf("  private chat keeps 5 stops; batched gateway filters to EOS   ok\n"); }
+
     rm_file(dir,"config.json"); rm_file(dir,"generation_config.json"); rm_file(dir,"tokenizer.json");
     rmdir(dir);
     if(fail){ printf("test_stops: FAIL\n"); return 1; }

--- a/c/tests/test_stops.c
+++ b/c/tests/test_stops.c
@@ -63,9 +63,17 @@ static int expect(const char *what, int id, int want){
     return 0;
 }
 
+static void test_set_env(const char *name, const char *value){
+#ifdef _WIN32
+    _putenv_s(name,value);
+#else
+    setenv(name,value,1);
+#endif
+}
+
 static void clear_env(const char *name){
 #ifdef _WIN32
-    SetEnvironmentVariableA(name,NULL);
+    _putenv_s(name,"");
 #else
     unsetenv(name);
 #endif
@@ -139,19 +147,19 @@ int main(void){
     /* 6. Private chat uses SERVE=1 for the byte protocol but has no Python
      *    StopFilter. Only the batched gateway may reduce the engine stop set. */
     { Cfg c; memset(&c,0,sizeof c); c.stop_ids[0]=100; c.n_stop=1;
-      setenv("SERVE","1",1); clear_env("SERVE_BATCH"); clear_env("COLI_SERVE_ALL_STOPS");
+      test_set_env("SERVE","1"); clear_env("SERVE_BATCH"); clear_env("COLI_SERVE_ALL_STOPS");
       stops_arm_tok(&c,100,&T);
       fail|=expect("private chat keeps <|user|>",101,1);
       fail|=expect("private chat keeps <|observation|>",102,1);
       if(g_nstop!=5){ fprintf(stderr,"  FAIL private chat: expected 5 stops, got %d\n",g_nstop); fail=1; }
 
-      setenv("SERVE_BATCH","1",1);
+      test_set_env("SERVE_BATCH","1");
       stops_arm_tok(&c,100,&T);
       fail|=expect("batched gateway keeps EOS",100,1);
       fail|=expect("batched gateway filters <|user|>",101,0);
       if(g_nstop!=1){ fprintf(stderr,"  FAIL batched gateway: expected 1 stop, got %d\n",g_nstop); fail=1; }
 
-      setenv("COLI_SERVE_ALL_STOPS","1",1);
+      test_set_env("COLI_SERVE_ALL_STOPS","1");
       stops_arm_tok(&c,100,&T);
       fail|=expect("gateway override restores <|user|>",101,1);
       if(g_nstop!=5){ fprintf(stderr,"  FAIL gateway override: expected 5 stops, got %d\n",g_nstop); fail=1; }

--- a/c/tests/test_stops.c
+++ b/c/tests/test_stops.c
@@ -63,6 +63,14 @@ static int expect(const char *what, int id, int want){
     return 0;
 }
 
+static void clear_env(const char *name){
+#ifdef _WIN32
+    SetEnvironmentVariableA(name,NULL);
+#else
+    unsetenv(name);
+#endif
+}
+
 int main(void){
     int fail=0;
     /* Relative to the CWD, like test_compat_direct's TMPF — NOT "/tmp/...".
@@ -131,7 +139,7 @@ int main(void){
     /* 6. Private chat uses SERVE=1 for the byte protocol but has no Python
      *    StopFilter. Only the batched gateway may reduce the engine stop set. */
     { Cfg c; memset(&c,0,sizeof c); c.stop_ids[0]=100; c.n_stop=1;
-      setenv("SERVE","1",1); unsetenv("SERVE_BATCH"); unsetenv("COLI_SERVE_ALL_STOPS");
+      setenv("SERVE","1",1); clear_env("SERVE_BATCH"); clear_env("COLI_SERVE_ALL_STOPS");
       stops_arm_tok(&c,100,&T);
       fail|=expect("private chat keeps <|user|>",101,1);
       fail|=expect("private chat keeps <|observation|>",102,1);
@@ -147,7 +155,7 @@ int main(void){
       stops_arm_tok(&c,100,&T);
       fail|=expect("gateway override restores <|user|>",101,1);
       if(g_nstop!=5){ fprintf(stderr,"  FAIL gateway override: expected 5 stops, got %d\n",g_nstop); fail=1; }
-      unsetenv("COLI_SERVE_ALL_STOPS"); unsetenv("SERVE_BATCH"); unsetenv("SERVE");
+      clear_env("COLI_SERVE_ALL_STOPS"); clear_env("SERVE_BATCH"); clear_env("SERVE");
       if(!fail) printf("  private chat keeps 5 stops; batched gateway filters to EOS   ok\n"); }
 
     rm_file(dir,"config.json"); rm_file(dir,"generation_config.json"); rm_file(dir,"tokenizer.json");


### PR DESCRIPTION
Fixes #381.

## Root cause

Private `coli chat` and the Python gateway both set `SERVE=1`, but only the gateway has a Python `StopFilter`. The engine therefore reduced private-chat stops to EOS-only, allowing role markers such as `<|user|>` to leak into output and generation to continue.

## Fix

Scope the EOS-only stop filtering to batched gateway mode (`SERVE_BATCH=1`). Private chat retains the tokenizer/config stop set, while `serve`/`web` keep the existing tool-call safety behavior. `COLI_SERVE_ALL_STOPS=1` remains supported.

## Validation

- `make -C c tests/test_stops`
- `./c/tests/test_stops`
- `make -C c glm -j2`
- `make check` (214 Python tests passed, 13 skipped; C suite passed)