### PR TITLE
fix(win): inkling and kimi_k3 build on Windows; CI covers every engine on every release platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,55 @@ jobs:
       - name: C test suite
         run: cd c && make test-c
 
+  # Every engine, on every platform a release archive is built for. Before this,
+  # CI built colibri + inkling on Linux only and kimi_k3 on nothing -- so the fact
+  # that inkling and kimi_k3 did not compile under msys2/UCRT64 at all was invisible
+  # for months, and binary releases silently shipped the GLM engine alone (#720).
+  # Each engine is built separately so one failure does not mask the others.
+  engines-all-platforms:
+    name: All engines (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            name: linux
+            shell: bash
+          - os: macos-latest
+            name: macos
+            shell: bash
+          - os: windows-latest
+            name: windows
+            # GitHub shells are format strings: 'msys2 {0}', never bare 'msys2'.
+            shell: "msys2 {0}"
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+    steps:
+      - uses: actions/checkout@v4
+      - if: matrix.os == 'windows-latest'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: false
+          path-type: inherit
+          install: >-
+            make
+            mingw-w64-ucrt-x86_64-gcc
+      - if: matrix.os == 'macos-latest'
+        run: brew install libomp
+      - name: Build every engine
+        run: |
+          cd c
+          rc=0
+          for t in colibri inkling kimi_k3 olmoe; do
+            echo "::group::$t"
+            make $t || { echo "FAILED: $t"; rc=1; }
+            echo "::endgroup::"
+          done
+          exit $rc
+
   engine-cuda-syntax:
     name: CUDA syntax check
     runs-on: ubuntu-latest

--- a/c/compat.h
+++ b/c/compat.h
@@ -1,8 +1,13 @@
 /* compat.h — shim di portabilita' per piattaforme non-Linux (oggi: macOS / Apple Silicon,
  * Windows 11 x86-64 via MinGW-w64).
- * Su Linux questo header e' un NO-OP totale: nessun simbolo definito o ridefinito,
- * zero impatto sul percorso x86 esistente.
- * Regola: ogni differenza di piattaforma vive QUI; i .c restano puliti. */
+ * Regola: ogni differenza di piattaforma vive QUI; i .c restano puliti.
+ *
+ * Storicamente su Linux questo header era un NO-OP totale (solo shim per le altre
+ * piattaforme). Non lo e' piu': coli_stdin_readable() definisce anche il ramo POSIX,
+ * perche' un helper *portabile* deve esistere su tutte le piattaforme -- altrimenti i
+ * .c dovrebbero avere il proprio #ifdef, che e' esattamente cio' che la regola vieta.
+ * Resta vero che il percorso Linux non e' alterato: nulla viene ridefinito, e la
+ * funzione e' static inline, quindi un TU che non la chiama non paga nulla. */
 #ifndef COMPAT_H
 #define COMPAT_H
 
@@ -10,9 +15,6 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/types.h>
-#ifndef _WIN32
-#include <sys/select.h>   /* select(), fd_set, struct timeval per coli_stdin_readable */
-#endif
 
 /* --- posix_fadvise: assente su macOS ---
  * WILLNEED -> F_RDADVISE (readahead esplicito: stessa semantica).
@@ -392,6 +394,10 @@ static inline char *compat_mkdtemp(char *tmpl){
  * dove nessuno li avrebbe cercati: sta qui una volta sola.
  *
  * static inline: e' un header condiviso, e un TU che non la usa non deve pagarla. */
+#ifndef _WIN32
+#include <sys/select.h>   /* select(), fd_set, struct timeval */
+#endif
+
 #ifdef _WIN32
 static inline int coli_stdin_readable(void)
 {
@@ -404,10 +410,11 @@ static inline int coli_stdin_readable(void)
 #else
 static inline int coli_stdin_readable(void)
 {
+    /* fd 0 letterale, non STDIN_FILENO: quella macro vive in <unistd.h>, che questo
+     * header non include su tutte le piattaforme, e stdin e' 0 ovunque per POSIX. */
     fd_set r; struct timeval tv = {0, 0};
-    FD_ZERO(&r); FD_SET(STDIN_FILENO, &r);
-    return select(STDIN_FILENO + 1, &r, NULL, NULL, &tv) > 0
-           && FD_ISSET(STDIN_FILENO, &r);
+    FD_ZERO(&r); FD_SET(0, &r);
+    return select(1, &r, NULL, NULL, &tv) > 0 && FD_ISSET(0, &r);
 }
 #endif
 

--- a/c/compat.h
+++ b/c/compat.h
@@ -10,6 +10,9 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/types.h>
+#ifndef _WIN32
+#include <sys/select.h>   /* select(), fd_set, struct timeval per coli_stdin_readable */
+#endif
 
 /* --- posix_fadvise: assente su macOS ---
  * WILLNEED -> F_RDADVISE (readahead esplicito: stessa semantica).
@@ -369,6 +372,43 @@ static inline char *compat_mkdtemp(char *tmpl){
 /* --- COMPAT_O_RDONLY: O_RDONLY con O_BINARY su Windows, O_RDONLY puro altrove --- */
 #ifndef COMPAT_O_RDONLY
 #define COMPAT_O_RDONLY O_RDONLY
+#endif
+
+/* --- coli_stdin_readable: "c'e' input su stdin adesso?", senza bloccare ---
+ *
+ * I serve loop di inkling.c e kimi_k3.c usavano select() su fd_set direttamente.
+ * Su Windows quei simboli non esistono in quella forma e le due build FALLIVANO
+ * (misurato: Linux ok, macOS ok, Windows/UCRT64 no) -- ed e' il motivo per cui
+ * le release binarie hanno sempre contenuto il solo motore GLM.
+ *
+ * La logica Windows non e' una traduzione meccanica: ha assorbito due bug.
+ *   #139  select() su un handle di pipe finisce in winsock e ritorna sempre
+ *         SOCKET_ERROR, quindi il loop non accettava mai una richiesta.
+ *   #195  le pipe anonime NON sono oggetti attendibili: WaitForSingleObject su
+ *         di esse e' undefined, e PeekNamedPipe fallisce su handle di file o
+ *         console. Su stdin non-pipe si riporta "niente da leggere" invece di
+ *         bloccare il loop.
+ * Duplicarla una terza volta avrebbe rifatto entrare quei due bug in due motori
+ * dove nessuno li avrebbe cercati: sta qui una volta sola.
+ *
+ * static inline: e' un header condiviso, e un TU che non la usa non deve pagarla. */
+#ifdef _WIN32
+static inline int coli_stdin_readable(void)
+{
+    HANDLE ih = (HANDLE)_get_osfhandle(_fileno(stdin));
+    DWORD avail = 0;
+    if (ih == INVALID_HANDLE_VALUE) return 0;
+    if (PeekNamedPipe(ih, NULL, 0, NULL, &avail, NULL)) return avail > 0;
+    return 0;   /* console/file: nessun poll non bloccante, meglio "niente" che bloccare */
+}
+#else
+static inline int coli_stdin_readable(void)
+{
+    fd_set r; struct timeval tv = {0, 0};
+    FD_ZERO(&r); FD_SET(STDIN_FILENO, &r);
+    return select(STDIN_FILENO + 1, &r, NULL, NULL, &tv) > 0
+           && FD_ISSET(STDIN_FILENO, &r);
+}
 #endif
 
 #endif /* COMPAT_H */

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -1393,9 +1393,9 @@ typedef struct { char id[64]; int max_tok; float temp, top_p; char *payload; int
 static SReq g_q[SRV_QMAX]; static int g_qn = 0;
 
 static int stdin_readable(void) {
-    fd_set r; struct timeval tv = {0, 0};
-    FD_ZERO(&r); FD_SET(0, &r);
-    return select(1, &r, NULL, NULL, &tv) > 0;
+    /* Windows non ha fd_set/select in questa forma: la build falliva del tutto.
+     * La versione portabile (con i fix #139/#195) vive in compat.h, incluso via st.h. */
+    return coli_stdin_readable();
 }
 
 /* read one control line (+ payload for SUBMIT). cur_id: request in flight;

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -1430,9 +1430,9 @@ static void model_state_reset(Model *m){
 }
 
 static int serve_stdin_readable(void){
-    fd_set r; struct timeval tv={0,0};
-    FD_ZERO(&r); FD_SET(0,&r);
-    return select(1,&r,NULL,NULL,&tv)>0;
+    /* Windows non ha fd_set/select in questa forma: la build falliva del tutto.
+     * La versione portabile (con i fix #139/#195) vive in compat.h, incluso via st.h. */
+    return coli_stdin_readable();
 }
 
 static int serve_read_req(ServeReq *q, const char *active){


### PR DESCRIPTION
Fixes the real blocker behind #720, and closes the hole that let it happen.

## The bug

`inkling` and `kimi_k3` **do not compile on Windows at all**. Their serve loops poll stdin with `fd_set`/`select` directly, which msys2/UCRT64 does not provide in that form:

```
inkling.c:1396: error: unknown type name ‘fd_set’
kimi_k3.c:1431: error: unknown type name ‘fd_set’
```

Measured across the release matrix before this change:

| | Linux | macOS arm64 | Windows |
|---|:---:|:---:|:---:|
| `colibri`, `olmoe` | ✅ | ✅ | ✅ |
| `inkling`, `kimi_k3` | ✅ | ✅ | ❌ |

This is why binary releases have only ever contained the GLM engine. @MichaelFomenko downloaded v1.3.0, pointed it at Kimi K3, and there was no engine to run — while the README promises four model families on the front page.

## The fix

`colibri.c` already solved this, and its Windows path is not a mechanical translation — it absorbed two bugs:

- **#139** — `select()` on a pipe handle routes to winsock and always returns `SOCKET_ERROR`, so the batch loop never accepted a request.
- **#195** — anonymous pipes are **not** waitable objects (`WaitForSingleObject` on them is undefined), and `PeekNamedPipe` fails on file/console handles.

Copying that a third and fourth time would have reintroduced both in engines where nobody would go looking. So it moves to `compat.h` as `coli_stdin_readable()` — already reachable from both engines through `st.h`, so no new include plumbing.

The engines keep their own function names and call sites; only the three-line body changes.

**`colibri.c` is deliberately not refactored onto the shared helper.** It works today, **14 open PRs touch that file**, and the churn would cost contributors a rebase for no functional gain. It can adopt the helper later, when the queue is drained.

## The hole that allowed this

CI built `colibri` + `inkling` on **Linux only**, and `kimi_k3` on **nothing**. A whole engine could stop compiling on two platforms and nothing would say so.

This adds `engines-all-platforms`: every engine, on Linux + macOS + Windows, the exact matrix release archives are built for. Each engine builds separately so one failure does not mask the others.

## Scope

`c/compat.h`, `c/inkling.c`, `c/kimi_k3.c`, `.github/workflows/ci.yml`. Chosen deliberately: `inkling.c` is touched by **0** open PRs and `kimi_k3.c`/`compat.h`/`ci.yml` by **1** each, so this lands without costing anyone a rebase.

All four engines build on Linux with the change; the Windows half is what this PR’s own CI run is there to prove.