### PR TITLE
fix(cuda): correct RAM budget on integrated/unified-memory GPUs (#653)

### DIFF
--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -710,6 +710,16 @@ extern "C" int coli_cuda_mem_info(int device, size_t *free_bytes, size_t *total_
     return cuda_ok(cudaMemGetInfo(free_bytes, total_bytes), "memory info");
 }
 
+/* #653: 1 when the device shares physical memory with the host (Grace-Blackwell /
+ * GB10, Jetson, integrated GPUs). On these the expert tier and the RAM cache draw
+ * from the same pool, so the RAM budget must account for the tier; on a discrete GPU
+ * VRAM is a separate pool and this returns 0. */
+extern "C" int coli_cuda_device_integrated(int device) {
+    cudaDeviceProp prop{};
+    if (!cuda_ok(cudaGetDeviceProperties(&prop, device), "device properties")) return 0;
+    return prop.integrated ? 1 : 0;
+}
+
 extern "C" void coli_cuda_stats(int device, size_t *tensor_count, size_t *tensor_bytes) {
     size_t count = 0, bytes = 0;
     for (int i = 0; i < g_nctx; i++) if (device < 0 || g_ctx[i].device == device) {

--- a/c/backend_cuda.h
+++ b/c/backend_cuda.h
@@ -30,6 +30,7 @@ COLI_CUDA_DLLEXPORT void coli_cuda_shutdown(void);
 COLI_CUDA_DLLEXPORT int coli_cuda_device_count(void);
 COLI_CUDA_DLLEXPORT int coli_cuda_device_at(int index);
 COLI_CUDA_DLLEXPORT int coli_cuda_mem_info(int device, size_t *free_bytes, size_t *total_bytes);
+COLI_CUDA_DLLEXPORT int coli_cuda_device_integrated(int device);
 /* device < 0 returns aggregate statistics for all configured devices. */
 COLI_CUDA_DLLEXPORT void coli_cuda_stats(int device, size_t *tensor_count, size_t *tensor_bytes);
 COLI_CUDA_DLLEXPORT void coli_cuda_group_stats(uint64_t *calls, uint64_t *experts, uint64_t *rows,

--- a/c/backend_loader.c
+++ b/c/backend_loader.c
@@ -33,6 +33,7 @@ typedef void           (*fn_shutdown)(void);
 typedef int            (*fn_device_count)(void);
 typedef int            (*fn_device_at)(int index);
 typedef int            (*fn_mem_info)(int device, size_t *free_bytes, size_t *total_bytes);
+typedef int            (*fn_device_integrated)(int device);
 typedef void           (*fn_stats)(int device, size_t *tensor_count, size_t *tensor_bytes);
 typedef void           (*fn_group_stats)(uint64_t *calls, uint64_t *experts, uint64_t *rows,
                                          double *h2d_ms, double *kernel_ms, double *d2h_ms);
@@ -106,6 +107,7 @@ static struct {
     fn_device_count    device_count;
     fn_device_at       device_at;
     fn_mem_info        mem_info;
+    fn_device_integrated device_integrated;
     fn_stats           stats;
     fn_group_stats     group_stats;
     fn_expert_mlp      expert_mlp;
@@ -216,6 +218,10 @@ static int coli_cuda_load(void){
     RESOLVE(device_count,   fn_device_count)
     RESOLVE(device_at,      fn_device_at)
     RESOLVE(mem_info,       fn_mem_info)
+    /* Optional: a DLL predating #653 leaves this NULL; the wrapper then reports
+     * "not integrated" (0), so the RAM-budget correction simply doesn't apply
+     * rather than taking the whole GPU backend down over one missing symbol. */
+    RESOLVE_OPT(device_integrated, fn_device_integrated)
     RESOLVE(stats,          fn_stats)
     RESOLVE(group_stats,    fn_group_stats)
     RESOLVE(expert_mlp,     fn_expert_mlp)
@@ -292,6 +298,11 @@ int coli_cuda_device_at(int index){
 int coli_cuda_mem_info(int device, size_t *free_bytes, size_t *total_bytes){
     if(!g_cuda.available){ if(free_bytes)*free_bytes=0; if(total_bytes)*total_bytes=0; return 0; }
     return g_cuda.mem_info(device, free_bytes, total_bytes);
+}
+
+int coli_cuda_device_integrated(int device){
+    if(!g_cuda.available || !g_cuda.device_integrated) return 0;
+    return g_cuda.device_integrated(device);
 }
 
 void coli_cuda_stats(int device, size_t *tensor_count, size_t *tensor_bytes){

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -6259,6 +6259,7 @@ static void pin_arena_bind(Model *m, PinRec *r, int *slot_of, int from, int to){
 }
 #endif
 static double expert_avail(Model *m, double ram_gb, int ebits, int max_ctx);  /* def. sotto */
+static double g_mem_avail_boot;   /* def. sotto (#653: corretta qui su GPU integrate) */
 static void pin_load(Model *m, const char *statspath, double gb){
     FILE *f=fopen(statspath,"r"); if(!f){ perror(statspath); return; }
     Cfg *c=&m->c; int cap=(c->n_layers+1)*c->n_experts;
@@ -6395,6 +6396,23 @@ static void pin_load(Model *m, const char *statspath, double gb){
             g_cuda_reserve_gb);
         for(int i=0;i<g_cuda_ndev;i++) fprintf(stderr,"[CUDA]   device %d: %d experts, %.2f GB\n",
             g_cuda_devices[i],placed_n[i],placed_b[i]/1e9);
+        /* #653: on integrated / unified-memory GPUs (Grace-Blackwell GB10, Jetson) the
+         * expert tier and the host RAM cache draw from ONE physical pool, so the boot
+         * MemAvailable snapshot -- captured before this tier was placed -- over-counts
+         * free RAM by exactly the tier size. The auto RAM budget (cap_for_ram) and the
+         * overcommit guard both read g_mem_avail_boot, so correcting it here fixes both:
+         * the budget shrinks by the placed bytes and no longer over-commits into an
+         * OOM-kill during prefill. Discrete GPUs have a separate VRAM pool -> integrated
+         * is 0 and this is a no-op, leaving their behaviour unchanged. */
+        if(g_cuda_ndev>0 && m->gpu_expert_bytes>0 && g_mem_avail_boot>0 &&
+           coli_cuda_device_integrated(g_cuda_devices[0])){
+            double tier_gb = m->gpu_expert_bytes/1e9;
+            g_mem_avail_boot -= tier_gb;
+            if(g_mem_avail_boot < 1.0) g_mem_avail_boot = 1.0;
+            fprintf(stderr,"[CUDA] integrated/unified memory: expert tier shares physical RAM; "
+                "RAM budget snapshot reduced by %.2f GB -> MemAvailable=%.1f GB (#653)\n",
+                tier_gb, g_mem_avail_boot);
+        }
     }
 #endif
     if(gpu_prefix>0&&gpu_prefix<npin){


### PR DESCRIPTION
## What

On **integrated / unified-memory GPUs** (Grace-Blackwell **GB10 / DGX Spark**, Jetson) the hot expert tier and the host RAM cache draw from **one physical memory pool**. The auto RAM budget reads `g_mem_avail_boot` — a `MemAvailable` snapshot taken at startup **before** the expert tier is placed — so on unified memory it over-counts free RAM by exactly the tier size. The budget then over-commits and the process is **OOM-killed during prefill** (reported on GB10, `RAM_GB` auto).

## Fix

- Add `coli_cuda_device_integrated(device)` → `cudaDeviceProp::integrated` (also valid under HIP).
- After the expert tier is placed, if the primary device is integrated, subtract the placed bytes from `g_mem_avail_boot`.
- Both consumers — `cap_for_ram` (auto budget) and the overcommit guard — read the corrected value, so the budget shrinks by the tier size and stops over-committing.

**Discrete GPUs are unaffected**: `integrated` is `0`, so the block is a no-op and their behaviour is byte-for-byte unchanged.

## Testing

- CPU build (`make glm`) clean, no warnings.
- `-DCOLI_CUDA` syntax check clean (validates the new branch).
- ⚠️ **The OOM only reproduces on unified-memory hardware, which I can't test here** — asking the reporter to verify on GB10.

Closes #653 (pending reporter confirmation on GB10).