### PR TITLE
Kimi K3: integrate coli chat, API, and Web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ c/glm
 c/glm.exe
 c/olmoe
 c/inkling
+c/kimi_k3
+c/kimi_k3.exe
 c/olmoe.exe
 c/iobench
 c/iobench.exe

--- a/c/Makefile
+++ b/c/Makefile
@@ -410,6 +410,9 @@ olmoe$(EXE): olmoe.c st.h json.h compat.h
 inkling$(EXE): inkling.c st.h json.h compat.h $(INK_CUDA_OBJ)
 	$(CC) $(CFLAGS) inkling.c $(INK_CUDA_OBJ) -o inkling$(EXE) $(LDFLAGS)
 
+kimi_k3$(EXE): kimi_k3.c st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h
+	$(CC) $(CFLAGS) kimi_k3.c -o kimi_k3$(EXE) $(LDFLAGS)
+
 # Use a baseline that matches the compiler target. macOS already targets a
 # portable baseline when ARCH is empty; forcing the x86 value there breaks
 # Apple Silicon. Unknown targets use native rather than an invalid x86 flag.

--- a/c/coli
+++ b/c/coli
@@ -152,13 +152,44 @@ def hline(w): return f"{C.dgray}{'─'*w}{C.r}"
 # ---------- util ----------
 def term_w(): return min(shutil.get_terminal_size((80,20)).columns, 100)
 
-def need_model(model):
+def model_arch(model):
+    try:
+        with open(os.path.join(model, "config.json"), encoding="utf-8") as f:
+            model_type = (json.load(f).get("model_type") or "").lower()
+    except (OSError, ValueError, TypeError):
+        return "glm"
+    if "inkling" in model_type:
+        return "inkling"
+    if "kimi" in model_type:
+        return "kimi"
+    return "glm"
+
+def engine_for(model):
+    arch = model_arch(model)
+    if arch == "glm" or os.environ.get("COLI_ENGINE"):
+        return GLM
+    name = "inkling" if arch == "inkling" else "kimi_k3"
+    local = os.path.join(HERE, name + _EXE)
+    return local if os.path.exists(local) else os.path.join(_LIBEXEC, name + _EXE)
+
+def need_model(model, engine=None):
     if not os.path.isdir(model):
         sys.exit(f"{C.yel}model not found:{C.r} {model}\n  set COLI_MODEL or use --model")
     if not os.path.exists(os.path.join(model,"tokenizer.json")):
         sys.exit(f"{C.yel}tokenizer.json is missing from {model}{C.r}")
-    if not os.path.exists(GLM):
-        sys.exit(f"{C.yel}engine is not built.{C.r} Run: coli build")
+    engine = engine or engine_for(model)
+    if not os.path.exists(engine):
+        arch = model_arch(model)
+        target = "kimi_k3" if arch == "kimi" else "inkling" if arch == "inkling" else "colibri"
+        sys.exit(f"{C.yel}{target} engine is not built.{C.r} Run: make -C c {target}")
+
+def env_for_engine(a, arch):
+    if arch == "glm":
+        return env_for(a)
+    env = os.environ.copy()
+    if a.ngen: env["NGEN"] = str(a.ngen)
+    if a.temp is not None: env["COLI_TEMP"] = str(a.temp)
+    return env
 
 def cuda_binary():
     if not os.path.exists(GLM): return False
@@ -702,6 +733,34 @@ def cmd_chat(a):
             chat_attached(a, base, mid); return
         if getattr(a,"attach",None):
             sys.exit(f"--attach: no coli serve answering at {base} (start one with: coli serve --model <dir>)")
+    arch=model_arch(a.model)
+    if arch!="glm":
+        engine=engine_for(a.model)
+        need_model(a.model,engine)
+        model_id="kimi-k3-colibri" if arch=="kimi" else "inkling-colibri"
+        banner(f"chat · {model_id} · local server")
+        import openai_server
+        cmd=[sys.executable,openai_server.__file__,"--model",a.model,
+             "--engine",engine,"--arch",arch,"--model-id",model_id,
+             "--host","127.0.0.1","--port","8000","--max-tokens",str(a.ngen)]
+        if a.api_key: cmd+=["--api-key",a.api_key]
+        p=subprocess.Popen(cmd,env=env_for_engine(a,arch))
+        try:
+            sp=Spinner(f"loading {model_id}…"); sp.start()
+            for _ in range(1800):
+                if p.poll() is not None:
+                    sp.stop(); sys.exit(f"{model_id} server exited while loading")
+                if server_probe("http://127.0.0.1:8000",a.api_key,timeout=1.0):
+                    sp.stop()
+                    chat_attached(a,"http://127.0.0.1:8000",model_id)
+                    return
+                time.sleep(1)
+            sp.stop(); sys.exit(f"timed out loading {model_id}")
+        finally:
+            if p.poll() is None:
+                p.terminate()
+                try: p.wait(timeout=10)
+                except subprocess.TimeoutExpired: p.kill()
     need_model(a.model)
     banner(f"chat · {os.path.basename(a.model)} · ram {a.ram or '-'}GB · topp {a.topp or 'off'}")
     kv_resume_notice(a.model)
@@ -840,16 +899,23 @@ def cmd_chat(a):
 def serve_pidfile(port): return os.path.join(tempfile.gettempdir(), f"coli-serve-{port}.pid")
 
 def cmd_serve(a):
-    need_model(a.model)
+    arch=model_arch(a.model)
+    engine=engine_for(a.model)
+    need_model(a.model,engine)
+    if arch!="glm" and a.kv_slots!=1:
+        sys.exit(f"{arch} currently supports exactly one KV slot")
     # pidfile: cosi' `coli stop` spegne tutto con un comando, senza pkill a mano.
     # EN: pidfile so `coli stop` can shut everything down without manual pkill.
     try:
         with open(serve_pidfile(a.port),"w") as f: f.write(f"{os.getpid()} {a.model}\n")
     except OSError: pass
-    from openai_server import serve
+    import openai_server
+    openai_server.ARCH=arch
+    model_id=a.model_id or ("kimi-k3-colibri" if arch=="kimi" else
+                            "inkling-colibri" if arch=="inkling" else "glm-5.2-colibri")
     try:
