### PR TITLE
feat(release): ship every engine in the archives, not just GLM (closes #720)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,17 @@ jobs:
       - if: matrix.os == 'macos-latest'
         run: brew install libomp
 
-      - name: Build engine
+      # Every engine, not just GLM. Until now the archives shipped `colibri` alone,
+      # so a user who downloaded a release and pointed it at Kimi K3 or Inkling found
+      # no engine at all (#720) -- while the README's front page promises four model
+      # families. CI (engines-all-platforms) proves all four build on this matrix.
+      - name: Build engines
         run: |
           cd c
-          make colibri ${{ matrix.make_args }}
-          ls -lh colibri${{ matrix.ext }}
+          for t in colibri inkling kimi_k3 olmoe; do
+            make $t ${{ matrix.make_args }}
+          done
+          ls -lh colibri${{ matrix.ext }} inkling${{ matrix.ext }} kimi_k3${{ matrix.ext }} olmoe${{ matrix.ext }}
 
       - uses: actions/setup-node@v4
         with:
@@ -85,6 +91,17 @@ jobs:
           # "engine is not built. Run: coli build" -- with the engine sitting right there.
           # The version lives in the ARCHIVE name, which is where a downloader looks for it.
           cp c/colibri${{ matrix.ext }} dist/colibri${{ matrix.ext }}
+          # The sibling engines go in under their plain names too: `coli` resolves the
+          # engine from the model's config.json and looks for kimi_k3/inkling next to
+          # itself (c/coli, engine_for()). ~830 KB for all four.
+          cp c/inkling${{ matrix.ext }} dist/inkling${{ matrix.ext }}
+          cp c/kimi_k3${{ matrix.ext }} dist/kimi_k3${{ matrix.ext }}
+          cp c/olmoe${{ matrix.ext }} dist/olmoe${{ matrix.ext }}
+          # Kimi K3 ships tiktoken.model, not tokenizer.json; k3_tokenizer.py synthesizes
+          # it. Without this the engine is in the archive but `coli chat` still cannot
+          # run it -- the second half of #720.
+          mkdir -p dist/tools
+          cp c/tools/k3_tokenizer.py dist/tools/
           cp c/coli dist/
           cp c/version.py dist/
           cp c/openai_server.py dist/
@@ -116,6 +133,27 @@ jobs:
             tar xzf ../dist/colibri-${TAG}-${{ matrix.name }}.tar.gz
           fi
           test -x colibri${{ matrix.ext }} || { echo "engine missing from archive"; ls -la; exit 1; }
+          # The sibling engines, asserted the same way. #720 was exactly this failure:
+          # a green build, green tests, and an archive with no engine for the model the
+          # user actually had. Presence is not enough -- assert they are executable, and
+          # that the launcher's own resolver finds them where it looks (next to coli).
+          for e in inkling kimi_k3 olmoe; do
+            test -x $e${{ matrix.ext }} || { echo "FAIL: $e missing from archive"; ls -la; exit 1; }
+          done
+          # Kimi K3 needs tokenizer.json synthesized from tiktoken.model; without this
+          # script in the archive the engine ships but cannot be driven by coli chat.
+          test -f tools/k3_tokenizer.py || { echo "FAIL: k3_tokenizer.py missing from archive"; exit 1; }
+          python3 -c "import ast,sys; ast.parse(open('tools/k3_tokenizer.py').read())" \
+            || { echo "FAIL: packaged k3_tokenizer.py does not parse"; exit 1; }
+          python3 - <<'PYCHK'
+          import os, sys
+          exe = ".exe" if os.name == "nt" else ""
+          missing = [n for n in ("inkling", "kimi_k3", "olmoe")
+                     if not os.path.exists(os.path.join(".", n + exe))]
+          if missing:
+              sys.exit("FAIL: coli would not resolve these next to itself: " + ", ".join(missing))
+          print("OK: every engine is where coli's engine_for() looks for it")
+          PYCHK
           out=$(python3 coli info 2>&1 || true)
           echo "$out"
           case "$out" in


### PR DESCRIPTION
Binary releases have only ever contained `c/colibri`. @MichaelFomenko downloaded v1.3.0, pointed it at Kimi K3, and there was no engine to run — while the README front page promises four model families. **Nothing he could have typed would have worked.**

## What changes

Build and package all four engines, plus `tools/k3_tokenizer.py`.

Kimi K3 ships `tiktoken.model` rather than `tokenizer.json`, and that script synthesizes it. Without it the engine would be in the archive and `coli chat` still could not drive it — the second half of the same issue.

**No launcher change is needed.** `engine_for()` in `c/coli` already resolves the engine from the model's `config.json` and looks for `kimi_k3`/`inkling` next to itself, which is exactly the layout an archive has.

**Cost: 863 KB** for all four — `colibri` 423K, `kimi_k3` 179K, `inkling` 154K, `olmoe` 128K.

## The verification step is extended, not trusted

That step exists because a packaging mistake is invisible to every other job in this repo: the build is green, the tests are green, and the artifact is unusable. It already unpacked the published archive and asserted `coli` finds the engine. It now also asserts:

- the three sibling engines are present **and executable**
- `tools/k3_tokenizer.py` is packaged **and parses**
- each engine sits where the launcher's own resolver looks for it

## Why this is safe now and was not before

CI proves all four engines build on Linux, macOS and Windows (`engines-all-platforms`, added with the Windows serve-loop fix). **Before that, `inkling` and `kimi_k3` did not compile on Windows at all** — packaging them would have produced a broken release rather than a fixed one.

Simulated the archive layout locally: all four executables present, tokenizer script valid, 863 KB total.

Workflow file only. Touched by 2 open PRs, so this lands without costing anyone a rebase.