### PR TITLE
release: ship the web dashboard, so the Expert Atlas actually reaches users (#578)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,26 @@ jobs:
           make colibri ${{ matrix.make_args }}
           ls -lh colibri${{ matrix.ext }}
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      # The dashboard is what README shows and what serves the Expert Atlas, but it
+      # was never packaged: a release user has no web/ to build from, so `coli web`
+      # pointed them at a directory the archive does not contain. Built here rather
+      # than committed, so dist/ stays a build artifact.
+      # shell: bash — on Windows the job default is msys2, but setup-node installs
+      # the native node/npm, which msys2's minimal PATH does not see.
+      - name: Build web dashboard
+        shell: bash
+        run: |
+          cd web
+          npm ci
+          npm run build
+          ls -lh dist/index.html dist/experts.json
+
       - name: Package
         run: |
           TAG=${GITHUB_REF#refs/tags/}
@@ -71,6 +91,10 @@ jobs:
           cp c/resource_plan.py dist/
           cp c/doctor.py dist/
           cp LICENSE dist/
+          # web/dist sits NEXT TO coli in the archive; both coli and openai_server.py
+          # probe that layout as well as the source checkout's one-level-up form.
+          mkdir -p dist/web
+          cp -r web/dist dist/web/dist
           cd dist
           if [ "${{ matrix.ext }}" = ".exe" ]; then
             7z a colibri-${TAG}-${{ matrix.name }}.zip *
@@ -100,6 +124,12 @@ jobs:
           # (The v1.1.0 tag build failed here when the banner still said "colibrì".)
           echo "$out" | grep -q "colibri" || { echo "FAIL: coli did not run"; exit 1; }
           echo "OK: coli locates the engine in the published archive"
+          # Same reasoning for the dashboard: assert the files are there AND that the
+          # server resolves them, since a right-looking archive with an unresolvable
+          # path is exactly the failure this whole step exists to catch.
+          test -f web/dist/index.html   || { echo "FAIL: dashboard missing from archive"; exit 1; }
+          test -f web/dist/experts.json || { echo "FAIL: expert atlas missing from archive"; exit 1; }
+          python3 -c "import sys; sys.path.insert(0, '.'); from openai_server import APIHandler as A; d = A.WEB_DIST; assert (d / 'index.html').is_file(), 'server resolved WEB_DIST to %s, which has no index.html' % d; assert (d / 'experts.json').is_file(), 'no expert atlas under %s' % d; print('OK: the packaged server resolves the dashboard at', d)"
 
       # Only the archives -- never the loose files. `dist/colibri-*.*` used to work by accident
       # (the engine was versioned, so it did not match); now that the engine is plainly named,

--- a/c/Makefile
+++ b/c/Makefile
@@ -514,6 +514,15 @@ install: colibri$(EXE) olmoe$(EXE)
 	$(INSTALL) -m 755 olmoe$(EXE) $(DESTDIR)$(LIBEXECDIR)/olmoe$(EXE)
 	$(INSTALL) -m 644 resource_plan.py doctor.py openai_server.py version.py $(DESTDIR)$(LIBEXECDIR)/
 	$(INSTALL) -m 644 tools/*.py $(DESTDIR)$(LIBEXECDIR)/tools/
+	@# The dashboard is an optional build artifact (cd web && npm run build), so install
+	@# it only when it exists. It goes NEXT TO openai_server.py, which probes ./web/dist.
+	@if [ -f ../web/dist/index.html ]; then \
+	  $(INSTALL) -d $(DESTDIR)$(LIBEXECDIR)/web/dist; \
+	  cp -R ../web/dist/. $(DESTDIR)$(LIBEXECDIR)/web/dist/; \
+	  echo "installed the web dashboard"; \
+	else \
+	  echo "web/dist absent -- skipping the dashboard (build it with: cd web && npm run build)"; \
+	fi
 
 uninstall:
 	rm -f $(DESTDIR)$(BINDIR)/coli

--- a/c/coli
+++ b/c/coli
@@ -897,7 +897,11 @@ def cmd_stop(a):
 def cmd_web(a):
     """serve + open the dashboard in the browser once the API answers."""
     need_model(a.model)
-    dist = os.path.join(os.path.dirname(os.path.abspath(HERE)), "web", "dist")
+    # Same two layouts openai_server.py resolves: next to this script (release
+    # archive / installed tree) or one level up (source checkout, where this is c/coli).
+    cands = [os.path.join(HERE, "web", "dist"),
+             os.path.join(os.path.dirname(os.path.abspath(HERE)), "web", "dist")]
+    dist = next((d for d in cands if os.path.exists(os.path.join(d, "index.html"))), cands[-1])
     if not os.path.exists(os.path.join(dist, "index.html")):
         print(f"{C.yel}web UI not built:{C.r} run  cd web && npm install && npm run build  first;")
         print("serving the API anyway (the dashboard will 404 until built).")

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -1534,7 +1534,16 @@ class APIHandler(BaseHTTPRequestHandler):
         if model != self.server.model_id:
             raise APIError(404, f"The model `{model}` does not exist.", "model", "model_not_found")
 
-    WEB_DIST = Path(__file__).resolve().parent.parent / "web" / "dist"
+    # The dashboard ships in two layouts and the old single path only knew one:
+    # a source checkout puts this file in c/ (so web/dist is one level UP), while
+    # a release archive and an installed tree put it next to web/dist. Probing for
+    # index.html rather than the directory keeps an empty leftover web/dist from
+    # shadowing a real one.
+    WEB_DIST = next(
+        (c for c in (Path(__file__).resolve().parent / "web" / "dist",
+                     Path(__file__).resolve().parent.parent / "web" / "dist")
+         if (c / "index.html").is_file()),
+        Path(__file__).resolve().parent.parent / "web" / "dist")
 
     def serve_static(self, path):
         """Serve the built web UI (web/dist) so `coli web` is one process.


### PR DESCRIPTION
This is the "why can't I see the atlas" thread, and the answer turned out not to be the atlas.

## What is actually broken

The README leads with a dashboard screenshot, and the site's entire argument is the **measured Expert Atlas** — but **no release archive has ever contained either**. `release.yml` packages the engine plus four `.py` files; `web/dist` is a build artifact and isn't tracked. So a release user has no `web/` to build from, and `coli web` helpfully told them to `cd web && npm install` — in a directory the archive does not have.

#578 was right and did work: `web/public/experts.json` (13,260 experts) does land in `web/dist/experts.json` at build time — I rebuilt to confirm, 3,497,647 bytes, byte-identical. It just never reached anyone who didn't build the front end themselves.

Worth stating plainly, since it caused the confusion: **there are two different atlases.**

| | data | shipped |
|---|---|---|
| `site/index.html` (inlined `ATLAS_RAW`) | 1,358 experts — 721 canonical + 637 gate-sensitive, "atlas v1" | ✅ live on the site |
| `web/` + `experts.json` | 13,260 entries from the full sweep | ❌ never packaged |

The site's atlas is fine and has been all along. This PR is about the second one. It does **not** touch `site/`, and it does not replace v1 with the sweep data — v1 is the stricter set (cross-validated across three kernel families), and mixing them is a separate judgement call.

## Packaging alone would not have fixed it

`WEB_DIST` was one path:

```python
WEB_DIST = Path(__file__).resolve().parent.parent / "web" / "dist"
```

That only resolves in a **source checkout**, where this file sits in `c/`. In a release archive or an installed tree the server sits **next to** `web/dist`, one level nearer — so shipping the files without touching this would have produced an archive that contains the dashboard and still 404s. Both `openai_server.py` and `coli` now probe for `index.html` across the two layouts. Probing for the file rather than the directory also stops an empty leftover `web/dist` from shadowing a real one.

## Changes

- **`release.yml`** — build the dashboard with `setup-node` + `npm ci && npm run build`, package it as `web/dist` next to `coli`. Built in CI rather than committed, so `dist/` stays an artifact. On Windows the step forces `shell: bash`: the job default is msys2, whose minimal PATH cannot see the node `setup-node` installs.
- **`openai_server.py` / `coli`** — two-layout resolution, described above.
- **`Makefile`** — `install` places `web/dist` next to `openai_server.py` when it exists, and prints how to build it when it doesn't (it's an optional artifact, so this must not become a hard dependency of `make install`).
- **archive verification** — the existing step's own comment says it best: *"a packaging mistake is invisible to every other job in this repo: the build is green, the tests are green, and the artifact is still unusable. Assert on behaviour."* So it now asserts not just that the files are in the archive, but that **the packaged server resolves them** — that's the failure mode this whole change is about.

## Verification

Replayed all three layouts locally and checked which path each resolves to:

| layout | resolves to | index.html + experts.json |
|---|---|---|
| source checkout (`c/`) | `<repo>/web/dist` | ✅ |
| unpacked release tree | `<pkg>/web/dist` | ✅ |
| `make install DESTDIR=…` | `<libexec>/colibri/web/dist` | ✅ |
| unbuilt tree | source-checkout default | falls through to the "web UI not built" hint, as before |

The new verify command was tested **both ways** — passing on a correct tree, and failing with the resolved path named when `web/` is removed. (Shipping an unrun verification step would be the same class of mistake this PR is fixing.)

`make check` 211 passed.

## Note on size

The archive grows by ~3.7 MB, almost all of it `experts.json` (3.5 MB; the built UI is ~250 KB). That is the atlas itself, so it's the payload rather than overhead — but it's a real jump against a ~1 MB engine, and worth a maintainer's call. If you'd rather keep archives lean, the alternatives are shipping the UI without the atlas data (the hover degrades, the dashboard still works) or serving `experts.json` compressed. Happy to do either.