### PR TITLE
fix: allow converter selftests without a model source

### DIFF
--- a/c/tests/test_int3_convert.py
+++ b/c/tests/test_int3_convert.py
@@ -13,7 +13,7 @@ except ImportError:
     raise unittest.SkipTest("numpy not installed")
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
-from convert_fp8_to_int4 import quant_int3_g64
+from convert_fp8_to_int4 import quant_int3_g64, source_label
 
 
 def decode(packed, scales, O, I, group=64):
@@ -42,6 +42,14 @@ def reference(w, group=64):
 
 
 class Int3ConvertTest(unittest.TestCase):
+    def test_source_label_allows_standalone_selftests(self):
+        class Args:
+            selftest = False
+            selftest_nvfp4 = True
+            indir = None
+            repo = None
+        self.assertEqual(source_label(Args()), "selftest")
+
     def test_round_trip(self):
         rng = np.random.default_rng(7)
         for I in (64, 128, 100, 65, 7168):

--- a/c/tools/convert_fp8_to_int4.py
+++ b/c/tools/convert_fp8_to_int4.py
@@ -374,6 +374,15 @@ def check_or_record_params(outdir, prefix, params):
 def _bits(v):                                   # "e8" -> fmt=6 marker; anything else an int width
     return E8 if v == E8 else int(v)
 
+def source_label(a):
+    if a.selftest or a.selftest_nvfp4:
+        return "selftest"
+    if a.indir:
+        return "local " + a.indir
+    if a.repo:
+        return "download " + a.repo
+    raise SystemExit("one of --indir or --repo is required")
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--repo", default=None)
@@ -476,7 +485,7 @@ def main():
     mode = "MTP head only" if a.mtp else "DSA indexer only" if a.indexer else "main model"
     grp = f"grouped gs={a.group_size} (fmt=4)" if (a.group_size and a.ebits <= 4) else \
           (f"PER-ROW (grouped branch needs bits<=4; ebits={a.ebits} disables it)" if a.group_size else "per-row")
-    print(f"[PLAN] mode: {mode} | source: {'local ' + a.indir if a.indir else 'download ' + a.repo} | "
+    print(f"[PLAN] mode: {mode} | source: {source_label(a)} | "
           f"experts {a.ebits}-bit, embed/lm_head {a.io_bits}-bit, x {a.xbits}-bit | {grp}")
 
     if a.selftest_nvfp4:


### PR DESCRIPTION
## What

- let `--selftest` and `--selftest-nvfp4` run without a dummy `--repo` or
  `--indir`
- preserve the existing resolved-plan output with an explicit `selftest`
  source label
- reject a normal conversion that supplies neither source
- add a regression test for the standalone selftest CLI contract

## Why

The converter dereferenced `a.repo` while printing its plan before entering the
selftest branch. The documented command:

```bash
python3 tools/convert_fp8_to_int4.py --selftest-nvfp4
```

therefore failed with `TypeError` instead of testing the NVFP4 decoder.

This was found while starting a full GLM-5.2 NVFP4 to fmt=6/E8 conversion.
After the fix, the real-host selftest passes with an exact NVFP4 round trip.

## Validation

- `python3 -m pytest -q c/tests/test_int3_convert.py`: 3 passed
- `make -C c test`: 227 passed, 10 skipped
- real host `--selftest-nvfp4`: max round-trip error 0, selftest OK
