### PR TITLE
fix(omp): COLI_CUDA/COLI_METAL are state, not kill-switches — test the value (#707)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -8729,6 +8729,16 @@ static int coli_resolve_cap(int cli_given, int cli, int env, int platform_fast, 
     return cli_given ? 8 : 64;   /* sentinel 0 -> coli's historic 8; bare ./glm -> historic 64 */
 }
 
+/* Una variabile di STATO e' attiva se e' impostata E non vale 0/false/off/no.
+ * Volutamente diverso dai kill-switch, che restano presence-based. */
+static int coli_env_on(const char *name)
+{
+    const char *v = getenv(name);
+    if(!v || !*v) return 0;
+    return !(strcmp(v,"0")==0 || strcmp(v,"false")==0 ||
+             strcmp(v,"off")==0 || strcmp(v,"no")==0);
+}
+
 int main(int argc, char **argv){
     /* ---- Permanent OpenMP hot-thread tuning. The per-expert matmul regions are
      * tiny and back-to-back; with the default passive wait policy libgomp parks
@@ -8749,8 +8759,18 @@ int main(int argc, char **argv){
      * re-exec + tuning path (distinct from the internal COLI_OMP_TUNED sentinel).
      *
      * Must remain the FIRST statement in main(): argv is passed verbatim to execv(). */
+    /* COLI_OMP_TUNED e COLI_NO_OMP_TUNE sono KILL-SWITCH: presence-based e' voluto
+     * (c/coli lo documenta: "impostarla a qualsiasi valore, anche 0, disattiva").
+     * COLI_CUDA e COLI_METAL invece sono STATO, e uno 0 significa "niente GPU":
+     * testarne la presenza faceva saltare il tuning proprio a chi la GPU non ce
+     * l'ha. Ed e' raggiungibile, non teorico -- `coli` stesso scrive
+     * e["COLI_CUDA"]="0" (c/coli:281 e :360) quando il piano non usa CUDA, quindi
+     * su un host Linux CPU-only un `coli run --auto-tier --gpu none` documentato
+     * perdeva silenziosamente il tuning che un `./colibri` nudo riceve. Grazie a
+     * @fredchu per averlo letto nel sorgente e detto chiaramente di non averlo
+     * misurato (#707). */
     if(!getenv("COLI_OMP_TUNED") && !getenv("COLI_NO_OMP_TUNE") &&
-       !getenv("COLI_CUDA") && !getenv("COLI_METAL")){
+       !coli_env_on("COLI_CUDA") && !coli_env_on("COLI_METAL")){
         setenv("OMP_WAIT_POLICY","active",0);  /* keep the team hot across the tiny per-expert matmul regions */
         setenv("GOMP_SPINCOUNT","200000",0);   /* spin briefly, then yield so long disk waits don't burn a core */
         /* LLVM libomp (clang builds: FreeBSD cc, macOS, some Linux setups) does not


### PR DESCRIPTION
The OMP tuning guard tested `getenv()` for **presence** on four variables. That is correct for two of them and wrong for the other two.

| variable | kind | presence-based? |
|---|---|---|
| `COLI_OMP_TUNED`, `COLI_NO_OMP_TUNE` | **kill-switch** | ✅ deliberate — `c/coli` documents it: *"impostarla a qualsiasi valore, anche 0, disattiva"* |
| `COLI_CUDA`, `COLI_METAL` | **state**, where `0` means no GPU | ❌ wrong — this PR |

Testing presence meant the tuning was skipped for exactly the users who have **no GPU** and therefore most need their CPU team configured.

## It is reachable, and the launcher triggers it

`coli` itself writes `e["COLI_CUDA"]="0"` at `c/coli:281` and `:360` when the plan does not use CUDA. So on a CPU-only Linux host, a documented `coli run --auto-tier --gpu none` **silently lost the tuning that a bare `./colibri` receives.**

## Measured, before and after

```
before (dev):  COLI_CUDA=0        -> no tuning      <- the bug
after:         COLI_CUDA=0        -> tuning runs
after:         COLI_CUDA=1        -> skipped (correct, #159)
after:         COLI_METAL=0       -> tuning runs
after:         COLI_NO_OMP_TUNE=0 -> still skipped (kill-switch, unchanged)
```

`coli_env_on()` treats `0`/`false`/`off`/`no` as off, so this also covers a user writing `COLI_CUDA=false`, not just the launcher’s `"0"`.

## Credit

Reported by @fredchu in #707, who read it out of the source and said plainly that he could not measure it — he has no Linux host. The measurement above is that missing half.

Scope: one guard condition plus a small helper in `colibri.c`. Kept deliberately minimal because **14 open PRs touch that file**.