### PR TITLE
docs: tell ARM64 users the prebuilt Linux archive will not run

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -42,6 +42,10 @@ CPU-only by default.
 > Build from source instead if you want the fastest binary for *your* CPU
 > (`ARCH=native` unlocks the vector instructions your chip actually has), or if
 > you plan to hack on the engine.
+>
+> **On ARM64 Linux (AWS Graviton, Ampere, Raspberry Pi, aarch64 VMs) there is no
+> shortcut**: the published Linux archive is x86_64 only. Build from source —
+> sections 1 and 2 work unchanged, and the engine needs no ARM-specific flags.
 
 ### Linux (Ubuntu / Debian)
 
@@ -51,7 +55,16 @@ sudo apt install -y build-essential git python3
 ```
 
 `build-essential` gives you `gcc`, `make`, and OpenMP (libgomp) — everything the
-engine needs.
+engine needs. The same line works on aarch64: the engine is portable C with
+OpenMP and no x86-only intrinsics, so `./setup.sh` builds it on ARM64 without
+source changes or extra flags (verified on AWS Graviton4, Ubuntu 24.04, gcc 13).
+
+> **Moving a build to another machine?** The engine links `libgomp.so.1` at run
+> time. A host that has never had a compiler installed — a minimal cloud image, a
+> fresh container, a restored volume attached to a new instance — may not carry
+> it, and the engine then exits at startup before printing anything. Install the
+> runtime package alone (`sudo apt install -y libgomp1`); `coli doctor` names the
+> missing library.
 
 ### Windows
 


### PR DESCRIPTION
## Problem

`docs/quickstart.md` opens with a shortcut: prebuilt archives are published for "Linux, macOS and Windows", unpack one and skip the build. The example is `colibri-v1.1.0-linux-x86_64.tar.gz`.

That archive is x86_64 only. An aarch64 reader — AWS Graviton, Ampere, Raspberry Pi, any ARM VM — follows the shortcut, unpacks a binary their machine cannot execute, and is given no explanation. Searching `docs/` for aarch64 guidance finds nothing: the only ARM64 mention anywhere is a single benchmark row.

## Change

Two additions to `docs/quickstart.md`, both at the point where the reader is already looking:

1. At the shortcut: on ARM64 Linux there is no shortcut, build from source. Also states that no ARM-specific flags or source changes are needed, so the reader knows this is a normal path and not a port.
2. In the Linux build section: the runtime `libgomp` dependency. An engine built on one machine and moved to another that has never had a compiler installed — minimal cloud image, fresh container, volume reattached to a new instance — exits at startup with no message, because `libgomp.so.1` cannot be resolved. `sudo apt install -y libgomp1` is sufficient; the compiler is not needed on the run host.

Documentation only. No code, no behaviour change.

## Verification

AWS Graviton4 (r8g.16xlarge), Ubuntu 24.04 aarch64, gcc 13.3: `./setup.sh` builds and self-tests with no source changes and no extra flags. The libgomp failure is the exact one hit when moving that build to a freshly provisioned instance.

Opened against `dev` per CONTRIBUTING.md.

Related: #634 (benchmark data from this machine), #635 (makes `coli doctor` name the unresolved library instead of failing silently).