### PR TITLE
fix(hip): support GPUs without matrix cores (gfx9xx, gfx101x/103x)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -183,7 +183,22 @@ HIP       ?= 0
 ROCM_HOME ?= /opt/rocm
 HIPCC     ?= $(ROCM_HOME)/bin/hipcc
 HIP_ARCH  ?= native
-HIPCCFLAGS ?= -O3 -std=c++17 -x hip --offload-arch=$(HIP_ARCH) -Wall -Wextra -fPIE
+# HIP_ARCH accepts a list (space- or comma-separated, e.g. "gfx906 gfx1030")
+# to fat-bundle several targets into one binary; COLI_GPUS picks at runtime.
+# `native` is resolved to the local GPUs' arch names HERE (not left to hipcc):
+# the NO_WMMA_ARCHS filter below must see real gfx names to know whether the
+# rocWMMA paths can compile at all. `override` beats command-line assignment.
+comma := ,
+override HIP_ARCH := $(subst $(comma), ,$(HIP_ARCH))
+ifeq ($(strip $(HIP_ARCH)),native)
+ifeq ($(HIP),1)
+override HIP_ARCH := $(shell $(ROCM_HOME)/bin/rocm_agent_enumerator 2>/dev/null | grep -v gfx000 | sort -u)
+ifeq ($(strip $(HIP_ARCH)),)
+$(error HIP_ARCH=native but rocm_agent_enumerator found no GPUs; set HIP_ARCH=gfxNNNN explicitly)
+endif
+endif
+endif
+HIPCCFLAGS ?= -O3 -std=c++17 -x hip $(foreach a,$(HIP_ARCH),--offload-arch=$(a)) -Wall -Wextra -fPIE
 GPUCC      = $(NVCC)
 GPUFLAGS   = $(NVCCFLAGS)
 GPUCC_NAME = nvcc (set CUDA_HOME or NVCC)
@@ -240,6 +255,23 @@ CUDA_OBJ   = backend_cuda.o
 GPUCC      = $(HIPCC)
 GPUFLAGS   = $(HIPCCFLAGS)
 GPUCC_NAME = hipcc (set ROCM_HOME or HIPCC)
+# rocWMMA needs matrix cores (MFMA gfx908+ / WMMA gfx11xx); on these archs its
+# headers static_assert (ROCm/TheRock#1944). Compile the WMMA paths out and
+# let backend_gpu_compat.h fall back via COLI_GPU_HAS_WMMA=0. The flag must
+# reach both hipcc passes, hence a compile define, not an arch macro. If a
+# HIP_ARCH=native build dies inside rocwmma, set the arch explicitly.
+NO_WMMA_ARCHS = gfx803 gfx900 gfx902 gfx904 gfx906 gfx90c \
+                gfx1010 gfx1011 gfx1012 gfx1013 \
+                gfx1030 gfx1031 gfx1032 gfx1033 gfx1034 gfx1035 gfx1036 gfx1103
+ifneq (,$(filter $(HIP_ARCH),$(NO_WMMA_ARCHS)))
+HIPCCFLAGS += -DCOLI_HIP_NO_WMMA
+# The define must hold for every arch in the fat binary (host dispatch is
+# shared), so one incapable arch disables the WMMA kernels for all of them.
+# Loud, because on a WMMA-capable card that is a real capability loss.
+ifneq (,$(filter-out $(NO_WMMA_ARCHS),$(HIP_ARCH)))
+$(warning mixed HIP_ARCH list: $(filter $(HIP_ARCH),$(NO_WMMA_ARCHS)) cannot run rocWMMA -> tensor-core kernels disabled for ALL targets ($(HIP_ARCH)). Build separate binaries to keep WMMA on the capable card.)
+endif
+endif
 endif
 
 # METAL=1 adds an opt-in Apple-GPU backend (macOS only). The shader is compiled at

