### PR TITLE
feat(omp): size the OpenMP team by physical cores on kimi_k3 and olmoe (#718)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -458,13 +458,13 @@ cuda-bench: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/bench_tens
 	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/bench_tensor_core.cu -o backend_cuda_bench$(EXE) $(ANS_NVCC_LIBS)
 	./backend_cuda_bench$(EXE)
 
-olmoe$(EXE): olmoe.c st.h json.h compat.h sample.h tok.h tok_unicode.h tok_unicode_o200k.h
+olmoe$(EXE): olmoe.c st.h json.h compat.h sample.h tok.h tok_unicode.h tok_unicode_o200k.h omp_tune.h
 	$(CC) $(CFLAGS) olmoe.c -o olmoe$(EXE) $(LDFLAGS)
 
 inkling$(EXE): inkling.c st.h json.h compat.h $(INK_CUDA_OBJ)
 	$(CC) $(CFLAGS) inkling.c $(INK_CUDA_OBJ) -o inkling$(EXE) $(LDFLAGS)
 
-kimi_k3$(EXE): kimi_k3.c st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h route_trace.h $(VK_OBJ) $(VK_SPV)
+kimi_k3$(EXE): kimi_k3.c st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h omp_tune.h route_trace.h $(VK_OBJ) $(VK_SPV)
 	$(CC) $(CFLAGS) kimi_k3.c $(VK_OBJ) -o kimi_k3$(EXE) $(LDFLAGS)
 
 # Use a baseline that matches the compiler target. macOS already targets a

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -80,6 +80,7 @@
 #include "st.h"
 #include "tok.h"
 #include "quant.h"
+#include "omp_tune.h"
 #include "route_trace.h"                 /* shared routing telemetry (#700) */
 
 /* ---------- config ---------- */
@@ -1564,6 +1565,7 @@ static void serve_loop(Model *m, Tok *T){
 }
 
 int main(int argc, char **argv){
+    coli_omp_tune_threads("kimi_k3");   /* squadra sui core fisici, niente spin-wait: vedi omp_tune.h */
     int serving=getenv("SERVE")&&getenv("SERVE")[0]=='1';
     if(!serving&&argc<2){
         fprintf(stderr,"usage: %s <model_dir> [prompt] [--ids \"1 2 3\"] [--ngen N]\n",argv[0]);

--- a/c/olmoe.c
+++ b/c/olmoe.c
@@ -32,6 +32,10 @@
 #include <unistd.h>
 #endif
 #include "st.h"
+#ifdef _OPENMP
+#include <omp.h>   /* omp_set_num_threads/omp_get_max_threads per omp_tune.h */
+#endif
+#include "omp_tune.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -1085,6 +1089,7 @@ static int *read_int_array(jval *o, const char *key, int *n_out) {
 }
 
 int main(int argc, char **argv) {
+    coli_omp_tune_threads("olmoe");   /* squadra sui core fisici, niente spin-wait: vedi omp_tune.h */
     const char *snap = getenv("SNAP");
     if (!snap) { fprintf(stderr, "set SNAP=<snapshot directory>\n"); return 1; }
     g_pilot = getenv("PILOT") ? atoi(getenv("PILOT")) : 0;

--- a/c/omp_tune.h
+++ b/c/omp_tune.h
@@ -1,0 +1,141 @@
+/* omp_tune.h — dimensionamento della squadra OpenMP sui CORE FISICI.
+ *
+ * PERCHE' SOLO IL DIMENSIONAMENTO, E NON LO SPIN-WAIT.
+ * Il blocco di tuning in colibri.c fa due cose che hanno profili di rischio
+ * OPPOSTI, e vanno tenute separate:
+ *
+ *   dimensionamento  OMP_NUM_THREADS = core fisici (niente SMT)
+ *                    #718: +2.3x su Zen3 (5950X, 16C/32T) solo cambiando
+ *                    il numero di thread. Il guadagno e' cosi' grande che
+ *                    "sommerge la maggior parte dei delta che si citano qui".
+ *
+ *   spin-wait        OMP_WAIT_POLICY=active, GOMP_SPINCOUNT, KMP_BLOCKTIME
+ *                    #707: -2.2x sul decode di un host a bassa residenza
+ *                          (M1 Max 32 GB, ~10% di expert residenti)
+ *                    #116: -39% su Metal      #159: ~3x su x86+CUDA
+ *                    #341: 3000% di CPU su FreeBSD con la squadra ferma
+ *                    Meccanismo: dove il token e' fatto di byte dal disco,
+ *                    una squadra che gira a vuoto ruba i core al pool di I/O
+ *                    che sta facendo il lavoro vero.
+ *
+ * Kimi K3 e OLMoE non avevano NESSUNA delle due. Qui prendono solo la prima:
+ * Kimi e' il motore piu' disk-bound del progetto (misurato: 6.7% di hit,
+ * 891 GB letti per 32 token), cioe' esattamente il regime in cui la seconda
+ * meta' fa danno. Aggiungergliela sarebbe stato un peggioramento misurabile.
+ *
+ * PERCHE' QUI NON SERVE IL RE-EXEC.
+ * colibri.c si ri-esegue perche' OMP_WAIT_POLICY & co. le legge il COSTRUTTORE
+ * di libgomp, prima di main(): un setenv() dentro main() arriva tardi. Il numero
+ * di thread no: omp_set_num_threads() e' una API di runtime e ha effetto subito.
+ * La meta' sicura e' anche la meta' semplice.
+ *
+ * REGOLA SUI FALLIMENTI: se il conteggio dei core fisici non e' determinabile,
+ * NON si indovina — si lascia il default di OpenMP. Un conteggio sbagliato e'
+ * peggio di nessun conteggio (cfr. #325, dove un fallback silenzioso a 1
+ * inchiodava il decode su un core solo).
+ */
+#ifndef COLI_OMP_TUNE_H
+#define COLI_OMP_TUNE_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(_WIN32)
+#include <windows.h>
+#elif defined(__APPLE__)
+#include <sys/sysctl.h>
+#else
+#include <dirent.h>
+#endif
+
+/* Numero di core FISICI, o 0 se non determinabile. Mai un valore inventato. */
+static int coli_physical_cores(void)
+{
+#if defined(_WIN32)
+    DWORD need = 0;
+    GetLogicalProcessorInformationEx(RelationProcessorCore, NULL, &need);
+    if (!need) return 0;
+    void *buf = malloc(need);
+    if (!buf) return 0;
+    int cores = 0;
+    if (GetLogicalProcessorInformationEx(RelationProcessorCore, buf, &need)) {
+        char *p = (char *)buf, *end = p + need;
+        while (p + sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX) <= end) {
+            SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *e =
+                (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *)p;
+            if (!e->Size) break;                 /* mai avanzare di 0: loop infinito */
+            if (e->Relationship == RelationProcessorCore) cores++;
+            p += e->Size;
+        }
+    }
+    free(buf);
+    return cores;
+
+#elif defined(__APPLE__)
+    /* hw.perflevel0.logicalcpu = i core PERFORMANCE. Su Apple Silicon
+     * hw.physicalcpu li conta tutti, E-core compresi (10 su un M1 Max), e con
+     * una barriera per matmul e' il thread piu' lento a dettare il passo: gli
+     * E-core rallentano la squadra invece di aiutarla (#707, -4.2% decode).
+     * Su Intel Mac perflevel* non esiste: li' hw.physicalcpu e' corretto. */
+    int v = 0; size_t sz = sizeof(v);
+    if (sysctlbyname("hw.perflevel0.logicalcpu", &v, &sz, NULL, 0) == 0 && v > 0) return v;
+    v = 0; sz = sizeof(v);
+    if (sysctlbyname("hw.physicalcpu", &v, &sz, NULL, 0) == 0 && v > 0) return v;
+    return 0;
+
+#else
+    /* Linux: un core fisico = una lista di thread_siblings distinta. Contare le
+     * liste uniche deduplica l'SMT senza dover interpretare la topologia. */
+    DIR *d = opendir("/sys/devices/system/cpu");
+    if (!d) return 0;
+    char seen[1024][64];
+    int n = 0;
+    struct dirent *e;
+    while ((e = readdir(d)) && n < 1024) {
+        if (strncmp(e->d_name, "cpu", 3) != 0 || e->d_name[3] < '0' || e->d_name[3] > '9')
+            continue;
+        char path[256], line[64];
+        snprintf(path, sizeof(path),
+                 "/sys/devices/system/cpu/%s/topology/thread_siblings_list", e->d_name);
+        FILE *f = fopen(path, "r");
+        if (!f) continue;
+        if (fgets(line, sizeof(line), f)) {
+            line[strcspn(line, "\n")] = 0;
+            int dup = 0;
+            for (int i = 0; i < n; i++) if (strcmp(seen[i], line) == 0) { dup = 1; break; }
+            if (!dup) { snprintf(seen[n], sizeof(seen[0]), "%s", line); n++; }
+        }
+        fclose(f);
+    }
+    closedir(d);
+    return n;
+#endif
+}
+
+/* Dimensiona la squadra OpenMP sui core fisici. Rispetta OMP_NUM_THREADS se
+ * l'utente l'ha impostata, e non fa nulla se il conteggio non e' affidabile.
+ * `engine` finisce solo nella riga di log. */
+static void coli_omp_tune_threads(const char *engine)
+{
+#ifdef _OPENMP
+    const char *off = getenv("COLI_NO_OMP_TUNE");
+    if (off) return;                       /* stesso kill-switch degli altri motori */
+    if (getenv("OMP_NUM_THREADS")) return; /* l'utente comanda */
+
+    int phys = coli_physical_cores();
+    if (phys <= 0) return;                 /* sconosciuto -> default di OpenMP */
+    int logical = omp_get_max_threads();
+    if (phys >= logical) return;           /* niente SMT da evitare: silenzio */
+
+    omp_set_num_threads(phys);
+    fprintf(stderr, "[OMP] %s: %d thread (core fisici) invece di %d logici — "
+                    "l'SMT dimezza il decode su alcune CPU (#718); "
+                    "OMP_NUM_THREADS=<n> per decidere tu\n",
+            engine, phys, logical);
+#else
+    (void)engine;
+#endif
+}
+
+#endif /* COLI_OMP_TUNE_H */


### PR DESCRIPTION
kimi_k3 and olmoe had **no OpenMP tuning of any kind**, while colibri.c and inkling.c did. On an SMT machine their team runs at logical-core count, and #718 measured the cost: **2.3x on a Ryzen 9 5950X (16C/32T) from the thread count alone** — large enough, as noted there, to swamp most tuning deltas people quote.

## They get the sizing half, not the spin-wait half — deliberately

The block in colibri.c does two things with **opposite risk profiles**:

| | evidence |
|---|---|
| **sizing** — OMP_NUM_THREADS = physical cores | ✅ **#718: +2.3x** on Zen3 |
| **spin-wait** — OMP_WAIT_POLICY=active, GOMP_SPINCOUNT, KMP_BLOCKTIME | ❌ **#707: -2.2x** decode at ~10% residency · #116: -39% Metal · #159: ~3x x86+CUDA · #341: 3000% CPU idle on FreeBSD |

**Kimi is the most disk-bound engine in the project** — measured at 6.7% expert hit and 891 GB streamed for 32 tokens. That is precisely the regime where a spinning team starves the I/O pool doing the actual work. Handing it the whole block would have been a measurable regression, so it gets the half that helps.

## No re-exec needed

colibri.c re-executes itself because OMP_WAIT_POLICY and friends are read by libgomps **constructor**, before main(). omp_set_num_threads() is a runtime API. The safe half turns out to also be the simple half.

## Inert unless it helps

Does nothing when the user set OMP_NUM_THREADS, when COLI_NO_OMP_TUNE is set, when there is no SMT to avoid, or when the physical-core count cannot be determined — **never a guessed number**. #325 is what a silent fallback to 1 costs.

macOS reads hw.perflevel0.logicalcpu before hw.physicalcpu: the point in #707 is that on Apple Silicon the latter counts E-cores too (10 on an M1 Max), and with a barrier per expert matmul the slowest thread paces the team — worth -4.2% there. Intel Macs have no perflevel*, where physicalcpu is correct.

## Not touched

colibri.c and inkling.c. They are tuned already, **14 open PRs touch colibri.c**, and refactoring them onto the shared header would cost contributors a rebase for zero functional gain.

## Verified

- All four engines build.
- Detection returns **6 physical of 12 logical** here, matching lscpu.
- The [OMP] line is suppressed under OMP_NUM_THREADS=3 and under COLI_NO_OMP_TUNE=1.
- make test-c passes.
- colibri.c / inkling.c: 0 occurrences of omp_tune — byte-identical behaviour.