### PR TITLE
docs: point the README to the gs64 model container (#642)

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -198,7 +198,7 @@ Un container **GLM-5.2 int4** pre-convertito è su Hugging Face — **usa la
 versione con le teste MTP int8**. Pesa circa **372 GB**, quindi mettilo su un
 disco che abbia lo spazio, meglio se veloce:
 
-**https://huggingface.co/mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp**
+**https://huggingface.co/mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp**
 
 > ⚠️ Il mirror originale contiene teste MTP int4 → accettazione dei draft allo 0%
 > ([#8](https://github.com/JustVugg/colibri/issues/8)). Verifica la tua versione:

--- a/README.md
+++ b/README.md
@@ -236,14 +236,18 @@ engine still lives in `c/` — an editable install from the clone, not a wheel).
 
 ### 2. Get the model
 
-A pre-converted **GLM-5.2 int4** container is on Hugging Face — **use the
-version with the int8 MTP heads**. It is about **372 GB**, so put it on a disk
-with the room, ideally a fast one:
+A pre-converted **GLM-5.2 int4** container is on Hugging Face — use the
+**group-scaled (gs64)** build with the **int8 MTP head**. It is about **372 GB**,
+so put it on a disk with the room, ideally a fast one:
 
-**https://huggingface.co/mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp**
+**https://huggingface.co/mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp**
 
-> ⚠️ The original mirror ships int4 MTP heads → 0% draft acceptance
-> ([#8](https://github.com/JustVugg/colibri/issues/8)). Check yours:
+> ⚠️ Use the **gs64** container above, not the older per-row int4 mirrors
+> (`mateogrgic/…`, `jlnsrk/…`): those measure ~9pp worse on quality and are the
+> root cause of the think-mode loops and never-terminating generations in
+> [#455](https://github.com/JustVugg/colibri/issues/455) — the gs64 container
+> cured every failing case there. The MTP head must also be **int8, not int4**
+> (int4 → 0% draft acceptance, [#8](https://github.com/JustVugg/colibri/issues/8)):
 > `ls -l <model>/out-mtp-*` — int8 (correct) is `3527131672 / 5366238584 / 1065950496`.
 
 Or convert from the FP8 source yourself — one resumable command that never needs

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -178,7 +178,7 @@ git clone https://github.com/JustVugg/colibri && cd colibri/c
 Hugging Face 上已有预转换的 **GLM-5.2 int4** 容器——请务必使用
 **含 int8 MTP head 的版本**。它约为 **372 GB**，请放在空间足够的磁盘上，最好是快盘：
 
-**https://huggingface.co/mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp**
+**https://huggingface.co/mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp**
 
 > ⚠️ 原始镜像使用 int4 MTP head → 草稿接受率为 0%
 >（[#8](https://github.com/JustVugg/colibri/issues/8)）。请检查你的版本：

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -178,7 +178,7 @@ git clone https://github.com/JustVugg/colibri && cd colibri/c
 Hugging Face 上已有預先轉換的 **GLM-5.2 int4** 容器——請務必使用
 **含 int8 MTP head 的版本**。它約為 **372 GB**，請放在空間足夠的硬碟上，最好是快碟：
 
-**https://huggingface.co/mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp**
+**https://huggingface.co/mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp**
 
 > ⚠️ 原始鏡像使用 int4 MTP head → 草稿接受率為 0%
 >（[#8](https://github.com/JustVugg/colibri/issues/8)）。請檢查你的版本：

--- a/docker/README.IT.md
+++ b/docker/README.IT.md
@@ -78,7 +78,7 @@ Il modello GLM 5.2 è circa **360 GB**. Scegli uno di questi metodi:
 
 2. **Scarica il modello** (apri il terminale nella cartella dove lo vuoi salvare):
    ```bash
-   hf_download mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp --local-dir .
+   hf_download mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp --local-dir .
    ```
    
    **Esempio**: se vuoi salvarlo in `C:\LLM\models\glm-5.2` (Windows):
@@ -89,7 +89,7 @@ Il modello GLM 5.2 è circa **360 GB**. Scegli uno di questi metodi:
 #### Metodo B: Senza Python (solo se necessario)
 
 Se sei su Windows e non riesci con Python:
-- Scarica manualmente da [Hugging Face](https://huggingface.co/mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp)
+- Scarica manualmente da [Hugging Face](https://huggingface.co/mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp)
 - Decomprimi in una cartella (es. `C:\LLM\models\glm-5.2`)
 
 ---
@@ -347,7 +347,7 @@ Poi riprova il comando `hf_download`.
 
 **Soluzione**:
 1. Attendi e riprova il comando `hf_download`
-2. Se continua, scarica manualmente da [qui](https://huggingface.co/mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp)
+2. Se continua, scarica manualmente da [qui](https://huggingface.co/mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp)
 3. Decomprimi il file ZIP nella cartella desiderata
 
 ---

--- a/docker/README.md
+++ b/docker/README.md
@@ -78,7 +78,7 @@ python -m pip install -U huggingface_hub[cli]
 On Linux, use `python3` instead of `python`.
 2. **Download the model** (open the terminal in the folder where you want to save it):
 ```bash
-hf_download mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp --local-dir .
+hf_download mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp --local-dir .
 ```
 
 **Example**: if you want to save it in `C:\LLM\models\glm-5.2` (Windows):
@@ -90,7 +90,7 @@ hf_download mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp --local-dir .
 
 If you are on Windows and cannot get it to work with Python:
 
-* Download manually from [Hugging Face](https://huggingface.co/mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp)
+* Download manually from [Hugging Face](https://huggingface.co/mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp)
 * Unzip into a folder (e.g., `C:\LLM\models\glm-5.2`)
 
 ---
@@ -371,7 +371,7 @@ Then retry the `hf_download` command.
 **Solution**:
 
 1. Wait and retry the `hf_download` command
-2. If it continues, download manually from [here](https://huggingface.co/mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp)
+2. If it continues, download manually from [here](https://huggingface.co/mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp)
 3. Unzip the ZIP file into the desired folder
 
 ---


### PR DESCRIPTION
Closes #642.

The README (and its zh-CN / zh-TW / it variants and the two docker READMEs) still linked the older per-row int4 mirror `mateogrgic/GLM-5.2-colibri-int4-with-int8-mtp`. Per #455 / #579 and `docs/quickstart.md`, that container measures ~9pp worse on quality and is the root cause of the think-mode loops and never-terminating generations; the **group-scaled (gs64)** container cured every failing case there.

- Point all user-facing READMEs to **https://huggingface.co/mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp**
- English README also explains gs64-over-per-row and keeps the int8-MTP-head check (#8).
- The historical experiment log (`docs/experiments/…`) keeps its original link — it records what was actually run.

Docs-only. Reported by @timwoelfle.