### PR TITLE
convert: make fmt=6 (E8/IQ3) conversion practical — 15x encoder, RAM blocking, progress

### DIFF
--- a/c/.gitignore
+++ b/c/.gitignore
@@ -5,3 +5,6 @@ olmoe_i4/
 .build-config
 tests/test_st_mirror
 tests/test_st_pread
+tools/libiq3.so
+tools/libiq3.dylib
+tools/iq3.dll

--- a/c/Makefile
+++ b/c/Makefile
@@ -322,6 +322,21 @@ gemm-test: tests/test_gemm_largebatch.mm backend_metal.mm backend_metal.h
 	$(METALXX) $(OMPC) tests/test_gemm_largebatch.mm backend_metal.mm $(OMPL) -framework Metal -framework Foundation -o gemm_largebatch_test
 	./gemm_largebatch_test
 
+# fmt=6 (E8/IQ3) encoder for tools/convert_fp8_to_int4.py. OPTIONAL: iq3_pack.py
+# falls back to its numpy path when the library is absent, producing the same
+# bytes ~13x slower. Uses the same ARCH as the engine, so an AVX2 host gets the
+# SIMD search and anything else compiles the scalar fallback.
+ifneq (,$(DARWIN))
+IQ3LIB = tools/libiq3.dylib
+else ifneq ($(IS_WIN),)
+IQ3LIB = tools/iq3.dll
+else
+IQ3LIB = tools/libiq3.so
+endif
+iq3: $(IQ3LIB)
+$(IQ3LIB): tools/iq3_encode.c
+	$(CC) $(CFLAGS) -fPIC -shared $< -o $@ $(LDFLAGS)
+
 cuda-test: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/test_backend_cuda.cu
 	@command -v "$(GPUCC)" >/dev/null 2>&1 || { echo "$(GPUCC_NAME) not found" >&2; exit 1; }
 	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/test_backend_cuda.cu -o backend_cuda_test$(EXE)
@@ -533,4 +548,4 @@ clean:
 
 bench: iobench$(EXE)
 	@if [ -n "$(ARGS)" ]; then ./iobench$(EXE) $(ARGS); else echo "built iobench$(EXE) — run: ./iobench$(EXE) <file> <MB> <iters> <threads> <direct 0|1>"; fi
-.PHONY: all colibri glm cuda-test hip-test gpu-compile cuda-bench cuda-dll portable test-c test-python test check clean install uninstall bench
+.PHONY: all colibri glm iq3 cuda-test hip-test gpu-compile cuda-bench cuda-dll portable test-c test-python test check clean install uninstall bench

--- a/c/tools/convert_fp8_to_int4.py
+++ b/c/tools/convert_fp8_to_int4.py
@@ -261,6 +261,25 @@ def dequant(f, name, keys):
 # record dict(PROJ_BITS) — this global is the definition those sites depend on.
 PROJ_BITS = {}
 
+# Rows per quantization block. Every non-E8 format here carries per-row scales (or
+# per-group scales along I), so rows never interact and blocking is BIT-IDENTICAL to
+# quantizing the whole tensor — it only caps the peak of the quantizer's full-size
+# temporaries. That matters on small hosts: embed/lm_head at [154880, 6144] is 3.8 GB
+# as f32, and abs/divide/rint/clip each materialise another copy (~15 GB peak) on a
+# box with 13 GB free. E8 is excluded — it is already blocked inside iq3_pack.encode,
+# and its ".qs" companion is a single format tag, not a per-row scale.
+QUANT_ROWS = int(os.environ.get("COLI_QUANT_ROWS", "8192"))
+
+def _rowwise(fn, w, *args):
+    O = w.shape[0]
+    if O <= QUANT_ROWS:
+        return fn(w, *args)
+    qs, ss = [], []
+    for r0 in range(0, O, QUANT_ROWS):
+        q, s = fn(w[r0:r0 + QUANT_ROWS], *args)
+        qs.append(q); ss.append(s)
+    return np.concatenate(qs), np.concatenate(ss)
+
 def convert_shard(path, out_dict, n_layers, ebits, io_bits, xbits,
                   keep_mtp=False, keep_idx=False, group_size=0, bits_map=None):
     from safetensors import safe_open
