### PR TITLE
entropy: in-tree rANS codec, int4-rans256-g0 container format, offline tools

### DIFF
--- a/c/.gitignore
+++ b/c/.gitignore
@@ -8,3 +8,6 @@ tests/test_st_pread
 tools/libiq3.so
 tools/libiq3.dylib
 tools/iq3.dll
+tools/librans_c.so
+tools/librans_c.dylib
+tools/rans_c.dll

--- a/c/.gitignore
+++ b/c/.gitignore
@@ -11,3 +11,5 @@ tools/iq3.dll
 tools/librans_c.so
 tools/librans_c.dylib
 tools/rans_c.dll
+tests/fuzz_rans
+tests/*.dSYM/

--- a/c/Makefile
+++ b/c/Makefile
@@ -460,6 +460,18 @@ tests/test_e8_kernel$(EXE): tests/test_e8_kernel.c quant.h
 tests/test_rans$(EXE): tests/test_rans.c rans.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
+# Structured-mutation fuzz for the rans record parser/decoder under
+# ASan+UBSan — seeded and bounded (a few thousand mutants, well under a
+# minute), asserting no sanitizer report and byte identity across every
+# compiled decode arm on every accepted record. NOT a test gate (sanitizer
+# flags differ from the normal build); build+run on demand:
+#   make fuzz-rans
+fuzz-rans: tests/fuzz_rans.c rans.h
+	$(CC) -O1 -g -fsanitize=address,undefined -fno-sanitize-recover=all \
+	  -Wall -Wextra -Wno-unused-parameter -Wno-unused-function \
+	  tests/fuzz_rans.c -o tests/fuzz_rans -lm
+	./tests/fuzz_rans
+
 tests/test_int3$(EXE): tests/test_int3.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
@@ -505,7 +517,12 @@ tests/test_pipe_block$(EXE): tests/test_pipe_block.c colibri.c st.h uring.h json
 test-c: $(TEST_BINS)
 	$(PYTHON) tools/run_tests.py $(TEST_BINS)
 
-test-python:
+# test-python builds the rans ctypes bridge first: without it the repack e2e
+# test's C-vs-Python byte-identity pin would silently compare Python against
+# itself (the test ALSO skips loudly if the library is somehow still absent,
+# e.g. when invoked via unittest directly — but a green `make test` must mean
+# the pin was actually checked).
+test-python: $(RANSLIB)
 	$(PYTHON) -m unittest discover -s tests -p 'test_*.py'
 
 test: test-c test-python
@@ -567,4 +584,4 @@ clean:
 
 bench: iobench$(EXE)
 	@if [ -n "$(ARGS)" ]; then ./iobench$(EXE) $(ARGS); else echo "built iobench$(EXE) — run: ./iobench$(EXE) <file> <MB> <iters> <threads> <direct 0|1>"; fi
-.PHONY: all colibri glm iq3 rans cuda-test hip-test gpu-compile cuda-bench cuda-dll portable test-c test-python test check clean install uninstall bench
+.PHONY: all colibri glm iq3 rans fuzz-rans cuda-test hip-test gpu-compile cuda-bench cuda-dll portable test-c test-python test check clean install uninstall bench

--- a/c/Makefile
+++ b/c/Makefile
@@ -337,6 +337,22 @@ iq3: $(IQ3LIB)
 $(IQ3LIB): tools/iq3_encode.c
 	$(CC) $(CFLAGS) -fPIC -shared $< -o $@ $(LDFLAGS)
 
+# int4-rans256-g0 codec bridge for tools/repack_rans.py + tools/rans_verify.py.
+# OPTIONAL: both tools fall back to a pure-Python codec producing the same
+# bytes far more slowly when the library is absent (fine for tests, not for a
+# real repack). Same ARCH story as the engine: an AVX-512/NEON host gets the
+# batched vector decoder, anything else the scalar paths.
+ifneq (,$(DARWIN))
+RANSLIB = tools/librans_c.dylib
+else ifneq ($(IS_WIN),)
+RANSLIB = tools/rans_c.dll
+else
+RANSLIB = tools/librans_c.so
+endif
+rans: $(RANSLIB)
+$(RANSLIB): tools/rans_ctypes.c rans.h
+	$(CC) $(CFLAGS) -fPIC -shared $< -o $@ $(LDFLAGS)
+
 cuda-test: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/test_backend_cuda.cu
 	@command -v "$(GPUCC)" >/dev/null 2>&1 || { echo "$(GPUCC_NAME) not found" >&2; exit 1; }
 	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/test_backend_cuda.cu -o backend_cuda_test$(EXE)
@@ -440,6 +456,7 @@ tests/test_kv_alloc$(EXE): tests/test_kv_alloc.c colibri.c st.h json.h tok.h tok
 # the reference codec (tools/make_e8_fixture.py) — regenerate if the layout moves.
 tests/test_e8_kernel$(EXE): tests/test_e8_kernel.c quant.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
 
 tests/test_int3$(EXE): tests/test_int3.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
@@ -548,4 +565,4 @@ clean:
 
 bench: iobench$(EXE)
 	@if [ -n "$(ARGS)" ]; then ./iobench$(EXE) $(ARGS); else echo "built iobench$(EXE) — run: ./iobench$(EXE) <file> <MB> <iters> <threads> <direct 0|1>"; fi
-.PHONY: all colibri glm iq3 cuda-test hip-test gpu-compile cuda-bench cuda-dll portable test-c test-python test check clean install uninstall bench
+.PHONY: all colibri glm iq3 rans cuda-test hip-test gpu-compile cuda-bench cuda-dll portable test-c test-python test check clean install uninstall bench

--- a/c/Makefile
+++ b/c/Makefile
@@ -199,7 +199,7 @@ else
 PYTHON    ?= python3
 endif
 CUDA_OBJ  =
-TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_st_mirror$(EXE) tests/test_st_pread$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_grouped$(EXE) tests/test_stops$(EXE) tests/test_topp$(EXE) tests/test_sample_nan$(EXE) tests/test_temp_env$(EXE) tests/test_tok_o200k$(EXE) tests/test_kv_alloc$(EXE) tests/test_int3$(EXE) tests/test_int3_load$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE) tests/test_dsa_select$(EXE) tests/test_logit_nan$(EXE) tests/test_router_nan$(EXE) tests/test_pipe_block$(EXE) tests/test_e8_kernel$(EXE)
+TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_st_mirror$(EXE) tests/test_st_pread$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_grouped$(EXE) tests/test_stops$(EXE) tests/test_topp$(EXE) tests/test_sample_nan$(EXE) tests/test_temp_env$(EXE) tests/test_tok_o200k$(EXE) tests/test_kv_alloc$(EXE) tests/test_int3$(EXE) tests/test_int3_load$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE) tests/test_dsa_select$(EXE) tests/test_logit_nan$(EXE) tests/test_router_nan$(EXE) tests/test_pipe_block$(EXE) tests/test_e8_kernel$(EXE) tests/test_rans$(EXE)
 ifneq (,$(LINUX))
 TEST_BINS += tests/test_uring$(EXE)
 endif
@@ -457,6 +457,8 @@ tests/test_kv_alloc$(EXE): tests/test_kv_alloc.c colibri.c st.h json.h tok.h tok
 tests/test_e8_kernel$(EXE): tests/test_e8_kernel.c quant.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
+tests/test_rans$(EXE): tests/test_rans.c rans.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_int3$(EXE): tests/test_int3.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)

--- a/c/rans.h
+++ b/c/rans.h
@@ -1,0 +1,1046 @@
+/* rans.h — static-table byte-renormalized rANS (range Asymmetric Numeral
+ * Systems) codec for 4-bit (nibble) alphabets, plus the `int4-rans256-g0`
+ * chunk-record reader/writer the offline tools (tools/repack_rans.py,
+ * tools/rans_verify.py) and a future engine decode stage share.
+ *
+ * Header-only, all functions static, dependency-free C99 — same shape as
+ * st.h/quant.h: the engine is a single translation unit and tests include
+ * this header directly. No engine types are used or touched here.
+ *
+ * CODEC (ryg_rans-style construction, Fabian Giesen's public-domain
+ * reference design): 32-bit state, byte renormalization, division-based
+ * encode step, table-lookup decode step. Encode walks the input BACKWARDS
+ * and fills the output buffer from the END backwards (standard rANS LIFO
+ * construction); decode reads the resulting byte range FORWARDS and emits
+ * symbols in the ORIGINAL forward order.
+ *
+ * RECORD FORMAT (`int4-rans256-g0`, one record = one tensor's nibble
+ * stream; all integers little-endian; docs/int4-rans256-g0.md is the full
+ * writeup):
+ *
+ *   offset 0:  n_symbols     u64   -- nibble count
+ *   offset 8:  packed_bytes  u64   -- original packed-byte count
+ *                                     (== ceil(n_symbols/2)), stored so a
+ *                                     reader can size its output buffer
+ *                                     without recomputing it
+ *   offset 16: stream_offsets[N+1]  u32 x (N+1)  -- N = n_streams (256 for
+ *                                     this format); offsets[i] is the byte
+ *                                     offset, relative to the start of
+ *                                     `payload`, where stream i begins;
+ *                                     offsets[N] is the total payload length
+ *   then:      zero-pad to the next 16-byte boundary (derived, never stored)
+ *   payload:   N independent rANS byte streams, concatenated in stream
+ *              order: stream i is payload[offsets[i] : offsets[i+1]]
+ *   then:      zero-pad to the next 16-byte boundary (derived, never stored)
+ *
+ * INTERLEAVING: nibble at logical index j belongs to stream (j % N) and is
+ * the (j / N)-th symbol in that stream's own order. Every stream is an
+ * ordinary self-contained single-state rANS stream over the SAME shared
+ * static table; there is no cross-stream coupling. Round-robin (not block)
+ * assignment is what makes wide decoders output-coalesced: lane l of a
+ * group based at stream b emits logical position r*N+b+l each round, so a
+ * group of G lanes writes G contiguous nibbles = G/2 whole packed bytes.
+ *
+ * BATCHED DECODE ARMS + ENVELOPE: scalar (branchy, structurally the
+ * reference decoder), scalar_bf (branch-free closed-form renorm — the same
+ * algebra the SIMD arms use, kept so that algebra is testable on machines
+ * without the ISA), NEON and AVX-512 (F+BW). Each vector arm follows the
+ * same discipline as quant.h's AVX-512 i4 accumulator: a compile-time ISA
+ * gate, a first-use encode/decode round-trip selftest (a failing arm is
+ * disabled loudly, never used), and an env kill-switch (RANS_NEON=0 /
+ * RANS_AVX512=0). RANS_PATH=scalar|scalar_bf|neon|avx512 forces one arm and
+ * REFUSES (no silent downgrade) if it is not available: a forced path that
+ * quietly runs something else would turn "we tested avx512" into a false
+ * claim. All arms are byte-identical to scalar by contract — this is a
+ * codec, not a float kernel; there is no tolerance, only identity.
+ *
+ * SLACK CONTRACT: the branch-free and SIMD arms read 4 bytes at a cursor
+ * that may sit at a stream's end, and gather 4 bytes at a symbol-table
+ * index that may be the last slot. Callers of the batched decode entry
+ * points must therefore hand in (a) a record buffer with at least
+ * RANS_SLACK readable bytes past its end and (b) a rans_table whose sym8
+ * mirror was built by rans_table_init (which allocates the slack). The
+ * offline tools copy each record into a slack-padded scratch buffer; an
+ * engine consumer must do the equivalent. The strictly scalar entry points
+ * (rans_decode_stream / RANS_PATH_SCALAR) never over-read.
+ */
+#ifndef COLI_RANS_H
+#define COLI_RANS_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#if defined(__AVX512F__) && defined(__AVX512BW__)
+#include <immintrin.h>
+#endif
+#ifdef __ARM_NEON
+#include <arm_neon.h>
+#endif
+
+#define RANS_L        (1u << 23)   /* lower bound of the normalization interval */
+#define RANS_ALPHABET 16
+#define RANS_NSTREAMS 256          /* int4-rans256-g0's stream count */
+#define RANS_SLACK    64           /* readable bytes required past record buffers */
+
+/* ---- scalar stream codec (ported unmodified from the proven prototype) --- */
+
+/* Encode n nibbles (values 0..15) into out_buf writing BACKWARDS from
+ * out_buf+out_cap. freq[16] must sum to 1<<scale_bits and start[] must be its
+ * exclusive prefix sum; every symbol present in the input needs freq > 0.
+ * Returns the byte OFFSET where the valid stream begins (stream occupies
+ * out_buf[offset..out_cap)), or (size_t)-1 if out_cap was too small. */
+static size_t rans_encode_stream(const uint8_t *nibbles, size_t n,
+                                 const uint32_t *freq, const uint32_t *start,
+                                 uint32_t scale_bits,
+                                 uint8_t *out_buf, size_t out_cap) {
+    uint32_t x = RANS_L;
+    uint8_t *ptr = out_buf + out_cap;              /* write backwards from the end */
+    for (size_t i = n; i-- > 0; ) {
+        uint32_t s = nibbles[i];
+        uint32_t f = freq[s];
+        uint32_t st = start[s];
+        /* renormalize: keep x below x_max so the update keeps x in [L, L*256) */
+        uint32_t x_max = ((RANS_L >> scale_bits) << 8) * f;
+        while (x >= x_max) {
+            if (ptr <= out_buf) return (size_t)-1;  /* overflow guard */
+            *--ptr = (uint8_t)(x & 0xff);
+            x >>= 8;
+        }
+        x = ((x / f) << scale_bits) + (x % f) + st;
+    }
+    for (int b = 0; b < 4; b++) {                  /* flush final state, 4 bytes */
+        if (ptr <= out_buf) return (size_t)-1;
+        *--ptr = (uint8_t)(x & 0xff);
+        x >>= 8;
+    }
+    return (size_t)(ptr - out_buf);
+}
+
+/* Decode n nibbles from the stream produced by rans_encode_stream.
+ * slot_to_symbol maps a slot (x & (M-1)) to its symbol — the O(1) lookup that
+ * makes decode fast. Returns 0 on success, 1 on buffer underrun. The
+ * `else break` in the renorm is load-bearing: the encoder stops feeding bytes
+ * once drained, so a stream's final symbols legally decode with x < RANS_L;
+ * a decoder that reads past `end` instead produces wrong tail symbols. */
+static int rans_decode_stream(const uint8_t *in_buf, size_t in_size, size_t n,
+                              const uint32_t *freq, const uint32_t *start,
+                              const uint16_t *slot_to_symbol, uint32_t scale_bits,
+                              uint8_t *out_nibbles) {
+    const uint8_t *ptr = in_buf;
+    const uint8_t *end = in_buf + in_size;
+    uint32_t mask = (1u << scale_bits) - 1;
+    uint32_t x = 0;
+    for (int b = 0; b < 4; b++) {
+        if (ptr >= end) return 1;
+        x = (x << 8) | *ptr++;
+    }
+    for (size_t i = 0; i < n; i++) {
+        uint32_t slot = x & mask;
+        uint32_t s = slot_to_symbol[slot];
+        x = freq[s] * (x >> scale_bits) + slot - start[s];
+        while (x < RANS_L) {
+            if (ptr >= end) break;
+            x = (x << 8) | *ptr++;
+        }
+        out_nibbles[i] = (uint8_t)s;
+    }
+    return 0;
+}
+
+/* Checked variant for verification: additionally enforces the invariants a
+ * genuine encoder output always satisfies, so a validator can refuse a
+ * corrupted stream WITHOUT ground-truth bytes. Returns one of RANS_OK /
+ * RANS_E_STREAM_STATE_RANGE / RANS_E_STREAM_UNDERRUN /
+ * RANS_E_STREAM_LEFTOVER / RANS_E_STREAM_FINAL_STATE (see rans_err below). */
+
+/* ---- named error codes --------------------------------------------------- */
+
+typedef enum {
+    RANS_OK = 0,
+    /* record-level refusals (rans_record_parse) */
+    RANS_E_TRUNCATED,          /* blob shorter than its own framing claims  */
+    RANS_E_EMPTY,              /* n_symbols == 0                            */
+    RANS_E_COUNT_MISMATCH,     /* packed_bytes != ceil(n_symbols/2)         */
+    RANS_E_OFFSET_FIRST,       /* stream_offsets[0] != 0                    */
+    RANS_E_OFFSETS_MONOTONIC,  /* stream_offsets not non-decreasing         */
+    RANS_E_STREAM_SHORT,       /* a stream shorter than its 4-byte state    */
+    RANS_E_LENGTH_MISMATCH,    /* blob length != derived framing length     */
+    RANS_E_PAD_NONZERO,        /* a derived padding byte is not zero        */
+    /* table-level refusals (rans_table_init) */
+    RANS_E_TABLE_SCALE,        /* scale_bits out of range (1..15)           */
+    RANS_E_TABLE_FREQ_SUM,     /* freq[] does not sum to M                  */
+    RANS_E_TABLE_START,        /* start[] not the prefix sum of freq[]      */
+    RANS_E_TABLE_SLOT,         /* slot_to_symbol inconsistent with freq[]   */
+    /* stream-level refusals (rans_decode_stream_checked)                   */
+    RANS_E_STREAM_STATE_RANGE, /* initial state outside [L, 256L)           */
+    RANS_E_STREAM_UNDERRUN,    /* fewer than 4 bytes for the initial state  */
+    RANS_E_STREAM_LEFTOVER,    /* decode finished with bytes unconsumed     */
+    RANS_E_STREAM_FINAL_STATE, /* final state != L (not an encoder output)  */
+    /* misc */
+    RANS_E_NOMEM,
+    RANS_E_PATH_UNAVAILABLE    /* RANS_PATH forced an arm this build/CPU/env
+                                  cannot provide (never silently downgraded) */
+} rans_err;
+
+static const char *rans_err_name(rans_err e) {
+    switch (e) {
+        case RANS_OK:                   return "OK";
+        case RANS_E_TRUNCATED:          return "E_TRUNCATED";
+        case RANS_E_EMPTY:              return "E_EMPTY";
+        case RANS_E_COUNT_MISMATCH:     return "E_COUNT_MISMATCH";
+        case RANS_E_OFFSET_FIRST:       return "E_OFFSET_FIRST";
+        case RANS_E_OFFSETS_MONOTONIC:  return "E_OFFSETS_MONOTONIC";
+        case RANS_E_STREAM_SHORT:       return "E_STREAM_SHORT";
+        case RANS_E_LENGTH_MISMATCH:    return "E_LENGTH_MISMATCH";
+        case RANS_E_PAD_NONZERO:        return "E_PAD_NONZERO";
+        case RANS_E_TABLE_SCALE:        return "E_TABLE_SCALE";
+        case RANS_E_TABLE_FREQ_SUM:     return "E_TABLE_FREQ_SUM";
+        case RANS_E_TABLE_START:        return "E_TABLE_START";
+        case RANS_E_TABLE_SLOT:         return "E_TABLE_SLOT";
+        case RANS_E_STREAM_STATE_RANGE: return "E_STREAM_STATE_RANGE";
+        case RANS_E_STREAM_UNDERRUN:    return "E_STREAM_UNDERRUN";
+        case RANS_E_STREAM_LEFTOVER:    return "E_STREAM_LEFTOVER";
+        case RANS_E_STREAM_FINAL_STATE: return "E_STREAM_FINAL_STATE";
+        case RANS_E_NOMEM:              return "E_NOMEM";
+        case RANS_E_PATH_UNAVAILABLE:   return "E_PATH_UNAVAILABLE";
+    }
+    return "E_UNKNOWN";
+}
+
+static rans_err rans_decode_stream_checked(const uint8_t *in_buf, size_t in_size,
+                                           size_t n,
+                                           const uint32_t *freq, const uint32_t *start,
+                                           const uint16_t *slot_to_symbol,
+                                           uint32_t scale_bits,
+                                           uint8_t *out_nibbles) {
+    const uint8_t *ptr = in_buf;
+    const uint8_t *end = in_buf + in_size;
+    uint32_t mask = (1u << scale_bits) - 1;
+    uint32_t x = 0;
+    if (in_size < 4) return RANS_E_STREAM_UNDERRUN;
+    for (int b = 0; b < 4; b++) x = (x << 8) | *ptr++;
+    /* the encoder's state invariant: x stays in [L, 256L) at every step, so
+     * the flushed initial state must land there too */
+    if (x < RANS_L) return RANS_E_STREAM_STATE_RANGE;   /* x < 256L is implicit: 32-bit */
+    for (size_t i = 0; i < n; i++) {
+        uint32_t slot = x & mask;
+        uint32_t s = slot_to_symbol[slot];
+        x = freq[s] * (x >> scale_bits) + slot - start[s];
+        while (x < RANS_L) {
+            if (ptr >= end) break;
+            x = (x << 8) | *ptr++;
+        }
+        out_nibbles[i] = (uint8_t)s;
+    }
+    /* a genuine encoder output is consumed exactly and drains back to the
+     * encoder's initial state — anything else is corruption */
+    if (ptr != end)   return RANS_E_STREAM_LEFTOVER;
+    if (x != RANS_L)  return RANS_E_STREAM_FINAL_STATE;
+    return RANS_OK;
+}
+
+/* ---- shared static table -------------------------------------------------- */
+
+typedef struct {
+    uint32_t scale_bits;
+    uint32_t M;                       /* 1u << scale_bits */
+    uint32_t freq[RANS_ALPHABET];
+    uint32_t start[RANS_ALPHABET];
+    const uint16_t *slot_to_symbol;   /* borrowed, M entries */
+    uint8_t *sym8;                    /* owned u8 mirror, M + RANS_SLACK bytes:
+                                         halves the hot-table footprint and lets
+                                         the SIMD arms use a scale-1 dword gather */
+} rans_table;
+
+/* Validate freq/start/slot_to_symbol coherence and build the sym8 mirror.
+ * slot_to_symbol is borrowed (must outlive the table); sym8 is owned — free
+ * with rans_table_free. On failure the table is zeroed and the named error
+ * returned; decode with an unvalidated table would be garbage in a way no
+ * downstream byte comparison could explain, so this refuses instead. */
+static rans_err rans_table_init(rans_table *t, uint32_t scale_bits,
+                                const uint32_t *freq, const uint32_t *start,
+                                const uint16_t *slot_to_symbol) {
+    memset(t, 0, sizeof(*t));
+    if (scale_bits < 1 || scale_bits > 15) return RANS_E_TABLE_SCALE;
+    uint32_t M = 1u << scale_bits;
+    uint64_t sum = 0;
+    for (int s = 0; s < RANS_ALPHABET; s++) {
+        if (start[s] != sum) return RANS_E_TABLE_START;
+        sum += freq[s];
+    }
+    if (sum != M) return RANS_E_TABLE_FREQ_SUM;
+    for (uint32_t i = 0; i < M; i++) {
+        uint16_t s = slot_to_symbol[i];
+        if (s >= RANS_ALPHABET) return RANS_E_TABLE_SLOT;
+        if (i < start[s] || i >= start[s] + freq[s]) return RANS_E_TABLE_SLOT;
+    }
+    uint8_t *sym8 = (uint8_t *)calloc((size_t)M + RANS_SLACK, 1);
+    if (!sym8) return RANS_E_NOMEM;
+    for (uint32_t i = 0; i < M; i++) sym8[i] = (uint8_t)slot_to_symbol[i];
+    t->scale_bits = scale_bits;
+    t->M = M;
+    memcpy(t->freq, freq, sizeof(t->freq));
+    memcpy(t->start, start, sizeof(t->start));
+    t->slot_to_symbol = slot_to_symbol;
+    t->sym8 = sym8;
+    return RANS_OK;
+}
+
+static void rans_table_free(rans_table *t) {
+    if (!t) return;
+    free(t->sym8);
+    memset(t, 0, sizeof(*t));
+}
+
+/* ---- chunk record: writer ------------------------------------------------- */
+
+static uint64_t rans_round16(uint64_t v) { return (v + 15u) & ~(uint64_t)15u; }
+
+/* Derived framing sizes. Header = n_symbols + packed_bytes + offsets table,
+ * padded; the payload pad closes the record. Never stored in any field — the
+ * padding rule is computed identically by writer and reader, which avoids a
+ * redundant length field that could disagree with the derived value. */
+static uint64_t rans_record_header_bytes(uint32_t n_streams) {
+    return rans_round16(16u + ((uint64_t)n_streams + 1u) * 4u);
+}
+
+/* Worst-case record size for n nibbles: per-stream worst case mirrors the
+ * encoder's own scratch rule (n + n/2 + 64 per stream is generous for any
+ * 16-symbol table whose present symbols have freq >= 1), plus framing. */
+static uint64_t rans_record_bound(uint64_t n_symbols, uint32_t n_streams) {
+    uint64_t per = n_symbols / n_streams + 1u;
+    return rans_record_header_bytes(n_streams) +
+           rans_round16((per + per / 2u + 64u) * n_streams);
+}
+
+/* Encode n nibbles as one int4-rans256-g0 chunk record (n_streams round-robin
+ * interleaved streams, shared table). Writes at most rans_record_bound()
+ * bytes into out; *out_len receives the exact record length. Deterministic:
+ * same input + same table => byte-identical output. Returns RANS_OK, or
+ * RANS_E_EMPTY / RANS_E_NOMEM. */
+static rans_err rans_record_encode(const uint8_t *nibbles, uint64_t n,
+                                   const rans_table *t, uint32_t n_streams,
+                                   uint8_t *out, uint64_t out_cap,
+                                   uint64_t *out_len) {
+    if (n == 0) return RANS_E_EMPTY;
+    uint64_t head = rans_record_header_bytes(n_streams);
+    if (out_cap < head) return RANS_E_NOMEM;
+    uint64_t sub_max = n / n_streams + 1u;
+    uint64_t scap = sub_max + sub_max / 2u + 64u;   /* per-stream scratch cap */
+    uint8_t *sub = (uint8_t *)malloc(sub_max ? sub_max : 1);
+    uint8_t *enc = (uint8_t *)malloc(scap);
+    if (!sub || !enc) { free(sub); free(enc); return RANS_E_NOMEM; }
+
+    memset(out, 0, head);
+    uint64_t packed_bytes = (n + 1u) / 2u;
+    memcpy(out, &n, 8);
+    memcpy(out + 8, &packed_bytes, 8);
+    uint32_t *offs = (uint32_t *)(out + 16);
+
+    uint64_t pos = 0;                                /* payload cursor */
+    uint8_t *payload = out + head;
+    for (uint32_t i = 0; i < n_streams; i++) {
+        uint64_t ns = 0;                             /* gather sub-stream i */
+        for (uint64_t j = i; j < n; j += n_streams) sub[ns++] = nibbles[j];
+        size_t off = rans_encode_stream(sub, ns, t->freq, t->start,
+                                        t->scale_bits, enc, scap);
+        if (off == (size_t)-1) { free(sub); free(enc); return RANS_E_NOMEM; }
+        uint64_t len = scap - off;
+        if (head + pos + len > out_cap) { free(sub); free(enc); return RANS_E_NOMEM; }
+        memcpy(payload + pos, enc + off, len);
+        offs[i] = (uint32_t)pos;
+        pos += len;
+        if (pos > 0xFFFFFFFFu) { free(sub); free(enc); return RANS_E_NOMEM; }
+    }
+    offs[n_streams] = (uint32_t)pos;
+    uint64_t total = head + rans_round16(pos);
+    if (total > out_cap) { free(sub); free(enc); return RANS_E_NOMEM; }
+    memset(payload + pos, 0, rans_round16(pos) - pos);
+    *out_len = total;
+    free(sub); free(enc);
+    return RANS_OK;
+}
+
+/* ---- chunk record: reader ------------------------------------------------- */
+
+typedef struct {
+    uint64_t n_symbols;
+    uint64_t packed_bytes;
+    const uint32_t *stream_offsets;   /* n_streams+1 entries, payload-relative */
+    const uint8_t *payload;
+    uint64_t payload_len;
+} rans_record;
+
+/* Parse + validate one record blob (a tensor's full byte range). TRUST-
+ * VERIFY-REFUSE: every malformation class returns its own named error and
+ * the record is unusable on failure; there is no partial acceptance. The
+ * blob is borrowed. NOTE for the batched decode arms: the blob must satisfy
+ * the RANS_SLACK contract (header comment) — parsing alone does not read
+ * past blob_len. */
+static rans_err rans_record_parse(const uint8_t *blob, uint64_t blob_len,
+                                  uint32_t n_streams, rans_record *out) {
+    memset(out, 0, sizeof(*out));
+    uint64_t head = rans_record_header_bytes(n_streams);
+    if (blob_len < head) return RANS_E_TRUNCATED;
+    uint64_t n_symbols, packed_bytes;
+    memcpy(&n_symbols, blob, 8);
+    memcpy(&packed_bytes, blob + 8, 8);
+    if (n_symbols == 0) return RANS_E_EMPTY;
+    if (packed_bytes != (n_symbols + 1u) / 2u) return RANS_E_COUNT_MISMATCH;
+    const uint32_t *offs = (const uint32_t *)(blob + 16);
+    if (offs[0] != 0) return RANS_E_OFFSET_FIRST;
+    for (uint32_t i = 0; i < n_streams; i++) {
+        if (offs[i + 1] < offs[i]) return RANS_E_OFFSETS_MONOTONIC;
+        /* every stream carries at least its 4-byte flushed state (true even
+         * for streams that encode zero symbols) */
+        if (offs[i + 1] - offs[i] < 4u) return RANS_E_STREAM_SHORT;
+    }
+    uint64_t payload_len = offs[n_streams];
+    if (head + payload_len > blob_len) return RANS_E_TRUNCATED;
+    if (blob_len != head + rans_round16(payload_len)) return RANS_E_LENGTH_MISMATCH;
+    /* derived padding must be zero: bits hiding in the pad would make two
+     * "identical" containers differ and defeat writer determinism */
+    for (uint64_t i = 16u + ((uint64_t)n_streams + 1u) * 4u; i < head; i++)
+        if (blob[i] != 0) return RANS_E_PAD_NONZERO;
+    for (uint64_t i = head + payload_len; i < blob_len; i++)
+        if (blob[i] != 0) return RANS_E_PAD_NONZERO;
+    out->n_symbols = n_symbols;
+    out->packed_bytes = packed_bytes;
+    out->stream_offsets = offs;
+    out->payload = blob + head;
+    out->payload_len = payload_len;
+    return RANS_OK;
+}
+
+/* ---- batched decode: path selection + envelope ---------------------------- */
+
+typedef enum {
+    RANS_PATH_SCALAR = 0,      /* portable, branchy renorm (mirrors the oracle) */
+    RANS_PATH_SCALAR_BF = 1,   /* portable, branch-free renorm (the SIMD algebra) */
+    RANS_PATH_NEON = 2,
+    RANS_PATH_AVX512 = 3,
+    RANS_PATH_INVALID = -1
+} rans_path;
+
+static const char *rans_path_name(rans_path p) {
+    switch (p) {
+        case RANS_PATH_SCALAR:    return "scalar";
+        case RANS_PATH_SCALAR_BF: return "scalar_bf";
+        case RANS_PATH_NEON:      return "neon";
+        case RANS_PATH_AVX512:    return "avx512";
+        default:                  return "invalid";
+    }
+}
+
+#define RANS_G_SCALAR 8u
+#define RANS_G_NEON   16u
+#define RANS_G_AVX512 16u
+
+static uint32_t rans_path_group_width(rans_path p) {
+    if (p == RANS_PATH_AVX512) return RANS_G_AVX512;
+    if (p == RANS_PATH_NEON)   return RANS_G_NEON;
+    return RANS_G_SCALAR;
+}
+
+/* forward declaration: the selftest below round-trips through the kernels */
+static rans_err rans_record_decode_packed(const rans_record *rec,
+                                          const rans_table *t,
+                                          uint32_t n_streams, rans_path p,
+                                          uint8_t *out_packed);
+
+/* First-use round-trip selftest for one vector arm (same envelope discipline
+ * as quant.h's AVX-512 accumulator selftest):
+ * encode a fixed pseudo-random nibble block with the scalar encoder, decode
+ * it with the arm under test AND the scalar arm, and demand byte identity
+ * with the input and with each other. Runs once per process per arm; a
+ * failing arm is reported on stderr and never used. */
+static int rans__selftest_arm(rans_path p) {
+    /* NSYM: even (so the group fast path — the thing under test — actually
+     * runs) but NOT a multiple of NT, so group_tail runs too; large enough
+     * that the rare-symbol states below reliably visit the multi-byte-renorm
+     * bands (verified by re-running the sabotage exercise against the
+     * selftest itself, not assumed). */
+    enum { NT = 32, NSYM = 32 * 40 + 6 };
+    uint8_t data[NSYM];
+    uint32_t rng = 0x9E3779B9u;
+    for (int i = 0; i < NSYM; i++) {
+        rng = rng * 1664525u + 1013904223u;
+        /* mostly the dominant symbol, with every rare symbol appearing: the
+         * low-frequency outliers below drive the decoder through post-update
+         * states far below RANS_L (multi-byte renorm refills) where a
+         * renorm bug in a vector arm hides from comfortable tables. The f=3
+         * group matters: power-of-two freqs keep floor(log2 x) on a rigid
+         * lattice that never visits some refill bands (measured, not
+         * theorized) — this table shape is load-bearing, found by a
+         * deliberate-sabotage exercise. */
+        data[i] = (uint8_t)(((rng >> 24) % 3 == 0) ? 1 + ((rng >> 8) % 14) : 15);
+    }
+    uint32_t sb = 10, M = 1u << sb;
+    uint32_t freq[RANS_ALPHABET] = {0}, start[RANS_ALPHABET] = {0};
+    for (int s = 1; s <= 7; s++) freq[s] = 1;          /* rare symbols */
+    for (int s = 8; s <= 14; s++) freq[s] = 3;         /* rare, off-lattice */
+    freq[15] = M - 7 - 21;                              /* dominant symbol */
+    uint64_t acc = 0;
+    for (int s = 0; s < RANS_ALPHABET; s++) { start[s] = (uint32_t)acc; acc += freq[s]; }
+    uint16_t slot[1u << 10];
+    for (int s = 0; s < RANS_ALPHABET; s++)
+        for (uint32_t i = 0; i < freq[s]; i++) slot[start[s] + i] = (uint16_t)s;
+
+    rans_table t;
+    if (rans_table_init(&t, sb, freq, start, slot) != RANS_OK) return 0;
+    uint64_t cap = rans_record_bound(NSYM, NT) + RANS_SLACK;
+    uint8_t *rec_buf = (uint8_t *)calloc(cap, 1);
+    uint8_t out_a[(NSYM + 1) / 2], out_b[(NSYM + 1) / 2], packed_ref[(NSYM + 1) / 2];
+    int ok = 0;
+    uint64_t rec_len = 0;
+    if (rec_buf &&
+        rans_record_encode(data, NSYM, &t, NT, rec_buf, cap, &rec_len) == RANS_OK) {
+        rans_record rec;
+        if (rans_record_parse(rec_buf, rec_len, NT, &rec) == RANS_OK) {
+            memset(packed_ref, 0, sizeof(packed_ref));
+            for (int i = 0; i < NSYM; i++)
+                packed_ref[i >> 1] |= (uint8_t)(data[i] << ((i & 1) * 4));
+            memset(out_a, 0xAA, sizeof(out_a));
+            memset(out_b, 0x55, sizeof(out_b));
+            if (rans_record_decode_packed(&rec, &t, NT, RANS_PATH_SCALAR, out_a) == RANS_OK &&
+                rans_record_decode_packed(&rec, &t, NT, p, out_b) == RANS_OK &&
+                memcmp(out_a, packed_ref, sizeof(packed_ref)) == 0 &&
+                memcmp(out_b, packed_ref, sizeof(packed_ref)) == 0)
+                ok = 1;
+        }
+    }
+    free(rec_buf);
+    rans_table_free(&t);
+    if (!ok)
+        fprintf(stderr, "[rans] %s selftest FAILED: arm disabled, scalar fallback\n",
+                rans_path_name(p));
+    return ok;
+}
+
+static int rans_path_available(rans_path p) {
+    switch (p) {
+        case RANS_PATH_SCALAR:
+        case RANS_PATH_SCALAR_BF:
+            return 1;
+#ifdef __ARM_NEON
+        case RANS_PATH_NEON: {
+            static int cached = -1;                     /* -1 unknown, else 0/1 */
+            const char *e = getenv("RANS_NEON");        /* kill-switch */
+            if (e && atoi(e) == 0) return 0;
+            if (cached < 0) cached = rans__selftest_arm(RANS_PATH_NEON);
+            return cached;
+        }
+#endif
+#if defined(__AVX512F__) && defined(__AVX512BW__)
+        case RANS_PATH_AVX512: {
+            static int cached = -1;
+            const char *e = getenv("RANS_AVX512");      /* kill-switch */
+            if (e && atoi(e) == 0) return 0;
+#if defined(__GNUC__) || defined(__clang__)
+            if (!(__builtin_cpu_supports("avx512f") &&
+                  __builtin_cpu_supports("avx512bw"))) return 0;
+#endif
+            if (cached < 0) cached = rans__selftest_arm(RANS_PATH_AVX512);
+            return cached;
+        }
+#endif
+        default:
+            return 0;
+    }
+}
+
+static rans_path rans_path_best(void) {
+    if (rans_path_available(RANS_PATH_AVX512)) return RANS_PATH_AVX512;
+    if (rans_path_available(RANS_PATH_NEON))   return RANS_PATH_NEON;
+    /* scalar_bf over scalar: the closed-form renorm removes a data-dependent,
+     * badly-predicted branch from the inner loop (measured ~1.9x on an
+     * M-series host in the prototype round); both are byte-exact. */
+    return RANS_PATH_SCALAR_BF;
+}
+
+/* Honours RANS_PATH=scalar|scalar_bf|neon|avx512. A forced arm that this
+ * build/CPU/env cannot provide returns RANS_PATH_INVALID — NEVER a silent
+ * downgrade. */
+static rans_path rans_path_select(void) {
+    const char *e = getenv("RANS_PATH");
+    if (!e || !*e) return rans_path_best();
+    rans_path p = RANS_PATH_INVALID;
+    if      (!strcmp(e, "scalar"))    p = RANS_PATH_SCALAR;
+    else if (!strcmp(e, "scalar_bf")) p = RANS_PATH_SCALAR_BF;
+    else if (!strcmp(e, "neon"))      p = RANS_PATH_NEON;
+    else if (!strcmp(e, "avx512"))    p = RANS_PATH_AVX512;
+    else return RANS_PATH_INVALID;
+    return rans_path_available(p) ? p : RANS_PATH_INVALID;
+}
+
+/* ---- batched decode: group kernels ---------------------------------------- */
+
+/* Everything a group kernel needs about the record it is decoding. */
+typedef struct {
+    const rans_table *tab;
+    const uint8_t *payload;
+    const uint32_t *offs;      /* n_streams+1 */
+    uint64_t n;                /* n_symbols, even on the fast path */
+    uint32_t N;                /* n_streams, even */
+    uint8_t *out;              /* packed output, n/2 bytes */
+} rans_kctx;
+
+/* Big-endian 4-byte state load (the format's stream-init rule). */
+static uint32_t rans_be32(const uint8_t *p) {
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) |
+           ((uint32_t)p[2] << 8) | (uint32_t)p[3];
+}
+
+/* Number of COMPLETE rounds for the group of G streams based at stream b: a
+ * round r is complete iff every lane's logical position r*N+b+l is a real
+ * symbol, i.e. r*N + b + G - 1 < n. */
+static uint64_t rans_full_rounds(uint64_t n, uint32_t N, uint32_t b, uint32_t G) {
+    if (n < (uint64_t)b + G) return 0;
+    return (n - (uint64_t)b - G) / N + 1;
+}
+
+/* Branchy (oracle-shaped) decode of the final, partially-populated round of
+ * a group, given the per-lane states/cursors the main loop left behind.
+ * k = min(G, n-p) is even on the fast path (n even, p = R*N+b even). */
+static void rans_group_tail(const rans_kctx *K, uint32_t b, uint32_t G,
+                            uint64_t R, uint32_t *x, uint32_t *cur,
+                            const uint32_t *end) {
+    uint64_t p = R * (uint64_t)K->N + b;
+    if (p >= K->n) return;
+    uint64_t rem = K->n - p;
+    uint32_t k = (rem < (uint64_t)G) ? (uint32_t)rem : G;
+    const uint32_t sb = K->tab->scale_bits;
+    const uint32_t mask = K->tab->M - 1u;
+    const uint32_t *fq = K->tab->freq;
+    const uint32_t *st = K->tab->start;
+    const uint8_t *sym = K->tab->sym8;
+    const uint8_t *pl = K->payload;
+    uint8_t s[RANS_G_AVX512];
+    for (uint32_t l = 0; l < k; l++) {
+        uint32_t xx = x[l], c = cur[l], e = end[l];
+        uint32_t slot = xx & mask;
+        uint32_t sy = sym[slot];
+        xx = fq[sy] * (xx >> sb) + slot - st[sy];
+        while (xx < RANS_L) { if (c < e) xx = (xx << 8) | pl[c++]; else break; }
+        x[l] = xx; cur[l] = c;
+        s[l] = (uint8_t)sy;
+    }
+    uint8_t *op = K->out + (p >> 1);
+    for (uint32_t i = 0; i < k / 2u; i++)
+        op[i] = (uint8_t)(s[2 * i] | (s[2 * i + 1] << 4));
+}
+
+static void rans_kernel_scalar(const rans_kctx *K, uint32_t g0, uint32_t g1) {
+    const uint32_t G = RANS_G_SCALAR;
+    const uint32_t sb = K->tab->scale_bits;
+    const uint32_t mask = K->tab->M - 1u;
+    const uint32_t *fq = K->tab->freq;
+    const uint32_t *st = K->tab->start;
+    const uint8_t *sym = K->tab->sym8;
+    const uint8_t *pl = K->payload;
+    const uint64_t n = K->n;
+    const uint32_t N = K->N;
+    const size_t ostride = N >> 1;
+    for (uint32_t g = g0; g < g1; g++) {
+        uint32_t b = g * G;
+        uint32_t x[RANS_G_SCALAR], cur[RANS_G_SCALAR], end[RANS_G_SCALAR];
+        for (uint32_t l = 0; l < G; l++) {
+            cur[l] = K->offs[b + l];
+            end[l] = K->offs[b + l + 1];
+            x[l] = rans_be32(pl + cur[l]);
+            cur[l] += 4;
+        }
+        uint64_t R = rans_full_rounds(n, N, b, G);
+        uint8_t *op = K->out + (b >> 1);
+        for (uint64_t r = 0; r < R; r++) {
+            uint8_t s[RANS_G_SCALAR];
+            for (uint32_t l = 0; l < G; l++) {
+                uint32_t xx = x[l], c = cur[l];
+                const uint32_t e = end[l];
+                uint32_t slot = xx & mask;
+                uint32_t sy = sym[slot];
+                xx = fq[sy] * (xx >> sb) + slot - st[sy];
+                /* byte-at-a-time renorm, verbatim from the stream decoder */
+                while (xx < RANS_L) { if (c < e) xx = (xx << 8) | pl[c++]; else break; }
+                x[l] = xx; cur[l] = c; s[l] = (uint8_t)sy;
+            }
+            for (uint32_t i = 0; i < G / 2u; i++)
+                op[i] = (uint8_t)(s[2 * i] | (s[2 * i + 1] << 4));
+            op += ostride;
+        }
+        rans_group_tail(K, b, G, R, x, cur, end);
+    }
+}
+
+/* Branch-free twin: same output, closed-form renorm. The renorm loop appends
+ * whole bytes, so the count it consumes is a pure function of x —
+ *   kb = (x < 2^23) + (x < 2^15) + (x < 2^7), capped by bytes remaining —
+ * and x' = (x << 8*kb) | (next kb bytes, big-endian). This is the exact
+ * algebra the NEON/AVX-512 arms use, kept scalar so it is testable on any
+ * machine. Reads 4 bytes at the cursor => needs the RANS_SLACK contract. */
+static void rans_kernel_scalar_bf(const rans_kctx *K, uint32_t g0, uint32_t g1) {
+    const uint32_t G = RANS_G_SCALAR;
+    const uint32_t sb = K->tab->scale_bits;
+    const uint32_t mask = K->tab->M - 1u;
+    const uint32_t *fq = K->tab->freq;
+    const uint32_t *st = K->tab->start;
+    const uint8_t *sym = K->tab->sym8;
+    const uint8_t *pl = K->payload;
+    const uint64_t n = K->n;
+    const uint32_t N = K->N;
+    const size_t ostride = N >> 1;
+    for (uint32_t g = g0; g < g1; g++) {
+        uint32_t b = g * G;
+        uint32_t x[RANS_G_SCALAR], cur[RANS_G_SCALAR], end[RANS_G_SCALAR];
+        for (uint32_t l = 0; l < G; l++) {
+            cur[l] = K->offs[b + l];
+            end[l] = K->offs[b + l + 1];
+            x[l] = rans_be32(pl + cur[l]);
+            cur[l] += 4;
+        }
+        uint64_t R = rans_full_rounds(n, N, b, G);
+        uint8_t *op = K->out + (b >> 1);
+        for (uint64_t r = 0; r < R; r++) {
+            uint8_t s[RANS_G_SCALAR];
+            for (uint32_t l = 0; l < G; l++) {
+                uint32_t xx = x[l], c = cur[l];
+                uint32_t slot = xx & mask;
+                uint32_t sy = sym[slot];
+                xx = fq[sy] * (xx >> sb) + slot - st[sy];
+                uint32_t kb = (uint32_t)(xx < (1u << 23)) +
+                              (uint32_t)(xx < (1u << 15)) +
+                              (uint32_t)(xx < (1u << 7));
+                uint32_t rem = end[l] - c;
+                if (rem < kb) kb = rem;
+                uint32_t be = rans_be32(pl + c);    /* RANS_SLACK over-read */
+                uint32_t val = (kb == 0) ? 0u : (be >> (8u * (4u - kb)));
+                xx = (kb == 0) ? xx : ((xx << (8u * kb)) | val);
+                c += kb;
+                x[l] = xx; cur[l] = c; s[l] = (uint8_t)sy;
+            }
+            for (uint32_t i = 0; i < G / 2u; i++)
+                op[i] = (uint8_t)(s[2 * i] | (s[2 * i + 1] << 4));
+            op += ostride;
+        }
+        rans_group_tail(K, b, G, R, x, cur, end);
+    }
+}
+
+#ifdef __ARM_NEON
+/* NEON group kernel: 16 streams per group in four 4-lane state vectors.
+ * NEON has no gather, so the two per-symbol memory operations (slot->symbol
+ * lookup, renorm-byte fetch) stay scalar per lane — but both are issued
+ * EARLY, before this round's arithmetic needs them, so all 32 independent
+ * loads are in flight together; the state update, the closed-form renorm
+ * count/merge (the scalar_bf algebra), the 16-entry freq/start lookups
+ * (vqtbl1q byte-table lookups on lo/hi bytes of the u16-narrowed tables) and
+ * the fused nibble repack (vuzp + shl + orr) are all vectorized. G=16 rather
+ * than 8 amortizes the per-round scalar<->vector traffic; measured ~1.15x
+ * over scalar_bf single-thread on an M-series host (a G=8 variant measured
+ * 0.88x — the width is load-bearing). Byte-identical to the scalar arms by
+ * construction, enforced by the first-use selftest + the identity sweep in
+ * tests/test_rans.c. Needs the RANS_SLACK contract (4-byte fetches at
+ * cursors that may sit at a stream end). */
+static void rans_kernel_neon(const rans_kctx *K, uint32_t g0, uint32_t g1) {
+    const uint32_t G = RANS_G_NEON;   /* 16 */
+    const uint32_t sb = K->tab->scale_bits;
+    const uint8_t *sym = K->tab->sym8;
+    const uint8_t *pl = K->payload;
+    const uint64_t n = K->n;
+    const uint32_t N = K->N;
+    const size_t ostride = N >> 1;
+
+    /* freq/start fit u16 (M <= 32768): narrow to two 16-byte tables each and
+     * look 16 lanes up with one vqtbl1q per table byte. */
+    uint8_t fq_lo[16], fq_hi[16], st_lo[16], st_hi[16];
+    for (int s = 0; s < RANS_ALPHABET; s++) {
+        fq_lo[s] = (uint8_t)(K->tab->freq[s] & 0xFF);
+        fq_hi[s] = (uint8_t)(K->tab->freq[s] >> 8);
+        st_lo[s] = (uint8_t)(K->tab->start[s] & 0xFF);
+        st_hi[s] = (uint8_t)(K->tab->start[s] >> 8);
+    }
+    const uint8x16_t vfq_lo = vld1q_u8(fq_lo), vfq_hi = vld1q_u8(fq_hi);
+    const uint8x16_t vst_lo = vld1q_u8(st_lo), vst_hi = vld1q_u8(st_hi);
+    const uint32x4_t vmask = vdupq_n_u32(K->tab->M - 1u);
+    const uint32x4_t t23 = vdupq_n_u32(1u << 23);
+    const uint32x4_t t15 = vdupq_n_u32(1u << 15);
+    const uint32x4_t t7 = vdupq_n_u32(1u << 7);
+    const uint32x4_t one = vdupq_n_u32(1);
+    const int32x4_t vsb_neg = vdupq_n_s32(-(int32_t)sb);
+    const int32x4_t m32 = vdupq_n_s32(-32);
+
+    for (uint32_t g = g0; g < g1; g++) {
+        uint32_t b = g * G;
+        uint32_t xa[RANS_G_NEON], ca[RANS_G_NEON], ea[RANS_G_NEON];
+        for (uint32_t l = 0; l < G; l++) {
+            ca[l] = K->offs[b + l];
+            ea[l] = K->offs[b + l + 1];
+            xa[l] = rans_be32(pl + ca[l]);
+            ca[l] += 4;
+        }
+        uint32x4_t vx[4], vc[4], ve[4];
+        for (int q = 0; q < 4; q++) {
+            vx[q] = vld1q_u32(xa + 4 * q);
+            vc[q] = vld1q_u32(ca + 4 * q);
+            ve[q] = vld1q_u32(ea + 4 * q);
+        }
+        uint64_t R = rans_full_rounds(n, N, b, G);
+        uint8_t *op = K->out + (b >> 1);
+
+        for (uint64_t r = 0; r < R; r++) {
+            uint8_t sarr[RANS_G_NEON];
+            uint32_t slt[RANS_G_NEON], cl[RANS_G_NEON], bew[RANS_G_NEON];
+            /* early per-lane loads: renorm words at the current cursors and
+             * symbols at the current slots — independent of this round's
+             * arithmetic, so all of them can be in flight at once */
+            uint32x4_t sl[4];
+            for (int q = 0; q < 4; q++) {
+                sl[q] = vandq_u32(vx[q], vmask);
+                vst1q_u32(slt + 4 * q, sl[q]);
+                vst1q_u32(cl + 4 * q, vc[q]);
+            }
+            for (uint32_t l = 0; l < G; l++) {
+                sarr[l] = sym[slt[l]];
+                bew[l] = rans_be32(pl + cl[l]);   /* RANS_SLACK over-read */
+            }
+            uint8x16_t sidx = vld1q_u8(sarr);
+            uint8x16_t flo = vqtbl1q_u8(vfq_lo, sidx), fhi = vqtbl1q_u8(vfq_hi, sidx);
+            uint8x16_t slo = vqtbl1q_u8(vst_lo, sidx), shi = vqtbl1q_u8(vst_hi, sidx);
+            uint16x8_t f16a = vorrq_u16(vmovl_u8(vget_low_u8(flo)),
+                                        vshlq_n_u16(vmovl_u8(vget_low_u8(fhi)), 8));
+            uint16x8_t f16b = vorrq_u16(vmovl_u8(vget_high_u8(flo)),
+                                        vshlq_n_u16(vmovl_u8(vget_high_u8(fhi)), 8));
+            uint16x8_t s16a = vorrq_u16(vmovl_u8(vget_low_u8(slo)),
+                                        vshlq_n_u16(vmovl_u8(vget_low_u8(shi)), 8));
+            uint16x8_t s16b = vorrq_u16(vmovl_u8(vget_high_u8(slo)),
+                                        vshlq_n_u16(vmovl_u8(vget_high_u8(shi)), 8));
+            uint32x4_t f[4] = {vmovl_u16(vget_low_u16(f16a)),
+                               vmovl_u16(vget_high_u16(f16a)),
+                               vmovl_u16(vget_low_u16(f16b)),
+                               vmovl_u16(vget_high_u16(f16b))};
+            uint32x4_t st[4] = {vmovl_u16(vget_low_u16(s16a)),
+                                vmovl_u16(vget_high_u16(s16a)),
+                                vmovl_u16(vget_low_u16(s16b)),
+                                vmovl_u16(vget_high_u16(s16b))};
+            for (int q = 0; q < 4; q++) {
+                /* x = f*(x>>sb) + slot - start */
+                vx[q] = vaddq_u32(vmulq_u32(f[q], vshlq_u32(vx[q], vsb_neg)),
+                                  vsubq_u32(sl[q], st[q]));
+                /* closed-form renorm count, capped by bytes remaining */
+                uint32x4_t kb = vandq_u32(vcltq_u32(vx[q], t23), one);
+                kb = vaddq_u32(kb, vandq_u32(vcltq_u32(vx[q], t15), one));
+                kb = vaddq_u32(kb, vandq_u32(vcltq_u32(vx[q], t7), one));
+                kb = vminq_u32(kb, vsubq_u32(ve[q], vc[q]));
+                /* merge: x' = (x << 8k) | (be >> 8*(4-k)); vshlq with a
+                 * negative count is a logical right shift and |count| >= 32
+                 * yields 0, so the kb==0 lane computes (x<<0)|0 = x — the
+                 * scalar_bf ternary with no branch */
+                uint32x4_t be = vld1q_u32(bew + 4 * q);
+                int32x4_t shl = vreinterpretq_s32_u32(vshlq_n_u32(kb, 3));
+                int32x4_t shr = vaddq_s32(shl, m32);
+                vx[q] = vorrq_u32(vshlq_u32(vx[q], shl), vshlq_u32(be, shr));
+                vc[q] = vaddq_u32(vc[q], kb);
+            }
+            /* fused repack: 16 nibbles -> 8 packed bytes */
+            {
+                uint8x8x2_t z = vuzp_u8(vget_low_u8(sidx), vget_high_u8(sidx));
+                vst1_u8(op, vorr_u8(z.val[0], vshl_n_u8(z.val[1], 4)));
+            }
+            op += ostride;
+        }
+        for (int q = 0; q < 4; q++) {
+            vst1q_u32(xa + 4 * q, vx[q]);
+            vst1q_u32(ca + 4 * q, vc[q]);
+        }
+        rans_group_tail(K, b, G, R, xa, ca, ea);
+    }
+}
+#endif /* __ARM_NEON */
+
+#if defined(__AVX512F__) && defined(__AVX512BW__)
+/* AVX-512 group kernel: 16 streams per group, 16 lanes. Ported from the
+ * proven prototype kernel (byte-exact on all shipped chunks in its round,
+ * 8.7 GB/s batched on a Zen 5 host). Two things get cheap at this width:
+ * the 16-entry freq/start lookups collapse to ONE vpermd each (a zmm holds
+ * exactly 16 dwords), and each round's 16 nibbles emit as one 8-byte packed
+ * store (vpmovqb). Uses only F+BW. Needs the RANS_SLACK contract (dword
+ * gathers at cursors that may sit at a stream end and at sym8[M-1]). */
+static void rans_kernel_avx512(const rans_kctx *K, uint32_t g0, uint32_t g1) {
+    const uint32_t G = RANS_G_AVX512;
+    const uint32_t sb = K->tab->scale_bits;
+    const uint8_t *pl = K->payload;
+    const uint8_t *sym = K->tab->sym8;
+    const uint64_t n = K->n;
+    const uint32_t N = K->N;
+    const size_t ostride = N >> 1;
+
+    const __m512i vmask = _mm512_set1_epi32((int)(K->tab->M - 1u));
+    const __m512i vff = _mm512_set1_epi32(0xFF);
+    const __m512i one = _mm512_set1_epi32(1);
+    const __m512i four = _mm512_set1_epi32(4);
+    const __m512i eight = _mm512_set1_epi32(8);
+    const __m512i t23 = _mm512_set1_epi32((int)(1u << 23));
+    const __m512i t15 = _mm512_set1_epi32((int)(1u << 15));
+    const __m512i t7 = _mm512_set1_epi32((int)(1u << 7));
+    const __m512i bswap = _mm512_set4_epi32(0x0C0D0E0F, 0x08090A0B,
+                                            0x04050607, 0x00010203);
+    const __m512i vfreq = _mm512_loadu_si512((const void *)K->tab->freq);
+    const __m512i vstart = _mm512_loadu_si512((const void *)K->tab->start);
+
+    for (uint32_t g = g0; g < g1; g++) {
+        uint32_t b = g * G;
+        uint32_t xa[RANS_G_AVX512], ca[RANS_G_AVX512], ea[RANS_G_AVX512];
+        for (uint32_t l = 0; l < G; l++) {
+            ca[l] = K->offs[b + l];
+            ea[l] = K->offs[b + l + 1];
+            xa[l] = rans_be32(pl + ca[l]);
+            ca[l] += 4;
+        }
+        __m512i vx = _mm512_loadu_si512((const void *)xa);
+        __m512i vcur = _mm512_loadu_si512((const void *)ca);
+        __m512i vend = _mm512_loadu_si512((const void *)ea);
+
+        uint64_t R = rans_full_rounds(n, N, b, G);
+        uint8_t *op = K->out + (b >> 1);
+
+        for (uint64_t r = 0; r < R; r++) {
+            __m512i slot = _mm512_and_si512(vx, vmask);
+            __m512i s = _mm512_and_si512(
+                _mm512_i32gather_epi32(slot, (const void *)sym, 1), vff);
+            __m512i f = _mm512_permutexvar_epi32(s, vfreq);
+            __m512i st = _mm512_permutexvar_epi32(s, vstart);
+
+            vx = _mm512_add_epi32(
+                _mm512_mullo_epi32(f, _mm512_srli_epi32(vx, (int)sb)),
+                _mm512_sub_epi32(slot, st));
+
+            __m512i kb = _mm512_setzero_si512();
+            kb = _mm512_mask_add_epi32(kb, _mm512_cmplt_epu32_mask(vx, t23), kb, one);
+            kb = _mm512_mask_add_epi32(kb, _mm512_cmplt_epu32_mask(vx, t15), kb, one);
+            kb = _mm512_mask_add_epi32(kb, _mm512_cmplt_epu32_mask(vx, t7), kb, one);
+            kb = _mm512_min_epu32(kb, _mm512_sub_epi32(vend, vcur));
+
+            __m512i be = _mm512_shuffle_epi8(
+                _mm512_i32gather_epi32(vcur, (const void *)pl, 1), bswap);
+            __m512i shl = _mm512_mullo_epi32(kb, eight);
+            __m512i shr = _mm512_mullo_epi32(_mm512_sub_epi32(four, kb), eight);
+            vx = _mm512_or_si512(_mm512_sllv_epi32(vx, shl),
+                                 _mm512_srlv_epi32(be, shr));
+            vcur = _mm512_add_epi32(vcur, kb);
+
+            /* fused repack: byte 0 of each 64-bit element is the packed byte,
+             * vpmovqb collects all eight into one 8-byte store */
+            __m512i p = _mm512_or_si512(s, _mm512_srli_epi64(s, 28));
+            __m128i packed8 = _mm512_cvtepi64_epi8(p);
+            long long v = _mm_cvtsi128_si64(packed8);
+            memcpy(op, &v, 8);
+            op += ostride;
+        }
+        _mm512_storeu_si512((void *)xa, vx);
+        _mm512_storeu_si512((void *)ca, vcur);
+        _mm512_storeu_si512((void *)ea, vend);
+        rans_group_tail(K, b, G, R, xa, ca, ea);
+    }
+}
+#endif /* AVX512F+BW */
+
+/* ---- batched decode: dispatch --------------------------------------------- */
+
+/* Portable per-stream reference: whole record to one NIBBLE per byte. Works
+ * for any n_symbols/n_streams combination, including odd n_symbols. */
+static void rans_record_decode_nibbles(const rans_record *rec, const rans_table *t,
+                                       uint32_t n_streams, uint8_t *out_nibbles) {
+    const uint32_t sb = t->scale_bits;
+    const uint32_t mask = t->M - 1u;
+    const uint32_t *fq = t->freq;
+    const uint32_t *st = t->start;
+    const uint16_t *sym = t->slot_to_symbol;
+    for (uint32_t i = 0; i < n_streams; i++) {
+        const uint8_t *ptr = rec->payload + rec->stream_offsets[i];
+        const uint8_t *e = rec->payload + rec->stream_offsets[i + 1];
+        uint32_t x = 0;
+        for (int b = 0; b < 4; b++) x = (x << 8) | *ptr++;
+        for (uint64_t j = i; j < rec->n_symbols; j += n_streams) {
+            uint32_t slot = x & mask;
+            uint32_t s = sym[slot];
+            x = fq[s] * (x >> sb) + slot - st[s];
+            while (x < RANS_L) { if (ptr < e) x = (x << 8) | *ptr++; else break; }
+            out_nibbles[j] = (uint8_t)s;
+        }
+    }
+}
+
+/* Fast path applies when whole groups tile the streams and the fused repack
+ * can own whole output bytes; otherwise 0 => use the generic path. */
+static uint32_t rans_record_group_count(const rans_record *rec, uint32_t n_streams,
+                                        rans_path p) {
+    uint32_t G = rans_path_group_width(p);
+    if (n_streams % G) return 0;
+    if (rec->n_symbols & 1u) return 0;
+    return n_streams / G;
+}
+
+/* Decode stream groups [g0,g1) straight into PACKED bytes. Each call writes
+ * only the bytes its own streams own, so disjoint group ranges may run
+ * concurrently on the same output buffer with no synchronization — this is
+ * the parallel entry point a threaded consumer (E2) partitions work with. */
+static void rans_record_decode_groups(const rans_record *rec, const rans_table *t,
+                                      uint32_t n_streams, rans_path p,
+                                      uint32_t g0, uint32_t g1,
+                                      uint8_t *out_packed) {
+    rans_kctx K;
+    K.tab = t;
+    K.payload = rec->payload;
+    K.offs = rec->stream_offsets;
+    K.n = rec->n_symbols;
+    K.N = n_streams;
+    K.out = out_packed;
+    switch (p) {
+#if defined(__AVX512F__) && defined(__AVX512BW__)
+        case RANS_PATH_AVX512:    rans_kernel_avx512(&K, g0, g1); return;
+#endif
+#ifdef __ARM_NEON
+        case RANS_PATH_NEON:      rans_kernel_neon(&K, g0, g1); return;
+#endif
+        case RANS_PATH_SCALAR_BF: rans_kernel_scalar_bf(&K, g0, g1); return;
+        default:                  rans_kernel_scalar(&K, g0, g1); return;
+    }
+}
+
+/* Whole record to packed bytes (out_packed must hold rec->packed_bytes).
+ * Dispatches to the requested arm's fast path, or the generic per-stream
+ * path when the record shape cannot use groups. RANS_PATH_INVALID refuses. */
+static rans_err rans_record_decode_packed(const rans_record *rec, const rans_table *t,
+                                          uint32_t n_streams, rans_path p,
+                                          uint8_t *out_packed) {
+    if (p == RANS_PATH_INVALID) return RANS_E_PATH_UNAVAILABLE;
+    /* an arm this build did not compile refuses rather than silently running
+     * scalar: a quiet downgrade would let "we tested <arm>" become a false
+     * claim (same rule rans_path_select applies to the env override) */
+#ifndef __ARM_NEON
+    if (p == RANS_PATH_NEON) return RANS_E_PATH_UNAVAILABLE;
+#endif
+#if !(defined(__AVX512F__) && defined(__AVX512BW__))
+    if (p == RANS_PATH_AVX512) return RANS_E_PATH_UNAVAILABLE;
+#endif
+    uint32_t ng = rans_record_group_count(rec, n_streams, p);
+    if (ng == 0) {
+        uint8_t *scratch = (uint8_t *)malloc((size_t)rec->n_symbols);
+        if (!scratch) return RANS_E_NOMEM;
+        rans_record_decode_nibbles(rec, t, n_streams, scratch);
+        uint64_t np = rec->packed_bytes;
+        for (uint64_t k = 0; k < np; k++) {
+            uint8_t lo = scratch[2 * k];
+            uint8_t hi = (2 * k + 1 < rec->n_symbols) ? scratch[2 * k + 1] : 0;
+            out_packed[k] = (uint8_t)(lo | (hi << 4));
+        }
+        free(scratch);
+        return RANS_OK;
+    }
+    rans_record_decode_groups(rec, t, n_streams, p, 0, ng, out_packed);
+    return RANS_OK;
+}
+
+#endif /* COLI_RANS_H */

