### PR TITLE
fix(cli): no invented model path — say what is missing instead (#724)

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -1034,6 +1034,11 @@ def cmd_bench(a):
 
 def cmd_convert(a):
     banner("convert")
+    # here --model is the DESTINATION the converted weights are written to, not an
+    # existing snapshot, so it needs its own wording rather than need_model's.
+    if not a.model:
+        sys.exit(f"{C.yel}no output directory given.{C.r}\n"
+                 f"  --model <dir> is where the converted model is written")
     # python con torch/safetensors: l'ambiente del progetto se c'e', altrimenti quello corrente
     venv_py = os.path.join(HERE, "mio_env", "Scripts" if sys.platform == "win32" else "bin", "python3")
     py = venv_py if os.path.exists(venv_py) else sys.executable

--- a/c/coli
+++ b/c/coli
@@ -14,7 +14,7 @@ Run GLM-5.2 (744B) locally on CPU with roughly 15-26 GB of RAM.
   coli build                build the engine
 
 Configuration through environment variables or flags (also valid after the subcommand):
-  COLI_MODEL=<dir>   model directory (default /home/vincenzo/glm52_i4)
+  COLI_MODEL=<dir>   model directory (required; or pass --model <dir>)
   COLI_MODEL_MIRROR=<dir>  second copy of the model on another drive: expert reads
                      are split across both SSDs (COLI_DISK_WEIGHTS=9,3 sets the
                      primary,mirror bandwidth ratio; default: measured at startup)
@@ -85,7 +85,11 @@ else:
     TOOLS = os.path.join(_LIBEXEC, "tools")
     sys.path.insert(0, _LIBEXEC)   # so `import resource_plan`, `doctor`, `openai_server` still resolve
 
-DEF_MODEL = os.environ.get("COLI_MODEL", "/home/vincenzo/glm52_i4")
+# No invented default: a path from whoever's machine this was written on is worse than
+# no path at all, because every downstream error then names a directory the user never
+# chose and cannot act on (#724). None here, and each command says so in its own voice.
+DEF_MODEL = os.environ.get("COLI_MODEL")
+NO_MODEL_HINT = "pass --model <dir>, or set COLI_MODEL=<dir>"
 END   = b"\x01\x01END\x01\x01\n"
 READY = b"\x01\x01READY\x01\x01\n"
 
@@ -173,6 +177,8 @@ def engine_for(model):
     return local if os.path.exists(local) else os.path.join(_LIBEXEC, name + _EXE)
 
 def need_model(model, engine=None):
+    if not model:
+        sys.exit(f"{C.yel}no model directory given.{C.r}\n  {NO_MODEL_HINT}")
     if not os.path.isdir(model):
         sys.exit(f"{C.yel}model not found:{C.r} {model}\n  set COLI_MODEL or use --model")
     if not os.path.exists(os.path.join(model,"tokenizer.json")):
@@ -529,6 +535,8 @@ def cmd_build(a):
 
 def cmd_info(a):
     banner("info")
+    if not a.model:
+        sys.exit(f"{C.yel}no model directory given.{C.r}\n  {NO_MODEL_HINT}")
     cfgp=os.path.join(a.model,"config.json")
     def row(k,v): print(f"   {C.gray}{k:<10}{C.r} {v}")
     if os.path.exists(cfgp):
@@ -562,6 +570,8 @@ def cmd_info(a):
 
 def cmd_plan(a):
     from resource_plan import build_plan, format_plan
+    if not a.model:
+        sys.exit(f"{C.yel}no model directory given.{C.r}\n  {NO_MODEL_HINT}")
     try:
         ram,ctx,devices,vram=resource_request(a,os.environ)
         if ctx<1: raise ValueError("--ctx must be positive")
@@ -579,12 +589,15 @@ def cmd_plan(a):
 def cmd_doctor(a):
     from doctor import exit_code, format_doctor, run_doctor
     try:
+        # doctor reports rather than exits, so a missing model is a failed check and not
+        # a sys.exit like everywhere else — it is exactly the thing doctor exists to say.
+        if not a.model: raise ValueError(f"no model directory given: {NO_MODEL_HINT}")
         ram,ctx,devices,vram=resource_request(a,os.environ)
         if ctx<1: raise ValueError("--ctx must be positive")
         if ram<0: raise ValueError("--ram cannot be negative")
         if vram<0: raise ValueError("--vram cannot be negative")
     except ValueError as error:
-        report={"schema_version":1,"status":"error","model":os.path.abspath(a.model),
+        report={"schema_version":1,"status":"error","model":os.path.abspath(a.model) if a.model else None,
                 "mode":"deep" if a.deep else "standard",
                 "checks":[{"id":"config.arguments","status":"fail","summary":str(error)}],
                 "plan":None}

--- a/c/doctor.py
+++ b/c/doctor.py
@@ -563,7 +563,8 @@ def run_doctor(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0, *,
 
 def format_doctor(report):
     icons = {"pass": "ok", "warn": "warn", "fail": "fail", "skip": "skip"}
-    lines = [f"colibri doctor · {report['model']}"]
+    # model is null in the JSON when none was given (#724); say that rather than "None"
+    lines = [f"colibri doctor · {report['model'] or '(no model given)'}"]
     for check in report["checks"]:
         lines.append(f"[{icons[check['status']]:>4}] {check['id']:<18} {check['summary']}")
     if report["plan"]:

--- a/c/scripts/run.sh
+++ b/c/scripts/run.sh
@@ -5,7 +5,7 @@
 #     (3) compila il motore, (4) genera testo restando nel budget RAM.
 set -euo pipefail
 
-DIR="${COLI_MODEL:-/home/vincenzo/glm52_i4}"          # modello int4 su ext4 (NON /mnt/c!)
+DIR="${COLI_MODEL:?set COLI_MODEL to the model directory (int4, on a native fs — NOT /mnt/c)}"
 REPO="${COLI_REPO:-zai-org/GLM-5.2-FP8}"
 CODE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RAM_GB="${RAM_GB:-15}"

--- a/c/scripts/supervisor.sh
+++ b/c/scripts/supervisor.sh
@@ -6,7 +6,7 @@
 #  - esce da solo quando tutti i 141 shard sono fatti
 # uso da c/:  nohup scripts/supervisor.sh > supervisor.log 2>&1 &
 set -u
-DIR="${COLI_MODEL:-/home/vincenzo/glm52_i4}"
+DIR="${COLI_MODEL:?set COLI_MODEL to the model directory}"
 CODE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TOTAL="${TOTAL_SHARDS:-141}"
 STALL_S=180          # secondi senza crescita del download -> riavvio

--- a/c/tools/convert_fp8_to_int4.py
+++ b/c/tools/convert_fp8_to_int4.py
@@ -23,7 +23,7 @@ USO:
   # selftest del dequant fp8 (richiede torch)
   python3 tools/convert_fp8_to_int4.py --selftest
   # reale: scarica+converte+cancella shard per shard
-  python3 tools/convert_fp8_to_int4.py --repo zai-org/GLM-5.2-FP8 --outdir /home/vincenzo/glm52_i4
+  python3 tools/convert_fp8_to_int4.py --repo zai-org/GLM-5.2-FP8 --outdir /path/to/glm52_i4
 """
 import os, sys, glob, json, shutil, argparse
 import numpy as np

--- a/c/tools/download_glm52.py
+++ b/c/tools/download_glm52.py
@@ -9,7 +9,7 @@ NB: i pesi sono F8_E4M3 + tensori `*.weight_scale_inv` (blocchi 128x128). Il loa
 deve supportare fp8+block-scale prima di poterli usare (vedi memoria glm52-specs).
 
 USO:
-    python3 tools/download_glm52.py            # scarica tutto in /home/vincenzo/glm52  (ripartibile)
+    GLM_DIR=/path/to/glm52 python3 tools/download_glm52.py     # scarica tutto li' (ripartibile)
     python3 tools/download_glm52.py --check    # solo stima spazio e conteggio file, niente download
 
 Lo scaricamento e' di centinaia di GB e ore: lancialo tu quando il resto e' pronto.
@@ -21,7 +21,10 @@ REPO = "zai-org/GLM-5.2-FP8"
 # Pin the model revision for supply-chain integrity: set GLM_REVISION to a commit SHA
 # so a mutated/compromised upstream can't silently swap the weights you fetch.
 REVISION = os.environ.get("GLM_REVISION", "main")
-DEST = os.environ.get("GLM_DIR", "/home/vincenzo/glm52")   # su ext4 (/dev/sdd), MAI su /mnt/c
+# No default: this writes ~400 GB, so it must land where the user chose and never on a
+# path inherited from whoever wrote the script (#724). Put it on a native filesystem —
+# on WSL that means NOT /mnt/c.
+DEST = os.environ.get("GLM_DIR")
 
 def human(n): return f"{n/1e9:.0f} GB"
 
@@ -51,6 +54,9 @@ def download():
     print("DONE. Weights saved in:", DEST)
 
 if __name__ == "__main__":
+    if not DEST:
+        sys.exit("set GLM_DIR to the destination directory, e.g.\n"
+                 "  GLM_DIR=/data/glm52 python3 tools/download_glm52.py")
     if "--check" in sys.argv:
         check()
     else:

--- a/c/tools/eval_glm.py
+++ b/c/tools/eval_glm.py
@@ -15,12 +15,12 @@ USO:
   # 1) (una volta, quando hai rete) scarica i benchmark in ./bench/*.jsonl
   python3 tools/fetch_benchmarks.py --out ./bench --tasks hellaswag,arc_challenge,mmlu --limit 200
   # 2) plumbing test della meccanica (senza motore):
-  python3 tools/eval_glm.py --snap /home/vincenzo/glm52_i4 --data ./bench --tasks smoke --dry
+  python3 tools/eval_glm.py --snap /path/to/glm52_i4 --data ./bench --tasks smoke --dry
   # 3) validazione vera quando il modello e' pronto:
-  python3 tools/eval_glm.py --snap /home/vincenzo/glm52_i4 --data ./bench \
+  python3 tools/eval_glm.py --snap /path/to/glm52_i4 --data ./bench \
                       --tasks hellaswag,arc_challenge,mmlu --limit 40 --ram 15
   # leve di ricerca: passate al motore via env
-  TOPP=0.9 python3 tools/eval_glm.py --snap /home/vincenzo/glm52_i4 --data ./bench --tasks mmlu --ram 15
+  TOPP=0.9 python3 tools/eval_glm.py --snap /path/to/glm52_i4 --data ./bench --tasks mmlu --ram 15
 """
 import os, sys, subprocess, argparse, random, json, tempfile, time, threading
 

--- a/c/tools/fetch_benchmarks.py
+++ b/c/tools/fetch_benchmarks.py
@@ -6,7 +6,7 @@ Richiede `datasets`:  pip install --break-system-packages datasets   (o in una v
 USO:
   python3 tools/fetch_benchmarks.py --out ./bench --tasks hellaswag,arc_challenge,arc_easy,mmlu,winogrande,piqa,openbookqa --limit 300
 Poi:
-  python3 tools/eval_glm.py --snap /home/vincenzo/glm52_i4 --data ./bench --tasks mmlu --limit 40 --ram 15
+  python3 tools/eval_glm.py --snap /path/to/glm52_i4 --data ./bench --tasks mmlu --limit 40 --ram 15
 """
 import os, sys, json, time, argparse, random
 


### PR DESCRIPTION
Fixes #724.

`DEF_MODEL` defaulted to `/home/vincenzo/glm52_i4`, so every error named a directory from someone
else's machine. There is no default now — `plan`, `info` and `need_model` say
`no model directory given` and how to fix it, and `doctor` reports it as a failed check instead of
exiting, since reporting is what doctor is for.

Same class, fixed with it: `tools/download_glm52.py` defaulted a **400 GB** download to that path
(`GLM_DIR` is now required), the two `scripts/*.sh` use `${COLI_MODEL:?…}`, and four tools printed
`/home/vincenzo/…` in their usage examples. `grep -rn vincenzo c/` is now empty.

Tested with and without a model directory; `doctor --json` against a real model is byte-identical
to `dev` apart from its live `available_bytes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
