### PR TITLE
doctor: report shared libraries the engine cannot load

### DIFF
--- a/c/doctor.py
+++ b/c/doctor.py
@@ -376,6 +376,28 @@ def cuda_linkage(engine_path):
     return {"linked": False, "missing": False}
 
 
+def missing_shared_libraries(engine_path):
+    """Shared libraries the engine needs but the loader cannot resolve.
+
+    A binary built elsewhere (a prebuilt release, a copied build, a disk moved to a
+    fresh host) can be present and executable yet still fail to start. The engine
+    exits before printing anything and the caller only sees "engine exited
+    unexpectedly", so name the unresolved libraries instead. Typical case: a minimal
+    image without libgomp1, where every OpenMP build reports
+    "libgomp.so.1 => not found".
+    """
+    engine = Path(engine_path)
+    if os.name != "posix" or not engine.is_file():
+        return []
+    try:
+        result = subprocess.run(["ldd", str(engine)], capture_output=True, text=True,
+                                timeout=3, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return []          # no ldd (musl, macOS): cannot tell, so claim nothing
+    return sorted({line.split("=>")[0].strip()
+                   for line in result.stdout.splitlines() if "not found" in line})
+
+
 def run_doctor(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0, *,
                engine_path, available_memory=None, available_disk=None, gpus=None,
                linkage=None, deep=False, mirror_dir=None):
@@ -419,7 +441,14 @@ def run_doctor(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0, *,
     else:
         engine_ok = engine.is_file() and os.access(engine, os.X_OK)
     if engine_ok:
-        checks.append(_check("engine.binary", "pass", "engine executable is ready", path=str(engine)))
+        unresolved = missing_shared_libraries(engine)
+        if unresolved:
+            checks.append(_check("engine.binary", "fail",
+                                 "engine cannot load: " + ", ".join(unresolved) +
+                                 " (install the runtime package, e.g. libgomp1, and retry)",
+                                 path=str(engine), missing=unresolved))
+        else:
+            checks.append(_check("engine.binary", "pass", "engine executable is ready", path=str(engine)))
     elif engine.is_file():
         checks.append(_check("engine.binary", "fail", "engine exists but is not executable", path=str(engine)))
     else:


### PR DESCRIPTION
## Problem

An engine binary can be present and executable yet still fail to start, when the loader cannot resolve one of its shared libraries. The engine exits before printing anything, so the caller sees only:

```
RuntimeError: colibri engine exited unexpectedly
```

`coli doctor` does not help: it reports `engine.binary: pass`, because the file exists and is executable. The actual cause is only visible by running `ldd` by hand.

## How I hit it

AWS Graviton (aarch64). Release tarballs are x86_64, so ARM hosts build from source. `./setup.sh` builds cleanly and its OpenMP check passes on the build host. Moving that build to a freshly provisioned image — new instance, restored volume, container — gives:

```
$ ldd colibri | grep gomp
        libgomp.so.1 => not found
```

Every OpenMP build hits this on a minimal image without `libgomp1`. `setup.sh` catches a missing libgomp at build time, but nothing catches it at run time on a different host, which is exactly where prebuilt or relocated binaries live.

## Change

`cuda_linkage()` already runs `ldd` on the engine but greps only for `libcudart`. This generalizes the same call: collect every `not found` entry, and fail `engine.binary` naming the libraries when any exist.

```
engine.binary  fail  engine cannot load: libgomp.so.1 (install the runtime package, e.g. libgomp1, and retry)
```

Returns an empty list where `ldd` is unavailable (musl, macOS) and on Windows, so no platform gains a false failure. No new imports — `subprocess` and `Path` are already used in this module.

## Verification

Tested on the affected hardware (r8g.16xlarge, Ubuntu 24.04 aarch64, gcc 13.3):

```
real engine (libs resolve)  -> []
engine missing libgomp      -> ['libgomp.so.1']
```

`make check` on a clean `dev` checkout with this patch:

```
Ran 213 tests in 112.645s
OK (skipped=24)
```

Opened against `dev` per CONTRIBUTING.md.

Related: #634 reports benchmark data from the same machine.