-        serve(a.model, a.host, a.port, a.model_id, a.api_key,
-              a.cap,a.ngen,GLM,env_for(a),a.cors_origin,
+        openai_server.serve(a.model,a.host,a.port,model_id,a.api_key,
+              a.cap,a.ngen,engine,env_for_engine(a,arch),a.cors_origin,
               a.max_queue,a.queue_timeout,a.kv_slots,allowed_hosts=a.allowed_host)
     finally:
         try: os.unlink(serve_pidfile(a.port))
@@ -878,7 +944,7 @@ def cmd_stop(a):
             if "coli" in cmd and " serve" in cmd and pid!=os.getpid():
                 if not any(p==pid for p,_ in targets): targets.append((pid,"coli serve (cmdline)"))
             comm=open(f"/proc/{pd}/comm").read().strip()
-            if comm in ("colibri","glm","exe","olmoe"):
+            if comm in ("colibri","glm","exe","olmoe","inkling","kimi_k3"):
                 env=open(f"/proc/{pd}/environ","rb").read().replace(b"\0",b"\n").decode("utf-8","replace")
                 if "SERVE=1" in env: targets.append((pid,f"engine `{comm}` (SERVE=1)"))
         except (OSError,PermissionError): continue
@@ -1008,7 +1074,7 @@ def main():
     pc.add_argument("--api-key", default=os.environ.get("COLI_API_KEY"))
     ps=sub.add_parser("serve", parents=[common])
     ps.add_argument("--host",default="127.0.0.1"); ps.add_argument("--port",type=int,default=8000)
-    ps.add_argument("--model-id",default=os.environ.get("COLI_MODEL_ID","glm-5.2-colibri"))
+    ps.add_argument("--model-id",default=os.environ.get("COLI_MODEL_ID"))
     ps.add_argument("--api-key",default=os.environ.get("COLI_API_KEY"))
     ps.add_argument("--cors-origin",action="append",default=None)
     ps.add_argument("--max-queue",type=int,default=int(os.environ.get("COLI_MAX_QUEUE","8")))
@@ -1021,7 +1087,7 @@ def main():
     pst.add_argument("--port",type=int,default=8000); pst.add_argument("--dry-run",action="store_true")
     pw=sub.add_parser("web", parents=[common], help="serve + open the dashboard in a browser")
     for arg,kw in (("--host",dict(default="127.0.0.1")),("--port",dict(type=int,default=8000)),
-                   ("--model-id",dict(default=os.environ.get("COLI_MODEL_ID","glm-5.2-colibri"))),
+                   ("--model-id",dict(default=os.environ.get("COLI_MODEL_ID"))),
                    ("--api-key",dict(default=os.environ.get("COLI_API_KEY"))),
                    ("--cors-origin",dict(action="append",default=None)),
                    ("--max-queue",dict(type=int,default=int(os.environ.get("COLI_MAX_QUEUE","8")))),

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -43,6 +43,8 @@
  *   K3_DIRECT=0|1        O_DIRECT expert reads (default 1; buffered fallback)
  *   K3_LAYERS=N          truncate to first N layers (validation; skips head)
  *   K3_TRACE=path        dump f32 hidden state after every layer (validation)
+ *   K3_LOGITS=path       dump f32 logits per PREFILL position (teacher-forced
+ *                        bit-width comparisons; use with --ngen 0)
  *   K3_MAXT=N            KV/context capacity (default prompt+ngen)
  *   COLI_TEMP=F          0 = greedy (default), else softmax temperature
  */
@@ -919,12 +921,19 @@ int main(int argc, char **argv){
     fprintf(stderr,"[K3] prompt: %d tokens | ngen %d | temp %.2f\n",np,ngen,temp);
     int max_t=getenv("K3_MAXT")?atoi(getenv("K3_MAXT")):np+ngen;
     kv_alloc(&m,max_t);
+    FILE *lfp=NULL;
+    if(getenv("K3_LOGITS")){
+        lfp=fopen(getenv("K3_LOGITS"),"wb");
+        if(!lfp){ perror(getenv("K3_LOGITS")); return 1; }
+    }
     double t0=now_s(); float *lo=NULL;
     for(int i=0;i<np;i++){
         if(lo) free(lo);
         lo=step(&m,ids[i],i);
+        if(lfp&&lo) fwrite(lo,sizeof(float),(size_t)m.c.vocab,lfp);
         fprintf(stderr,"\r[K3] prefill %d/%d (%.1fs)",i+1,np,now_s()-t0);
     }
+    if(lfp) fclose(lfp);
     fprintf(stderr,"\n[K3] prefill done in %.1fs (%.2f tok/s)\n",now_s()-t0,np/(now_s()-t0));
     if(!m.has_head||!lo){
         fprintf(stderr,"[K3] no head — trace written, stopping after prefill\n");

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -40,6 +40,7 @@
  *   K3_MLA_BITS=8|4|32   MLA projections (default 8)
  *   K3_HEAD_BITS=8|4|32  lm_head (default 8)
  *   K3_EXPERT_GB=N       routed-expert LRU cache budget (default 8)
+ *   K3_DIRECT=0|1        O_DIRECT expert reads (default 1; buffered fallback)
  *   K3_LAYERS=N          truncate to first N layers (validation; skips head)
  *   K3_TRACE=path        dump f32 hidden state after every layer (validation)
  *   K3_MAXT=N            KV/context capacity (default prompt+ngen)
@@ -112,7 +113,9 @@ typedef struct {
 
 /* ---------- routed-expert streaming (native MXFP4 from the HF shards) ---- */
 typedef struct { int fd[6]; int64_t off[6]; int contig; } ERef;  /* w1p w1s w2p w2s w3p w3s */
-typedef struct { int eid; uint8_t *buf; uint64_t used; } Slot;
+typedef struct { int eid; uint8_t *buf, *base; uint64_t used; } Slot;
+                          /* base = 4K-aligned allocation (O_DIRECT target);
+                           * buf = expert data view inside it (= base + off%4K) */
 typedef struct { Slot *s; int n, cap; } LCache;
 
 typedef struct {
@@ -123,6 +126,8 @@ typedef struct {
     float *final_norm, *out_sw;
     W lm_head;
     int has_head;
+    Slot ws[64];                          /* working set: parallel loads land here,
+                                           * then swap into the layer LRU */
     /* KDA state */
     float **kstate;                       /* [layer] -> [heads*hd*hd], S[k][v] */
     float **cwq, **cwk, **cwv;            /* conv windows [proj*conv_k], oldest first */
@@ -192,6 +197,9 @@ static float w_rowdot(const W *w, int r, const float *x){
 }
 
 #define QCHUNK 1024                      /* rows per load-quantize pass */
+static int g_bits_env=0;                 /* K3_BITS explicitly set: enables the
+                                          * int8-container -> int4 load downcast */
+static int g_k3_direct=-1;               /* K3_DIRECT: O_DIRECT expert reads */
 static void w_load(Model *m, W *w, const char *name, int O, int I, int bits){
     char nm[512]; snprintf(nm,sizeof(nm),"%s%s",m->pfx,name);
     st_tensor *t=st_find(&m->S,nm);
@@ -199,11 +207,39 @@ static void w_load(Model *m, W *w, const char *name, int O, int I, int bits){
     memset(w,0,sizeof(*w)); w->O=O; w->I=I;
     if(t->dtype==3){
         /* repacked container (tools/k3_repack.py): pre-quantized U8 + .qs f32
-         * scales — no load-time quantization, K3_BITS is ignored for these */
+         * scales — no load-time quantization, K3_BITS is ignored for these
+         * (except the explicit =4 downcast below) */
         char qn[560]; snprintf(qn,sizeof(qn),"%s.qs",nm);
         st_tensor *ts=st_find(&m->S,qn);
         if(!ts){ fprintf(stderr,"%s: quantized (U8) but no %s scale sidecar\n",nm,qn); exit(1); }
         if(t->nbytes==(int64_t)O*I && ts->numel==O){                  /* int8 per-row */
+            if(g_bits_env && bits==4 && I%64==0){
+                /* EXPLICIT K3_BITS=4 on an int8 container: downcast to int4-g64
+                 * at load. Halves resident RAM (the 62 GB box cannot hold the
+                 * 93-layer non-expert set at int8 next to a desktop session);
+                 * the int8 grid is 16x finer than int4, so the double-quant
+                 * noise ~ the direct-int4 noise. Unset K3_BITS keeps the
+                 * container's own bits — the default is untouched. */
+                int gs=64, rb=I/2, ng=I/gs;
+                int8_t *q8=malloc((size_t)O*I); float *s8=falloc(O);
+                if(!q8){fprintf(stderr,"OOM int8 tmp %s\n",nm);exit(1);}
+                st_read_raw(&m->S,nm,q8,1); st_read_f32(&m->S,qn,s8,0);
+                w->fmt=4; w->gs=gs;
+                w->q4=malloc((int64_t)O*rb); w->s=falloc((int64_t)O*ng);
+                if(!w->q4){fprintf(stderr,"OOM int4 %s\n",nm);exit(1);}
+                for(int r=0;r<O;r++){
+                    const int8_t *src=q8+(int64_t)r*I; float sc8=s8[r];
+                    uint8_t *dst=w->q4+(int64_t)r*rb; float *scl=w->s+(int64_t)r*ng;
+                    for(int g=0;g<ng;g++){ const int8_t *gp=src+g*gs;
+                        int am=0; for(int i=0;i<gs;i++){ int a=gp[i]<0?-gp[i]:gp[i]; if(a>am)am=a; }
+                        float s=am*sc8/7.f; if(s<1e-20f)s=1e-20f; scl[g]=s; float inv=sc8/s;
+                        for(int i=0;i<gs;i+=2){
+                            int v0=(int)lrintf(gp[i]*inv);   if(v0>7)v0=7; if(v0<-8)v0=-8;
+                            int v1=(int)lrintf(gp[i+1]*inv); if(v1>7)v1=7; if(v1<-8)v1=-8;
+                            dst[(g*gs+i)>>1]=(uint8_t)((v0+8)|((v1+8)<<4)); } } }
+                free(q8); free(s8);
+                return;
+            }
             w->fmt=1; w->q8=malloc((size_t)O*I);
             if(!w->q8){fprintf(stderr,"OOM int8 %s\n",nm);exit(1);}
             st_read_raw(&m->S,nm,w->q8,1);
@@ -370,6 +406,8 @@ static void model_init(Model *m, const char *snap, int n_layers_env){
        st_has(&m->S,"language_model.model.layers.0.input_layernorm.weight"))
         snprintf(m->pfx,sizeof(m->pfx),"language_model.");
     if((c->n_layers+c->res_bs-1)/c->res_bs+1>16){ fprintf(stderr,"attn_res: too many blocks\n"); exit(1); }
+    g_bits_env = getenv("K3_BITS")!=NULL;
+    g_k3_direct = getenv("K3_DIRECT")?atoi(getenv("K3_DIRECT")):1;
     int bits   = getenv("K3_BITS")?atoi(getenv("K3_BITS")):4;
     int mbits  = getenv("K3_MLA_BITS")?atoi(getenv("K3_MLA_BITS")):8;
     int hbits  = getenv("K3_HEAD_BITS")?atoi(getenv("K3_HEAD_BITS")):8;
@@ -467,7 +505,12 @@ static void model_init(Model *m, const char *snap, int n_layers_env){
     double egb = getenv("K3_EXPERT_GB")?atof(getenv("K3_EXPERT_GB")):8.0;
     int nmoe=0; for(int i=0;i<c->n_layers;i++) if(m->L[i].sparse) nmoe++;
     int cap=(int)((egb*1e9)/((double)m->e_slot*(nmoe?nmoe:1)));
-    if(cap<c->topk) cap=c->topk;
+    /* floor 1, NOT topk: experts are loaded and consumed one at a time inside
+     * a token, so slots never need to hold a whole top-k set. A topk floor
+     * would silently commit topk*nmoe slots (~26 GB on the 93-layer model)
+     * regardless of K3_EXPERT_GB. */
+    if(cap<1) cap=1;
+    if(cap>c->n_experts) cap=c->n_experts;
     m->ecache=calloc(c->n_layers,sizeof(LCache));
     for(int i=0;i<c->n_layers;i++) if(m->L[i].sparse){
         m->ecache[i].cap=cap; m->ecache[i].s=calloc(cap,sizeof(Slot));
@@ -598,36 +641,101 @@ static void mla_forward(Model *m, Layer *l, int li, const float *x, int pos, flo
     free(qa);free(qv);free(ckv);free(gv);free(ctx);
 }
 
-/* ---------- routed experts: LRU + direct pread from the HF shards ---------- */
-static Slot *expert_get(Model *m, int li, int eid){
+/* ---------- routed experts: LRU + pread from the shards ----------
+ * Loads are issued in PARALLEL (OMP over the token's misses, working-set
+ * slots) and, when K3_DIRECT=1 (default) and st.h has an O_DIRECT twin fd,
+ * bypass the page cache: measured on the box 7.1 GB/s direct vs 2.9 buffered
+ * (and ~1.8 effective once the resident weights leave no cache headroom). */
+static Slot *slot_find(Model *m, int li, int eid){
     LCache *lc=&m->ecache[li];
     for(int i=0;i<lc->n;i++) if(lc->s[i].eid==eid){ m->hits++; lc->s[i].used=++m->clock; return &lc->s[i]; }
-    m->miss++;
-    Slot *s;
-    if(lc->n<lc->cap){ s=&lc->s[lc->n++]; }
-    else { int lru=0; for(int i=1;i<lc->n;i++) if(lc->s[i].used<lc->s[lru].used) lru=i; s=&lc->s[lru]; }
-    if(!s->buf){ s->buf=malloc(m->e_slot); if(!s->buf){fprintf(stderr,"OOM expert slot\n");exit(1);} }
+    return NULL;
+}
+static void expert_read(Model *m, int li, int eid, Slot *s){
+    if(!s->base){
+        if(posix_memalign((void**)&s->base,4096,(size_t)m->e_slot+8192)){
+            fprintf(stderr,"OOM expert slot\n"); exit(1); }
+    }
     ERef *er=&m->eref[(int64_t)li*m->c.n_experts+eid];
     int64_t sizes[6]={m->e_w1p,m->e_w1s,m->e_w2p,m->e_w2s,m->e_w1p,m->e_w1s};
-    double t0=now_s();
     if(er->fd[0]<0){ fprintf(stderr,"[K3] expert L%d E%d missing on disk\n",li,eid); exit(1); }
     if(er->contig){
-        st_pread_full(er->fd[0],s->buf,m->e_slot,er->off[0],"pread expert");
+        int dfd = g_k3_direct ? st_direct_fd(&m->S,er->fd[0]) : -1;
+        if(dfd>=0){
+            /* aligned window read; sub-4K head/tail slack handled explicitly.
+             * The tail past the last aligned block (or past EOF) is fetched
+             * with a tiny buffered pread — O_DIRECT wants aligned lengths. */
+            int64_t a0=er->off[0]&~4095LL, pad=er->off[0]-a0;
+            int64_t want=pad+m->e_slot;
+            struct stat sb;
+            int64_t dlen=(want+4095)&~4095LL;
+            if(fstat(dfd,&sb)==0 && a0+dlen>sb.st_size) dlen=(sb.st_size-a0)&~4095LL;
+            if(dlen>0) st_pread_full(dfd,s->base,dlen,a0,"pread expert direct");
+            if(dlen<want)
+                st_pread_full(er->fd[0],s->base+dlen,want-dlen,a0+dlen,"pread expert tail");
+            s->buf=s->base+pad;
+        } else {
+            st_pread_full(er->fd[0],s->base,m->e_slot,er->off[0],"pread expert");
+            s->buf=s->base;
+        }
     } else {
-        uint8_t *dst=s->buf;
+        uint8_t *dst=s->base;
         for(int k=0;k<6;k++){
             if(er->fd[k]<0){ fprintf(stderr,"[K3] expert L%d E%d tensor %d missing on disk\n",li,eid,k); exit(1); }
             st_pread_full(er->fd[k],dst,sizes[k],er->off[k],"pread expert");
             dst+=sizes[k];
         }
+        s->buf=s->base;
     }
-    m->ebytes+=m->e_slot; m->t_eload+=now_s()-t0;
-    s->eid=eid; s->used=++m->clock;
-    return s;
+    s->eid=eid;
 }
 
 static inline float situf_(float g, float u, float b1, float b2){
     return b1*tanhf(g/b1)*sigmoidf_(g) * b2*tanhf(u/b2);
+}
+
+/* u += wk * E(z) for one loaded expert slot (SiTU-GLU in the latent).
+ * gate/up are [moe_inter] scratch, hz is [latent] scratch. */
+static void expert_apply(Model *m, Slot *s, const float *z, float wk,
+                         float *u, float *gate, float *up, float *hz){
+    Cfg *c=&m->c;
+    uint8_t *w1p=s->buf, *w1s=w1p+m->e_w1p, *w2p=w1s+m->e_w1s, *w2s=w2p+m->e_w2p,
+            *w3p=w2s+m->e_w2s, *w3s=w3p+m->e_w1p;
+    matmul_mxfp4(gate,z,w1p,w1s,1,c->latent,c->moe_inter);
+    matmul_mxfp4(up,z,w3p,w3s,1,c->latent,c->moe_inter);
+    for(int i=0;i<c->moe_inter;i++) gate[i]=situf_(gate[i],up[i],c->situ_b1,c->situ_b2);
+    matmul_mxfp4(hz,gate,w2p,w2s,1,c->moe_inter,c->latent);
+    for(int i=0;i<c->latent;i++) u[i]+=wk*hz[i];
+}
+
+/* the full routed-expert pass for one token+layer: resolve (LRU hit or
+ * working-set slot), load misses IN PARALLEL, compute, promote into the LRU. */
+static void experts_run(Model *m, int li, int n, const int *ids, const float *w,
+                        const float *z, float *u, float *gate, float *up, float *hz){
+    Slot *use[64]; int missk[64]; int nmiss=0;
+    for(int j=0;j<n;j++){
+        use[j]=slot_find(m,li,ids[j]);
+        if(!use[j]){ m->miss++; use[j]=&m->ws[nmiss]; missk[nmiss++]=j; }
+    }
+    if(nmiss){
+        double t0=now_s();
+        #pragma omp parallel for schedule(dynamic,1)
+        for(int q=0;q<nmiss;q++) expert_read(m,li,ids[missk[q]],&m->ws[q]);
+        m->t_eload+=now_s()-t0;
+        m->ebytes+=(uint64_t)nmiss*(uint64_t)m->e_slot;
+    }
+    for(int j=0;j<n;j++)
+        expert_apply(m,use[j],z,w[j],u,gate,up,hz);
+    /* promotion: swap the freshly-read slots into the layer LRU */
+    LCache *lc=&m->ecache[li];
+    int promo = nmiss<lc->cap ? nmiss : lc->cap;
+    for(int a=0;a<promo;a++){
+        int q=nmiss-1-a; Slot *dst;
+        if(lc->n<lc->cap) dst=&lc->s[lc->n++];
+        else { int lru=0; for(int i=1;i<lc->n;i++) if(lc->s[i].used<lc->s[lru].used) lru=i; dst=&lc->s[lru]; }
+        Slot tmp=*dst; *dst=m->ws[q]; m->ws[q]=tmp;
+        dst->used=++m->clock;
+    }
 }
 
 static void moe_forward(Model *m, Layer *l, int li, const float *x, float *out){
@@ -648,33 +756,25 @@ static void moe_forward(Model *m, Layer *l, int li, const float *x, float *out){
     }
     { float sm=0; for(int kk=0;kk<K;kk++) sm+=wsel[kk];
       for(int kk=0;kk<K;kk++) wsel[kk]/=(sm+1e-20f); }
-    /* prefetch every selected expert, then load in DISK-OFFSET order (experts
-     * are NOT id-ordered inside the HF shards — measured 169/895 out-of-order) */
-    for(int kk=0;kk<K;kk++){
-        ERef *er=&m->eref[(int64_t)li*E+idx[kk]];
-        int64_t sizes[6]={m->e_w1p,m->e_w1s,m->e_w2p,m->e_w2s,m->e_w1p,m->e_w1s};
-        if(er->contig){ if(er->fd[0]>=0) posix_fadvise(er->fd[0],er->off[0],m->e_slot,POSIX_FADV_WILLNEED); }
-        else for(int k2=0;k2<6;k2++) if(er->fd[k2]>=0) posix_fadvise(er->fd[k2],er->off[k2],sizes[k2],POSIX_FADV_WILLNEED);
-    }
+    /* keep loads in DISK-OFFSET order (experts are NOT id-ordered inside the
+     * HF shards — measured 169/895; helps the buffered fallback, harmless
+     * under O_DIRECT). WILLNEED prefetch only for the buffered path. */
     for(int a2=0;a2<K-1;a2++) for(int b2=a2+1;b2<K;b2++){
         ERef *ea=&m->eref[(int64_t)li*E+idx[a2]], *eb=&m->eref[(int64_t)li*E+idx[b2]];
         if(eb->fd[0]<ea->fd[0]||(eb->fd[0]==ea->fd[0]&&eb->off[0]<ea->off[0])){
             int t=idx[a2];idx[a2]=idx[b2];idx[b2]=t; float tw=wsel[a2];wsel[a2]=wsel[b2];wsel[b2]=tw; }
     }
+    if(!g_k3_direct)
+        for(int kk=0;kk<K;kk++){
+            ERef *er=&m->eref[(int64_t)li*E+idx[kk]];
+            int64_t sizes[6]={m->e_w1p,m->e_w1s,m->e_w2p,m->e_w2s,m->e_w1p,m->e_w1s};
+            if(er->contig){ if(er->fd[0]>=0) posix_fadvise(er->fd[0],er->off[0],m->e_slot,POSIX_FADV_WILLNEED); }
+            else for(int k2=0;k2<6;k2++) if(er->fd[k2]>=0) posix_fadvise(er->fd[k2],er->off[k2],sizes[k2],POSIX_FADV_WILLNEED);
+        }
     float *z=falloc(LT), *u=falloc(LT), *gate=falloc(MI), *up=falloc(MI), *hz=falloc(LT);
     w_matmul(z,x,&o->lat_down,1);
     memset(u,0,LT*sizeof(float));
-    for(int kk=0;kk<K;kk++){
-        Slot *s=expert_get(m,li,idx[kk]);
-        uint8_t *w1p=s->buf, *w1s=w1p+m->e_w1p, *w2p=w1s+m->e_w1s, *w2s=w2p+m->e_w2p,
-                *w3p=w2s+m->e_w2s, *w3s=w3p+m->e_w1p;
-        matmul_mxfp4(gate,z,w1p,w1s,1,LT,MI);
-        matmul_mxfp4(up,z,w3p,w3s,1,LT,MI);
-        for(int i=0;i<MI;i++) gate[i]=situf_(gate[i],up[i],c->situ_b1,c->situ_b2);
-        matmul_mxfp4(hz,gate,w2p,w2s,1,MI,LT);
-        float wk=wsel[kk];
-        for(int i=0;i<LT;i++) u[i]+=wk*hz[i];
-    }
+    experts_run(m,li,K,idx,wsel,z,u,gate,up,hz);
     rmsnorm_(u,u,o->lat_norm,LT,c->eps);
     w_matmul(out,u,&o->lat_up,1);
     /* shared experts at full width */

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -1,0 +1,859 @@
+/* Kimi K3 inference engine in pure C — sibling of colibri.c (GLM-5.2) / olmoe.c /
+ * inkling.c, sharing st.h / json.h / tok.h / quant.h.
+ *
+ * Architecture (2.8T total / 104B active, 93 layers, hidden 7168):
+ *   - Hybrid attention: 69 KDA (Kimi Delta Attention, linear/recurrent) +
+ *     24 gated MLA layers (every 4th, plus the final layer). MLA is NoPE —
+ *     no positional encoding anywhere in the model; position lives in KDA's
+ *     decay/conv. Both attention types carry a full-rank sigmoid output gate.
+ *   - AttnRes (Attention Residuals) REPLACE the plain residual stream: a
+ *     running prefix_sum plus block snapshots (layers 0,12,24,...,84), mixed
+ *     by softmax twice per layer (before attention, before MLP) and once at
+ *     the end. Weights: per-layer {self_attention,mlp}_res_{norm,proj}.
+ *   - Stable LatentMoE: router (sigmoid + e_score_correction_bias, top-16 of
+ *     896, renormalized raw scores), shared latent down/up projections
+ *     (7168<->3584), per-expert GLU in the 3584 latent with moe_inter 3072,
+ *     RMSNorm on the aggregate, plus 2 fused shared experts (inter 6144) at
+ *     full width. Activation is SiTU-GLU:
+ *         b1*tanh(g/b1)*sigmoid(g) * b2*tanh(u/b2),  b1=4, b2=25.
+ *   - Routed experts are NATIVE MXFP4 (QAT; e2m1 nibbles + ue8m0 scale per
+ *     32, compressed-tensors "mxfp4-pack-quantized") and are streamed
+ *     straight from the original HF shards — never re-encoded, never
+ *     converted. Everything else is BF16 in the checkpoint and quantized at
+ *     LOAD TIME into RAM (int8 per-row / int4-g64 / f32, see K3_*BITS).
+ *
+ * KDA per-head recurrence (head dim 128, 96 heads; fla fused_recurrent_kda):
+ *     q,k,v = SiLU(ShortConv4(W{q,k,v} x));  q,k L2-normalized (eps 1e-6
+ *     inside the sqrt), q *= 128^-0.5
+ *     z = W_fb(W_fa x) + dt_bias            (per channel, dt_bias[12288])
+ *     gk = gmin * sigmoid(exp(A_log[h]) * z),  gmin=-5;  alpha = exp(gk)
+ *     S = (I - beta k k^T) Diag(alpha) S + beta k v^T,  beta = sigmoid(W_b x)
+ *     o = S^T q;  out = W_o [ sigmoid(W_g x) * RMSNorm_head(o) ]
+ *   (checkpoint A_log is [128] = per-head [96] zero-padded, first 96 used)
+ *
+ * Model dir = the HF snapshot (config.json + model-*-of-000096.safetensors).
+ * tokenizer.json is synthesized once by tools/k3_tokenizer.py (the HF repo
+ * ships only tiktoken.model); without it the engine still runs on raw ids.
+ *
+ * ENV:
+ *   K3_BITS=4|8|32       load-time quant of KDA/latent/shared/dense (default 4)
+ *   K3_MLA_BITS=8|4|32   MLA projections (default 8)
+ *   K3_HEAD_BITS=8|4|32  lm_head (default 8)
+ *   K3_EXPERT_GB=N       routed-expert LRU cache budget (default 8)
+ *   K3_LAYERS=N          truncate to first N layers (validation; skips head)
+ *   K3_TRACE=path        dump f32 hidden state after every layer (validation)
+ *   K3_MAXT=N            KV/context capacity (default prompt+ngen)
+ *   COLI_TEMP=F          0 = greedy (default), else softmax temperature
+ */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
+#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
+#include <sys/resource.h>
+#include <unistd.h>
+#endif
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+#include "st.h"
+#include "tok.h"
+#include "quant.h"
+
+/* ---------- config ---------- */
+typedef struct {
+    int hidden, n_layers, vocab, first_dense, dense_inter;
+    /* MLA */
+    int n_heads, q_lora, kv_lora, qk_nope, qk_rope, qk_head, v_head;
+    float attn_scale;
+    /* KDA */
+    int kda_heads, kda_hd, kda_proj, conv_k;
+    float gate_lb;
+    /* MoE */
+    int n_experts, topk, moe_inter, latent, n_shared;
+    float situ_b1, situ_b2;
+    /* AttnRes */
+    int res_bs;
+    float eps;
+    int8_t is_kda[128];
+    int bos, eos[8], n_eos;
+} Cfg;
+
+/* ---------- RAM-resident weight, quantized at load ---------- */
+typedef struct { int fmt; float *f; int8_t *q8; uint8_t *q4; float *s; int O, I, gs; } W;
+
+typedef struct {                          /* KDA layer */
+    W q, k, v, o, g;
+    float *conv_q, *conv_k, *conv_v;      /* [proj*4] depthwise taps, oldest first */
+    float *fa, *fb;                       /* decay low-rank, f32 [hd,hidden] [proj,hd] */
+    float *bp;                            /* beta proj f32 [heads,hidden] */
+    float *dt, *A, *onw;                  /* dt_bias[proj], exp(A_log)[heads], o_norm[hd] */
+} Kda;
+
+typedef struct {                          /* gated MLA layer */
+    W qa, qb, kva, kvb, o, g;
+    float *qa_ln, *kva_ln;
+} Mla;
+
+typedef struct {                          /* LatentMoE */
+    float *router, *rbias, *lat_norm;     /* [E,hidden] f32, [E], [latent] */
+    W lat_down, lat_up, sh_gate, sh_up, sh_down;
+} Moe;
+
+typedef struct {
+    int kda, sparse;
+    Kda a; Mla m; Moe moe;
+    W d_gate, d_up, d_down;               /* dense layer only */
+    float *in_ln, *post_ln;
+    float *attn_sw, *mlp_sw;              /* AttnRes score weights: norm.w * proj.w */
+} Layer;
+
+/* ---------- routed-expert streaming (native MXFP4 from the HF shards) ---- */
+typedef struct { int fd[6]; int64_t off[6]; int contig; } ERef;  /* w1p w1s w2p w2s w3p w3s */
+typedef struct { int eid; uint8_t *buf; uint64_t used; } Slot;
+typedef struct { Slot *s; int n, cap; } LCache;
+
+typedef struct {
+    Cfg c;
+    shards S;
+    char pfx[40];                         /* "language_model." or "" */
+    Layer *L;
+    float *final_norm, *out_sw;
+    W lm_head;
+    int has_head;
+    /* KDA state */
+    float **kstate;                       /* [layer] -> [heads*hd*hd], S[k][v] */
+    float **cwq, **cwk, **cwv;            /* conv windows [proj*conv_k], oldest first */
+    /* MLA cache */
+    float **Lc, **Rc; int max_t;
+    /* experts */
+    ERef *eref;                           /* [n_layers][n_experts] (dense rows zeroed) */
+    LCache *ecache;
+    int64_t e_w1p, e_w1s, e_w2p, e_w2s, e_slot;
+    uint64_t clock, hits, miss, ebytes;
+    double t_attn, t_moe, t_eload, t_head;
+    FILE *trace;
+} Model;
+
+static double now_s(void){ struct timespec t; clock_gettime(CLOCK_MONOTONIC,&t); return t.tv_sec+t.tv_nsec*1e-9; }
+static double rss_gb(void){ struct rusage r; getrusage(RUSAGE_SELF,&r);
+#if defined(__APPLE__)
+    return r.ru_maxrss/(1024.0*1024.0*1024.0);
+#else
+    return r.ru_maxrss/(1024.0*1024.0);
+#endif
+}
+static float *falloc(int64_t n){ float *p=malloc((size_t)n*sizeof(float)); if(!p){fprintf(stderr,"OOM %lld floats\n",(long long)n);exit(1);} return p; }
+static float *fcalloc(int64_t n){ float *p=calloc((size_t)n,sizeof(float)); if(!p){fprintf(stderr,"OOM %lld floats\n",(long long)n);exit(1);} return p; }
+static inline float sigmoidf_(float x){ return 1.f/(1.f+expf(-x)); }
+static inline float siluf_(float x){ return x/(1.f+expf(-x)); }
+static void softmax_(float *x, int n){ float m=x[0]; for(int i=1;i<n;i++) if(x[i]>m)m=x[i];
+    float s=0; for(int i=0;i<n;i++){ x[i]=expf(x[i]-m); s+=x[i]; } for(int i=0;i<n;i++) x[i]/=s; }
+static void rmsnorm_(float *out, const float *x, const float *w, int D, float eps){
+    double ms=0; for(int i=0;i<D;i++) ms+=(double)x[i]*x[i];
+    float r=1.f/sqrtf((float)(ms/D)+eps);
+    for(int i=0;i<D;i++) out[i]=x[i]*r*w[i];
+}
+
+/* ---------- W: load-time quantization + matvec ---------- */
+static void w_matmul(float *y, const float *x, const W *w, int S){
+    if(w->fmt==0)      matmul(y,x,w->f,S,w->I,w->O);
+    else if(w->fmt==1) matmul_q(y,x,w->q8,w->s,S,w->I,w->O);
+    else if(w->fmt==4) matmul_i4_grouped(y,x,w->q4,w->s,S,w->I,w->O,w->gs);
+    else { fprintf(stderr,"w_matmul: bad fmt %d\n",w->fmt); exit(1); }
+}
+/* acc[0..I) += coef * row r (MLA absorb builds q_abs from kv_b rows) */
+static void w_addrow(const W *w, int r, float coef, float *acc){
+    int I=w->I;
+    if(w->fmt==0){ const float *p=w->f+(int64_t)r*I; for(int i=0;i<I;i++) acc[i]+=coef*p[i]; }
+    else if(w->fmt==1){ const int8_t *p=w->q8+(int64_t)r*I; float s=w->s[r]*coef;
+        for(int i=0;i<I;i++) acc[i]+=s*p[i]; }
+    else { int rb=(I+1)/2, ng=(I+w->gs-1)/w->gs; const uint8_t *p=w->q4+(int64_t)r*rb;
+        const float *scl=w->s+(int64_t)r*ng;
+        for(int g=0;g*w->gs<I;g++){ float s=scl[g]*coef; int e=(g+1)*w->gs; if(e>I)e=I;
+            for(int i=g*w->gs;i<e;i+=2){ uint8_t b=p[i>>1];
+                acc[i]+=s*(float)((int)(b&0xF)-8);
+                if(i+1<e) acc[i+1]+=s*(float)((int)(b>>4)-8); } } }
+}
+static float w_rowdot(const W *w, int r, const float *x){
+    int I=w->I; float a=0;
+    if(w->fmt==0){ const float *p=w->f+(int64_t)r*I; for(int i=0;i<I;i++) a+=x[i]*p[i]; return a; }
+    if(w->fmt==1){ const int8_t *p=w->q8+(int64_t)r*I; for(int i=0;i<I;i++) a+=x[i]*p[i]; return a*w->s[r]; }
+    { int rb=(I+1)/2, ng=(I+w->gs-1)/w->gs; const uint8_t *p=w->q4+(int64_t)r*rb;
+      const float *scl=w->s+(int64_t)r*ng;
+      for(int g=0;g*w->gs<I;g++){ float ga=0; int e=(g+1)*w->gs; if(e>I)e=I;
+          for(int i=g*w->gs;i<e;i+=2){ uint8_t b=p[i>>1];
+              ga+=x[i]*(float)((int)(b&0xF)-8);
+              if(i+1<e) ga+=x[i+1]*(float)((int)(b>>4)-8); }
+          a+=ga*scl[g]; } }
+    return a;
+}
+
+#define QCHUNK 1024                      /* rows per load-quantize pass */
+static void w_load(Model *m, W *w, const char *name, int O, int I, int bits){
+    char nm[512]; snprintf(nm,sizeof(nm),"%s%s",m->pfx,name);
+    st_tensor *t=st_find(&m->S,nm);
+    if(!t) st_die_missing(&m->S,nm);
+    memset(w,0,sizeof(*w)); w->O=O; w->I=I;
+    if(t->dtype==3){
+        /* repacked container (tools/k3_repack.py): pre-quantized U8 + .qs f32
+         * scales — no load-time quantization, K3_BITS is ignored for these */
+        char qn[560]; snprintf(qn,sizeof(qn),"%s.qs",nm);
+        st_tensor *ts=st_find(&m->S,qn);
+        if(!ts){ fprintf(stderr,"%s: quantized (U8) but no %s scale sidecar\n",nm,qn); exit(1); }
+        if(t->nbytes==(int64_t)O*I && ts->numel==O){                  /* int8 per-row */
+            w->fmt=1; w->q8=malloc((size_t)O*I);
+            if(!w->q8){fprintf(stderr,"OOM int8 %s\n",nm);exit(1);}
+            st_read_raw(&m->S,nm,w->q8,1);
+            w->s=falloc(O); st_read_f32(&m->S,qn,w->s,0);
+        } else if(I%64==0 && t->nbytes==(int64_t)O*(I/2) && ts->numel==(int64_t)O*(I/64)){
+            w->fmt=4; w->gs=64;                                       /* int4-g64 */
+            w->q4=malloc((size_t)O*(I/2));
+            if(!w->q4){fprintf(stderr,"OOM int4 %s\n",nm);exit(1);}
+            st_read_raw(&m->S,nm,w->q4,1);
+            w->s=falloc((int64_t)O*(I/64)); st_read_f32(&m->S,qn,w->s,0);
+        } else {
+            fprintf(stderr,"%s: U8 tensor is %lld bytes / %lld scales — matches neither int8 [%d,%d] nor int4-g64, refusing (untrusted container)\n",
+                    nm,(long long)t->nbytes,(long long)ts->numel,O,I); exit(1);
+        }
+        return;
+    }
+    if(t->numel!=(int64_t)O*I){ fprintf(stderr,"%s: numel %lld != %dx%d\n",nm,(long long)t->numel,O,I); exit(1); }
+    if(bits>=32){ w->fmt=0; w->f=falloc((int64_t)O*I); st_read_f32(&m->S,nm,w->f,0); return; }
+    int gs=64;
+    if(bits<=4 && I%gs){ bits=8; }        /* int4-g64 wants I%64==0; fall back */
+    float *scr=falloc((int64_t)QCHUNK*I);
+    if(bits>4){ w->fmt=1; w->q8=malloc((int64_t)O*I); w->s=falloc(O);
+        if(!w->q8){fprintf(stderr,"OOM int8 %s\n",nm);exit(1);}
+        for(int r0=0;r0<O;r0+=QCHUNK){ int n=O-r0<QCHUNK?O-r0:QCHUNK;
+            st_read_slice_f32(&m->S,nm,(int64_t)r0*I,(int64_t)n*I,scr,1);
+            for(int r=0;r<n;r++){ const float *src=scr+(int64_t)r*I;
+                float am=0; for(int i=0;i<I;i++){ float a=fabsf(src[i]); if(a>am)am=a; }
+                float s=am/127.f; if(s<1e-20f)s=1e-20f; w->s[r0+r]=s; float inv=1.f/s;
+                int8_t *dst=w->q8+(int64_t)(r0+r)*I;
+                for(int i=0;i<I;i++){ int v=(int)lrintf(src[i]*inv); if(v>127)v=127; if(v<-127)v=-127; dst[i]=(int8_t)v; } } }
+    } else { w->fmt=4; w->gs=gs; int rb=I/2, ng=I/gs;
+        w->q4=malloc((int64_t)O*rb); w->s=falloc((int64_t)O*ng);
+        if(!w->q4){fprintf(stderr,"OOM int4 %s\n",nm);exit(1);}
+        for(int r0=0;r0<O;r0+=QCHUNK){ int n=O-r0<QCHUNK?O-r0:QCHUNK;
+            st_read_slice_f32(&m->S,nm,(int64_t)r0*I,(int64_t)n*I,scr,1);
+            for(int r=0;r<n;r++){ const float *src=scr+(int64_t)r*I;
+                uint8_t *dst=w->q4+(int64_t)(r0+r)*rb; float *scl=w->s+(int64_t)(r0+r)*ng;
+                for(int g=0;g<ng;g++){ const float *gp=src+g*gs;
+                    float am=0; for(int i=0;i<gs;i++){ float a=fabsf(gp[i]); if(a>am)am=a; }
+                    float s=am/7.f; if(s<1e-20f)s=1e-20f; scl[g]=s; float inv=1.f/s;
+                    for(int i=0;i<gs;i+=2){
+                        int v0=(int)lrintf(gp[i]*inv);   if(v0>7)v0=7; if(v0<-8)v0=-8;
+                        int v1=(int)lrintf(gp[i+1]*inv); if(v1>7)v1=7; if(v1<-8)v1=-8;
+                        dst[(g*gs+i)>>1]=(uint8_t)((v0+8)|((v1+8)<<4)); } } } }
+    }
+    free(scr);
+}
+static float *f32_load(Model *m, const char *name, int64_t want){
+    char nm[512]; snprintf(nm,sizeof(nm),"%s%s",m->pfx,name);
+    st_tensor *t=st_find(&m->S,nm);
+    if(!t) st_die_missing(&m->S,nm);
+    if(want>0 && t->numel!=want){ fprintf(stderr,"%s: numel %lld != %lld\n",nm,(long long)t->numel,(long long)want); exit(1); }
+    float *p=falloc(t->numel); st_read_f32(&m->S,nm,p,0); return p;
+}
+
+/* ---------- config ---------- */
+static double req_num(jval *r, const char *k){
+    jval *v=json_get(r,k);
+    if(!v||v->t!=J_NUM){ fprintf(stderr,"config.json: missing or non-numeric \"%s\"\n",k); exit(1); }
+    return v->num;
+}
+static void load_cfg(Cfg *c, const char *snap){
+    char path[2048]; snprintf(path,sizeof(path),"%s/config.json",snap);
+    long n; char *buf;
+    { FILE *f=fopen(path,"rb"); if(!f){perror(path);exit(1);}
+      fseek(f,0,SEEK_END); n=ftell(f); fseek(f,0,SEEK_SET);
+      if(n<0||n>(64L<<20)){ fprintf(stderr,"%s: bad size\n",path); exit(1); }
+      buf=malloc((size_t)n+1); if(!buf){fprintf(stderr,"OOM cfg\n");exit(1);}
+      if(fread(buf,1,(size_t)n,f)!=(size_t)n){ fprintf(stderr,"%s: short read\n",path); exit(1); }
+      buf[n]=0; fclose(f); }
+    char *arena=NULL; jval *root=json_parse(buf,&arena);
+    jval *tc=json_get(root,"text_config"); if(!tc||tc->t!=J_OBJ) tc=root;
+    memset(c,0,sizeof(*c));
+    c->hidden      =(int)req_num(tc,"hidden_size");
+    c->n_layers    =(int)req_num(tc,"num_hidden_layers");
+    c->vocab       =(int)req_num(tc,"vocab_size");
+    c->first_dense =(int)req_num(tc,"first_k_dense_replace");
+    c->dense_inter =(int)req_num(tc,"intermediate_size");
+    c->n_heads     =(int)req_num(tc,"num_attention_heads");
+    c->q_lora      =(int)req_num(tc,"q_lora_rank");
+    c->kv_lora     =(int)req_num(tc,"kv_lora_rank");
+    c->qk_nope     =(int)req_num(tc,"qk_nope_head_dim");
+    c->qk_rope     =(int)req_num(tc,"qk_rope_head_dim");
+    c->v_head      =(int)req_num(tc,"v_head_dim");
+    c->n_experts   =(int)req_num(tc,"num_experts");
+    c->topk        =(int)req_num(tc,"num_experts_per_token");
+    c->moe_inter   =(int)req_num(tc,"moe_intermediate_size");
+    c->latent      =(int)req_num(tc,"routed_expert_hidden_size");
+    c->n_shared    =(int)req_num(tc,"num_shared_experts");
+    c->res_bs      =(int)req_num(tc,"attn_res_block_size");
+    c->situ_b1     =(float)req_num(tc,"activation_situ_beta");
+    c->situ_b2     =(float)req_num(tc,"activation_situ_linear_beta");
+    jval *ep=json_get(tc,"rms_norm_eps"); c->eps=ep?(float)ep->num:1e-5f;
+    c->qk_head=c->qk_nope+c->qk_rope;
+    c->attn_scale=1.f/sqrtf((float)c->qk_head);
+    jval *la=json_get(tc,"linear_attn_config");
+    if(!la||la->t!=J_OBJ){ fprintf(stderr,"config.json: missing linear_attn_config\n"); exit(1); }
+    c->kda_heads=(int)req_num(la,"num_heads");
+    c->kda_hd   =(int)req_num(la,"head_dim");
+    c->conv_k   =(int)req_num(la,"short_conv_kernel_size");
+    jval *lb=json_get(la,"gate_lower_bound"); c->gate_lb=lb?(float)lb->num:-5.f;
+    c->kda_proj=c->kda_heads*c->kda_hd;
+    if(c->hidden<1||c->hidden>65536||c->n_layers<1||c->n_layers>128||
+       c->n_experts<1||c->n_experts>4096||c->topk<1||c->topk>64||c->topk>c->n_experts||
+       c->vocab<1||c->vocab>(1<<22)||c->kda_proj<1||c->kda_proj>(1<<20)||
+       c->conv_k<1||c->conv_k>8||c->latent<32||c->latent%32||c->moe_inter%32||
+       c->res_bs<1||c->kda_hd>512||c->kv_lora>4096){
+        fprintf(stderr,"config.json: dimension out of range\n"); exit(1); }
+    jval *kl=json_get(la,"kda_layers");
+    if(!kl||kl->t!=J_ARR){ fprintf(stderr,"config.json: missing kda_layers\n"); exit(1); }
+    for(int i=0;i<kl->len;i++){ int v=(int)kl->kids[i]->num;      /* 1-indexed */
+        if(v>=1&&v<=c->n_layers) c->is_kda[v-1]=1; }
+    jval *b=json_get(root,"bos_token_id"); if(!b) b=json_get(tc,"bos_token_id");
+    c->bos = b&&b->t==J_NUM ? (int)b->num : -1;
+    jval *e=json_get(root,"eos_token_id"); if(!e) e=json_get(tc,"eos_token_id");
+    if(e&&e->t==J_NUM) c->eos[c->n_eos++]=(int)e->num;
+    else if(e&&e->t==J_ARR) for(int i=0;i<e->len&&c->n_eos<8;i++) c->eos[c->n_eos++]=(int)e->kids[i]->num;
+    free(buf); (void)arena;
+}
+
+/* ---------- init ---------- */
+static void expert_table_init(Model *m){
+    Cfg *c=&m->c;
+    m->e_w1p=(int64_t)c->moe_inter*(c->latent/2);   m->e_w1s=(int64_t)c->moe_inter*(c->latent/32);
+    m->e_w2p=(int64_t)c->latent*(c->moe_inter/2);   m->e_w2s=(int64_t)c->latent*(c->moe_inter/32);
+    m->e_slot=2*(m->e_w1p+m->e_w1s)+m->e_w2p+m->e_w2s;
+    m->eref=calloc((size_t)c->n_layers*c->n_experts,sizeof(ERef));
+    if(!m->eref){fprintf(stderr,"OOM expert table\n");exit(1);}
+    const char *mat[3]={"w1","w2","w3"};
+    int64_t want[6]={m->e_w1p,m->e_w1s,m->e_w2p,m->e_w2s,m->e_w1p,m->e_w1s};
+    int missing=0;
+    for(int li=0;li<c->n_layers;li++){
+        if(!m->L[li].sparse) continue;
+        for(int e2=0;e2<c->n_experts;e2++){
+            ERef *er=&m->eref[(int64_t)li*c->n_experts+e2];
+            for(int k=0;k<6;k++){
+                char nm[512];
+                snprintf(nm,sizeof(nm),"%smodel.layers.%d.block_sparse_moe.experts.%d.%s.weight_%s",
+                         m->pfx,li,e2,mat[k/2],(k&1)?"scale":"packed");
+                st_tensor *t=st_find(&m->S,nm);
+                if(!t){ missing++; er->fd[k]=-1; continue; }
+                if(t->nbytes!=want[k]){ fprintf(stderr,"%s: %lld bytes, expected %lld — refusing (untrusted container)\n",
+                        nm,(long long)t->nbytes,(long long)want[k]); exit(1); }
+                er->fd[k]=t->fd; er->off[k]=t->off;
+            }
+            /* HF shards store the six tensors back-to-back (measured: 0 gaps
+             * across a whole layer) — collapse the load to ONE pread when so */
+            er->contig=1;
+            for(int k=0;k<5;k++)
+                if(er->fd[k]!=er->fd[k+1]||er->off[k]+want[k]!=er->off[k+1]) er->contig=0;
+        }
+    }
+    if(missing) fprintf(stderr,"[K3] WARNING: %d expert tensors missing (incomplete download?) — touching one aborts\n",missing);
+}
+
+static void model_init(Model *m, const char *snap, int n_layers_env){
+    memset(m,0,sizeof(*m));
+    load_cfg(&m->c,snap);
+    Cfg *c=&m->c;
+    if(n_layers_env>0&&n_layers_env<c->n_layers) c->n_layers=n_layers_env;
+    st_init_multi(&m->S,snap,getenv("K3_DIRS"));   /* K3_DIRS: extra shard dirs (multi-drive split) */
+    m->pfx[0]=0;   /* probe a layer-0 tensor: embed/head live in one of the LAST shards */
+    if(!st_has(&m->S,"model.layers.0.input_layernorm.weight")&&
+       st_has(&m->S,"language_model.model.layers.0.input_layernorm.weight"))
+        snprintf(m->pfx,sizeof(m->pfx),"language_model.");
+    if((c->n_layers+c->res_bs-1)/c->res_bs+1>16){ fprintf(stderr,"attn_res: too many blocks\n"); exit(1); }
+    int bits   = getenv("K3_BITS")?atoi(getenv("K3_BITS")):4;
+    int mbits  = getenv("K3_MLA_BITS")?atoi(getenv("K3_MLA_BITS")):8;
+    int hbits  = getenv("K3_HEAD_BITS")?atoi(getenv("K3_HEAD_BITS")):8;
+    double t0=now_s();
+    m->L=calloc(c->n_layers,sizeof(Layer));
+    m->kstate=calloc(c->n_layers,sizeof(float*));
+    m->cwq=calloc(c->n_layers,sizeof(float*));
+    m->cwk=calloc(c->n_layers,sizeof(float*));
+    m->cwv=calloc(c->n_layers,sizeof(float*));
+    char nm[512];
+    #define NM(...) (snprintf(nm,sizeof(nm),__VA_ARGS__),nm)
+    for(int i=0;i<c->n_layers;i++){
+        Layer *l=&m->L[i];
+        l->kda=c->is_kda[i];
+        l->sparse=(i>=c->first_dense);
+        l->in_ln  =f32_load(m,NM("model.layers.%d.input_layernorm.weight",i),c->hidden);
+        l->post_ln=f32_load(m,NM("model.layers.%d.post_attention_layernorm.weight",i),c->hidden);
+        /* AttnRes score weight = res_norm.weight * res_proj.weight (elementwise) */
+        { float *rn=f32_load(m,NM("model.layers.%d.self_attention_res_norm.weight",i),c->hidden);
+          float *rp=f32_load(m,NM("model.layers.%d.self_attention_res_proj.weight",i),c->hidden);
+          l->attn_sw=falloc(c->hidden); for(int d=0;d<c->hidden;d++) l->attn_sw[d]=rn[d]*rp[d];
+          free(rn); free(rp);
+          rn=f32_load(m,NM("model.layers.%d.mlp_res_norm.weight",i),c->hidden);
+          rp=f32_load(m,NM("model.layers.%d.mlp_res_proj.weight",i),c->hidden);
+          l->mlp_sw=falloc(c->hidden); for(int d=0;d<c->hidden;d++) l->mlp_sw[d]=rn[d]*rp[d];
+          free(rn); free(rp); }
+        if(l->kda){
+            Kda *a=&l->a; int P=c->kda_proj;
+            w_load(m,&a->q,NM("model.layers.%d.self_attn.q_proj.weight",i),P,c->hidden,bits);
+            w_load(m,&a->k,NM("model.layers.%d.self_attn.k_proj.weight",i),P,c->hidden,bits);
+            w_load(m,&a->v,NM("model.layers.%d.self_attn.v_proj.weight",i),P,c->hidden,bits);
+            w_load(m,&a->g,NM("model.layers.%d.self_attn.g_proj.weight",i),P,c->hidden,bits);
+            w_load(m,&a->o,NM("model.layers.%d.self_attn.o_proj.weight",i),c->hidden,P,bits);
+            a->conv_q=f32_load(m,NM("model.layers.%d.self_attn.q_conv1d.weight",i),(int64_t)P*c->conv_k);
+            a->conv_k=f32_load(m,NM("model.layers.%d.self_attn.k_conv1d.weight",i),(int64_t)P*c->conv_k);
+            a->conv_v=f32_load(m,NM("model.layers.%d.self_attn.v_conv1d.weight",i),(int64_t)P*c->conv_k);
+            a->fa=f32_load(m,NM("model.layers.%d.self_attn.f_a_proj.weight",i),(int64_t)c->kda_hd*c->hidden);
+            a->fb=f32_load(m,NM("model.layers.%d.self_attn.f_b_proj.weight",i),(int64_t)P*c->kda_hd);
+            a->bp=f32_load(m,NM("model.layers.%d.self_attn.b_proj.weight",i),(int64_t)c->kda_heads*c->hidden);
+            a->dt=f32_load(m,NM("model.layers.%d.self_attn.dt_bias",i),P);
+            a->onw=f32_load(m,NM("model.layers.%d.self_attn.o_norm.weight",i),c->kda_hd);
+            { /* A_log in the checkpoint is [kda_hd] = per-head zero-padded */
+              char an[512]; snprintf(an,sizeof(an),"%smodel.layers.%d.self_attn.A_log",m->pfx,i);
+              st_tensor *t=st_find(&m->S,an); if(!t) st_die_missing(&m->S,an);
+              if(t->numel<c->kda_heads){ fprintf(stderr,"%s: %lld < heads\n",an,(long long)t->numel); exit(1); }
+              float *al=falloc(t->numel); st_read_f32(&m->S,an,al,0);
+              a->A=falloc(c->kda_heads);
+              for(int h=0;h<c->kda_heads;h++) a->A[h]=expf(al[h]);
+              free(al); }
+            m->kstate[i]=fcalloc((int64_t)c->kda_heads*c->kda_hd*c->kda_hd);
+            m->cwq[i]=fcalloc((int64_t)P*c->conv_k);
+            m->cwk[i]=fcalloc((int64_t)P*c->conv_k);
+            m->cwv[i]=fcalloc((int64_t)P*c->conv_k);
+        } else {
+            Mla *a=&l->m;
+            w_load(m,&a->qa,NM("model.layers.%d.self_attn.q_a_proj.weight",i),c->q_lora,c->hidden,mbits);
+            w_load(m,&a->qb,NM("model.layers.%d.self_attn.q_b_proj.weight",i),c->n_heads*c->qk_head,c->q_lora,mbits);
+            w_load(m,&a->kva,NM("model.layers.%d.self_attn.kv_a_proj_with_mqa.weight",i),c->kv_lora+c->qk_rope,c->hidden,mbits);
+            w_load(m,&a->kvb,NM("model.layers.%d.self_attn.kv_b_proj.weight",i),c->n_heads*(c->qk_nope+c->v_head),c->kv_lora,mbits);
+            w_load(m,&a->o,NM("model.layers.%d.self_attn.o_proj.weight",i),c->hidden,c->n_heads*c->v_head,mbits);
+            w_load(m,&a->g,NM("model.layers.%d.self_attn.g_proj.weight",i),c->n_heads*c->v_head,c->hidden,mbits);
+            a->qa_ln =f32_load(m,NM("model.layers.%d.self_attn.q_a_layernorm.weight",i),c->q_lora);
+            a->kva_ln=f32_load(m,NM("model.layers.%d.self_attn.kv_a_layernorm.weight",i),c->kv_lora);
+        }
+        if(l->sparse){
+            Moe *o=&l->moe;
+            o->router=f32_load(m,NM("model.layers.%d.block_sparse_moe.gate.weight",i),(int64_t)c->n_experts*c->hidden);
+            o->rbias =f32_load(m,NM("model.layers.%d.block_sparse_moe.gate.e_score_correction_bias",i),c->n_experts);
+            o->lat_norm=f32_load(m,NM("model.layers.%d.block_sparse_moe.routed_expert_norm.weight",i),c->latent);
+            w_load(m,&o->lat_down,NM("model.layers.%d.block_sparse_moe.routed_expert_down_proj.weight",i),c->latent,c->hidden,bits);
+            w_load(m,&o->lat_up,NM("model.layers.%d.block_sparse_moe.routed_expert_up_proj.weight",i),c->hidden,c->latent,bits);
+            int shi=c->moe_inter*c->n_shared;
+            w_load(m,&o->sh_gate,NM("model.layers.%d.block_sparse_moe.shared_experts.gate_proj.weight",i),shi,c->hidden,bits);
+            w_load(m,&o->sh_up,NM("model.layers.%d.block_sparse_moe.shared_experts.up_proj.weight",i),shi,c->hidden,bits);
+            w_load(m,&o->sh_down,NM("model.layers.%d.block_sparse_moe.shared_experts.down_proj.weight",i),c->hidden,shi,bits);
+        } else {
+            w_load(m,&l->d_gate,NM("model.layers.%d.mlp.gate_proj.weight",i),c->dense_inter,c->hidden,bits);
+            w_load(m,&l->d_up,NM("model.layers.%d.mlp.up_proj.weight",i),c->dense_inter,c->hidden,bits);
+            w_load(m,&l->d_down,NM("model.layers.%d.mlp.down_proj.weight",i),c->hidden,c->dense_inter,bits);
+        }
+        if(i%8==0) fprintf(stderr,"[K3] loaded layer %d/%d (%.1fs, RSS %.1f GB)\n",i+1,c->n_layers,now_s()-t0,rss_gb());
+    }
+    snprintf(nm,sizeof(nm),"%smodel.norm.weight",m->pfx);
+    m->has_head = st_has(&m->S,nm);
+    if(m->has_head){
+        m->final_norm=f32_load(m,"model.norm.weight",c->hidden);
+        { float *rn=f32_load(m,"model.output_attn_res_norm.weight",c->hidden);
+          float *rp=f32_load(m,"model.output_attn_res_proj.weight",c->hidden);
+          m->out_sw=falloc(c->hidden); for(int d=0;d<c->hidden;d++) m->out_sw[d]=rn[d]*rp[d];
+          free(rn); free(rp); }
+        w_load(m,&m->lm_head,"lm_head.weight",c->vocab,c->hidden,hbits);
+    } else fprintf(stderr,"[K3] final norm/lm_head not present — trace-only mode\n");
+    expert_table_init(m);
+    /* expert LRU cache, per-layer slots from the global budget */
+    double egb = getenv("K3_EXPERT_GB")?atof(getenv("K3_EXPERT_GB")):8.0;
+    int nmoe=0; for(int i=0;i<c->n_layers;i++) if(m->L[i].sparse) nmoe++;
+    int cap=(int)((egb*1e9)/((double)m->e_slot*(nmoe?nmoe:1)));
+    if(cap<c->topk) cap=c->topk;
+    m->ecache=calloc(c->n_layers,sizeof(LCache));
+    for(int i=0;i<c->n_layers;i++) if(m->L[i].sparse){
+        m->ecache[i].cap=cap; m->ecache[i].s=calloc(cap,sizeof(Slot));
+        for(int j2=0;j2<cap;j2++) m->ecache[i].s[j2].eid=-1;
+    }
+    fprintf(stderr,"[K3] init done in %.1fs | %d layers | expert cache %d/layer (%.1f MB/slot) | RSS %.1f GB\n",
+            now_s()-t0,c->n_layers,cap,m->e_slot/1e6,rss_gb());
+    #undef NM
+}
+
+/* ---------- AttnRes softmax mix over [bres rows..., prefix] ---------- */
+static void res_mix(float *out, const float *prefix, const float *bres, int nb, int D,
+                    const float *sw, float eps){
+    const float *v[16]; float sc[16];
+    for(int e=0;e<nb;e++) v[e]=bres+(int64_t)e*D;
+    v[nb]=prefix;
+    for(int e=0;e<=nb;e++){
+        double ms=0,dot=0;
+        for(int d=0;d<D;d++){ double x=v[e][d]; ms+=x*x; dot+=x*(double)sw[d]; }
+        sc[e]=(float)(dot/sqrt(ms/D+eps));
+    }
+    softmax_(sc,nb+1);
+    for(int d=0;d<D;d++){ float a=0; for(int e=0;e<=nb;e++) a+=sc[e]*v[e][d]; out[d]=a; }
+}
+
+/* ---------- KDA layer (single token) ---------- */
+static void kda_forward(Model *m, Layer *l, int li, const float *x, float *out){
+    Cfg *c=&m->c; Kda *a=&l->a;
+    int P=c->kda_proj, H=c->kda_heads, hd=c->kda_hd, K=c->conv_k;
+    float *q=falloc(P), *k=falloc(P), *v=falloc(P), *gp=falloc(P), *on=falloc(P);
+    float *t1=falloc(c->kda_hd), *graw=falloc(P), *braw=falloc(H);
+    w_matmul(q,x,&a->q,1); w_matmul(k,x,&a->k,1); w_matmul(v,x,&a->v,1);
+    w_matmul(gp,x,&a->g,1);
+    matmul(t1,x,a->fa,1,c->hidden,c->kda_hd);
+    matmul(graw,t1,a->fb,1,c->kda_hd,P);
+    matmul(braw,x,a->bp,1,c->hidden,H);
+    /* depthwise causal conv (window: oldest..newest) + SiLU, window rolls forward */
+    float *wins[3]={m->cwq[li],m->cwk[li],m->cwv[li]};
+    float *vecs[3]={q,k,v}; float *taps[3]={a->conv_q,a->conv_k,a->conv_v};
+    for(int t=0;t<3;t++){
+        float *win=wins[t], *vec=vecs[t]; const float *cw=taps[t];
+        #pragma omp parallel for schedule(static)
+        for(int d=0;d<P;d++){
+            float *wd=win+(int64_t)d*K;
+            for(int j=0;j<K-1;j++) wd[j]=wd[j+1];
+            wd[K-1]=vec[d];
+            float acc=0; const float *cd=cw+(int64_t)d*K;
+            for(int j=0;j<K;j++) acc+=cd[j]*wd[j];
+            vec[d]=siluf_(acc);
+        }
+    }
+    float qscale=1.f/sqrtf((float)hd);
+    #pragma omp parallel for schedule(static)
+    for(int h=0;h<H;h++){
+        const float *qh=q+(int64_t)h*hd, *kh=k+(int64_t)h*hd, *vh=v+(int64_t)h*hd;
+        float qn[512], kn[512], alpha[512], kS[512], vt[512], oh[512];
+        float sq=0,sk=0;
+        for(int i=0;i<hd;i++){ sq+=qh[i]*qh[i]; sk+=kh[i]*kh[i]; }
+        sq=1.f/sqrtf(sq+1e-6f); sk=1.f/sqrtf(sk+1e-6f);
+        for(int i=0;i<hd;i++){ qn[i]=qh[i]*sq*qscale; kn[i]=kh[i]*sk; }
+        for(int i=0;i<hd;i++){
+            float z=graw[(int64_t)h*hd+i]+a->dt[(int64_t)h*hd+i];
+            alpha[i]=expf(c->gate_lb*sigmoidf_(a->A[h]*z));
+        }
+        float beta=sigmoidf_(braw[h]);
+        float *S=m->kstate[li]+(int64_t)h*hd*hd;
+        memset(kS,0,hd*sizeof(float));
+        for(int kk=0;kk<hd;kk++){
+            float *row=S+(int64_t)kk*hd; float al=alpha[kk], kv=kn[kk];
+            for(int vv=0;vv<hd;vv++){ row[vv]*=al; kS[vv]+=kv*row[vv]; }
+        }
+        for(int vv=0;vv<hd;vv++) vt[vv]=(vh[vv]-kS[vv])*beta;
+        memset(oh,0,hd*sizeof(float));
+        for(int kk=0;kk<hd;kk++){
+            float *row=S+(int64_t)kk*hd; float kv=kn[kk], qq=qn[kk];
+            for(int vv=0;vv<hd;vv++){ row[vv]+=kv*vt[vv]; oh[vv]+=qq*row[vv]; }
+        }
+        /* per-head RMSNorm * sigmoid(full-rank gate) */
+        double ms=0; for(int vv=0;vv<hd;vv++) ms+=(double)oh[vv]*oh[vv];
+        float r=1.f/sqrtf((float)(ms/hd)+c->eps);
+        float *dst=on+(int64_t)h*hd;
+        for(int vv=0;vv<hd;vv++) dst[vv]=oh[vv]*r*a->onw[vv]*sigmoidf_(gp[(int64_t)h*hd+vv]);
+    }
+    w_matmul(out,on,&a->o,1);
+    free(q);free(k);free(v);free(gp);free(on);free(t1);free(graw);free(braw);
+}
+
+/* ---------- gated MLA layer (single token, NoPE, absorb) ---------- */
+static void mla_forward(Model *m, Layer *l, int li, const float *x, int pos, float *out){
+    Cfg *c=&m->c; Mla *a=&l->m;
+    int H=c->n_heads, qh=c->qk_head, vh=c->v_head, kvl=c->kv_lora, qr=c->qk_rope;
+    float *qa=falloc(c->q_lora), *qv=falloc((int64_t)H*qh), *ckv=falloc(kvl+qr);
+    float *gv=falloc((int64_t)H*vh), *ctx=falloc((int64_t)H*vh);
+    w_matmul(qa,x,&a->qa,1);
+    rmsnorm_(qa,qa,a->qa_ln,c->q_lora,c->eps);
+    w_matmul(qv,qa,&a->qb,1);
+    w_matmul(ckv,x,&a->kva,1);
+    float *Lrow=m->Lc[li]+(int64_t)pos*kvl, *Rrow=m->Rc[li]+(int64_t)pos*qr;
+    rmsnorm_(Lrow,ckv,a->kva_ln,kvl,c->eps);
+    memcpy(Rrow,ckv+kvl,qr*sizeof(float));           /* NoPE: cached raw, no rotation */
+    w_matmul(gv,x,&a->g,1);
+    int nt=pos+1;
+    #pragma omp parallel for schedule(static)
+    for(int h=0;h<H;h++){
+        const float *qp=qv+(int64_t)h*qh, *qrp=qp+c->qk_nope;
+        int rbase=h*(c->qk_nope+vh);
+        float qabs[4096]; memset(qabs,0,kvl*sizeof(float));
+        for(int d=0;d<c->qk_nope;d++) w_addrow(&a->kvb,rbase+d,qp[d],qabs);
+        float *sc=falloc(nt);
+        for(int t=0;t<nt;t++){
+            const float *Lt=m->Lc[li]+(int64_t)t*kvl, *Rt=m->Rc[li]+(int64_t)t*qr;
+            float s2=0; for(int i=0;i<kvl;i++) s2+=qabs[i]*Lt[i];
+            for(int i=0;i<qr;i++) s2+=qrp[i]*Rt[i];
+            sc[t]=s2*c->attn_scale;
+        }
+        softmax_(sc,nt);
+        float clat[4096]; memset(clat,0,kvl*sizeof(float));
+        for(int t=0;t<nt;t++){
+            const float *Lt=m->Lc[li]+(int64_t)t*kvl; float s2=sc[t];
+            for(int i=0;i<kvl;i++) clat[i]+=s2*Lt[i];
+        }
+        free(sc);
+        float *cx=ctx+(int64_t)h*vh;
+        for(int d=0;d<vh;d++)
+            cx[d]=w_rowdot(&a->kvb,rbase+c->qk_nope+d,clat)*sigmoidf_(gv[(int64_t)h*vh+d]);
+    }
+    w_matmul(out,ctx,&a->o,1);
+    free(qa);free(qv);free(ckv);free(gv);free(ctx);
+}
+
+/* ---------- routed experts: LRU + direct pread from the HF shards ---------- */
+static Slot *expert_get(Model *m, int li, int eid){
+    LCache *lc=&m->ecache[li];
+    for(int i=0;i<lc->n;i++) if(lc->s[i].eid==eid){ m->hits++; lc->s[i].used=++m->clock; return &lc->s[i]; }
+    m->miss++;
+    Slot *s;
+    if(lc->n<lc->cap){ s=&lc->s[lc->n++]; }
+    else { int lru=0; for(int i=1;i<lc->n;i++) if(lc->s[i].used<lc->s[lru].used) lru=i; s=&lc->s[lru]; }
+    if(!s->buf){ s->buf=malloc(m->e_slot); if(!s->buf){fprintf(stderr,"OOM expert slot\n");exit(1);} }
+    ERef *er=&m->eref[(int64_t)li*m->c.n_experts+eid];
+    int64_t sizes[6]={m->e_w1p,m->e_w1s,m->e_w2p,m->e_w2s,m->e_w1p,m->e_w1s};
+    double t0=now_s();
+    if(er->fd[0]<0){ fprintf(stderr,"[K3] expert L%d E%d missing on disk\n",li,eid); exit(1); }
+    if(er->contig){
+        st_pread_full(er->fd[0],s->buf,m->e_slot,er->off[0],"pread expert");
+    } else {
+        uint8_t *dst=s->buf;
+        for(int k=0;k<6;k++){
+            if(er->fd[k]<0){ fprintf(stderr,"[K3] expert L%d E%d tensor %d missing on disk\n",li,eid,k); exit(1); }
+            st_pread_full(er->fd[k],dst,sizes[k],er->off[k],"pread expert");
+            dst+=sizes[k];
+        }
+    }
+    m->ebytes+=m->e_slot; m->t_eload+=now_s()-t0;
+    s->eid=eid; s->used=++m->clock;
+    return s;
+}
+
+static inline float situf_(float g, float u, float b1, float b2){
+    return b1*tanhf(g/b1)*sigmoidf_(g) * b2*tanhf(u/b2);
+}
+
+static void moe_forward(Model *m, Layer *l, int li, const float *x, float *out){
+    Cfg *c=&m->c; Moe *o=&l->moe;
+    int E=c->n_experts, K=c->topk, LT=c->latent, MI=c->moe_inter;
+    float *sco=falloc(E);
+    matmul(sco,x,o->router,1,c->hidden,E);
+    for(int e=0;e<E;e++) sco[e]=sigmoidf_(sco[e]);
+    int idx[64]; float wsel[64];
+    for(int kk=0;kk<K;kk++){
+        int best=-1; float bv=-1e30f;
+        for(int e=0;e<E;e++){
+            int taken=0; for(int j=0;j<kk;j++) if(idx[j]==e){taken=1;break;}
+            float sv=sco[e]+o->rbias[e];
+            if(!taken&&sv>bv){ bv=sv; best=e; }
+        }
+        idx[kk]=best; wsel[kk]=sco[best];             /* weight = RAW sigmoid score */
+    }
+    { float sm=0; for(int kk=0;kk<K;kk++) sm+=wsel[kk];
+      for(int kk=0;kk<K;kk++) wsel[kk]/=(sm+1e-20f); }
+    /* prefetch every selected expert, then load in DISK-OFFSET order (experts
+     * are NOT id-ordered inside the HF shards — measured 169/895 out-of-order) */
+    for(int kk=0;kk<K;kk++){
+        ERef *er=&m->eref[(int64_t)li*E+idx[kk]];
+        int64_t sizes[6]={m->e_w1p,m->e_w1s,m->e_w2p,m->e_w2s,m->e_w1p,m->e_w1s};
+        if(er->contig){ if(er->fd[0]>=0) posix_fadvise(er->fd[0],er->off[0],m->e_slot,POSIX_FADV_WILLNEED); }
+        else for(int k2=0;k2<6;k2++) if(er->fd[k2]>=0) posix_fadvise(er->fd[k2],er->off[k2],sizes[k2],POSIX_FADV_WILLNEED);
+    }
+    for(int a2=0;a2<K-1;a2++) for(int b2=a2+1;b2<K;b2++){
+        ERef *ea=&m->eref[(int64_t)li*E+idx[a2]], *eb=&m->eref[(int64_t)li*E+idx[b2]];
+        if(eb->fd[0]<ea->fd[0]||(eb->fd[0]==ea->fd[0]&&eb->off[0]<ea->off[0])){
+            int t=idx[a2];idx[a2]=idx[b2];idx[b2]=t; float tw=wsel[a2];wsel[a2]=wsel[b2];wsel[b2]=tw; }
+    }
+    float *z=falloc(LT), *u=falloc(LT), *gate=falloc(MI), *up=falloc(MI), *hz=falloc(LT);
+    w_matmul(z,x,&o->lat_down,1);
+    memset(u,0,LT*sizeof(float));
+    for(int kk=0;kk<K;kk++){
+        Slot *s=expert_get(m,li,idx[kk]);
+        uint8_t *w1p=s->buf, *w1s=w1p+m->e_w1p, *w2p=w1s+m->e_w1s, *w2s=w2p+m->e_w2p,
+                *w3p=w2s+m->e_w2s, *w3s=w3p+m->e_w1p;
+        matmul_mxfp4(gate,z,w1p,w1s,1,LT,MI);
+        matmul_mxfp4(up,z,w3p,w3s,1,LT,MI);
+        for(int i=0;i<MI;i++) gate[i]=situf_(gate[i],up[i],c->situ_b1,c->situ_b2);
+        matmul_mxfp4(hz,gate,w2p,w2s,1,MI,LT);
+        float wk=wsel[kk];
+        for(int i=0;i<LT;i++) u[i]+=wk*hz[i];
+    }
+    rmsnorm_(u,u,o->lat_norm,LT,c->eps);
+    w_matmul(out,u,&o->lat_up,1);
+    /* shared experts at full width */
+    int shi=MI*c->n_shared;
+    float *sg=falloc(shi), *su=falloc(shi), *sd=falloc(c->hidden);
+    w_matmul(sg,x,&o->sh_gate,1); w_matmul(su,x,&o->sh_up,1);
+    for(int i=0;i<shi;i++) sg[i]=situf_(sg[i],su[i],c->situ_b1,c->situ_b2);
+    w_matmul(sd,sg,&o->sh_down,1);
+    for(int d=0;d<c->hidden;d++) out[d]+=sd[d];
+    free(sco);free(z);free(u);free(gate);free(up);free(hz);free(sg);free(su);free(sd);
+}
+
+static void dense_forward(Model *m, Layer *l, const float *x, float *out){
+    Cfg *c=&m->c; int DI=c->dense_inter;
+    float *g=falloc(DI), *u=falloc(DI);
+    w_matmul(g,x,&l->d_gate,1); w_matmul(u,x,&l->d_up,1);
+    for(int i=0;i<DI;i++) g[i]=situf_(g[i],u[i],c->situ_b1,c->situ_b2);
+    w_matmul(out,g,&l->d_down,1);
+    free(g);free(u);
+}
+
+/* ---------- one token through the stack; returns logits (or NULL pre-head) --- */
+static float *g_x0=NULL; static int g_x0_n=0;  /* K3_X0: injected inputs (validation) */
+static float *step(Model *m, int id, int pos){
+    Cfg *c=&m->c; int D=c->hidden;
+    int nbmax=(c->n_layers+c->res_bs-1)/c->res_bs;
+    float *hidden=falloc(D), *bres=falloc((int64_t)nbmax*D), *prefix=falloc(D);
+    float *nrm=falloc(D), *att=falloc(D), *mix=falloc(D), *mlp=falloc(D);
+    int nb=0;
+    if(g_x0){
+        if(pos>=g_x0_n){ fprintf(stderr,"K3_X0: pos %d beyond %d injected rows\n",pos,g_x0_n); exit(1); }
+        memcpy(hidden,g_x0+(int64_t)pos*D,D*sizeof(float));
+    } else {
+        char nm[512]; snprintf(nm,sizeof(nm),"%smodel.embed_tokens.weight",m->pfx);
+        st_read_slice_f32(&m->S,nm,(int64_t)id*D,D,hidden,0);
+    }
+    for(int i=0;i<c->n_layers;i++){
+        Layer *l=&m->L[i];
+        memcpy(prefix,hidden,D*sizeof(float));            /* prefix_sum at entry */
+        int have_prefix=1;
+        if(nb>0) res_mix(hidden,prefix,bres,nb,D,l->attn_sw,c->eps);
+        if(i%c->res_bs==0){
+            memcpy(bres+(int64_t)nb*D,prefix,D*sizeof(float)); nb++;
+            have_prefix=0;
+        }
+        double t0=now_s();
+        for(int d=0;d<D;d++) nrm[d]=hidden[d];
+        rmsnorm_(nrm,nrm,l->in_ln,D,c->eps);
+        if(l->kda) kda_forward(m,l,i,nrm,att);
+        else       mla_forward(m,l,i,nrm,pos,att);
+        m->t_attn+=now_s()-t0;
+        if(have_prefix){ for(int d=0;d<D;d++) prefix[d]+=att[d]; }
+        else           { memcpy(prefix,att,D*sizeof(float)); }
+        res_mix(mix,prefix,bres,nb,D,l->mlp_sw,c->eps);
+        rmsnorm_(nrm,mix,l->post_ln,D,c->eps);
+        t0=now_s();
+        if(l->sparse) moe_forward(m,l,i,nrm,mlp);
+        else          dense_forward(m,l,nrm,mlp);
+        m->t_moe+=now_s()-t0;
+        for(int d=0;d<D;d++) prefix[d]+=mlp[d];
+        memcpy(hidden,prefix,D*sizeof(float));
+        if(m->trace) fwrite(hidden,sizeof(float),D,m->trace);
+    }
+    float *logits=NULL;
+    if(m->has_head){
+        double t0=now_s();
+        res_mix(mix,hidden,bres,nb,D,m->out_sw,c->eps);
+        rmsnorm_(mix,mix,m->final_norm,D,c->eps);
+        if(m->trace) fwrite(mix,sizeof(float),D,m->trace);
+        logits=falloc(c->vocab);
+        w_matmul(logits,mix,&m->lm_head,1);
+        m->t_head+=now_s()-t0;
+    }
+    free(hidden);free(bres);free(prefix);free(nrm);free(att);free(mix);free(mlp);
+    return logits;
+}
+
+static void kv_alloc(Model *m, int max_t){
+    Cfg *c=&m->c; m->max_t=max_t;
+    m->Lc=calloc(c->n_layers,sizeof(float*));
+    m->Rc=calloc(c->n_layers,sizeof(float*));
+    for(int i=0;i<c->n_layers;i++) if(!m->L[i].kda){
+        m->Lc[i]=falloc((int64_t)max_t*c->kv_lora);
+        m->Rc[i]=falloc((int64_t)max_t*c->qk_rope);
+    }
+}
+
+static int sample_tok(const float *lo, int V, float temp){
+    if(temp<=0.f){ int b=0; for(int i=1;i<V;i++) if(lo[i]>lo[b]) b=i; return b; }
+    float *p=falloc(V); float mx=lo[0];
+    for(int i=1;i<V;i++) if(lo[i]>mx) mx=lo[i];
+    double s=0; for(int i=0;i<V;i++){ p[i]=expf((lo[i]-mx)/temp); s+=p[i]; }
+    double r=((double)rand()/RAND_MAX)*s, acc=0; int pick=V-1;
+    for(int i=0;i<V;i++){ acc+=p[i]; if(acc>=r){ pick=i; break; } }
+    free(p); return pick;
+}
+
+int main(int argc, char **argv){
+    if(argc<2){
+        fprintf(stderr,"usage: %s <model_dir> [prompt] [--ids \"1 2 3\"] [--ngen N]\n",argv[0]);
+        return 1;
+    }
+    const char *snap=argv[1], *prompt=NULL, *idstr=NULL;
+    int ngen=32;
+    for(int i=2;i<argc;i++){
+        if(!strcmp(argv[i],"--ngen")&&i+1<argc) ngen=atoi(argv[++i]);
+        else if(!strcmp(argv[i],"--ids")&&i+1<argc) idstr=argv[++i];
+        else if(!prompt) prompt=argv[i];
+    }
+    float temp=getenv("COLI_TEMP")?(float)atof(getenv("COLI_TEMP")):0.f;
+    int nlayers=getenv("K3_LAYERS")?atoi(getenv("K3_LAYERS")):0;
+    Model m;
+    model_init(&m,snap,nlayers);
+    if(getenv("K3_TRACE")){
+        m.trace=fopen(getenv("K3_TRACE"),"wb");
+        if(!m.trace){ perror(getenv("K3_TRACE")); return 1; }
+    }
+    if(getenv("K3_X0")){       /* injected input rows [T,hidden] f32, bypasses embed */
+        FILE *f=fopen(getenv("K3_X0"),"rb");
+        if(!f){ perror(getenv("K3_X0")); return 1; }
+        fseek(f,0,SEEK_END); long fn=ftell(f); fseek(f,0,SEEK_SET);
+        g_x0_n=(int)(fn/((long)m.c.hidden*4));
+        g_x0=falloc((int64_t)g_x0_n*m.c.hidden);
+        if(fread(g_x0,4,(size_t)g_x0_n*m.c.hidden,f)!=(size_t)g_x0_n*m.c.hidden){ fprintf(stderr,"K3_X0 short read\n"); return 1; }
+        fclose(f);
+        fprintf(stderr,"[K3] K3_X0: %d injected input rows\n",g_x0_n);
+    }
+    /* tokenize */
+    int ids[65536], np=0;
+    Tok T; int has_tok=0;
+    { char tp[2048]; snprintf(tp,sizeof(tp),"%s/tokenizer.json",snap);
+      FILE *f=fopen(tp,"rb"); if(f){ fclose(f); tok_load(&T,tp); has_tok=1;
+          fprintf(stderr,"[K3] tokenizer.json loaded (family=%s)\n",T.kimi?"kimi":(T.o200k?"o200k":"cl100k")); } }
+    if(idstr){
+        const char *p=idstr;
+        while(*p&&np<65536){ while(*p==' '||*p==',')p++; if(!*p)break; ids[np++]=(int)strtol(p,(char**)&p,10); }
+    } else if(prompt){
+        if(!has_tok){ fprintf(stderr,"no tokenizer.json — pass --ids (generate one with tools/k3_tokenizer.py)\n"); return 1; }
+        if(m.c.bos>=0) ids[np++]=m.c.bos;
+        np+=tok_encode(&T,prompt,(int)strlen(prompt),ids+np,65536-np);
+    } else { fprintf(stderr,"no prompt and no --ids\n"); return 1; }
+    fprintf(stderr,"[K3] prompt: %d tokens | ngen %d | temp %.2f\n",np,ngen,temp);
+    int max_t=getenv("K3_MAXT")?atoi(getenv("K3_MAXT")):np+ngen;
+    kv_alloc(&m,max_t);
+    double t0=now_s(); float *lo=NULL;
+    for(int i=0;i<np;i++){
+        if(lo) free(lo);
+        lo=step(&m,ids[i],i);
+        fprintf(stderr,"\r[K3] prefill %d/%d (%.1fs)",i+1,np,now_s()-t0);
+    }
+    fprintf(stderr,"\n[K3] prefill done in %.1fs (%.2f tok/s)\n",now_s()-t0,np/(now_s()-t0));
+    if(!m.has_head||!lo){
+        fprintf(stderr,"[K3] no head — trace written, stopping after prefill\n");
+        if(m.trace) fclose(m.trace);
+        return 0;
+    }
+    double tg=now_s(); int ntok=0;
+    char buf[512];
+    for(int s=0;s<ngen;s++){
+        int t=sample_tok(lo,m.c.vocab,temp);
+        free(lo); lo=NULL;
+        int is_eos=0; for(int e=0;e<m.c.n_eos;e++) if(t==m.c.eos[e]) is_eos=1;
+        if(has_tok){ int n2=tok_decode(&T,&t,1,buf,sizeof(buf)-1); fwrite(buf,1,n2,stdout); fflush(stdout); }
+        else { printf("%d ",t); fflush(stdout); }
+        ntok++;
+        if(is_eos){ fprintf(stderr,"\n[K3] eos\n"); break; }
+        if(np+ntok>=max_t){ fprintf(stderr,"\n[K3] context full\n"); break; }
+        lo=step(&m,t,np+ntok-1);
+        double el=now_s()-tg;
+        fprintf(stderr,"  [tok %d: %.1fs/tok, hit %.0f%%, %.1f GB read]\n",
+                ntok,el/ntok,100.0*m.hits/(m.hits+m.miss+1e-9),m.ebytes/1e9);
+    }
+    if(lo) free(lo);
+    double dt=now_s()-tg;
+    fprintf(stderr,"\n[K3] decode %d tokens in %.1fs (%.2f tok/s) | expert hit %.1f%% (%llu/%llu) | %.1f GB streamed\n",
+            ntok,dt,ntok/dt,100.0*m.hits/(m.hits+m.miss+1e-9),
+            (unsigned long long)m.hits,(unsigned long long)(m.hits+m.miss),m.ebytes/1e9);
+    fprintf(stderr,"[K3] time: attn %.1fs moe %.1fs (eload %.1fs) head %.1fs | RSS %.1f GB\n",
+            m.t_attn,m.t_moe,m.t_eload,m.t_head,rss_gb());
+    if(m.trace) fclose(m.trace);
+    return 0;
+}

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -46,6 +46,7 @@
  *   K3_LOAD_THREADS=N    loader threads for K3_PIPE (default 4)
  *   K3_TOPP=F            keep routed experts to cumulative weight F (0 = off)
  *   K3_CHUNK=N           prefill chunk size (default 32; 1 = token-at-a-time)
+ *   K3_THINK=0|1         chat mode: open the think channel (default 1)
  *   K3_LAYERS=N          truncate to first N layers (validation; skips head)
  *   K3_TRACE=path        dump f32 hidden state after every layer (validation)
  *   K3_LOGITS=path       dump f32 logits per PREFILL position (teacher-forced
@@ -1099,16 +1100,73 @@ static int sample_tok(const float *lo, int V, float temp){
     free(p); return pick;
 }
 
+/* ---------- K3 XTML chat format (faithful to the shipped encoding_k3.py) --
+ * Only <|open|>, <|close|>, <|sep|>, <|end_of_msg|> are special TOKENS; tag
+ * names and attributes are ordinary text, encoded as the same standalone
+ * segments as the reference (segment boundaries are token boundaries). A
+ * turn renders as
+ *   <|open|>message role="user"<|sep|>TEXT<|close|>message<|sep|><|end_of_msg|>
+ * and the generation prompt opens the assistant message plus its structural
+ * thinking channel:
+ *   <|open|>message role="assistant"<|sep|><|open|>think<|sep|>
+ * (K3_THINK=0 opens <response> directly = non-thinking mode). The model then
+ * closes think, opens response, and finishes with <|end_of_msg|> (the eos). */
+typedef struct { Tok *T; int *ids; int n, cap;
+                 int sp_open, sp_close, sp_sep, sp_eom; } ChatB;
+static void cb_special(ChatB *b, int id){
+    if(b->n>=b->cap){ fprintf(stderr,"chat prompt too long\n"); exit(1); }
+    b->ids[b->n++]=id;
+}
+static void cb_text(ChatB *b, const char *s){
+    if(!*s) return;
+    b->n+=tok_encode(b->T,s,(int)strlen(s),b->ids+b->n,b->cap-b->n);
+}
+static void cb_open(ChatB *b, const char *tag, const char *role){
+    cb_special(b,b->sp_open); cb_text(b,tag);
+    if(role){ cb_text(b," role"); cb_text(b,"=\""); cb_text(b,role); cb_text(b,"\""); }
+    cb_special(b,b->sp_sep);
+}
+static void cb_close(ChatB *b, const char *tag){
+    cb_special(b,b->sp_close); cb_text(b,tag); cb_special(b,b->sp_sep);
+}
+static int chat_special(Tok *T, const char *s){
+    int l=(int)strlen(s);
+    for(int i=0;i<T->nsp;i++)
+        if(T->sp[i].len==l && !memcmp(T->sp[i].str,s,l)) return T->sp[i].id;
+    return -1;
+}
+/* returns prompt length; sp[4] = {open, close, sep, end_of_msg} ids */
+static int chat_build(Tok *T, const char *sys, const char *user, int thinking,
+                      int *ids, int cap, int *sp){
+    ChatB b={T,ids,0,cap,
+        chat_special(T,"<|open|>"), chat_special(T,"<|close|>"),
+        chat_special(T,"<|sep|>"),  chat_special(T,"<|end_of_msg|>")};
+    if(b.sp_open<0||b.sp_close<0||b.sp_sep<0||b.sp_eom<0){
+        fprintf(stderr,"chat: XTML special tokens not in tokenizer.json\n"); exit(1); }
+    sp[0]=b.sp_open; sp[1]=b.sp_close; sp[2]=b.sp_sep; sp[3]=b.sp_eom;
+    if(sys&&*sys){
+        cb_open(&b,"message","system"); cb_text(&b,sys);
+        cb_close(&b,"message"); cb_special(&b,b.sp_eom);
+    }
+    cb_open(&b,"message","user"); cb_text(&b,user);
+    cb_close(&b,"message"); cb_special(&b,b.sp_eom);
+    cb_open(&b,"message","assistant");
+    cb_open(&b,thinking?"think":"response",NULL);
+    return b.n;
+}
+
 int main(int argc, char **argv){
     if(argc<2){
         fprintf(stderr,"usage: %s <model_dir> [prompt] [--ids \"1 2 3\"] [--ngen N]\n",argv[0]);
         return 1;
     }
-    const char *snap=argv[1], *prompt=NULL, *idstr=NULL;
-    int ngen=32;
+    const char *snap=argv[1], *prompt=NULL, *idstr=NULL, *sysmsg=NULL;
+    int ngen=32, chat=0;
     for(int i=2;i<argc;i++){
         if(!strcmp(argv[i],"--ngen")&&i+1<argc) ngen=atoi(argv[++i]);
         else if(!strcmp(argv[i],"--ids")&&i+1<argc) idstr=argv[++i];
+        else if(!strcmp(argv[i],"--chat")) chat=1;
+        else if(!strcmp(argv[i],"--system")&&i+1<argc) sysmsg=argv[++i];
         else if(!prompt) prompt=argv[i];
     }
     float temp=getenv("COLI_TEMP")?(float)atof(getenv("COLI_TEMP")):0.f;
@@ -1135,9 +1193,21 @@ int main(int argc, char **argv){
     { char tp[2048]; snprintf(tp,sizeof(tp),"%s/tokenizer.json",snap);
       FILE *f=fopen(tp,"rb"); if(f){ fclose(f); tok_load(&T,tp); has_tok=1;
           fprintf(stderr,"[K3] tokenizer.json loaded (family=%s)\n",T.kimi?"kimi":(T.o200k?"o200k":"cl100k")); } }
+    int sp[4]={-1,-1,-1,-1};
+    int think=getenv("K3_THINK")?atoi(getenv("K3_THINK")):1;
     if(idstr){
         const char *p=idstr;
         while(*p&&np<65536){ while(*p==' '||*p==',')p++; if(!*p)break; ids[np++]=(int)strtol(p,(char**)&p,10); }
+    } else if(chat){
+        if(!has_tok){ fprintf(stderr,"--chat needs tokenizer.json\n"); return 1; }
+        if(!prompt){ fprintf(stderr,"--chat needs a user message\n"); return 1; }
+        if(m.c.bos>=0) ids[np++]=m.c.bos;
+        np+=chat_build(&T,sysmsg,prompt,think,ids+np,65536-np,sp);
+        if(getenv("K3_CHAT_IDS")){
+            fprintf(stderr,"[K3] chat ids:");
+            for(int i=0;i<np;i++) fprintf(stderr," %d",ids[i]);
+            fprintf(stderr,"\n");
+        }
     } else if(prompt){
         if(!has_tok){ fprintf(stderr,"no tokenizer.json — pass --ids (generate one with tools/k3_tokenizer.py)\n"); return 1; }
         if(m.c.bos>=0) ids[np++]=m.c.bos;
@@ -1173,12 +1243,33 @@ int main(int argc, char **argv){
     }
     double tg=now_s(); int ntok=0;
     char buf[512];
+    /* chat print filter: hide the XTML structure, label the channels.
+     * Structural runs are <|open|>/<|close|> TAGTEXT <|sep|> — suppress them
+     * and print a channel banner when the response channel opens. */
+    int xsup=0, xopen=0; char xtag[64]; int xtl=0;
+    if(chat&&think){ printf("[think] "); fflush(stdout); }
     for(int s=0;s<ngen;s++){
         int t=sample_tok(lo,m.c.vocab,temp);
         free(lo); lo=NULL;
         int is_eos=0; for(int e=0;e<m.c.n_eos;e++) if(t==m.c.eos[e]) is_eos=1;
-        if(has_tok){ int n2=tok_decode(&T,&t,1,buf,sizeof(buf)-1); fwrite(buf,1,n2,stdout); fflush(stdout); }
-        else { printf("%d ",t); fflush(stdout); }
+        int show=1;
+        if(chat&&sp[0]>=0){
+            if(t==sp[0]||t==sp[1]){ xsup=1; xopen=(t==sp[0]); xtl=0; show=0; }
+            else if(t==sp[2]){
+                if(xsup){ xsup=0; xtag[xtl]=0;
+                    if(xopen&&!strcmp(xtag,"response")){ printf("\n\n[response] "); fflush(stdout); }
+                }
+                show=0;
+            } else if(xsup){
+                if(has_tok){ int n2=tok_decode(&T,&t,1,buf,sizeof(buf)-1);
+                    if(xtl+n2<(int)sizeof(xtag)){ memcpy(xtag+xtl,buf,n2); xtl+=n2; } }
+                show=0;
+            } else if(t==sp[3]) show=0;
+        }
+        if(show){
+            if(has_tok){ int n2=tok_decode(&T,&t,1,buf,sizeof(buf)-1); fwrite(buf,1,n2,stdout); fflush(stdout); }
+            else { printf("%d ",t); fflush(stdout); }
+        }
         ntok++;
         if(is_eos){ fprintf(stderr,"\n[K3] eos\n"); break; }
         if(np+ntok>=max_t){ fprintf(stderr,"\n[K3] context full\n"); break; }

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -45,6 +45,7 @@
  *   K3_PIPE=0|1          overlap expert loads with compute (default 1)
  *   K3_LOAD_THREADS=N    loader threads for K3_PIPE (default 4)
  *   K3_TOPP=F            keep routed experts to cumulative weight F (0 = off)
+ *   K3_CHUNK=N           prefill chunk size (default 32; 1 = token-at-a-time)
  *   K3_LAYERS=N          truncate to first N layers (validation; skips head)
  *   K3_TRACE=path        dump f32 hidden state after every layer (validation)
  *   K3_LOGITS=path       dump f32 logits per PREFILL position (teacher-forced
@@ -552,108 +553,154 @@ static void res_mix(float *out, const float *prefix, const float *bres, int nb, 
     for(int d=0;d<D;d++){ float a=0; for(int e=0;e<=nb;e++) a+=sc[e]*v[e][d]; out[d]=a; }
 }
 
-/* ---------- KDA layer (single token) ---------- */
-static void kda_forward(Model *m, Layer *l, int li, const float *x, float *out){
+/* ---------- KDA layer (chunk of C tokens; projections batched, recurrence
+ * sequential per token, AVX2 on the state sweeps) ---------- */
+static void kda_forward(Model *m, Layer *l, int li, const float *x, int C, float *out){
     Cfg *c=&m->c; Kda *a=&l->a;
     int P=c->kda_proj, H=c->kda_heads, hd=c->kda_hd, K=c->conv_k;
-    float *q=falloc(P), *k=falloc(P), *v=falloc(P), *gp=falloc(P), *on=falloc(P);
-    float *t1=falloc(c->kda_hd), *graw=falloc(P), *braw=falloc(H);
-    w_matmul(q,x,&a->q,1); w_matmul(k,x,&a->k,1); w_matmul(v,x,&a->v,1);
-    w_matmul(gp,x,&a->g,1);
-    matmul(t1,x,a->fa,1,c->hidden,c->kda_hd);
-    matmul(graw,t1,a->fb,1,c->kda_hd,P);
-    matmul(braw,x,a->bp,1,c->hidden,H);
-    /* depthwise causal conv (window: oldest..newest) + SiLU, window rolls forward */
-    float *wins[3]={m->cwq[li],m->cwk[li],m->cwv[li]};
-    float *vecs[3]={q,k,v}; float *taps[3]={a->conv_q,a->conv_k,a->conv_v};
-    for(int t=0;t<3;t++){
-        float *win=wins[t], *vec=vecs[t]; const float *cw=taps[t];
-        #pragma omp parallel for schedule(static)
-        for(int d=0;d<P;d++){
-            float *wd=win+(int64_t)d*K;
-            for(int j=0;j<K-1;j++) wd[j]=wd[j+1];
-            wd[K-1]=vec[d];
-            float acc=0; const float *cd=cw+(int64_t)d*K;
-            for(int j=0;j<K;j++) acc+=cd[j]*wd[j];
-            vec[d]=siluf_(acc);
-        }
-    }
+    float *q=falloc((int64_t)C*P), *k=falloc((int64_t)C*P), *v=falloc((int64_t)C*P);
+    float *gp=falloc((int64_t)C*P), *on=falloc((int64_t)C*P);
+    float *t1=falloc((int64_t)C*c->kda_hd), *graw=falloc((int64_t)C*P), *braw=falloc((int64_t)C*H);
+    w_matmul(q,x,&a->q,C); w_matmul(k,x,&a->k,C); w_matmul(v,x,&a->v,C);
+    w_matmul(gp,x,&a->g,C);
+    matmul(t1,x,a->fa,C,c->hidden,c->kda_hd);
+    matmul(graw,t1,a->fb,C,c->kda_hd,P);
+    matmul(braw,x,a->bp,C,c->hidden,H);
     float qscale=1.f/sqrtf((float)hd);
-    #pragma omp parallel for schedule(static)
-    for(int h=0;h<H;h++){
-        const float *qh=q+(int64_t)h*hd, *kh=k+(int64_t)h*hd, *vh=v+(int64_t)h*hd;
-        float qn[512], kn[512], alpha[512], kS[512], vt[512], oh[512];
-        float sq=0,sk=0;
-        for(int i=0;i<hd;i++){ sq+=qh[i]*qh[i]; sk+=kh[i]*kh[i]; }
-        sq=1.f/sqrtf(sq+1e-6f); sk=1.f/sqrtf(sk+1e-6f);
-        for(int i=0;i<hd;i++){ qn[i]=qh[i]*sq*qscale; kn[i]=kh[i]*sk; }
-        for(int i=0;i<hd;i++){
-            float z=graw[(int64_t)h*hd+i]+a->dt[(int64_t)h*hd+i];
-            alpha[i]=expf(c->gate_lb*sigmoidf_(a->A[h]*z));
+    for(int t=0;t<C;t++){
+        float *qt=q+(int64_t)t*P, *kt=k+(int64_t)t*P, *tv=v+(int64_t)t*P;
+        float *gpt=gp+(int64_t)t*P, *ont=on+(int64_t)t*P;
+        const float *rgt=graw+(int64_t)t*P, *bt=braw+(int64_t)t*H;
+        /* depthwise causal conv (window: oldest..newest) + SiLU, rolls forward */
+        float *wins[3]={m->cwq[li],m->cwk[li],m->cwv[li]};
+        float *vecs[3]={qt,kt,tv}; float *taps[3]={a->conv_q,a->conv_k,a->conv_v};
+        for(int w2=0;w2<3;w2++){
+            float *win=wins[w2], *vec=vecs[w2]; const float *cw=taps[w2];
+            #pragma omp parallel for schedule(static)
+            for(int d=0;d<P;d++){
+                float *wd=win+(int64_t)d*K;
+                for(int j=0;j<K-1;j++) wd[j]=wd[j+1];
+                wd[K-1]=vec[d];
+                float acc=0; const float *cd=cw+(int64_t)d*K;
+                for(int j=0;j<K;j++) acc+=cd[j]*wd[j];
+                vec[d]=siluf_(acc);
+            }
         }
-        float beta=sigmoidf_(braw[h]);
-        float *S=m->kstate[li]+(int64_t)h*hd*hd;
-        memset(kS,0,hd*sizeof(float));
-        for(int kk=0;kk<hd;kk++){
-            float *row=S+(int64_t)kk*hd; float al=alpha[kk], kv=kn[kk];
-            for(int vv=0;vv<hd;vv++){ row[vv]*=al; kS[vv]+=kv*row[vv]; }
+        #pragma omp parallel for schedule(static)
+        for(int h=0;h<H;h++){
+            const float *qh=qt+(int64_t)h*hd, *kh=kt+(int64_t)h*hd, *vh=tv+(int64_t)h*hd;
+            float qn[512], kn[512], alpha[512], kS[512], vt[512], oh[512];
+            float sq=0,sk=0;
+            for(int i=0;i<hd;i++){ sq+=qh[i]*qh[i]; sk+=kh[i]*kh[i]; }
+            sq=1.f/sqrtf(sq+1e-6f); sk=1.f/sqrtf(sk+1e-6f);
+            for(int i=0;i<hd;i++){ qn[i]=qh[i]*sq*qscale; kn[i]=kh[i]*sk; }
+            for(int i=0;i<hd;i++){
+                float z=rgt[(int64_t)h*hd+i]+a->dt[(int64_t)h*hd+i];
+                alpha[i]=expf(c->gate_lb*sigmoidf_(a->A[h]*z));
+            }
+            float beta=sigmoidf_(bt[h]);
+            float *S=m->kstate[li]+(int64_t)h*hd*hd;
+            memset(kS,0,sizeof(kS));
+#ifdef __AVX2__
+            if(!(hd&7)){
+                for(int kk=0;kk<hd;kk++){
+                    float *row=S+(int64_t)kk*hd;
+                    __m256 al8=_mm256_set1_ps(alpha[kk]), kv8=_mm256_set1_ps(kn[kk]);
+                    for(int vv=0;vv<hd;vv+=8){
+                        __m256 r=_mm256_mul_ps(_mm256_loadu_ps(row+vv),al8);
+                        _mm256_storeu_ps(row+vv,r);
+                        _mm256_storeu_ps(kS+vv,_mm256_fmadd_ps(kv8,r,_mm256_loadu_ps(kS+vv)));
+                    }
+                }
+                for(int vv=0;vv<hd;vv++) vt[vv]=(vh[vv]-kS[vv])*beta;
+                memset(oh,0,sizeof(oh));
+                for(int kk=0;kk<hd;kk++){
+                    float *row=S+(int64_t)kk*hd;
+                    __m256 kv8=_mm256_set1_ps(kn[kk]), qq8=_mm256_set1_ps(qn[kk]);
+                    for(int vv=0;vv<hd;vv+=8){
+                        __m256 r=_mm256_fmadd_ps(kv8,_mm256_loadu_ps(vt+vv),_mm256_loadu_ps(row+vv));
+                        _mm256_storeu_ps(row+vv,r);
+                        _mm256_storeu_ps(oh+vv,_mm256_fmadd_ps(qq8,r,_mm256_loadu_ps(oh+vv)));
+                    }
+                }
+            } else {
+#endif
+            for(int kk=0;kk<hd;kk++){
+                float *row=S+(int64_t)kk*hd; float al=alpha[kk], kv=kn[kk];
+                for(int vv=0;vv<hd;vv++){ row[vv]*=al; kS[vv]+=kv*row[vv]; }
+            }
+            for(int vv=0;vv<hd;vv++) vt[vv]=(vh[vv]-kS[vv])*beta;
+            memset(oh,0,sizeof(oh));
+            for(int kk=0;kk<hd;kk++){
+                float *row=S+(int64_t)kk*hd; float kv=kn[kk], qq=qn[kk];
+                for(int vv=0;vv<hd;vv++){ row[vv]+=kv*vt[vv]; oh[vv]+=qq*row[vv]; }
+            }
+#ifdef __AVX2__
+            }
+#endif
+            /* per-head RMSNorm * sigmoid(full-rank gate) */
+            double ms=0; for(int vv=0;vv<hd;vv++) ms+=(double)oh[vv]*oh[vv];
+            float r=1.f/sqrtf((float)(ms/hd)+c->eps);
+            float *dst=ont+(int64_t)h*hd;
+            for(int vv=0;vv<hd;vv++) dst[vv]=oh[vv]*r*a->onw[vv]*sigmoidf_(gpt[(int64_t)h*hd+vv]);
         }
-        for(int vv=0;vv<hd;vv++) vt[vv]=(vh[vv]-kS[vv])*beta;
-        memset(oh,0,hd*sizeof(float));
-        for(int kk=0;kk<hd;kk++){
-            float *row=S+(int64_t)kk*hd; float kv=kn[kk], qq=qn[kk];
-            for(int vv=0;vv<hd;vv++){ row[vv]+=kv*vt[vv]; oh[vv]+=qq*row[vv]; }
-        }
-        /* per-head RMSNorm * sigmoid(full-rank gate) */
-        double ms=0; for(int vv=0;vv<hd;vv++) ms+=(double)oh[vv]*oh[vv];
-        float r=1.f/sqrtf((float)(ms/hd)+c->eps);
-        float *dst=on+(int64_t)h*hd;
-        for(int vv=0;vv<hd;vv++) dst[vv]=oh[vv]*r*a->onw[vv]*sigmoidf_(gp[(int64_t)h*hd+vv]);
     }
-    w_matmul(out,on,&a->o,1);
+    w_matmul(out,on,&a->o,C);
     free(q);free(k);free(v);free(gp);free(on);free(t1);free(graw);free(braw);
 }
 
-/* ---------- gated MLA layer (single token, NoPE, absorb) ---------- */
-static void mla_forward(Model *m, Layer *l, int li, const float *x, int pos, float *out){
+/* ---------- gated MLA layer (chunk of C tokens, NoPE, absorb; projections
+ * batched, per-token causal attention — token t attends to 0..pos0+t) ------ */
+static void mla_forward(Model *m, Layer *l, int li, const float *x, int pos0, int C, float *out){
     Cfg *c=&m->c; Mla *a=&l->m;
     int H=c->n_heads, qh=c->qk_head, vh=c->v_head, kvl=c->kv_lora, qr=c->qk_rope;
-    float *qa=falloc(c->q_lora), *qv=falloc((int64_t)H*qh), *ckv=falloc(kvl+qr);
-    float *gv=falloc((int64_t)H*vh), *ctx=falloc((int64_t)H*vh);
-    w_matmul(qa,x,&a->qa,1);
-    rmsnorm_(qa,qa,a->qa_ln,c->q_lora,c->eps);
-    w_matmul(qv,qa,&a->qb,1);
-    w_matmul(ckv,x,&a->kva,1);
-    float *Lrow=m->Lc[li]+(int64_t)pos*kvl, *Rrow=m->Rc[li]+(int64_t)pos*qr;
-    rmsnorm_(Lrow,ckv,a->kva_ln,kvl,c->eps);
-    memcpy(Rrow,ckv+kvl,qr*sizeof(float));           /* NoPE: cached raw, no rotation */
-    w_matmul(gv,x,&a->g,1);
-    int nt=pos+1;
-    #pragma omp parallel for schedule(static)
-    for(int h=0;h<H;h++){
-        const float *qp=qv+(int64_t)h*qh, *qrp=qp+c->qk_nope;
-        int rbase=h*(c->qk_nope+vh);
-        float qabs[4096]; memset(qabs,0,kvl*sizeof(float));
-        for(int d=0;d<c->qk_nope;d++) w_addrow(&a->kvb,rbase+d,qp[d],qabs);
-        float *sc=falloc(nt);
-        for(int t=0;t<nt;t++){
-            const float *Lt=m->Lc[li]+(int64_t)t*kvl, *Rt=m->Rc[li]+(int64_t)t*qr;
-            float s2=0; for(int i=0;i<kvl;i++) s2+=qabs[i]*Lt[i];
-            for(int i=0;i<qr;i++) s2+=qrp[i]*Rt[i];
-            sc[t]=s2*c->attn_scale;
-        }
-        softmax_(sc,nt);
-        float clat[4096]; memset(clat,0,kvl*sizeof(float));
-        for(int t=0;t<nt;t++){
-            const float *Lt=m->Lc[li]+(int64_t)t*kvl; float s2=sc[t];
-            for(int i=0;i<kvl;i++) clat[i]+=s2*Lt[i];
-        }
-        free(sc);
-        float *cx=ctx+(int64_t)h*vh;
-        for(int d=0;d<vh;d++)
-            cx[d]=w_rowdot(&a->kvb,rbase+c->qk_nope+d,clat)*sigmoidf_(gv[(int64_t)h*vh+d]);
+    float *qa=falloc((int64_t)C*c->q_lora), *qv=falloc((int64_t)C*H*qh);
+    float *ckv=falloc((int64_t)C*(kvl+qr));
+    float *gv=falloc((int64_t)C*H*vh), *ctx=falloc((int64_t)C*H*vh);
+    w_matmul(qa,x,&a->qa,C);
+    for(int t=0;t<C;t++)
+        rmsnorm_(qa+(int64_t)t*c->q_lora,qa+(int64_t)t*c->q_lora,a->qa_ln,c->q_lora,c->eps);
+    w_matmul(qv,qa,&a->qb,C);
+    w_matmul(ckv,x,&a->kva,C);
+    for(int t=0;t<C;t++){                            /* append the whole chunk to the
+                                                      * cache first: token t's scores
+                                                      * only read rows 0..pos0+t */
+        float *Lrow=m->Lc[li]+(int64_t)(pos0+t)*kvl, *Rrow=m->Rc[li]+(int64_t)(pos0+t)*qr;
+        const float *cv=ckv+(int64_t)t*(kvl+qr);
+        rmsnorm_(Lrow,cv,a->kva_ln,kvl,c->eps);
+        memcpy(Rrow,cv+kvl,qr*sizeof(float));        /* NoPE: cached raw, no rotation */
     }
-    w_matmul(out,ctx,&a->o,1);
+    w_matmul(gv,x,&a->g,C);
+    for(int tt=0;tt<C;tt++){
+        int nt=pos0+tt+1;
+        const float *qvt=qv+(int64_t)tt*H*qh, *gvt=gv+(int64_t)tt*H*vh;
+        float *ctxt=ctx+(int64_t)tt*H*vh;
+        #pragma omp parallel for schedule(static)
+        for(int h=0;h<H;h++){
+            const float *qp=qvt+(int64_t)h*qh, *qrp=qp+c->qk_nope;
+            int rbase=h*(c->qk_nope+vh);
+            float qabs[4096]; memset(qabs,0,kvl*sizeof(float));
+            for(int d=0;d<c->qk_nope;d++) w_addrow(&a->kvb,rbase+d,qp[d],qabs);
+            float *sc=falloc(nt);
+            for(int t=0;t<nt;t++){
+                const float *Lt=m->Lc[li]+(int64_t)t*kvl, *Rt=m->Rc[li]+(int64_t)t*qr;
+                float s2=0; for(int i=0;i<kvl;i++) s2+=qabs[i]*Lt[i];
+                for(int i=0;i<qr;i++) s2+=qrp[i]*Rt[i];
+                sc[t]=s2*c->attn_scale;
+            }
+            softmax_(sc,nt);
+            float clat[4096]; memset(clat,0,kvl*sizeof(float));
+            for(int t=0;t<nt;t++){
+                const float *Lt=m->Lc[li]+(int64_t)t*kvl; float s2=sc[t];
+                for(int i=0;i<kvl;i++) clat[i]+=s2*Lt[i];
+            }
+            free(sc);
+            float *cx=ctxt+(int64_t)h*vh;
+            for(int d=0;d<vh;d++)
+                cx[d]=w_rowdot(&a->kvb,rbase+c->qk_nope+d,clat)*sigmoidf_(gvt[(int64_t)h*vh+d]);
+        }
+    }
+    w_matmul(out,ctx,&a->o,C);
     free(qa);free(qv);free(ckv);free(gv);free(ctx);
 }
 
@@ -780,178 +827,252 @@ static void lp_submit(Model *m, int n){
     pthread_mutex_unlock(&g_lp.mx);
 }
 
-/* the full routed-expert pass for one token+layer: resolve (LRU hit or
- * working-set slot), load misses (pipelined with compute under K3_PIPE,
- * else all-parallel up front), compute, promote into the LRU. */
-static void experts_run(Model *m, int li, int n, const int *ids, const float *w,
-                        const float *z, float *u, float *gate, float *up, float *hz){
-    Slot *use[64]; int missk[64]; int qof[64]; int nmiss=0;
-    for(int j=0;j<n;j++){
-        use[j]=slot_find(m,li,ids[j]); qof[j]=-1;
-        if(!use[j]){ m->miss++; use[j]=&m->ws[nmiss]; qof[j]=nmiss; missk[nmiss++]=j; }
-    }
-    if(nmiss){
-        if(g_k3_pipe){
-            if(!g_lp.started) lp_start();
+/* the general expert pass for one layer over a CHUNK of positions: nu unique
+ * experts, expert j applied to pcnt[j] positions (poslist/wlist rows starting
+ * at pfirst[j]). Loads run in blocks of <=LP_MAX working-set slots, pipelined
+ * with compute under K3_PIPE (expert j's matmuls overlap expert j+1's read),
+ * else all-parallel up front. Z/U are [C, stride] position-major. */
+static void experts_apply_union(Model *m, int li, int nu, const int *uids,
+                                const int *pfirst, const int *pcnt,
+                                const int *poslist, const float *wlist,
+                                const float *Z, int stride, float *U,
+                                float *gate, float *up, float *hz){
+    for(int base=0;base<nu;base+=LP_MAX){
+        int nb=nu-base<LP_MAX?nu-base:LP_MAX;
+        Slot *use[LP_MAX]; int missk[LP_MAX]; int qof[LP_MAX]; int nmiss=0;
+        for(int j=0;j<nb;j++){
+            use[j]=slot_find(m,li,uids[base+j]); qof[j]=-1;
+            if(!use[j]){ m->miss++; use[j]=&m->ws[nmiss]; qof[j]=nmiss; missk[nmiss++]=j; }
         }
-        if(g_k3_pipe){
-            for(int q=0;q<nmiss;q++){
-                g_lp.job[q].li=li; g_lp.job[q].eid=ids[missk[q]]; g_lp.job[q].s=&m->ws[q];
+        if(nmiss){
+            if(g_k3_pipe && !g_lp.started) lp_start();
+            if(g_k3_pipe){
+                for(int q=0;q<nmiss;q++){
+                    g_lp.job[q].li=li; g_lp.job[q].eid=uids[base+missk[q]]; g_lp.job[q].s=&m->ws[q];
+                }
+                lp_submit(m,nmiss);
+            } else {
+                double t0=now_s();
+                #pragma omp parallel for schedule(dynamic,1)
+                for(int q=0;q<nmiss;q++) expert_read(m,li,uids[base+missk[q]],&m->ws[q]);
+                m->t_eload+=now_s()-t0;
             }
-            lp_submit(m,nmiss);
-        } else {
-            double t0=now_s();
-            #pragma omp parallel for schedule(dynamic,1)
-            for(int q=0;q<nmiss;q++) expert_read(m,li,ids[missk[q]],&m->ws[q]);
-            m->t_eload+=now_s()-t0;
+            m->ebytes+=(uint64_t)nmiss*(uint64_t)m->e_slot;
         }
-        m->ebytes+=(uint64_t)nmiss*(uint64_t)m->e_slot;
-    }
-    for(int j=0;j<n;j++){
-        if(g_k3_pipe && qof[j]>=0 &&
-           !atomic_load_explicit(&g_lp.ready[qof[j]],memory_order_acquire)){
-            double t0=now_s();          /* t_eload = UN-hidden I/O (wait) time */
-            while(!atomic_load_explicit(&g_lp.ready[qof[j]],memory_order_acquire))
-                usleep(50);
-            m->t_eload+=now_s()-t0;
+        for(int j=0;j<nb;j++){
+            if(g_k3_pipe && qof[j]>=0 &&
+               !atomic_load_explicit(&g_lp.ready[qof[j]],memory_order_acquire)){
+                double t0=now_s();      /* t_eload = UN-hidden I/O (wait) time */
+                while(!atomic_load_explicit(&g_lp.ready[qof[j]],memory_order_acquire))
+                    usleep(50);
+                m->t_eload+=now_s()-t0;
+            }
+            int f=pfirst[base+j];
+            for(int p2=0;p2<pcnt[base+j];p2++){
+                int t=poslist[f+p2];
+                expert_apply(m,use[j],Z+(int64_t)t*stride,wlist[f+p2],
+                             U+(int64_t)t*stride,gate,up,hz);
+            }
         }
-        expert_apply(m,use[j],z,w[j],u,gate,up,hz);
-    }
-    /* promotion: swap the freshly-read slots into the layer LRU */
-    LCache *lc=&m->ecache[li];
-    int promo = nmiss<lc->cap ? nmiss : lc->cap;
-    for(int a=0;a<promo;a++){
-        int q=nmiss-1-a; Slot *dst;
-        if(lc->n<lc->cap) dst=&lc->s[lc->n++];
-        else { int lru=0; for(int i=1;i<lc->n;i++) if(lc->s[i].used<lc->s[lru].used) lru=i; dst=&lc->s[lru]; }
-        Slot tmp=*dst; *dst=m->ws[q]; m->ws[q]=tmp;
-        dst->used=++m->clock;
+        /* promotion: swap the freshly-read slots into the layer LRU */
+        LCache *lc=&m->ecache[li];
+        int promo = nmiss<lc->cap ? nmiss : lc->cap;
+        for(int a=0;a<promo;a++){
+            int q=nmiss-1-a; Slot *dst;
+            if(lc->n<lc->cap) dst=&lc->s[lc->n++];
+            else { int lru=0; for(int i=1;i<lc->n;i++) if(lc->s[i].used<lc->s[lru].used) lru=i; dst=&lc->s[lru]; }
+            Slot tmp=*dst; *dst=m->ws[q]; m->ws[q]=tmp;
+            dst->used=++m->clock;
+        }
     }
 }
 
-static void moe_forward(Model *m, Layer *l, int li, const float *x, float *out){
+static void moe_forward(Model *m, Layer *l, int li, const float *x, int C, float *out){
     Cfg *c=&m->c; Moe *o=&l->moe;
     int E=c->n_experts, K=c->topk, LT=c->latent, MI=c->moe_inter;
-    float *sco=falloc(E);
-    matmul(sco,x,o->router,1,c->hidden,E);
-    for(int e=0;e<E;e++) sco[e]=sigmoidf_(sco[e]);
-    int idx[64]; float wsel[64];
-    for(int kk=0;kk<K;kk++){
-        int best=-1; float bv=-1e30f;
-        for(int e=0;e<E;e++){
-            int taken=0; for(int j=0;j<kk;j++) if(idx[j]==e){taken=1;break;}
-            float sv=sco[e]+o->rbias[e];
-            if(!taken&&sv>bv){ bv=sv; best=e; }
-        }
-        idx[kk]=best; wsel[kk]=sco[best];             /* weight = RAW sigmoid score */
-    }
-    { float sm=0; for(int kk=0;kk<K;kk++) sm+=wsel[kk];
-      for(int kk=0;kk<K;kk++) wsel[kk]/=(sm+1e-20f); }
-    /* K3_TOPP: drop the low-weight tail of the top-16 — the only lever that
-     * cuts expert I/O AND compute proportionally. Weights renormalize over
-     * the kept set (GLM's TOPP semantics). Quality-gate via K3_LOGITS. */
-    if(g_k3_topp>0.f && g_k3_topp<1.f){
-        for(int a2=1;a2<K;a2++){ int e=idx[a2]; float w2=wsel[a2]; int b2=a2-1;
-            while(b2>=0&&wsel[b2]<w2){ idx[b2+1]=idx[b2]; wsel[b2+1]=wsel[b2]; b2--; }
-            idx[b2+1]=e; wsel[b2+1]=w2; }
-        float cum=0; int keep=K;
-        for(int kk=0;kk<K;kk++){ cum+=wsel[kk]; if(cum>=g_k3_topp){ keep=kk+1; break; } }
-        if(keep<K){
-            float sm=0; for(int kk=0;kk<keep;kk++) sm+=wsel[kk];
-            for(int kk=0;kk<keep;kk++) wsel[kk]/=(sm+1e-20f);
-            K=keep;
-        }
-    }
-    /* keep loads in DISK-OFFSET order (experts are NOT id-ordered inside the
-     * HF shards — measured 169/895; helps the buffered fallback, harmless
-     * under O_DIRECT). WILLNEED prefetch only for the buffered path. */
-    for(int a2=0;a2<K-1;a2++) for(int b2=a2+1;b2<K;b2++){
-        ERef *ea=&m->eref[(int64_t)li*E+idx[a2]], *eb=&m->eref[(int64_t)li*E+idx[b2]];
-        if(eb->fd[0]<ea->fd[0]||(eb->fd[0]==ea->fd[0]&&eb->off[0]<ea->off[0])){
-            int t=idx[a2];idx[a2]=idx[b2];idx[b2]=t; float tw=wsel[a2];wsel[a2]=wsel[b2];wsel[b2]=tw; }
-    }
-    if(!g_k3_direct)
+    float *sco=falloc((int64_t)C*E);
+    matmul(sco,x,o->router,C,c->hidden,E);
+    int *idxs=malloc((size_t)C*K*sizeof(int)); float *wsels=falloc((int64_t)C*K);
+    int *keff=malloc((size_t)C*sizeof(int));
+    if(!idxs||!keff){fprintf(stderr,"OOM moe sel\n");exit(1);}
+    for(int t=0;t<C;t++){
+        float *st=sco+(int64_t)t*E;
+        for(int e=0;e<E;e++) st[e]=sigmoidf_(st[e]);
+        int *idx=idxs+(int64_t)t*K; float *wsel=wsels+(int64_t)t*K;
         for(int kk=0;kk<K;kk++){
-            ERef *er=&m->eref[(int64_t)li*E+idx[kk]];
-            int64_t sizes[6]={m->e_w1p,m->e_w1s,m->e_w2p,m->e_w2s,m->e_w1p,m->e_w1s};
-            if(er->contig){ if(er->fd[0]>=0) posix_fadvise(er->fd[0],er->off[0],m->e_slot,POSIX_FADV_WILLNEED); }
-            else for(int k2=0;k2<6;k2++) if(er->fd[k2]>=0) posix_fadvise(er->fd[k2],er->off[k2],sizes[k2],POSIX_FADV_WILLNEED);
+            int best=-1; float bv=-1e30f;
+            for(int e=0;e<E;e++){
+                int taken=0; for(int j=0;j<kk;j++) if(idx[j]==e){taken=1;break;}
+                float sv=st[e]+o->rbias[e];
+                if(!taken&&sv>bv){ bv=sv; best=e; }
+            }
+            idx[kk]=best; wsel[kk]=st[best];          /* weight = RAW sigmoid score */
         }
-    float *z=falloc(LT), *u=falloc(LT), *gate=falloc(MI), *up=falloc(MI), *hz=falloc(LT);
-    w_matmul(z,x,&o->lat_down,1);
-    memset(u,0,LT*sizeof(float));
-    experts_run(m,li,K,idx,wsel,z,u,gate,up,hz);
-    rmsnorm_(u,u,o->lat_norm,LT,c->eps);
-    w_matmul(out,u,&o->lat_up,1);
+        { float sm=0; for(int kk=0;kk<K;kk++) sm+=wsel[kk];
+          for(int kk=0;kk<K;kk++) wsel[kk]/=(sm+1e-20f); }
+        int Kt=K;
+        /* K3_TOPP: drop the low-weight tail — the only lever that cuts expert
+         * I/O AND compute proportionally. Weights renormalize over the kept
+         * set (GLM's TOPP semantics). Quality-gate via K3_LOGITS. */
+        if(g_k3_topp>0.f && g_k3_topp<1.f){
+            for(int a2=1;a2<Kt;a2++){ int e=idx[a2]; float w2=wsel[a2]; int b2=a2-1;
+                while(b2>=0&&wsel[b2]<w2){ idx[b2+1]=idx[b2]; wsel[b2+1]=wsel[b2]; b2--; }
+                idx[b2+1]=e; wsel[b2+1]=w2; }
+            float cum=0; int keep=Kt;
+            for(int kk=0;kk<Kt;kk++){ cum+=wsel[kk]; if(cum>=g_k3_topp){ keep=kk+1; break; } }
+            if(keep<Kt){
+                float sm=0; for(int kk=0;kk<keep;kk++) sm+=wsel[kk];
+                for(int kk=0;kk<keep;kk++) wsel[kk]/=(sm+1e-20f);
+                Kt=keep;
+            }
+        }
+        keff[t]=Kt;
+    }
+    float *z=falloc((int64_t)C*LT), *u=falloc((int64_t)C*LT);
+    float *gate=falloc(MI), *up=falloc(MI), *hz=falloc(LT);
+    w_matmul(z,x,&o->lat_down,C);
+    memset(u,0,(size_t)C*LT*sizeof(float));
+    /* union across the chunk: each unique expert loads ONCE and applies to
+     * every position that selected it (position lists via counting sort).
+     * With QB-flat routing the dedup is modest (~15% at C=32), but the loads
+     * arrive as one deep burst for the NVMe and the dense side above/below
+     * batches perfectly. */
+    {
+        int *map=malloc((size_t)E*sizeof(int));
+        int *uid=malloc((size_t)C*K*sizeof(int));
+        int *pcnt=malloc((size_t)C*K*sizeof(int)), *pfirst=malloc((size_t)C*K*sizeof(int));
+        int *poslist=malloc((size_t)C*K*sizeof(int)); float *wlist=falloc((int64_t)C*K);
+        int *cur=malloc((size_t)C*K*sizeof(int));
+        if(!map||!uid||!pcnt||!pfirst||!poslist||!cur){fprintf(stderr,"OOM moe union\n");exit(1);}
+        for(int e=0;e<E;e++) map[e]=-1;
+        int nu=0;
+        for(int t=0;t<C;t++) for(int kk=0;kk<keff[t];kk++){
+            int e=idxs[(int64_t)t*K+kk];
+            if(map[e]<0){ map[e]=nu; uid[nu]=e; pcnt[nu]=0; nu++; }
+            pcnt[map[e]]++;
+        }
+        int acc=0;
+        for(int j=0;j<nu;j++){ pfirst[j]=acc; cur[j]=acc; acc+=pcnt[j]; }
+        for(int t=0;t<C;t++) for(int kk=0;kk<keff[t];kk++){
+            int j=map[idxs[(int64_t)t*K+kk]];
+            poslist[cur[j]]=t; wlist[cur[j]]=wsels[(int64_t)t*K+kk]; cur[j]++;
+        }
+        /* keep loads in DISK-OFFSET order (experts are NOT id-ordered inside
+         * the HF shards — measured 169/895); permute the list heads with the
+         * ids. WILLNEED prefetch only for the buffered path. */
+        for(int a2=0;a2<nu-1;a2++) for(int b2=a2+1;b2<nu;b2++){
+            ERef *ea=&m->eref[(int64_t)li*E+uid[a2]], *eb=&m->eref[(int64_t)li*E+uid[b2]];
+            if(eb->fd[0]<ea->fd[0]||(eb->fd[0]==ea->fd[0]&&eb->off[0]<ea->off[0])){
+                int tt=uid[a2];uid[a2]=uid[b2];uid[b2]=tt;
+                tt=pcnt[a2];pcnt[a2]=pcnt[b2];pcnt[b2]=tt;
+                tt=pfirst[a2];pfirst[a2]=pfirst[b2];pfirst[b2]=tt; }
+        }
+        if(!g_k3_direct)
+            for(int j=0;j<nu;j++){
+                ERef *er=&m->eref[(int64_t)li*E+uid[j]];
+                int64_t sizes[6]={m->e_w1p,m->e_w1s,m->e_w2p,m->e_w2s,m->e_w1p,m->e_w1s};
+                if(er->contig){ if(er->fd[0]>=0) posix_fadvise(er->fd[0],er->off[0],m->e_slot,POSIX_FADV_WILLNEED); }
+                else for(int k2=0;k2<6;k2++) if(er->fd[k2]>=0) posix_fadvise(er->fd[k2],er->off[k2],sizes[k2],POSIX_FADV_WILLNEED);
+            }
+        experts_apply_union(m,li,nu,uid,pfirst,pcnt,poslist,wlist,z,LT,u,gate,up,hz);
+        free(map);free(uid);free(pcnt);free(pfirst);free(poslist);free(wlist);free(cur);
+    }
+    for(int t=0;t<C;t++)
+        rmsnorm_(u+(int64_t)t*LT,u+(int64_t)t*LT,o->lat_norm,LT,c->eps);
+    w_matmul(out,u,&o->lat_up,C);
     /* shared experts at full width */
     int shi=MI*c->n_shared;
-    float *sg=falloc(shi), *su=falloc(shi), *sd=falloc(c->hidden);
-    w_matmul(sg,x,&o->sh_gate,1); w_matmul(su,x,&o->sh_up,1);
-    for(int i=0;i<shi;i++) sg[i]=situf_(sg[i],su[i],c->situ_b1,c->situ_b2);
-    w_matmul(sd,sg,&o->sh_down,1);
-    for(int d=0;d<c->hidden;d++) out[d]+=sd[d];
-    free(sco);free(z);free(u);free(gate);free(up);free(hz);free(sg);free(su);free(sd);
+    float *sg=falloc((int64_t)C*shi), *su=falloc((int64_t)C*shi), *sd=falloc((int64_t)C*c->hidden);
+    w_matmul(sg,x,&o->sh_gate,C); w_matmul(su,x,&o->sh_up,C);
+    for(int64_t i=0;i<(int64_t)C*shi;i++) sg[i]=situf_(sg[i],su[i],c->situ_b1,c->situ_b2);
+    w_matmul(sd,sg,&o->sh_down,C);
+    for(int64_t d=0;d<(int64_t)C*c->hidden;d++) out[d]+=sd[d];
+    free(sco);free(idxs);free(wsels);free(keff);
+    free(z);free(u);free(gate);free(up);free(hz);free(sg);free(su);free(sd);
 }
 
-static void dense_forward(Model *m, Layer *l, const float *x, float *out){
+static void dense_forward(Model *m, Layer *l, const float *x, int C, float *out){
     Cfg *c=&m->c; int DI=c->dense_inter;
-    float *g=falloc(DI), *u=falloc(DI);
-    w_matmul(g,x,&l->d_gate,1); w_matmul(u,x,&l->d_up,1);
-    for(int i=0;i<DI;i++) g[i]=situf_(g[i],u[i],c->situ_b1,c->situ_b2);
-    w_matmul(out,g,&l->d_down,1);
+    float *g=falloc((int64_t)C*DI), *u=falloc((int64_t)C*DI);
+    w_matmul(g,x,&l->d_gate,C); w_matmul(u,x,&l->d_up,C);
+    for(int64_t i=0;i<(int64_t)C*DI;i++) g[i]=situf_(g[i],u[i],c->situ_b1,c->situ_b2);
+    w_matmul(out,g,&l->d_down,C);
     free(g);free(u);
 }
 
-/* ---------- one token through the stack; returns logits (or NULL pre-head) --- */
+/* ---------- a CHUNK of C tokens through the stack, layer-major: every dense
+ * matmul batches over the chunk (weights stream from RAM once per chunk), the
+ * MoE loads each unique expert once. Sequential state (KDA recurrence, MLA
+ * cache, AttnRes bookkeeping) advances per token inside each layer, which is
+ * exactly the original order — chunked results are bit-identical to C=1.
+ * Returns the LAST position's logits (falloc'd), or NULL pre-head. ---------- */
 static float *g_x0=NULL; static int g_x0_n=0;  /* K3_X0: injected inputs (validation) */
-static float *step(Model *m, int id, int pos){
+static FILE *g_lfp=NULL;                       /* K3_LOGITS: per-position logit dump */
+static float *step_chunk(Model *m, const int *ids, int pos0, int C){
     Cfg *c=&m->c; int D=c->hidden;
     int nbmax=(c->n_layers+c->res_bs-1)/c->res_bs;
-    float *hidden=falloc(D), *bres=falloc((int64_t)nbmax*D), *prefix=falloc(D);
-    float *nrm=falloc(D), *att=falloc(D), *mix=falloc(D), *mlp=falloc(D);
+    float *hidden=falloc((int64_t)C*D), *bres=falloc((int64_t)C*nbmax*D);
+    float *prefix=falloc((int64_t)C*D), *nrm=falloc((int64_t)C*D);
+    float *att=falloc((int64_t)C*D), *mix=falloc(D), *mlp=falloc((int64_t)C*D);
     int nb=0;
-    if(g_x0){
-        if(pos>=g_x0_n){ fprintf(stderr,"K3_X0: pos %d beyond %d injected rows\n",pos,g_x0_n); exit(1); }
-        memcpy(hidden,g_x0+(int64_t)pos*D,D*sizeof(float));
-    } else {
-        char nm[512]; snprintf(nm,sizeof(nm),"%smodel.embed_tokens.weight",m->pfx);
-        st_read_slice_f32(&m->S,nm,(int64_t)id*D,D,hidden,0);
+    for(int t=0;t<C;t++){
+        if(g_x0){
+            if(pos0+t>=g_x0_n){ fprintf(stderr,"K3_X0: pos %d beyond %d injected rows\n",pos0+t,g_x0_n); exit(1); }
+            memcpy(hidden+(int64_t)t*D,g_x0+(int64_t)(pos0+t)*D,D*sizeof(float));
+        } else {
+            char nm[512]; snprintf(nm,sizeof(nm),"%smodel.embed_tokens.weight",m->pfx);
+            st_read_slice_f32(&m->S,nm,(int64_t)ids[t]*D,D,hidden+(int64_t)t*D,0);
+        }
     }
     for(int i=0;i<c->n_layers;i++){
         Layer *l=&m->L[i];
-        memcpy(prefix,hidden,D*sizeof(float));            /* prefix_sum at entry */
-        int have_prefix=1;
-        if(nb>0) res_mix(hidden,prefix,bres,nb,D,l->attn_sw,c->eps);
-        if(i%c->res_bs==0){
-            memcpy(bres+(int64_t)nb*D,prefix,D*sizeof(float)); nb++;
-            have_prefix=0;
+        int snap=(i%c->res_bs==0);                    /* block boundary: same for all t */
+        for(int t=0;t<C;t++){
+            float *h=hidden+(int64_t)t*D, *p=prefix+(int64_t)t*D;
+            memcpy(p,h,D*sizeof(float));              /* prefix_sum at entry */
+            if(nb>0) res_mix(h,p,bres+(int64_t)t*nbmax*D,nb,D,l->attn_sw,c->eps);
+            if(snap) memcpy(bres+(int64_t)t*nbmax*D+(int64_t)nb*D,p,D*sizeof(float));
+            rmsnorm_(nrm+(int64_t)t*D,h,l->in_ln,D,c->eps);
         }
+        int have_prefix=!snap;
+        if(snap) nb++;
         double t0=now_s();
-        for(int d=0;d<D;d++) nrm[d]=hidden[d];
-        rmsnorm_(nrm,nrm,l->in_ln,D,c->eps);
-        if(l->kda) kda_forward(m,l,i,nrm,att);
-        else       mla_forward(m,l,i,nrm,pos,att);
+        if(l->kda) kda_forward(m,l,i,nrm,C,att);
+        else       mla_forward(m,l,i,nrm,pos0,C,att);
         m->t_attn+=now_s()-t0;
-        if(have_prefix){ for(int d=0;d<D;d++) prefix[d]+=att[d]; }
-        else           { memcpy(prefix,att,D*sizeof(float)); }
-        res_mix(mix,prefix,bres,nb,D,l->mlp_sw,c->eps);
-        rmsnorm_(nrm,mix,l->post_ln,D,c->eps);
+        for(int t=0;t<C;t++){
+            float *p=prefix+(int64_t)t*D, *a=att+(int64_t)t*D;
+            if(have_prefix){ for(int d=0;d<D;d++) p[d]+=a[d]; }
+            else           { memcpy(p,a,D*sizeof(float)); }
+            res_mix(mix,p,bres+(int64_t)t*nbmax*D,nb,D,l->mlp_sw,c->eps);
+            rmsnorm_(nrm+(int64_t)t*D,mix,l->post_ln,D,c->eps);
+        }
         t0=now_s();
-        if(l->sparse) moe_forward(m,l,i,nrm,mlp);
-        else          dense_forward(m,l,nrm,mlp);
+        if(l->sparse) moe_forward(m,l,i,nrm,C,mlp);
+        else          dense_forward(m,l,nrm,C,mlp);
         m->t_moe+=now_s()-t0;
-        for(int d=0;d<D;d++) prefix[d]+=mlp[d];
-        memcpy(hidden,prefix,D*sizeof(float));
-        if(m->trace) fwrite(hidden,sizeof(float),D,m->trace);
+        for(int t=0;t<C;t++){
+            float *p=prefix+(int64_t)t*D;
+            for(int d=0;d<D;d++) p[d]+=mlp[(int64_t)t*D+d];
+            memcpy(hidden+(int64_t)t*D,p,D*sizeof(float));
+            if(m->trace) fwrite(hidden+(int64_t)t*D,sizeof(float),D,m->trace);
+        }
     }
     float *logits=NULL;
     if(m->has_head){
         double t0=now_s();
-        res_mix(mix,hidden,bres,nb,D,m->out_sw,c->eps);
-        rmsnorm_(mix,mix,m->final_norm,D,c->eps);
-        if(m->trace) fwrite(mix,sizeof(float),D,m->trace);
-        logits=falloc(c->vocab);
-        w_matmul(logits,mix,&m->lm_head,1);
+        for(int t=0;t<C;t++){
+            /* head only where needed: the chunk's last token (feeds sampling)
+             * and every position when K3_LOGITS dumps teacher-forced logits */
+            if(!g_lfp && t<C-1) continue;
+            res_mix(mix,hidden+(int64_t)t*D,bres+(int64_t)t*nbmax*D,nb,D,m->out_sw,c->eps);
+            rmsnorm_(mix,mix,m->final_norm,D,c->eps);
+            if(m->trace) fwrite(mix,sizeof(float),D,m->trace);
+            float *lo=falloc(c->vocab);
+            w_matmul(lo,mix,&m->lm_head,1);
+            if(g_lfp) fwrite(lo,sizeof(float),(size_t)c->vocab,g_lfp);
+            if(t==C-1) logits=lo; else free(lo);
+        }
         m->t_head+=now_s()-t0;
     }
     free(hidden);free(bres);free(prefix);free(nrm);free(att);free(mix);free(mlp);
@@ -1025,19 +1146,25 @@ int main(int argc, char **argv){
     fprintf(stderr,"[K3] prompt: %d tokens | ngen %d | temp %.2f\n",np,ngen,temp);
     int max_t=getenv("K3_MAXT")?atoi(getenv("K3_MAXT")):np+ngen;
     kv_alloc(&m,max_t);
-    FILE *lfp=NULL;
     if(getenv("K3_LOGITS")){
-        lfp=fopen(getenv("K3_LOGITS"),"wb");
-        if(!lfp){ perror(getenv("K3_LOGITS")); return 1; }
+        g_lfp=fopen(getenv("K3_LOGITS"),"wb");
+        if(!g_lfp){ perror(getenv("K3_LOGITS")); return 1; }
+    }
+    int chunk=getenv("K3_CHUNK")?atoi(getenv("K3_CHUNK")):32;
+    if(chunk<1) chunk=1;
+    if(chunk>512) chunk=512;
+    if(m.trace && chunk>1){
+        chunk=1;                       /* trace rows are token-major by contract */
+        fprintf(stderr,"[K3] K3_TRACE set: prefill chunk forced to 1\n");
     }
     double t0=now_s(); float *lo=NULL;
-    for(int i=0;i<np;i++){
+    for(int i=0;i<np;i+=chunk){
+        int Cc=np-i<chunk?np-i:chunk;
         if(lo) free(lo);
-        lo=step(&m,ids[i],i);
-        if(lfp&&lo) fwrite(lo,sizeof(float),(size_t)m.c.vocab,lfp);
-        fprintf(stderr,"\r[K3] prefill %d/%d (%.1fs)",i+1,np,now_s()-t0);
+        lo=step_chunk(&m,ids+i,i,Cc);
+        fprintf(stderr,"\r[K3] prefill %d/%d (%.1fs)",i+Cc,np,now_s()-t0);
     }
-    if(lfp) fclose(lfp);
+    if(g_lfp){ fclose(g_lfp); g_lfp=NULL; }
     fprintf(stderr,"\n[K3] prefill done in %.1fs (%.2f tok/s)\n",now_s()-t0,np/(now_s()-t0));
     if(!m.has_head||!lo){
         fprintf(stderr,"[K3] no head — trace written, stopping after prefill\n");
@@ -1055,7 +1182,7 @@ int main(int argc, char **argv){
         ntok++;
         if(is_eos){ fprintf(stderr,"\n[K3] eos\n"); break; }
         if(np+ntok>=max_t){ fprintf(stderr,"\n[K3] context full\n"); break; }
-        lo=step(&m,t,np+ntok-1);
+        lo=step_chunk(&m,&t,np+ntok-1,1);
         double el=now_s()-tg;
         fprintf(stderr,"  [tok %d: %.1fs/tok, hit %.0f%%, %.1f GB read]\n",
                 ntok,el/ntok,100.0*m.hits/(m.hits+m.miss+1e-9),m.ebytes/1e9);

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -41,6 +41,10 @@
  *   K3_HEAD_BITS=8|4|32  lm_head (default 8)
  *   K3_EXPERT_GB=N       routed-expert LRU cache budget (default 8)
  *   K3_DIRECT=0|1        O_DIRECT expert reads (default 1; buffered fallback)
+ *   K3_IDOT=0|1          int8-activation expert matmuls (default 1; 0 = float)
+ *   K3_PIPE=0|1          overlap expert loads with compute (default 1)
+ *   K3_LOAD_THREADS=N    loader threads for K3_PIPE (default 4)
+ *   K3_TOPP=F            keep routed experts to cumulative weight F (0 = off)
  *   K3_LAYERS=N          truncate to first N layers (validation; skips head)
  *   K3_TRACE=path        dump f32 hidden state after every layer (validation)
  *   K3_LOGITS=path       dump f32 logits per PREFILL position (teacher-forced
@@ -58,6 +62,8 @@
 #include <sys/resource.h>
 #include <unistd.h>
 #endif
+#include <pthread.h>
+#include <stdatomic.h>
 #ifdef _OPENMP
 #include <omp.h>
 #endif
@@ -202,6 +208,9 @@ static float w_rowdot(const W *w, int r, const float *x){
 static int g_bits_env=0;                 /* K3_BITS explicitly set: enables the
                                           * int8-container -> int4 load downcast */
 static int g_k3_direct=-1;               /* K3_DIRECT: O_DIRECT expert reads */
+static int g_k3_idot=1;                  /* K3_IDOT: int8-activation expert matmuls */
+static int g_k3_pipe=1;                  /* K3_PIPE: overlap loads with compute */
+static float g_k3_topp=0.f;              /* K3_TOPP: routed-expert top-p pruning */
 static void w_load(Model *m, W *w, const char *name, int O, int I, int bits){
     char nm[512]; snprintf(nm,sizeof(nm),"%s%s",m->pfx,name);
     st_tensor *t=st_find(&m->S,nm);
@@ -410,6 +419,11 @@ static void model_init(Model *m, const char *snap, int n_layers_env){
     if((c->n_layers+c->res_bs-1)/c->res_bs+1>16){ fprintf(stderr,"attn_res: too many blocks\n"); exit(1); }
     g_bits_env = getenv("K3_BITS")!=NULL;
     g_k3_direct = getenv("K3_DIRECT")?atoi(getenv("K3_DIRECT")):1;
+    g_k3_idot  = getenv("K3_IDOT")?atoi(getenv("K3_IDOT")):1;
+    g_k3_pipe  = getenv("K3_PIPE")?atoi(getenv("K3_PIPE")):1;
+    g_k3_topp  = getenv("K3_TOPP")?(float)atof(getenv("K3_TOPP")):0.f;
+    if(g_k3_topp>0.f)
+        fprintf(stderr,"[K3] TOPP=%.2f: routed experts pruned to cumulative weight (quality lever — A/B with K3_LOGITS)\n",g_k3_topp);
     int bits   = getenv("K3_BITS")?atoi(getenv("K3_BITS")):4;
     int mbits  = getenv("K3_MLA_BITS")?atoi(getenv("K3_MLA_BITS")):8;
     int hbits  = getenv("K3_HEAD_BITS")?atoi(getenv("K3_HEAD_BITS")):8;
@@ -703,31 +717,106 @@ static void expert_apply(Model *m, Slot *s, const float *z, float wk,
     Cfg *c=&m->c;
     uint8_t *w1p=s->buf, *w1s=w1p+m->e_w1p, *w2p=w1s+m->e_w1s, *w2s=w2p+m->e_w2p,
             *w3p=w2s+m->e_w2s, *w3s=w3p+m->e_w1p;
-    matmul_mxfp4(gate,z,w1p,w1s,1,c->latent,c->moe_inter);
-    matmul_mxfp4(up,z,w3p,w3s,1,c->latent,c->moe_inter);
+    void (*mm)(float*,const float*,const uint8_t*,const uint8_t*,int,int,int)
+        = g_k3_idot ? matmul_mxfp4_i8 : matmul_mxfp4;
+    mm(gate,z,w1p,w1s,1,c->latent,c->moe_inter);
+    mm(up,z,w3p,w3s,1,c->latent,c->moe_inter);
     for(int i=0;i<c->moe_inter;i++) gate[i]=situf_(gate[i],up[i],c->situ_b1,c->situ_b2);
-    matmul_mxfp4(hz,gate,w2p,w2s,1,c->moe_inter,c->latent);
+    mm(hz,gate,w2p,w2s,1,c->moe_inter,c->latent);
     for(int i=0;i<c->latent;i++) u[i]+=wk*hz[i];
 }
 
+/* ---------- async loader pool (K3_PIPE): expert preads overlap compute ----
+ * A batch of jobs is submitted per token+layer; the compute loop below waits
+ * per-expert on its ready flag, so expert j's math runs while j+1.. load.
+ * One batch in flight at a time (the submitter consumes every job before the
+ * next submit), so the flags need no generation counter. */
+#define LP_MAX 64
+typedef struct { int li, eid; Slot *s; } LJob;
+static struct {
+    pthread_t th[16]; int nth, started;
+    pthread_mutex_t mx; pthread_cond_t cv;
+    Model *m;
+    LJob job[LP_MAX];
+    _Atomic int ready[LP_MAX];
+    _Atomic int next; int count;
+} g_lp = { .mx=PTHREAD_MUTEX_INITIALIZER, .cv=PTHREAD_COND_INITIALIZER };
+
+static void *lp_main(void *arg){
+    (void)arg;
+    for(;;){
+        pthread_mutex_lock(&g_lp.mx);
+        while(atomic_load_explicit(&g_lp.next,memory_order_relaxed)>=g_lp.count)
+            pthread_cond_wait(&g_lp.cv,&g_lp.mx);
+        int idx=atomic_fetch_add_explicit(&g_lp.next,1,memory_order_relaxed);
+        pthread_mutex_unlock(&g_lp.mx);
+        if(idx>=g_lp.count) continue;
+        LJob *j=&g_lp.job[idx];
+        expert_read(g_lp.m,j->li,j->eid,j->s);
+        atomic_store_explicit(&g_lp.ready[idx],1,memory_order_release);
+    }
+    return NULL;
+}
+static void lp_start(void){
+    if(g_lp.started) return;
+    g_lp.nth = getenv("K3_LOAD_THREADS")?atoi(getenv("K3_LOAD_THREADS")):4;
+    if(g_lp.nth<1) g_lp.nth=1;
+    if(g_lp.nth>16) g_lp.nth=16;
+    g_lp.count=0; atomic_store(&g_lp.next,0);
+    for(int i=0;i<g_lp.nth;i++)
+        if(pthread_create(&g_lp.th[i],NULL,lp_main,NULL)){
+            fprintf(stderr,"[K3] K3_PIPE: pthread_create failed, falling back\n");
+            g_k3_pipe=0; g_lp.nth=i; break;
+        }
+    g_lp.started=1;
+}
+static void lp_submit(Model *m, int n){
+    pthread_mutex_lock(&g_lp.mx);
+    g_lp.m=m;
+    for(int q=0;q<n;q++) atomic_store_explicit(&g_lp.ready[q],0,memory_order_relaxed);
+    atomic_store_explicit(&g_lp.next,0,memory_order_relaxed);
+    g_lp.count=n;
+    pthread_cond_broadcast(&g_lp.cv);
+    pthread_mutex_unlock(&g_lp.mx);
+}
+
 /* the full routed-expert pass for one token+layer: resolve (LRU hit or
- * working-set slot), load misses IN PARALLEL, compute, promote into the LRU. */
+ * working-set slot), load misses (pipelined with compute under K3_PIPE,
+ * else all-parallel up front), compute, promote into the LRU. */
 static void experts_run(Model *m, int li, int n, const int *ids, const float *w,
                         const float *z, float *u, float *gate, float *up, float *hz){
-    Slot *use[64]; int missk[64]; int nmiss=0;
+    Slot *use[64]; int missk[64]; int qof[64]; int nmiss=0;
     for(int j=0;j<n;j++){
-        use[j]=slot_find(m,li,ids[j]);
-        if(!use[j]){ m->miss++; use[j]=&m->ws[nmiss]; missk[nmiss++]=j; }
+        use[j]=slot_find(m,li,ids[j]); qof[j]=-1;
+        if(!use[j]){ m->miss++; use[j]=&m->ws[nmiss]; qof[j]=nmiss; missk[nmiss++]=j; }
     }
     if(nmiss){
-        double t0=now_s();
-        #pragma omp parallel for schedule(dynamic,1)
-        for(int q=0;q<nmiss;q++) expert_read(m,li,ids[missk[q]],&m->ws[q]);
-        m->t_eload+=now_s()-t0;
+        if(g_k3_pipe){
+            if(!g_lp.started) lp_start();
+        }
+        if(g_k3_pipe){
+            for(int q=0;q<nmiss;q++){
+                g_lp.job[q].li=li; g_lp.job[q].eid=ids[missk[q]]; g_lp.job[q].s=&m->ws[q];
+            }
+            lp_submit(m,nmiss);
+        } else {
+            double t0=now_s();
+            #pragma omp parallel for schedule(dynamic,1)
+            for(int q=0;q<nmiss;q++) expert_read(m,li,ids[missk[q]],&m->ws[q]);
+            m->t_eload+=now_s()-t0;
+        }
         m->ebytes+=(uint64_t)nmiss*(uint64_t)m->e_slot;
     }
-    for(int j=0;j<n;j++)
+    for(int j=0;j<n;j++){
+        if(g_k3_pipe && qof[j]>=0 &&
+           !atomic_load_explicit(&g_lp.ready[qof[j]],memory_order_acquire)){
+            double t0=now_s();          /* t_eload = UN-hidden I/O (wait) time */
+            while(!atomic_load_explicit(&g_lp.ready[qof[j]],memory_order_acquire))
+                usleep(50);
+            m->t_eload+=now_s()-t0;
+        }
         expert_apply(m,use[j],z,w[j],u,gate,up,hz);
+    }
     /* promotion: swap the freshly-read slots into the layer LRU */
     LCache *lc=&m->ecache[li];
     int promo = nmiss<lc->cap ? nmiss : lc->cap;
@@ -758,6 +847,21 @@ static void moe_forward(Model *m, Layer *l, int li, const float *x, float *out){
     }
     { float sm=0; for(int kk=0;kk<K;kk++) sm+=wsel[kk];
       for(int kk=0;kk<K;kk++) wsel[kk]/=(sm+1e-20f); }
+    /* K3_TOPP: drop the low-weight tail of the top-16 — the only lever that
+     * cuts expert I/O AND compute proportionally. Weights renormalize over
+     * the kept set (GLM's TOPP semantics). Quality-gate via K3_LOGITS. */
+    if(g_k3_topp>0.f && g_k3_topp<1.f){
+        for(int a2=1;a2<K;a2++){ int e=idx[a2]; float w2=wsel[a2]; int b2=a2-1;
+            while(b2>=0&&wsel[b2]<w2){ idx[b2+1]=idx[b2]; wsel[b2+1]=wsel[b2]; b2--; }
+            idx[b2+1]=e; wsel[b2+1]=w2; }
+        float cum=0; int keep=K;
+        for(int kk=0;kk<K;kk++){ cum+=wsel[kk]; if(cum>=g_k3_topp){ keep=kk+1; break; } }
+        if(keep<K){
+            float sm=0; for(int kk=0;kk<keep;kk++) sm+=wsel[kk];
+            for(int kk=0;kk<keep;kk++) wsel[kk]/=(sm+1e-20f);
+            K=keep;
+        }
+    }
     /* keep loads in DISK-OFFSET order (experts are NOT id-ordered inside the
      * HF shards — measured 169/895; helps the buffered fallback, harmless
      * under O_DIRECT). WILLNEED prefetch only for the buffered path. */

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -62,6 +62,7 @@
 #include <time.h>
 #if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
 #include <sys/resource.h>
+#include <sys/select.h>
 #include <unistd.h>
 #endif
 #include <pthread.h>
@@ -1090,14 +1091,24 @@ static void kv_alloc(Model *m, int max_t){
     }
 }
 
-static int sample_tok(const float *lo, int V, float temp){
+typedef struct { float p; int id; } SampleProb;
+static int sample_prob_desc(const void *a,const void *b){
+    float d=((const SampleProb*)b)->p-((const SampleProb*)a)->p;
+    return d>0?1:d<0?-1:0;
+}
+static int sample_tok(const float *lo, int V, float temp, float top_p){
     if(temp<=0.f){ int b=0; for(int i=1;i<V;i++) if(lo[i]>lo[b]) b=i; return b; }
-    float *p=falloc(V); float mx=lo[0];
+    SampleProb *rank=malloc((size_t)V*sizeof(SampleProb)); float mx=lo[0];
+    if(!rank){ fprintf(stderr,"OOM sampling\n"); exit(1); }
     for(int i=1;i<V;i++) if(lo[i]>mx) mx=lo[i];
-    double s=0; for(int i=0;i<V;i++){ p[i]=expf((lo[i]-mx)/temp); s+=p[i]; }
-    double r=((double)rand()/RAND_MAX)*s, acc=0; int pick=V-1;
-    for(int i=0;i<V;i++){ acc+=p[i]; if(acc>=r){ pick=i; break; } }
-    free(p); return pick;
+    double sum=0;
+    for(int i=0;i<V;i++){ float p=expf((lo[i]-mx)/temp); sum+=p; rank[i]=(SampleProb){p,i}; }
+    qsort(rank,(size_t)V,sizeof(SampleProb),sample_prob_desc);
+    double cut=(top_p>0.f&&top_p<1.f)?top_p*sum:sum, kept=0; int n=0;
+    while(n<V&&kept<cut) kept+=rank[n++].p;
+    double r=((double)rand()/RAND_MAX)*kept, acc=0; int pick=rank[0].id;
+    for(int i=0;i<n;i++){ acc+=rank[i].p; if(acc>=r){ pick=rank[i].id; break; } }
+    free(rank); return pick;
 }
 
 /* ---------- K3 XTML chat format (faithful to the shipped encoding_k3.py) --
@@ -1155,19 +1166,258 @@ static int chat_build(Tok *T, const char *sys, const char *user, int thinking,
     return b.n;
 }
 
+static void chat_message(ChatB *b, const char *role, const char *text, int assistant){
+    cb_open(b,"message",role);
+    if(assistant) cb_open(b,"response",NULL);
+    cb_text(b,text);
+    if(assistant) cb_close(b,"response");
+    cb_close(b,"message");
+    cb_special(b,b->sp_eom);
+}
+
+static void chat_assistant(ChatB *b, const char *reasoning, const char *text){
+    cb_open(b,"message","assistant");
+    cb_open(b,"think",NULL); cb_text(b,reasoning); cb_close(b,"think");
+    cb_open(b,"response",NULL); cb_text(b,text); cb_close(b,"response");
+    cb_close(b,"message"); cb_special(b,b->sp_eom);
+}
+
+/* Internal gateway payload. Length framing keeps arbitrary UTF-8/newlines in
+ * message content while preserving the segment boundaries required by K3's
+ * rank-BPE chat template:
+ *   K3CHAT1\n
+ *   M <role> <utf8-bytes>\n<content> ...
+ *   G <thinking>\n
+ */
+static int chat_build_wire(Tok *T, const char *wire, int nwire, int *thinking,
+                           int *ids, int cap, int *sp){
+    ChatB b={T,ids,0,cap,
+        chat_special(T,"<|open|>"), chat_special(T,"<|close|>"),
+        chat_special(T,"<|sep|>"),  chat_special(T,"<|end_of_msg|>")};
+    if(b.sp_open<0||b.sp_close<0||b.sp_sep<0||b.sp_eom<0) return -1;
+    sp[0]=b.sp_open; sp[1]=b.sp_close; sp[2]=b.sp_sep; sp[3]=b.sp_eom;
+    const char *p=wire, *end=wire+nwire;
+    if(nwire<8||memcmp(p,"K3CHAT1\n",8)) return -1;
+    p+=8; *thinking=0;
+    while(p<end){
+        const char *nl=memchr(p,'\n',(size_t)(end-p));
+        if(!nl) return -1;
+        if(*p=='G'){
+            int v=0;
+            if(sscanf(p,"G %d",&v)!=1) return -1;
+            *thinking=!!v; p=nl+1; break;
+        }
+        if(*p=='A'){
+            int nr=-1, nt=-1;
+            if(sscanf(p,"A %d %d",&nr,&nt)!=2||nr<0||nt<0||nl+1+nr+nt>end) return -1;
+            char *reason=malloc((size_t)nr+1), *text=malloc((size_t)nt+1);
+            if(!reason||!text){ fprintf(stderr,"OOM chat assistant\n"); exit(1); }
+            memcpy(reason,nl+1,(size_t)nr); reason[nr]=0;
+            memcpy(text,nl+1+nr,(size_t)nt); text[nt]=0;
+            chat_assistant(&b,reason,text);
+            free(reason); free(text); p=nl+1+nr+nt; continue;
+        }
+        char role[16]; int nb=-1;
+        if(sscanf(p,"M %15s %d",role,&nb)!=2||nb<0||nl+1+nb>end) return -1;
+        char *text=malloc((size_t)nb+1);
+        if(!text){ fprintf(stderr,"OOM chat message\n"); exit(1); }
+        memcpy(text,nl+1,(size_t)nb); text[nb]=0;
+        const char *r=!strcmp(role,"developer")?"system":role;
+        if(strcmp(r,"system")&&strcmp(r,"user")&&strcmp(r,"assistant")){ free(text); return -1; }
+        chat_message(&b,r,text,!strcmp(r,"assistant"));
+        free(text); p=nl+1+nb;
+    }
+    cb_open(&b,"message","assistant");
+    cb_open(&b,*thinking?"think":"response",NULL);
+    return b.n;
+}
+
+/* ---------- serve mode: shared openai_server.py protocol ---------- */
+typedef struct {
+    char id[64];
+    int max_tok;
+    float temp, top_p;
+    char *payload;
+    int plen;
+} ServeReq;
+
+static void model_state_reset(Model *m){
+    Cfg *c=&m->c;
+    for(int i=0;i<c->n_layers;i++){
+        if(m->L[i].kda){
+            memset(m->kstate[i],0,(size_t)c->kda_heads*c->kda_hd*c->kda_hd*sizeof(float));
+            memset(m->cwq[i],0,(size_t)c->kda_proj*c->conv_k*sizeof(float));
+            memset(m->cwk[i],0,(size_t)c->kda_proj*c->conv_k*sizeof(float));
+            memset(m->cwv[i],0,(size_t)c->kda_proj*c->conv_k*sizeof(float));
+        }
+        if(m->Lc&&m->Lc[i]) free(m->Lc[i]);
+        if(m->Rc&&m->Rc[i]) free(m->Rc[i]);
+    }
+    free(m->Lc); free(m->Rc);
+    m->Lc=NULL; m->Rc=NULL; m->max_t=0;
+}
+
+static int serve_stdin_readable(void){
+    fd_set r; struct timeval tv={0,0};
+    FD_ZERO(&r); FD_SET(0,&r);
+    return select(1,&r,NULL,NULL,&tv)>0;
+}
+
+static int serve_read_req(ServeReq *q, const char *active){
+    char line[512], cmd[16], id[64];
+    if(!fgets(line,sizeof(line),stdin)) return -1;
+    if(sscanf(line,"%15s %63s",cmd,id)<2) return 0;
+    if(!strcmp(cmd,"CANCEL")||!strcmp(cmd,"STOP")) return active&&!strcmp(active,id);
+    if(strcmp(cmd,"SUBMIT")) return 0;
+    int slot, plen, max_tok; float temp, top_p;
+    if(sscanf(line,"%*s %*s %d %d %d %f %f",&slot,&plen,&max_tok,&temp,&top_p)!=5||
+       plen<0||plen>(1<<24)||max_tok<1){
+        printf("ERROR %s bad submit header\n",id); fflush(stdout); return 0;
+    }
+    (void)slot;
+    char *payload=malloc((size_t)plen+1);
+    if(!payload){ printf("ERROR %s out of memory\n",id); fflush(stdout); return 0; }
+    if(fread(payload,1,(size_t)plen,stdin)!=(size_t)plen){ free(payload); return -1; }
+    (void)fgetc(stdin); payload[plen]=0;
+    snprintf(q->id,sizeof(q->id),"%s",id);
+    q->max_tok=max_tok; q->temp=temp; q->top_p=top_p;
+    q->payload=payload; q->plen=plen;
+    return 2;
+}
+
+static void serve_data(const char *id, const char *p, int n){
+    if(n<=0) return;
+    printf("DATA %s %d\n",id,n);
+    fwrite(p,1,(size_t)n,stdout); fputc('\n',stdout); fflush(stdout);
+}
+
+static void serve_one(Model *m, Tok *T, ServeReq *q){
+    int cap=65536, *ids=malloc((size_t)cap*sizeof(int)), np=0;
+    if(!ids){ printf("ERROR %s out of memory\n",q->id); fflush(stdout); return; }
+    int sp[4]={-1,-1,-1,-1}, chat=0, thinking=0;
+    if(m->c.bos>=0) ids[np++]=m->c.bos;
+    if(q->plen>=8&&!memcmp(q->payload,"K3CHAT1\n",8)){
+        int n=chat_build_wire(T,q->payload,q->plen,&thinking,ids+np,cap-np,sp);
+        if(n<0){ printf("ERROR %s invalid K3 chat payload\n",q->id); fflush(stdout); free(ids); return; }
+        np+=n; chat=1;
+    } else {
+        np+=tok_encode(T,q->payload,q->plen,ids+np,cap-np);
+    }
+    int max_ctx=getenv("K3_MAXT")?atoi(getenv("K3_MAXT")):8192;
+    if(np<1||np+q->max_tok>max_ctx){
+        printf("ERROR %s CONTEXT_EXCEEDED prompt_tokens=%d requested=%d capacity=%d\n",
+               q->id,np,q->max_tok,max_ctx);
+        fflush(stdout); free(ids); return;
+    }
+    printf("ACCEPT %s %d\n",q->id,np); fflush(stdout);
+    model_state_reset(m);
+    kv_alloc(m,np+q->max_tok+8);
+    int chunk=getenv("K3_CHUNK")?atoi(getenv("K3_CHUNK")):32;
+    if(chunk<1) chunk=1; if(chunk>512) chunk=512;
+    double t0=now_s(), a0=m->t_attn, e0=m->t_moe, d0=m->t_eload, h0=m->t_head;
+    uint64_t hit0=m->hits, miss0=m->miss;
+    float *lo=NULL;
+    for(int i=0;i<np;i+=chunk){
+        int C=np-i<chunk?np-i:chunk;
+        free(lo); lo=step_chunk(m,ids+i,i,C);
+    }
+    int gen=0, limited=1, cancelled=0, xsup=0, xopen=0, xtl=0;
+    char buf[512], xtag[64];
+    double tg=now_s();
+    for(int s=0;s<q->max_tok&&!cancelled;s++){
+        int tk=sample_tok(lo,m->c.vocab,q->temp,q->top_p);
+        free(lo); lo=NULL;
+        int eos=0; for(int i=0;i<m->c.n_eos;i++) if(tk==m->c.eos[i]) eos=1;
+        int show=!eos;
+        if(chat&&sp[0]>=0){
+            if(tk==sp[0]||tk==sp[1]){
+                xsup=1; xopen=(tk==sp[0]); xtl=0; show=0;
+            } else if(tk==sp[2]){
+                if(xsup){
+                    xsup=0; xtag[xtl]=0;
+                    if(xopen&&!strcmp(xtag,"response")&&thinking)
+                        serve_data(q->id,"</think>",8);
+                }
+                show=0;
+            } else if(xsup){
+                int nb=tok_decode(T,&tk,1,buf,sizeof(buf)-1);
+                if(xtl+nb<(int)sizeof(xtag)){ memcpy(xtag+xtl,buf,(size_t)nb); xtl+=nb; }
+                show=0;
+            } else if(tk==sp[3]) show=0;
+        }
+        if(show){
+            int nb=tok_decode(T,&tk,1,buf,sizeof(buf)-1);
+            serve_data(q->id,buf,nb);
+        }
+        if(!eos) gen++;
+        while(serve_stdin_readable()){
+            ServeReq queued={0};
+            int r=serve_read_req(&queued,q->id);
+            if(r<0){ cancelled=1; break; }
+            if(r==1) cancelled=1;
+            if(r==2){
+                printf("ERROR %s engine busy\n",queued.id); fflush(stdout); free(queued.payload);
+            }
+        }
+        if(cancelled){ limited=0; break; }
+        if(eos){ limited=0; break; }
+        if(s+1<q->max_tok) lo=step_chunk(m,&tk,np+s,1);
+    }
+    free(lo); free(ids);
+    double dt=now_s()-t0, decode=now_s()-tg;
+    uint64_t hits=m->hits-hit0, misses=m->miss-miss0, total=hits+misses;
+    printf("DONE %s STAT %d %.3f %.1f %.2f %d %d\n",q->id,gen,
+           decode>0?gen/decode:0.0,total?100.0*hits/total:0.0,rss_gb(),np,limited);
+    double moe=m->t_moe-e0, disk=m->t_eload-d0;
+    printf("PROF %.3f %d %d %.3f %.3f %.3f %.3f %.3f %d\n",
+           dt,np,gen,disk,0.0,moe>disk?moe-disk:moe,m->t_attn-a0,m->t_head-h0,gen+1);
+    fflush(stdout);
+}
+
+static void serve_loop(Model *m, Tok *T){
+    setvbuf(stdin,NULL,_IONBF,0);
+    fputs("\x01\x01READY\x01\x01\n",stdout);
+    printf("STAT 0 0.0 0.0 %.2f 0 0\n",rss_gb());
+    fflush(stdout);
+    for(;;){
+        ServeReq q={0}; int r;
+        do r=serve_read_req(&q,NULL); while(r==0);
+        if(r<0) return;
+        if(r==2){ serve_one(m,T,&q); free(q.payload); }
+    }
+}
+
 int main(int argc, char **argv){
-    if(argc<2){
+    int serving=getenv("SERVE")&&getenv("SERVE")[0]=='1';
+    if(!serving&&argc<2){
         fprintf(stderr,"usage: %s <model_dir> [prompt] [--ids \"1 2 3\"] [--ngen N]\n",argv[0]);
         return 1;
     }
-    const char *snap=argv[1], *prompt=NULL, *idstr=NULL, *sysmsg=NULL;
+    const char *snap=serving?getenv("SNAP"):argv[1], *prompt=NULL, *idstr=NULL, *sysmsg=NULL, *wirepath=NULL;
+    if(!snap||!*snap){ fprintf(stderr,"set SNAP=<Kimi K3 snapshot directory>\n"); return 1; }
     int ngen=32, chat=0;
-    for(int i=2;i<argc;i++){
+    for(int i=serving?1:2;i<argc;i++){
         if(!strcmp(argv[i],"--ngen")&&i+1<argc) ngen=atoi(argv[++i]);
         else if(!strcmp(argv[i],"--ids")&&i+1<argc) idstr=argv[++i];
         else if(!strcmp(argv[i],"--chat")) chat=1;
         else if(!strcmp(argv[i],"--system")&&i+1<argc) sysmsg=argv[++i];
+        else if(!strcmp(argv[i],"--wire-test")&&i+1<argc) wirepath=argv[++i];
         else if(!prompt) prompt=argv[i];
+    }
+    if(wirepath){
+        char tp[2048]; snprintf(tp,sizeof(tp),"%s/tokenizer.json",snap);
+        Tok wt; tok_load(&wt,tp);
+        FILE *wf=fopen(wirepath,"rb"); if(!wf){ perror(wirepath); return 1; }
+        fseek(wf,0,SEEK_END); long wn=ftell(wf); fseek(wf,0,SEEK_SET);
+        if(wn<0||wn>(1<<24)){ fprintf(stderr,"wire payload too large\n"); fclose(wf); return 1; }
+        char *wire=malloc((size_t)wn+1); int *wid=malloc(65536*sizeof(int));
+        if(!wire||!wid){ fprintf(stderr,"OOM wire test\n"); return 1; }
+        if(fread(wire,1,(size_t)wn,wf)!=(size_t)wn){ fprintf(stderr,"short wire read\n"); return 1; }
+        fclose(wf); wire[wn]=0;
+        int thinking=0, wsp[4], n=chat_build_wire(&wt,wire,(int)wn,&thinking,wid,65536,wsp);
+        if(n<0){ fprintf(stderr,"invalid K3 chat wire payload\n"); return 1; }
+        for(int i=0;i<n;i++) printf("%s%d",i?" ":"",wid[i]);
+        printf("\n"); free(wire); free(wid); return 0;
     }
     float temp=getenv("COLI_TEMP")?(float)atof(getenv("COLI_TEMP")):0.f;
     int nlayers=getenv("K3_LAYERS")?atoi(getenv("K3_LAYERS")):0;
@@ -1193,6 +1443,11 @@ int main(int argc, char **argv){
     { char tp[2048]; snprintf(tp,sizeof(tp),"%s/tokenizer.json",snap);
       FILE *f=fopen(tp,"rb"); if(f){ fclose(f); tok_load(&T,tp); has_tok=1;
           fprintf(stderr,"[K3] tokenizer.json loaded (family=%s)\n",T.kimi?"kimi":(T.o200k?"o200k":"cl100k")); } }
+    if(serving){
+        if(!has_tok){ fprintf(stderr,"serve mode needs tokenizer.json\n"); return 1; }
+        serve_loop(&m,&T);
+        return 0;
+    }
     int sp[4]={-1,-1,-1,-1};
     int think=getenv("K3_THINK")?atoi(getenv("K3_THINK")):1;
     if(idstr){
@@ -1249,7 +1504,7 @@ int main(int argc, char **argv){
     int xsup=0, xopen=0; char xtag[64]; int xtl=0;
     if(chat&&think){ printf("[think] "); fflush(stdout); }
     for(int s=0;s<ngen;s++){
-        int t=sample_tok(lo,m.c.vocab,temp);
+        int t=sample_tok(lo,m.c.vocab,temp,1.f);
         free(lo); lo=NULL;
         int is_eos=0; for(int e=0;e<m.c.n_eos;e++) if(t==m.c.eos[e]) is_eos=1;
         int show=1;

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -374,7 +374,7 @@ def parse_tool_calls(reply, tools=None):
     return text.strip(), calls
 
 
-ARCH = "glm"   # set in main(): "glm" | "inkling" (auto-detected from the model's config.json)
+ARCH = "glm"   # set in main(): "glm" | "inkling" | "kimi" (auto-detected)
 
 INK_THINK, INK_TEXT = "<|content_thinking|>", "<|content_text|>"
 
@@ -455,6 +455,42 @@ def split_inkling(text):
         reasoning.append(think)
         text = pre + after
     return _INK_MARKER.sub("", text), _INK_MARKER.sub("", "".join(reasoning))
+
+
+def render_chat_kimi(messages, enable_thinking=False, reasoning_effort=None, tools=None,
+                     tool_choice=None):
+    """Validated multi-turn K3 payload for the C engine.
+
+    K3's rank-BPE makes ordinary-text segment boundaries part of the tokenizer
+    contract. This private length-framed payload preserves roles, UTF-8 bytes,
+    and message boundaries; kimi_k3.c constructs the native XTML tokens.
+    """
+    if not isinstance(messages, list) or not messages:
+        raise APIError(400, "`messages` must be a non-empty array.", "messages")
+    if tools or tool_choice not in (None, "none"):
+        raise APIError(400, "Tool use is not wired up for the Kimi K3 engine yet.",
+                       "tools", "unsupported_parameter")
+    parts = ["K3CHAT1\n"]
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict):
+            raise APIError(400, "Each message must be an object.", f"messages.{index}")
+        role = message.get("role")
+        if role not in ("system", "developer", "user", "assistant"):
+            raise APIError(400, f"Unsupported role {role!r}.", f"messages.{index}.role")
+        raw = message.get("content")
+        text = content_text(raw, f"messages.{index}.content") if raw is not None else ""
+        reasoning = message.get("reasoning_content") if role == "assistant" else None
+        if reasoning is not None and not isinstance(reasoning, str):
+            raise APIError(400, "`reasoning_content` must be a string.",
+                           f"messages.{index}.reasoning_content")
+        if role == "assistant" and enable_thinking:
+            reasoning = reasoning or ""
+            parts.append(f"A {len(reasoning.encode('utf-8'))} {len(text.encode('utf-8'))}\n"
+                         f"{reasoning or ''}{text}")
+        else:
+            parts.append(f"M {role} {len(text.encode('utf-8'))}\n{text}")
+    parts.append(f"G {1 if enable_thinking else 0}\n")
+    return "".join(parts)
 
 
 def render_chat_inkling(messages, enable_thinking=False, reasoning_effort=None, tools=None,
@@ -1696,10 +1732,10 @@ class APIHandler(BaseHTTPRequestHandler):
             sys.stderr.flush()
         maximum, temperature, top_p, grammar, _requested_stop_sequences = generation_options(
             body, self.server.max_tokens)
-        if grammar is not None and ARCH == "inkling":
-            # inkling.c's serve loop speaks the 6-field SUBMIT header only; sending the
+        if grammar is not None and ARCH in ("inkling", "kimi"):
+            # sibling engines speak the 6-field SUBMIT header only; sending the
             # grammar payload extension would desync its stdin framing.
-            raise APIError(400, "`response_format` grammars are not supported by the Inkling "
+            raise APIError(400, f"`response_format` grammars are not supported by the {ARCH} "
                                 "engine yet.", "response_format", "unsupported_parameter")
         stop_sequences, ignore_leading_stop = stop_policy(body, chat)
         # tools and tool_choice come from chat_completion() already processed/filtered
@@ -1995,7 +2031,8 @@ class APIHandler(BaseHTTPRequestHandler):
             raise APIError(400, "`enable_thinking` must be a boolean.", "enable_thinking")
         tools = body.get("tools") or body.get("functions") or None
         tool_choice = body.get("tool_choice")
-        renderer = render_chat_inkling if ARCH == "inkling" else render_chat
+        renderer = (render_chat_inkling if ARCH == "inkling" else
+                    render_chat_kimi if ARCH == "kimi" else render_chat)
         prompt = renderer(body.get("messages"), enable_thinking, reasoning_effort, tools,
                           tool_choice)
         self.generation(body, prompt, request_id, True, tools, tool_choice,
@@ -2267,6 +2304,8 @@ def serve(model, host="127.0.0.1", port=8000, model_id="glm-5.2-colibri", api_ke
         raise ValueError("queue_timeout must be positive")
     if not 1 <= kv_slots <= 16:
         raise ValueError("kv_slots must be between 1 and 16")
+    if ARCH in ("inkling", "kimi") and kv_slots != 1:
+        raise ValueError(f"{ARCH} engine currently supports exactly one KV slot")
     if host not in ("127.0.0.1", "localhost", "::1") and not api_key:
         # (#SEC-6) Fail closed: an unauthenticated engine on a non-loopback bind exposes
         # a compute-heavy API to the network. Refuse unless explicitly overridden.
@@ -2302,7 +2341,7 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model", default=os.environ.get("COLI_MODEL"), required=not os.environ.get("COLI_MODEL"))
     parser.add_argument("--engine", default=str(default_engine()))
-    parser.add_argument("--arch", choices=("auto", "glm", "inkling"), default="auto",
+    parser.add_argument("--arch", choices=("auto", "glm", "inkling", "kimi"), default="auto",
                         help="chat-template family; auto reads model_type from the model's config.json")
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
@@ -2327,11 +2366,14 @@ def main():
     if ARCH == "auto":
         try:
             with open(Path(args.model) / "config.json") as fh:
-                ARCH = "inkling" if "inkling" in (json.load(fh).get("model_type") or "") else "glm"
+                model_type = (json.load(fh).get("model_type") or "").lower()
+                ARCH = ("inkling" if "inkling" in model_type else
+                        "kimi" if "kimi" in model_type else "glm")
         except OSError:
             ARCH = "glm"
     if args.model_id is None:
-        args.model_id = "inkling-colibri" if ARCH == "inkling" else "glm-5.2-colibri"
+        args.model_id = ("inkling-colibri" if ARCH == "inkling" else
+                         "kimi-k3-colibri" if ARCH == "kimi" else "glm-5.2-colibri")
     serve(args.model, args.host, args.port, args.model_id, args.api_key,
           args.cap,args.max_tokens,args.engine,cors_origins=args.cors_origin,
           max_queue=args.max_queue,queue_timeout=args.queue_timeout,kv_slots=args.kv_slots,

--- a/c/quant.h
+++ b/c/quant.h
@@ -1239,6 +1239,73 @@ static inline void e8_rot_rows(float *rows, int nr, int dim){
     }
 }
 
+/* ---- MXFP4 (OCP microscaling FP4) ----------------------------------------
+ * The native layout of compressed-tensors "mxfp4-pack-quantized" checkpoints
+ * (Kimi K3 routed experts are QAT in this format — pass-through, never
+ * re-encoded):
+ *   packed [O, I/2]  u8 — e2m1 nibbles, LOW nibble = even column, bit3 = sign,
+ *                         bits 0..2 index {0,.5,1,1.5,2,3,4,6}
+ *   scales [O, I/32] u8 — ue8m0 exponent per 32-column group, w = v * 2^(s-127)
+ * = 4.25 bits/weight all-in. The exponent is decoded with the bit trick
+ * (s<<23 as a float): exact for s in [1,254]; s=0 (2^-127, denormal) decodes
+ * to +0 and s=255 to +inf on BOTH the scalar and SIMD paths, so the two stay
+ * bit-identical — real checkpoints never contain either. */
+static const float mx4_lut[16] = {0.f,.5f,1.f,1.5f,2.f,3.f,4.f,6.f,
+                                  -0.f,-.5f,-1.f,-1.5f,-2.f,-3.f,-4.f,-6.f};
+static inline float mx4_scale(uint8_t s){
+    union { uint32_t u; float f; } b; b.u = (uint32_t)s << 23; return b.f;
+}
+static void matmul_mxfp4(float *y, const float *x, const uint8_t *q4, const uint8_t *e8s,
+                         int S, int I, int O){
+    int rb=(I+1)/2, ng=(I+31)/32;
+    #pragma omp parallel for schedule(static)
+    for(int o=0;o<O;o++){
+        const uint8_t *w=q4+(int64_t)o*rb;
+        const uint8_t *scl=e8s+(int64_t)o*ng;
+        for(int s=0;s<S;s++){
+            const float *xs=x+(int64_t)s*I; float a=0;
+#ifdef __AVX2__
+            if(I%32==0){
+                /* doubled e2m1 values are exact int8 -> one pshufb decodes a
+                 * nibble vector; the 0.5f un-doubling rides the group scale */
+                const __m128i lut2=_mm_setr_epi8(0,1,2,3,4,6,8,12,0,-1,-2,-3,-4,-6,-8,-12);
+                const __m128i m4=_mm_set1_epi8(0x0F);
+                __m256 acc=_mm256_setzero_ps();
+                for(int g=0;g<ng;g++){
+                    __m128i by=_mm_loadu_si128((const __m128i*)(w+g*16));
+                    __m128i lo=_mm_and_si128(by,m4), hi=_mm_and_si128(_mm_srli_epi16(by,4),m4);
+                    __m128i n0=_mm_shuffle_epi8(lut2,_mm_unpacklo_epi8(lo,hi));  /* cols g*32+0..15  */
+                    __m128i n1=_mm_shuffle_epi8(lut2,_mm_unpackhi_epi8(lo,hi));  /* cols g*32+16..31 */
+                    const float *xg=xs+g*32;
+                    __m256 ga=_mm256_mul_ps(_mm256_loadu_ps(xg),
+                                            _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(n0)));
+                    ga=_mm256_fmadd_ps(_mm256_loadu_ps(xg+8),
+                                       _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(n0,8))),ga);
+                    ga=_mm256_fmadd_ps(_mm256_loadu_ps(xg+16),
+                                       _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(n1)),ga);
+                    ga=_mm256_fmadd_ps(_mm256_loadu_ps(xg+24),
+                                       _mm256_cvtepi32_ps(_mm256_cvtepi8_epi32(_mm_srli_si128(n1,8))),ga);
+                    acc=_mm256_fmadd_ps(ga,_mm256_set1_ps(mx4_scale(scl[g])*0.5f),acc);
+                }
+                y[(int64_t)s*O+o]=hsum256(acc);
+                continue;
+            }
+#endif
+            for(int g=0;g<ng;g++){
+                int base=g*32, glen=32; if(base+glen>I) glen=I-base;
+                float sc=mx4_scale(scl[g]), ga=0;
+                for(int i=base;i<base+glen;i+=2){
+                    uint8_t byte=w[i>>1];
+                    ga+=xs[i]*mx4_lut[byte&0xF];
+                    if(i+1<base+glen) ga+=xs[i+1]*mx4_lut[byte>>4];
+                }
+                a+=ga*sc;
+            }
+            y[(int64_t)s*O+o]=a;
+        }
+    }
+}
+
 static void matmul_e8(float *y, const float *x, const uint8_t *q, const float *unused,
                       int S, int I, int O){
     (void)unused;                                  /* scales live inside the blocks */

--- a/c/quant.h
+++ b/c/quant.h
@@ -1306,6 +1306,81 @@ static void matmul_mxfp4(float *y, const float *x, const uint8_t *q4, const uint
     }
 }
 
+/* IDOT variant of matmul_mxfp4: per-32-group int8 activation quantization +
+ * integer dots. The doubled e2m1 values are exact int8 (same LUT as the float
+ * path), so a group reduces to maddubs(|w|, sign(x,w)) like dot_i4i8 — no
+ * per-weight int->float conversion. Group-exact scale folding:
+ *     y = sum_g idot_g * (2^(e8-127) * 0.5) * xscale_g
+ * Activation-quant noise (~0.4%/group) rides on top of the e2m1 grid; gate
+ * with K3_IDOT=0 in the K3 engine for exact-float A/B. */
+static void matmul_mxfp4_i8(float *y, const float *x, const uint8_t *q4, const uint8_t *e8s,
+                            int S, int I, int O){
+    if(I%32){ matmul_mxfp4(y,x,q4,e8s,S,I,O); return; }
+    int rb=I/2, ng=I/32;
+    int8_t *xq=(int8_t*)malloc((size_t)S*I);
+    float *xsc=(float*)malloc((size_t)S*ng*sizeof(float));
+    if(!xq||!xsc){ fprintf(stderr,"OOM mxfp4 idot scratch\n"); exit(1); }
+    for(int s=0;s<S;s++)
+        for(int g=0;g<ng;g++){
+            const float *xg=x+(int64_t)s*I+g*32;
+            float am=0; for(int i=0;i<32;i++){ float a=fabsf(xg[i]); if(a>am)am=a; }
+            float sc=am/127.f; if(sc<1e-20f)sc=1e-20f;
+            xsc[(int64_t)s*ng+g]=sc; float inv=1.f/sc;
+            int8_t *qg=xq+(int64_t)s*I+g*32;
+            for(int i=0;i<32;i++){
+                int v=(int)lrintf(xg[i]*inv);
+                if(v>127)v=127; if(v<-127)v=-127; qg[i]=(int8_t)v;
+            }
+        }
+    #pragma omp parallel for schedule(static)
+    for(int o=0;o<O;o++){
+        const uint8_t *w=q4+(int64_t)o*rb;
+        const uint8_t *scl=e8s+(int64_t)o*ng;
+        for(int s=0;s<S;s++){
+            const int8_t *xr=xq+(int64_t)s*I;
+            const float *xsr=xsc+(int64_t)s*ng;
+#ifdef __AVX2__
+            {
+                const __m128i lut2=_mm_setr_epi8(0,1,2,3,4,6,8,12,0,-1,-2,-3,-4,-6,-8,-12);
+                const __m128i m4=_mm_set1_epi8(0x0F);
+                const __m256i ones=_mm256_set1_epi16(1);
+                __m256 acc=_mm256_setzero_ps();
+                for(int g=0;g<ng;g++){
+                    __m128i by=_mm_loadu_si128((const __m128i*)(w+g*16));
+                    __m128i lo=_mm_and_si128(by,m4), hi=_mm_and_si128(_mm_srli_epi16(by,4),m4);
+                    __m128i n0=_mm_shuffle_epi8(lut2,_mm_unpacklo_epi8(lo,hi));
+                    __m128i n1=_mm_shuffle_epi8(lut2,_mm_unpackhi_epi8(lo,hi));
+                    __m256i wv=_mm256_set_m128i(n1,n0);        /* signed doubled e2m1 */
+                    __m256i xv=_mm256_loadu_si256((const __m256i*)(xr+g*32));
+                    /* |w| <= 12, |x| <= 127: pair sums <= 3048, no int16 overflow */
+                    __m256i p=_mm256_maddubs_epi16(_mm256_sign_epi8(wv,wv),
+                                                   _mm256_sign_epi8(xv,wv));
+                    acc=_mm256_fmadd_ps(_mm256_cvtepi32_ps(_mm256_madd_epi16(p,ones)),
+                                        _mm256_set1_ps(mx4_scale(scl[g])*0.5f*xsr[g]),acc);
+                }
+                y[(int64_t)s*O+o]=hsum256(acc);
+                continue;
+            }
+#endif
+            {
+                static const int8_t l2[16]={0,1,2,3,4,6,8,12,0,-1,-2,-3,-4,-6,-8,-12};
+                float a=0;
+                for(int g=0;g<ng;g++){
+                    const int8_t *qg=xr+g*32;
+                    int32_t gi=0;
+                    for(int i=0;i<32;i+=2){
+                        uint8_t byte=w[(g*32+i)>>1];
+                        gi+=(int32_t)l2[byte&0xF]*qg[i]+(int32_t)l2[byte>>4]*qg[i+1];
+                    }
+                    a+=(float)gi*(mx4_scale(scl[g])*0.5f*xsr[g]);
+                }
+                y[(int64_t)s*O+o]=a;
+            }
+        }
+    }
+    free(xq); free(xsc);
+}
+
 static void matmul_e8(float *y, const float *x, const uint8_t *q, const float *unused,
                       int S, int I, int O){
     (void)unused;                                  /* scales live inside the blocks */

--- a/c/tests/fixtures/kimi_chat_wire.txt
+++ b/c/tests/fixtures/kimi_chat_wire.txt
@@ -1,0 +1,7 @@
+K3CHAT1
+M system 11
+Be precise.M user 11
+你好
+KimiA 7 9
+because你好。M user 8
+ContinueG 1

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -16,7 +16,8 @@ from openai_server import (APIError, APIHandler, APIServer, ClientCancelled,
                            READY, Engine, InklingStreamSplit, StopFilter, ThinkingStreamSplit,
                            _engine_error, conversation_cache_slot, generation_options,
                            parse_tool_calls, read_engine_turn,
-                           render_chat, serve, split_thinking_reply, stop_policy)
+                           render_chat, render_chat_kimi, serve,
+                           split_thinking_reply, stop_policy)
 
 
 class FakeEngine:
@@ -77,6 +78,37 @@ class TemplateTest(unittest.TestCase):
         self.assertEqual(
             render_chat([{"role": "user", "content": "Hi"}], True, "high"),
             "[gMASK]<sop><|system|>Reasoning Effort: High<|user|>Hi<|assistant|><think>",
+        )
+
+    def test_kimi_payload_preserves_utf8_lengths_and_turns(self):
+        prompt = render_chat_kimi([
+            {"role": "system", "content": "Be precise."},
+            {"role": "user", "content": "你好\nKimi"},
+            {"role": "assistant", "content": "你好。"},
+            {"role": "user", "content": "Continue"},
+        ], enable_thinking=True)
+        self.assertEqual(
+            prompt,
+            "K3CHAT1\n"
+            "M system 11\nBe precise."
+            "M user 11\n你好\nKimi"
+            "A 0 9\n你好。"
+            "M user 8\nContinue"
+            "G 1\n",
+        )
+
+    def test_kimi_rejects_tools_and_unknown_roles(self):
+        with self.assertRaisesRegex(APIError, "Tool use"):
+            render_chat_kimi([{"role": "user", "content": "Hi"}],
+                             tools=[{"type": "function"}])
+        with self.assertRaisesRegex(APIError, "Unsupported role"):
+            render_chat_kimi([{"role": "tool", "content": "result"}])
+
+    def test_kimi_preserves_prior_reasoning_channel(self):
+        self.assertEqual(
+            render_chat_kimi([{"role": "assistant", "reasoning_content": "why",
+                               "content": "answer"}], enable_thinking=True),
+            "K3CHAT1\nA 3 6\nwhyanswerG 1\n",
         )
 
     def test_validates_generation_limits(self):
@@ -637,6 +669,28 @@ class HTTPTest(unittest.TestCase):
         self.assertIsNotNone(queue_wait)
         self.assertIn("<|user|>Hi<|assistant|><think></think>", self.engine.calls[-1][0])
         self.assertEqual(self.engine.calls[-1][4], 1)
+
+    def test_kimi_chat_completion_uses_multiturn_wire_payload(self):
+        with patch("openai_server.ARCH", "kimi"):
+            with self.request("/v1/chat/completions", {
+                "model": "test-model",
+                "messages": [
+                    {"role": "user", "content": "你好"},
+                    {"role": "assistant", "content": "你好。"},
+                    {"role": "user", "content": "Continue"},
+                ],
+                "enable_thinking": False,
+            }) as response:
+                body = json.load(response)
+        self.assertEqual(body["choices"][0]["message"]["content"], "Héllo")
+        self.assertEqual(
+            self.engine.calls[-1][0],
+            "K3CHAT1\n"
+            "M user 6\n你好"
+            "M assistant 9\n你好。"
+            "M user 8\nContinue"
+            "G 0\n",
+        )
 
     def test_chat_completion_stops_across_engine_chunks(self):
         before = self.engine.stop_requests

--- a/c/tests/test_tok_kimi.c
+++ b/c/tests/test_tok_kimi.c
@@ -1,0 +1,33 @@
+/* Cross-check tok.h's kimi family + rank-BPE against tiktoken.
+ * Input: argv[1] = tokenizer.json, argv[2] = cases.bin
+ *   cases.bin: u32 n, then n x { u32 len, bytes }  (raw UTF-8, newlines included)
+ * Output: one line per case: space-separated token ids.
+ * The python driver (tools/k3_tokenizer.py --ctest) generates cases.bin,
+ * runs tiktoken on the same texts and diffs. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../tok.h"
+
+int main(int argc, char **argv){
+    if(argc<3){ fprintf(stderr,"usage: %s tokenizer.json cases.bin\n",argv[0]); return 2; }
+    Tok T; tok_load(&T,argv[1]);
+    fprintf(stderr,"family=%s rankbpe=%d\n",T.kimi?"kimi":(T.o200k?"o200k":"cl100k"),T.rankbpe);
+    FILE *f=fopen(argv[2],"rb"); if(!f){ perror(argv[2]); return 2; }
+    unsigned n;
+    if(fread(&n,4,1,f)!=1){ fprintf(stderr,"bad cases file\n"); return 2; }
+    for(unsigned i=0;i<n;i++){
+        unsigned len;
+        if(fread(&len,4,1,f)!=1||len>(1u<<20)){ fprintf(stderr,"bad case %u\n",i); return 2; }
+        char *buf=malloc(len+1);
+        if(fread(buf,1,len,f)!=len){ fprintf(stderr,"short case %u\n",i); return 2; }
+        buf[len]=0;
+        int ids[65536];
+        int m=tok_encode(&T,buf,(int)len,ids,65536);
+        for(int j=0;j<m;j++) printf("%d%c",ids[j],j+1<m?' ':'\n');
+        if(m==0) printf("\n");
+        free(buf);
+    }
+    fclose(f);
+    return 0;
+}

--- a/c/tok.h
+++ b/c/tok.h
@@ -52,6 +52,11 @@ typedef struct {
     uint32_t byte2cp[256]; int byte2cp_len[256]; char byte2str[256][3];
     int16_t cp2byte[1024];
     int o200k;           /* pre_tokenizer regex family: 0 = cl100k (GLM), 1 = o200k (Inkling) */
+    int kimi;            /* 1 = Kimi (K3) family: o200k rules + a leading \p{Han}-run rule,
+                          * Han excluded from the letter classes, no '/' tail in the punct rule */
+    int rankbpe;         /* 1 = no merges list (tiktoken-derived vocab): merge the adjacent
+                          * pair whose CONCATENATION has the lowest vocab id — exactly
+                          * tiktoken's byte_pair_encode, no recovered merges to diverge */
 } Tok;
 
 /* ---------- UTF-8 ---------- */
@@ -110,7 +115,8 @@ static void tok_load(Tok *T, const char *path){
     jval *vocab=json_get(model,"vocab");
     jval *merges=json_get(model,"merges");
     jval *added=json_get(root,"added_tokens");
-    if(!vocab||!merges){ fprintf(stderr,"tokenizer.json: missing model.vocab/merges\n"); exit(1); }
+    if(!vocab){ fprintf(stderr,"tokenizer.json: missing model.vocab\n"); exit(1); }
+    if(!merges||merges->len==0){ T->rankbpe=1; merges=NULL; }
 
     /* id massimo per dimensionare id2str. Gli id vengono da un tokenizer.json di
      * mirror non fidato: un id NEGATIVO indicizzerebbe id2str[id] SOTTO l'allocazione
@@ -144,9 +150,9 @@ static void tok_load(Tok *T, const char *path){
         T->id2str[id]=(char*)k;
     }
     /* merges: "left\0right" -> rank=i */
-    int mc=1; while(mc < merges->len*2) mc<<=1;
+    int mc=1; while(merges && mc < merges->len*2) mc<<=1;
     hm_init(&T->merges, mc);
-    for(int i=0;i<merges->len;i++){
+    if(merges) for(int i=0;i<merges->len;i++){
         jval *pr=merges->kids[i];
         if(!pr||pr->t!=J_ARR||pr->len<2||!pr->kids[0]||!pr->kids[1]||
            pr->kids[0]->t!=J_STR||pr->kids[1]->t!=J_STR){
@@ -181,6 +187,7 @@ static void tok_load(Tok *T, const char *path){
             jval *pat=json_get(ps->kids[i],"pattern");
             jval *rx=pat?json_get(pat,"Regex"):NULL;
             if(rx&&rx->t==J_STR&&strstr(rx->str,"\\p{Lu}")) T->o200k=1;
+            if(rx&&rx->t==J_STR&&strstr(rx->str,"\\p{Han}")) T->kimi=1;
         }
     }
     /* arena/buf restano allocati: le stringhe (j_dup) sono malloc indipendenti e ci servono vive */
@@ -206,8 +213,13 @@ static void bpe_piece(Tok *T, const unsigned char *p, int a, int b, int *out, in
         int best=INT_MAX, bp=-1;
         for(int i=0;i+1<ns;i++){
             int ll=slen[i], rl=slen[i+1];
-            memcpy(kbuf,s+soff[i],ll); kbuf[ll]=0; memcpy(kbuf+ll+1,s+soff[i+1],rl);
-            int rk=hm_get(&T->merges,kbuf,ll+1+rl);
+            int rk;
+            if(T->rankbpe){                                /* tiktoken: rank of the CONCATENATION */
+                rk=hm_get(&T->vocab,s+soff[i],ll+rl);      /* contigui in s */
+            } else {
+                memcpy(kbuf,s+soff[i],ll); kbuf[ll]=0; memcpy(kbuf+ll+1,s+soff[i+1],rl);
+                rk=hm_get(&T->merges,kbuf,ll+1+rl);
+            }
             if(rk>=0 && rk<best){ best=rk; bp=i; }
         }
         if(bp<0) break;
@@ -378,6 +390,113 @@ static void pretok_chunk_o200k(Tok *T, const unsigned char *p, int a, int b, int
     free(cp); free(off);
 }
 
+/* ---------- pre-tokenizer Kimi (K3 / tiktoken tokenization_kimi.py) ----------
+ * Split regex (fancy-regex, with && class intersection):
+ *   H: [\p{Han}]+
+ *   A: [^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?
+ *   B: [^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?
+ *   C: \p{N}{1,3}   D: ' ?[^\s\p{L}\p{N}]+[\r\n]*'   E: \s*[\r\n]+   F: \s+(?!\S)   G: \s+
+ * Identical to o200k except: Han runs are their own chunks, Han never joins a
+ * letter run (it is \p{Lo}, so it must be masked out of S1/S2), and rule D has
+ * no '/' in its newline tail. A Han codepoint can ONLY match rule H: it is
+ * \p{L}, so it is excluded from the optional prefix, from rule D's
+ * [^\s\p{L}\p{N}]+ and from \p{N} — on Han-free text this family therefore
+ * tokenizes exactly like o200k minus the '/' tail. */
+static int is_han(uint32_t c){
+    /* Script=Han ranges (Unicode 15) */
+    static const uint32_t r[][2]={
+        {0x2E80,0x2E99},{0x2E9B,0x2EF3},{0x2F00,0x2FD5},{0x3005,0x3005},
+        {0x3007,0x3007},{0x3021,0x3029},{0x3038,0x303B},{0x3400,0x4DBF},
+        {0x4E00,0x9FFF},{0xF900,0xFA6D},{0xFA70,0xFAD9},{0x16FE2,0x16FE3},
+        {0x16FF0,0x16FF1},{0x20000,0x2A6DF},{0x2A700,0x2B739},{0x2B740,0x2B81D},
+        {0x2B820,0x2CEA1},{0x2CEB0,0x2EBE0},{0x2EBF0,0x2EE5D},{0x2F800,0x2FA1D},
+        {0x30000,0x3134A},{0x31350,0x323AF}};
+    if(c<0x2E80) return 0;
+    int lo=0, hi=(int)(sizeof(r)/sizeof(r[0]))-1;
+    while(lo<=hi){ int mid=(lo+hi)/2;
+        if(c<r[mid][0]) hi=mid-1; else if(c>r[mid][1]) lo=mid+1; else return 1; }
+    return 0;
+}
+#define KM_S1(c) ((is_U(c)||is_X(c)) && !is_han(c))
+#define KM_S2(c) ((is_X(c)||(is_L(c)&&!is_U(c))) && !is_han(c))
+/* end (cp index) of branch A|B match at i, or -1 — o2_letters with Han-masked classes */
+static int km_letters(const uint32_t *cp, int n, int i){
+    for(int pfx=1; pfx>=0; pfx--){
+        int j0=i;
+        if(pfx){
+            uint32_t c=cp[i];
+            if(c=='\r'||c=='\n'||is_L(c)||is_N(c)||i+1>=n) continue;
+            j0=i+1;
+        }
+        int m1=j0; while(m1<n && KM_S1(cp[m1])) m1++;
+        for(int s=m1; s>=j0; s--){
+            if(s<n && KM_S2(cp[s])){
+                int k=s+1; while(k<n && KM_S2(cp[k])) k++;
+                return o2_contraction(cp,n,k);
+            }
+        }
+    }
+    for(int pfx=1; pfx>=0; pfx--){
+        int j0=i;
+        if(pfx){
+            uint32_t c=cp[i];
+            if(c=='\r'||c=='\n'||is_L(c)||is_N(c)||i+1>=n) continue;
+            j0=i+1;
+        }
+        int m1=j0; while(m1<n && KM_S1(cp[m1])) m1++;
+        if(m1>j0){
+            int k=m1; while(k<n && KM_S2(cp[k])) k++;
+            return o2_contraction(cp,n,k);
+        }
+    }
+    return -1;
+}
+
+static void pretok_chunk_kimi(Tok *T, const unsigned char *p, int a, int b, int *out, int *no, int max){
+    int nb=b-a; if(nb<=0) return;
+    uint32_t *cp=malloc((nb+1)*sizeof(uint32_t)); int *off=malloc((nb+2)*sizeof(int)); int n=0;
+    for(int i=a;i<b;){ uint32_t c; int k=u8_next(p,b,i,&c); off[n]=i; cp[n]=c; n++; i+=k; }
+    off[n]=b;
+    #define ISNL(c) ((c)=='\r'||(c)=='\n')
+    int i=0;
+    while(i<n){
+        int start=i; uint32_t c=cp[i];
+        /* H: [\p{Han}]+ */
+        if(is_han(c)){ int j=i; while(j<n && is_han(cp[j])) j++; i=j; bpe_piece(T,p,off[start],off[i],out,no,max); continue; }
+        /* A|B: letter runs, Han excluded */
+        {
+            int e=km_letters(cp,n,i);
+            if(e>i){ i=e; bpe_piece(T,p,off[start],off[i],out,no,max); continue; }
+        }
+        /* C: \p{N}{1,3} */
+        if(is_N(c)){ int j=i,k=0; while(j<n && is_N(cp[j]) && k<3){ j++; k++; } i=j; bpe_piece(T,p,off[start],off[i],out,no,max); continue; }
+        /* D: ' ?[^\s\p{L}\p{N}]+[\r\n]*'  (no '/' tail, unlike o200k) */
+        {
+            int j=i;
+            if(c==' ' && j+1<n && !is_S(cp[j+1]) && !is_L(cp[j+1]) && !is_N(cp[j+1])) j++;
+            if(j<n && !is_S(cp[j]) && !is_L(cp[j]) && !is_N(cp[j])){
+                while(j<n && !is_S(cp[j]) && !is_L(cp[j]) && !is_N(cp[j])) j++;
+                while(j<n && ISNL(cp[j])) j++;
+                i=j; bpe_piece(T,p,off[start],off[i],out,no,max); continue;
+            }
+        }
+        /* E: \s*[\r\n]+  F: \s+(?!\S)  G: \s+ */
+        {
+            int r=i; while(r<n && is_S(cp[r])) r++;
+            if(r>i){ int last=-1; for(int j=i;j<r;j++) if(ISNL(cp[j])) last=j;
+                if(last>=0){ i=last+1; bpe_piece(T,p,off[start],off[i],out,no,max); continue; }
+                int end = (r<n) ? r-1 : r;
+                if(end<=i) end=i+1;
+                i=end; bpe_piece(T,p,off[start],off[i],out,no,max); continue;
+            }
+        }
+        i++;
+        bpe_piece(T,p,off[start],off[i],out,no,max);
+    }
+    #undef ISNL
+    free(cp); free(off);
+}
+
 /* ---------- encode: testo -> id (split sugli added token, poi pretok+BPE) ---------- */
 static int tok_encode(Tok *T, const char *text, int len, int *out, int max){
     const unsigned char *p=(const unsigned char*)text; int no=0; int i=0;
@@ -392,8 +511,9 @@ static int tok_encode(Tok *T, const char *text, int len, int *out, int max){
         }
         int chunk_end = (hitpos<0) ? len : hitpos;
         if(chunk_end>i){
-            if(T->o200k) pretok_chunk_o200k(T,p,i,chunk_end,out,&no,max);
-            else         pretok_chunk(T,p,i,chunk_end,out,&no,max);
+            if(T->kimi)       pretok_chunk_kimi(T,p,i,chunk_end,out,&no,max);
+            else if(T->o200k) pretok_chunk_o200k(T,p,i,chunk_end,out,&no,max);
+            else              pretok_chunk(T,p,i,chunk_end,out,&no,max);
         }
         if(hitpos<0) break;
         if(no<max) out[no++]=hitid;

--- a/c/tools/k3_ref.py
+++ b/c/tools/k3_ref.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Numpy reference for the first N layers of Kimi K3 — validates c/kimi_k3.c.
+
+Reads tensors straight from the HF shards (BF16 -> f32, MXFP4 dequant), runs T
+injected input rows [T, hidden] (the engine's K3_X0 hook, bypassing the
+embedding, which lives in one of the last shards) through layers 0..N-1
+exactly as modeling_kimi_linear.py does — KDA recurrence, gated NoPE MLA,
+AttnRes, LatentMoE with SiTU-GLU — and writes the same trace layout the C
+engine emits under K3_TRACE: per token, per layer, hidden[hidden] f32.
+
+  gen   : k3_ref.py gen <x0.bin> --tokens 6 --dim 7168 [--seed 7]
+  run   : k3_ref.py run <hf_dir> --x0 x0.bin --layers 4 --out ref.bin
+  cmp   : k3_ref.py cmp <c_trace.bin> <ref.bin> --dim 7168 --layers 4
+
+Pure numpy, no torch. Everything f32 (f64 only where the C engine also
+accumulates in double: AttnRes scores, RMS means).
+"""
+import argparse
+import json
+import os
+import struct
+import sys
+
+import numpy as np
+
+E2M1 = np.array([0, .5, 1, 1.5, 2, 3, 4, 6, -0., -.5, -1, -1.5, -2, -3, -4, -6],
+                dtype=np.float32)
+
+
+class Shards:
+    def __init__(self, d):
+        self.dir = d
+        idx = json.load(open(os.path.join(d, "model.safetensors.index.json")))
+        self.wmap = idx["weight_map"]
+        self.hdrs = {}
+
+    def _hdr(self, fn):
+        if fn not in self.hdrs:
+            with open(os.path.join(self.dir, fn), "rb") as f:
+                n = struct.unpack("<Q", f.read(8))[0]
+                self.hdrs[fn] = (json.loads(f.read(n)), 8 + n)
+        return self.hdrs[fn]
+
+    def get(self, name):
+        fn = self.wmap[name]
+        h, base = self._hdr(fn)
+        v = h[name]
+        o0, o1 = v["data_offsets"]
+        with open(os.path.join(self.dir, fn), "rb") as f:
+            f.seek(base + o0)
+            raw = f.read(o1 - o0)
+        if v["dtype"] == "BF16":
+            u = np.frombuffer(raw, dtype=np.uint16).astype(np.uint32) << 16
+            a = u.view(np.float32)
+        elif v["dtype"] == "F32":
+            a = np.frombuffer(raw, dtype=np.float32)
+        elif v["dtype"] == "U8":
+            a = np.frombuffer(raw, dtype=np.uint8)
+        else:
+            raise ValueError(v["dtype"])
+        return a.reshape(v["shape"]).copy()
+
+
+def sigmoid(x):
+    return 1.0 / (1.0 + np.exp(-x))
+
+
+def silu(x):
+    return x * sigmoid(x)
+
+
+def rmsnorm(x, w, eps):
+    ms = np.mean(x.astype(np.float64) ** 2, axis=-1, keepdims=True)
+    return (x * (1.0 / np.sqrt(ms + eps))).astype(np.float32) * w
+
+
+def situ(g, u, b1, b2):
+    return (b1 * np.tanh(g / b1) * sigmoid(g)) * (b2 * np.tanh(u / b2))
+
+
+def deq_mx4(packed, scale):
+    O, half = packed.shape
+    nib = np.empty((O, half * 2), dtype=np.uint8)
+    nib[:, 0::2] = packed & 0xF
+    nib[:, 1::2] = packed >> 4
+    w = E2M1[nib]
+    sc = np.ldexp(np.float32(1.0), scale.astype(np.int32) - 127).astype(np.float32)
+    I = half * 2
+    return (w.reshape(O, I // 32, 32) * sc[:, :, None]).reshape(O, I)
+
+
+def res_mix(prefix, bres, sw, eps):
+    """entries = bres rows + prefix (last); softmax over RMS-normed dots; mix RAW."""
+    vs = list(bres) + [prefix]
+    sc = np.empty(len(vs), dtype=np.float32)
+    sw64 = sw.astype(np.float64)
+    for e, v in enumerate(vs):
+        v64 = v.astype(np.float64)
+        ms = np.mean(v64 ** 2)
+        sc[e] = np.dot(v64, sw64) / np.sqrt(ms + eps)
+    p = np.exp(sc - sc.max())
+    p /= p.sum()
+    out = np.zeros_like(prefix)
+    for e, v in enumerate(vs):
+        out += p[e] * v
+    return out
+
+
+class K3Ref:
+    def __init__(self, hf_dir, n_layers):
+        self.S = Shards(hf_dir)
+        cfg = json.load(open(os.path.join(hf_dir, "config.json")))
+        tc = cfg.get("text_config", cfg)
+        self.tc = tc
+        self.D = tc["hidden_size"]
+        self.eps = tc["rms_norm_eps"]
+        self.b1 = tc["activation_situ_beta"]
+        self.b2 = tc["activation_situ_linear_beta"]
+        self.res_bs = tc["attn_res_block_size"]
+        self.first_dense = tc["first_k_dense_replace"]
+        la = tc["linear_attn_config"]
+        self.kda_layers = set(x - 1 for x in la["kda_layers"])   # 0-indexed
+        self.kh, self.hd = la["num_heads"], la["head_dim"]
+        self.lb = la["gate_lower_bound"]
+        self.conv_k = la["short_conv_kernel_size"]
+        self.n_layers = n_layers
+        self.pfx = "language_model." if any(
+            k.startswith("language_model.") for k in list(self.S.wmap)[:5]) else ""
+
+    def t(self, name):
+        return self.S.get(self.pfx + name)
+
+    def kda(self, li, x):
+        """x [T,D] -> [T,D]; sequential recurrence, T small."""
+        p = f"model.layers.{li}.self_attn."
+        T = x.shape[0]
+        H, hd = self.kh, self.hd
+        qp = x @ self.t(p + "q_proj.weight").T
+        kp = x @ self.t(p + "k_proj.weight").T
+        vp = x @ self.t(p + "v_proj.weight").T
+        outs = []
+        for nm, arr in (("q_conv1d", qp), ("k_conv1d", kp), ("v_conv1d", vp)):
+            w = self.t(p + nm + ".weight").reshape(-1, self.conv_k)  # [P,K]
+            P = arr.shape[1]
+            pad = np.zeros((self.conv_k - 1, P), dtype=np.float32)
+            xp = np.concatenate([pad, arr], axis=0)                  # [T+K-1, P]
+            y = np.zeros_like(arr)
+            for j in range(self.conv_k):
+                y += xp[j:j + T] * w[:, j]
+            outs.append(silu(y))
+        q, k, v = outs
+        g_low = (x @ self.t(p + "f_a_proj.weight").T) @ self.t(p + "f_b_proj.weight").T
+        beta = sigmoid(x @ self.t(p + "b_proj.weight").T)            # [T,H]
+        dt = self.t(p + "dt_bias")                                    # [H*hd]
+        A = np.exp(self.t(p + "A_log")[:H])                           # padded ckpt
+        onw = self.t(p + "o_norm.weight")
+        gfull = x @ self.t(p + "g_proj.weight").T                     # [T,H*hd]
+        q = q.reshape(T, H, hd)
+        k = k.reshape(T, H, hd)
+        v = v.reshape(T, H, hd)
+        z = g_low.reshape(T, H, hd) + dt.reshape(H, hd)
+        alpha = np.exp(self.lb * sigmoid(A[None, :, None] * z))       # [T,H,hd]
+        qn = q / np.sqrt((q ** 2).sum(-1, keepdims=True) + 1e-6) * (hd ** -0.5)
+        kn = k / np.sqrt((k ** 2).sum(-1, keepdims=True) + 1e-6)
+        on = np.zeros((T, H, hd), dtype=np.float32)
+        for h in range(H):
+            S = np.zeros((hd, hd), dtype=np.float32)                  # S[k,v]
+            for t in range(T):
+                S = S * alpha[t, h][:, None]
+                kS = kn[t, h] @ S
+                vt = (v[t, h] - kS) * beta[t, h]
+                S = S + np.outer(kn[t, h], vt)
+                on[t, h] = qn[t, h] @ S
+        ms = np.mean(on.astype(np.float64) ** 2, axis=-1, keepdims=True)
+        on = (on * (1.0 / np.sqrt(ms + self.eps))).astype(np.float32) * onw
+        on = on * sigmoid(gfull.reshape(T, H, hd))
+        return on.reshape(T, H * hd) @ self.t(p + "o_proj.weight").T
+
+    def mla(self, li, x):
+        p = f"model.layers.{li}.self_attn."
+        tc = self.tc
+        T = x.shape[0]
+        H = tc["num_attention_heads"]
+        nope, rope, vh = tc["qk_nope_head_dim"], tc["qk_rope_head_dim"], tc["v_head_dim"]
+        kvl = tc["kv_lora_rank"]
+        qh = nope + rope
+        qa = rmsnorm(x @ self.t(p + "q_a_proj.weight").T,
+                     self.t(p + "q_a_layernorm.weight"), self.eps)
+        q = (qa @ self.t(p + "q_b_proj.weight").T).reshape(T, H, qh)
+        ckv = x @ self.t(p + "kv_a_proj_with_mqa.weight").T
+        c = rmsnorm(ckv[:, :kvl], self.t(p + "kv_a_layernorm.weight"), self.eps)
+        k_rot = ckv[:, kvl:]                                          # [T,rope] raw (NoPE)
+        kv = (c @ self.t(p + "kv_b_proj.weight").T).reshape(T, H, nope + vh)
+        k_pass, v = kv[..., :nope], kv[..., nope:]
+        scale = qh ** -0.5
+        sc = (np.einsum("thd,shd->hts", q[..., :nope], k_pass) +
+              np.einsum("thd,sd->hts", q[..., nope:], k_rot)) * scale
+        mask = np.tril(np.ones((T, T), dtype=bool))
+        sc = np.where(mask[None], sc, -np.inf)
+        sc = sc - sc.max(-1, keepdims=True)
+        w = np.exp(sc)
+        w /= w.sum(-1, keepdims=True)
+        ctx = np.einsum("hts,shd->thd", w.astype(np.float32), v)
+        g = sigmoid(x @ self.t(p + "g_proj.weight").T)
+        ctx = ctx.reshape(T, H * vh) * g
+        return ctx @ self.t(p + "o_proj.weight").T
+
+    def moe(self, li, x):
+        p = f"model.layers.{li}.block_sparse_moe."
+        tc = self.tc
+        T = x.shape[0]
+        K = tc["num_experts_per_token"]
+        router = self.t(p + "gate.weight")
+        bias = self.t(p + "gate.e_score_correction_bias")
+        lat_dn = self.t(p + "routed_expert_down_proj.weight")
+        lat_up = self.t(p + "routed_expert_up_proj.weight")
+        lat_nw = self.t(p + "routed_expert_norm.weight")
+        sg = self.t(p + "shared_experts.gate_proj.weight")
+        su = self.t(p + "shared_experts.up_proj.weight")
+        sd = self.t(p + "shared_experts.down_proj.weight")
+        out = np.zeros_like(x)
+        experts = {}
+        for t in range(T):
+            s = sigmoid(x[t] @ router.T)
+            sel = np.argsort(-(s + bias), kind="stable")[:K]
+            w = s[sel]
+            w = w / (w.sum() + 1e-20)
+            z = x[t] @ lat_dn.T
+            u = np.zeros(z.shape[0], dtype=np.float32)
+            for e, we in zip(sel, w):
+                if e not in experts:
+                    ep = f"{p}experts.{e}."
+                    W1 = deq_mx4(self.t(ep + "w1.weight_packed"), self.t(ep + "w1.weight_scale"))
+                    W2 = deq_mx4(self.t(ep + "w2.weight_packed"), self.t(ep + "w2.weight_scale"))
+                    W3 = deq_mx4(self.t(ep + "w3.weight_packed"), self.t(ep + "w3.weight_scale"))
+                    experts[e] = (W1, W2, W3)
+                W1, W2, W3 = experts[e]
+                act = situ(z @ W1.T, z @ W3.T, self.b1, self.b2)
+                u += we * (act @ W2.T)
+            u = rmsnorm(u, lat_nw, self.eps)
+            y = u @ lat_up.T
+            act = situ(x[t] @ sg.T, x[t] @ su.T, self.b1, self.b2)
+            out[t] = y + act @ sd.T
+        return out
+
+    def dense(self, li, x):
+        p = f"model.layers.{li}.mlp."
+        act = situ(x @ self.t(p + "gate_proj.weight").T,
+                   x @ self.t(p + "up_proj.weight").T, self.b1, self.b2)
+        return act @ self.t(p + "down_proj.weight").T
+
+    def run(self, x0, out_path):
+        """x0 [T,D]; per-token trace rows in the SAME order as the C engine
+        (token-major: the C engine steps one token at a time through all
+        layers). Recurrent/cache state must therefore persist across tokens —
+        we instead run all T at once per layer and emit token-major at the
+        end, which is equivalent because layer l for token t only depends on
+        layers <= l of tokens <= t."""
+        T = x0.shape[0]
+        trace = np.zeros((T, self.n_layers, self.D), dtype=np.float32)
+        hidden = x0.copy()
+        bres = []
+        prefix = None
+        for li in range(self.n_layers):
+            lp = f"model.layers.{li}."
+            in_ln = self.t(lp + "input_layernorm.weight")
+            post_ln = self.t(lp + "post_attention_layernorm.weight")
+            asw = self.t(lp + "self_attention_res_norm.weight") * \
+                self.t(lp + "self_attention_res_proj.weight").reshape(-1)
+            msw = self.t(lp + "mlp_res_norm.weight") * \
+                self.t(lp + "mlp_res_proj.weight").reshape(-1)
+            prefix = hidden.copy()
+            have_prefix = True
+            if bres:
+                hidden = np.stack([res_mix(prefix[t], [b[t] for b in bres], asw, self.eps)
+                                   for t in range(T)])
+            if li % self.res_bs == 0:
+                bres.append(prefix.copy())
+                have_prefix = False
+            nrm = rmsnorm(hidden, in_ln, self.eps)
+            att = self.kda(li, nrm) if li in self.kda_layers else self.mla(li, nrm)
+            prefix = (prefix + att) if have_prefix else att
+            mix = np.stack([res_mix(prefix[t], [b[t] for b in bres], msw, self.eps)
+                            for t in range(T)])
+            nrm = rmsnorm(mix, post_ln, self.eps)
+            mlp = self.moe(li, nrm) if li >= self.first_dense else self.dense(li, nrm)
+            prefix = prefix + mlp
+            hidden = prefix.copy()
+            trace[:, li] = hidden
+            print(f"[ref] layer {li} done ({'KDA' if li in self.kda_layers else 'MLA'},"
+                  f" {'moe' if li >= self.first_dense else 'dense'})", flush=True)
+        trace.tofile(out_path)
+        print(f"[ref] wrote {out_path}: {T} tokens x {self.n_layers} layers x {self.D}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    g = sub.add_parser("gen")
+    g.add_argument("out")
+    g.add_argument("--tokens", type=int, default=6)
+    g.add_argument("--dim", type=int, default=7168)
+    g.add_argument("--seed", type=int, default=7)
+    g.add_argument("--scale", type=float, default=0.02)
+    r = sub.add_parser("run")
+    r.add_argument("hf_dir")
+    r.add_argument("--x0", required=True)
+    r.add_argument("--layers", type=int, default=4)
+    r.add_argument("--out", required=True)
+    c = sub.add_parser("cmp")
+    c.add_argument("a")
+    c.add_argument("b")
+    c.add_argument("--dim", type=int, default=7168)
+    c.add_argument("--layers", type=int, default=4)
+    a = ap.parse_args()
+    if a.cmd == "gen":
+        rng = np.random.default_rng(a.seed)
+        x = (rng.standard_normal((a.tokens, a.dim)) * a.scale).astype(np.float32)
+        x.tofile(a.out)
+        print(f"wrote {a.out}: {a.tokens}x{a.dim}")
+    elif a.cmd == "run":
+        x0 = np.fromfile(a.x0, dtype=np.float32).reshape(-1, 7168)
+        K3Ref(a.hf_dir, a.layers).run(x0, a.out)
+    else:
+        A = np.fromfile(a.a, dtype=np.float32).reshape(-1, a.layers, a.dim)
+        B = np.fromfile(a.b, dtype=np.float32).reshape(-1, a.layers, a.dim)
+        assert A.shape == B.shape, (A.shape, B.shape)
+        worst = 0.0
+        for li in range(a.layers):
+            x, y = A[:, li], B[:, li]
+            rel = np.linalg.norm(x - y) / (np.linalg.norm(y) + 1e-30)
+            worst = max(worst, rel)
+            print(f"layer {li}: rel_l2 {rel:.3e}  (|c|={np.linalg.norm(x):.4g} |ref|={np.linalg.norm(y):.4g})")
+        print("VERDICT:", "OK" if worst < 3e-4 else "MISMATCH", f"(worst {worst:.3e})")
+
+
+if __name__ == "__main__":
+    main()

--- a/c/tools/k3_repack.py
+++ b/c/tools/k3_repack.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Repack a Kimi K3 HF snapshot into colibri's ideal ingestion layout.
+
+Designed so the HDD->NVMe copy IS the conversion (one read of the source):
+
+  - routed experts (MXFP4, QAT): byte-identical passthrough, written in
+    expert-id order, the six tensors of an expert back-to-back (the engine
+    reads one expert = one pread)
+  - big BF16 matrices: quantized ON THE WAY with EXACTLY the engine's
+    load-time algorithm (int8 per-row absmax/127 or int4-g64 absmax/7,
+    round-half-even, same f32 op order), stored as U8 + <name>.qs f32 scale
+    sidecar -> the engine skips its 10-15 min load-time quantization and
+    cold-starts from the container in ~1-2 min
+  - everything small or sensitive (norms, router, conv taps, dt_bias, A_log,
+    o_norm, f_a/f_b, b_proj, res_*, embed_tokens, final norm): passthrough
+    in the source dtype (BF16/F32) — quantizing these saves ~nothing and the
+    engine keeps them f32 in RAM anyway
+  - vision_tower / mm_projector (shards 95-96): dropped
+  - output: model-XXXXX-of-000094.safetensors (same shard split: one layer
+    per shard + shard 94 = embed/head), spec-valid safetensors (no holes),
+    regenerated model.safetensors.index.json, config/tokenizer files copied
+
+Resume-safe: each shard is written to .tmp and renamed; existing outputs are
+skipped. Rerun after an interruption and it continues.
+
+usage: k3_repack.py <src_dir> <dst_dir> [--bits 8] [--mla-bits N] [--head-bits N]
+                    [--shards 1,2,94] [--verify-full]
+
+Classification needs the layer type (o_proj/g_proj exist on BOTH KDA and MLA
+layers) — read from config.json linear_attn_config.
+"""
+import argparse
+import json
+import os
+import shutil
+import struct
+import sys
+import time
+
+import numpy as np
+
+CHUNK_ROWS = 4096          # quantize in row blocks (bounds RAM to ~120 MB)
+COPY_BLOCK = 64 << 20      # passthrough copy block
+
+
+def read_header(path):
+    with open(path, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        h = json.loads(f.read(n))
+    h.pop("__metadata__", None)
+    return h, 8 + n
+
+
+def bf16_to_f32(buf):
+    u = np.frombuffer(buf, dtype=np.uint16).astype(np.uint32) << 16
+    return u.view(np.float32)
+
+
+def quant_int8(rows):
+    """rows [n,I] f32 -> (int8 bytes, f32 scales [n]); engine w_load exact."""
+    am = np.abs(rows).max(axis=1)
+    s = (am / np.float32(127.0)).astype(np.float32)
+    s = np.maximum(s, np.float32(1e-20))
+    q = np.clip(np.rint(rows * (np.float32(1.0) / s)[:, None]), -127, 127).astype(np.int8)
+    return q.tobytes(), s
+
+
+def quant_int4_g64(rows):
+    """rows [n,I] f32, I%64==0 -> (packed bytes low-nibble-even biased+8,
+    f32 scales [n, I/64]); engine w_load / matmul_i4_grouped exact."""
+    n, I = rows.shape
+    g = rows.reshape(n, I // 64, 64)
+    am = np.abs(g).max(axis=2)
+    s = (am / np.float32(7.0)).astype(np.float32)
+    s = np.maximum(s, np.float32(1e-20))
+    q = np.clip(np.rint(g * (np.float32(1.0) / s)[:, :, None]), -8, 7).astype(np.int32) + 8
+    q = q.reshape(n, I)
+    packed = (q[:, 0::2] | (q[:, 1::2] << 4)).astype(np.uint8)
+    return packed.tobytes(), s
+
+
+class Classifier:
+    def __init__(self, src):
+        cfg = json.load(open(os.path.join(src, "config.json")))
+        tc = cfg.get("text_config", cfg)
+        self.kda = set(x - 1 for x in tc["linear_attn_config"]["kda_layers"])
+
+    def __call__(self, name):
+        """-> ('skip'|'expert'|'pass'|'q8class', class) where class in
+        {'bits','mla','head'} for quantized tensors."""
+        n = name
+        if n.startswith("vision_tower") or n.startswith("mm_projector"):
+            return "skip", None
+        if n.startswith("language_model."):
+            n = n[len("language_model."):]
+        if ".block_sparse_moe.experts." in n:
+            return "expert", None
+        if n == "lm_head.weight":
+            return "quant", "head"
+        parts = n.split(".")
+        li = int(parts[2]) if len(parts) > 3 and parts[1] == "layers" else -1
+        if ".self_attn." in n and n.endswith(".weight"):
+            leaf = parts[-2]
+            if leaf in ("q_a_proj", "q_b_proj", "kv_a_proj_with_mqa", "kv_b_proj"):
+                return "quant", "mla"
+            if leaf in ("q_proj", "k_proj", "v_proj"):
+                return "quant", "bits"
+            if leaf in ("o_proj", "g_proj"):
+                return ("quant", "bits") if li in self.kda else ("quant", "mla")
+            return "pass", None            # conv taps, norms, f_a/f_b, b_proj
+        for leaf in ("routed_expert_down_proj", "routed_expert_up_proj",
+                     "shared_experts.gate_proj", "shared_experts.up_proj",
+                     "shared_experts.down_proj",
+                     "mlp.gate_proj", "mlp.up_proj", "mlp.down_proj"):
+            if n.endswith(leaf + ".weight"):
+                return "quant", "bits"
+        return "pass", None                # router, biases, norms, embed, res_*
+
+
+def expert_sort_key(name):
+    # ...experts.<E>.<w1|w2|w3>.weight_<packed|scale>
+    p = name.split(".experts.")[1].split(".")
+    e = int(p[0])
+    mat = {"w1": 0, "w2": 1, "w3": 2}[p[1]]
+    kind = 0 if p[2].endswith("packed") else 1
+    # engine slot order: w1p w1s w2p w2s w3p w3s
+    return (e, mat, kind)
+
+
+def repack_shard(src_path, dst_path, cls, bits_map, verify_full):
+    hdr, data_start = read_header(src_path)
+    items = sorted(hdr.items(), key=lambda kv: kv[1]["data_offsets"][0])
+    non_expert, experts = [], []
+    for name, v in items:
+        kind, qc = cls(name)
+        if kind == "skip":
+            continue
+        (experts if kind == "expert" else non_expert).append((name, v, kind, qc))
+    experts.sort(key=lambda t: expert_sort_key(t[0]))
+    plan = non_expert + experts
+
+    # pass 1: output sizes -> header with final offsets
+    out_entries = []       # (name, dtype, shape, nbytes)  (+ .qs after its tensor)
+    for name, v, kind, qc in plan:
+        if kind == "quant":
+            O, I = v["shape"]
+            bits = bits_map[qc]
+            if bits <= 4 and I % 64 == 0:
+                out_entries.append((name, "U8", [O, I // 2], O * (I // 2)))
+                out_entries.append((name + ".qs", "F32", [O, I // 64], O * (I // 64) * 4))
+            else:
+                out_entries.append((name, "U8", [O, I], O * I))
+                out_entries.append((name + ".qs", "F32", [O], O * 4))
+        else:
+            out_entries.append((name, v["dtype"], v["shape"],
+                                v["data_offsets"][1] - v["data_offsets"][0]))
+    oh, off = {}, 0
+    for name, dt, shape, nb in out_entries:
+        oh[name] = {"dtype": dt, "shape": shape, "data_offsets": [off, off + nb]}
+        off += nb
+    hjson = json.dumps(oh, separators=(",", ":")).encode()
+    pad = (-(8 + len(hjson))) % 8
+    hjson += b" " * pad
+
+    tmp = dst_path + ".tmp"
+    written = 0
+    with open(src_path, "rb") as fin, open(tmp, "wb") as fout:
+        fout.write(struct.pack("<Q", len(hjson)) + hjson)
+        for name, v, kind, qc in plan:
+            a0, b0 = v["data_offsets"]
+            fin.seek(data_start + a0)
+            if kind == "quant":
+                O, I = v["shape"]
+                bits = bits_map[qc]
+                use4 = bits <= 4 and I % 64 == 0
+                qparts, sparts = [], []
+                for r0 in range(0, O, CHUNK_ROWS):
+                    n = min(CHUNK_ROWS, O - r0)
+                    raw = fin.read(n * I * 2)
+                    rows = bf16_to_f32(raw).reshape(n, I)
+                    qb, s = quant_int4_g64(rows) if use4 else quant_int8(rows)
+                    qparts.append(qb)
+                    sparts.append(s.astype(np.float32).tobytes())
+                for qb in qparts:
+                    fout.write(qb)
+                for sb in sparts:
+                    fout.write(sb)
+                written += sum(len(x) for x in qparts) + sum(len(x) for x in sparts)
+            else:
+                left = b0 - a0
+                while left:
+                    blk = fin.read(min(COPY_BLOCK, left))
+                    if not blk:
+                        raise IOError(f"short read in {name}")
+                    fout.write(blk)
+                    left -= len(blk)
+                written += b0 - a0
+    # sanity: bytes written == declared
+    want = off
+    got = os.path.getsize(tmp) - 8 - len(hjson)
+    if got != want:
+        raise IOError(f"{dst_path}: wrote {got} data bytes, header declares {want}")
+    os.replace(tmp, dst_path)
+
+    if verify_full and experts:
+        vh, vstart = read_header(dst_path)
+        with open(src_path, "rb") as fs, open(dst_path, "rb") as fd:
+            for name, v, kind, qc in experts:
+                sa, sb = v["data_offsets"]
+                da, db = vh[name]["data_offsets"]
+                assert sb - sa == db - da, name
+                fs.seek(data_start + sa)
+                fd.seek(vstart + da)
+                left = sb - sa
+                while left:
+                    n = min(COPY_BLOCK, left)
+                    if fs.read(n) != fd.read(n):
+                        raise IOError(f"VERIFY FAILED: {name}")
+                    left -= n
+    return oh, written
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("src")
+    ap.add_argument("dst")
+    ap.add_argument("--bits", type=int, default=8)
+    ap.add_argument("--mla-bits", type=int, default=None)
+    ap.add_argument("--head-bits", type=int, default=None)
+    ap.add_argument("--shards", help="comma list of shard numbers (default 1..94)")
+    ap.add_argument("--verify-full", action="store_true",
+                    help="re-read every expert byte and compare with the source")
+    a = ap.parse_args()
+    bits_map = {"bits": a.bits,
+                "mla": a.mla_bits if a.mla_bits is not None else max(a.bits, 8),
+                "head": a.head_bits if a.head_bits is not None else max(a.bits, 8)}
+    os.makedirs(a.dst, exist_ok=True)
+    cls = Classifier(a.src)
+    shard_nums = ([int(x) for x in a.shards.split(",")] if a.shards
+                  else list(range(1, 95)))
+    index = {}
+    t0 = time.time()
+    total = 0
+    done_any = False
+    for i, num in enumerate(shard_nums):
+        sp = os.path.join(a.src, f"model-{num:05d}-of-000096.safetensors")
+        dname = f"model-{num:05d}-of-000094.safetensors"
+        dp = os.path.join(a.dst, dname)
+        if not os.path.exists(sp):
+            print(f"[{num:2d}] SOURCE MISSING — skipped (rerun when downloaded)", flush=True)
+            continue
+        if os.path.exists(dp):
+            oh, _ = read_header(dp)
+            for name in oh:
+                index[name] = dname
+            print(f"[{num:2d}] exists — skipped (resume)", flush=True)
+            continue
+        oh, written = repack_shard(sp, dp, cls, bits_map, a.verify_full)
+        for name in oh:
+            index[name] = dname
+        total += written
+        done_any = True
+        el = time.time() - t0
+        print(f"[{num:2d}] {os.path.getsize(dp)/1e9:6.2f} GB out "
+              f"({total/1e9:7.1f} GB total, {total/1e9/max(el,1e-9):5.2f} GB/s, {el:6.0f}s)",
+              flush=True)
+    if done_any or index:
+        with open(os.path.join(a.dst, "model.safetensors.index.json"), "w") as f:
+            json.dump({"metadata": {"total_size": total}, "weight_map": index}, f)
+    for extra in ("config.json", "generation_config.json", "tokenizer.json",
+                  "tokenizer_config.json"):
+        s = os.path.join(a.src, extra)
+        if os.path.exists(s):
+            shutil.copy2(s, os.path.join(a.dst, extra))
+    print(f"done: {total/1e9:.1f} GB written in {time.time()-t0:.0f}s -> {a.dst}")
+
+
+if __name__ == "__main__":
+    main()

--- a/c/tools/k3_tokenizer.py
+++ b/c/tools/k3_tokenizer.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Synthesize tokenizer.json for Kimi K3 from the repo's tiktoken.model.
+
+The K3 HF repo ships only a raw tiktoken BPE (base64 token -> rank) plus
+tokenization_kimi.py; the colibri-family engines load HuggingFace
+tokenizer.json (tok.h). This tool writes one:
+
+  - vocab: every tiktoken byte sequence mapped through the GPT-2 byte-level
+    alphabet (the same map tok.h rebuilds), id = rank
+  - merges: EMPTY on purpose. Rank-recovered merge lists cannot be made
+    exactly faithful (verified: "newlines" merges new+l+ines instead of
+    new+lines under the standard max-rank-minimizing recovery). tok.h
+    detects the empty list and switches to rank-BPE — merge the adjacent
+    pair whose concatenation has the lowest vocab id — which IS tiktoken's
+    algorithm, so encoding is exact by construction.
+  - added_tokens: ids num_base..num_base+255 from tokenizer_config.json's
+    added_tokens_decoder, gaps filled with <|reserved_token_N|>
+  - pre_tokenizer: the Kimi Split regex (contains \\p{Han} and \\p{Lu} — the
+    markers tok.h sniffs to select the kimi family), plus ByteLevel
+
+usage: k3_tokenizer.py <hf_dir> [-o out.json] [--check "text" ...]
+       --check re-encodes text with tiktoken (if installed) and with a pure-
+       python replay of the emitted tokenizer.json; both must agree.
+"""
+import argparse
+import base64
+import json
+import os
+import sys
+
+PAT = "|".join([
+    r"""[\p{Han}]+""",
+    r"""[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?""",
+    r"""[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?""",
+    r"""\p{N}{1,3}""",
+    r""" ?[^\s\p{L}\p{N}]+[\r\n]*""",
+    r"""\s*[\r\n]+""",
+    r"""\s+(?!\S)""",
+    r"""\s+""",
+])
+
+NUM_RESERVED = 256
+
+
+def bytes_to_unicode():
+    bs = list(range(33, 127)) + list(range(161, 173)) + list(range(174, 256))
+    cs = bs[:]
+    n = 0
+    for b in range(256):
+        if b not in bs:
+            bs.append(b)
+            cs.append(256 + n)
+            n += 1
+    return dict(zip(bs, [chr(c) for c in cs]))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("hf_dir")
+    ap.add_argument("-o", "--out")
+    ap.add_argument("--check", nargs="*", default=None)
+    ap.add_argument("--ctest", metavar="BINARY",
+                    help="cross-check the C tokenizer (tests/test_tok_kimi) against tiktoken")
+    a = ap.parse_args()
+    out = a.out or os.path.join(a.hf_dir, "tokenizer.json")
+
+    ranks = {}
+    with open(os.path.join(a.hf_dir, "tiktoken.model"), "rb") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            tok, rank = line.split()
+            ranks[base64.b64decode(tok)] = int(rank)
+    num_base = len(ranks)
+    print(f"tiktoken vocab: {num_base} tokens")
+
+    b2u = bytes_to_unicode()
+
+    def bl(bs):  # bytes -> byte-level string
+        return "".join(b2u[b] for b in bs)
+
+    vocab = {bl(tok): rank for tok, rank in ranks.items()}
+    merges = []          # empty on purpose -> tok.h rank-BPE (see module docstring)
+
+    tc = {}
+    tcp = os.path.join(a.hf_dir, "tokenizer_config.json")
+    if os.path.exists(tcp):
+        tc = json.load(open(tcp))
+    named = {int(k): v["content"] for k, v in tc.get("added_tokens_decoder", {}).items()}
+    special = {int(k): bool(v.get("special", False))
+               for k, v in tc.get("added_tokens_decoder", {}).items()}
+    added = []
+    for i in range(num_base, num_base + NUM_RESERVED):
+        content = named.get(i, f"<|reserved_token_{i}|>")
+        added.append({"id": i, "content": content, "single_word": False,
+                      "lstrip": False, "rstrip": False, "normalized": False,
+                      "special": special.get(i, True)})
+
+    tj = {
+        "version": "1.0",
+        "truncation": None,
+        "padding": None,
+        "added_tokens": added,
+        "normalizer": None,
+        "pre_tokenizer": {
+            "type": "Sequence",
+            "pretokenizers": [
+                {"type": "Split", "pattern": {"Regex": PAT},
+                 "behavior": "Isolated", "invert": False},
+                {"type": "ByteLevel", "add_prefix_space": False,
+                 "trim_offsets": True, "use_regex": False},
+            ],
+        },
+        "post_processor": None,
+        "decoder": {"type": "ByteLevel", "add_prefix_space": True,
+                    "trim_offsets": True, "use_regex": True},
+        "model": {
+            "type": "BPE", "dropout": None, "unk_token": None,
+            "continuing_subword_prefix": None, "end_of_word_suffix": None,
+            "fuse_unk": False, "byte_fallback": False, "ignore_merges": True,
+            "vocab": vocab, "merges": merges,
+        },
+    }
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(tj, f, ensure_ascii=False)
+    print(f"wrote {out} ({os.path.getsize(out)/1e6:.1f} MB)")
+
+    corpus = [
+        "Hello, world! The quick brown fox jumps over 12345 lazy dogs.",
+        "def main():\n    return {'a': 1}\n",
+        "Kimi K3 是一个开源模型。它支持中文和English mixed text!",
+        "  indented\n\n\nnewlines\t\ttabs   ",
+        "I'll say we've DONE it. HTTPResponse XMLHttpRequest",
+        "今天天气怎么样？我们去公园散步吧。",
+        "日本語のテキストです。カタカナとひらがな、漢字も。",
+        "한국어 텍스트도 있습니다.",
+        "naïve café résumé ÜBER Straße mañana",
+        "don't CAN'T it's I'M we'RE you'll",
+        "1 12 123 1234 12345 3.14159 -42",
+        "!!! ??? ... --- /// ***bold*** `code`",
+        "  a\n\n\nb\t\t  c   \n d  ",
+        "🚀 emoji test 🎉 ½ ² € §",
+        "iPhone macOS HTTPResponse XMLHttpRequest camelCase snake_case",
+        "々 〇 一二三 中中中English中文",
+        "\r\nwindows\r\nline\r\nendings\r\n",
+        "mixed 中文with no space英文boundaries测试",
+    ]
+    if a.ctest:
+        import struct as _st
+        import subprocess
+        try:
+            import tiktoken
+        except ImportError:
+            print("--ctest: tiktoken not installed", file=sys.stderr)
+            return
+        enc = tiktoken.Encoding(name="k3", pat_str=PAT,
+                                mergeable_ranks=ranks, special_tokens={})
+        cases = "/tmp/k3_tok_cases.bin"
+        with open(cases, "wb") as f:
+            f.write(_st.pack("<I", len(corpus)))
+            for t in corpus:
+                b = t.encode("utf-8")
+                f.write(_st.pack("<I", len(b)) + b)
+        r = subprocess.run([a.ctest, out, cases], capture_output=True, text=True)
+        print(r.stderr.strip(), file=sys.stderr)
+        got = [([int(x) for x in ln.split()] if ln else [])
+               for ln in r.stdout.splitlines()]
+        ok = True
+        for t, g in zip(corpus, got):
+            want = enc.encode(t)
+            if want != g:
+                ok = False
+                print(f"C MISMATCH on {t!r}\n  tiktoken: {want}\n  tok.h   : {g}")
+        print("ctest:", "OK — tok.h matches tiktoken on all cases" if ok else "FAILED")
+        return
+
+    if a.check is not None:
+        texts = a.check or corpus
+        try:
+            import tiktoken
+        except ImportError:
+            print("--check: tiktoken not installed, skipping", file=sys.stderr)
+            return
+        enc = tiktoken.Encoding(name="k3", pat_str=PAT,
+                                mergeable_ranks=ranks, special_tokens={})
+        def bpe_py(piece_bytes):
+            """rank-BPE replay: what tok.h does with an empty merges list"""
+            s = bl(piece_bytes)
+            if s in vocab:
+                return [vocab[s]]
+            sym = [c for c in s]
+            while True:
+                best, bp = None, -1
+                for i in range(len(sym) - 1):
+                    r = vocab.get(sym[i] + sym[i + 1])
+                    if r is not None and (best is None or r < best):
+                        best, bp = r, i
+                if bp < 0:
+                    break
+                sym[bp:bp + 2] = [sym[bp] + sym[bp + 1]]
+            return [vocab[t] for t in sym if t in vocab]
+
+        import regex
+        # Python's regex module wants V1 set-difference syntax for what
+        # fancy-regex writes as [...&&[^\p{Han}]]
+        py_pat = PAT.replace(
+            r"[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]",
+            r"[[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]--[\p{Han}]]").replace(
+            r"[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]",
+            r"[[\p{Ll}\p{Lm}\p{Lo}\p{M}]--[\p{Han}]]")
+        cre = regex.compile(py_pat, flags=regex.V1)
+        ok = True
+        for t in texts:
+            want = enc.encode(t)
+            got = []
+            for mt in cre.finditer(t):
+                got += bpe_py(mt.group().encode("utf-8"))
+            if want != got:
+                ok = False
+                print(f"MISMATCH on {t!r}\n  tiktoken: {want}\n  replay  : {got}")
+        print("check:", "OK — merges replay matches tiktoken" if ok else "FAILED")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/kimi_k3.md
+++ b/docs/kimi_k3.md
@@ -1,0 +1,154 @@
+# Kimi K3 engine (`c/kimi_k3.c`)
+
+A sibling engine for [Kimi K3](https://huggingface.co/moonshotai/Kimi-K3)
+(2.8T parameters, 104B active, 93 layers), following the one-engine-per-family
+pattern (`colibri.c` = GLM-5.2, `olmoe.c`, `inkling.c`). It shares `st.h`,
+`json.h`, `tok.h`, `quant.h` and touches nothing in the GLM engine.
+
+```
+make kimi_k3
+./kimi_k3 <model_dir> "prompt" --ngen 64
+```
+
+`<model_dir>` is either the plain HF snapshot (config.json +
+`model-*-of-000096.safetensors`) or a repacked container (below). Text-only:
+the vision tower (shards 95–96) is never read.
+
+## Architecture notes
+
+K3 is not a DeepSeek-shaped model; four pieces are new relative to everything
+else in this repo:
+
+- **Hybrid attention, NoPE.** 69 KDA (Kimi Delta Attention) layers + 24 gated
+  MLA layers (every 4th, plus the final layer). There is no positional
+  encoding anywhere — position lives in KDA's convolution and decay. The MLA
+  block has DeepSeek dims (q_lora 1536, kv_lora 512, nope 128 + 64 uncached
+  extra dims, v 128, 96 heads) and both attention types multiply their output
+  by a full-rank sigmoid gate `σ(W_g x)` before `o_proj`.
+- **KDA** per head (dim 128, 96 heads): `q,k,v = SiLU(causal-conv4(W x))`,
+  q/k L2-normalized (ε=1e-6 inside the sqrt), q scaled by 128^-1/2; per-channel
+  decay `gk = -5·σ(exp(A_log[h])·(W_fb W_fa x + dt_bias))`; the delta-rule
+  state update `S = (I − βkkᵀ)·Diag(e^gk)·S + βkvᵀ`; output
+  `W_o[σ(W_g x) ⊙ RMSNorm_head(Sᵀq)]`. The checkpoint stores `A_log` as
+  `[128]`: that is the per-head `[96]` parameter zero-padded (verified —
+  entries 96..127 are exactly 0). Decode state: 96×128×128 f32 per layer.
+- **AttnRes replaces the residual stream.** Each layer keeps a running
+  `prefix_sum`; at layers 0, 12, 24, …, 84 it is snapshotted into a block
+  list. Twice per layer (before attention, before the MLP) and once at the
+  end, the hidden state is REPLACED by a softmax mix over
+  `[snapshots…, prefix_sum]`, scored by `(v · (res_norm.w ⊙ res_proj.w)) /
+  rms(v)` and mixing the raw (un-normalized) entries in fp32.
+- **Stable LatentMoE.** Sigmoid router `[896, 7168]` + score-correction bias,
+  top-16 selected on biased scores, weights are the raw scores renormalized.
+  The token is projected 7168→3584, the 16 experts run in that latent space
+  (GLU, inter 3072), the aggregate is RMSNorm-ed and projected back
+  3584→7168; two fused full-width shared experts (inter 6144) are added.
+  Activation is **SiTU-GLU**: `4·tanh(g/4)·σ(g) · 25·tanh(u/25)`.
+
+### Weights
+
+Only the routed experts (`experts.N.w{1,2,3}`) are quantized in the
+checkpoint — **MXFP4** (compressed-tensors `mxfp4-pack-quantized`,
+quantization-aware trained): e2m1 nibbles packed two per byte (low nibble =
+even column, bit 3 = sign) with a ue8m0 power-of-two scale per 32 columns,
+`w = v · 2^(scale-127)`. 17.55 MB per expert, 82,432 experts ≈ 1.45 TB.
+`quant.h` gained `matmul_mxfp4` (scalar + AVX2) that computes on this layout
+directly — expert bytes are **never converted**; QAT weights are exactly the
+trained values and any re-encode only adds error.
+
+Everything else is BF16 and is quantized into RAM **at load time** (int8
+per-row / int4-g64), or read pre-quantized from a repacked container.
+
+## Streaming design
+
+Experts are streamed straight from the safetensors shards through a per-layer
+LRU (`K3_EXPERT_GB`). Measured layout facts the engine exploits: the six
+tensors of an expert are stored back-to-back (one expert = one `pread`), and
+experts are *not* id-ordered inside a shard, so loads are issued in disk-offset
+order. Note that K3's router was trained with Quantile Balancing (deliberately
+flat expert usage), so LRU hit rates are structurally lower than on models
+with skewed routing — expect the expert tier to be bandwidth-bound.
+
+## Repacked container (`tools/k3_repack.py`)
+
+```
+python3 tools/k3_repack.py <hf_src> <dst> --bits 8 [--mla-bits 8] [--head-bits 8]
+```
+
+One streaming read of the source (so a disk-to-disk copy can *be* the
+conversion): experts pass through byte-identical (id-ordered, single-pread
+layout), the big BF16 matrices are quantized with exactly the engine's
+load-time algorithm and stored as `U8` + `<name>.qs` f32 scales, the small /
+sensitive tensors (norms, router, conv taps, `dt_bias`, `A_log`, `f_a/f_b`,
+`b_proj`, embeddings) pass through, vision is dropped. Output is spec-valid
+safetensors (`model-XXXXX-of-000094.safetensors`) plus a regenerated index;
+interrupted runs resume per shard. `--verify-full` re-reads every expert byte
+and compares against the source.
+
+The engine auto-detects container tensors (dtype U8 + `.qs` sidecar) and skips
+load-time quantization: measured on two layers, init drops **30.4 s → 0.6 s**;
+on the full model this removes a 10–15 minute quantization pass. Quantized
+values are bit-identical to the load-time path (verified by hidden-state
+trace), so the two formats are numerically interchangeable.
+
+Sizes: source 1.56 TB → ≈1.50 TB (`--bits 8`) / ≈1.48 TB (`--bits 4`). The
+experts (93 % of bytes) are already at 4.25 bits/weight and cannot shrink
+losslessly; sub-4-bit expert re-encodes (fmt=5/6) would be double quantization
+of QAT weights and are deliberately not offered here.
+
+## Tokenizer
+
+The HF repo ships only a raw tiktoken vocab (`tiktoken.model`).
+`tools/k3_tokenizer.py` writes a `tokenizer.json` for it, and `tok.h` gained:
+
+- a **kimi pre-tokenizer family** (sniffed via `\p{Han}` in the Split regex):
+  the o200k case-aware rules plus a leading Han-run rule, Han excluded from
+  the letter classes, and no `/` tail in the punctuation rule;
+- a **rank-BPE mode**, used when `model.merges` is empty: merge the adjacent
+  pair whose concatenation has the lowest vocab id — which is tiktoken's own
+  algorithm, so encoding is exact by construction. (Merge-list recovery from
+  ranks is provably lossy: the standard reconstruction mis-merges e.g.
+  "newlines"; that is why the generator emits no merges.)
+
+`tools/k3_tokenizer.py --ctest tests/test_tok_kimi` cross-checks the C
+tokenizer against tiktoken; it matches on all 18 corpus cases (Chinese,
+kanji-vs-kana, Korean, CRLF, contractions, emoji, mixed-script boundaries).
+
+## Validation
+
+`tools/k3_ref.py` is an independent numpy implementation of the full layer
+stack (KDA recurrence, gated MLA, AttnRes, LatentMoE with MXFP4 dequant). With
+injected inputs (`K3_X0`, bypassing the embedding) and f32 weights
+(`K3_BITS=32`), the C engine matches it on real checkpoint weights across all
+four layer types to **rel-L2 ≤ 2.2e-6** (float32 noise).
+
+One property worth knowing: the AttnRes mix logits sit close together
+(margins ~0.02), so the mix leverages *weight* noise strongly even though it
+does not amplify *input* perturbations (a 1e-4 input perturbation stays 1e-4
+through the stack). Load-time int8 produces a hidden-state drift growing to
+~14 % over four layers on synthetic inputs — per-tensor quantization SNR is a
+uniform ~1 %, so this is architectural sensitivity, not an outlier problem.
+Judge quantization choices on real-text logits, not synthetic-vector norms.
+
+## Environment variables
+
+| var | default | meaning |
+|---|---|---|
+| `K3_BITS` | 4 | load-time bits for KDA/latent/shared/dense mats (4, 8, 32=f32) |
+| `K3_MLA_BITS` | 8 | load-time bits for MLA projections |
+| `K3_HEAD_BITS` | 8 | load-time bits for lm_head |
+| `K3_EXPERT_GB` | 8 | routed-expert LRU budget |
+| `K3_DIRS` | — | extra shard directories (multi-drive split, no duplication) |
+| `K3_MAXT` | prompt+ngen | context capacity |
+| `K3_LAYERS` | all | truncate the stack (validation) |
+| `K3_TRACE` | — | dump f32 hidden state after every layer (validation) |
+| `K3_X0` | — | inject input rows, bypass embedding (validation) |
+| `COLI_TEMP` | 0 | 0 = greedy, else softmax temperature |
+
+## Current limitations
+
+- Single-token stepping only (prefill is sequential; no chunked KDA, no
+  batched MLA prefill).
+- CPU only (no CUDA/Metal/Vulkan tier), scalar KDA inner loops.
+- No chat template handling; prompts are raw text after `[BOS]`.
+- No speculative decoding (K3 has no MTP head).

--- a/docs/kimi_k3.md
+++ b/docs/kimi_k3.md
@@ -65,7 +65,13 @@ Experts are streamed straight from the safetensors shards through a per-layer
 LRU (`K3_EXPERT_GB`). Measured layout facts the engine exploits: the six
 tensors of an expert are stored back-to-back (one expert = one `pread`), and
 experts are *not* id-ordered inside a shard, so loads are issued in disk-offset
-order. Note that K3's router was trained with Quantile Balancing (deliberately
+order. A token's misses are read **in parallel** (OMP over working-set slots)
+and by default with **O_DIRECT** (`K3_DIRECT=0` for buffered): the resident
+weights leave little page-cache headroom, and flat routing means cached reads
+mostly cannot be reused anyway — measured on the 93-layer model this took
+expert reads from ~1.8 to ~6.3 GB/s (drive ceiling 7.1) and decode from ~21
+to ~9.4 s/token. The LRU slot floor is 1 (experts are consumed one at a time),
+so `K3_EXPERT_GB` is honored even at tiny budgets. Note that K3's router was trained with Quantile Balancing (deliberately
 flat expert usage), so LRU hit rates are structurally lower than on models
 with skewed routing — expect the expert tier to be bandwidth-bound.
 
@@ -86,7 +92,11 @@ interrupted runs resume per shard. `--verify-full` re-reads every expert byte
 and compares against the source.
 
 The engine auto-detects container tensors (dtype U8 + `.qs` sidecar) and skips
-load-time quantization: measured on two layers, init drops **30.4 s → 0.6 s**;
+load-time quantization. Setting `K3_BITS=4` **explicitly** on an int8 container
+downcasts the int8 matrices to int4-g64 at load (~35 vs ~57 GiB resident on
+the 93-layer model — fits next to a desktop session; the int8 grid is 16x
+finer than int4, so the double-quant noise ~ direct int4). Unset `K3_BITS`
+keeps the container's own bits. Startup: measured on two layers, init drops **30.4 s → 0.6 s**;
 on the full model this removes a 10–15 minute quantization pass. Quantized
 values are bit-identical to the load-time path (verified by hidden-state
 trace), so the two formats are numerically interchangeable.
@@ -138,6 +148,7 @@ Judge quantization choices on real-text logits, not synthetic-vector norms.
 | `K3_MLA_BITS` | 8 | load-time bits for MLA projections |
 | `K3_HEAD_BITS` | 8 | load-time bits for lm_head |
 | `K3_EXPERT_GB` | 8 | routed-expert LRU budget |
+| `K3_DIRECT` | 1 | O_DIRECT expert reads (0 = buffered + WILLNEED) |
 | `K3_DIRS` | — | extra shard directories (multi-drive split, no duplication) |
 | `K3_MAXT` | prompt+ngen | context capacity |
 | `K3_LAYERS` | all | truncate the stack (validation) |

--- a/docs/kimi_k3.md
+++ b/docs/kimi_k3.md
@@ -71,7 +71,13 @@ weights leave little page-cache headroom, and flat routing means cached reads
 mostly cannot be reused anyway — measured on the 93-layer model this took
 expert reads from ~1.8 to ~6.3 GB/s (drive ceiling 7.1) and decode from ~21
 to ~9.4 s/token. The LRU slot floor is 1 (experts are consumed one at a time),
-so `K3_EXPERT_GB` is honored even at tiny budgets. Note that K3's router was trained with Quantile Balancing (deliberately
+so `K3_EXPERT_GB` is honored even at tiny budgets. On top of that, `K3_PIPE`
+(default on) runs the reads on loader threads so expert j's matmuls overlap
+expert j+1's pread, `K3_IDOT` (default on) computes the expert matmuls with
+per-32-group int8-quantized activations via integer dots (the e2m1 doubled
+values are exact int8 — same trick as `dot_i4i8`), and `K3_TOPP` optionally
+drops the low-weight tail of the top-16 (renormalized; quality-gate any
+setting with a `K3_LOGITS` A/B first). Note that K3's router was trained with Quantile Balancing (deliberately
 flat expert usage), so LRU hit rates are structurally lower than on models
 with skewed routing — expect the expert tier to be bandwidth-bound.
 
@@ -149,6 +155,10 @@ Judge quantization choices on real-text logits, not synthetic-vector norms.
 | `K3_HEAD_BITS` | 8 | load-time bits for lm_head |
 | `K3_EXPERT_GB` | 8 | routed-expert LRU budget |
 | `K3_DIRECT` | 1 | O_DIRECT expert reads (0 = buffered + WILLNEED) |
+| `K3_IDOT` | 1 | int8-activation expert matmuls (0 = exact-float kernel) |
+| `K3_PIPE` | 1 | overlap expert loads with compute (loader threads) |
+| `K3_LOAD_THREADS` | 4 | loader threads for `K3_PIPE` |
+| `K3_TOPP` | 0 | keep routed experts to cumulative weight p (0 = off) |
 | `K3_DIRS` | — | extra shard directories (multi-drive split, no duplication) |
 | `K3_MAXT` | prompt+ngen | context capacity |
 | `K3_LAYERS` | all | truncate the stack (validation) |

--- a/docs/kimi_k3.md
+++ b/docs/kimi_k3.md
@@ -183,10 +183,16 @@ teacher-forced logit streams at C=32 vs C=1 match exactly). Measured prefill:
 ~5.3 -> **2.0 s/token** at C=32. The KDA state-update sweeps are AVX2
 (scalar fallback for head dims not divisible by 8).
 
-## Chat mode (`--chat`)
+## Chat, API, and Web
 
-```
+```sh
+# standalone one-turn diagnostic
 ./kimi_k3 <model_dir> --chat "your question" [--system "..."] --ngen 300
+
+# first-class multi-turn interfaces (config.json auto-detects Kimi K3)
+COLI_MODEL=<model_dir> ./coli chat
+COLI_MODEL=<model_dir> ./coli serve
+COLI_MODEL=<model_dir> ./coli web
 ```
 
 K3's chat format ("XTML", from the checkpoint's own `encoding_k3.py`) uses
@@ -198,18 +204,28 @@ only four special tokens — `<|open|>`, `<|close|>`, `<|sep|>`,
 <|open|>message role="assistant"<|sep|><|open|>think<|sep|>        <- generation prompt
 ```
 
-The assistant's thinking is a *structural* channel (preserved across turns in
-multi-turn use); `K3_THINK=0` opens `<response>` directly instead. The C
-builder mirrors the reference segment-for-segment (segment boundaries are
-token boundaries) and was verified **token-exact** against `encoding_k3.py` +
-tiktoken for system/no-system and thinking/non-thinking prompts. At decode
-the CLI hides the XTML structure and prints `[think]` / `[response]` channel
-banners; generation stops at `<|end_of_msg|>` (the eos).
+The assistant's thinking is a *structural* channel and is preserved when an
+OpenAI-compatible client sends prior `reasoning_content`; `enable_thinking=false`
+opens `<response>` directly. The gateway does not flatten XTML into a string:
+it sends length-framed messages to the C engine, which builds every structural
+and ordinary-text segment at the tokenizer boundary required by K3's rank-BPE.
+The multi-turn wire was compared against the official `encoding_k3.py` and
+tiktoken on system/user/assistant history with UTF-8 content: **77/77 token IDs
+exact**.
+
+`coli chat` starts a private local server for Kimi and keeps the 2.8T model
+loaded for the whole terminal session. `coli serve` exposes streaming and
+non-streaming `/v1/chat/completions`; `coli web` uses that same API. Reasoning
+is returned as `reasoning_content`, response text as `content`, and
+`<|end_of_msg|>` remains the model-owned stop token. `STOP` and `CANCEL` are
+honoured between generated tokens.
 
 ## Current limitations
 
 - Decode is single-token (no speculative decoding — K3 has no MTP head).
-- `--chat` renders a single system+user turn (no multi-turn CLI loop, no
-  tool-call rendering — the format supports both; see `encoding_k3.py`).
-- CPU only (no CUDA/Metal/Vulkan tier), scalar KDA inner loops.
-- No chat template handling; prompts are raw text after `[BOS]`.
+- Tool declarations/calls and image content are not exposed through the shared
+  gateway yet; unsupported requests fail explicitly.
+- CPU only (no CUDA/Metal/Vulkan tier).
+- The protocol, tokenizer, gateway, TUI, and Web client paths are locally
+  testable without the 1.5 TB checkpoint. A release claim still requires one
+  full-model multi-turn TUI/Web run on a host that owns the complete snapshot.

--- a/docs/kimi_k3.md
+++ b/docs/kimi_k3.md
@@ -160,6 +160,7 @@ Judge quantization choices on real-text logits, not synthetic-vector norms.
 | `K3_LOAD_THREADS` | 4 | loader threads for `K3_PIPE` |
 | `K3_TOPP` | 0 | keep routed experts to cumulative weight p (0 = off) |
 | `K3_CHUNK` | 32 | prefill chunk size (1 = token-at-a-time; forced 1 under `K3_TRACE`) |
+| `K3_THINK` | 1 | chat mode: open the structural think channel (0 = response-only) |
 | `K3_DIRS` | — | extra shard directories (multi-drive split, no duplication) |
 | `K3_MAXT` | prompt+ngen | context capacity |
 | `K3_LAYERS` | all | truncate the stack (validation) |
@@ -182,8 +183,33 @@ teacher-forced logit streams at C=32 vs C=1 match exactly). Measured prefill:
 ~5.3 -> **2.0 s/token** at C=32. The KDA state-update sweeps are AVX2
 (scalar fallback for head dims not divisible by 8).
 
+## Chat mode (`--chat`)
+
+```
+./kimi_k3 <model_dir> --chat "your question" [--system "..."] --ngen 300
+```
+
+K3's chat format ("XTML", from the checkpoint's own `encoding_k3.py`) uses
+only four special tokens — `<|open|>`, `<|close|>`, `<|sep|>`,
+`<|end_of_msg|>` — around ordinary-text tag names and attributes:
+
+```
+<|open|>message role="user"<|sep|>TEXT<|close|>message<|sep|><|end_of_msg|>
+<|open|>message role="assistant"<|sep|><|open|>think<|sep|>        <- generation prompt
+```
+
+The assistant's thinking is a *structural* channel (preserved across turns in
+multi-turn use); `K3_THINK=0` opens `<response>` directly instead. The C
+builder mirrors the reference segment-for-segment (segment boundaries are
+token boundaries) and was verified **token-exact** against `encoding_k3.py` +
+tiktoken for system/no-system and thinking/non-thinking prompts. At decode
+the CLI hides the XTML structure and prints `[think]` / `[response]` channel
+banners; generation stops at `<|end_of_msg|>` (the eos).
+
 ## Current limitations
 
 - Decode is single-token (no speculative decoding — K3 has no MTP head).
+- `--chat` renders a single system+user turn (no multi-turn CLI loop, no
+  tool-call rendering — the format supports both; see `encoding_k3.py`).
 - CPU only (no CUDA/Metal/Vulkan tier), scalar KDA inner loops.
 - No chat template handling; prompts are raw text after `[BOS]`.

--- a/docs/kimi_k3.md
+++ b/docs/kimi_k3.md
@@ -159,6 +159,7 @@ Judge quantization choices on real-text logits, not synthetic-vector norms.
 | `K3_PIPE` | 1 | overlap expert loads with compute (loader threads) |
 | `K3_LOAD_THREADS` | 4 | loader threads for `K3_PIPE` |
 | `K3_TOPP` | 0 | keep routed experts to cumulative weight p (0 = off) |
+| `K3_CHUNK` | 32 | prefill chunk size (1 = token-at-a-time; forced 1 under `K3_TRACE`) |
 | `K3_DIRS` | — | extra shard directories (multi-drive split, no duplication) |
 | `K3_MAXT` | prompt+ngen | context capacity |
 | `K3_LAYERS` | all | truncate the stack (validation) |
@@ -166,10 +167,23 @@ Judge quantization choices on real-text logits, not synthetic-vector norms.
 | `K3_X0` | — | inject input rows, bypass embedding (validation) |
 | `COLI_TEMP` | 0 | 0 = greedy, else softmax temperature |
 
+## Chunked prefill
+
+Prefill processes the prompt in chunks of `K3_CHUNK` tokens, layer-major:
+every dense matmul batches over the chunk (each weight matrix streams from
+RAM once per chunk instead of once per token), the MoE loads each unique
+expert of the chunk once (measured at C=32 on real text: 2.7x dedup —
+neighbouring tokens share experts far more than QB-flat routing suggests —
+9.6 instead of 25.8 GB/token), and the lm_head runs only on the chunk's last
+token. Sequential state (KDA recurrence, MLA cache, AttnRes bookkeeping)
+advances per token inside each layer in the original order, so chunked
+results are **bit-identical** to token-at-a-time (verified: 125-position
+teacher-forced logit streams at C=32 vs C=1 match exactly). Measured prefill:
+~5.3 -> **2.0 s/token** at C=32. The KDA state-update sweeps are AVX2
+(scalar fallback for head dims not divisible by 8).
+
 ## Current limitations
 
-- Single-token stepping only (prefill is sequential; no chunked KDA, no
-  batched MLA prefill).
+- Decode is single-token (no speculative decoding — K3 has no MTP head).
 - CPU only (no CUDA/Metal/Vulkan tier), scalar KDA inner loops.
 - No chat template handling; prompts are raw text after `[BOS]`.
-- No speculative decoding (K3 has no MTP head).


### PR DESCRIPTION
## Summary

- add the shared `SERVE=1` protocol to `kimi_k3`
- route Kimi models through `coli chat`, `coli serve`, and `coli web`
- add validated multi-turn K3 message framing and reasoning/content streaming
- add top-p sampling, cancellation, state reset, and profiling output
- document the supported workflow and current limitations

Depends on #676. This is intentionally stacked on its exact commits; once #676 lands, this PR should reduce to the integration commit.

## Validation

- `make -C c kimi_k3`
- `make -C c check` — 224 Python tests passed, 13 skipped, plus all C tests
- `PYTHONPATH=c python3 -m unittest c.tests.test_openai_server` — 104 passed
- K3 wire fixture compared against Moonshot's official `encoding_k3.py`: 77 token IDs, exact match
- `git diff --check`

## Full-model test boundary

The local validation host has 93 GiB RAM and a 12 GiB RTX 4070, so it cannot load the full Kimi K3 snapshot. Tokenization, protocol, gateway, TUI/Web paths, compilation, and regression tests are covered here; a complete model generation run remains the release gate on a host that can load #676's snapshot.

## Current limitations

- text chat only; tools and image input return explicit unsupported errors
- one KV slot only; sibling state is not isolated for concurrent decode yet
- CPU engine path from #676; no new GPU claim
