### PR TITLE
serve: trigger Claude Code system-role fallback

### DIFF
--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -745,7 +745,7 @@ def anthropic_to_openai(body):
             raise APIError(400, "Each message must be an object.", f"messages.{index}")
         role = message.get("role")
         if role not in ("user", "assistant"):
-            raise APIError(400, f"Unsupported message role: {role!r}. Anthropic messages are "
+            raise APIError(400, f"Input message role {role!r} is not supported. Anthropic messages are "
                            "`user` or `assistant`; a system prompt goes in the top-level `system`.",
                            f"messages.{index}.role", "unsupported_role")
         content = message.get("content")

--- a/c/tests/test_anthropic_messages.py
+++ b/c/tests/test_anthropic_messages.py
@@ -11,6 +11,7 @@ is the reference client from the issue — not merely that the handler returns 2
   - the Anthropic error envelope, which is not the OpenAI one.
 """
 import json
+import re
 import threading
 import unittest
 from urllib.error import HTTPError
@@ -102,10 +103,15 @@ class TranslationTest(unittest.TestCase):
         self.assertEqual(anthropic_tools({"tool_choice": {"type": "any"}})[1], "required")
         self.assertEqual(anthropic_tools({"tool_choice": {"type": "auto"}})[1], "auto")
 
-    def test_rejects_system_role_in_messages(self):
+    def test_system_role_rejection_triggers_claude_code_fallback(self):
         with self.assertRaises(APIError) as caught:
             anthropic_to_openai({"messages": [{"role": "system", "content": "no"}]})
-        self.assertIn("system", caught.exception.message)
+        error = caught.exception
+        self.assertEqual(error.status, 400)
+        # Claude Code 2.1.212 retries without its model-gated mid-conversation
+        # system turn only when the upstream rejection matches this contract.
+        self.assertIn("not supported", error.message)
+        self.assertRegex(error.message, re.compile(r"role .{0,2}system", re.IGNORECASE))
 
 
 class MessagesHTTPTest(unittest.TestCase):


### PR DESCRIPTION
## What changed

- Reword the Anthropic Messages API rejection for a mid-conversation `system` role so Claude Code recognizes that the role is not supported.
- Strengthen the regression test to cover the fallback-detection contract: HTTP 400, `not supported`, and a matcher-compatible `role … system` phrase.

## Root cause

Claude Code may send a model-gated mid-conversation `system` message to a custom Anthropic-compatible gateway. When the gateway rejects that role with a recognized 400 error, Claude Code retries using only supported `user` and `assistant` messages.

Colibri returned the correct 400 and error type, but its wording did not match Claude Code’s fallback detector: `Unsupported` did not contain `not supported`, and `role: 'system'` put too many characters between `role` and `system` for the client matcher. The client therefore surfaced the error instead of retrying.

The behavior was reproduced against Claude Code 2.1.212. A sanitized request-shape capture confirmed the first request contained a mid-conversation `system` turn, and the revised error caused a second request containing only supported roles.

## Impact

Claude Code can recover automatically when used with `coli serve`, while Colibri continues to enforce the Anthropic message-role contract.

## Validation

- `python3 -m unittest tests.test_openai_server tests.test_anthropic_messages`
- 126 tests passed on a branch rooted directly at current `dev`

This PR changes only `c/openai_server.py` and `c/tests/test_anthropic_messages.py`; it contains no Metal backend changes.