### PR TITLE
fix(web): stop truncating reasoning at 512 tokens by default

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ import {
   Globe,
   HardDrive,
   KeyRound,
+  AlertTriangle,
   Layers,
   Link2,
   LoaderCircle,
@@ -57,7 +58,7 @@ export default function App() {
   const [models, setModels] = useState<string[]>([])
   const [model, setModel] = useState(() => stored(localStorage, "colibri.model", "glm-5.2-colibri"))
   const [temperature, setTemperature] = useState(0.7)
-  const [maxTokens, setMaxTokens] = useState(512)
+  const [maxTokens, setMaxTokens] = useState(4096)
   const [thinking, setThinking] = useState(false)
   const [cacheSlot, setCacheSlot] = useState(0)
   const [conversations, setConversations] = useState<Record<number, ChatMessage[]>>({ 0: [] })
@@ -299,7 +300,7 @@ export default function App() {
             {Array.from({ length: kvSlots }, (_, slot) => <option key={slot} value={slot}>{t("sidebar.sessionLabel", { slot: slot + 1 })}</option>)}
           </select><span className="field-help">{t("sidebar.kvSessionHelp")}</span></label> : null}
           <label><span className="label-line"><span>{t("sidebar.temperature")}</span><code>{temperature.toFixed(1)}</code></span><input className="range" type="range" min="0" max="2" step="0.1" value={temperature} onChange={(event) => setTemperature(Number(event.target.value))} /></label>
-          <label>{t("sidebar.maxTokens")}<Input type="number" min={1} max={4096} value={maxTokens} onChange={(event) => { const value = Number(event.target.value); if (Number.isFinite(value)) setMaxTokens(Math.min(4096, Math.max(1, Math.round(value)))) }} /></label>
+          <label>{t("sidebar.maxTokens")}<Input type="number" min={1} max={32768} value={maxTokens} onChange={(event) => { const value = Number(event.target.value); if (Number.isFinite(value)) setMaxTokens(Math.min(32768, Math.max(1, Math.round(value)))) }} /></label>
           <button type="button" className={cn("toggle-row", thinking && "active")} aria-pressed={thinking} onClick={() => setThinking((value) => !value)}>
             <span><BrainCircuit className="size-4" /> {t("sidebar.reasoning")}</span><i><b /></i>
           </button>
@@ -329,6 +330,7 @@ export default function App() {
               {!loading && tokPerSec != null ? <Badge className="badge-speed"><Gauge className="size-3" /> {t("topbar.tokPerSec", { n: tokPerSec.toFixed(1) })}</Badge> : null}
               {!loading && ttft != null ? <Badge><Timer className="size-3" /> TTFT {(ttft/1000).toFixed(1)}s</Badge> : null}
               {!loading && lastRun?.usage ? <Badge><Layers className="size-3" /> {lastRun.usage.prompt_tokens}→{lastRun.usage.completion_tokens}</Badge> : null}
+              {!loading && lastRun?.finishReason === "length" ? <Badge className="badge-warn" title={t("topbar.truncatedHelp")}><AlertTriangle className="size-3" /> {t("topbar.truncated")}</Badge> : null}
               {lastRun?.queueWaitMs != null ? <Badge><Clock className="size-3" /> queue {Math.round(lastRun.queueWaitMs)}ms</Badge> : null}
               <Badge><MonitorDot className="size-3" /> {t("topbar.slot", { n: cacheSlot + 1 })}</Badge>
               <Button variant="ghost" size="sm" onClick={() => { updateMessages([]); setTokPerSec(null); setTtft(null); setTokenCount(0); setTotalTokens({prompt:0,completion:0}) }} disabled={!messages.length || loading}><Trash2 className="size-3.5" /> {t("topbar.clear")}</Button>

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -54,6 +54,8 @@ const en: Record<string, string> = {
   "topbar.tokens": "{{n}} tokens",
   "topbar.tokPerSec": "{{n}} tok/s",
   "topbar.slot": "slot {{n}}",
+  "topbar.truncated": "Truncated",
+  "topbar.truncatedHelp": "The response hit the max output tokens limit and was cut off. Raise \"Max output tokens\" to see the full answer.",
   "topbar.clear": "Clear",
 
   // hero / empty state

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -47,6 +47,8 @@ const it: Record<string, string> = {
   "topbar.tokens": "{{n}} token",
   "topbar.tokPerSec": "{{n}} tok/s",
   "topbar.slot": "slot {{n}}",
+  "topbar.truncated": "Troncato",
+  "topbar.truncatedHelp": "La risposta ha raggiunto il limite di token di output ed e' stata tagliata. Aumenta \"Token di output massimi\" per vedere la risposta completa.",
   "topbar.clear": "Pulisci",
 
   "hero.title": "MOTORE COLIBRÌ",

--- a/web/src/i18n/zh-CN.ts
+++ b/web/src/i18n/zh-CN.ts
@@ -47,6 +47,8 @@ const zhCN: Record<string, string> = {
   "topbar.tokens": "{{n}} tokens",
   "topbar.tokPerSec": "{{n}} tok/s",
   "topbar.slot": "槽位 {{n}}",
+  "topbar.truncated": "已截断",
+  "topbar.truncatedHelp": "回复达到最大输出 token 上限而被截断。请调高“最大输出 token 数”以查看完整回答。",
   "topbar.clear": "清空",
 
   "hero.title": "COLIBRÌ 引擎",

--- a/web/src/i18n/zh-TW.ts
+++ b/web/src/i18n/zh-TW.ts
@@ -47,6 +47,8 @@ const zhTW: Record<string, string> = {
   "topbar.tokens": "{{n}} tokens",
   "topbar.tokPerSec": "{{n}} tok/s",
   "topbar.slot": "插槽 {{n}}",
+  "topbar.truncated": "已截斷",
+  "topbar.truncatedHelp": "回應達到最大輸出 token 上限而被截斷。請提高「最大輸出 token 數」以查看完整答案。",
   "topbar.clear": "清除",
 
   "hero.title": "COLIBRÌ 引擎",

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -105,6 +105,7 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
 /* ---- rich metrics badges & animations ---- */
 .badge-live { background: rgba(78,214,165,.15); border-color: rgba(78,214,165,.4); color: #4ed6a5; }
 .badge-speed { background: rgba(90,155,216,.12); border-color: rgba(90,155,216,.35); color: #5a9bd8; }
+.badge-warn { background: rgba(230,170,60,.14); border-color: rgba(230,170,60,.4); color: #e6aa3c; }
 .flash { animation: flash 0.6s ease infinite alternate; }
 @keyframes flash { from { opacity: 1; } to { opacity: 0.3; } }
 .top-actions { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }


### PR DESCRIPTION
## Problem (reported in #634, third defect)

The bundled web dashboard set `maxTokens` to **512** by default and capped the input at 4096. A GLM-5.2 reasoning trace on any non-trivial prompt exceeds 512 tokens, so the dashboard cut the answer mid-trace **with no indication** to the user, who just saw an incomplete response.

## Fix (dashboard-only)

- Default **Max output tokens 512 → 4096**.
- Raise the input ceiling **4096 → 32768** so long reasoning is actually reachable.
- Add a **`Truncated` badge** (with a tooltip pointing at the setting) shown when the stream finishes with `finish_reason=length` — a cutoff is never silent again. The signal (`finishReason`) was already carried in `StreamChatResult`; this just surfaces it.
- i18n strings added for en / it / zh-TW / zh-CN.

No gateway or engine changes. Type-check passes.

Closes the web-truncation defect from #634.