--- a/c/rans.h
+++ b/c/rans.h
@@ -72,6 +72,15 @@
 #include <string.h>
 #include <stdint.h>
 
+/* ENDIANNESS PRECONDITION: record header integers (n_symbols, packed_bytes,
+ * stream_offsets) are little-endian on the wire, and this implementation
+ * reads/writes them with native-order memcpy — correct only on little-endian
+ * hosts. Refuse to compile elsewhere rather than emit byte-swapped records
+ * that silently break the cross-host byte-identity contract. */
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__)
+#error "rans.h assumes a little-endian host (record integers are little-endian)"
+#endif
+
 #if defined(__AVX512F__) && defined(__AVX512BW__)
 #include <immintrin.h>
 #endif
@@ -83,6 +92,7 @@
 #define RANS_ALPHABET 16
 #define RANS_NSTREAMS 256          /* int4-rans256-g0's stream count */
 #define RANS_SLACK    64           /* readable bytes required past record buffers */
+#define RANS_SCALE_BITS_MAX 15     /* rans_table_init's upper bound on scale_bits */
 
 /* ---- scalar stream codec (ported unmodified from the proven prototype) --- */
 
@@ -98,7 +108,11 @@ static size_t rans_encode_stream(const uint8_t *nibbles, size_t n,
     uint32_t x = RANS_L;
     uint8_t *ptr = out_buf + out_cap;              /* write backwards from the end */
     for (size_t i = n; i-- > 0; ) {
-        uint32_t s = nibbles[i];
+        /* mask to the nibble alphabet: an out-of-range input byte must never
+         * index past freq[16]/start[16] (record-level entry points refuse
+         * such input by name BEFORE encoding; the mask makes this primitive
+         * memory-safe for any bytes regardless) */
+        uint32_t s = nibbles[i] & 15u;
         uint32_t f = freq[s];
         uint32_t st = start[s];
         /* renormalize: keep x below x_max so the update keeps x in [L, L*256) */
@@ -163,11 +177,14 @@ typedef enum {
     RANS_E_TRUNCATED,          /* blob shorter than its own framing claims  */
     RANS_E_EMPTY,              /* n_symbols == 0                            */
     RANS_E_COUNT_MISMATCH,     /* packed_bytes != ceil(n_symbols/2)         */
+    RANS_E_OVERSIZE,           /* n_symbols impossibly large for payload    */
     RANS_E_OFFSET_FIRST,       /* stream_offsets[0] != 0                    */
     RANS_E_OFFSETS_MONOTONIC,  /* stream_offsets not non-decreasing         */
     RANS_E_STREAM_SHORT,       /* a stream shorter than its 4-byte state    */
     RANS_E_LENGTH_MISMATCH,    /* blob length != derived framing length     */
     RANS_E_PAD_NONZERO,        /* a derived padding byte is not zero        */
+    RANS_E_UNALIGNED,          /* record buffer not 4-byte aligned          */
+    RANS_E_NSTREAMS,           /* n_streams zero / wrong for the format     */
     /* table-level refusals (rans_table_init) */
     RANS_E_TABLE_SCALE,        /* scale_bits out of range (1..15)           */
     RANS_E_TABLE_FREQ_SUM,     /* freq[] does not sum to M                  */
@@ -178,6 +195,11 @@ typedef enum {
     RANS_E_STREAM_UNDERRUN,    /* fewer than 4 bytes for the initial state  */
     RANS_E_STREAM_LEFTOVER,    /* decode finished with bytes unconsumed     */
     RANS_E_STREAM_FINAL_STATE, /* final state != L (not an encoder output)  */
+    /* encode-side refusals */
+    RANS_E_SYMBOL_UNCODABLE,   /* input contains a value > 15 or a symbol
+                                  whose table frequency is zero             */
+    RANS_E_SCRATCH,            /* encoder scratch/output bound exhausted
+                                  (a bound failure, NOT a memory condition) */
     /* misc */
     RANS_E_NOMEM,
     RANS_E_PATH_UNAVAILABLE    /* RANS_PATH forced an arm this build/CPU/env
@@ -190,11 +212,16 @@ static const char *rans_err_name(rans_err e) {
         case RANS_E_TRUNCATED:          return "E_TRUNCATED";
         case RANS_E_EMPTY:              return "E_EMPTY";
         case RANS_E_COUNT_MISMATCH:     return "E_COUNT_MISMATCH";
+        case RANS_E_OVERSIZE:           return "E_OVERSIZE";
         case RANS_E_OFFSET_FIRST:       return "E_OFFSET_FIRST";
         case RANS_E_OFFSETS_MONOTONIC:  return "E_OFFSETS_MONOTONIC";
         case RANS_E_STREAM_SHORT:       return "E_STREAM_SHORT";
         case RANS_E_LENGTH_MISMATCH:    return "E_LENGTH_MISMATCH";
         case RANS_E_PAD_NONZERO:        return "E_PAD_NONZERO";
+        case RANS_E_UNALIGNED:          return "E_UNALIGNED";
+        case RANS_E_NSTREAMS:           return "E_NSTREAMS";
+        case RANS_E_SYMBOL_UNCODABLE:   return "E_SYMBOL_UNCODABLE";
+        case RANS_E_SCRATCH:            return "E_SCRATCH";
         case RANS_E_TABLE_SCALE:        return "E_TABLE_SCALE";
         case RANS_E_TABLE_FREQ_SUM:     return "E_TABLE_FREQ_SUM";
         case RANS_E_TABLE_START:        return "E_TABLE_START";
@@ -306,38 +333,54 @@ static uint64_t rans_record_header_bytes(uint32_t n_streams) {
     return rans_round16(16u + ((uint64_t)n_streams + 1u) * 4u);
 }
 
-/* Worst-case record size for n nibbles: per-stream worst case mirrors the
- * encoder's own scratch rule (n + n/2 + 64 per stream is generous for any
- * 16-symbol table whose present symbols have freq >= 1), plus framing. */
+/* Worst-case record size for n nibbles. A symbol with table frequency f
+ * costs at most log2(M/f) bits, so the per-stream worst case over any valid
+ * table (f >= 1) is scale_bits bits/symbol — 1.875 bytes/symbol at the
+ * maximum scale_bits of 15 — plus the 4 flushed state bytes. This bound
+ * uses RANS_SCALE_BITS_MAX so it is table-independent and safe for every
+ * table rans_table_init accepts (the old "n + n/2" rule was FALSE for
+ * freq=1 symbols at scale_bits >= 13). Returns 0 for n_streams == 0. */
 static uint64_t rans_record_bound(uint64_t n_symbols, uint32_t n_streams) {
+    if (n_streams == 0) return 0;
     uint64_t per = n_symbols / n_streams + 1u;
+    uint64_t per_bytes = (per * RANS_SCALE_BITS_MAX + 7u) / 8u + 4u + 64u;
     return rans_record_header_bytes(n_streams) +
-           rans_round16((per + per / 2u + 64u) * n_streams);
+           rans_round16(per_bytes * n_streams);
 }
 
 /* Encode n nibbles as one int4-rans256-g0 chunk record (n_streams round-robin
  * interleaved streams, shared table). Writes at most rans_record_bound()
  * bytes into out; *out_len receives the exact record length. Deterministic:
- * same input + same table => byte-identical output. Returns RANS_OK, or
- * RANS_E_EMPTY / RANS_E_NOMEM. */
+ * same input + same table => byte-identical output. Returns RANS_OK, or:
+ * RANS_E_EMPTY (n == 0), RANS_E_NSTREAMS (n_streams == 0),
+ * RANS_E_SYMBOL_UNCODABLE (an input value > 15, or a symbol whose table
+ * frequency is zero — detected by a pre-scan BEFORE any encoding work),
+ * RANS_E_SCRATCH (a codec bound was exceeded — a logic/bound failure, never
+ * reported as a memory condition), RANS_E_NOMEM (malloc failed). */
 static rans_err rans_record_encode(const uint8_t *nibbles, uint64_t n,
                                    const rans_table *t, uint32_t n_streams,
                                    uint8_t *out, uint64_t out_cap,
                                    uint64_t *out_len) {
+    if (n_streams == 0) return RANS_E_NSTREAMS;
     if (n == 0) return RANS_E_EMPTY;
+    /* pre-scan: refuse uncodable input by name, before touching `out` */
+    for (uint64_t j = 0; j < n; j++)
+        if (nibbles[j] > 15u || t->freq[nibbles[j]] == 0)
+            return RANS_E_SYMBOL_UNCODABLE;
     uint64_t head = rans_record_header_bytes(n_streams);
-    if (out_cap < head) return RANS_E_NOMEM;
+    if (out_cap < head) return RANS_E_SCRATCH;
     uint64_t sub_max = n / n_streams + 1u;
-    uint64_t scap = sub_max + sub_max / 2u + 64u;   /* per-stream scratch cap */
+    /* per-stream scratch: a freq>=1 symbol costs at most scale_bits bits, so
+     * ceil(sub_max*scale_bits/8) + 4 flush bytes (+ slack) always fits */
+    uint64_t scap = (sub_max * t->scale_bits + 7u) / 8u + 4u + 64u;
     uint8_t *sub = (uint8_t *)malloc(sub_max ? sub_max : 1);
     uint8_t *enc = (uint8_t *)malloc(scap);
     if (!sub || !enc) { free(sub); free(enc); return RANS_E_NOMEM; }
 
     memset(out, 0, head);
-    uint64_t packed_bytes = (n + 1u) / 2u;
+    uint64_t packed_bytes = n / 2u + (n & 1u);
     memcpy(out, &n, 8);
     memcpy(out + 8, &packed_bytes, 8);
-    uint32_t *offs = (uint32_t *)(out + 16);
 
     uint64_t pos = 0;                                /* payload cursor */
     uint8_t *payload = out + head;
@@ -346,17 +389,19 @@ static rans_err rans_record_encode(const uint8_t *nibbles, uint64_t n,
         for (uint64_t j = i; j < n; j += n_streams) sub[ns++] = nibbles[j];
         size_t off = rans_encode_stream(sub, ns, t->freq, t->start,
                                         t->scale_bits, enc, scap);
-        if (off == (size_t)-1) { free(sub); free(enc); return RANS_E_NOMEM; }
+        if (off == (size_t)-1) { free(sub); free(enc); return RANS_E_SCRATCH; }
         uint64_t len = scap - off;
-        if (head + pos + len > out_cap) { free(sub); free(enc); return RANS_E_NOMEM; }
+        if (head + pos + len > out_cap) { free(sub); free(enc); return RANS_E_SCRATCH; }
         memcpy(payload + pos, enc + off, len);
-        offs[i] = (uint32_t)pos;
+        uint32_t pos32 = (uint32_t)pos;
+        memcpy(out + 16 + (uint64_t)i * 4u, &pos32, 4);
         pos += len;
-        if (pos > 0xFFFFFFFFu) { free(sub); free(enc); return RANS_E_NOMEM; }
+        if (pos > 0xFFFFFFFFu) { free(sub); free(enc); return RANS_E_SCRATCH; }
     }
-    offs[n_streams] = (uint32_t)pos;
+    uint32_t total32 = (uint32_t)pos;
+    memcpy(out + 16 + (uint64_t)n_streams * 4u, &total32, 4);
     uint64_t total = head + rans_round16(pos);
-    if (total > out_cap) { free(sub); free(enc); return RANS_E_NOMEM; }
+    if (total > out_cap) { free(sub); free(enc); return RANS_E_SCRATCH; }
     memset(payload + pos, 0, rans_round16(pos) - pos);
     *out_len = total;
     free(sub); free(enc);
@@ -376,30 +421,53 @@ typedef struct {
 /* Parse + validate one record blob (a tensor's full byte range). TRUST-
  * VERIFY-REFUSE: every malformation class returns its own named error and
  * the record is unusable on failure; there is no partial acceptance. The
- * blob is borrowed. NOTE for the batched decode arms: the blob must satisfy
- * the RANS_SLACK contract (header comment) — parsing alone does not read
- * past blob_len. */
+ * blob is borrowed and must be 4-byte aligned (any malloc'd or numpy-backed
+ * buffer qualifies; refused by name otherwise) so the stream_offsets
+ * pointer handed to the decode kernels indexes with defined behavior.
+ * NOTE for the batched decode arms: the blob must additionally satisfy the
+ * RANS_SLACK contract (header comment) — parsing alone does not read past
+ * blob_len, and it performs no allocation (in particular nothing
+ * proportional to the untrusted n_symbols field). */
 static rans_err rans_record_parse(const uint8_t *blob, uint64_t blob_len,
                                   uint32_t n_streams, rans_record *out) {
     memset(out, 0, sizeof(*out));
+    if (n_streams == 0) return RANS_E_NSTREAMS;
+    if (((uintptr_t)blob & 3u) != 0) return RANS_E_UNALIGNED;
     uint64_t head = rans_record_header_bytes(n_streams);
     if (blob_len < head) return RANS_E_TRUNCATED;
     uint64_t n_symbols, packed_bytes;
     memcpy(&n_symbols, blob, 8);
     memcpy(&packed_bytes, blob + 8, 8);
     if (n_symbols == 0) return RANS_E_EMPTY;
-    if (packed_bytes != (n_symbols + 1u) / 2u) return RANS_E_COUNT_MISMATCH;
-    const uint32_t *offs = (const uint32_t *)(blob + 16);
-    if (offs[0] != 0) return RANS_E_OFFSET_FIRST;
+    /* non-wrapping form of packed_bytes == ceil(n_symbols/2): the additive
+     * form (n_symbols+1)/2 wraps at UINT64_MAX and would accept
+     * packed_bytes == 0 for it */
+    if (packed_bytes != n_symbols / 2u + (n_symbols & 1u))
+        return RANS_E_COUNT_MISMATCH;
+    uint32_t off_prev, off_cur;
+    memcpy(&off_prev, blob + 16, 4);
+    if (off_prev != 0) return RANS_E_OFFSET_FIRST;
     for (uint32_t i = 0; i < n_streams; i++) {
-        if (offs[i + 1] < offs[i]) return RANS_E_OFFSETS_MONOTONIC;
+        memcpy(&off_cur, blob + 16 + ((uint64_t)i + 1u) * 4u, 4);
+        if (off_cur < off_prev) return RANS_E_OFFSETS_MONOTONIC;
         /* every stream carries at least its 4-byte flushed state (true even
          * for streams that encode zero symbols) */
-        if (offs[i + 1] - offs[i] < 4u) return RANS_E_STREAM_SHORT;
+        if (off_cur - off_prev < 4u) return RANS_E_STREAM_SHORT;
+        off_prev = off_cur;
     }
-    uint64_t payload_len = offs[n_streams];
+    uint64_t payload_len = off_prev;               /* == offsets[n_streams] */
     if (head + payload_len > blob_len) return RANS_E_TRUNCATED;
     if (blob_len != head + rans_round16(payload_len)) return RANS_E_LENGTH_MISMATCH;
+    /* amplification bound: a symbol costs at least log2(M/(M-1)) bits under
+     * any valid table (present symbols of a genuine record cost more; the
+     * degenerate freq==M single-symbol table costs ~0 per symbol but still
+     * satisfies this bound easily). n_symbols beyond payload_len*8*M_max is
+     * impossible for ANY table this format admits — refuse the
+     * decompression bomb here, before any consumer sizes buffers from
+     * n_symbols. (No overflow: payload_len < 2^32, M_max = 2^15.) */
+    if (n_symbols > payload_len * 8u * (uint64_t)(1u << RANS_SCALE_BITS_MAX))
+        return RANS_E_OVERSIZE;
+    const uint32_t *offs = (const uint32_t *)(blob + 16);  /* aligned: checked */
     /* derived padding must be zero: bits hiding in the pad would make two
      * "identical" containers differ and defeat writer determinism */
     for (uint64_t i = 16u + ((uint64_t)n_streams + 1u) * 4u; i < head; i++)
@@ -499,6 +567,40 @@ static int rans__selftest_arm(rans_path p) {
         rans_record_encode(data, NSYM, &t, NT, rec_buf, cap, &rec_len) == RANS_OK) {
         rans_record rec;
         if (rans_record_parse(rec_buf, rec_len, NT, &rec) == RANS_OK) {
+            /* MACHINE-CHECKED band coverage: the load-bearing property of
+             * this fixture is that it drives multi-byte renorm refills
+             * (post-update x < 2^15 => refill count kb == 2) — the band a
+             * comfortable table never visits and where a vector-arm renorm
+             * bug hides. Count kb with the oracle-shaped loop and FAIL the
+             * selftest if the fixture ever stops covering it, instead of
+             * trusting a comment. (kb == 3 needs x < 2^7, impossible
+             * mid-stream: post-update x >= L >> scale_bits >= 2^8.) */
+            uint64_t kb2 = 0;
+            for (uint32_t i = 0; i < NT; i++) {
+                const uint8_t *ptr = rec.payload + rec.stream_offsets[i];
+                const uint8_t *e2 = rec.payload + rec.stream_offsets[i + 1];
+                uint32_t x = 0;
+                for (int b2 = 0; b2 < 4; b2++) x = (x << 8) | *ptr++;
+                for (uint64_t j = i; j < rec.n_symbols; j += NT) {
+                    uint32_t sl2 = x & (M - 1u);
+                    uint32_t sy2 = slot[sl2];
+                    x = freq[sy2] * (x >> sb) + sl2 - start[sy2];
+                    uint32_t kb = 0;
+                    while (x < RANS_L) {
+                        if (ptr >= e2) break;
+                        x = (x << 8) | *ptr++;
+                        kb++;
+                    }
+                    if (kb >= 2) kb2++;
+                }
+            }
+            if (kb2 == 0) {
+                fprintf(stderr, "[rans] selftest fixture lost multi-byte "
+                        "renorm coverage — fixture bug, arm not trusted\n");
+                free(rec_buf);
+                rans_table_free(&t);
+                return 0;
+            }
             memset(packed_ref, 0, sizeof(packed_ref));
             for (int i = 0; i < NSYM; i++)
                 packed_ref[i >> 1] |= (uint8_t)(data[i] << ((i & 1) * 4));
@@ -1015,6 +1117,9 @@ static void rans_record_decode_groups(const rans_record *rec, const rans_table *
 static rans_err rans_record_decode_packed(const rans_record *rec, const rans_table *t,
                                           uint32_t n_streams, rans_path p,
                                           uint8_t *out_packed) {
+    /* n_streams == 0 would decode zero streams and return uninitialized
+     * scratch as "successful" output — refuse before any path can run */
+    if (n_streams == 0) return RANS_E_NSTREAMS;
     if (p == RANS_PATH_INVALID) return RANS_E_PATH_UNAVAILABLE;
     /* an arm this build did not compile refuses rather than silently running
      * scalar: a quiet downgrade would let "we tested <arm>" become a false

--- a/c/tests/fuzz_rans.c
+++ b/c/tests/fuzz_rans.c
@@ -1,0 +1,177 @@
+/* Structured-mutation fuzz for rans.h parse+decode against hostile records.
+ * Every mutant blob is placed in a fresh heap buffer of exactly
+ * blob_len + RANS_SLACK bytes so ASan catches any read past the documented
+ * slack contract. Decode output buffer is exactly packed_bytes.
+ *
+ * Seeded and bounded (7 base records x 700 structured mutants). Build+run
+ * via `make fuzz-rans` (ASan+UBSan, non-recoverable). Exit nonzero on any
+ * cross-arm divergence; sanitizers abort on any memory/UB report. NOT part
+ * of TEST_BINS: the sanitizer flags differ from the normal test build.
+ * Adopted from the E1 review round's audit harness (its first run found the
+ * u64-wrap acceptance in rans_record_parse that E_COUNT_MISMATCH's
+ * non-wrapping form now refuses). */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include "../rans.h"
+
+static uint64_t rng_state = 0x9E3779B97F4A7C15ULL;
+static uint32_t rnd(void) {
+    rng_state ^= rng_state << 13; rng_state ^= rng_state >> 7;
+    rng_state ^= rng_state << 17; return (uint32_t)(rng_state >> 32);
+}
+
+static int parsed_ok = 0, refused = 0, decoded_ok = 0, decode_refused = 0,
+           skipped_alloc = 0;
+
+static void exercise(const uint8_t *mut, uint64_t mlen, const rans_table *t,
+                     uint32_t N) {
+    /* fresh allocation: blob + slack ONLY */
+    uint8_t *blob = (uint8_t *)malloc(mlen + RANS_SLACK);
+    if (!blob) return;
+    memcpy(blob, mut, mlen);
+    memset(blob + mlen, 0, RANS_SLACK);
+    rans_record rec;
+    rans_err e = rans_record_parse(blob, mlen, N, &rec);
+    if (e != RANS_OK) { refused++; free(blob); return; }
+    parsed_ok++;
+    if (rec.n_symbols > (1ull << 24) || rec.packed_bytes > (1ull << 28)) { skipped_alloc++; free(blob); return; }
+    uint8_t *out = (uint8_t *)malloc(rec.packed_bytes ? rec.packed_bytes : 1);
+    if (!out) { skipped_alloc++; free(blob); return; }
+    const rans_path arms[] = {RANS_PATH_SCALAR, RANS_PATH_SCALAR_BF,
+                              RANS_PATH_NEON};
+    uint8_t *ref = NULL;
+    for (int a = 0; a < 3; a++) {
+        memset(out, 0xEE, rec.packed_bytes);
+        e = rans_record_decode_packed(&rec, t, N, arms[a], out);
+        if (e != RANS_OK) { decode_refused++; continue; }
+        decoded_ok++;
+        if (a == 0) { ref = (uint8_t *)malloc(rec.packed_bytes);
+                      memcpy(ref, out, rec.packed_bytes); }
+        else if (ref && memcmp(ref, out, rec.packed_bytes) != 0) {
+            fprintf(stderr, "ARM DIVERGENCE on mutant (arm %d)\n", a);
+            exit(2);
+        }
+    }
+    /* checked per-stream decode over every stream too */
+    for (uint32_t i = 0; i < N; i++) {
+        uint64_t off0 = rec.stream_offsets[i], off1 = rec.stream_offsets[i + 1];
+        uint64_t ns = 0;
+        for (uint64_t j = i; j < rec.n_symbols; j += N) ns++;
+        if (ns > (1ull << 26)) break;
+        uint8_t *nib = (uint8_t *)malloc(ns ? ns : 1);
+        rans_decode_stream_checked(rec.payload + off0, off1 - off0, ns,
+                                   t->freq, t->start, t->slot_to_symbol,
+                                   t->scale_bits, nib);
+        free(nib);
+    }
+    free(ref); free(out); free(blob);
+}
+
+int main(void) {
+    /* base table: the 15-symbol rare-mix shape */
+    uint32_t sb = 14, M = 1u << 14;
+    uint32_t freq[16] = {0}, start[16] = {0};
+    for (int s = 1; s <= 7; s++) freq[s] = 1;
+    for (int s = 8; s <= 14; s++) freq[s] = 3;
+    freq[15] = M - 7 - 21;
+    uint64_t acc = 0;
+    for (int s = 0; s < 16; s++) { start[s] = (uint32_t)acc; acc += freq[s]; }
+    uint16_t *slot = (uint16_t *)malloc(sizeof(uint16_t) * M);
+    for (int s = 0; s < 16; s++)
+        for (uint32_t i = 0; i < freq[s]; i++) slot[start[s] + i] = (uint16_t)s;
+    rans_table t;
+    if (rans_table_init(&t, sb, freq, start, slot) != RANS_OK) return 1;
+
+    const uint32_t N = RANS_NSTREAMS;
+    const uint64_t nsyms[] = {2, 255, 256, 511, 512, 8192, 65537};
+    for (size_t bi = 0; bi < sizeof(nsyms) / sizeof(nsyms[0]); bi++) {
+        uint64_t n = nsyms[bi];
+        uint8_t *data = (uint8_t *)malloc(n);
+        for (uint64_t i = 0; i < n; i++)
+            data[i] = (uint8_t)((rnd() % 3 == 0) ? 1 + (rnd() % 14) : 15);
+        uint64_t cap = rans_record_bound(n, N) + RANS_SLACK;
+        uint8_t *base = (uint8_t *)calloc(cap, 1);
+        uint64_t blen = 0;
+        if (rans_record_encode(data, n, &t, N, base, cap, &blen) != RANS_OK)
+            return 3;
+        /* sanity: unmutated parses+decodes */
+        exercise(base, blen, &t, N);
+
+        uint8_t *mut = (uint8_t *)malloc(blen + 64);
+        for (int it = 0; it < 700; it++) {
+            uint64_t mlen = blen;
+            memcpy(mut, base, blen);
+            switch (it % 7) {
+            case 0: {   /* random byte corruption, 1-8 bytes anywhere */
+                int k = 1 + (int)(rnd() % 8);
+                for (int j = 0; j < k; j++) mut[rnd() % blen] ^= (uint8_t)(1 + (rnd() & 0xFF));
+                break; }
+            case 1: {   /* header field attacks */
+                uint64_t v;
+                switch (rnd() % 6) {
+                case 0: v = 0; break;
+                case 1: v = UINT64_MAX; break;
+                case 2: v = UINT64_MAX - 1; break;
+                case 3: v = (uint64_t)1 << 32; break;
+                case 4: v = n + 1; break;
+                default: v = n - 1; break;
+                }
+                if (rnd() & 1) memcpy(mut, &v, 8);
+                else memcpy(mut + 8, &v, 8);
+                /* half the time keep packed_bytes consistent with lying n */
+                if (rnd() & 1) {
+                    uint64_t nn; memcpy(&nn, mut, 8);
+                    uint64_t pb = (nn + 1) / 2;
+                    memcpy(mut + 8, &pb, 8);
+                }
+                break; }
+            case 2: {   /* offsets attacks */
+                uint32_t idx = rnd() % (N + 1);
+                uint32_t v;
+                switch (rnd() % 5) {
+                case 0: v = 0xFFFFFFFFu; break;
+                case 1: v = 0; break;
+                case 2: v = (uint32_t)(rnd()); break;
+                case 3: { uint32_t cur; memcpy(&cur, mut + 16 + 4 * (uint64_t)idx, 4);
+                          v = cur + 1; break; }
+                default: { uint32_t cur; memcpy(&cur, mut + 16 + 4 * (uint64_t)idx, 4);
+                           v = cur ? cur - 1 : 0; break; }
+                }
+                memcpy(mut + 16 + 4 * (uint64_t)idx, &v, 4);
+                break; }
+            case 3:     /* truncate */
+                mlen = rnd() % blen;
+                break;
+            case 4:     /* extend with garbage */
+                mlen = blen + 1 + rnd() % 63;
+                for (uint64_t j = blen; j < mlen; j++) mut[j] = (uint8_t)rnd();
+                break;
+            case 5: {   /* swap two offsets (reversed ranges) */
+                uint32_t i1 = rnd() % (N + 1), i2 = rnd() % (N + 1);
+                uint32_t a1, a2;
+                memcpy(&a1, mut + 16 + 4 * (uint64_t)i1, 4);
+                memcpy(&a2, mut + 16 + 4 * (uint64_t)i2, 4);
+                memcpy(mut + 16 + 4 * (uint64_t)i1, &a2, 4);
+                memcpy(mut + 16 + 4 * (uint64_t)i2, &a1, 4);
+                break; }
+            default: {  /* payload bit flips near stream boundaries */
+                uint32_t i1 = rnd() % N;
+                uint32_t o; memcpy(&o, base + 16 + 4 * (uint64_t)i1, 4);
+                uint64_t head = rans_record_header_bytes(N);
+                uint64_t p = head + o + (rnd() % 8);
+                if (p < blen) mut[p] ^= (uint8_t)(1u << (rnd() % 8));
+                break; }
+            }
+            if (mlen == 0) { refused++; continue; }
+            exercise(mut, mlen, &t, N);
+        }
+        free(mut); free(base); free(data);
+    }
+    printf("fuzz done: parsed_ok=%d refused=%d decoded_ok=%d decode_refused=%d skipped=%d\n",
+           parsed_ok, refused, decoded_ok, decode_refused, skipped_alloc);
+    rans_table_free(&t);
+    free(slot);
+    return 0;
+}

--- a/c/tests/test_rans.c
+++ b/c/tests/test_rans.c
@@ -615,6 +615,233 @@ static void test_path_envelope(void) {
 #undef UNSET_ENV
 }
 
+/* ---- 5. fix-round hardening regressions ---------------------------------- */
+
+/* Header-field overflow/amplification battery (u64 wrap + decompression
+ * bomb): reproduces the review round's poc_overflow.c cases and pins the
+ * non-wrapping count check + the E_OVERSIZE payload bound. */
+static void test_header_field_battery(void) {
+    const uint32_t N = RANS_NSTREAMS;
+    const uint64_t n = 8192;
+    uint8_t *d = (uint8_t *)malloc(n);
+    for (uint64_t i = 0; i < n; i++) d[i] = (uint8_t)(1 + (rnd() % 15));
+    test_table tt;
+    tt_from_hist(&tt, 14, d, n);
+    uint64_t rec_len = 0;
+    uint8_t *buf = make_record(d, n, &tt, N, &rec_len);
+    uint8_t *cp = (uint8_t *)malloc(rec_len + RANS_SLACK);
+    rans_record rec;
+    rans_err e;
+
+    struct { uint64_t n_symbols, packed_bytes; rans_err want; const char *why; }
+    cases[] = {
+        {UINT64_MAX, 0,                  RANS_E_COUNT_MISMATCH,
+         "u64 wrap: (n+1)/2 overflows to 0"},
+        {UINT64_MAX, (1ull << 63),       RANS_E_OVERSIZE,
+         "u64 max with non-wrapping-consistent pb"},
+        {UINT64_MAX - 1, (1ull << 63) - 1, RANS_E_OVERSIZE, "u64 max-1"},
+        {1ull << 63, 1ull << 62,         RANS_E_OVERSIZE, "2^63"},
+        {1ull << 40, 1ull << 39,         RANS_E_OVERSIZE, "decompression bomb 2^40"},
+        {1ull << 32, 1ull << 31,         RANS_E_OVERSIZE, "2^32"},
+        {(1ull << 32) + 1, (1ull << 31) + 1, RANS_E_OVERSIZE, "2^32+1"},
+        {0, 0,                           RANS_E_EMPTY, "zero symbols"},
+        {n + 1, (n + 1) / 2,             RANS_E_COUNT_MISMATCH, "n+1, stale pb"},
+    };
+    for (size_t c = 0; c < sizeof(cases) / sizeof(cases[0]); c++) {
+        memcpy(cp, buf, rec_len);
+        memcpy(cp, &cases[c].n_symbols, 8);
+        memcpy(cp + 8, &cases[c].packed_bytes, 8);
+        e = rans_record_parse(cp, rec_len, N, &rec);
+        CHECK(e == cases[c].want, "%s: want %s got %s", cases[c].why,
+              rans_err_name(cases[c].want), rans_err_name(e));
+    }
+
+    /* minimally-framed bomb (every stream exactly its 4 flushed bytes,
+     * n_symbols = 2^40): must refuse at parse, which allocates nothing */
+    {
+        uint64_t head = rans_record_header_bytes(N);
+        uint64_t payload_len = 4ull * N;
+        uint64_t blen = head + rans_round16(payload_len);
+        uint8_t *bomb = (uint8_t *)calloc(blen + RANS_SLACK, 1);
+        uint64_t nb = 1ull << 40, pb = nb / 2;
+        memcpy(bomb, &nb, 8);
+        memcpy(bomb + 8, &pb, 8);
+        for (uint32_t i = 0; i <= N; i++) {
+            uint32_t v = 4u * i;
+            memcpy(bomb + 16 + (uint64_t)i * 4u, &v, 4);
+        }
+        for (uint64_t i = head; i < head + payload_len; i++) bomb[i] = 0x80;
+        e = rans_record_parse(bomb, blen, N, &rec);
+        CHECK(e == RANS_E_OVERSIZE, "minimal bomb: want E_OVERSIZE got %s",
+              rans_err_name(e));
+        free(bomb);
+    }
+    free(cp); free(buf); free(d);
+    tt_free(&tt);
+}
+
+/* Encoder scratch bound: bulk freq=1 input must encode fine at every
+ * scale_bits (the old n+n/2 rule failed at >= 13 — review poc_bound.c). */
+static void test_encoder_scratch_bound(void) {
+    for (uint32_t sb = 12; sb <= 15; sb++) {
+        uint32_t M = 1u << sb;
+        uint32_t freq[16] = {0};
+        freq[3] = 1;
+        freq[15] = M - 1;
+        test_table tt;
+        tt_build(&tt, sb, freq);
+        const uint64_t n = 8192;
+        uint8_t *d = (uint8_t *)malloc(n);
+        memset(d, 3, n);                      /* every symbol is the rare one */
+        uint64_t cap = rans_record_bound(n, 16) + RANS_SLACK, rl = 0;
+        uint8_t *rb = (uint8_t *)calloc(cap, 1);
+        rans_err e = rans_record_encode(d, n, &tt.t, 16, rb, cap, &rl);
+        CHECK(e == RANS_OK, "freq=1 bulk encode at sb=%u: %s", sb,
+              rans_err_name(e));
+        if (e == RANS_OK) {                   /* and it round-trips */
+            rans_record rec;
+            CHECK(rans_record_parse(rb, rl, 16, &rec) == RANS_OK,
+                  "freq=1 sb=%u parse", sb);
+            uint8_t *out = (uint8_t *)malloc(n / 2);
+            uint8_t *ref = (uint8_t *)malloc(n / 2);
+            pack_ref(d, n, ref);
+            CHECK(rans_record_decode_packed(&rec, &tt.t, 16, RANS_PATH_SCALAR,
+                                            out) == RANS_OK &&
+                  memcmp(out, ref, n / 2) == 0, "freq=1 sb=%u round trip", sb);
+            free(out); free(ref);
+        }
+        /* E_SCRATCH is a bound failure, never conflated with malloc failure:
+         * a too-small caller buffer names the bound, not the allocator */
+        e = rans_record_encode(d, n, &tt.t, 16, rb,
+                               rans_record_header_bytes(16) + 8, &rl);
+        CHECK(e == RANS_E_SCRATCH, "small out_cap at sb=%u: want E_SCRATCH "
+              "got %s", sb, rans_err_name(e));
+        free(rb); free(d);
+        tt_free(&tt);
+    }
+}
+
+/* Uncodable input is refused by name BEFORE any encoding work: a present
+ * symbol with table freq 0, and out-of-alphabet bytes (review poc_encode.c).
+ * The stream primitive itself masks to the nibble alphabet, so garbage
+ * bytes can never index past freq[16] (byte-identical to pre-masked input). */
+static void test_uncodable_input(void) {
+    uint32_t freq[16] = {0};
+    freq[1] = 1; freq[2] = 1; freq[3] = 1;
+    freq[15] = (1u << 14) - 3;                /* 4..14 have freq 0 */
+    test_table tt;
+    tt_build(&tt, 14, freq);
+    uint8_t d[64];
+    memset(d, 15, sizeof(d));
+    uint64_t cap = rans_record_bound(64, 16) + RANS_SLACK, rl = 0;
+    uint8_t *rb = (uint8_t *)calloc(cap, 1);
+    rans_err e;
+
+    d[7] = 9;                                 /* freq[9] == 0 */
+    e = rans_record_encode(d, 64, &tt.t, 16, rb, cap, &rl);
+    CHECK(e == RANS_E_SYMBOL_UNCODABLE, "freq=0 symbol: want "
+          "E_SYMBOL_UNCODABLE got %s", rans_err_name(e));
+
+    d[7] = 200;                               /* out of the nibble alphabet */
+    e = rans_record_encode(d, 64, &tt.t, 16, rb, cap, &rl);
+    CHECK(e == RANS_E_SYMBOL_UNCODABLE, "value 200: want E_SYMBOL_UNCODABLE "
+          "got %s", rans_err_name(e));
+
+    /* stream primitive: masked, so 200 encodes as 200&15 == 8, byte-exact */
+    uint32_t f2[16];
+    for (int s = 0; s < 16; s++) f2[s] = (1u << 14) / 16;
+    test_table t2;
+    tt_build(&t2, 14, f2);
+    uint8_t da[64], db[64], ba[512], bb[512];
+    for (int i = 0; i < 64; i++) da[i] = db[i] = (uint8_t)(rnd() & 15);
+    da[3] = 200; db[3] = 200 & 15;
+    size_t oa = rans_encode_stream(da, 64, t2.t.freq, t2.t.start,
+                                   t2.t.scale_bits, ba, sizeof(ba));
+    size_t ob = rans_encode_stream(db, 64, t2.t.freq, t2.t.start,
+                                   t2.t.scale_bits, bb, sizeof(bb));
+    CHECK(oa == ob && oa != (size_t)-1 &&
+          memcmp(ba + oa, bb + ob, sizeof(ba) - oa) == 0,
+          "stream mask: 200 must encode as 200&15, byte-identical");
+    free(rb);
+    tt_free(&tt); tt_free(&t2);
+}
+
+/* n_streams validation + record-buffer alignment refusals. */
+static void test_nstreams_and_alignment(void) {
+    const uint64_t n = 512;
+    uint8_t *d = (uint8_t *)malloc(n);
+    for (uint64_t i = 0; i < n; i++) d[i] = (uint8_t)(1 + (rnd() % 15));
+    test_table tt;
+    tt_from_hist(&tt, 14, d, n);
+    uint64_t rec_len = 0;
+    uint8_t *buf = make_record(d, n, &tt, RANS_NSTREAMS, &rec_len);
+    rans_record rec;
+    rans_err e;
+
+    CHECK(rans_record_bound(n, 0) == 0, "bound with n_streams=0 returns 0");
+    uint64_t rl = 0;
+    e = rans_record_encode(d, n, &tt.t, 0, buf, rec_len, &rl);
+    CHECK(e == RANS_E_NSTREAMS, "encode n_streams=0: %s", rans_err_name(e));
+    e = rans_record_parse(buf, rec_len, 0, &rec);
+    CHECK(e == RANS_E_NSTREAMS, "parse n_streams=0: %s", rans_err_name(e));
+    CHECK(rans_record_parse(buf, rec_len, RANS_NSTREAMS, &rec) == RANS_OK,
+          "control parse");
+    uint8_t out[256];
+    e = rans_record_decode_packed(&rec, &tt.t, 0, RANS_PATH_SCALAR, out);
+    CHECK(e == RANS_E_NSTREAMS, "decode n_streams=0: %s", rans_err_name(e));
+
+    /* a misaligned record buffer is refused by name, not cast through */
+    uint8_t *mis = (uint8_t *)malloc(rec_len + RANS_SLACK + 1);
+    memcpy(mis + 1, buf, rec_len);
+    e = rans_record_parse(mis + 1, rec_len, RANS_NSTREAMS, &rec);
+    CHECK(e == RANS_E_UNALIGNED, "misaligned blob: %s", rans_err_name(e));
+    free(mis); free(buf); free(d);
+    tt_free(&tt);
+}
+
+/* Band coverage as a checked property of the suite's own rare-symbol
+ * fixture (the runtime selftest asserts the same on its fixture): the
+ * multi-byte renorm band the sabotage exercise proved load-bearing must
+ * actually be visited, or the identity sweep is running blind. */
+static void test_band_coverage(void) {
+    const uint64_t n = 32768;
+    uint8_t *d = (uint8_t *)malloc(n);
+    uint32_t rare[16] = {0};
+    for (int s = 1; s <= 7; s++) rare[s] = 1;
+    for (int s = 8; s <= 14; s++) rare[s] = 3;
+    rare[15] = (1u << 14) - 7 - 21;
+    test_table tt;
+    tt_build(&tt, 14, rare);
+    for (uint64_t i = 0; i < n; i++)
+        d[i] = (uint8_t)((rnd() % 3 == 0) ? 1 + (rnd() % 14) : 15);
+    uint64_t rec_len = 0;
+    uint8_t *buf = make_record(d, n, &tt, RANS_NSTREAMS, &rec_len);
+    rans_record rec;
+    CHECK(rans_record_parse(buf, rec_len, RANS_NSTREAMS, &rec) == RANS_OK,
+          "band fixture parse");
+    uint64_t kb2 = 0, steps = 0;
+    for (uint32_t i = 0; i < RANS_NSTREAMS; i++) {
+        const uint8_t *ptr = rec.payload + rec.stream_offsets[i];
+        const uint8_t *end = rec.payload + rec.stream_offsets[i + 1];
+        uint32_t x = 0;
+        for (int b = 0; b < 4; b++) x = (x << 8) | *ptr++;
+        for (uint64_t j = i; j < rec.n_symbols; j += RANS_NSTREAMS) {
+            uint32_t slot = x & (tt.t.M - 1u);
+            uint32_t s = tt.slot[slot];
+            x = tt.t.freq[s] * (x >> tt.t.scale_bits) + slot - tt.t.start[s];
+            uint32_t kb = 0;
+            while (x < RANS_L) { if (ptr >= end) break; x = (x << 8) | *ptr++; kb++; }
+            if (kb >= 2) kb2++;
+            steps++;
+        }
+    }
+    CHECK(kb2 > steps / 100, "multi-byte renorm band: %llu of %llu steps "
+          "(need > 1%%) — the rare-symbol fixture lost its coverage",
+          (unsigned long long)kb2, (unsigned long long)steps);
+    free(buf); free(d);
+    tt_free(&tt);
+}
+
 int main(void) {
     test_stream_property_suite();
     test_stream_checked_refusals();
@@ -622,6 +849,11 @@ int main(void) {
     test_record_refusals();
     test_arm_identity_suite();
     test_path_envelope();
+    test_header_field_battery();
+    test_encoder_scratch_bound();
+    test_uncodable_input();
+    test_nstreams_and_alignment();
+    test_band_coverage();
     if (failures) {
         printf("test_rans: FAIL (%d)\n", failures);
         return 1;

--- a/c/tests/test_rans.c
+++ b/c/tests/test_rans.c
@@ -1,0 +1,631 @@
+/* rans.h codec + int4-rans256-g0 record oracle.
+ *
+ * A codec has no tolerance band: every check in this file is byte identity.
+ * Covered:
+ *   1. stream round-trip property suite — random and adversarial nibble
+ *      streams (all-zero, all-max, single-symbol, 15-symbol boundary, empty,
+ *      length edges) across several table shapes;
+ *   2. checked-decode invariants: a genuine encoder output always passes
+ *      the state-range / full-consumption / final-state checks, and seeded
+ *      corruptions are refused with a named error;
+ *   3. record framing: encode -> parse -> decode round trip at the format's
+ *      real N=256 plus small-N shapes, and the full named-refusal battery
+ *      (truncation, count mismatch, offset malformations, short streams,
+ *      nonzero padding, trailing garbage);
+ *   4. batched-arm identity: scalar, scalar_bf and every compiled vector arm
+ *      (NEON here, AVX-512 on x86 builds) must produce byte-identical packed
+ *      output on the whole suite — plus the kill-switch and forced-path
+ *      refusal semantics (a forced unavailable arm is an error, never a
+ *      silent downgrade).
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "../rans.h"
+
+static int failures = 0;
+#define CHECK(cond, ...) do { \
+    if (!(cond)) { \
+        failures++; \
+        fprintf(stderr, "FAIL %s:%d: ", __FILE__, __LINE__); \
+        fprintf(stderr, __VA_ARGS__); \
+        fprintf(stderr, "\n"); \
+    } } while (0)
+
+/* xorshift rng, deterministic across platforms */
+static uint64_t rng_state = 0x243F6A8885A308D3ULL;
+static uint32_t rnd(void) {
+    rng_state ^= rng_state << 13;
+    rng_state ^= rng_state >> 7;
+    rng_state ^= rng_state << 17;
+    return (uint32_t)(rng_state >> 32);
+}
+
+/* ---- table construction helpers ---------------------------------------- */
+
+typedef struct {
+    uint32_t scale_bits;
+    uint32_t freq[16], start[16];
+    uint16_t *slot;
+    rans_table t;
+} test_table;
+
+/* Build a valid table for the given frequency spec (must sum to 1<<sb). */
+static void tt_build(test_table *tt, uint32_t sb, const uint32_t *freq) {
+    uint32_t M = 1u << sb;
+    tt->scale_bits = sb;
+    memcpy(tt->freq, freq, sizeof(tt->freq));
+    uint64_t acc = 0;
+    for (int s = 0; s < 16; s++) { tt->start[s] = (uint32_t)acc; acc += freq[s]; }
+    CHECK(acc == M, "table spec must sum to M");
+    tt->slot = (uint16_t *)malloc(sizeof(uint16_t) * M);
+    for (int s = 0; s < 16; s++)
+        for (uint32_t i = 0; i < freq[s]; i++) tt->slot[tt->start[s] + i] = (uint16_t)s;
+    rans_err e = rans_table_init(&tt->t, sb, tt->freq, tt->start, tt->slot);
+    CHECK(e == RANS_OK, "rans_table_init: %s", rans_err_name(e));
+}
+
+/* Build a table from the data's own histogram (largest-remainder-lite: floor
+ * shares + deficit to the most frequent present symbol). Any valid table
+ * round-trips; closeness to optimal is not what these tests measure. */
+static void tt_from_hist(test_table *tt, uint32_t sb, const uint8_t *data, size_t n) {
+    uint32_t M = 1u << sb;
+    uint64_t hist[16] = {0};
+    for (size_t i = 0; i < n; i++) hist[data[i]]++;
+    uint32_t freq[16] = {0};
+    uint32_t used = 0;
+    int top = -1;
+    for (int s = 0; s < 16; s++) {
+        if (!hist[s]) continue;
+        freq[s] = (uint32_t)(hist[s] * M / (n ? n : 1));
+        if (freq[s] == 0) freq[s] = 1;
+        used += freq[s];
+        if (top < 0 || hist[s] > hist[top]) top = s;
+    }
+    if (top < 0) { top = 0; freq[0] = 0; }
+    if (used < M) freq[top] += M - used;
+    else if (used > M) {
+        uint32_t over = used - M;
+        CHECK(freq[top] > over, "histogram quantization underflow");
+        freq[top] -= over;
+    }
+    tt_build(tt, sb, freq);
+}
+
+static void tt_free(test_table *tt) {
+    rans_table_free(&tt->t);
+    free(tt->slot);
+}
+
+static void pack_ref(const uint8_t *nib, uint64_t n, uint8_t *out) {
+    memset(out, 0, (size_t)((n + 1) / 2));
+    for (uint64_t i = 0; i < n; i++)
+        out[i >> 1] |= (uint8_t)(nib[i] << ((i & 1) * 4));
+}
+
+/* ---- 1. stream round-trip property suite -------------------------------- */
+
+static void stream_roundtrip(const uint8_t *data, size_t n, test_table *tt,
+                             const char *label) {
+    size_t cap = n + n / 2 + 4096;
+    uint8_t *buf = (uint8_t *)malloc(cap);
+    uint8_t *dec = (uint8_t *)malloc(n ? n : 1);
+    size_t off = rans_encode_stream(data, n, tt->t.freq, tt->t.start,
+                                    tt->t.scale_bits, buf, cap);
+    CHECK(off != (size_t)-1, "%s: encode overflow", label);
+    if (off != (size_t)-1) {
+        rans_err e = rans_decode_stream_checked(buf + off, cap - off, n,
+                                                tt->t.freq, tt->t.start,
+                                                tt->slot, tt->t.scale_bits, dec);
+        CHECK(e == RANS_OK, "%s: checked decode: %s", label, rans_err_name(e));
+        CHECK(n == 0 || memcmp(data, dec, n) == 0, "%s: round-trip mismatch", label);
+        /* the plain decoder must agree with the checked one */
+        memset(dec, 0xEE, n ? n : 1);
+        int rc = rans_decode_stream(buf + off, cap - off, n, tt->t.freq,
+                                    tt->t.start, tt->slot, tt->t.scale_bits, dec);
+        CHECK(rc == 0, "%s: plain decode rc=%d", label, rc);
+        CHECK(n == 0 || memcmp(data, dec, n) == 0, "%s: plain round-trip", label);
+    }
+    free(buf); free(dec);
+}
+
+static void test_stream_property_suite(void) {
+    const size_t sizes[] = {0, 1, 2, 3, 5, 16, 255, 256, 257, 1000, 4096, 100003};
+    /* random 16-symbol data, uniform table */
+    for (size_t si = 0; si < sizeof(sizes) / sizeof(sizes[0]); si++) {
+        size_t n = sizes[si];
+        uint8_t *d = (uint8_t *)malloc(n ? n : 1);
+        for (size_t i = 0; i < n; i++) d[i] = (uint8_t)(rnd() & 15);
+        uint32_t uni[16];
+        for (int s = 0; s < 16; s++) uni[s] = (1u << 14) / 16;
+        test_table tt;
+        tt_build(&tt, 14, uni);
+        char label[64];
+        snprintf(label, sizeof(label), "uniform n=%zu", n);
+        stream_roundtrip(d, n, &tt, label);
+        tt_free(&tt);
+        /* same data, histogram-matched table */
+        if (n) {
+            tt_from_hist(&tt, 14, d, n);
+            snprintf(label, sizeof(label), "hist n=%zu", n);
+            stream_roundtrip(d, n, &tt, label);
+            tt_free(&tt);
+        }
+        free(d);
+    }
+    /* adversarial patterns at a few sizes */
+    const size_t an = 8192;
+    uint8_t *d = (uint8_t *)malloc(an);
+    test_table tt;
+
+    memset(d, 0, an);                                  /* all-zero */
+    tt_from_hist(&tt, 14, d, an);
+    stream_roundtrip(d, an, &tt, "all-zero");
+    tt_free(&tt);
+
+    memset(d, 15, an);                                 /* all-max */
+    tt_from_hist(&tt, 14, d, an);
+    stream_roundtrip(d, an, &tt, "all-max");
+    tt_free(&tt);
+
+    for (size_t i = 0; i < an; i++) d[i] = 7;          /* single-symbol */
+    uint32_t single[16] = {0};
+    single[7] = 1u << 14;
+    tt_build(&tt, 14, single);
+    stream_roundtrip(d, an, &tt, "single-symbol freq=M");
+    tt_free(&tt);
+
+    /* 15-symbol boundary: value 0 never appears (the real corpus's shape) */
+    for (size_t i = 0; i < an; i++) d[i] = (uint8_t)(1 + (rnd() % 15));
+    tt_from_hist(&tt, 14, d, an);
+    CHECK(tt.t.freq[0] == 0, "15-symbol table keeps freq[0]==0");
+    stream_roundtrip(d, an, &tt, "15-symbol");
+    tt_free(&tt);
+
+    /* highly skewed: symbol 8 dominates, extremes rare (real-ish histogram) */
+    for (size_t i = 0; i < an; i++) {
+        uint32_t r = rnd() % 100;
+        d[i] = (uint8_t)(r < 60 ? 8 : r < 80 ? 7 : r < 90 ? 9 : 1 + (rnd() % 15));
+    }
+    tt_from_hist(&tt, 14, d, an);
+    stream_roundtrip(d, an, &tt, "skewed");
+    tt_free(&tt);
+
+    /* low-resolution table (scale_bits=6) on 16-symbol data */
+    for (size_t i = 0; i < an; i++) d[i] = (uint8_t)(rnd() & 15);
+    tt_from_hist(&tt, 6, d, an);
+    stream_roundtrip(d, an, &tt, "scale_bits=6");
+    tt_free(&tt);
+
+    free(d);
+}
+
+/* ---- 2. checked-decode refusal semantics -------------------------------- */
+
+static void test_stream_checked_refusals(void) {
+    const size_t n = 4096;
+    uint8_t *d = (uint8_t *)malloc(n);
+    for (size_t i = 0; i < n; i++) d[i] = (uint8_t)(1 + (rnd() % 15));
+    test_table tt;
+    tt_from_hist(&tt, 14, d, n);
+    size_t cap = n + n / 2 + 4096;
+    uint8_t *buf = (uint8_t *)malloc(cap);
+    uint8_t *dec = (uint8_t *)malloc(n);
+    size_t off = rans_encode_stream(d, n, tt.t.freq, tt.t.start, tt.t.scale_bits,
+                                    buf, cap);
+    CHECK(off != (size_t)-1, "encode");
+    size_t len = cap - off;
+    uint8_t *stream = buf + off;
+
+    /* truncated to under 4 bytes -> underrun */
+    rans_err e = rans_decode_stream_checked(stream, 3, n, tt.t.freq, tt.t.start,
+                                            tt.slot, tt.t.scale_bits, dec);
+    CHECK(e == RANS_E_STREAM_UNDERRUN, "3-byte stream: got %s", rans_err_name(e));
+
+    /* zeroed initial state -> state range */
+    uint8_t *cp = (uint8_t *)malloc(len);
+    memcpy(cp, stream, len);
+    cp[0] = cp[1] = cp[2] = cp[3] = 0;
+    e = rans_decode_stream_checked(cp, len, n, tt.t.freq, tt.t.start,
+                                   tt.slot, tt.t.scale_bits, dec);
+    CHECK(e == RANS_E_STREAM_STATE_RANGE, "zero state: got %s", rans_err_name(e));
+
+    /* trailing garbage byte -> leftover */
+    uint8_t *cp2 = (uint8_t *)malloc(len + 1);
+    memcpy(cp2, stream, len);
+    cp2[len] = 0x5A;
+    e = rans_decode_stream_checked(cp2, len + 1, n, tt.t.freq, tt.t.start,
+                                   tt.slot, tt.t.scale_bits, dec);
+    CHECK(e == RANS_E_STREAM_LEFTOVER || e == RANS_E_STREAM_FINAL_STATE,
+          "trailing byte: got %s", rans_err_name(e));
+
+    /* single-bit corruption sweep: every flip must be refused (state-range /
+     * leftover / final-state) — a corrupted stream that still PASSES the
+     * checked decode would be a verifier hole, so enumerate, don't sample */
+    int caught = 0, missed = 0;
+    for (size_t bit = 0; bit < len * 8; bit += 7) {   /* stride keeps runtime sane */
+        memcpy(cp, stream, len);
+        cp[bit / 8] ^= (uint8_t)(1u << (bit % 8));
+        e = rans_decode_stream_checked(cp, len, n, tt.t.freq, tt.t.start,
+                                       tt.slot, tt.t.scale_bits, dec);
+        if (e != RANS_OK) caught++;
+        else if (memcmp(dec, d, n) != 0) missed++;    /* passed checks, wrong bytes */
+        else CHECK(0, "bit flip at %zu decoded to the original bytes", bit);
+    }
+    CHECK(missed == 0, "%d corruptions passed the checked decode silently "
+          "(%d refused)", missed, caught);
+
+    free(cp); free(cp2); free(buf); free(dec); free(d);
+    tt_free(&tt);
+}
+
+/* ---- 3. record framing: round trip + refusal battery --------------------- */
+
+static uint8_t *make_record(const uint8_t *nib, uint64_t n, test_table *tt,
+                            uint32_t N, uint64_t *out_len) {
+    uint64_t cap = rans_record_bound(n, N) + RANS_SLACK;
+    uint8_t *buf = (uint8_t *)calloc(cap, 1);
+    rans_err e = rans_record_encode(nib, n, &tt->t, N, buf, cap, out_len);
+    CHECK(e == RANS_OK, "record encode: %s", rans_err_name(e));
+    return buf;
+}
+
+static void record_roundtrip(const uint8_t *nib, uint64_t n, test_table *tt,
+                             uint32_t N, const char *label) {
+    uint64_t rec_len = 0;
+    uint8_t *buf = make_record(nib, n, tt, N, &rec_len);
+    rans_record rec;
+    rans_err e = rans_record_parse(buf, rec_len, N, &rec);
+    CHECK(e == RANS_OK, "%s: parse: %s", label, rans_err_name(e));
+    if (e == RANS_OK) {
+        CHECK(rec.n_symbols == n, "%s: n_symbols", label);
+        CHECK(rec.packed_bytes == (n + 1) / 2, "%s: packed_bytes", label);
+        uint64_t np = rec.packed_bytes;
+        uint8_t *ref = (uint8_t *)malloc(np);
+        uint8_t *got = (uint8_t *)malloc(np);
+        pack_ref(nib, n, ref);
+        memset(got, 0xEE, np);
+        e = rans_record_decode_packed(&rec, &tt->t, N, RANS_PATH_SCALAR, got);
+        CHECK(e == RANS_OK && memcmp(ref, got, np) == 0,
+              "%s: scalar packed decode", label);
+        /* determinism: re-encoding the decoded stream reproduces the record */
+        uint8_t *nib2 = (uint8_t *)malloc(n);
+        for (uint64_t i = 0; i < n; i++)
+            nib2[i] = (uint8_t)((got[i >> 1] >> ((i & 1) * 4)) & 15);
+        uint64_t len2 = 0;
+        uint8_t *buf2 = make_record(nib2, n, tt, N, &len2);
+        CHECK(len2 == rec_len && memcmp(buf, buf2, rec_len) == 0,
+              "%s: re-encode determinism", label);
+        free(buf2); free(nib2); free(ref); free(got);
+    }
+    free(buf);
+}
+
+static void test_record_roundtrip(void) {
+    /* the format's real stream count, on sizes below/at/above N and a
+     * realistically-sized block; odd n exercises the generic path */
+    const uint64_t sizes[] = {1, 2, 100, 255, 256, 257, 512, 8192, 12289, 65536};
+    for (size_t si = 0; si < sizeof(sizes) / sizeof(sizes[0]); si++) {
+        uint64_t n = sizes[si];
+        uint8_t *d = (uint8_t *)malloc(n);
+        for (uint64_t i = 0; i < n; i++) d[i] = (uint8_t)(1 + (rnd() % 15));
+        test_table tt;
+        tt_from_hist(&tt, 14, d, n);
+        char label[64];
+        snprintf(label, sizeof(label), "record N=256 n=%llu", (unsigned long long)n);
+        record_roundtrip(d, n, &tt, RANS_NSTREAMS, label);
+        tt_free(&tt);
+        free(d);
+    }
+    /* small stream counts (kernel widths and non-multiples) */
+    const uint32_t Ns[] = {8, 16, 24, 32};
+    for (size_t ni = 0; ni < sizeof(Ns) / sizeof(Ns[0]); ni++) {
+        uint64_t n = 4096 + 2 * ni;
+        uint8_t *d = (uint8_t *)malloc(n);
+        for (uint64_t i = 0; i < n; i++) d[i] = (uint8_t)(rnd() & 15);
+        test_table tt;
+        tt_from_hist(&tt, 14, d, n);
+        char label[64];
+        snprintf(label, sizeof(label), "record N=%u", Ns[ni]);
+        record_roundtrip(d, n, &tt, Ns[ni], label);
+        tt_free(&tt);
+        free(d);
+    }
+}
+
+static void test_record_refusals(void) {
+    const uint32_t N = RANS_NSTREAMS;
+    const uint64_t n = 8192;
+    uint8_t *d = (uint8_t *)malloc(n);
+    for (uint64_t i = 0; i < n; i++) d[i] = (uint8_t)(1 + (rnd() % 15));
+    test_table tt;
+    tt_from_hist(&tt, 14, d, n);
+    uint64_t rec_len = 0;
+    uint8_t *buf = make_record(d, n, &tt, N, &rec_len);
+    rans_record rec;
+    uint64_t head_raw = 16 + ((uint64_t)N + 1) * 4;   /* before padding */
+    uint64_t head = rans_record_header_bytes(N);
+    uint8_t *cp = (uint8_t *)calloc(rec_len + 16 + RANS_SLACK, 1);
+    rans_err e;
+
+#define EXPECT(err_want, what) do { \
+        e = rans_record_parse(cp, cp_len, N, &rec); \
+        CHECK(e == (err_want), "%s: want %s got %s", what, \
+              rans_err_name(err_want), rans_err_name(e)); \
+    } while (0)
+
+    uint64_t cp_len;
+
+    /* truncated inside the header */
+    memcpy(cp, buf, rec_len); cp_len = head - 1;
+    EXPECT(RANS_E_TRUNCATED, "short header");
+
+    /* truncated inside the payload (cut to a 16-byte boundary so the length
+     * check sees a plausible-but-short record) */
+    memcpy(cp, buf, rec_len); cp_len = head + 16;
+    EXPECT(RANS_E_TRUNCATED, "short payload");
+
+    /* n_symbols = 0 */
+    memcpy(cp, buf, rec_len); cp_len = rec_len;
+    memset(cp, 0, 16);
+    EXPECT(RANS_E_EMPTY, "empty");
+
+    /* packed_bytes disagreeing with n_symbols */
+    memcpy(cp, buf, rec_len); cp_len = rec_len;
+    cp[8] ^= 1;
+    EXPECT(RANS_E_COUNT_MISMATCH, "count mismatch");
+
+    /* offsets[0] != 0 */
+    memcpy(cp, buf, rec_len); cp_len = rec_len;
+    cp[16] = 1;
+    EXPECT(RANS_E_OFFSET_FIRST, "offset[0]");
+
+    /* non-monotonic offsets */
+    memcpy(cp, buf, rec_len); cp_len = rec_len;
+    { uint32_t v; memcpy(&v, cp + 16 + 8 * 4, 4); v += 1u << 20;
+      memcpy(cp + 16 + 8 * 4, &v, 4); }
+    EXPECT(RANS_E_OFFSETS_MONOTONIC, "monotonic");
+
+    /* a stream shorter than its flushed state: collapse stream 3 to 0 bytes */
+    memcpy(cp, buf, rec_len); cp_len = rec_len;
+    { uint32_t v; memcpy(&v, cp + 16 + 3 * 4, 4);
+      memcpy(cp + 16 + 4 * 4, &v, 4); }
+    EXPECT(RANS_E_STREAM_SHORT, "stream short");
+
+    /* final offset larger than the blob -> truncated */
+    memcpy(cp, buf, rec_len); cp_len = rec_len;
+    { uint32_t v; memcpy(&v, cp + 16 + (uint64_t)N * 4, 4); v += 4096;
+      memcpy(cp + 16 + (uint64_t)N * 4, &v, 4); }
+    EXPECT(RANS_E_TRUNCATED, "offsets out of bounds");
+
+    /* trailing garbage past the derived record end */
+    memcpy(cp, buf, rec_len); cp_len = rec_len + 16;
+    EXPECT(RANS_E_LENGTH_MISMATCH, "trailing garbage");
+
+    /* nonzero header padding */
+    memcpy(cp, buf, rec_len); cp_len = rec_len;
+    CHECK(head > head_raw, "N=256 framing leaves header pad bytes");
+    cp[head_raw] = 0x77;
+    EXPECT(RANS_E_PAD_NONZERO, "header pad");
+
+    /* nonzero payload padding (only if this record has any) */
+    memcpy(cp, buf, rec_len); cp_len = rec_len;
+    { uint32_t plen; memcpy(&plen, cp + 16 + (uint64_t)N * 4, 4);
+      if (rec_len > head + plen) {
+          cp[head + plen] = 0x77;
+          EXPECT(RANS_E_PAD_NONZERO, "payload pad");
+      } }
+
+#undef EXPECT
+
+    /* table validation refusals */
+    {
+        rans_table t2;
+        uint32_t bad_freq[16];
+        memcpy(bad_freq, tt.freq, sizeof(bad_freq));
+        bad_freq[15] += 1;   /* sum != M (last symbol: start[] stays coherent,
+                                so the sum check is what fires) */
+        e = rans_table_init(&t2, tt.scale_bits, bad_freq, tt.start, tt.slot);
+        CHECK(e == RANS_E_TABLE_FREQ_SUM, "freq sum: %s", rans_err_name(e));
+
+        uint32_t bad_start[16];
+        memcpy(bad_start, tt.start, sizeof(bad_start));
+        bad_start[5] += 1;                             /* not the prefix sum */
+        e = rans_table_init(&t2, tt.scale_bits, tt.freq, bad_start, tt.slot);
+        CHECK(e == RANS_E_TABLE_START, "start prefix: %s", rans_err_name(e));
+
+        uint32_t M = 1u << tt.scale_bits;
+        uint16_t *bad_slot = (uint16_t *)malloc(sizeof(uint16_t) * M);
+        memcpy(bad_slot, tt.slot, sizeof(uint16_t) * M);
+        bad_slot[M / 2] = 16;                          /* symbol out of range */
+        e = rans_table_init(&t2, tt.scale_bits, tt.freq, tt.start, bad_slot);
+        CHECK(e == RANS_E_TABLE_SLOT, "slot range: %s", rans_err_name(e));
+        memcpy(bad_slot, tt.slot, sizeof(uint16_t) * M);
+        bad_slot[0] = tt.slot[M - 1];                  /* slot outside its band */
+        e = rans_table_init(&t2, tt.scale_bits, tt.freq, tt.start, bad_slot);
+        CHECK(e == RANS_E_TABLE_SLOT, "slot band: %s", rans_err_name(e));
+        free(bad_slot);
+
+        e = rans_table_init(&t2, 0, tt.freq, tt.start, tt.slot);
+        CHECK(e == RANS_E_TABLE_SCALE, "scale 0: %s", rans_err_name(e));
+    }
+
+    free(cp); free(buf); free(d);
+    tt_free(&tt);
+}
+
+/* ---- 4. batched-arm byte identity --------------------------------------- */
+
+static void arms_identity(const uint8_t *nib, uint64_t n, test_table *tt,
+                          uint32_t N, const char *label) {
+    uint64_t rec_len = 0;
+    uint8_t *buf = make_record(nib, n, tt, N, &rec_len);
+    rans_record rec;
+    rans_err e = rans_record_parse(buf, rec_len, N, &rec);
+    CHECK(e == RANS_OK, "%s: parse: %s", label, rans_err_name(e));
+    uint64_t np = (n + 1) / 2;
+    uint8_t *ref = (uint8_t *)malloc(np);
+    uint8_t *got = (uint8_t *)malloc(np);
+    pack_ref(nib, n, ref);
+
+    const rans_path arms[] = {RANS_PATH_SCALAR, RANS_PATH_SCALAR_BF,
+                              RANS_PATH_NEON, RANS_PATH_AVX512};
+    for (size_t a = 0; a < sizeof(arms) / sizeof(arms[0]); a++) {
+        rans_path p = arms[a];
+        memset(got, 0xEE, np);
+        e = rans_record_decode_packed(&rec, &tt->t, N, p, got);
+        if (e == RANS_E_PATH_UNAVAILABLE) {
+            /* arm not compiled into this build: refusal (never a silent
+             * scalar run) is exactly the required behavior */
+            int compiled = 1;
+#ifndef __ARM_NEON
+            if (p == RANS_PATH_NEON) compiled = 0;
+#endif
+#if !(defined(__AVX512F__) && defined(__AVX512BW__))
+            if (p == RANS_PATH_AVX512) compiled = 0;
+#endif
+            CHECK(!compiled, "%s: %s refused despite being compiled",
+                  label, rans_path_name(p));
+            continue;
+        }
+        CHECK(e == RANS_OK, "%s: %s decode: %s", label, rans_path_name(p),
+              rans_err_name(e));
+        CHECK(memcmp(ref, got, np) == 0,
+              "%s: %s output differs from packed reference", label,
+              rans_path_name(p));
+    }
+    free(ref); free(got); free(buf);
+}
+
+static void test_arm_identity_suite(void) {
+    /* size sweep at the real N: even sizes drive the group kernels + tails,
+     * odd sizes the generic path; per-stream lengths straddle the kernels'
+     * full-round/tail boundaries */
+    const uint64_t sizes[] = {256, 512, 4096, 4098, 8192, 12288, 12289,
+                              65536, 262144, 262146};
+    for (size_t si = 0; si < sizeof(sizes) / sizeof(sizes[0]); si++) {
+        uint64_t n = sizes[si];
+        uint8_t *d = (uint8_t *)malloc(n);
+        for (uint64_t i = 0; i < n; i++) d[i] = (uint8_t)(1 + (rnd() % 15));
+        test_table tt;
+        tt_from_hist(&tt, 14, d, n);
+        char label[64];
+        snprintf(label, sizeof(label), "arms n=%llu", (unsigned long long)n);
+        arms_identity(d, n, &tt, RANS_NSTREAMS, label);
+        tt_free(&tt);
+        free(d);
+    }
+    /* adversarial content through the arms too */
+    const uint64_t an = 32768;
+    uint8_t *d = (uint8_t *)malloc(an);
+    test_table tt;
+    memset(d, 0, an);
+    tt_from_hist(&tt, 14, d, an);
+    arms_identity(d, an, &tt, RANS_NSTREAMS, "arms all-zero");
+    tt_free(&tt);
+    memset(d, 15, an);
+    tt_from_hist(&tt, 14, d, an);
+    arms_identity(d, an, &tt, RANS_NSTREAMS, "arms all-max");
+    tt_free(&tt);
+    for (uint64_t i = 0; i < an; i++) d[i] = 9;
+    uint32_t single[16] = {0};
+    single[9] = 1u << 14;
+    tt_build(&tt, 14, single);
+    arms_identity(d, an, &tt, RANS_NSTREAMS, "arms single-symbol");
+    tt_free(&tt);
+
+    /* rare-symbol table: low-frequency outliers force the decoder through
+     * post-update states far below RANS_L, where the renorm has to refill 2+
+     * bytes at once — comfortable tables never visit the [2^14, 2^15) band,
+     * so a renorm-threshold off-by-one in a vector arm is invisible without
+     * this case. Power-of-two freqs alone do NOT reach it either (the shift
+     * algebra keeps floor(log2 x) on a rigid lattice, measured directly);
+     * the f=3 group is what actually populates the band (~3% of steps).
+     * Found by the deliberate-sabotage exercise; keep forever. */
+    uint32_t rare[16] = {0};
+    for (int s = 1; s <= 7; s++) rare[s] = 1;
+    for (int s = 8; s <= 14; s++) rare[s] = 3;
+    rare[15] = (1u << 14) - 7 - 21;
+    tt_build(&tt, 14, rare);
+    for (uint64_t i = 0; i < an; i++)
+        d[i] = (uint8_t)((rnd() % 3 == 0) ? 1 + (rnd() % 14) : 15);
+    arms_identity(d, an, &tt, RANS_NSTREAMS, "arms rare-symbol");
+    stream_roundtrip(d, an, &tt, "rare-symbol stream");
+    tt_free(&tt);
+    free(d);
+}
+
+static void test_path_envelope(void) {
+#ifdef _WIN32
+    _putenv_s("RANS_PATH", ""); _putenv_s("RANS_NEON", ""); _putenv_s("RANS_AVX512", "");
+#else
+    unsetenv("RANS_PATH"); unsetenv("RANS_NEON"); unsetenv("RANS_AVX512");
+#endif
+    /* default selection is never invalid, and its name is real */
+    rans_path best = rans_path_select();
+    CHECK(best != RANS_PATH_INVALID, "default path select");
+    CHECK(strcmp(rans_path_name(best), "invalid") != 0, "best path name");
+
+    /* kill-switches force the vector arms out of best-path selection */
+#ifdef _WIN32
+#define SET_ENV(k, v) _putenv_s(k, v)
+#define UNSET_ENV(k) _putenv_s(k, "")
+#else
+#define SET_ENV(k, v) setenv(k, v, 1)
+#define UNSET_ENV(k) unsetenv(k)
+#endif
+    SET_ENV("RANS_NEON", "0");
+    SET_ENV("RANS_AVX512", "0");
+    rans_path p = rans_path_select();
+    CHECK(p == RANS_PATH_SCALAR_BF, "kill-switches leave scalar_bf, got %s",
+          rans_path_name(p));
+
+    /* forcing a killed arm must refuse, not downgrade */
+    SET_ENV("RANS_PATH", "neon");
+    p = rans_path_select();
+    CHECK(p == RANS_PATH_INVALID, "forced killed neon: got %s", rans_path_name(p));
+    SET_ENV("RANS_PATH", "avx512");
+    p = rans_path_select();
+    CHECK(p == RANS_PATH_INVALID, "forced killed avx512: got %s", rans_path_name(p));
+
+    /* unknown forced name refuses */
+    SET_ENV("RANS_PATH", "warp-drive");
+    p = rans_path_select();
+    CHECK(p == RANS_PATH_INVALID, "unknown forced path");
+
+    /* forcing scalar always works */
+    SET_ENV("RANS_PATH", "scalar");
+    p = rans_path_select();
+    CHECK(p == RANS_PATH_SCALAR, "forced scalar");
+
+    UNSET_ENV("RANS_PATH");
+    UNSET_ENV("RANS_NEON");
+    UNSET_ENV("RANS_AVX512");
+
+    /* with the switches cleared, any compiled+selftested vector arm is
+     * preferred over the scalar twins */
+#ifdef __ARM_NEON
+    p = rans_path_select();
+    CHECK(p == RANS_PATH_NEON || p == RANS_PATH_AVX512,
+          "vector arm preferred on this build, got %s", rans_path_name(p));
+#endif
+#undef SET_ENV
+#undef UNSET_ENV
+}
+
+int main(void) {
+    test_stream_property_suite();
+    test_stream_checked_refusals();
+    test_record_roundtrip();
+    test_record_refusals();
+    test_arm_identity_suite();
+    test_path_envelope();
+    if (failures) {
+        printf("test_rans: FAIL (%d)\n", failures);
+        return 1;
+    }
+    printf("test_rans: ok\n");
+    return 0;
+}

--- a/c/tests/test_rans_repack.py
+++ b/c/tests/test_rans_repack.py
@@ -1,0 +1,263 @@
+"""int4-rans256-g0 offline-tool e2e: repack_rans.py + rans_verify.py against
+synthetic per-row-int4 fixtures.
+
+Covers the tool-level contract the C oracle (test_rans.c) cannot see:
+  - end-to-end lossless round trip through real shard files (original weight
+    bytes reproduced exactly; .qs sidecars byte-identical pass-through);
+  - writer determinism (two runs diff clean, including a C-codec run vs a
+    forced pure-Python run — the two implementations must emit identical
+    bytes, not just equivalent ones);
+  - the MANDATORY stamp + per-shard table metadata shape;
+  - the verifier's named-refusal battery: every corruption class produces
+    its class, enumerated not sampled;
+  - writer-side geometry refusals (g64-signature and missing-scales inputs
+    are refused by name, never silently entropy-coded).
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+np = None
+rf = None
+try:
+    import numpy as np
+
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
+    import rans_format as rf
+except ImportError:  # pragma: no cover - dependency-free CI skips these
+    pass
+
+TOOLS = Path(__file__).resolve().parent.parent / "tools"
+
+
+def run_tool(script, *args, env_extra=None):
+    env = dict(os.environ)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run([sys.executable, str(TOOLS / script), *args],
+                          capture_output=True, text=True, env=env)
+
+
+@unittest.skipIf(rf is None, "numpy not available (offline-tooling test)")
+class TestRansRepack(unittest.TestCase):
+    O, I = 8, 128           # per-row ratio I/2 = 64 (safely above the g64 signature)
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.indir = self.root / "int4"
+        self.indir.mkdir()
+        rng = np.random.default_rng(42)
+        self.weights = {}
+        tensors_a, tensors_b = [], []
+        wb = self.O * self.I // 2
+        for e in range(3):
+            for proj in ("gate", "up", "down"):
+                name = f"model.layers.0.mlp.experts.{e}.{proj}_proj.weight"
+                # skewed 15-symbol nibbles (value 0 never used, like the corpus)
+                nib = rng.choice(
+                    np.arange(1, 16, dtype=np.uint8), size=wb * 2,
+                    p=np.array([30, 5, 4, 3, 3, 2, 2, 20, 10, 6, 5, 4, 3, 2, 1],
+                               dtype=np.float64) / 100.0)
+                raw = rf.pack_nibbles(nib)
+                qs = rng.standard_normal(self.O).astype(np.float32).tobytes()
+                self.weights[name] = (raw, qs)
+                tensors_a.append((name, "U8", [wb], raw))
+                # one expert's sidecars live in a SECOND shard: the tool must
+                # find them through its corpus-wide index
+                (tensors_b if e == 2 else tensors_a).append(
+                    (name + ".qs", "F32", [self.O], qs))
+        tensors_a.append(("model.norm.weight", "F32", [4],
+                          np.ones(4, dtype=np.float32).tobytes()))
+        rf.write_shard(str(self.indir / "out-00000.safetensors"), tensors_a, {})
+        rf.write_shard(str(self.indir / "out-00001.safetensors"), tensors_b, {})
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def repack(self, outdir, **env):
+        r = run_tool("repack_rans.py", "--indir", str(self.indir),
+                     "--outdir", str(outdir), env_extra=env or None)
+        self.assertEqual(r.returncode, 0, msg=r.stdout + r.stderr)
+        return sorted(Path(outdir).glob("*.safetensors"))
+
+    def test_roundtrip_stamp_and_determinism(self):
+        out1 = self.repack(self.root / "out1")
+        self.assertEqual(len(out1), 1)      # only shard A holds weight tensors
+        header, data_start = rf.read_header(str(out1[0]))
+        meta = header["__metadata__"]
+
+        # MANDATORY stamp + table metadata
+        fmt_map = json.loads(meta[rf.METADATA_KEY])
+        self.assertEqual(sorted(fmt_map), sorted(self.weights))
+        self.assertTrue(all(v == rf.FORMAT_NAME for v in fmt_map.values()))
+        table = rf.parse_table_blob(meta[rf.TABLE_KEY])
+        self.assertEqual(table["table_id"], rf.TABLE_ID)
+        self.assertEqual(int(table["freq"][0]), 0)   # 15-symbol corpus shape
+
+        # byte-exact round trip + raw .qs pass-through
+        for name, (raw, qs) in self.weights.items():
+            blob, _ = rf.read_tensor_bytes(str(out1[0]), header, data_start, name)
+            self.assertEqual(rf.decode_record(blob, table), raw, name)
+            qblob, _ = rf.read_tensor_bytes(str(out1[0]), header, data_start,
+                                            name + ".qs")
+            self.assertEqual(qblob, qs, name + ".qs")
+
+        # determinism: an independent second run is byte-identical
+        out2 = self.repack(self.root / "out2")
+        self.assertEqual(out1[0].read_bytes(), out2[0].read_bytes())
+
+        # implementation identity: a forced pure-Python run emits the SAME
+        # bytes as the (lib-backed, when built) default run
+        out3 = self.repack(self.root / "out3", RANS_FORCE_PYTHON="1")
+        self.assertEqual(out1[0].read_bytes(), out3[0].read_bytes())
+
+        # the validator trusts it
+        r = run_tool("rans_verify.py", str(out1[0]))
+        self.assertEqual(r.returncode, 0, msg=r.stdout + r.stderr)
+        self.assertIn("RESULT: TRUST", r.stdout)
+
+    def _reshard(self, shard, meta_mutator=None, tensor_mutator=None):
+        """Read a shard fully, apply mutators, rewrite it deterministically."""
+        header, data_start = rf.read_header(str(shard))
+        meta = dict(header["__metadata__"])
+        tensors = []
+        for name, info in header.items():
+            if name == "__metadata__":
+                continue
+            blob, _ = rf.read_tensor_bytes(str(shard), header, data_start, name)
+            if tensor_mutator:
+                blob = tensor_mutator(name, bytearray(blob))
+            tensors.append((name, info["dtype"], info["shape"], bytes(blob)))
+        if meta_mutator:
+            meta = meta_mutator(meta)
+        rf.write_shard(str(shard), tensors, meta)
+
+    def _corrupt_reshard_and_expect(self, expected_code, meta_mutator=None,
+                                    tensor_mutator=None):
+        outdir = self.root / f"corrupt_{expected_code}"
+        shard = self.repack(outdir)[0]
+        self._reshard(shard, meta_mutator, tensor_mutator)
+        r = run_tool("rans_verify.py", str(shard))
+        self.assertEqual(r.returncode, 1,
+                         msg=f"{expected_code}: verifier did not refuse\n"
+                             f"{r.stdout}{r.stderr}")
+        self.assertIn(expected_code, r.stdout,
+                      msg=f"wanted {expected_code} in:\n{r.stdout}")
+
+    def test_refusal_battery(self):
+        target = "model.layers.0.mlp.experts.0.gate_proj.weight"
+
+        def flip_payload(name, blob):
+            if name == target:
+                blob[rf.record_header_bytes() + 5] ^= 0x10   # payload corruption
+            return blob
+
+        def flip_count(name, blob):
+            if name == target:
+                blob[8] ^= 1                                  # packed_bytes field
+            return blob
+
+        def break_offsets(name, blob):
+            if name == target:
+                blob[16 + 8 * 4] ^= 0x80                      # offsets landmine
+            return blob
+
+        def truncate(name, blob):
+            if name == target:
+                del blob[len(blob) - 16:]                     # drop final 16 bytes
+            return blob
+
+        def pad_dirt(name, blob):
+            if name == target:
+                blob[16 + (rf.N_STREAMS + 1) * 4] = 0x77      # header pad byte
+            return blob
+
+        def drop_stamp(meta):
+            del meta[rf.METADATA_KEY]
+            return meta
+
+        def drop_table(meta):
+            del meta[rf.TABLE_KEY]
+            return meta
+
+        def break_crc(meta):
+            blob = json.loads(meta[rf.TABLE_KEY])
+            blob["table_crc32"] = "00000000"
+            meta[rf.TABLE_KEY] = json.dumps(blob, sort_keys=True)
+            return meta
+
+        def break_freq(meta):
+            blob = json.loads(meta[rf.TABLE_KEY])
+            blob["freq"][15] += 1
+            meta[rf.TABLE_KEY] = json.dumps(blob, sort_keys=True)
+            return meta
+
+        def dangling_stamp(meta):
+            fmt = json.loads(meta[rf.METADATA_KEY])
+            fmt["model.layers.0.mlp.experts.99.gate_proj.weight"] = rf.FORMAT_NAME
+            meta[rf.METADATA_KEY] = json.dumps(fmt, sort_keys=True)
+            return meta
+
+        # payload corruption trips a stream invariant or the re-encode pin;
+        # both are refusals — assert on the shared prefix
+        self._corrupt_reshard_and_expect("E_", tensor_mutator=flip_payload)
+        self._corrupt_reshard_and_expect("E_COUNT_MISMATCH",
+                                         tensor_mutator=flip_count)
+        self._corrupt_reshard_and_expect("E_", tensor_mutator=break_offsets)
+        self._corrupt_reshard_and_expect("E_", tensor_mutator=truncate)
+        self._corrupt_reshard_and_expect("E_PAD_NONZERO", tensor_mutator=pad_dirt)
+        self._corrupt_reshard_and_expect("E_STAMP_MISSING", meta_mutator=drop_stamp)
+        self._corrupt_reshard_and_expect("E_TABLE_MISSING", meta_mutator=drop_table)
+        self._corrupt_reshard_and_expect("E_TABLE_CRC", meta_mutator=break_crc)
+        self._corrupt_reshard_and_expect("E_TABLE_FREQ_SUM", meta_mutator=break_freq)
+        self._corrupt_reshard_and_expect("E_STAMP_DANGLING",
+                                         meta_mutator=dangling_stamp)
+
+    def test_geometry_refusals(self):
+        # g64 signature: weight/scale ratio exactly 32 -> named refusal
+        g64dir = self.root / "g64"
+        g64dir.mkdir()
+        wb = 2048
+        rows = wb // 32
+        rf.write_shard(str(g64dir / "out-00000.safetensors"), [
+            ("model.layers.0.mlp.experts.0.gate_proj.weight", "U8", [wb],
+             bytes(wb)),
+            ("model.layers.0.mlp.experts.0.gate_proj.weight.qs", "F32", [rows],
+             bytes(rows * 4)),
+        ], {})
+        r = run_tool("repack_rans.py", "--indir", str(g64dir),
+                     "--outdir", str(self.root / "g64out"))
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("E_GEOMETRY_G64", r.stderr)
+
+        # missing .qs sidecar -> named refusal
+        nsdir = self.root / "noscales"
+        nsdir.mkdir()
+        rf.write_shard(str(nsdir / "out-00000.safetensors"), [
+            ("model.layers.0.mlp.experts.0.gate_proj.weight", "U8", [64],
+             bytes(64)),
+        ], {})
+        r = run_tool("repack_rans.py", "--indir", str(nsdir),
+                     "--outdir", str(self.root / "nsout"))
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("E_GEOMETRY_NO_SCALES", r.stderr)
+
+        # nothing selected -> loud error, no silent empty container
+        emptydir = self.root / "empty"
+        emptydir.mkdir()
+        rf.write_shard(str(emptydir / "out-00000.safetensors"), [
+            ("model.norm.weight", "F32", [4], bytes(16)),
+        ], {})
+        r = run_tool("repack_rans.py", "--indir", str(emptydir),
+                     "--outdir", str(self.root / "emptyout"))
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("refusing to emit an empty container", r.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tests/test_rans_repack.py
+++ b/c/tests/test_rans_repack.py
@@ -140,7 +140,13 @@ class TestRansRepack(unittest.TestCase):
         self.assertIn("RESULT: TRUST", r.stdout)
 
     def _reshard(self, shard, meta_mutator=None, tensor_mutator=None):
-        """Read a shard fully, apply mutators, rewrite it deterministically."""
+        """Read a shard fully, apply mutators, rewrite it deterministically.
+        Drops the manifest sitting next to it: the battery tests the
+        PER-RECORD layer, which must hold even when an attacker removes the
+        whole-artifact manifest (digest tampering has its own test)."""
+        manifest = shard.parent / "repack-manifest.json"
+        if manifest.exists():
+            manifest.unlink()
         header, data_start = rf.read_header(str(shard))
         meta = dict(header["__metadata__"])
         tensors = []
@@ -470,6 +476,138 @@ class TestRansRepack(unittest.TestCase):
         self.assertTrue(manifest.exists())
         fresh = self.repack(self.root / "partial_fresh")
         self.assertEqual(shards[0].read_bytes(), fresh[0].read_bytes())
+
+    def test_manifest_digests(self):
+        """Whole-artifact digest layer: mint-time digests verify green; a
+        tampered record bites as E_DIGEST_MISMATCH; retro --manifest-only
+        reproduces the mint manifest byte-for-byte; a digest-less manifest
+        (older mint) means note-and-proceed, never an error."""
+        import hashlib
+        out = self.root / "digests"
+        shard = self.repack(out)[0]
+        manifest = out / "repack-manifest.json"
+        man = json.loads(manifest.read_text())
+
+        # every weight record has a digest, and it matches the bytes on disk;
+        # the whole-file sha256 matches the complete shard bytes
+        header, data_start = rf.read_header(str(shard))
+        recs = man["shards"][0]["records"]
+        self.assertEqual(sorted(recs), sorted(self.weights))
+        for name, want in recs.items():
+            blob, _ = rf.read_tensor_bytes(str(shard), header, data_start, name)
+            self.assertEqual(hashlib.sha256(blob).hexdigest(), want, name)
+        self.assertEqual(man["shards"][0]["sha256"],
+                         hashlib.sha256(shard.read_bytes()).hexdigest())
+
+        # verify green, and it says both digest layers were actually checked
+        r = run_tool("rans_verify.py", str(shard))
+        self.assertEqual(r.returncode, 0, msg=r.stdout + r.stderr)
+        self.assertIn("file digest checked", r.stdout)
+        self.assertIn("record digests checked", r.stdout)
+
+        # retro equivalence: --manifest-only over the minted dir must
+        # reproduce the manifest byte-for-byte (fields preserved, digests
+        # recomputed identical)
+        mint_bytes = manifest.read_bytes()
+        r = run_tool("repack_rans.py", "--manifest-only", str(out))
+        self.assertEqual(r.returncode, 0, msg=r.stdout + r.stderr)
+        self.assertEqual(manifest.read_bytes(), mint_bytes)
+
+        # retro from scratch (manifest deleted): digests must equal the
+        # mint-time ones; provenance-only fields (source) are unknowable
+        manifest.unlink()
+        r = run_tool("repack_rans.py", "--manifest-only", str(out))
+        self.assertEqual(r.returncode, 0, msg=r.stdout + r.stderr)
+        # provenance loss is visible in output, not just by field absence
+        self.assertIn("provenance is unknowable in retro mode", r.stderr)
+        man2 = json.loads(manifest.read_text())
+        self.assertEqual(man2["shards"][0]["records"], recs)
+        self.assertEqual(man2["shards"][0]["sha256"], man["shards"][0]["sha256"])
+        self.assertEqual(man2["table_crc32"], man["table_crc32"])
+        r = run_tool("rans_verify.py", str(shard))
+        self.assertEqual(r.returncode, 0, msg=r.stdout + r.stderr)
+
+        # tamper bite A: flip one payload byte of a digested record IN THE
+        # SHARD FILE (manifest untouched) -> the whole-file gate fires AND
+        # the per-record layer localizes it to the tensor
+        target = sorted(recs)[0]
+        b, e = header[target]["data_offsets"]
+        raw = bytearray(shard.read_bytes())
+        raw[data_start + b + rf.record_header_bytes() + 3] ^= 0x40
+        shard.write_bytes(bytes(raw))
+        r = run_tool("rans_verify.py", str(shard))
+        self.assertEqual(r.returncode, 1, msg=r.stdout)
+        self.assertIn("E_SHARD_DIGEST_MISMATCH", r.stdout)
+        self.assertIn("E_DIGEST_MISMATCH", r.stdout)
+
+        # tamper bite B — the exact gap the whole-file hash closes: flip a
+        # byte inside a .qs SIDECAR (raw passthrough; not covered by any
+        # record digest or record invariant). Only the file-level gate can
+        # see it: E_SHARD_DIGEST_MISMATCH fires, and NO record-level digest
+        # refusal appears (every record is intact)
+        raw[data_start + b + rf.record_header_bytes() + 3] ^= 0x40  # restore
+        qs_b, qs_e = header[target + ".qs"]["data_offsets"]
+        raw[data_start + qs_b + 1] ^= 0x01
+        shard.write_bytes(bytes(raw))
+        r = run_tool("rans_verify.py", str(shard))
+        self.assertEqual(r.returncode, 1, msg=r.stdout)
+        self.assertIn("E_SHARD_DIGEST_MISMATCH", r.stdout)
+        self.assertNotIn("E_DIGEST_MISMATCH:", r.stdout.replace(
+            "E_SHARD_DIGEST_MISMATCH:", ""))
+        raw[data_start + qs_b + 1] ^= 0x01                          # restore
+        shard.write_bytes(bytes(raw))
+
+        # backward compat: a manifest WITHOUT digest evidence (older mint)
+        # is note-and-proceed
+        for entry in man["shards"]:
+            del entry["records"]
+            del entry["sha256"]
+        manifest.write_text(json.dumps(man, indent=1, sort_keys=True))
+        r = run_tool("rans_verify.py", str(shard))
+        self.assertEqual(r.returncode, 0, msg=r.stdout + r.stderr)
+        self.assertIn("carries no digests", r.stdout)
+        self.assertIn("file digest unavailable", r.stdout)
+        self.assertIn("record digests unavailable", r.stdout)
+
+        # degraded mid-state: file sha present, records absent -> the file
+        # gate still runs (green here), record layer notes-and-skips
+        for entry, src in zip(man["shards"], man2["shards"]):
+            entry["sha256"] = src["sha256"]
+        manifest.write_text(json.dumps(man, indent=1, sort_keys=True))
+        r = run_tool("rans_verify.py", str(shard))
+        self.assertEqual(r.returncode, 0, msg=r.stdout + r.stderr)
+        self.assertIn("file digest checked", r.stdout)
+        self.assertIn("no record digests", r.stdout)
+
+        # a corrupt manifest is refused by name, not skipped
+        manifest.write_text("{not json")
+        r = run_tool("rans_verify.py", str(shard))
+        self.assertEqual(r.returncode, 1, msg=r.stdout)
+        self.assertIn("E_MANIFEST_MALFORMED", r.stdout)
+        self.assertNotIn("Traceback", r.stderr)
+
+        # malformed-typed digest fields must be malformation even when the
+        # malformation removes ALL digest evidence — an entry whose only
+        # digest fields are wrong-typed must never be classed as a
+        # digest-less older mint (note + TRUST)
+        for corpse in (
+            {"shards": [{"file": shard.name, "sha256": 12345}]},
+            {"shards": [{"file": shard.name, "records": ["a"]}]},
+        ):
+            manifest.write_text(json.dumps(corpse, sort_keys=True))
+            r = run_tool("rans_verify.py", str(shard))
+            self.assertEqual(r.returncode, 1, msg=f"{corpse}\n{r.stdout}")
+            self.assertIn("E_MANIFEST_MALFORMED", r.stdout, msg=str(corpse))
+            self.assertNotIn("RESULT: TRUST", r.stdout, msg=str(corpse))
+            self.assertNotIn("Traceback", r.stderr, msg=str(corpse))
+
+        # digests present but this shard missing from the set -> refusal
+        manifest.write_text(json.dumps(
+            {"shards": [{"file": "out-rans-99999.safetensors",
+                         "records": {"x": "0" * 64}}]}, sort_keys=True))
+        r = run_tool("rans_verify.py", str(shard))
+        self.assertEqual(r.returncode, 1, msg=r.stdout)
+        self.assertIn("E_DIGEST_MISSING", r.stdout)
 
     def test_quantize_freq_ties_and_termination(self):
         """Exact fractional-remainder ties must break identically everywhere

--- a/c/tests/test_rans_repack.py
+++ b/c/tests/test_rans_repack.py
@@ -44,7 +44,8 @@ def run_tool(script, *args, env_extra=None):
 
 @unittest.skipIf(rf is None, "numpy not available (offline-tooling test)")
 class TestRansRepack(unittest.TestCase):
-    O, I = 8, 128           # per-row ratio I/2 = 64 (safely above the g64 signature)
+    O, I = 8, 256           # per-row ratio I/2 = 128, above every grouped
+                            # signature (32 = g64, 64 = g128/ambiguous)
 
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
@@ -107,14 +108,31 @@ class TestRansRepack(unittest.TestCase):
                                             name + ".qs")
             self.assertEqual(qblob, qs, name + ".qs")
 
-        # determinism: an independent second run is byte-identical
+        # determinism: an independent second run is byte-identical, manifest
+        # (the completion marker) included
         out2 = self.repack(self.root / "out2")
         self.assertEqual(out1[0].read_bytes(), out2[0].read_bytes())
+        self.assertEqual(
+            (out1[0].parent / "repack-manifest.json").read_bytes(),
+            (out2[0].parent / "repack-manifest.json").read_bytes())
 
         # implementation identity: a forced pure-Python run emits the SAME
-        # bytes as the (lib-backed, when built) default run
+        # bytes as the C-bridge run. VACUOUS unless the bridge is actually
+        # loaded, so that is asserted — `make test-python` builds the bridge;
+        # a direct unittest invocation without it skips LOUDLY instead of
+        # green-lighting a pin it never checked.
+        if rf.LIB is None:
+            self.skipTest("tools/librans_c not built (run `make rans`): "
+                          "the C-vs-Python byte-identity pin was NOT checked")
         out3 = self.repack(self.root / "out3", RANS_FORCE_PYTHON="1")
         self.assertEqual(out1[0].read_bytes(), out3[0].read_bytes())
+
+        # bridge-presence: the default run must actually have used the C
+        # codec (not fallen back to Python with the lib sitting there)
+        r = run_tool("repack_rans.py", "--indir", str(self.indir),
+                     "--outdir", str(self.root / "outdry"), "--dry-run")
+        self.assertEqual(r.returncode, 0, msg=r.stdout + r.stderr)
+        self.assertIn("codec: C (librans_c)", r.stdout)
 
         # the validator trusts it
         r = run_tool("rans_verify.py", str(out1[0]))
@@ -137,9 +155,12 @@ class TestRansRepack(unittest.TestCase):
             meta = meta_mutator(meta)
         rf.write_shard(str(shard), tensors, meta)
 
+    _corrupt_seq = 0
+
     def _corrupt_reshard_and_expect(self, expected_code, meta_mutator=None,
                                     tensor_mutator=None):
-        outdir = self.root / f"corrupt_{expected_code}"
+        TestRansRepack._corrupt_seq += 1
+        outdir = self.root / f"corrupt_{TestRansRepack._corrupt_seq}_{expected_code}"
         shard = self.repack(outdir)[0]
         self._reshard(shard, meta_mutator, tensor_mutator)
         r = run_tool("rans_verify.py", str(shard))
@@ -177,6 +198,15 @@ class TestRansRepack(unittest.TestCase):
                 blob[16 + (rf.N_STREAMS + 1) * 4] = 0x77      # header pad byte
             return blob
 
+        def bomb_header(name, blob):
+            if name == target:
+                # n_symbols = 2^40 with a consistent packed_bytes: the
+                # "oversize fields" class the spec names — must refuse as
+                # E_OVERSIZE, never an allocator traceback
+                blob[0:8] = (1 << 40).to_bytes(8, "little")
+                blob[8:16] = (1 << 39).to_bytes(8, "little")
+            return blob
+
         def drop_stamp(meta):
             del meta[rf.METADATA_KEY]
             return meta
@@ -206,6 +236,7 @@ class TestRansRepack(unittest.TestCase):
         # payload corruption trips a stream invariant or the re-encode pin;
         # both are refusals — assert on the shared prefix
         self._corrupt_reshard_and_expect("E_", tensor_mutator=flip_payload)
+        self._corrupt_reshard_and_expect("E_OVERSIZE", tensor_mutator=bomb_header)
         self._corrupt_reshard_and_expect("E_COUNT_MISMATCH",
                                          tensor_mutator=flip_count)
         self._corrupt_reshard_and_expect("E_", tensor_mutator=break_offsets)
@@ -235,6 +266,46 @@ class TestRansRepack(unittest.TestCase):
         self.assertEqual(r.returncode, 1)
         self.assertIn("E_GEOMETRY_G64", r.stderr)
 
+        # gs=128 signature (upstream grouped-int4's actual group size):
+        # ratio exactly 64, byte-indistinguishable from per-row I=128 ->
+        # its own named refusal, never silently accepted as per-row
+        g128dir = self.root / "g128"
+        g128dir.mkdir()
+        rows128 = wb // 64
+        rf.write_shard(str(g128dir / "out-00000.safetensors"), [
+            ("model.layers.0.mlp.experts.0.gate_proj.weight", "U8", [wb],
+             bytes(wb)),
+            ("model.layers.0.mlp.experts.0.gate_proj.weight.qs", "F32",
+             [rows128], bytes(rows128 * 4)),
+        ], {})
+        r = run_tool("repack_rans.py", "--indir", str(g128dir),
+                     "--outdir", str(self.root / "g128out"))
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("E_GEOMETRY_AMBIGUOUS", r.stderr)
+
+        # 2-D weight shape: per-row geometry is verified POSITIVELY from the
+        # shape fields — accepted when qs rows == O, refused by name when not
+        rng = np.random.default_rng(3)
+        O, rb2 = 8, 64
+        nib = rng.choice(np.arange(1, 16, dtype=np.uint8), size=O * rb2 * 2)
+        raw = rf.pack_nibbles(nib)
+        for rows2d, expect_ok in ((O, True), (O * 2, False)):
+            d2 = self.root / f"twod_{rows2d}"
+            d2.mkdir()
+            rf.write_shard(str(d2 / "out-00000.safetensors"), [
+                ("model.layers.0.mlp.experts.0.gate_proj.weight", "U8",
+                 [O, rb2], raw),
+                ("model.layers.0.mlp.experts.0.gate_proj.weight.qs", "F32",
+                 [rows2d], bytes(rows2d * 4)),
+            ], {})
+            r = run_tool("repack_rans.py", "--indir", str(d2),
+                         "--outdir", str(self.root / f"twod_out_{rows2d}"))
+            if expect_ok:
+                self.assertEqual(r.returncode, 0, msg=r.stdout + r.stderr)
+            else:
+                self.assertEqual(r.returncode, 1)
+                self.assertIn("E_GEOMETRY_NOT_PER_ROW", r.stderr)
+
         # missing .qs sidecar -> named refusal
         nsdir = self.root / "noscales"
         nsdir.mkdir()
@@ -257,6 +328,162 @@ class TestRansRepack(unittest.TestCase):
                      "--outdir", str(self.root / "emptyout"))
         self.assertEqual(r.returncode, 1)
         self.assertIn("refusing to emit an empty container", r.stderr)
+
+    def test_parity_c_python_refusal_classes(self):
+        """Same bytes into the C parser (via the bridge) and the Python
+        parser must produce the same named class — parity is a tested
+        property, not a documented intention. Covers the u64-wrap and
+        decompression-bomb header battery."""
+        if rf.LIB is None:
+            self.skipTest("tools/librans_c not built (run `make rans`): "
+                          "C/Python refusal parity was NOT checked")
+        import ctypes
+
+        def c_parse(blob):
+            buf = np.zeros(len(blob) + rf.SLACK, dtype=np.uint8)
+            buf[:len(blob)] = np.frombuffer(blob, dtype=np.uint8)
+            ns = ctypes.c_uint64()
+            pb = ctypes.c_uint64()
+            rc = rf.LIB.rc_record_parse(rf._p8(buf), len(blob), rf.N_STREAMS,
+                                        ctypes.byref(ns), ctypes.byref(pb))
+            return "OK" if rc == 0 else rf.LIB.rc_err_name(rc).decode()
+
+        def py_parse(blob):
+            try:
+                rf.parse_record(blob)
+                return "OK"
+            except rf.RansRefusal as exc:
+                return exc.code
+
+        rng = np.random.default_rng(11)
+        n = 4096
+        nib = rng.choice(np.arange(1, 16, dtype=np.uint8), size=n)
+        hist = np.bincount(nib, minlength=16)
+        freq = rf.quantize_freq(hist)
+        start, slot = rf.build_table(freq)
+        base = bytearray(rf.build_record(nib, freq, start, slot))
+        u64max = (1 << 64) - 1
+
+        def hdr(ns, pb):
+            b = bytearray(base)
+            b[0:8] = ns.to_bytes(8, "little")
+            b[8:16] = pb.to_bytes(8, "little")
+            return bytes(b)
+
+        cases = [bytes(base)]                          # the valid control
+        for ns, pb in ((u64max, 0), (u64max, 1 << 63), (0, 0),
+                       (1 << 40, 1 << 39), (1 << 32, 1 << 31),
+                       (n + 1, (n + 1) // 2), (n, n)):
+            cases.append(hdr(ns, pb))
+        cases.append(bytes(base[:64]))                 # truncated header
+        cases.append(bytes(base[:len(base) - 16]))     # truncated payload
+        cases.append(bytes(base) + b"\x00" * 16)       # trailing pad-shaped
+        cases.append(bytes(base) + b"\x77" * 16)       # trailing garbage
+        mono = bytearray(base)
+        mono[16 + 8 * 4] ^= 0x80                       # offsets landmine
+        cases.append(bytes(mono))
+        dirty = bytearray(base)
+        dirty[16 + (rf.N_STREAMS + 1) * 4] = 0x55      # header pad byte
+        cases.append(bytes(dirty))
+
+        for i, blob in enumerate(cases):
+            c_cls, py_cls = c_parse(blob), py_parse(blob)
+            self.assertEqual(c_cls, py_cls,
+                             msg=f"case {i}: C={c_cls} Python={py_cls}")
+        self.assertEqual(c_parse(cases[0]), "OK")      # control really is OK
+
+    def test_verifier_never_crashes(self):
+        """Hostile safetensors headers (the review round's traceback
+        classes): zero tracebacks, nonzero exit, a named REFUSE line each."""
+        name = "model.layers.0.mlp.experts.0.gate_proj.weight"
+        ok_entry = {"dtype": "U8", "shape": [4], "data_offsets": [0, 4]}
+        stamp = json.dumps({name: rf.FORMAT_NAME})
+        cases = {
+            "meta_not_string": {"__metadata__": {rf.METADATA_KEY: 5},
+                                name: dict(ok_entry)},
+            "header_array": [1, 2, 3],
+            "no_data_offsets": {"__metadata__": {rf.METADATA_KEY: stamp,
+                                                 rf.TABLE_KEY: "{}"},
+                                name: {"dtype": "U8", "shape": [4]}},
+            "entry_not_dict": {"__metadata__": {rf.METADATA_KEY: stamp,
+                                                rf.TABLE_KEY: "{}"},
+                               name: "hello"},
+            "fmt_value_list": {"__metadata__":
+                               {rf.METADATA_KEY: json.dumps({name: ["a"]})},
+                               name: dict(ok_entry)},
+            "reversed_offsets": {"__metadata__": {rf.METADATA_KEY: stamp,
+                                                  rf.TABLE_KEY: "{}"},
+                                 name: {"dtype": "U8", "shape": [4],
+                                        "data_offsets": [8, 2]}},
+            "offsets_past_eof": {"__metadata__": {rf.METADATA_KEY: stamp,
+                                                  rf.TABLE_KEY: "{}"},
+                                 name: {"dtype": "U8", "shape": [4],
+                                        "data_offsets": [0, 4096]}},
+            "offsets_not_pair": {"__metadata__": {rf.METADATA_KEY: stamp,
+                                                  rf.TABLE_KEY: "{}"},
+                                 name: {"dtype": "U8", "shape": [4],
+                                        "data_offsets": [1, 2, 3]}},
+        }
+        hostile = self.root / "hostile"
+        hostile.mkdir()
+        for label, hdr in cases.items():
+            p = hostile / f"h_{label}.safetensors"
+            hj = json.dumps(hdr, separators=(",", ":")).encode()
+            with open(p, "wb") as f:
+                f.write(len(hj).to_bytes(8, "little"))
+                f.write(hj)
+                f.write(b"\x00" * 32)
+            r = run_tool("rans_verify.py", str(p))
+            self.assertNotIn("Traceback", r.stderr,
+                             msg=f"{label}: crashed\n{r.stderr}")
+            self.assertEqual(r.returncode, 1, msg=f"{label}: {r.stdout}")
+            self.assertIn("REFUSE", r.stdout, msg=f"{label}: no REFUSE line")
+
+    def test_partial_output_refusal(self):
+        """An outdir already holding repack output is refused (crash
+        evidence: an interrupted set must not be papered over); --force
+        redoes it; a completed run leaves repack-manifest.json."""
+        out = self.root / "partial"
+        shards = self.repack(out)
+        manifest = out / "repack-manifest.json"
+        self.assertTrue(manifest.exists())
+        man = json.loads(manifest.read_text())
+        self.assertEqual(man["n_shards"], len(shards))
+
+        # rerun over completed output: refused
+        r = run_tool("repack_rans.py", "--indir", str(self.indir),
+                     "--outdir", str(out))
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("refusing to overwrite", r.stderr)
+
+        # simulate a crashed run: shards present, no completion manifest
+        manifest.unlink()
+        r = run_tool("repack_rans.py", "--indir", str(self.indir),
+                     "--outdir", str(out))
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("NO manifest", r.stderr)
+
+        # --force redoes from scratch, byte-identical to a fresh run
+        r = run_tool("repack_rans.py", "--indir", str(self.indir),
+                     "--outdir", str(out), "--force")
+        self.assertEqual(r.returncode, 0, msg=r.stdout + r.stderr)
+        self.assertTrue(manifest.exists())
+        fresh = self.repack(self.root / "partial_fresh")
+        self.assertEqual(shards[0].read_bytes(), fresh[0].read_bytes())
+
+    def test_quantize_freq_ties_and_termination(self):
+        """Exact fractional-remainder ties must break identically everywhere
+        (stable argsort -> lowest symbol index wins), and an impossible table
+        size must raise instead of looping forever."""
+        hist = np.zeros(16, dtype=np.int64)
+        hist[1] = hist[2] = hist[3] = 1        # remainders tie exactly at 1/3
+        freq = rf.quantize_freq(hist)
+        self.assertEqual(freq.tolist(),
+                         [0, 5462, 5461, 5461, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0, 0, 0, 0])
+        self.assertEqual(int(freq.sum()), rf.M)
+        with self.assertRaises(ValueError):
+            rf.quantize_freq(np.ones(16, dtype=np.int64), m=8)
 
 
 if __name__ == "__main__":

--- a/c/tools/rans_ctypes.c
+++ b/c/tools/rans_ctypes.c
@@ -15,6 +15,14 @@
 #define RC_EXPORT
 #endif
 
+/* This bridge serves the int4-rans256-g0 TOOLS, so unlike the format-generic
+ * header entry points it can and does pin n_streams to the format's 256 —
+ * a zero or wrong-for-format value is refused by name before any division
+ * or decode dispatch (the header entries additionally refuse zero). */
+static int rc__nstreams_ok(uint32_t n_streams) {
+    return n_streams == RANS_NSTREAMS;
+}
+
 /* Encode n nibbles into one chunk record. Returns the record length, or the
  * negated rans_err on failure. out_cap should come from rc_record_bound. */
 RC_EXPORT int64_t rc_record_encode(const uint8_t *nibbles, uint64_t n,
@@ -22,6 +30,7 @@ RC_EXPORT int64_t rc_record_encode(const uint8_t *nibbles, uint64_t n,
                                    const uint16_t *slot_to_symbol,
                                    uint32_t scale_bits, uint32_t n_streams,
                                    uint8_t *out, uint64_t out_cap) {
+    if (!rc__nstreams_ok(n_streams)) return -(int64_t)RANS_E_NSTREAMS;
     rans_table t;
     rans_err e = rans_table_init(&t, scale_bits, freq, start, slot_to_symbol);
     if (e != RANS_OK) return -(int64_t)e;
@@ -33,6 +42,7 @@ RC_EXPORT int64_t rc_record_encode(const uint8_t *nibbles, uint64_t n,
 }
 
 RC_EXPORT uint64_t rc_record_bound(uint64_t n_symbols, uint32_t n_streams) {
+    if (!rc__nstreams_ok(n_streams)) return 0;   /* callers treat 0 as refusal */
     return rans_record_bound(n_symbols, n_streams);
 }
 
@@ -41,6 +51,7 @@ RC_EXPORT uint64_t rc_record_bound(uint64_t n_symbols, uint32_t n_streams) {
 RC_EXPORT int32_t rc_record_parse(const uint8_t *blob, uint64_t blob_len,
                                   uint32_t n_streams,
                                   uint64_t *n_symbols, uint64_t *packed_bytes) {
+    if (!rc__nstreams_ok(n_streams)) return (int32_t)RANS_E_NSTREAMS;
     rans_record rec;
     rans_err e = rans_record_parse(blob, blob_len, n_streams, &rec);
     if (e == RANS_OK) {
@@ -61,6 +72,7 @@ RC_EXPORT int32_t rc_record_decode(const uint8_t *blob, uint64_t blob_len,
                                    const uint16_t *slot_to_symbol,
                                    uint32_t scale_bits, int32_t path,
                                    uint8_t *out_packed) {
+    if (!rc__nstreams_ok(n_streams)) return (int32_t)RANS_E_NSTREAMS;
     rans_record rec;
     rans_err e = rans_record_parse(blob, blob_len, n_streams, &rec);
     if (e != RANS_OK) return (int32_t)e;

--- a/c/tools/rans_ctypes.c
+++ b/c/tools/rans_ctypes.c
@@ -1,0 +1,95 @@
+/* rans_ctypes.c — thin exported-symbol bridge over rans.h for the Python
+ * offline tools (repack_rans.py, rans_verify.py), built as a shared library
+ * by `make rans` (same optional-accelerator shape as tools/iq3_encode.c:
+ * the Python side falls back to a slow pure-Python codec producing the SAME
+ * bytes when this library is absent, and the Python e2e test pins the two
+ * implementations byte-identical).
+ *
+ * Everything in rans.h is static; these wrappers are the only symbols the
+ * library exports. No engine code is included or touched. */
+#include "../rans.h"
+
+#ifdef _WIN32
+#define RC_EXPORT __declspec(dllexport)
+#else
+#define RC_EXPORT
+#endif
+
+/* Encode n nibbles into one chunk record. Returns the record length, or the
+ * negated rans_err on failure. out_cap should come from rc_record_bound. */
+RC_EXPORT int64_t rc_record_encode(const uint8_t *nibbles, uint64_t n,
+                                   const uint32_t *freq, const uint32_t *start,
+                                   const uint16_t *slot_to_symbol,
+                                   uint32_t scale_bits, uint32_t n_streams,
+                                   uint8_t *out, uint64_t out_cap) {
+    rans_table t;
+    rans_err e = rans_table_init(&t, scale_bits, freq, start, slot_to_symbol);
+    if (e != RANS_OK) return -(int64_t)e;
+    uint64_t len = 0;
+    e = rans_record_encode(nibbles, n, &t, n_streams, out, out_cap, &len);
+    rans_table_free(&t);
+    if (e != RANS_OK) return -(int64_t)e;
+    return (int64_t)len;
+}
+
+RC_EXPORT uint64_t rc_record_bound(uint64_t n_symbols, uint32_t n_streams) {
+    return rans_record_bound(n_symbols, n_streams);
+}
+
+/* Parse + fully validate a record blob; fills n_symbols/packed_bytes on
+ * success. Returns a rans_err. */
+RC_EXPORT int32_t rc_record_parse(const uint8_t *blob, uint64_t blob_len,
+                                  uint32_t n_streams,
+                                  uint64_t *n_symbols, uint64_t *packed_bytes) {
+    rans_record rec;
+    rans_err e = rans_record_parse(blob, blob_len, n_streams, &rec);
+    if (e == RANS_OK) {
+        if (n_symbols) *n_symbols = rec.n_symbols;
+        if (packed_bytes) *packed_bytes = rec.packed_bytes;
+    }
+    return (int32_t)e;
+}
+
+/* Parse + decode a record blob to packed bytes with the requested path
+ * (path < 0 => rans_path_select(): env-honouring best arm). out_packed must
+ * hold the record's packed_bytes; the CALLER must satisfy the RANS_SLACK
+ * contract (blob allocated with >= RANS_SLACK readable bytes past blob_len —
+ * the Python side copies each record into a padded buffer). */
+RC_EXPORT int32_t rc_record_decode(const uint8_t *blob, uint64_t blob_len,
+                                   uint32_t n_streams,
+                                   const uint32_t *freq, const uint32_t *start,
+                                   const uint16_t *slot_to_symbol,
+                                   uint32_t scale_bits, int32_t path,
+                                   uint8_t *out_packed) {
+    rans_record rec;
+    rans_err e = rans_record_parse(blob, blob_len, n_streams, &rec);
+    if (e != RANS_OK) return (int32_t)e;
+    rans_table t;
+    e = rans_table_init(&t, scale_bits, freq, start, slot_to_symbol);
+    if (e != RANS_OK) return (int32_t)e;
+    rans_path p = (path < 0) ? rans_path_select() : (rans_path)path;
+    e = rans_record_decode_packed(&rec, &t, n_streams, p, out_packed);
+    rans_table_free(&t);
+    return (int32_t)e;
+}
+
+/* Checked per-stream decode (verification invariants: state range, exact
+ * consumption, final state). Returns a rans_err. */
+RC_EXPORT int32_t rc_stream_decode_checked(const uint8_t *in_buf, uint64_t in_size,
+                                           uint64_t n,
+                                           const uint32_t *freq, const uint32_t *start,
+                                           const uint16_t *slot_to_symbol,
+                                           uint32_t scale_bits,
+                                           uint8_t *out_nibbles) {
+    return (int32_t)rans_decode_stream_checked(in_buf, (size_t)in_size, (size_t)n,
+                                               freq, start, slot_to_symbol,
+                                               scale_bits, out_nibbles);
+}
+
+RC_EXPORT const char *rc_err_name(int32_t e) {
+    return rans_err_name((rans_err)(e < 0 ? -e : e));
+}
+
+RC_EXPORT const char *rc_path_name(void) {
+    return rans_path_name(rans_path_select());
+}

--- a/c/tools/rans_format.py
+++ b/c/tools/rans_format.py
@@ -1,0 +1,476 @@
+"""int4-rans256-g0 format reference module, shared by repack_rans.py (writer)
+and rans_verify.py (validator).
+
+This is the Python twin of c/rans.h — the same codec, the same chunk-record
+framing, the same named refusal classes. When the optional C bridge library
+(`make rans` -> tools/librans_c.*) is present it does the heavy per-stream
+work; when absent, the pure-Python fallback here produces byte-identical
+output far more slowly (the e2e test pins the two implementations equal, the
+same relationship iq3_pack.py has with tools/libiq3).
+
+FORMAT SUMMARY (docs/int4-rans256-g0.md is the full specification):
+  - a weight tensor's bytes are ONE chunk record: n_symbols u64,
+    packed_bytes u64, stream_offsets[N+1] u32, zero-pad to 16, payload
+    (N=256 independent rANS streams, round-robin symbol assignment j -> j%N),
+    zero-pad to 16;
+  - the shared static table ships once per shard in
+    __metadata__["colibri.int4-rans256-g0.table"] (JSON: table_id, n_streams,
+    scale_bits, M, freq[16], start[16], slot_to_symbol_b64, table_crc32);
+  - __metadata__["colibri.fmt"] maps each entropy-coded WEIGHT tensor name to
+    the format NAME "int4-rans256-g0". THE STAMP IS MANDATORY: entropy-coded
+    sizes are data-dependent, so no byte-arithmetic inference exists for this
+    format — the stamp is the ONLY signal a U8 tensor is entropy-coded, not a
+    cross-check on an inference (unlike fmt=7's optional stamp).
+
+Table construction is the standard largest-remainder frequency quantization
+(FSE/rANS convention): scale an empirical histogram to sum exactly to
+M = 2**scale_bits, keep every present symbol encodable (freq >= 1), hand out
+the remainder by largest fractional part.
+"""
+import base64
+import ctypes
+import json
+import os
+import struct
+import zlib
+
+import numpy as np
+
+FORMAT_NAME = "int4-rans256-g0"
+N_STREAMS = 256
+SCALE_BITS = 14                # M = 16384; generous for a 16-symbol alphabet
+M = 1 << SCALE_BITS
+TABLE_ID = "g0"                # shared-global-table generation 0
+METADATA_KEY = "colibri.fmt"   # same key/shape as the fmt=7 stamp convention
+TABLE_KEY = "colibri.int4-rans256-g0.table"
+RANS_L = 1 << 23
+SLACK = 64                     # readable bytes past a record buffer (SIMD contract)
+
+
+class RansRefusal(Exception):
+    """A named TRUST-VERIFY-REFUSE failure. `code` matches c/rans.h's
+    rans_err_name strings (E_TRUNCATED, E_TABLE_CRC, ...) plus the
+    container-level classes only the Python tools can see (stamps, metadata)."""
+
+    def __init__(self, code, detail):
+        self.code = code
+        self.detail = detail
+        super().__init__(f"{code}: {detail}")
+
+
+# ---------------------------------------------------------------------------
+# table construction (ported unchanged from the proven prototype)
+# ---------------------------------------------------------------------------
+def quantize_freq(hist, m=M):
+    """hist: length-16 array of raw counts. Returns freq[16] uint32 summing to
+    m; largest-remainder quantization; min 1 count for any nonzero-count
+    symbol (so it stays encodable); absent symbols get exactly 0."""
+    hist = np.asarray(hist, dtype=np.float64)
+    total = hist.sum()
+    assert total > 0
+    raw = hist / total * m
+    freq = np.floor(raw).astype(np.int64)
+    nonzero = hist > 0
+    freq[nonzero & (freq == 0)] = 1
+    deficit = m - freq.sum()
+    if deficit > 0:
+        remainder = raw - np.floor(raw)
+        remainder[~nonzero] = -1     # never give slots to symbols absent from data
+        order = np.argsort(-remainder)
+        i = 0
+        while deficit > 0 and i < len(order):
+            idx = order[i]
+            if nonzero[idx]:
+                freq[idx] += 1
+                deficit -= 1
+            i += 1
+    elif deficit < 0:
+        order = np.argsort(-freq)
+        i = 0
+        while deficit < 0:
+            idx = order[i % len(order)]
+            if freq[idx] > 1:
+                freq[idx] -= 1
+                deficit += 1
+            i += 1
+    assert freq.sum() == m, (freq.sum(), m)
+    return freq.astype(np.uint32)
+
+
+def build_table(freq, m=M):
+    start = np.zeros(len(freq), dtype=np.uint32)
+    start[1:] = np.cumsum(freq)[:-1].astype(np.uint32)
+    slot_to_symbol = np.zeros(m, dtype=np.uint16)
+    for s, (f, st) in enumerate(zip(freq, start)):
+        if f:
+            slot_to_symbol[st:st + f] = s
+    return start, slot_to_symbol
+
+
+def table_blob(freq, start, slot_to_symbol):
+    """The per-shard __metadata__ table value (as a dict; the writer
+    json.dumps(..., sort_keys=True) it — deterministic, diffable)."""
+    slot_bytes = np.ascontiguousarray(slot_to_symbol, dtype="<u2").tobytes()
+    return {
+        "table_id": TABLE_ID,
+        "n_streams": N_STREAMS,
+        "scale_bits": SCALE_BITS,
+        "M": M,
+        "freq": [int(x) for x in freq],
+        "start": [int(x) for x in start],
+        "slot_to_symbol_b64": base64.b64encode(slot_bytes).decode("ascii"),
+        "table_crc32": f"{zlib.crc32(slot_bytes):08x}",
+    }
+
+
+def parse_table_blob(raw):
+    """Validate + decode the metadata table value. Raises RansRefusal with a
+    named class for every malformation the break-it battery covers."""
+    try:
+        blob = json.loads(raw)
+    except ValueError as exc:
+        raise RansRefusal("E_TABLE_MALFORMED", f"table metadata is not JSON: {exc}")
+    for key in ("table_id", "n_streams", "scale_bits", "M", "freq", "start",
+                "slot_to_symbol_b64", "table_crc32"):
+        if key not in blob:
+            raise RansRefusal("E_TABLE_MALFORMED", f"table metadata lacks '{key}'")
+    sb = blob["scale_bits"]
+    if not isinstance(sb, int) or not (1 <= sb <= 15):
+        raise RansRefusal("E_TABLE_SCALE", f"scale_bits={sb!r} out of range 1..15")
+    m = blob["M"]
+    if m != (1 << sb):
+        raise RansRefusal("E_TABLE_SCALE", f"M={m!r} != 1<<scale_bits={1 << sb}")
+    if blob["n_streams"] != N_STREAMS:
+        raise RansRefusal("E_TABLE_MALFORMED",
+                          f"n_streams={blob['n_streams']!r} (this format fixes 256)")
+    freq = blob["freq"]
+    start = blob["start"]
+    if len(freq) != 16 or len(start) != 16 or \
+            not all(isinstance(x, int) and 0 <= x <= m for x in freq + start):
+        raise RansRefusal("E_TABLE_MALFORMED", "freq/start must be 16 ints each")
+    if sum(freq) != m:
+        raise RansRefusal("E_TABLE_FREQ_SUM", f"freq sums to {sum(freq)}, not M={m}")
+    acc = 0
+    for s in range(16):
+        if start[s] != acc:
+            raise RansRefusal("E_TABLE_START", f"start[{s}]={start[s]} != prefix {acc}")
+        acc += freq[s]
+    try:
+        slot_bytes = base64.b64decode(blob["slot_to_symbol_b64"], validate=True)
+    except Exception as exc:
+        raise RansRefusal("E_TABLE_MALFORMED", f"slot_to_symbol_b64: {exc}")
+    if len(slot_bytes) != 2 * m:
+        raise RansRefusal("E_TABLE_MALFORMED",
+                          f"slot_to_symbol is {len(slot_bytes)} bytes, want {2 * m}")
+    crc = f"{zlib.crc32(slot_bytes):08x}"
+    if crc != blob["table_crc32"]:
+        raise RansRefusal("E_TABLE_CRC",
+                          f"slot table crc {crc} != stamped {blob['table_crc32']}")
+    slot = np.frombuffer(slot_bytes, dtype="<u2")
+    freq_a = np.asarray(freq, dtype=np.uint32)
+    start_a = np.asarray(start, dtype=np.uint32)
+    counts = np.bincount(slot, minlength=17)
+    if slot.max(initial=0) > 15 or counts[:16].tolist() != freq or \
+            not np.array_equal(np.sort(slot), slot):
+        # sortedness + per-symbol counts == freq pins the slot table to be
+        # exactly the canonical start/freq banding
+        raise RansRefusal("E_TABLE_SLOT", "slot_to_symbol inconsistent with freq[]")
+    return {"scale_bits": sb, "M": m, "freq": freq_a, "start": start_a,
+            "slot_to_symbol": np.ascontiguousarray(slot, dtype=np.uint16),
+            "table_id": blob["table_id"]}
+
+
+# ---------------------------------------------------------------------------
+# nibble packing (low-nibble-first, the container convention)
+# ---------------------------------------------------------------------------
+def unpack_nibbles(raw_bytes):
+    b = np.frombuffer(raw_bytes, dtype=np.uint8)
+    out = np.empty(b.size * 2, dtype=np.uint8)
+    out[0::2] = b & 0x0F
+    out[1::2] = b >> 4
+    return out
+
+
+def pack_nibbles(nibbles):
+    n = nibbles.reshape(-1, 2)
+    return ((n[:, 0] | (n[:, 1] << 4)).astype(np.uint8)).tobytes()
+
+
+# ---------------------------------------------------------------------------
+# optional C bridge (make rans)
+# ---------------------------------------------------------------------------
+def _load_lib():
+    here = os.path.dirname(os.path.abspath(__file__))
+    for name in ("librans_c.dylib", "librans_c.so", "rans_c.dll"):
+        path = os.path.join(here, name)
+        if not os.path.exists(path):
+            continue
+        lib = ctypes.CDLL(path)
+        u8p = ctypes.POINTER(ctypes.c_uint8)
+        u16p = ctypes.POINTER(ctypes.c_uint16)
+        u32p = ctypes.POINTER(ctypes.c_uint32)
+        u64p = ctypes.POINTER(ctypes.c_uint64)
+        lib.rc_record_encode.argtypes = [u8p, ctypes.c_uint64, u32p, u32p, u16p,
+                                         ctypes.c_uint32, ctypes.c_uint32,
+                                         u8p, ctypes.c_uint64]
+        lib.rc_record_encode.restype = ctypes.c_int64
+        lib.rc_record_bound.argtypes = [ctypes.c_uint64, ctypes.c_uint32]
+        lib.rc_record_bound.restype = ctypes.c_uint64
+        lib.rc_record_parse.argtypes = [u8p, ctypes.c_uint64, ctypes.c_uint32,
+                                        u64p, u64p]
+        lib.rc_record_parse.restype = ctypes.c_int32
+        lib.rc_record_decode.argtypes = [u8p, ctypes.c_uint64, ctypes.c_uint32,
+                                         u32p, u32p, u16p, ctypes.c_uint32,
+                                         ctypes.c_int32, u8p]
+        lib.rc_record_decode.restype = ctypes.c_int32
+        lib.rc_stream_decode_checked.argtypes = [u8p, ctypes.c_uint64,
+                                                 ctypes.c_uint64, u32p, u32p,
+                                                 u16p, ctypes.c_uint32, u8p]
+        lib.rc_stream_decode_checked.restype = ctypes.c_int32
+        lib.rc_err_name.argtypes = [ctypes.c_int32]
+        lib.rc_err_name.restype = ctypes.c_char_p
+        return lib
+    return None
+
+
+LIB = None if os.environ.get("RANS_FORCE_PYTHON") else _load_lib()
+
+
+def _p8(a):
+    return a.ctypes.data_as(ctypes.POINTER(ctypes.c_uint8))
+
+
+def _p16(a):
+    return a.ctypes.data_as(ctypes.POINTER(ctypes.c_uint16))
+
+
+def _p32(a):
+    return a.ctypes.data_as(ctypes.POINTER(ctypes.c_uint32))
+
+
+def _err_name(code):
+    return LIB.rc_err_name(code).decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# pure-Python codec fallback (bit-exact twin of c/rans.h's scalar paths)
+# ---------------------------------------------------------------------------
+def _py_encode_stream(nibbles, freq, start, scale_bits):
+    out = bytearray()                      # collected backwards, reversed at the end
+    x = RANS_L
+    for s in nibbles[::-1]:
+        s = int(s)
+        f = int(freq[s])
+        x_max = ((RANS_L >> scale_bits) << 8) * f
+        while x >= x_max:
+            out.append(x & 0xFF)
+            x >>= 8
+        x = ((x // f) << scale_bits) + (x % f) + int(start[s])
+    for _ in range(4):
+        out.append(x & 0xFF)
+        x >>= 8
+    return bytes(out[::-1])
+
+
+def _py_decode_stream_checked(buf, n, freq, start, slot_to_symbol, scale_bits):
+    """Returns (nibbles ndarray, refusal-name-or-None); mirrors
+    rans_decode_stream_checked in c/rans.h refusal for refusal."""
+    if len(buf) < 4:
+        return None, "E_STREAM_UNDERRUN"
+    mask = (1 << scale_bits) - 1
+    pos = 4
+    x = int.from_bytes(buf[:4], "big")
+    if x < RANS_L:
+        return None, "E_STREAM_STATE_RANGE"
+    end = len(buf)
+    out = np.empty(n, dtype=np.uint8)
+    for i in range(n):
+        slot = x & mask
+        s = int(slot_to_symbol[slot])
+        x = int(freq[s]) * (x >> scale_bits) + slot - int(start[s])
+        while x < RANS_L:
+            if pos >= end:
+                break
+            x = (x << 8) | buf[pos]
+            pos += 1
+        out[i] = s
+    if pos != end:
+        return None, "E_STREAM_LEFTOVER"
+    if x != RANS_L:
+        return None, "E_STREAM_FINAL_STATE"
+    return out, None
+
+
+# ---------------------------------------------------------------------------
+# chunk record: build / parse / decode
+# ---------------------------------------------------------------------------
+def _round16(v):
+    return (v + 15) & ~15
+
+
+def record_header_bytes(n_streams=N_STREAMS):
+    return _round16(16 + (n_streams + 1) * 4)
+
+
+def build_record(nibbles, freq, start, slot_to_symbol, scale_bits=SCALE_BITS,
+                 n_streams=N_STREAMS):
+    """nibbles -> one chunk-record bytes object. Deterministic."""
+    nib = np.ascontiguousarray(nibbles, dtype=np.uint8)
+    n = nib.size
+    if n == 0:
+        raise RansRefusal("E_EMPTY", "refusing to encode an empty tensor")
+    if LIB is not None:
+        cap = int(LIB.rc_record_bound(n, n_streams)) + SLACK
+        out = np.zeros(cap, dtype=np.uint8)
+        freq_a = np.ascontiguousarray(freq, dtype=np.uint32)
+        start_a = np.ascontiguousarray(start, dtype=np.uint32)
+        slot_a = np.ascontiguousarray(slot_to_symbol, dtype=np.uint16)
+        rc = LIB.rc_record_encode(_p8(nib), n, _p32(freq_a), _p32(start_a),
+                                  _p16(slot_a), scale_bits, n_streams,
+                                  _p8(out), cap)
+        if rc < 0:
+            raise RansRefusal(_err_name(int(rc)), "rc_record_encode failed")
+        return out[:rc].tobytes()
+    # pure-Python fallback: identical construction
+    streams = [_py_encode_stream(nib[i::n_streams], freq, start, scale_bits)
+               for i in range(n_streams)]
+    offsets = np.zeros(n_streams + 1, dtype=np.uint32)
+    offsets[1:] = np.cumsum([len(s) for s in streams]).astype(np.uint32)
+    payload = b"".join(streams)
+    head = struct.pack("<QQ", n, (n + 1) // 2) + offsets.astype("<u4").tobytes()
+    head += b"\x00" * (_round16(len(head)) - len(head))
+    payload += b"\x00" * (_round16(len(payload)) - len(payload))
+    return head + payload
+
+
+def parse_record(blob, n_streams=N_STREAMS):
+    """Validate framing; returns dict(n_symbols, packed_bytes, offsets,
+    payload). Raises RansRefusal with the same named classes as c/rans.h."""
+    head = record_header_bytes(n_streams)
+    if len(blob) < head:
+        raise RansRefusal("E_TRUNCATED", f"{len(blob)} bytes < {head}-byte header")
+    n_symbols, packed_bytes = struct.unpack_from("<QQ", blob, 0)
+    if n_symbols == 0:
+        raise RansRefusal("E_EMPTY", "n_symbols == 0")
+    if packed_bytes != (n_symbols + 1) // 2:
+        raise RansRefusal("E_COUNT_MISMATCH",
+                          f"packed_bytes={packed_bytes} != ceil({n_symbols}/2)")
+    offsets = np.frombuffer(blob, dtype="<u4", count=n_streams + 1, offset=16)
+    if offsets[0] != 0:
+        raise RansRefusal("E_OFFSET_FIRST", f"stream_offsets[0]={offsets[0]}")
+    d = np.diff(offsets.astype(np.int64))
+    if (d < 0).any():
+        raise RansRefusal("E_OFFSETS_MONOTONIC", "stream_offsets not non-decreasing")
+    if (d < 4).any():
+        raise RansRefusal("E_STREAM_SHORT",
+                          f"stream {int(np.argmax(d < 4))} shorter than its 4-byte state")
+    payload_len = int(offsets[n_streams])
+    if head + payload_len > len(blob):
+        raise RansRefusal("E_TRUNCATED",
+                          f"payload claims {payload_len} bytes past the blob end")
+    if len(blob) != head + _round16(payload_len):
+        raise RansRefusal("E_LENGTH_MISMATCH",
+                          f"blob is {len(blob)} bytes, framing derives "
+                          f"{head + _round16(payload_len)}")
+    raw_head_end = 16 + (n_streams + 1) * 4
+    if any(blob[raw_head_end:head]) or any(blob[head + payload_len:]):
+        raise RansRefusal("E_PAD_NONZERO", "derived padding bytes are not zero")
+    return {"n_symbols": n_symbols, "packed_bytes": packed_bytes,
+            "offsets": offsets, "payload": blob[head:head + payload_len]}
+
+
+def decode_record(blob, table, n_streams=N_STREAMS, checked=True):
+    """Record bytes -> original packed bytes. `table` is parse_table_blob's
+    result (or an equivalent dict). Raises RansRefusal on any malformation,
+    including the stream-level invariants a genuine encoder output always
+    satisfies (state range / exact consumption / final state)."""
+    rec = parse_record(blob, n_streams)
+    freq = np.ascontiguousarray(table["freq"], dtype=np.uint32)
+    start = np.ascontiguousarray(table["start"], dtype=np.uint32)
+    slot = np.ascontiguousarray(table["slot_to_symbol"], dtype=np.uint16)
+    sb = table["scale_bits"]
+    n = rec["n_symbols"]
+    if LIB is not None and not checked:
+        buf = np.zeros(len(blob) + SLACK, dtype=np.uint8)   # SLACK contract
+        buf[:len(blob)] = np.frombuffer(blob, dtype=np.uint8)
+        out = np.empty(rec["packed_bytes"], dtype=np.uint8)
+        rc = LIB.rc_record_decode(_p8(buf), len(blob), n_streams, _p32(freq),
+                                  _p32(start), _p16(slot), sb, -1, _p8(out))
+        if rc != 0:
+            raise RansRefusal(_err_name(rc), "rc_record_decode failed")
+        return out.tobytes()
+    # checked per-stream decode (verification path), C-accelerated per stream
+    payload = rec["payload"]
+    offsets = rec["offsets"]
+    nib = np.empty(n, dtype=np.uint8)
+    for i in range(n_streams):
+        sub = payload[int(offsets[i]):int(offsets[i + 1])]
+        n_i = len(range(i, n, n_streams))
+        if LIB is not None:
+            sbuf = np.frombuffer(sub, dtype=np.uint8)
+            sout = np.empty(max(n_i, 1), dtype=np.uint8)
+            rc = LIB.rc_stream_decode_checked(_p8(np.ascontiguousarray(sbuf)),
+                                              len(sub), n_i, _p32(freq),
+                                              _p32(start), _p16(slot), sb,
+                                              _p8(sout))
+            if rc != 0:
+                raise RansRefusal(_err_name(rc), f"stream {i} failed checked decode")
+            dec = sout[:n_i]
+        else:
+            dec, err = _py_decode_stream_checked(sub, n_i, freq, start, slot, sb)
+            if err:
+                raise RansRefusal(err, f"stream {i} failed checked decode")
+        nib[i::n_streams] = dec
+    if n % 2:
+        nib = np.concatenate([nib, np.zeros(1, dtype=np.uint8)])
+    return pack_nibbles(nib)
+
+
+# ---------------------------------------------------------------------------
+# minimal safetensors i/o (header-only reads; deterministic writes) — no
+# external safetensors dependency, same spirit as doctor.py's own parser
+# ---------------------------------------------------------------------------
+def read_header(path):
+    with open(path, "rb") as f:
+        raw = f.read(8)
+        if len(raw) != 8:
+            raise RansRefusal("E_SHARD_MALFORMED", f"{path}: no header length")
+        hlen = struct.unpack("<Q", raw)[0]
+        if hlen > 512 * 1024 * 1024:
+            raise RansRefusal("E_SHARD_MALFORMED", f"{path}: absurd header ({hlen} B)")
+        try:
+            header = json.loads(f.read(hlen))
+        except ValueError as exc:
+            raise RansRefusal("E_SHARD_MALFORMED", f"{path}: header not JSON: {exc}")
+    return header, 8 + hlen
+
+
+def read_tensor_bytes(path, header, data_start, name):
+    info = header[name]
+    b, e = info["data_offsets"]
+    with open(path, "rb") as f:
+        f.seek(data_start + b)
+        raw = f.read(e - b)
+    if len(raw) != e - b:
+        raise RansRefusal("E_SHARD_MALFORMED", f"{path}:{name}: short read")
+    return raw, info
+
+
+def write_shard(path, tensors, metadata):
+    """tensors: list of (name, dtype, shape, bytes) — written in the given
+    order; metadata: {str: str}. Fully deterministic byte layout (sorted
+    metadata keys, insertion-ordered tensors, no timestamps)."""
+    header = {"__metadata__": {k: metadata[k] for k in sorted(metadata)}}
+    offset = 0
+    for name, dtype, shape, raw in tensors:
+        header[name] = {"dtype": dtype, "shape": list(shape),
+                        "data_offsets": [offset, offset + len(raw)]}
+        offset += len(raw)
+    hjson = json.dumps(header, separators=(",", ":"), sort_keys=False).encode()
+    tmp = path + ".tmp"
+    with open(tmp, "wb") as f:
+        f.write(struct.pack("<Q", len(hjson)))
+        f.write(hjson)
+        for _, _, _, raw in tensors:
+            f.write(raw)
+    os.replace(tmp, path)

--- a/c/tools/rans_format.py
+++ b/c/tools/rans_format.py
@@ -64,10 +64,25 @@ class RansRefusal(Exception):
 def quantize_freq(hist, m=M):
     """hist: length-16 array of raw counts. Returns freq[16] uint32 summing to
     m; largest-remainder quantization; min 1 count for any nonzero-count
-    symbol (so it stays encodable); absent symbols get exactly 0."""
+    symbol (so it stays encodable); absent symbols get exactly 0.
+
+    Determinism: both argsorts use kind="stable" so exact fractional-remainder
+    (or frequency) ties break by symbol index identically on every host and
+    numpy version — contract 4's cross-host byte-identity depends on it.
+
+    Termination: requires m >= the number of present symbols (raises
+    ValueError otherwise — the min-1 constraint would be unsatisfiable).
+    Given that, the deficit<0 loop provably terminates: while deficit < 0,
+    sum(freq) = m - deficit > m >= n_present, so some entry exceeds 1 and
+    every full pass over `order` decrements at least one entry."""
     hist = np.asarray(hist, dtype=np.float64)
     total = hist.sum()
     assert total > 0
+    n_present = int(np.count_nonzero(hist))
+    if m < n_present:
+        raise ValueError(
+            f"quantize_freq: m={m} < {n_present} present symbols — every "
+            f"present symbol needs freq >= 1, so this table size is impossible")
     raw = hist / total * m
     freq = np.floor(raw).astype(np.int64)
     nonzero = hist > 0
@@ -76,7 +91,7 @@ def quantize_freq(hist, m=M):
     if deficit > 0:
         remainder = raw - np.floor(raw)
         remainder[~nonzero] = -1     # never give slots to symbols absent from data
-        order = np.argsort(-remainder)
+        order = np.argsort(-remainder, kind="stable")
         i = 0
         while deficit > 0 and i < len(order):
             idx = order[i]
@@ -85,7 +100,7 @@ def quantize_freq(hist, m=M):
                 deficit -= 1
             i += 1
     elif deficit < 0:
-        order = np.argsort(-freq)
+        order = np.argsort(-freq, kind="stable")
         i = 0
         while deficit < 0:
             idx = order[i % len(order)]
@@ -317,8 +332,18 @@ def build_record(nibbles, freq, start, slot_to_symbol, scale_bits=SCALE_BITS,
     """nibbles -> one chunk-record bytes object. Deterministic."""
     nib = np.ascontiguousarray(nibbles, dtype=np.uint8)
     n = nib.size
+    if n_streams != N_STREAMS:
+        raise RansRefusal("E_NSTREAMS",
+                          f"n_streams={n_streams} (this format fixes {N_STREAMS})")
     if n == 0:
         raise RansRefusal("E_EMPTY", "refusing to encode an empty tensor")
+    # pre-scan parity with c/rans.h: refuse uncodable input by name before
+    # any encoding work (values > 15, or symbols the table gives freq 0)
+    freq_a = np.asarray(freq, dtype=np.uint32)
+    if int(nib.max(initial=0)) > 15 or (freq_a[nib] == 0).any():
+        raise RansRefusal("E_SYMBOL_UNCODABLE",
+                          "input contains a value > 15 or a symbol whose "
+                          "table frequency is zero")
     if LIB is not None:
         cap = int(LIB.rc_record_bound(n, n_streams)) + SLACK
         out = np.zeros(cap, dtype=np.uint8)
@@ -345,13 +370,19 @@ def build_record(nibbles, freq, start, slot_to_symbol, scale_bits=SCALE_BITS,
 
 def parse_record(blob, n_streams=N_STREAMS):
     """Validate framing; returns dict(n_symbols, packed_bytes, offsets,
-    payload). Raises RansRefusal with the same named classes as c/rans.h."""
+    payload). Raises RansRefusal with the same named classes as c/rans.h —
+    that parity is a TESTED property (the e2e suite feeds identical bytes to
+    both implementations and asserts identical classes)."""
+    if n_streams == 0:
+        raise RansRefusal("E_NSTREAMS", "n_streams == 0")
     head = record_header_bytes(n_streams)
     if len(blob) < head:
         raise RansRefusal("E_TRUNCATED", f"{len(blob)} bytes < {head}-byte header")
     n_symbols, packed_bytes = struct.unpack_from("<QQ", blob, 0)
     if n_symbols == 0:
         raise RansRefusal("E_EMPTY", "n_symbols == 0")
+    # Python ints do not wrap, so ceil(n/2) here already agrees with the C
+    # side's non-wrapping n/2 + (n&1) for every uint64 value incl. UINT64_MAX
     if packed_bytes != (n_symbols + 1) // 2:
         raise RansRefusal("E_COUNT_MISMATCH",
                           f"packed_bytes={packed_bytes} != ceil({n_symbols}/2)")
@@ -372,6 +403,14 @@ def parse_record(blob, n_streams=N_STREAMS):
         raise RansRefusal("E_LENGTH_MISMATCH",
                           f"blob is {len(blob)} bytes, framing derives "
                           f"{head + _round16(payload_len)}")
+    # amplification bound, identical to c/rans.h: no table this format admits
+    # can encode more than payload_len*8*M_max symbols into this payload —
+    # refuse the decompression bomb before anything sizes buffers from
+    # n_symbols
+    if n_symbols > payload_len * 8 * (1 << 15):
+        raise RansRefusal("E_OVERSIZE",
+                          f"n_symbols={n_symbols} impossibly large for a "
+                          f"{payload_len}-byte payload")
     raw_head_end = 16 + (n_streams + 1) * 4
     if any(blob[raw_head_end:head]) or any(blob[head + payload_len:]):
         raise RansRefusal("E_PAD_NONZERO", "derived padding bytes are not zero")
@@ -390,10 +429,18 @@ def decode_record(blob, table, n_streams=N_STREAMS, checked=True):
     slot = np.ascontiguousarray(table["slot_to_symbol"], dtype=np.uint16)
     sb = table["scale_bits"]
     n = rec["n_symbols"]
+    # parse_record bounded n_symbols against the payload (E_OVERSIZE); a
+    # record that legitimately passes can still be too big for THIS machine —
+    # that is a named refusal, never an allocator traceback
+    try:
+        nib = np.empty(n, dtype=np.uint8)
+        out = np.empty(rec["packed_bytes"], dtype=np.uint8)
+    except MemoryError:
+        raise RansRefusal("E_NOMEM",
+                          f"cannot allocate buffers for n_symbols={n}")
     if LIB is not None and not checked:
         buf = np.zeros(len(blob) + SLACK, dtype=np.uint8)   # SLACK contract
         buf[:len(blob)] = np.frombuffer(blob, dtype=np.uint8)
-        out = np.empty(rec["packed_bytes"], dtype=np.uint8)
         rc = LIB.rc_record_decode(_p8(buf), len(blob), n_streams, _p32(freq),
                                   _p32(start), _p16(slot), sb, -1, _p8(out))
         if rc != 0:
@@ -402,7 +449,6 @@ def decode_record(blob, table, n_streams=N_STREAMS, checked=True):
     # checked per-stream decode (verification path), C-accelerated per stream
     payload = rec["payload"]
     offsets = rec["offsets"]
-    nib = np.empty(n, dtype=np.uint8)
     for i in range(n_streams):
         sub = payload[int(offsets[i]):int(offsets[i + 1])]
         n_i = len(range(i, n, n_streams))
@@ -431,23 +477,58 @@ def decode_record(blob, table, n_streams=N_STREAMS, checked=True):
 # external safetensors dependency, same spirit as doctor.py's own parser
 # ---------------------------------------------------------------------------
 def read_header(path):
+    """Parse AND validate a shard header. An untrusted container reaches the
+    tools through this function, so the whole header shape is pinned here —
+    every malformation is a named E_SHARD_MALFORMED refusal, never a
+    downstream KeyError/TypeError traceback: the header must be a JSON
+    object; every tensor entry an object with a string dtype, a list shape,
+    and data_offsets = [b, e] with 0 <= b <= e <= data size; __metadata__
+    (when present) a string-to-string object."""
+    fsize = os.path.getsize(path)
     with open(path, "rb") as f:
         raw = f.read(8)
         if len(raw) != 8:
             raise RansRefusal("E_SHARD_MALFORMED", f"{path}: no header length")
         hlen = struct.unpack("<Q", raw)[0]
-        if hlen > 512 * 1024 * 1024:
+        if hlen > 512 * 1024 * 1024 or 8 + hlen > fsize:
             raise RansRefusal("E_SHARD_MALFORMED", f"{path}: absurd header ({hlen} B)")
         try:
             header = json.loads(f.read(hlen))
         except ValueError as exc:
             raise RansRefusal("E_SHARD_MALFORMED", f"{path}: header not JSON: {exc}")
-    return header, 8 + hlen
+    if not isinstance(header, dict):
+        raise RansRefusal("E_SHARD_MALFORMED",
+                          f"{path}: header is {type(header).__name__}, not an object")
+    data_start = 8 + hlen
+    data_size = fsize - data_start
+    for name, info in header.items():
+        if name == "__metadata__":
+            if not isinstance(info, dict) or \
+                    not all(isinstance(k, str) and isinstance(v, str)
+                            for k, v in info.items()):
+                raise RansRefusal("E_SHARD_MALFORMED",
+                                  f"{path}: __metadata__ is not a str->str object")
+            continue
+        if not isinstance(info, dict):
+            raise RansRefusal("E_SHARD_MALFORMED",
+                              f"{path}:{name}: tensor entry is not an object")
+        if not isinstance(info.get("dtype"), str) or \
+                not isinstance(info.get("shape"), list):
+            raise RansRefusal("E_SHARD_MALFORMED",
+                              f"{path}:{name}: missing/malformed dtype or shape")
+        off = info.get("data_offsets")
+        if (not isinstance(off, list) or len(off) != 2 or
+                not all(isinstance(x, int) and not isinstance(x, bool) for x in off) or
+                not (0 <= off[0] <= off[1] <= data_size)):
+            raise RansRefusal("E_SHARD_MALFORMED",
+                              f"{path}:{name}: data_offsets {off!r} invalid for "
+                              f"{data_size} data bytes")
+    return header, data_start
 
 
 def read_tensor_bytes(path, header, data_start, name):
     info = header[name]
-    b, e = info["data_offsets"]
+    b, e = info["data_offsets"]          # validated by read_header
     with open(path, "rb") as f:
         f.seek(data_start + b)
         raw = f.read(e - b)

--- a/c/tools/rans_format.py
+++ b/c/tools/rans_format.py
@@ -29,6 +29,7 @@ the remainder by largest fractional part.
 """
 import base64
 import ctypes
+import hashlib
 import json
 import os
 import struct
@@ -540,7 +541,10 @@ def read_tensor_bytes(path, header, data_start, name):
 def write_shard(path, tensors, metadata):
     """tensors: list of (name, dtype, shape, bytes) — written in the given
     order; metadata: {str: str}. Fully deterministic byte layout (sorted
-    metadata keys, insertion-ordered tensors, no timestamps)."""
+    metadata keys, insertion-ordered tensors, no timestamps). Returns the
+    sha256 hex of the COMPLETE file bytes, computed while streaming the
+    write (before the atomic rename) — the whole-file digest the manifest
+    records."""
     header = {"__metadata__": {k: metadata[k] for k in sorted(metadata)}}
     offset = 0
     for name, dtype, shape, raw in tensors:
@@ -548,10 +552,26 @@ def write_shard(path, tensors, metadata):
                         "data_offsets": [offset, offset + len(raw)]}
         offset += len(raw)
     hjson = json.dumps(header, separators=(",", ":"), sort_keys=False).encode()
+    h = hashlib.sha256()
     tmp = path + ".tmp"
     with open(tmp, "wb") as f:
-        f.write(struct.pack("<Q", len(hjson)))
-        f.write(hjson)
+        for chunk in (struct.pack("<Q", len(hjson)), hjson):
+            f.write(chunk)
+            h.update(chunk)
         for _, _, _, raw in tensors:
             f.write(raw)
+            h.update(raw)
     os.replace(tmp, path)
+    return h.hexdigest()
+
+
+def sha256_file(path, bufsize=1 << 20):
+    """sha256 hex of a whole file, chunked (shards can be GB-scale)."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(bufsize)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()

--- a/c/tools/rans_verify.py
+++ b/c/tools/rans_verify.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""int4-rans256-g0 container validator: TRUST-VERIFY-REFUSE at the format
+boundary. Accepts a spec-conformant shard; produces a NAMED refusal for every
+corruption class; never crashes, never silently accepts.
+
+WHAT IS CHECKED, per shard:
+  stamp layer (the stamp is MANDATORY for this format — entropy-coded sizes
+  are data-dependent, so the stamp is the ONLY signal a U8 tensor is
+  entropy-coded at all):
+    E_STAMP_MISSING        __metadata__ or its colibri.fmt key absent while
+                           the shard was named on the command line as an
+                           entropy container
+    E_STAMP_MALFORMED      colibri.fmt not a JSON {name: format} object
+    E_STAMP_DANGLING       a stamped name with no tensor in the shard
+    E_STAMP_DTYPE          a stamped tensor whose dtype is not U8
+  table layer:
+    E_TABLE_MISSING        colibri.int4-rans256-g0.table absent while stamps
+                           claim this format
+    E_TABLE_MALFORMED      table JSON/fields/b64 malformed
+    E_TABLE_SCALE          scale_bits/M out of range or inconsistent
+    E_TABLE_FREQ_SUM       freq[] does not sum to M
+    E_TABLE_START          start[] not the prefix sum of freq[]
+    E_TABLE_SLOT           slot_to_symbol inconsistent with freq[]/start[]
+    E_TABLE_CRC            slot-table bytes do not match the stamped crc32
+  record layer (per stamped tensor; same names as c/rans.h's rans_err):
+    E_TRUNCATED E_EMPTY E_COUNT_MISMATCH E_OFFSET_FIRST E_OFFSETS_MONOTONIC
+    E_STREAM_SHORT E_LENGTH_MISMATCH E_PAD_NONZERO
+  payload layer (per stream; a genuine encoder output ALWAYS satisfies
+  these, so corruption is refused without any ground-truth bytes):
+    E_STREAM_STATE_RANGE   initial state outside the encoder's invariant
+    E_STREAM_UNDERRUN      stream shorter than its flushed state
+    E_STREAM_LEFTOVER      decode finished with bytes unconsumed
+    E_STREAM_FINAL_STATE   final state != the encoder's initial state
+  plus a re-encode cross-check: re-encoding the decoded nibbles with the
+  shard's own table must reproduce the record byte-for-byte
+  (E_REENCODE_MISMATCH) — the writer is deterministic, so any surviving
+  divergence is corruption the invariants above happened to miss.
+
+Exit status: 0 = every named shard TRUSTED; 1 = at least one refusal
+(each printed as `REFUSE <shard> <tensor|-> <CLASS>: detail`); 2 = usage.
+
+Build `make rans` first for the C codec; the pure-Python fallback verifies
+the same things far more slowly.
+
+Usage:
+  python3 tools/rans_verify.py <shard.safetensors> [more shards...]
+  python3 tools/rans_verify.py --max-tensors 8 <shard>   # sampled quick look
+"""
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import rans_format as rf  # noqa: E402
+
+
+def refuse(failures, shard, tensor, code, detail):
+    print(f"REFUSE {os.path.basename(shard)} {tensor or '-'} {code}: {detail}")
+    failures.append((shard, tensor, code))
+
+
+def verify_shard(path, failures, max_tensors=None):
+    try:
+        header, data_start = rf.read_header(path)
+    except rf.RansRefusal as exc:
+        refuse(failures, path, None, exc.code, exc.detail)
+        return
+    meta = header.get("__metadata__")
+    if not isinstance(meta, dict) or rf.METADATA_KEY not in meta:
+        refuse(failures, path, None, "E_STAMP_MISSING",
+               f"no __metadata__[{rf.METADATA_KEY!r}] — for this format the "
+               f"stamp is load-bearing, not optional")
+        return
+    try:
+        fmt_map = json.loads(meta[rf.METADATA_KEY])
+        if not isinstance(fmt_map, dict) or \
+                not all(isinstance(k, str) and isinstance(v, str)
+                        for k, v in fmt_map.items()):
+            raise ValueError("not a {name: format} object")
+    except ValueError as exc:
+        refuse(failures, path, None, "E_STAMP_MALFORMED", str(exc))
+        return
+
+    ours = sorted(n for n, v in fmt_map.items() if v == rf.FORMAT_NAME)
+    others = {n: v for n, v in fmt_map.items() if v != rf.FORMAT_NAME}
+    if others:
+        print(f"[note] {os.path.basename(path)}: {len(others)} stamp(s) for "
+              f"other formats — out of this validator's scope, skipped")
+    if not ours:
+        refuse(failures, path, None, "E_STAMP_MISSING",
+               f"colibri.fmt carries no {rf.FORMAT_NAME!r} stamps")
+        return
+
+    if rf.TABLE_KEY not in meta:
+        refuse(failures, path, None, "E_TABLE_MISSING",
+               f"stamps claim {rf.FORMAT_NAME} but __metadata__"
+               f"[{rf.TABLE_KEY!r}] is absent")
+        return
+    try:
+        table = rf.parse_table_blob(meta[rf.TABLE_KEY])
+    except rf.RansRefusal as exc:
+        refuse(failures, path, None, exc.code, exc.detail)
+        return
+
+    checked = 0
+    trusted = 0
+    for name in ours:
+        if max_tensors is not None and checked >= max_tensors:
+            print(f"[note] {os.path.basename(path)}: stopped after "
+                  f"--max-tensors {max_tensors} of {len(ours)} stamped tensors")
+            break
+        checked += 1
+        if name not in header:
+            refuse(failures, path, name, "E_STAMP_DANGLING",
+                   "stamped but not present in this shard")
+            continue
+        info = header[name]
+        if info["dtype"] != "U8":
+            refuse(failures, path, name, "E_STAMP_DTYPE",
+                   f"dtype {info['dtype']} != U8")
+            continue
+        try:
+            blob, _ = rf.read_tensor_bytes(path, header, data_start, name)
+        except rf.RansRefusal as exc:
+            refuse(failures, path, name, exc.code, exc.detail)
+            continue
+        try:
+            packed = rf.decode_record(blob, table)
+        except rf.RansRefusal as exc:
+            refuse(failures, path, name, exc.code, exc.detail)
+            continue
+        # deterministic re-encode cross-check
+        try:
+            re_rec = rf.build_record(rf.unpack_nibbles(packed), table["freq"],
+                                     table["start"], table["slot_to_symbol"],
+                                     table["scale_bits"])
+        except rf.RansRefusal as exc:
+            refuse(failures, path, name, exc.code, exc.detail)
+            continue
+        if re_rec != blob:
+            refuse(failures, path, name, "E_REENCODE_MISMATCH",
+                   "re-encoding the decoded stream does not reproduce the "
+                   "record — content corruption")
+            continue
+        trusted += 1
+    print(f"[trust] {os.path.basename(path)}: {trusted}/{checked} verified "
+          f"tensor(s) byte-exact (table_id={table['table_id']}, "
+          f"codec={'C' if rf.LIB else 'python'})")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("shards", nargs="+", help="entropy-container shard(s) to verify")
+    ap.add_argument("--max-tensors", type=int, default=None,
+                    help="verify at most N stamped tensors per shard (sampling; "
+                         "default: all — full verification is the deliverable)")
+    a = ap.parse_args()
+    failures = []
+    for p in a.shards:
+        if not os.path.exists(p):
+            refuse(failures, p, None, "E_SHARD_MALFORMED", "no such file")
+            continue
+        verify_shard(p, failures, a.max_tensors)
+    if failures:
+        print(f"RESULT: REFUSE ({len(failures)} refusal(s))")
+        sys.exit(1)
+    print("RESULT: TRUST")
+
+
+if __name__ == "__main__":
+    main()

--- a/c/tools/rans_verify.py
+++ b/c/tools/rans_verify.py
@@ -46,6 +46,31 @@ WHAT IS CHECKED, per shard:
   shard's own table must reproduce the record byte-for-byte
   (E_REENCODE_MISMATCH) — the writer is deterministic, so any surviving
   divergence is corruption the invariants above happened to miss.
+  whole-artifact layer (repack-manifest.json next to the shards, written by
+  repack_rans.py; per-shard whole-file sha256 + per-record sha256 digests):
+    E_MANIFEST_MALFORMED   a manifest file exists but cannot be parsed as
+                           the expected JSON shape — refused rather than
+                           treated as "no manifest", since a corrupted
+                           manifest is itself evidence of tampering
+    E_SHARD_DIGEST_MISMATCH  the complete shard file does not hash to the
+                           digest the mint run recorded — checked FIRST;
+                           covers .qs sidecars, headers and padding, which
+                           the per-record map cannot see. On mismatch the
+                           per-record layer still runs, to localize the
+                           damage when it sits inside a record
+    E_DIGEST_MISSING       the manifest carries digests but not for this
+                           shard or this stamped tensor (a record the
+                           mint run never produced)
+    E_DIGEST_MISMATCH      a record's bytes do not hash to the digest the
+                           mint run recorded — the wrong-checkpoint /
+                           swapped-record case per-record checks alone
+                           cannot see
+  No manifest, or a manifest without digest maps, means NO check is
+  possible (older mint runs): a note is printed and per-record
+  verification proceeds — never an error. This layer checks BUILD
+  integrity (these exact bytes came from that mint run); container
+  identity proper is the stamp/registry lineage, and the consumer-side
+  load check ships with the consumer PR.
 
 Exit status: 0 = every named shard TRUSTED; 1 = at least one refusal
 (each printed as `REFUSE <shard> <tensor|-> <CLASS>: detail`); 2 = usage.
@@ -58,6 +83,7 @@ Usage:
   python3 tools/rans_verify.py --max-tensors 8 <shard>   # sampled quick look
 """
 import argparse
+import hashlib
 import json
 import os
 import sys
@@ -69,6 +95,70 @@ import rans_format as rf  # noqa: E402
 def refuse(failures, shard, tensor, code, detail):
     print(f"REFUSE {os.path.basename(shard)} {tensor or '-'} {code}: {detail}")
     failures.append((shard, tensor, code))
+
+
+def load_manifest_digests(shard_path):
+    """Digest evidence for one shard from the repack-manifest.json next to
+    it. Returns (file_sha256-or-None, records-map-or-None, notes:list);
+    raises RansRefusal E_MANIFEST_MALFORMED when a manifest exists but is
+    not the expected shape (a corrupt manifest is evidence, not an excuse
+    to skip checks), and E_DIGEST_MISSING when the manifest carries digest
+    evidence but no entry for this shard."""
+    mpath = os.path.join(os.path.dirname(os.path.abspath(shard_path)),
+                         "repack-manifest.json")
+    if not os.path.exists(mpath):
+        return None, None, ["no repack-manifest.json — whole-artifact digest "
+                            "check skipped"]
+    try:
+        with open(mpath) as fh:
+            man = json.load(fh)
+        if not isinstance(man, dict) or not isinstance(man.get("shards"), list):
+            raise ValueError("not the expected {.., shards: [..]} object")
+        entries = man["shards"]
+    except (OSError, ValueError) as exc:
+        raise rf.RansRefusal("E_MANIFEST_MALFORMED",
+                             f"repack-manifest.json unreadable: {exc}")
+    # type-validate EVERY entry's shape unconditionally, BEFORE the evidence
+    # scan: a wrong-typed sha256/records field is malformation regardless of
+    # whether any valid evidence remains elsewhere — otherwise an entry
+    # whose only digest fields are malformed-typed would zero the evidence
+    # scan and be silently classed as a digest-less older mint
+    for i, e in enumerate(entries):
+        if not isinstance(e, dict):
+            raise rf.RansRefusal("E_MANIFEST_MALFORMED",
+                                 f"shards[{i}] is not an object")
+        sha = e.get("sha256")
+        if sha is not None and not isinstance(sha, str):
+            raise rf.RansRefusal("E_MANIFEST_MALFORMED",
+                                 f"shards[{i}].sha256 is not a string")
+        rec = e.get("records")
+        if rec is not None and (not isinstance(rec, dict) or
+                                not all(isinstance(k, str) and isinstance(v, str)
+                                        for k, v in rec.items())):
+            raise rf.RansRefusal("E_MANIFEST_MALFORMED",
+                                 f"shards[{i}].records is not a str->str map")
+    any_evidence = any(e.get("records") is not None or
+                       e.get("sha256") is not None for e in entries)
+    if not any_evidence:
+        return None, None, ["repack-manifest.json carries no digests "
+                            "(older mint) — whole-artifact digest check skipped"]
+    base = os.path.basename(shard_path)
+    for e in entries:
+        if e.get("file") != base:
+            continue
+        sha = e.get("sha256")
+        rec = e.get("records")
+        notes = []
+        if sha is None:
+            notes.append("manifest entry has no whole-file sha256 — "
+                         "file-level check skipped")
+        if rec is None:
+            notes.append("manifest entry has no record digests — "
+                         "record-level digest check skipped")
+        return sha, rec, notes
+    raise rf.RansRefusal("E_DIGEST_MISSING",
+                         f"manifest carries digests but no entry for {base} — "
+                         f"this shard is not part of the minted set")
 
 
 def verify_shard(path, failures, max_tensors=None):
@@ -116,6 +206,24 @@ def verify_shard(path, failures, max_tensors=None):
         refuse(failures, path, None, exc.code, exc.detail)
         return
 
+    try:
+        file_sha, digests, digest_notes = load_manifest_digests(path)
+    except rf.RansRefusal as exc:
+        refuse(failures, path, None, exc.code, exc.detail)
+        return
+    for note in digest_notes:
+        print(f"[note] {os.path.basename(path)}: {note}")
+    if file_sha is not None:
+        # whole-file gate FIRST (cheapest whole-artifact check; covers .qs
+        # sidecars, headers and padding the per-record map cannot see); on
+        # mismatch, continue into the per-record layer so the refusal gets
+        # localized to a tensor when the damage is inside a record
+        got = rf.sha256_file(path)
+        if got != file_sha:
+            refuse(failures, path, None, "E_SHARD_DIGEST_MISMATCH",
+                   f"file hashes {got[:16]}…, manifest recorded "
+                   f"{file_sha[:16]}… — shard bytes differ from the mint run")
+
     checked = 0
     trusted = 0
     for name in ours:
@@ -133,6 +241,20 @@ def verify_shard(path, failures, max_tensors=None):
                 raise rf.RansRefusal("E_STAMP_DTYPE",
                                      f"dtype {info['dtype']} != U8")
             blob, _ = rf.read_tensor_bytes(path, header, data_start, name)
+            if digests is not None:
+                # whole-artifact check first: the swapped-valid-record case
+                # every per-record invariant below is structurally blind to
+                if name not in digests:
+                    raise rf.RansRefusal(
+                        "E_DIGEST_MISSING",
+                        "manifest carries digests but none for this tensor — "
+                        "a record the mint run never produced")
+                got = hashlib.sha256(blob).hexdigest()
+                if got != digests[name]:
+                    raise rf.RansRefusal(
+                        "E_DIGEST_MISMATCH",
+                        f"record hashes {got[:16]}…, manifest recorded "
+                        f"{digests[name][:16]}… — bytes differ from the mint run")
             packed = rf.decode_record(blob, table)
             # deterministic re-encode cross-check
             re_rec = rf.build_record(rf.unpack_nibbles(packed), table["freq"],
@@ -153,7 +275,10 @@ def verify_shard(path, failures, max_tensors=None):
         trusted += 1
     print(f"[trust] {os.path.basename(path)}: {trusted}/{checked} verified "
           f"tensor(s) byte-exact (table_id={table['table_id']}, "
-          f"codec={'C' if rf.LIB else 'python'})")
+          f"codec={'C' if rf.LIB else 'python'}, file digest "
+          f"{'checked' if file_sha is not None else 'unavailable'}, "
+          f"record digests "
+          f"{'checked' if digests is not None else 'unavailable'})")
 
 
 def main():

--- a/c/tools/rans_verify.py
+++ b/c/tools/rans_verify.py
@@ -4,6 +4,15 @@ boundary. Accepts a spec-conformant shard; produces a NAMED refusal for every
 corruption class; never crashes, never silently accepts.
 
 WHAT IS CHECKED, per shard:
+  container layer:
+    E_SHARD_MALFORMED      unreadable/absurd header; header not a JSON
+                           object; tensor entries not objects; dtype/shape
+                           missing; data_offsets absent, non-[b,e],
+                           reversed, or past the end of the file;
+                           __metadata__ not a str->str object
+    E_INTERNAL             anything unexpected — a catch-all that converts
+                           any surprise into a named refusal so "never
+                           crashes" is a property, not a hope
   stamp layer (the stamp is MANDATORY for this format — entropy-coded sizes
   are data-dependent, so the stamp is the ONLY signal a U8 tensor is
   entropy-coded at all):
@@ -22,9 +31,11 @@ WHAT IS CHECKED, per shard:
     E_TABLE_START          start[] not the prefix sum of freq[]
     E_TABLE_SLOT           slot_to_symbol inconsistent with freq[]/start[]
     E_TABLE_CRC            slot-table bytes do not match the stamped crc32
-  record layer (per stamped tensor; same names as c/rans.h's rans_err):
-    E_TRUNCATED E_EMPTY E_COUNT_MISMATCH E_OFFSET_FIRST E_OFFSETS_MONOTONIC
-    E_STREAM_SHORT E_LENGTH_MISMATCH E_PAD_NONZERO
+  record layer (per stamped tensor; same names as c/rans.h's rans_err, and
+  the same-bytes/same-class parity with the C parser is a tested property):
+    E_TRUNCATED E_EMPTY E_COUNT_MISMATCH E_OVERSIZE E_OFFSET_FIRST
+    E_OFFSETS_MONOTONIC E_STREAM_SHORT E_LENGTH_MISMATCH E_PAD_NONZERO
+    E_NOMEM (a record too large for this machine refuses by name)
   payload layer (per stream; a genuine encoder output ALWAYS satisfies
   these, so corruption is refused without any ground-truth bytes):
     E_STREAM_STATE_RANGE   initial state outside the encoder's invariant
@@ -61,6 +72,8 @@ def refuse(failures, shard, tensor, code, detail):
 
 
 def verify_shard(path, failures, max_tensors=None):
+    """One shard. Wrapped by main()'s catch-all so no input can escape as a
+    traceback; rf.read_header pins the whole header shape by name first."""
     try:
         header, data_start = rf.read_header(path)
     except rf.RansRefusal as exc:
@@ -111,37 +124,31 @@ def verify_shard(path, failures, max_tensors=None):
                   f"--max-tensors {max_tensors} of {len(ours)} stamped tensors")
             break
         checked += 1
-        if name not in header:
-            refuse(failures, path, name, "E_STAMP_DANGLING",
-                   "stamped but not present in this shard")
-            continue
-        info = header[name]
-        if info["dtype"] != "U8":
-            refuse(failures, path, name, "E_STAMP_DTYPE",
-                   f"dtype {info['dtype']} != U8")
-            continue
         try:
+            if name not in header:
+                raise rf.RansRefusal("E_STAMP_DANGLING",
+                                     "stamped but not present in this shard")
+            info = header[name]
+            if info["dtype"] != "U8":
+                raise rf.RansRefusal("E_STAMP_DTYPE",
+                                     f"dtype {info['dtype']} != U8")
             blob, _ = rf.read_tensor_bytes(path, header, data_start, name)
-        except rf.RansRefusal as exc:
-            refuse(failures, path, name, exc.code, exc.detail)
-            continue
-        try:
             packed = rf.decode_record(blob, table)
-        except rf.RansRefusal as exc:
-            refuse(failures, path, name, exc.code, exc.detail)
-            continue
-        # deterministic re-encode cross-check
-        try:
+            # deterministic re-encode cross-check
             re_rec = rf.build_record(rf.unpack_nibbles(packed), table["freq"],
                                      table["start"], table["slot_to_symbol"],
                                      table["scale_bits"])
+            if re_rec != blob:
+                raise rf.RansRefusal("E_REENCODE_MISMATCH",
+                                     "re-encoding the decoded stream does not "
+                                     "reproduce the record — content corruption")
         except rf.RansRefusal as exc:
             refuse(failures, path, name, exc.code, exc.detail)
             continue
-        if re_rec != blob:
-            refuse(failures, path, name, "E_REENCODE_MISMATCH",
-                   "re-encoding the decoded stream does not reproduce the "
-                   "record — content corruption")
+        except Exception as exc:                      # noqa: BLE001 — the point
+            # anything unexpected becomes a named refusal: "never crashes"
+            # is enforced here, not promised
+            refuse(failures, path, name, "E_INTERNAL", repr(exc))
             continue
         trusted += 1
     print(f"[trust] {os.path.basename(path)}: {trusted}/{checked} verified "
@@ -162,7 +169,10 @@ def main():
         if not os.path.exists(p):
             refuse(failures, p, None, "E_SHARD_MALFORMED", "no such file")
             continue
-        verify_shard(p, failures, a.max_tensors)
+        try:
+            verify_shard(p, failures, a.max_tensors)
+        except Exception as exc:                      # noqa: BLE001 — the point
+            refuse(failures, p, None, "E_INTERNAL", repr(exc))
     if failures:
         print(f"RESULT: REFUSE ({len(failures)} refusal(s))")
         sys.exit(1)

--- a/c/tools/repack_rans.py
+++ b/c/tools/repack_rans.py
@@ -40,12 +40,32 @@ Build `make rans` first for the C codec (tools/librans_c.*); without it this
 tool falls back to a pure-Python codec that emits the same bytes orders of
 magnitude slower (fine for the test fixtures, not for a real container).
 
+WHOLE-ARTIFACT DIGESTS: repack-manifest.json carries, per output shard,
+BOTH a whole-file `sha256` (the complete .safetensors bytes, hashed while
+streaming the write before the atomic rename — subsumes .qs sidecars,
+headers, and padding) AND a `records` map — original tensor name -> sha256
+of the emitted RECORD bytes (the U8 blob exactly as written) for granular
+diagnosis. The record wire format is untouched (sidecar-file fields only).
+rans_verify.py checks the file hash first, then records, when the manifest
+sits next to the shards; a manifest without digests (or no manifest) means
+"no check possible", never an error.
+`--manifest-only <dir>` regenerates the manifest for an ALREADY-minted
+output directory by hashing the existing shards in place (no re-encoding);
+it preserves every field of an existing manifest and only recomputes the
+digest maps, so retro output is byte-identical to mint output for the same
+shards. This mode lives HERE and not in rans_verify.py deliberately: the
+manifest is the writer's completion/provenance artifact, and the verifier
+stays side-effect-free — a tool you point at a stranger's download must
+never write into it.
+
 Usage:
   python3 tools/repack_rans.py --indir <int4_dir> --outdir <out> --dry-run
   python3 tools/repack_rans.py --indir <int4_dir> --outdir <out> [--layers 20,55]
+  python3 tools/repack_rans.py --manifest-only <outdir>
 """
 import argparse
 import glob
+import hashlib
 import json
 import os
 import re
@@ -160,12 +180,114 @@ def select_targets(index, layers):
     return selected
 
 
+def write_manifest(manifest_path, manifest):
+    """Deterministic manifest write (sorted keys, no timestamps), atomic."""
+    tmp = manifest_path + ".tmp"
+    with open(tmp, "w") as fh:
+        json.dump(manifest, fh, indent=1, sort_keys=True)
+    os.replace(tmp, manifest_path)
+
+
+def shard_record_digests(path):
+    """Hash every stamped record in one emitted shard: {name: sha256hex}.
+    Returns (digests, n_bytes). Read-only with respect to the shard."""
+    header, data_start = rf.read_header(path)
+    meta = header.get("__metadata__", {})
+    try:
+        fmt_map = json.loads(meta.get(rf.METADATA_KEY, "{}"))
+    except ValueError:
+        fmt_map = {}
+    digests = {}
+    for name in sorted(n for n, v in fmt_map.items()
+                       if v == rf.FORMAT_NAME and n in header):
+        blob, _ = rf.read_tensor_bytes(path, header, data_start, name)
+        digests[name] = hashlib.sha256(blob).hexdigest()
+    return digests, os.path.getsize(path)
+
+
+def manifest_only(outdir):
+    """Retro-manifest: (re)generate repack-manifest.json for an already-
+    minted output directory by hashing the existing shards in place — no
+    re-encoding. Preserves every field of an existing manifest and only
+    recomputes the per-shard digest maps, so the result is byte-identical
+    to what a fresh mint of the same shards writes."""
+    shards = sorted(glob.glob(os.path.join(outdir, "out-rans-*.safetensors")))
+    if not shards:
+        print(f"ERROR: no out-rans-*.safetensors under {outdir} — nothing to "
+              f"manifest", file=sys.stderr)
+        sys.exit(1)
+    manifest_path = os.path.join(outdir, "repack-manifest.json")
+    existing = {}
+    if os.path.exists(manifest_path):
+        try:
+            with open(manifest_path) as fh:
+                existing = json.load(fh)
+            if not isinstance(existing, dict):
+                raise ValueError("manifest is not a JSON object")
+        except (OSError, ValueError) as exc:
+            print(f"ERROR: existing {manifest_path} is unreadable ({exc}) — "
+                  f"remove it first if a rebuild from the shards is intended",
+                  file=sys.stderr)
+            sys.exit(1)
+    by_file = {e.get("file"): e for e in existing.get("shards", [])
+               if isinstance(e, dict)}
+
+    entries = []
+    total_records = 0
+    fmt_seen = None
+    crc_seen = None
+    for p in shards:
+        base = os.path.basename(p)
+        digests, nbytes = shard_record_digests(p)
+        if not digests:
+            print(f"ERROR: {base} carries no {rf.FORMAT_NAME} stamps — not an "
+                  f"entropy container this tool minted", file=sys.stderr)
+            sys.exit(1)
+        header, _ = rf.read_header(p)
+        meta = header.get("__metadata__", {})
+        try:
+            crc_seen = json.loads(meta[rf.TABLE_KEY]).get("table_crc32", crc_seen)
+        except (KeyError, ValueError):
+            pass
+        fmt_seen = rf.FORMAT_NAME
+        prior = by_file.get(base)
+        if prior is None or "source" not in prior:
+            # visible in output, not just by field absence: retro mode cannot
+            # reconstruct mint-time provenance
+            print(f"[manifest] warning: {base}: no prior manifest entry — "
+                  f"`source` provenance is unknowable in retro mode and is "
+                  f"omitted", file=sys.stderr)
+        entry = dict(prior or {})
+        entry.update({
+            "file": base,
+            "bytes": nbytes,
+            "weight_tensors": len(digests),
+            "sha256": rf.sha256_file(p),   # whole-file: subsumes .qs/header/pad
+            "records": digests,
+        })
+        entries.append(entry)
+        total_records += len(digests)
+        print(f"[manifest] {base}: {len(digests)} record digest(s)")
+
+    manifest = dict(existing)
+    manifest.update({
+        "format": existing.get("format", fmt_seen),
+        "table_crc32": existing.get("table_crc32", crc_seen),
+        "n_shards": len(entries),
+        "n_weight_tensors": total_records,
+        "shards": entries,
+    })
+    write_manifest(manifest_path, manifest)
+    print(f"[manifest] wrote {manifest_path}: {len(entries)} shard(s), "
+          f"{total_records} record digest(s)")
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--indir", required=True,
+    ap.add_argument("--indir",
                     help="directory of per-row-int4 *.safetensors shards")
-    ap.add_argument("--outdir", required=True,
+    ap.add_argument("--outdir",
                     help="destination for the entropy-coded container shards")
     ap.add_argument("--layers",
                     help="comma-separated layer subset (default: every layer)")
@@ -175,7 +297,21 @@ def main():
                     help="overwrite an outdir that already contains repack output "
                          "(default: refuse — a pre-existing partial set from an "
                          "interrupted run must never be silently papered over)")
+    ap.add_argument("--manifest-only", metavar="DIR",
+                    help="regenerate repack-manifest.json (incl. per-record "
+                         "sha256 digests) for an already-minted output "
+                         "directory, hashing shards in place — no re-encoding")
     a = ap.parse_args()
+
+    if a.manifest_only:
+        if a.indir or a.outdir:
+            print("ERROR: --manifest-only takes no --indir/--outdir",
+                  file=sys.stderr)
+            sys.exit(2)
+        manifest_only(a.manifest_only)
+        return
+    if not a.indir or not a.outdir:
+        ap.error("--indir and --outdir are required (unless --manifest-only)")
 
     layers = None
     if a.layers:
@@ -256,6 +392,7 @@ def main():
     for p in sorted(by_shard):
         tensors = []
         fmt_map = {}
+        digests = {}
         for name in by_shard[p]:
             _, header, data_start = index[name]
             raw, info = rf.read_tensor_bytes(p, header, data_start, name)
@@ -269,6 +406,8 @@ def main():
                 sys.exit(1)
             tensors.append((name, "U8", [len(record)], record))
             fmt_map[name] = rf.FORMAT_NAME
+            # whole-artifact digest: hash the record bytes already in hand
+            digests[name] = hashlib.sha256(record).hexdigest()
             total_record += len(record)
             qs = name + ".qs"
             qp, qheader, qdata_start = index[qs]
@@ -279,12 +418,14 @@ def main():
             rf.TABLE_KEY: table_json,
         }
         out_path = os.path.join(a.outdir, f"out-rans-{out_n:05d}.safetensors")
-        rf.write_shard(out_path, tensors, metadata)
+        file_sha = rf.write_shard(out_path, tensors, metadata)
         shard_manifest.append({
             "file": os.path.basename(out_path),
             "source": os.path.basename(p),
             "bytes": os.path.getsize(out_path),
             "weight_tensors": len(fmt_map),
+            "sha256": file_sha,
+            "records": digests,
         })
         print(f"[write] {out_path}: {len(tensors)} tensor(s) "
               f"({os.path.getsize(out_path) / 1e9:.4f} GB) "
@@ -300,10 +441,7 @@ def main():
         "n_weight_tensors": len(selected),
         "shards": shard_manifest,
     }
-    tmp = manifest_path + ".tmp"
-    with open(tmp, "w") as fh:
-        json.dump(manifest, fh, indent=1, sort_keys=True)
-    os.replace(tmp, manifest_path)
+    write_manifest(manifest_path, manifest)
 
     ratio = total_record / total_w
     print(f"[ratio] record/original: {ratio:.4f} ({(1 - ratio) * 100:.2f}% "

--- a/c/tools/repack_rans.py
+++ b/c/tools/repack_rans.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""int4-rans256-g0 repack tool: per-row-int4 expert shards -> an
+entropy-coded container (lossless, byte-exact round trip guaranteed and
+verified before anything is written).
+
+WHAT IT DOES
+  1. Scans every input shard's header (header-only reads, cheap) and builds a
+     corpus-wide {tensor -> shard} index — routed-expert tensors and their
+     `.qs` sidecars can live in different shards.
+  2. Selects routed-expert projection weights
+     (model.layers.{L}.mlp.experts.{E}.{gate,up,down}_proj.weight, dtype U8)
+     whose `.qs` sidecar is per-row F32 — the per-row ("gs=0") int4 geometry
+     this format's v1 targets. GEOMETRY GUARD (enforced, not assumed): for a
+     per-row container weight_bytes/scale_rows == I/2, a per-group (g64)
+     container measures exactly 32 — any tensor at ratio 32, at a
+     non-integral ratio, or below MIN_ROW_RATIO is REFUSED by name rather
+     than silently entropy-coded under the wrong format identity.
+  3. Builds ONE global static rANS table from the pooled nibble histogram of
+     every selected tensor (pass 1), then encodes each tensor as a 256-stream
+     round-robin-interleaved chunk record (pass 2). The byte-identical table
+     is stamped into EVERY output shard (the encoder invariant: readers are
+     shard-local, so each shard must carry the same copy).
+  4. Verifies EVERY record byte-exact (decode -> repack -> compare against
+     the original weight bytes) before its shard is written. Not sampled.
+  5. Writes ordinary safetensors shards: each weight tensor keeps its
+     ORIGINAL logical name (its bytes are the chunk record), `.qs` sidecars
+     pass through raw and untouched, and __metadata__ carries:
+       colibri.fmt                      = JSON {weight_name: "int4-rans256-g0"}
+       colibri.int4-rans256-g0.table    = JSON shared-table blob
+     The colibri.fmt stamp is MANDATORY for this format: entropy-coded sizes
+     are data-dependent, so no byte-arithmetic inference exists — the stamp
+     is the only signal a U8 tensor is entropy-coded at all (see
+     docs/int4-rans256-g0.md, "the stamp is load-bearing").
+
+DETERMINISM: two runs over the same input produce byte-identical output —
+sorted tensor order, sorted JSON keys, no timestamps, a codec whose output
+is a pure function of (bytes, table). The e2e test diffs two runs.
+
+Build `make rans` first for the C codec (tools/librans_c.*); without it this
+tool falls back to a pure-Python codec that emits the same bytes orders of
+magnitude slower (fine for the test fixtures, not for a real container).
+
+Usage:
+  python3 tools/repack_rans.py --indir <int4_dir> --outdir <out> --dry-run
+  python3 tools/repack_rans.py --indir <int4_dir> --outdir <out> [--layers 20,55]
+"""
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import rans_format as rf  # noqa: E402
+
+EXPERT_RE = re.compile(
+    r"^model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.(gate|up|down)_proj\.weight$")
+
+# Per-row geometry guard (see module docstring). MIN_ROW_RATIO = I/2 for the
+# smallest hidden dim this tool accepts; the load-bearing exclusion is 32,
+# the exact ratio EVERY per-group-64 container measures regardless of shape.
+G64_RATIO = 32
+MIN_ROW_RATIO = 64
+
+
+def build_index(indir):
+    paths = sorted(glob.glob(os.path.join(indir, "*.safetensors")))
+    index = {}
+    for p in paths:
+        header, data_start = rf.read_header(p)
+        for name in header:
+            if name == "__metadata__":
+                continue
+            index[name] = (p, header, data_start)
+    return index, paths
+
+
+def select_targets(index, layers):
+    """Returns sorted list of selected weight names; refuses (loud, named)
+    any expert tensor whose geometry is not per-row int4."""
+    selected = []
+    for name in sorted(index):
+        m = EXPERT_RE.match(name)
+        if not m:
+            continue
+        if layers is not None and int(m.group(1)) not in layers:
+            continue
+        _, header, _ = index[name]
+        info = header[name]
+        if info["dtype"] != "U8":
+            continue                     # not a packed-int4 weight (e.g. int8 MTP)
+        qs = name + ".qs"
+        if qs not in index:
+            raise rf.RansRefusal(
+                "E_GEOMETRY_NO_SCALES",
+                f"{name}: no {qs} sidecar anywhere in the corpus — refusing to "
+                f"entropy-code a tensor whose format cannot be confirmed")
+        qpath, qheader, _ = index[qs]
+        qinfo = qheader[qs]
+        if qinfo["dtype"] != "F32":
+            raise rf.RansRefusal(
+                "E_GEOMETRY_NOT_PER_ROW",
+                f"{name}: {qs} dtype {qinfo['dtype']} != F32")
+        wb = info["data_offsets"][1] - info["data_offsets"][0]
+        sb = qinfo["data_offsets"][1] - qinfo["data_offsets"][0]
+        if sb % 4 or sb == 0:
+            raise rf.RansRefusal("E_GEOMETRY_NOT_PER_ROW",
+                                 f"{name}: {qs} is {sb} bytes (not F32-shaped)")
+        rows = sb // 4
+        if wb % rows:
+            raise rf.RansRefusal(
+                "E_GEOMETRY_NOT_PER_ROW",
+                f"{name}: weight bytes {wb} not divisible by scale rows {rows}")
+        ratio = wb // rows
+        if ratio == G64_RATIO:
+            raise rf.RansRefusal(
+                "E_GEOMETRY_G64",
+                f"{name}: weight/scale ratio {ratio} is the per-group-64 "
+                f"signature — g64 containers are out of this format's v1 scope "
+                f"(materially weaker entropy payoff; needs its own round)")
+        if ratio < MIN_ROW_RATIO:
+            raise rf.RansRefusal(
+                "E_GEOMETRY_NOT_PER_ROW",
+                f"{name}: weight/scale ratio {ratio} < {MIN_ROW_RATIO} — not a "
+                f"per-row int4 shape this tool recognizes")
+        selected.append(name)
+    return selected
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--indir", required=True,
+                    help="directory of per-row-int4 *.safetensors shards")
+    ap.add_argument("--outdir", required=True,
+                    help="destination for the entropy-coded container shards")
+    ap.add_argument("--layers",
+                    help="comma-separated layer subset (default: every layer)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="inventory only: scan headers, print selection, write nothing")
+    a = ap.parse_args()
+
+    layers = None
+    if a.layers:
+        layers = {int(x) for x in a.layers.split(",")}
+
+    index, shard_paths = build_index(a.indir)
+    if not shard_paths:
+        print(f"ERROR: no *.safetensors files in {a.indir}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        selected = select_targets(index, layers)
+    except rf.RansRefusal as exc:
+        print(f"REFUSED {exc}", file=sys.stderr)
+        sys.exit(1)
+    if not selected:
+        print(f"ERROR: no per-row int4 routed-expert tensors selected under "
+              f"{a.indir} — nothing to repack; refusing to emit an empty "
+              f"container", file=sys.stderr)
+        sys.exit(1)
+
+    by_shard = {}
+    total_w = 0
+    for name in selected:
+        p, header, _ = index[name]
+        by_shard.setdefault(p, []).append(name)
+        total_w += header[name]["data_offsets"][1] - header[name]["data_offsets"][0]
+    print(f"[select] {len(selected)} weight tensor(s), {total_w / 1e9:.3f} GB "
+          f"packed bytes, across {len(by_shard)} input shard(s)"
+          + (f", layers={sorted(layers)}" if layers else ""))
+    if a.dry_run:
+        for p in sorted(by_shard):
+            print(f"[dry-run] {os.path.basename(p)}: {len(by_shard[p])} tensor(s)")
+        print(f"[dry-run] codec: {'C (librans_c)' if rf.LIB else 'pure Python'}")
+        return
+
+    if rf.LIB is None:
+        print("[warn] tools/librans_c.* not built (make rans): using the "
+              "pure-Python codec — identical bytes, orders of magnitude slower",
+              file=sys.stderr)
+
+    # pass 1: pooled histogram -> the ONE global table
+    hist = np.zeros(16, dtype=np.int64)
+    for name in selected:
+        p, header, data_start = index[name]
+        raw, _ = rf.read_tensor_bytes(p, header, data_start, name)
+        hist += np.bincount(rf.unpack_nibbles(raw), minlength=16)
+    freq = rf.quantize_freq(hist)
+    start, slot = rf.build_table(freq)
+    table_json = json.dumps(rf.table_blob(freq, start, slot), sort_keys=True)
+    table = rf.parse_table_blob(table_json)     # writer trusts nothing, not even itself
+    print(f"[table] pooled histogram {hist.tolist()}")
+    print(f"[table] freq {freq.tolist()} (M={rf.M}, scale_bits={rf.SCALE_BITS})")
+
+    # pass 2: encode + verify + write, one output shard per input shard
+    os.makedirs(a.outdir, exist_ok=True)
+    out_n = 0
+    total_record = 0
+    for p in sorted(by_shard):
+        tensors = []
+        fmt_map = {}
+        for name in by_shard[p]:
+            _, header, data_start = index[name]
+            raw, info = rf.read_tensor_bytes(p, header, data_start, name)
+            nib = rf.unpack_nibbles(raw)
+            record = rf.build_record(nib, freq, start, slot)
+            # verify BEFORE writing: full checked decode, byte-exact repack
+            back = rf.decode_record(record, table)
+            if back != raw:
+                print(f"FATAL: {name}: decode(encode(x)) != x — refusing to "
+                      f"write a container that does not round-trip", file=sys.stderr)
+                sys.exit(1)
+            tensors.append((name, "U8", [len(record)], record))
+            fmt_map[name] = rf.FORMAT_NAME
+            total_record += len(record)
+            qs = name + ".qs"
+            qp, qheader, qdata_start = index[qs]
+            qraw, qinfo = rf.read_tensor_bytes(qp, qheader, qdata_start, qs)
+            tensors.append((qs, qinfo["dtype"], qinfo["shape"], qraw))
+        metadata = {
+            rf.METADATA_KEY: json.dumps(fmt_map, sort_keys=True),
+            rf.TABLE_KEY: table_json,
+        }
+        out_path = os.path.join(a.outdir, f"out-rans-{out_n:05d}.safetensors")
+        rf.write_shard(out_path, tensors, metadata)
+        print(f"[write] {out_path}: {len(tensors)} tensor(s) "
+              f"({os.path.getsize(out_path) / 1e9:.4f} GB) "
+              f"from {os.path.basename(p)}")
+        out_n += 1
+
+    ratio = total_record / total_w
+    print(f"[ratio] record/original: {ratio:.4f} ({(1 - ratio) * 100:.2f}% "
+          f"reduction incl. framing), {total_w / 1e6:.1f} MB -> "
+          f"{total_record / 1e6:.1f} MB")
+    print(f"[done] {out_n} shard(s), every record round-trip-verified byte-exact")
+
+
+if __name__ == "__main__":
+    main()

--- a/c/tools/repack_rans.py
+++ b/c/tools/repack_rans.py
@@ -59,10 +59,20 @@ import rans_format as rf  # noqa: E402
 EXPERT_RE = re.compile(
     r"^model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.(gate|up|down)_proj\.weight$")
 
-# Per-row geometry guard (see module docstring). MIN_ROW_RATIO = I/2 for the
-# smallest hidden dim this tool accepts; the load-bearing exclusion is 32,
-# the exact ratio EVERY per-group-64 container measures regardless of shape.
+# Per-row geometry guard (see module docstring). When the weight tensor
+# carries a 2-D [O, rb] shape, per-row geometry is verified POSITIVELY
+# (qs elements == O). Flattened 1-D containers (what convert_fp8_to_int4.py
+# emits) can only be judged by the weight-bytes/scale-rows ratio:
+#   per-row      -> ratio == I/2 (3072 / 1024 for real GLM projections)
+#   per-group-64 -> ratio == exactly 32, ALWAYS, regardless of shape
+#   per-group-128 (upstream fmt=4's actual gs) -> ratio == exactly 64
+# so 32 refuses as g64, 64 refuses as AMBIGUOUS (indistinguishable from a
+# per-row I=128 tensor by bytes alone), and anything below MIN_ROW_RATIO
+# refuses as not-per-row. Collateral: 1-D per-row tensors with I <= 128 are
+# refused — loud, by name, and vacuous for every real container this repo
+# targets.
 G64_RATIO = 32
+G128_RATIO = 64
 MIN_ROW_RATIO = 64
 
 
@@ -110,6 +120,18 @@ def select_targets(index, layers):
             raise rf.RansRefusal("E_GEOMETRY_NOT_PER_ROW",
                                  f"{name}: {qs} is {sb} bytes (not F32-shaped)")
         rows = sb // 4
+        wshape = info["shape"]
+        if len(wshape) == 2:
+            # positive per-row verification: [O, rb] weight demands exactly
+            # one scale per row — no ratio heuristics involved
+            if rows != wshape[0]:
+                raise rf.RansRefusal(
+                    "E_GEOMETRY_NOT_PER_ROW",
+                    f"{name}: weight shape {wshape} has {wshape[0]} rows but "
+                    f"{qs} carries {rows} scales — not per-row geometry")
+            selected.append(name)
+            continue
+        # flattened 1-D container: byte-ratio judgement (docstring above)
         if wb % rows:
             raise rf.RansRefusal(
                 "E_GEOMETRY_NOT_PER_ROW",
@@ -121,6 +143,14 @@ def select_targets(index, layers):
                 f"{name}: weight/scale ratio {ratio} is the per-group-64 "
                 f"signature — g64 containers are out of this format's v1 scope "
                 f"(materially weaker entropy payoff; needs its own round)")
+        if ratio == G128_RATIO:
+            raise rf.RansRefusal(
+                "E_GEOMETRY_AMBIGUOUS",
+                f"{name}: weight/scale ratio {ratio} is exactly the "
+                f"per-group-128 signature (upstream grouped-int4's gs) and "
+                f"indistinguishable by bytes from a per-row I=128 tensor — "
+                f"refusing rather than stamping per-row geometry it cannot "
+                f"prove")
         if ratio < MIN_ROW_RATIO:
             raise rf.RansRefusal(
                 "E_GEOMETRY_NOT_PER_ROW",
@@ -141,6 +171,10 @@ def main():
                     help="comma-separated layer subset (default: every layer)")
     ap.add_argument("--dry-run", action="store_true",
                     help="inventory only: scan headers, print selection, write nothing")
+    ap.add_argument("--force", action="store_true",
+                    help="overwrite an outdir that already contains repack output "
+                         "(default: refuse — a pre-existing partial set from an "
+                         "interrupted run must never be silently papered over)")
     a = ap.parse_args()
 
     layers = None
@@ -195,9 +229,29 @@ def main():
     print(f"[table] pooled histogram {hist.tolist()}")
     print(f"[table] freq {freq.tolist()} (M={rf.M}, scale_bits={rf.SCALE_BITS})")
 
-    # pass 2: encode + verify + write, one output shard per input shard
+    # pass 2: encode + verify + write, one output shard per input shard.
+    # CRASH EVIDENCE: refuse a non-empty output directory (a crashed earlier
+    # run leaves individually-valid shards with no marker that the SET is
+    # incomplete — rerunning over them silently would hide that), and write
+    # repack-manifest.json only after every shard landed, so "manifest
+    # present and matching" == "the set is complete".
     os.makedirs(a.outdir, exist_ok=True)
+    manifest_path = os.path.join(a.outdir, "repack-manifest.json")
+    pre_existing = sorted(glob.glob(os.path.join(a.outdir, "out-rans-*.safetensors")))
+    if (pre_existing or os.path.exists(manifest_path)) and not a.force:
+        print(f"ERROR: {a.outdir} already contains repack output "
+              f"({len(pre_existing)} shard(s)"
+              f"{', manifest present' if os.path.exists(manifest_path) else ', NO manifest — likely an interrupted run'}) "
+              f"— refusing to overwrite; pass --force to redo from scratch",
+              file=sys.stderr)
+        sys.exit(1)
+    if a.force:
+        for p in pre_existing:
+            os.remove(p)
+        if os.path.exists(manifest_path):
+            os.remove(manifest_path)
     out_n = 0
+    shard_manifest = []
     total_record = 0
     for p in sorted(by_shard):
         tensors = []
@@ -226,16 +280,37 @@ def main():
         }
         out_path = os.path.join(a.outdir, f"out-rans-{out_n:05d}.safetensors")
         rf.write_shard(out_path, tensors, metadata)
+        shard_manifest.append({
+            "file": os.path.basename(out_path),
+            "source": os.path.basename(p),
+            "bytes": os.path.getsize(out_path),
+            "weight_tensors": len(fmt_map),
+        })
         print(f"[write] {out_path}: {len(tensors)} tensor(s) "
               f"({os.path.getsize(out_path) / 1e9:.4f} GB) "
               f"from {os.path.basename(p)}")
         out_n += 1
 
+    # completion marker, written LAST and deterministically (no timestamps):
+    # its absence over a shard set means the producing run did not finish
+    manifest = {
+        "format": rf.FORMAT_NAME,
+        "table_crc32": json.loads(table_json)["table_crc32"],
+        "n_shards": out_n,
+        "n_weight_tensors": len(selected),
+        "shards": shard_manifest,
+    }
+    tmp = manifest_path + ".tmp"
+    with open(tmp, "w") as fh:
+        json.dump(manifest, fh, indent=1, sort_keys=True)
+    os.replace(tmp, manifest_path)
+
     ratio = total_record / total_w
     print(f"[ratio] record/original: {ratio:.4f} ({(1 - ratio) * 100:.2f}% "
           f"reduction incl. framing), {total_w / 1e6:.1f} MB -> "
           f"{total_record / 1e6:.1f} MB")
-    print(f"[done] {out_n} shard(s), every record round-trip-verified byte-exact")
+    print(f"[done] {out_n} shard(s) + repack-manifest.json, every record "
+          f"round-trip-verified byte-exact")
 
 
 if __name__ == "__main__":

--- a/docs/int4-rans256-g0.md
+++ b/docs/int4-rans256-g0.md
@@ -211,6 +211,30 @@ description above to read records: parse the shard header, find the stamp
 and table in `__metadata__`, locate a tensor's record by name, and decode
 its 256 streams with the table (in any order or in parallel).
 
+## Whole-artifact verification
+
+Per-record validation (framing, stream invariants, re-encode pin) proves a
+record is *a* well-formed artifact of this format — it cannot prove it is
+*the* record a given mint run produced: a well-formed record swapped in
+from another checkpoint passes every check above. For that, the writer's
+`repack-manifest.json` (the completion marker, written last, deterministic)
+carries per shard a whole-file `sha256` (the complete `.safetensors` bytes,
+hashed while streaming the write — it subsumes the `.qs` sidecars, the
+header, and the padding, none of which per-record digests can see) plus a
+`records` map — original tensor name → sha256 of the emitted record bytes
+exactly as written — for granular diagnosis. `rans_verify.py` checks the
+file hash first, then every record against its digest, whenever the
+manifest sits next to the shards (named refusals:
+`E_SHARD_DIGEST_MISMATCH`, `E_DIGEST_MISMATCH`, `E_DIGEST_MISSING`,
+`E_MANIFEST_MALFORMED`); a manifest without digests, or no manifest, means
+no check is possible (a note, never an error), and
+`repack_rans.py --manifest-only <dir>` retro-generates digests for
+already-minted directories by hashing shards in place. This is **build
+integrity** — these exact bytes came from that mint run; container
+*identity* proper remains the stamp/registry lineage above, and the
+engine-side load check ships with the consumer PR. The record wire format
+is untouched by all of this: the manifest is a sidecar file.
+
 ## Proposed registry row
 
 | ordinal | name | weight bytes | scale layout | status |

--- a/docs/int4-rans256-g0.md
+++ b/docs/int4-rans256-g0.md
@@ -1,0 +1,185 @@
+# `int4-rans256-g0` — lossless entropy-coded container tier for per-row int4 experts
+
+Status: format specification + offline tools, PR 1 of a 3-PR ladder. This PR
+adds the codec (`c/rans.h`), the repack/verify tools
+(`c/tools/repack_rans.py`, `c/tools/rans_verify.py`) and this document —
+**no engine code paths change**. PR 2 (loader + CPU decode on expert load)
+and PR 3 (Metal batched decode) build on it. A registry row is *proposed*
+here, not claimed: the format's identity is the NAME string
+`int4-rans256-g0`; the numeric `fmt` ordinal is left for the maintainer to
+assign whenever a registry (FORMATS.md) lands.
+
+## What it is, in one paragraph
+
+`int4-rans256-g0` losslessly entropy-codes the packed int4 weight bytes of
+routed-expert projections (`gate_proj`/`up_proj`/`down_proj`) with a
+**single static rANS table shared per shard**, laid out as **256 independent
+round-robin-interleaved streams per tensor** so wide decoders (SIMD lanes,
+GPU threadgroups) get coalesced output. On a full-corpus census of a per-row
+int4 GLM-5.2 container the achieved ratio is ~0.76 (≈24% fewer bytes to
+store and stream), with byte-exact reconstruction — this is a codec, not a
+quantizer: decode reproduces the original packed bytes exactly, always.
+
+Name breakdown: `int4` — source alphabet is 4-bit quantization codes
+(nominally 16, effectively 15 symbols: the symmetric quantizer never emits
+the -8 code point, and the table handles that automatically via a zero
+frequency); `rans256` — rANS entropy coding, 256-way interleave; `g0` —
+shared static table, generation 0.
+
+## Container shape
+
+Output is **ordinary safetensors shards**. Each entropy-coded weight tensor
+keeps its **original, unmodified logical name** (so any name-indexed loader
+finds it with zero special-casing), stored as dtype `U8`, shape
+`[record_len]` — an opaque byte blob whose contents are the chunk record
+below. The `.qs` per-row scale sidecars are **unchanged raw F32** (they are
+~0.1% of the byte stream on per-row geometry; coding them is not worth a
+second codec path in v1).
+
+### Chunk record (one record = one weight tensor's bytes)
+
+All integers little-endian. `N` = 256 streams.
+
+```
+offset 0:  n_symbols     u64   -- nibble count for this tensor
+offset 8:  packed_bytes  u64   -- original packed-byte count (= ceil(n_symbols/2)),
+                                  stored so a reader can size its output buffer
+offset 16: stream_offsets[N+1]  u32 x (N+1)
+                                -- offsets[i] = byte offset, relative to the start
+                                   of `payload`, where stream i begins;
+                                   offsets[N] = total payload length
+then:      zero-pad to the next 16-byte boundary (derived, never stored)
+payload:   N independent rANS byte streams, concatenated in stream order:
+           stream i is payload[offsets[i] : offsets[i+1]]
+then:      zero-pad to the next 16-byte boundary (derived, never stored)
+```
+
+The two padding runs are computed identically by writer and reader
+(`round16()`), never stored — a stored length could disagree with the
+derived value. Validators refuse nonzero padding bytes. Alignment is
+**record-relative**, not file-absolute: safetensors does not 16-align
+tensor offsets, so a consumer that wants aligned u32/u64 access must read or
+map the tensor's bytes into an aligned allocation (any `malloc`/GPU-buffer
+allocation qualifies).
+
+### Interleaving
+
+Nibbles are unpacked low-nibble-first (`nib[2k] = byte[k] & 0xF`,
+`nib[2k+1] = byte[k] >> 4`). Nibble at logical index `j` belongs to stream
+`j % N` and is the `(j / N)`-th symbol of that stream. Every stream is an
+ordinary, self-contained, single-state rANS stream over the same shared
+table — no cross-stream coupling. Round-robin (not block) assignment is the
+property that makes wide decode output-coalesced: lane `l` of a group based
+at stream `b` emits logical position `r*N + b + l` at round `r`, so a
+G-lane group writes G contiguous nibbles = G/2 whole packed bytes.
+
+### Per-stream codec
+
+ryg_rans-style construction (Fabian Giesen's public-domain reference
+design): 32-bit state, byte renormalization, `L = 2^23`,
+`scale_bits = 14` (`M = 16384`).
+
+- encode walks the input backwards, writes bytes backwards, flushes the
+  final 4-byte state; decode reads forward:
+  `x = 4 bytes big-endian`, then per symbol:
+  `slot = x & (M-1)`; `s = slot_to_symbol[slot]`;
+  `x = freq[s]*(x >> scale_bits) + slot - start[s]`;
+  `while (x < L) { if bytes remain: x = (x<<8)|next byte; else break; }`.
+- The `else break` is load-bearing: a stream's final symbols legally decode
+  with `x < L`; a decoder that reads past the stream end produces wrong
+  tail symbols.
+- Verifiable invariants of any genuine encoder output (validators use them
+  to refuse corruption **without ground-truth bytes**): the initial 4-byte
+  state lies in `[L, 256L)`; decode consumes the stream exactly; the final
+  state is exactly `L`.
+
+### Shared table, in shard metadata
+
+The table ships **once per shard** in
+`__metadata__["colibri.int4-rans256-g0.table"]`, a JSON string:
+
+```json
+{
+  "table_id": "g0",
+  "n_streams": 256,
+  "scale_bits": 14,
+  "M": 16384,
+  "freq": [16 uint32, summing to M],
+  "start": [16 uint32, the exclusive prefix sum of freq],
+  "slot_to_symbol_b64": "<base64 of M x uint16, little-endian>",
+  "table_crc32": "<hex crc32 of the raw slot_to_symbol bytes>"
+}
+```
+
+Decode is always shard-local: every record in a shard decodes against that
+shard's embedded copy, no cross-shard or external-file dependency. A
+multi-shard writer must stamp the byte-identical table into every shard it
+emits (the repack tool builds the table once, from the pooled histogram of
+every selected tensor, and reuses the same JSON string). `table_crc32`
+lets tooling confirm two shards used the identical table without diffing
+the base64 blob. `table_id` is provenance metadata (a retuned future table
+would ship as `g1`); readers never resolve it externally.
+
+## THE STAMP IS MANDATORY (the load-bearing difference from fmt=7)
+
+`__metadata__["colibri.fmt"]` maps each entropy-coded **weight** tensor
+name (never `.qs`) to the string `int4-rans256-g0`, JSON-encoded with
+sorted keys.
+
+For the existing formats the engine can infer identity from byte arithmetic
+(`weight bytes == formula(O, I)`), and a stamp is at most a cross-check.
+**That inference is structurally impossible here**: entropy-coded size is
+data-dependent — there is no `expected_bytes(O, I)` to compare against. The
+stamp is therefore the **only** signal that a `U8` tensor is entropy-coded
+at all. Consequences any consumer must respect:
+
+- an *unstamped* `U8` tensor must never be presumed entropy-coded by any
+  size heuristic;
+- a future engine read path needs a stamp-gated dispatch **ahead of** the
+  byte-arithmetic format inference: stamped `int4-rans256-g0` → rANS decode
+  path; anything else → today's inference, completely unchanged. Getting
+  that order wrong would misread a compressed blob as a fixed-ratio format
+  and corrupt every weight with no error;
+- validators refuse a shard whose stamps and table are not both present and
+  coherent (`tools/rans_verify.py` is the reference validator, with a named
+  refusal per corruption class).
+
+## Scope (v1)
+
+Per-row ("gs=0") int4 expert containers only. Per-group (g64-class)
+containers are out of scope: their better-normalized codes measure a much
+weaker ratio (~0.89 vs ~0.76) and their scale arrays are a two-orders-larger
+share of the stream — a g64 round would need scale coding to be worth
+doing, which is its own design. The repack tool *refuses* (by name) a
+tensor whose weight-bytes/scale-rows ratio is the g64 signature rather than
+silently coding it under this format's identity.
+
+## Reference implementation map
+
+- `c/rans.h` — dependency-free C99, header-only: scalar codec, record
+  writer/reader with named refusals, batched decode arms (scalar, branch-free
+  scalar, NEON, AVX-512 F+BW). Vector arms are byte-identical to scalar by
+  contract and carry a compile-time ISA gate, a first-use round-trip
+  selftest (a failing arm disables itself loudly) and env kill-switches
+  (`RANS_NEON=0`, `RANS_AVX512=0`; `RANS_PATH=<arm>` forces one and refuses
+  if unavailable — never a silent downgrade).
+- `make rans` — builds `tools/librans_c.*`, the ctypes bridge the Python
+  tools prefer; without it they fall back to a pure-Python codec that emits
+  identical bytes, slowly.
+- `c/tools/repack_rans.py` — writer. Deterministic: same input ⇒
+  byte-identical shards. Verifies every record byte-exact before writing.
+- `c/tools/rans_verify.py` — validator (TRUST-VERIFY-REFUSE; the doc of
+  refusal classes is its module docstring).
+- `c/tests/test_rans.c`, `c/tests/test_rans_repack.py` — property suite,
+  arm-identity sweep, framing/refusal battery, e2e round trip.
+
+A third-party consumer needs only this document plus the scalar decode
+description above to read records: parse the shard header, find the stamp
+and table in `__metadata__`, locate a tensor's record by name, and decode
+its 256 streams with the table (in any order or in parallel).
+
+## Proposed registry row
+
+| ordinal | name | weight bytes | scale layout | status |
+|---|---|---|---|---|
+| *(maintainer-assigned)* | `int4-rans256-g0` | data-dependent (chunk record above; **stamp mandatory**) | per-row `F32` `.qs`, raw (unchanged from int4-row) | proposed, offline tools only |

--- a/docs/int4-rans256-g0.md
+++ b/docs/int4-rans256-g0.md
@@ -38,7 +38,12 @@ second codec path in v1).
 
 ### Chunk record (one record = one weight tensor's bytes)
 
-All integers little-endian. `N` = 256 streams.
+All integers little-endian — explicitly including the `n_symbols` and
+`packed_bytes` u64 fields and every `stream_offsets` u32 (the same
+byte order the base64 `slot_to_symbol` field spells out). `N` = 256
+streams. The reference C implementation reads/writes these with
+native-order accesses and therefore refuses to compile on a big-endian
+host rather than emit byte-swapped records.
 
 ```
 offset 0:  n_symbols     u64   -- nibble count for this tensor
@@ -60,7 +65,24 @@ derived value. Validators refuse nonzero padding bytes. Alignment is
 **record-relative**, not file-absolute: safetensors does not 16-align
 tensor offsets, so a consumer that wants aligned u32/u64 access must read or
 map the tensor's bytes into an aligned allocation (any `malloc`/GPU-buffer
-allocation qualifies).
+allocation qualifies; the reference parser refuses a buffer that is not at
+least 4-byte aligned rather than perform unaligned accesses).
+
+Validity rules every conformant record satisfies (and validators enforce):
+
+- `packed_bytes == ceil(n_symbols / 2)`, computed in a non-wrapping form
+  (`n/2 + (n & 1)`) so `n_symbols = 2^64 - 1` cannot forge a match;
+- `stream_offsets[0] == 0`, offsets non-decreasing, and **every stream is at
+  least 4 bytes** — even a stream that encodes zero symbols carries its
+  4 flushed state bytes;
+- the record's total length equals the derived framing exactly (no trailing
+  bytes), and every derived padding byte is zero;
+- **amplification bound**: no admissible table can encode more than
+  `payload_len * 8 * M_max` symbols into a payload (`M_max = 2^15`, the
+  format's largest table size — a symbol's cost is bounded below by
+  `log2(M / (M-1))` bits). A header claiming more `n_symbols` than that is
+  a decompression bomb and must be refused *before* anything sizes buffers
+  from it.
 
 ### Interleaving
 
@@ -80,7 +102,18 @@ design): 32-bit state, byte renormalization, `L = 2^23`,
 `scale_bits = 14` (`M = 16384`).
 
 - encode walks the input backwards, writes bytes backwards, flushes the
-  final 4-byte state; decode reads forward:
+  final 4-byte state. Per symbol `s` (this is the complete recipe a
+  bit-identical third-party **writer** needs): with the state
+  `x` (initialized to `L`), first renormalize by emitting low bytes —
+  `x_max = ((L >> scale_bits) << 8) * freq[s]`;
+  `while (x >= x_max) { emit byte x & 0xFF; x >>= 8; }` — then update
+  `x = ((x / freq[s]) << scale_bits) + (x % freq[s]) + start[s]`
+  (integer division). After the last (i.e. first-in-stream-order) symbol,
+  emit the remaining 32-bit state as 4 bytes, low byte last. The emitted
+  byte sequence, reversed into forward order, is the stream. Worst case a
+  `freq = 1` symbol emits `scale_bits` bits, so a stream of `n` symbols
+  never exceeds `ceil(n * scale_bits / 8) + 4` bytes;
+- decode reads forward:
   `x = 4 bytes big-endian`, then per symbol:
   `slot = x & (M-1)`; `s = slot_to_symbol[slot]`;
   `x = freq[s]*(x >> scale_bits) + slot - start[s]`;


### PR DESCRIPTION
*Authored by Fable 5 in Claude Code, analysis in partnership with @Monotophic
(We/our = the joint work; me/my = @Monotophic's own hardware and containers).*

## What this is

The first deliverable of the transport-layer build declared on #651
(follow-through on #594): a dependency-free C99 rANS codec (`c/rans.h`,
header-only), the **`int4-rans256-g0`** container record format, and the
offline tools to mint, verify, and document it. **No engine inference path
is touched** — `colibri.o` compiles byte-identical to base; everything here
is codec + tools + tests + docs, useful standalone and consumable by any
tier (the CUDA capacity tier included — one codec, every consumer, no
external dependency).

- **Codec**: scalar + vectorized batch decode (AVX-512 F+BW and NEON arms),
  each carrying the i4-precedent runtime envelope — first-use round-trip
  selftest (with machine-checked renorm-band coverage) and env
  kill-switches. Vector arms are byte-identical to scalar by contract and
  by test — this is a codec: no tolerance, only identity.
- **Format**: per-tensor records under original safetensors names (256
  round-robin-interleaved rANS streams, GPU/threadgroup-friendly), the
  shared table embedded per-shard in `__metadata__`, and a **mandatory
  format stamp** — entropy-coded sizes are data-dependent, so no
  byte-arithmetic inference exists; unstamped tensors can never be
  misread (refuse-rather-than-guess, same philosophy as #529).
- **Tools**: `repack_rans.py` (deterministic: two runs byte-identical;
  positive per-row geometry verification; crash-evident multi-shard
  manifest) and `rans_verify.py` (TRUST-VERIFY-REFUSE: a named refusal
  class for every corruption class, never a crash — fuzz-hardened).
- **Docs**: `docs/int4-rans256-g0.md` is complete enough that a third-party
  reader AND writer can be built from the doc alone (independently
  demonstrated during review).

## Measured

| | ratio / throughput |
|---|---|
| Real-corpus repack (2 shards, 5.4 GB, GLM-5.2 int4) | **0.7305** (27.0% smaller incl. framing); full-corpus census anchor 0.763 |
| Decode, Zen 5 AVX-512 (32T, pure C) | **20.2 GB/s** nibble-out (10.1 GB/s packed), 3.0× scalar |
| Decode, M-series NEON (12T, pure C) | 5.0 GB/s nibble-out (2.5 GB/s packed), 1.5× scalar |
| Decode, Metal (prototype, prior work) | 24.3 GB/s single-dispatch warm median |
| Encoder reproduces the proven prototype bitstream | **byte-for-byte** (offsets + payload) |

## Capstone matrix

| requirement | decisive evidence |
|---|---|
| engine untouched | `colibri.o` byte-identical base-vs-branch; diff = new files + Makefile/test wiring only |
| lossless, always | round-trip property suite (random/adversarial/real tensors) + 4,907-mutant structured fuzz under ASan+UBSan: zero memory errors, zero arm divergence |
| vector = scalar, bit-exact | byte-identity across arms on every fuzz-accepted record + real chunks, on both silicons |
| refuse, never guess | named-refusal battery (25+ classes incl. u64-wraparound, decompression-bomb bounds, hostile headers) with **C/Python refusal parity as a tested property** |
| deterministic containers | two-run byte-identity + stable-sort table construction + cross-implementation (C vs pure-Python) byte-identity |
| third-party consumable | reference parser + decoder built from the docs alone during review, decoding real records byte-exact |

<details>
<summary>Review + hardening detail</summary>

Built under a two-reviewer gate (blind validator + deep audit, independent
harnesses). The hardening round closed everything found: non-wrapping
header validation + amplification bounds (`E_OVERSIZE`), corrected encoder
scratch bound (+`E_SCRATCH`), `E_SYMBOL_UNCODABLE` pre-scan, never-crash
verifier (hostile-header suite: zero tracebacks), positive 2-D geometry
verification (g64/g128 refused by name — this PR scopes v1 to per-row int4
deliberately), `E_NSTREAMS`/`E_UNALIGNED` guards, big-endian `#error`,
crash-evident repack manifest. The fuzzer ships as `make fuzz-rans`
(seeded, sanitizer-built, non-gating). Suite: `make check` +227-test Python
battery; gcc-13 `-Wall -Wextra -Wpedantic -Wshadow` clean; the AVX-512
arm's first silicon run passed the full suite with the envelope exercised
both ways.

</details>

Scope notes: v1 targets per-row int4 expert tensors (the census's 0.763
container class); g64-class and scale-array coding are documented future
rounds with their own (weaker) payoff cases. Engine integration (loader +
CPU streaming decode, then Metal batched decode) follows as separate PRs —
this one is deliberately inert: format + codec + tools, reviewable and
usable on their own.

*Durable vs current-state: format, codec, envelope, and refusal semantics
are durable; throughput figures are calibrations at (Zen 5 Strix Halo /
M5 Max, 2026-07-28, dev fa599e0 base) and the ratio at (GLM-5.2 int4
per-row container, 2-shard sample vs 372 GB census).*
