### PR TITLE
build: derive TEST_BINS by wildcard — stop manufacturing Makefile conflicts

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -214,7 +214,20 @@ else
 PYTHON    ?= python3
 endif
 CUDA_OBJ  =
-TEST_BINS = tests/test_json$(EXE) tests/test_st$(EXE) tests/test_st_mirror$(EXE) tests/test_st_pread$(EXE) tests/test_tier$(EXE) tests/test_grammar$(EXE) tests/test_schema_gbnf$(EXE) tests/test_decode_batch$(EXE) tests/test_idot$(EXE) tests/test_i4_grouped$(EXE) tests/test_stops$(EXE) tests/test_topp$(EXE) tests/test_sample_nan$(EXE) tests/test_temp_env$(EXE) tests/test_tok_o200k$(EXE) tests/test_kv_alloc$(EXE) tests/test_int3$(EXE) tests/test_int3_load$(EXE) tests/test_i4_acc512$(EXE) tests/test_compat_direct$(EXE) tests/test_dsa_select$(EXE) tests/test_logit_nan$(EXE) tests/test_router_nan$(EXE) tests/test_pipe_block$(EXE) tests/test_e8_kernel$(EXE) tests/test_rans$(EXE) tests/test_corpus_draft$(EXE) tests/test_pilot_ring$(EXE)
+# Gates: every tests/test_*.c that has a build rule further down. Derived with a
+# wildcard rather than hand-listed, because TEST_BINS used to be ONE long shared line:
+# any two PRs that each added a test conflicted in the Makefile by construction, even
+# when they touched entirely unrelated code. #386 hit exactly that twice while being
+# rebased. Adding a gate now means adding your .c plus its own rule below -- nobody
+# edits a line somebody else is also editing.
+#
+# TEST_EXCLUDE is for test_*.c that are deliberately NOT default gates:
+#   test_uring      Linux-only, appended conditionally just below
+#   test_vk_mxfp4   needs a Vulkan build (VK=1) to link the backend
+#   test_fse, test_tok, test_tok_kimi   no build rule below; never were gates
+TEST_EXCLUDE = test_uring test_vk_mxfp4 test_fse test_tok test_tok_kimi
+TEST_NAMES   = $(filter-out $(TEST_EXCLUDE),$(basename $(notdir $(wildcard tests/test_*.c))))
+TEST_BINS    = $(addprefix tests/,$(addsuffix $(EXE),$(TEST_NAMES)))
 ifneq (,$(LINUX))
 TEST_BINS += tests/test_uring$(EXE)
 endif


### PR DESCRIPTION
A structural fix for the rebase churn, not a cleanup.

## The problem

`TEST_BINS` was a single shared line listing 28 test gates. Every PR that adds a test appended to **that same line**, so any two such PRs conflicted in `c/Makefile` **by construction** — even when they touched completely unrelated parts of the engine.

This is measurable rather than theoretical: **`c/Makefile` appears in 26 of the 40 currently open PRs.** And #386 hit this exact conflict twice while being rebased:

> *"One conflict (both sides appended a test binary to `TEST_BINS`)"*

Every one of those rebases was real work by a contributor, caused by a line that did not need to be shared.

## The fix

Derive the list with a wildcard. Adding a gate now means adding your `tests/test_*.c` and its own build rule — those land in different places in the file, so they do not collide.

`TEST_EXCLUDE` holds the ones that are deliberately not default gates, each with its reason in a comment:

- `test_uring` — Linux-only, appended conditionally just below. A bare wildcard would have promoted it to every platform; this is the behaviour change the exclusion prevents.
- `test_vk_mxfp4` — needs a Vulkan build (`VK=1`) to link the backend.
- `test_fse`, `test_tok`, `test_tok_kimi` — no build rule in the Makefile; never were gates.

## Verification

- **The derived set is identical to the hand-written one**: 29 entries including `test_uring` on Linux, same names. Compared by rendering `$(TEST_BINS)` from both the old and new Makefile and diffing — no differences.
- `make test-c` passes.
- A freshly created `tests/test_zz_probe.c` is picked up automatically, without touching any shared line.

One file, build system only. No engine code, no behaviour change.