### PR TITLE
fix(tooling): recognize AMD/ROCm GPUs in doctor + resource_plan (#662, #663)

### DIFF
--- a/c/doctor.py
+++ b/c/doctor.py
@@ -356,7 +356,11 @@ def cuda_linkage(engine_path):
                                     timeout=3, check=False)
         except (OSError, subprocess.SubprocessError):
             return {"linked": False, "missing": False}
-        lines = [line for line in result.stdout.splitlines() if "libcudart" in line]
+        # A HIP/ROCm build links libamdhip64 (never libcudart), so match both
+        # vendors here or a working AMD engine is reported CPU-only (#663). Mirrors
+        # the vendor-aware probe cuda_binary() already uses in c/coli.
+        lines = [line for line in result.stdout.splitlines()
+                 if "libcudart" in line or "libamdhip64" in line]
         return {"linked": any("not found" not in line for line in lines),
                 "missing": any("not found" in line for line in lines)}
     if sys.platform == "win32":

--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -144,6 +144,15 @@ def memory_available():
 
 
 def discover_gpus():
+    # NVIDIA first; if there are none (or no nvidia-smi), fall back to ROCm/HIP so
+    # a working AMD engine isn't planned CPU-only and --gpu N stops failing (#662).
+    devices = _discover_nvidia_gpus()
+    if devices:
+        return devices
+    return _discover_amd_gpus()
+
+
+def _discover_nvidia_gpus():
     command = ["nvidia-smi", "--query-gpu=index,name,memory.total,memory.free",
                "--format=csv,noheader,nounits"]
     try:
@@ -176,6 +185,53 @@ def discover_gpus():
         devices.append({"index": index, "name": fields[1],
                         "total_bytes": total * 1024 * 1024,
                         "free_bytes": free * 1024 * 1024})
+    return devices
+
+
+def _discover_amd_gpus():
+    """ROCm/HIP discovery via rocm-smi (#662). Absent on non-AMD hosts, so this
+    returns [] there. rocm-smi --showmeminfo vram reports BYTES (unlike nvidia-smi's
+    MiB), so no unit scaling. Column names drift across ROCm versions, so match them
+    by substring rather than position. VERIFY on AMD hardware (labelled
+    hardware-owner-needed) -- authored without a ROCm host to test against."""
+    command = ["rocm-smi", "--showmeminfo", "vram", "--showproductname", "--csv"]
+    try:
+        result = subprocess.run(command, text=True, capture_output=True, check=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return []
+    import csv
+    rows = list(csv.DictReader(result.stdout.splitlines()))
+    if not rows:
+        return []
+
+    def find_col(row, *needles):
+        for key in row:
+            low = (key or "").lower()
+            if all(n in low for n in needles):
+                return key
+        return None
+
+    devices = []
+    for i, row in enumerate(rows):
+        dev = (row.get("device") or "").strip()
+        m = re.search(r"(\d+)", dev)
+        index = int(m.group(1)) if m else i
+        total_col = find_col(row, "vram", "total", "memory")
+        used_col = find_col(row, "vram", "used")
+        name_col = (find_col(row, "card", "series") or find_col(row, "card", "model")
+                    or find_col(row, "product"))
+        try:
+            total = int((row.get(total_col) or "0").strip())
+        except (ValueError, TypeError):
+            total = 0
+        try:
+            used = int((row.get(used_col) or "0").strip())
+        except (ValueError, TypeError):
+            used = 0
+        free = max(total - used, 0)
+        name = (row.get(name_col) or "").strip() if name_col else ""
+        devices.append({"index": index, "name": name or f"AMD GPU {index}",
+                        "total_bytes": total, "free_bytes": free})
     return devices
 
 


### PR DESCRIPTION
## What

The C engine ships a **HIP backend**, but the Python tooling around it only knew NVIDIA — so a correctly built AMD/ROCm engine was reported **CPU-only** and `--gpu N` failed with "one or more requested GPUs were not detected".

## Fixes

**#663 — `doctor.py` `cuda_linkage()`**: a HIP build links `libamdhip64` (never `libcudart`), so the linkage probe matched nothing. Now matches **both** vendors — mirrors the vendor-aware `cuda_binary()` already in `c/coli` (from #395/#435).

**#662 — `resource_plan.discover_gpus()`**: split into an NVIDIA path and a ROCm path. When `nvidia-smi` finds nothing, fall back to `rocm-smi --showmeminfo vram --showproductname --csv`. Notes:
- `rocm-smi --showmeminfo vram` reports **bytes** (unlike `nvidia-smi`'s MiB) → no unit scaling.
- rocm-smi column names drift across ROCm versions → columns matched **by substring**, not position.
- `free = total − used`.

## Testing

- `test_doctor.py`: **22/22 pass**.
- Both paths degrade to `[]` / not-linked on non-AMD hosts (no `rocm-smi` → `FileNotFoundError` → `[]`, verified).
- ⚠️ The ROCm path is **authored without a ROCm host to test against** (issues labelled `hardware-owner-needed`). `test_resource_plan.py` hangs in my local WSL environment on the **unmodified** file too (pre-existing, not from this change) — CI's Linux runner exercises it.

## Verify

@kvbkvbkvb — could you build this branch and confirm on your AMD box that `coli doctor` no longer reports CPU-only (#663) and `coli plan` / `--gpu 0` now sizes the card (#662)? If the `rocm-smi --csv` column names differ on your ROCm version, paste `rocm-smi --showmeminfo vram --showproductname --csv` and I'll adjust the matching.

Closes #662, closes #663 (pending AMD verification).