@@ -290,15 +309,16 @@ def convert_shard(path, out_dict, n_layers, ebits, io_bits, xbits,
                     out_dict[name] = w.astype(np.float32); continue
                 if bits == E8:
                     # fmt=6 E8/IQ3 — routed-expert projections only, enforced in main().
+                    # Already row-blocked inside iq3_pack.encode.
                     q, s = quant_e8(w)
                 elif bits == 3:
                     # int3-g64 (fmt=5): inherently group-64, distinct from grouped-int4.
-                    q, s = quant_int3_g64(w)
+                    q, s = _rowwise(quant_int3_g64, w)
                 elif group_size > 0 and bits <= 4:
-                    q, s = quant_int4_grouped(w, bits, group_size)
+                    q, s = _rowwise(quant_int4_grouped, w, bits, group_size)
                 else:
-                    q, s = (quant_int2(w, bits) if bits <= 2 else
-                            quant_int4(w, bits) if bits <= 4 else quant_int8(w, bits))
+                    q, s = _rowwise(quant_int2 if bits <= 2 else
+                                    quant_int4 if bits <= 4 else quant_int8, w, bits)
                 out_dict[name] = q
                 out_dict[name + ".qs"] = s
 
@@ -567,6 +587,8 @@ def main():
                 return
         done = prog.setdefault("shards", {}); prog["params"] = params
         n = 0; fresh = 0; skipped = 0
+        import time as _t
+        t_start = _t.time()
         for i, sp in enumerate(shards):
             key = os.path.basename(sp)
             prev = done.get(key)                          # None = mai visto; "" = visto, vuoto; nome = emesso
@@ -574,6 +596,14 @@ def main():
                 if prev: n += 1
                 skipped += 1
                 continue
+            # Progress + ETA: the local pass can run for days on a big model (E8 on
+            # GLM-5.2 is ~50 h split across workers), and without this the loop is
+            # silent until it finishes. flush because stdout is a redirected file.
+            eta = ""
+            if fresh:
+                per = (_t.time() - t_start) / fresh
+                eta = f", ETA {per * (len(shards) - i) / 3600:.1f} h"
+            print(f"[{i + 1}/{len(shards)}] {key} ({free_gb(a.outdir):.0f} GB free{eta})", flush=True)
             out = {}
             convert_shard(sp, out, a.n_layers, a.ebits, a.io_bits, a.xbits,
                           keep_mtp=a.mtp, keep_idx=a.indexer,

--- a/c/tools/iq3_encode.c
+++ b/c/tools/iq3_encode.c
@@ -1,0 +1,275 @@
+/* fmt=6 (E8/IQ3 lattice) encoder — SIMD/OpenMP core for tools/iq3_pack.py.
+ *
+ * Same algorithm as the numpy encoder, byte for byte: per 32-weight sub-block,
+ * try all 16 sub-scale codes, and for each take the nearest of the 256 codebook
+ * entries for every 4-dim group, keeping the code with the lowest squared error.
+ *
+ * The numpy version is memory-bound, not compute-bound: it materialises a
+ * [groups, 256] score array per candidate code, so every score is written to
+ * memory and read back by argmin — ~12 KB of traffic per weight, which measured
+ * out at ~10 GB/s, i.e. exactly one core's share of bandwidth. Here the whole
+ * working set for a sub-block is the 8x256 float table of m.g (8 KB, L1-resident)
+ * and the scores never leave registers, so the same arithmetic runs at cache
+ * speed instead of DRAM speed.
+ *
+ * The search is written against the identity
+ *     argmin_g ||m/db - g||^2 = argmin_g [ db*||g||^2 - 2*(m.g) ]        (db > 0)
+ * so m.g is computed once per sub-block and shared by all 16 codes.
+ *
+ * The codebook is passed in from Python rather than duplicated here, so
+ * tools/iq3xxs_grid.json stays the single source of truth for this side.
+ */
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <float.h>
+
+#if defined(__x86_64__) || defined(_M_X64)
+#include <immintrin.h>
+#endif
+
+#define QK   256                 /* weights per super-block */
+#define SUB  32                  /* weights per sign/scale word */
+#define NG   256                 /* codebook entries */
+#define BB   98                  /* packed bytes per super-block */
+#define GRP  (SUB / 4)           /* 4-dim groups per sub-block = 8 */
+
+#ifdef _WIN32
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT __attribute__((visibility("default")))
+#endif
+
+/* IEEE754 binary32 -> binary16, round-to-nearest-even. Matches numpy's
+ * astype(float16) exactly, including the carry out of the mantissa into the
+ * exponent; the encoder must agree with numpy here because the super-scale is
+ * stored as fp16 and then read back for the search. */
+static inline uint16_t f32_to_f16(float f) {
+    uint32_t x; memcpy(&x, &f, 4);
+    uint32_t sign = (x >> 16) & 0x8000u;
+    uint32_t e    = (x >> 23) & 0xffu;
+    uint32_t man  = x & 0x7fffffu;
+    if (e == 0xff) return (uint16_t)(sign | 0x7c00u | (man ? (0x200u | (man >> 13)) : 0u));
+    int32_t ex = (int32_t)e - 127 + 15;
+    if (ex >= 0x1f) return (uint16_t)(sign | 0x7c00u);          /* overflow -> inf */
+    if (ex <= 0) {
+        if (ex < -10) return (uint16_t)sign;                    /* underflow -> +-0 */
+        man |= 0x800000u;
+        uint32_t sh = (uint32_t)(14 - ex);
+        uint32_t r = man >> sh, rem = man & ((1u << sh) - 1u), half = 1u << (sh - 1);
+        if (rem > half || (rem == half && (r & 1u))) r++;
+        return (uint16_t)(sign | r);
+    }
+    uint32_t r = man >> 13, rem = man & 0x1fffu;
+    uint32_t o = ((uint32_t)ex << 10) | r;
+    if (rem > 0x1000u || (rem == 0x1000u && (r & 1u))) o++;     /* carries into ex */
+    return (uint16_t)(sign | o);
+}
+
+/* binary16 -> binary32, exact (numpy semantics, including subnormals). */
+static inline float f16_to_f32(uint16_t h) {
+    uint32_t sign = (uint32_t)(h >> 15) << 31, e = (h >> 10) & 0x1fu, man = h & 0x3ffu, bits;
+    if (!e) {
+        if (!man) bits = sign;
+        else {                                                  /* subnormal -> normalise */
+            int s = 0; uint32_t m = man;
+            while (!(m & 0x400u)) { m <<= 1; s++; }
+            bits = sign | ((uint32_t)(127 - 15 - s) << 23) | ((m & 0x3ffu) << 13);
+        }
+    } else if (e == 0x1fu) bits = sign | 0x7f800000u | (man << 13);
+    else bits = sign | ((e + 112u) << 23) | (man << 13);
+    float f; memcpy(&f, &bits, 4); return f;
+}
+
+/* Nearest codebook entry for each of the 8 groups of one sub-block, under a
+ * given db. crit[j] = db*G2[j] - 2*(m.g_j); A2 already holds -2*(m.g).
+ * Ties resolve to the LOWEST index, as numpy's argmin does. */
+static inline void nearest8(const float *A2, const float *G2, float db,
+                            int *idx, float *val) {
+#if defined(__AVX2__)
+    const __m256 vdb = _mm256_set1_ps(db);
+    for (int g = 0; g < GRP; g++) {
+        const float *a = A2 + (size_t)g * NG;
+        __m256 best = _mm256_set1_ps(FLT_MAX);
+        __m256i bi  = _mm256_setzero_si256();
+        __m256i jv  = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
+        const __m256i eight = _mm256_set1_epi32(8);
+        for (int j = 0; j < NG; j += 8) {
+            __m256 v = _mm256_fmadd_ps(vdb, _mm256_loadu_ps(G2 + j), _mm256_loadu_ps(a + j));
+            __m256 lt = _mm256_cmp_ps(v, best, _CMP_LT_OQ);      /* strict: first wins */
+            best = _mm256_blendv_ps(best, v, lt);
+            bi   = _mm256_castps_si256(_mm256_blendv_ps(_mm256_castsi256_ps(bi),
+                                                        _mm256_castsi256_ps(jv), lt));
+            jv   = _mm256_add_epi32(jv, eight);
+        }
+        /* horizontal argmin over the 8 lanes; lane k held indices k, k+8, ... so
+         * an exact tie must still resolve to the smaller index. */
+        float bv[8]; int bx[8];
+        _mm256_storeu_ps(bv, best);
+        _mm256_storeu_si256((__m256i *)bx, bi);
+        float bestv = bv[0]; int besti = bx[0];
+        for (int k = 1; k < 8; k++)
+            if (bv[k] < bestv || (bv[k] == bestv && bx[k] < besti)) { bestv = bv[k]; besti = bx[k]; }
+        idx[g] = besti; val[g] = bestv;
+    }
+#else
+    for (int g = 0; g < GRP; g++) {
+        const float *a = A2 + (size_t)g * NG;
+        float bestv = FLT_MAX; int besti = 0;
+        for (int j = 0; j < NG; j++) {
+            float v = db * G2[j] + a[j];
+            if (v < bestv) { bestv = v; besti = j; }
+        }
+        idx[g] = besti; val[g] = bestv;
+    }
+#endif
+}
+
+/* One row, one super-block. `gs` is the codebook as 4 planes of 256 (SoA), G2
+ * the squared norms, blk the 256 input weights, out the 98 packed bytes. */
+static void encode_block(const float *blk, const float *const gs[4], const float *G2,
+                         uint8_t *out) {
+    float mag[QK];
+    uint8_t neg[QK];
+    for (int i = 0; i < QK; i++) {
+        neg[i] = blk[i] < 0.0f;                 /* -0.0 counts as positive, as numpy's where does */
+        mag[i] = fabsf(blk[i]);
+    }
+    /* Odd-parity fix: the 8th sign of every eight is implied, so a group whose
+     * true signs multiply to -1 gets its SMALLEST magnitude flipped (first
+     * minimum on ties, matching argmin). */
+    for (int b = 0; b < QK / 8; b++) {
+        uint8_t *n = neg + b * 8; const float *m = mag + b * 8;
+        int cnt = 0; for (int j = 0; j < 8; j++) cnt += n[j];
+        if (cnt & 1) {
+            int am = 0; for (int j = 1; j < 8; j++) if (m[j] < m[am]) am = j;
+            n[am] ^= 1;
+        }
+    }
+    /* super-scale: RMS anchor, stored fp16 and read back so the search sees the
+     * value that will actually be decoded */
+    double acc = 0.0;
+    for (int i = 0; i < QK; i++) acc += (double)mag[i] * (double)mag[i];
+    float d = sqrtf((float)(acc / QK)) / 20.0f + 1e-12f;
+    uint16_t dh = f32_to_f16(d);
+    memcpy(out + 96, &dh, 2);
+    d = f16_to_f32(dh);
+
+    for (int ib = 0; ib < QK / SUB; ib++) {
+        const float *m = mag + ib * SUB;
+        /* A2[g][j] = -2 * (m_g . g_j) — computed once, shared by all 16 codes */
+        float A2[GRP * NG];
+        for (int g = 0; g < GRP; g++) {
+            const float m0 = m[g * 4 + 0], m1 = m[g * 4 + 1], m2 = m[g * 4 + 2], m3 = m[g * 4 + 3];
+            float *a = A2 + (size_t)g * NG;
+#if defined(__AVX2__)
+            const __m256 v0 = _mm256_set1_ps(-2.0f * m0), v1 = _mm256_set1_ps(-2.0f * m1),
+                         v2 = _mm256_set1_ps(-2.0f * m2), v3 = _mm256_set1_ps(-2.0f * m3);
+            for (int j = 0; j < NG; j += 8) {
+                __m256 s = _mm256_mul_ps(v0, _mm256_loadu_ps(gs[0] + j));
+                s = _mm256_fmadd_ps(v1, _mm256_loadu_ps(gs[1] + j), s);
+                s = _mm256_fmadd_ps(v2, _mm256_loadu_ps(gs[2] + j), s);
+                s = _mm256_fmadd_ps(v3, _mm256_loadu_ps(gs[3] + j), s);
+                _mm256_storeu_ps(a + j, s);
+            }
+#else
+            for (int j = 0; j < NG; j++)
+                a[j] = -2.0f * (m0 * gs[0][j] + m1 * gs[1][j] + m2 * gs[2][j] + m3 * gs[3][j]);
+#endif
+        }
+        /* Choosing the code needs only the SUM of the 8 group minima — the
+         * indices matter for the winner alone. So the 16 candidate passes track
+         * a bare minimum (one _mm256_min_ps, no compare/blend and no index
+         * bookkeeping) and the indices are recovered in a single extra pass at
+         * the end: 17 cheap passes instead of 16 expensive ones.
+         * err = sum_g [db^2*G2 - 2*db*(m.g)] = db * sum_g [db*G2 - 2*(m.g)]
+         * = db * (sum of the minima), which is the quantity minimised. */
+        int bestcode = 0; float besterr = 0.0f;
+        for (int code = 0; code < 16; code++) {
+            float db = d * (0.5f + (float)code) * 0.5f;
+            if (db < 1e-20f) db = 1e-20f;
+            float sum = 0.0f;
+#if defined(__AVX2__)
+            const __m256 vdb = _mm256_set1_ps(db);
+            for (int g = 0; g < GRP; g++) {
+                const float *a = A2 + (size_t)g * NG;
+                /* four independent chains: a single running min over 32 vectors
+                 * is a 32-deep latency chain, which is what left the search
+                 * far short of the SIMD width */
+                __m256 m0 = _mm256_set1_ps(FLT_MAX), m1 = m0, m2 = m0, m3 = m0;
+                for (int j = 0; j < NG; j += 32) {
+                    m0 = _mm256_min_ps(m0, _mm256_fmadd_ps(vdb, _mm256_loadu_ps(G2 + j),      _mm256_loadu_ps(a + j)));
+                    m1 = _mm256_min_ps(m1, _mm256_fmadd_ps(vdb, _mm256_loadu_ps(G2 + j + 8),  _mm256_loadu_ps(a + j + 8)));
+                    m2 = _mm256_min_ps(m2, _mm256_fmadd_ps(vdb, _mm256_loadu_ps(G2 + j + 16), _mm256_loadu_ps(a + j + 16)));
+                    m3 = _mm256_min_ps(m3, _mm256_fmadd_ps(vdb, _mm256_loadu_ps(G2 + j + 24), _mm256_loadu_ps(a + j + 24)));
+                }
+                m0 = _mm256_min_ps(_mm256_min_ps(m0, m1), _mm256_min_ps(m2, m3));
+                __m128 lo = _mm256_castps256_ps128(m0), hi = _mm256_extractf128_ps(m0, 1);
+                lo = _mm_min_ps(lo, hi);
+                lo = _mm_min_ps(lo, _mm_movehl_ps(lo, lo));
+                lo = _mm_min_ss(lo, _mm_shuffle_ps(lo, lo, 1));
+                sum += _mm_cvtss_f32(lo);
+            }
+#else
+            for (int g = 0; g < GRP; g++) {
+                const float *a = A2 + (size_t)g * NG;
+                float b0 = FLT_MAX, b1 = FLT_MAX, b2 = FLT_MAX, b3 = FLT_MAX;
+                for (int j = 0; j < NG; j += 4) {
+                    float v0 = db * G2[j]     + a[j];     if (v0 < b0) b0 = v0;
+                    float v1 = db * G2[j + 1] + a[j + 1]; if (v1 < b1) b1 = v1;
+                    float v2 = db * G2[j + 2] + a[j + 2]; if (v2 < b2) b2 = v2;
+                    float v3 = db * G2[j + 3] + a[j + 3]; if (v3 < b3) b3 = v3;
+                }
+                float lo0 = b0 < b1 ? b0 : b1, lo1 = b2 < b3 ? b2 : b3;
+                sum += lo0 < lo1 ? lo0 : lo1;
+            }
+#endif
+            float err = db * sum;
+            if (code == 0 || err < besterr) { besterr = err; bestcode = code; }
+        }
+        {   /* one index pass for the winning code */
+            float db = d * (0.5f + (float)bestcode) * 0.5f;
+            if (db < 1e-20f) db = 1e-20f;
+            int idx[GRP]; float val[GRP];
+            nearest8(A2, G2, db, idx, val);
+            for (int g = 0; g < GRP; g++) out[ib * 8 + g] = (uint8_t)idx[g];
+        }
+
+        /* four 7-bit sign words + the 4-bit sub-scale code */
+        uint32_t word = 0;
+        for (int l = 0; l < 4; l++) {
+            uint32_t seven = 0;
+            const uint8_t *n = neg + ib * SUB + l * 8;
+            for (int j = 0; j < 7; j++) seven |= (uint32_t)n[j] << j;
+            word |= seven << (7 * l);
+        }
+        word |= ((uint32_t)bestcode & 0xfu) << 28;
+        uint8_t wb[4] = {(uint8_t)word, (uint8_t)(word >> 8),
+                         (uint8_t)(word >> 16), (uint8_t)(word >> 24)};   /* little-endian */
+        memcpy(out + QK / 4 + ib * 4, wb, 4);
+    }
+}
+
+/* rows: [nrow, K] float32, K % 256 == 0. out: [nrow, K/256*98] uint8.
+ * grid: [256*4] float32 in weight units (the published table already halved). */
+EXPORT void iq3_encode(const float *rows, int64_t nrow, int64_t K,
+                       const float *grid, uint8_t *out) {
+    float gp[4][NG], G2[NG];
+    for (int j = 0; j < NG; j++) {
+        for (int c = 0; c < 4; c++) gp[c][j] = grid[j * 4 + c];
+        G2[j] = gp[0][j] * gp[0][j] + gp[1][j] * gp[1][j]
+              + gp[2][j] * gp[2][j] + gp[3][j] * gp[3][j];
+    }
+    const float *gs[4] = {gp[0], gp[1], gp[2], gp[3]};
+    const int64_t nsb = K / QK;
+#ifdef _OPENMP
+    #pragma omp parallel for schedule(static)
+#endif
+    for (int64_t r = 0; r < nrow; r++)
+        for (int64_t sb = 0; sb < nsb; sb++)
+            encode_block(rows + r * K + sb * QK, gs, G2,
+                         out + r * nsb * BB + sb * BB);
+}
+
+/* Reported by the Python side so a stale/mismatched build is visible. */
+EXPORT int iq3_encode_abi(void) { return 1; }

--- a/c/tools/iq3_pack.py
+++ b/c/tools/iq3_pack.py
@@ -38,6 +38,7 @@ import numpy as np
 QK = 256                      # weights per super-block
 SUB = 32                      # weights per sub-block (one uint32 of signs+scale)
 BLOCK_BYTES = QK // 4 + (QK // SUB) * 4 + 2      # 64 + 32 + 2 = 98
+ROW_CHUNK = int(os.environ.get("IQ3_ROW_CHUNK", "128"))   # rows per encode pass (measured optimum)
 
 _GRID = None
 
@@ -63,7 +64,13 @@ def _nearest(mag4):
 
 
 def encode(x):
-    """float32 [..., K] (K % 256 == 0) -> packed uint8 [..., K//256 * 98]."""
+    """float32 [..., K] (K % 256 == 0) -> packed uint8 [..., K//256 * 98].
+
+    Rows encode independently, so they are processed in cache-sized blocks: the
+    search keeps a [rows*8, 256] score array live per sub-block, and letting that
+    grow to a whole expert tensor turns the argmin memory-bound (measured 2.4x
+    over the naive loop at 2048 rows against 5.6x at 256).
+    """
     x = np.ascontiguousarray(x, dtype=np.float32)
     K = x.shape[-1]
     if K % QK:
@@ -71,7 +78,13 @@ def encode(x):
     rows = x.reshape(-1, K)
     nsb = K // QK
     out = np.empty((len(rows), nsb * BLOCK_BYTES), dtype=np.uint8)
+    rc = max(1, ROW_CHUNK)
+    for r0 in range(0, len(rows), rc):
+        _encode_rows(rows[r0:r0 + rc], out[r0:r0 + rc], nsb)
+    return out.reshape(*x.shape[:-1], nsb * BLOCK_BYTES)
 
+
+def _encode_rows(rows, out, nsb):
     for sb in range(nsb):
         blk = rows[:, sb * QK:(sb + 1) * QK]                     # [R,256]
         sign = np.where(blk < 0, -1.0, 1.0).astype(np.float32)
@@ -93,33 +106,42 @@ def encode(x):
         d = d.astype(np.float16).astype(np.float32)              # encode what we store
 
         g = grid()
+        G2 = (g * g).sum(1)                                      # [256] ||g||^2
+        R = len(rows)
         for ib in range(QK // SUB):
             m = mag[:, ib * SUB:(ib + 1) * SUB]                  # [R,32]
-            best_err = None
-            best = None
+            # The sub-scale search is 16 candidates for the SAME magnitudes, and the
+            # only code-dependent quantity is the scalar db. Writing the nearest-grid
+            # test as
+            #     argmin_g ||m/db - g||^2 = argmin_g [ db*||g||^2 - 2*(m.g) ]     (db>0)
+            # takes m.g outside the loop: one [R*8,4]x[4,256] product serves all 16
+            # codes instead of one each. The squared error follows from the same
+            # product — sum (db*g - m)^2 = db^2*||g||^2 - 2*db*(m.g) + ||m||^2 — and
+            # ||m||^2 is the same for every code, so it drops out of the comparison.
+            # Measured 4.6x on the GLM-5.2 expert shapes; the encoding is unchanged
+            # except where two codes tie to within float rounding.
+            m4 = m.reshape(-1, 4)                                # [R*8,4]
+            A = m4 @ g.T                                         # [R*8,256] = m.g
+            A2 = -2.0 * A
+            nrow = np.arange(len(m4))
+            best_err = None; best_idx = None; best_code = None
             for code in range(16):
-                db = d * (0.5 + code) * 0.5
-                q = (m / np.maximum(db, 1e-20)).reshape(-1, 4)
-                idx = _nearest(q)
-                rec = g[idx].reshape(len(rows), SUB) * db
-                err = ((rec - m) ** 2).sum(-1, keepdims=True)
+                db = np.maximum(d * (0.5 + code) * 0.5, 1e-20)   # [R,1]
+                dbN = np.repeat(db, SUB // 4, axis=0)[:, 0]      # [R*8]
+                idx = np.argmin(dbN[:, None] * G2[None, :] + A2, axis=1)
+                gi = G2[idx]; ai = A[nrow, idx]
+                err = ((dbN * dbN * gi - 2.0 * dbN * ai)
+                       .reshape(R, SUB // 4).sum(1, keepdims=True))
+                iu = idx.astype(np.uint8).reshape(R, SUB // 4)
                 if best_err is None:
-                    best_err, best = err, (idx.reshape(len(rows), SUB // 4), code)
+                    best_err, best_idx, best_code = err, iu, np.zeros(R, np.int64)
                 else:
                     take = (err < best_err)[:, 0]
                     if take.any():
-                        keep_idx, keep_code = best
-                        ni = idx.reshape(len(rows), SUB // 4)
-                        keep_idx = np.where(take[:, None], ni, keep_idx)
-                        # per-row code: store alongside, resolved below
-                        keep_code = np.where(take, code, keep_code) if isinstance(
-                            keep_code, np.ndarray) else np.where(
-                            take, code, np.full(len(rows), keep_code))
-                        best = (keep_idx, keep_code)
+                        best_idx = np.where(take[:, None], iu, best_idx)
+                        best_code = np.where(take, code, best_code)
                         best_err = np.where(take[:, None], err, best_err)
-            bidx, bcode = best
-            if not isinstance(bcode, np.ndarray):
-                bcode = np.full(len(rows), bcode)
+            bidx, bcode = best_idx, best_code
             out[:, base + ib * 8:base + (ib + 1) * 8] = bidx.astype(np.uint8)
 
             # signs: four 7-bit words for this sub-block + the 4-bit code
@@ -135,7 +157,6 @@ def encode(x):
             off = base + QK // 4 + ib * 4
             out[:, off:off + 4] = word.view(np.uint8).reshape(len(rows), 4) if False else \
                 np.ascontiguousarray(word).view(np.uint8).reshape(len(rows), 4)
-    return out.reshape(*x.shape[:-1], nsb * BLOCK_BYTES)
 
 
 def decode(packed, K):

--- a/c/tools/iq3_pack.py
+++ b/c/tools/iq3_pack.py
@@ -63,13 +63,54 @@ def _nearest(mag4):
     return out
 
 
+_LIB = False        # False = not tried yet, None = unavailable
+
+def _native():
+    """iq3_encode.c built as a shared library, if it is next to this file.
+
+    Optional by design: without it everything still works through numpy, just
+    ~25x slower. IQ3_NATIVE=0 forces the numpy path (used to A/B the two).
+    """
+    global _LIB
+    if _LIB is not False:
+        return _LIB
+    _LIB = None
+    want = os.environ.get("IQ3_NATIVE", "1") != "0"
+    if want:
+        import ctypes, ctypes.util
+        for name in ("libiq3.so", "libiq3.dylib", "iq3.dll"):
+            path = os.path.join(os.path.dirname(os.path.abspath(__file__)), name)
+            if not os.path.exists(path):
+                continue
+            try:
+                lib = ctypes.CDLL(path)
+                if lib.iq3_encode_abi() != 1:
+                    break                       # stale build: fall back rather than corrupt
+                lib.iq3_encode.restype = None
+                lib.iq3_encode.argtypes = [ctypes.c_void_p, ctypes.c_int64, ctypes.c_int64,
+                                           ctypes.c_void_p, ctypes.c_void_p]
+                _LIB = lib
+            except (OSError, AttributeError):
+                pass
+            break
+    if _LIB is None and want:
+        # Once per process, and only when an E8 encode is actually about to run:
+        # the numpy path is correct but ~15x slower, which on a large model is the
+        # difference between hours and days. Silence here would just cost the user
+        # that time without telling them why.
+        import sys as _sys
+        print("[iq3] native encoder not built - using the numpy path (~15x slower). "
+              "Build it with:  make iq3", file=_sys.stderr, flush=True)
+    return _LIB
+
+
 def encode(x):
     """float32 [..., K] (K % 256 == 0) -> packed uint8 [..., K//256 * 98].
 
-    Rows encode independently, so they are processed in cache-sized blocks: the
-    search keeps a [rows*8, 256] score array live per sub-block, and letting that
-    grow to a whole expert tensor turns the argmin memory-bound (measured 2.4x
-    over the naive loop at 2048 rows against 5.6x at 256).
+    Uses the native encoder when available (see _native); otherwise falls back to
+    the numpy path, which processes rows in cache-sized blocks — the search keeps
+    a [rows*8, 256] score array live per sub-block, and letting that grow to a
+    whole expert tensor turns the argmin memory-bound.
     """
     x = np.ascontiguousarray(x, dtype=np.float32)
     K = x.shape[-1]
@@ -78,6 +119,11 @@ def encode(x):
     rows = x.reshape(-1, K)
     nsb = K // QK
     out = np.empty((len(rows), nsb * BLOCK_BYTES), dtype=np.uint8)
+    lib = _native()
+    if lib is not None:
+        g = np.ascontiguousarray(grid(), dtype=np.float32)
+        lib.iq3_encode(rows.ctypes.data, rows.shape[0], K, g.ctypes.data, out.ctypes.data)
+        return out.reshape(*x.shape[:-1], nsb * BLOCK_BYTES)
     rc = max(1, ROW_CHUNK)
     for r0 in range(0, len(rows), rc):
         _encode_rows(rows[r0:r0 + rc], out[r0:r0 + rc], nsb)


### PR DESCRIPTION
Converting a large model to fmt=6 is currently impractical, and the reason is inherent to the format rather than incidental: E8/IQ3 is a **codebook** quantizer. For every 4 weights it searches a 256-entry lattice, and repeats that for all 16 candidate sub-scales — roughly 1280 ops per weight against ~5 for int4. Measured on GLM-5.2, whose routed experts are 725e9 weights, `iq3_pack.encode` ran at **0.27 Mw/s → about 27 days of CPU**.

This brings it to a few hours, in three independent pieces. It is not a one-off fix: the cost is in the format, so every future E8 conversion pays it.

### 1. Algebra: hoist the code-independent product (3×)

The 16 sub-scale candidates search the *same* magnitudes; only the scalar `db` differs. Writing the nearest-grid test as

```
argmin_g ||m/db - g||^2  =  argmin_g [ db*||g||^2 - 2*(m.g) ]      (db > 0)
```

takes `m.g` outside the loop — one `[R*8,4] x [4,256]` product serves all 16 codes instead of one each. The squared error falls out of the same product, and its `||m||^2` term is identical across codes so it drops out of the comparison, which also removes the per-code gather of `g[idx]`. Rows are then encoded in cache-sized blocks, since a `[rows*8, 256]` score array grown to a whole expert tensor turns the argmin memory-bound.

**Byte-identical output** on every shape tested — the algebra is exact and the argmin is over the same values scaled by a positive constant.

### 2. A native encoder (a further 13×, optional)

`tools/iq3_encode.c`, loaded through ctypes, built with `make iq3`. Measuring the two halves separately is what shaped it (2048×6144, one thread):

```
numpy         0.95 Mw/s
C scalar      1.58 Mw/s   1.7x   plain fusion
C AVX2+FMA   12.71 Mw/s   8.0x   over scalar
```

So a scalar C port with no DRAM traffic is barely faster than numpy — the cost is the search itself, and SIMD is where the win is. Two things beyond widening: four independent min chains (a single running min over 256 entries is a 32-deep latency chain), and dropping index tracking from 15 of the 16 passes, since choosing a code needs only the *sum* of the 8 group minima. 17 cheap passes instead of 16 expensive ones. Threads scale near-linearly to 4 (12.9 → 47.2 Mw/s).

**The library is optional.** `iq3_pack` falls back to numpy when it is absent, so no build step becomes mandatory; it now prints a one-time notice pointing at `make iq3` rather than silently costing the user 15×. `IQ3_NATIVE=0` forces the numpy path, which is how the two were A/B'd. Output is byte-identical to the numpy encoder on two different hosts — the fp16 super-scale uses a hand-written round-to-nearest-even to match numpy's `astype` rather than the hardware path, and the error expression keeps numpy's association so code selection cannot diverge on a near-tie.

### 3. Two things that only bite on a big model / small host

**RAM.** `embed`/`lm_head` at `[154880, 6144]` is 3.8 GB as f32, and abs/divide/rint/clip each materialise another copy — ~15 GB peak on a box with 13 GB free. Every non-E8 format here carries per-row scales (or per-group scales along I), so rows never interact and quantizing a row block at a time is **bit-identical**; it only caps the peak. Verified equal for int8/int4/int4-g64/int3-g64/int2. E8 is excluded: it is already blocked inside `encode`, and its `.qs` companion is a single format tag rather than a per-row scale, so it must not be concatenated.

**Progress.** The `--indir` loop printed nothing per shard, so a local run taking days was silent until it finished (stdout is a redirected file, so block-buffered too). It now prints shard, free space and an ETA, flushed — the feedback the download path already gave.

### Result

GLM-5.2 → fmt=6, 141 shards / 725 GB of FP8 source, on a 6-core / 15 GB host: **~27 days → ~5 h** (5 workers). The resulting container loads and runs; `make check` 220.
