### PR TITLE
fix(test): resolve the temp root so test_mirror_plan passes on macOS (dev is red)

### DIFF
--- a/c/tests/test_mirror_plan.py
+++ b/c/tests/test_mirror_plan.py
@@ -12,7 +12,11 @@ from tools.mirror_plan import (RECEIPT, MirrorError, create_plan, discover_shard
 class MirrorPlannerTest(unittest.TestCase):
     def setUp(self):
         self.temporary = tempfile.TemporaryDirectory()
-        self.root = Path(self.temporary.name)
+        # .resolve(): on macOS /var is a symlink to /private/var, so mkdtemp hands
+        # back /var/folders/... while mirror_plan resolves every path it is given
+        # (discover_shards, create_plan). Comparing a resolved path from the tool
+        # against an unresolved one built here fails on macOS and passes on Linux.
+        self.root = Path(self.temporary.name).resolve()
         self.model = self.root / "model"
         self.mirror = self.root / "mirror"
         self.split = self.root / "split"


### PR DESCRIPTION
`dev` is currently red on **macOS only**, in the test that arrived with #536:

```
AssertionError: PosixPath("/private/var/folders/.../same.safetensors")
            != PosixPath("/var/folders/.../same.safetensors")
```

## Cause

On macOS `/var` is a symlink to `/private/var`. `tempfile.TemporaryDirectory()` hands back `/var/folders/...`, while `mirror_plan.py` resolves every path it is given — `discover_shards` (line 115) and `create_plan` (lines 197–199). The test then compared a **resolved** path returned by the tool against an **unresolved** one it had built itself.

Linux has no such symlink, so the two are identical there and the test passes — including in the run I did before merging #536, which is how this reached `dev`.

## Fix

Resolve the temp root once in `setUp`, so every path derived from it is resolved and both sides of every assertion match on every platform. **Test-only** — `mirror_plan.py` is not touched.

## Verification

Reproduced the macOS condition on Linux by creating a symlinked temp directory and running `discover_shards` through it:

```
  tool returns    : /tmp/real_xxx/model/a.safetensors
  old comparison  : /tmp/real_xxx_link/model/a.safetensors  -> FAILS
  new comparison  : /tmp/real_xxx/model/a.safetensors       -> PASSES
```

Plus the suite itself: 8 passed.