### PR TITLE
build: derive TEST_BINS from the build rules, not the .c files (corrects #731)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -216,20 +216,20 @@ else
 PYTHON    ?= python3
 endif
 CUDA_OBJ  =
-# Gates: every tests/test_*.c that has a build rule further down. Derived with a
-# wildcard rather than hand-listed, because TEST_BINS used to be ONE long shared line:
-# any two PRs that each added a test conflicted in the Makefile by construction, even
-# when they touched entirely unrelated code. #386 hit exactly that twice while being
-# rebased. Adding a gate now means adding your .c plus its own rule below -- nobody
-# edits a line somebody else is also editing.
+# Gates are exactly the tests that have a build rule further down -- derived from those
+# rules, so adding a gate means adding your tests/test_*.c and its rule, and nothing else.
+# There is no shared list to conflict on.
 #
-# TEST_EXCLUDE is for test_*.c that are deliberately NOT default gates:
-#   test_uring      Linux-only, appended conditionally just below
-#   test_vk_mxfp4   needs a Vulkan build (VK=1) to link the backend
-#   test_fse, test_tok, test_tok_kimi   no build rule below; never were gates
-TEST_EXCLUDE = test_uring test_vk_mxfp4 test_fse test_tok test_tok_kimi
-TEST_NAMES   = $(filter-out $(TEST_EXCLUDE),$(basename $(notdir $(wildcard tests/test_*.c))))
-TEST_BINS    = $(addprefix tests/,$(addsuffix $(EXE),$(TEST_NAMES)))
+# This replaced a single hand-written TEST_BINS line. c/Makefile appears in most open PRs,
+# and any two that each added a test conflicted on that line by construction; #386 hit it
+# twice while being rebased. A first attempt (#731) globbed tests/test_*.c, which was wrong
+# in the other direction: it promoted files that deliberately have no rule (a branch's
+# work-in-progress test, test_fse, test_tok, test_tok_kimi, test_vk_mxfp4) into gates, and
+# they fail to link. Having a rule is the honest definition of "this is a gate".
+TEST_RULES  := $(shell sed -n 's|^tests/\(test_[a-z0-9_]*\)\$$(EXE):.*|\1|p' $(firstword $(MAKEFILE_LIST)))
+# test_uring has a rule but is Linux-only; it is appended conditionally just below.
+TEST_EXCLUDE = test_uring
+TEST_BINS    = $(addprefix tests/,$(addsuffix $(EXE),$(filter-out $(TEST_EXCLUDE),$(TEST_RULES))))
 ifneq (,$(LINUX))
 TEST_BINS += tests/test_uring$(EXE)
 endif


### PR DESCRIPTION
Correction to #731, found by merging `dev` into a real contributor branch rather than by reasoning about it.

## What #731 got wrong

#731 replaced the hand-written `TEST_BINS` line with a glob of `tests/test_*.c`. That was wrong in the opposite direction from the list it replaced: it promotes **any** `test_*.c` file into a gate, including ones that deliberately have no build rule.

On `dev` the four such files were known and excluded by name, so the resulting set was identical and the mistake was invisible. On a contributor branch it is not. Merging `dev` into #529 promoted that branch's `tests/test_fp8_e2e_loader.c` — a file @monotophic has but never gated — and the build failed:

```
test_fp8_e2e_loader.c:(.text+0x4c5cd): undefined reference to `sqrtf'
collect2: error: ld returned 1 exit status
```

Every future branch carrying an un-wired test would have hit the same thing at merge time.

## The fix

**Having a build rule is the honest definition of a gate**, so derive the list from the rules instead of from the files. `TEST_EXCLUDE` drops from five entries to one — `test_uring`, which has a rule but is Linux-only and is appended conditionally just below.

The property that motivated all of this is unchanged and now stronger: adding a gate means adding your `.c` and its own rule, which land in different places in the file. **There is no shared list left to conflict on at all.**

## Verification

- Identical to current `dev`: 31 entries, same names.
- `make test-c` green.
- Re-ran the #529 merge with this in place: 34 gates — @monotophic's `test_fp8_load`, `test_fp8_passthrough` and `test_qt_addrow` all included (they have rules), and `test_fp8_e2e_loader` correctly left out.

One file, build system only.