### PR TITLE
fix(win): test_st_mirror stale dirs + two -Wformat-truncation warnings

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -1509,7 +1509,10 @@ static int expert_load_impl(Model *m, int layer, int eid, ESlot *s, int fatal, i
     st_tensor *tw[3], *tq[3];
     for(int k=0;k<3;k++){
         tw[k]=st_find(&m->S,nm[k]);
-        snprintf(qn,sizeof(qn),"%s.qs",nm[k]); tq[k]=st_find(&m->S,qn);
+        /* strnlen+memcpy come al load fmt-aware (#484): gcc -Wformat-truncation
+         * vede nm[k] a indice variabile come l'intero nm[3][] e segnala 863>320 */
+        { size_t n=strnlen(nm[k],sizeof(nm[k])); memcpy(qn,nm[k],n); memcpy(qn+n,".qs",4); }
+        tq[k]=st_find(&m->S,qn);
         if(!tw[k]||!tq[k]){ if(fatal) st_die_missing(&m->S,nm[k]);   /* #586: diagnose, don't just name it */
                             fprintf(stderr,"missing %s\n",nm[k]); return -1; }
     }

--- a/c/st.h
+++ b/c/st.h
@@ -271,7 +271,7 @@ static void st_init_multi(shards *S, const char *snap_dir, const char *extra_dir
                 ndir, nf, snap_dir, c0);
     }
     for (int a = 0; a < nf; a++) for (int b = a+1; b < nf; b++)
-        if (strcmp(files[a], files[b]) > 0) { char tmp[1024]; snprintf(tmp, sizeof(tmp), "%s", files[a]); snprintf(files[a], 1024, "%s", files[b]); snprintf(files[b], 1024, "%s", tmp); }
+        if (strcmp(files[a], files[b]) > 0) { char tmp[1024]; memcpy(tmp, files[a], 1024); memcpy(files[a], files[b], 1024); memcpy(files[b], tmp, 1024); }
 
     for (int fi = 0; fi < nf; fi++) {
         int fd = st_open_fd(S, files[fi]);

--- a/c/tests/test_st_mirror.c
+++ b/c/tests/test_st_mirror.c
@@ -12,9 +12,12 @@
 #ifdef _WIN32
 #include <direct.h>
 #define MKDIR(p) _mkdir(p)
+#define RMDIR(p) _rmdir(p)
 #else
 #include <sys/stat.h>
+#include <unistd.h>
 #define MKDIR(p) mkdir(p, 0777)
+#define RMDIR(p) rmdir(p)
 #endif
 
 #define CHECK(condition) do { \
@@ -56,7 +59,7 @@ static void cleanup(void) {
         char path[256];
         snprintf(path, sizeof(path), "%s/model.safetensors", dirs[i]);
         remove(path);
-        remove(dirs[i]);
+        RMDIR(dirs[i]);   /* remove() deletes only files on Windows: stale dirs made every 2nd run fail */
     }
 }
 


### PR DESCRIPTION
## Summary

Three small Windows/gcc-15 issues, found while running `make check` on Windows
(upstream CI is Linux-only, so it never sees them):

- **`tests/test_st_mirror.c`**: `cleanup()` deletes its `tmp_mirror_*` fixture
  dirs with `remove()`, but on Windows the CRT `remove()` deletes only files —
  the dirs survive, and the next run's `MKDIR` check fails. The test passes on
  a fresh tree and fails on every run after. Fixed with an `RMDIR` macro
  (`_rmdir` / `rmdir`) mirroring the existing `MKDIR` macro.
- **`st.h` (shard-name sort)**: the fixed-size 1024-byte name buffers were
  swapped via three `snprintf("%s")` calls, which gcc 15 flags with
  `-Wformat-truncation`. Swapped with `memcpy` instead — same behavior, no
  warning.
- **`colibri.c` (expert `.qs` lookup)**: `snprintf(qn, …, "%s.qs", nm[k])` with
  a variable index makes gcc bound `nm[k]` by the whole `nm[3][288]` array
  (863 > 320) — a false positive. Replaced with the `strnlen` + `memcpy` idiom
  the same file already uses for the identical pattern in the fmt-aware load
  path (#484).

## Validation

- [x] `make -C c check` — full pass on Windows (gcc 15, C suite + Python
      tests); both warnings gone
- [x] `test_st_mirror` verified on back-to-back runs in the same tree (fails
      on run 2 before this patch, passes repeatedly after)
- [x] CUDA changes — n/a
- [x] No performance claims

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included