--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -976,7 +976,11 @@ extern "C" int coli_cuda_expert_group(ColiCudaTensor *const *gates,
     if(profile) cudaEventRecord(ev[1],ctx->stream);
     GroupDesc *dev=(GroupDesc*)ctx->group_desc;
     int tc=getenv("COLI_CUDA_TC_INT4")&&atoi(getenv("COLI_CUDA_TC_INT4"));
-    tc=tc&&all_s4&&D%32==0&&I%32==0&&D%8==0&&I%8==0;
+    /* grouped_s4_wmma's body needs __CUDA_ARCH__>=750: on builds where the
+     * WMMA kernels are compiled out (COLI_HIP_NO_WMMA) the launch would
+     * succeed with an EMPTY kernel and the output buffer would silently keep
+     * stale data. Gate the branch like TC_W4A16 below does. */
+    tc=tc&&COLI_GPU_HAS_WMMA&&all_s4&&D%32==0&&I%32==0&&D%8==0&&I%8==0;
     int tc_min=getenv("COLI_CUDA_TC_MIN_ROWS")?atoi(getenv("COLI_CUDA_TC_MIN_ROWS")):8;
     for(int c=0;c<count&&tc;c++)tc=rows[c]>=tc_min;
     if(tc){

--- a/c/backend_gpu_compat.h
+++ b/c/backend_gpu_compat.h
@@ -24,6 +24,15 @@
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIP__)
 #include <hip/hip_runtime.h>
 #include <hip/hip_fp16.h>
+/* rocWMMA requires matrix cores (MFMA: gfx908+, WMMA: gfx11xx); on other
+ * targets (gfx906, gfx101x, gfx103x) its headers static_assert. The Makefile
+ * passes -DCOLI_HIP_NO_WMMA for those archs: the WMMA kernel bodies stay
+ * compiled out (__CUDA_ARCH__ undefined fails the >= 700 guard) and the host
+ * dispatch sites fall back via COLI_GPU_HAS_WMMA=0, same as pre-Volta CUDA.
+ * The flag must be set for BOTH hipcc passes (host + device) — an arch-macro
+ * check here would let the host dispatch kernels whose bodies were compiled
+ * out, silently computing nothing. */
+#ifndef COLI_HIP_NO_WMMA
 #if __has_include(<rocwmma/rocwmma.hpp>)
 #include <rocwmma/rocwmma.hpp>
 #define COLI_GPU_HAS_WMMA        1
@@ -32,7 +41,14 @@
 namespace nvcuda { namespace wmma = ::rocwmma; }
 #define __syncwarp()            __syncthreads()
 #else
-#error "rocWMMA headers not found. Install rocwmma-dev (or rocm-hip-runtime-dev) to build with HIP."
+/* WMMA-capable arch but no headers: stop loudly rather than silently build
+ * a binary with the tensor-core kernels disabled. */
+#error "rocWMMA headers not found. Install rocwmma-dev (or rocm-hip-runtime-dev), or build for a non-WMMA arch (see NO_WMMA_ARCHS in the Makefile)."
+#endif
+#else
+/* Arch has no matrix cores: rocWMMA is not needed and not included. */
+#define COLI_GPU_HAS_WMMA        0
+#define __syncwarp()            __syncthreads()
 #endif
 #define cudaError_t              hipError_t
 #define cudaSuccess              hipSuccess

--- a/c/coli
+++ b/c/coli
@@ -183,8 +183,11 @@ def cuda_binary():
 
 def resource_request(a, env):
     ctx=a.ctx or int(env.get("CTX",4096))
-    ram=a.ram or float(env.get("RAM_GB",0))
-    vram=a.vram or float(env.get("CUDA_EXPERT_GB",0))
+    def num(v):
+        try: return float(v)
+        except ValueError: return 0.0  # "auto": the planner sizes it; the engine reads the string itself
+    ram=a.ram or num(env.get("RAM_GB",0))
+    vram=a.vram or num(env.get("CUDA_EXPERT_GB",0))
     gpu=a.gpu
     if gpu is None:
         gpu=env.get("COLI_GPUS",env.get("COLI_GPU","auto"))


### PR DESCRIPTION
> **Authorship**: this patch and write-up were authored by Claude Fable 5 (Anthropic's AI) working interactively on MrMetric's machine; MrMetric reviewed the diff, ran the builds on his hardware, and submits it. Questions in review will be answered by both.

## Problem

`make glm HIP=1` fails on any AMD GPU without matrix cores — MI50/Vega (gfx9xx without MFMA), RDNA1 (gfx101x), RDNA2 (gfx103x) — because `backend_gpu_compat.h` unconditionally includes rocWMMA, whose headers `static_assert("Unsupported architecture")` for those targets (tracked upstream as ROCm/TheRock#1944; these archs will never be supported).

The engine itself doesn't need WMMA to run: both WMMA host-dispatch sites already have fallbacks (`compute_major<7` pre-Volta path), and the grouped expert kernels (`grouped_hidden_g4_dual` etc.) are plain HIP.

## Change

- **`c/backend_gpu_compat.h`** — rocWMMA is included only when the target arch can use it. Otherwise `COLI_GPU_HAS_WMMA=0` and `__CUDA_ARCH__` stays undefined, so the WMMA kernel bodies compile out and host dispatch takes the existing fallbacks. Missing `rocwmma-dev` on a WMMA-*capable* arch remains a hard `#error` (a silent tensor-core downgrade would be worse). Non-WMMA archs no longer need `rocwmma-dev` installed at all.
- **`c/Makefile`** — the decision is a compile define (`-DCOLI_HIP_NO_WMMA`) derived from `HIP_ARCH`, because it must be identical in both hipcc passes: an arch-macro check inside the header fires only in the device pass, and the host side would then dispatch kernels whose bodies were compiled out (empty launch, no error, stale output buffer). To make the arch filter reliable, `HIP_ARCH` is normalized first: comma lists accepted, and `native` is resolved to real gfx names via `rocm_agent_enumerator` at make time. `HIP_ARCH` may now be a list, producing a fat binary (`--offload-arch` per entry); a mixed capable/incapable list warns loudly that WMMA is off for all targets (shared host dispatch requires one consistent setting).
- **`c/backend_cuda.cu`** — gate the opt-in `COLI_CUDA_TC_INT4` branch on `COLI_GPU_HAS_WMMA`, exactly as its `TC_W4A16` sibling already is. `grouped_s4_wmma`'s body is `__CUDA_ARCH__>=750`-guarded, so on a no-WMMA build the env var would launch an empty kernel: no error, output buffer never written.

## Verified

- ROCm 7.2.4, Ryzen 9 5950X, Radeon Instinct MI50 32 GB (gfx906) + RX 6900 XT (gfx1030), Arch Linux.
- `make glm HIP=1` (native → resolves to `gfx906 gfx1030`, fat binary), `HIP_ARCH=gfx906`, and `HIP_ARCH="gfx906,gfx1030"` all build clean.
- Engine serves GLM-5.2 int4-gs64 on the MI50 with the VRAM expert tier active (`[CUDA] hot expert tier: 727/727 experts` on first bring-up; pinned tier grows with usage history as designed). Related field report for this hardware class: #510.
- `make check`: 229 tests pass.

## Noticed but not touched (flagging for a maintainer)

- The same empty-kernel hazard exists on **CUDA sm_70/Volta**: `grouped_s4_wmma` needs `>=750` but the host never checks the minor version. This PR's `COLI_GPU_HAS_WMMA` gate doesn't cover that case (compile-time 1 on CUDA).
- `backend_gpu_compat.h` references `HIP-KNOWN-BUGS.md` (BUG-002), which doesn't exist in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
