### PR TITLE
fix(cuda): stage the VRAM tier in rounds so host RSS is bounded (closes #730)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -8076,17 +8076,43 @@ static void pin_load(Model *m, const char *statspath, double gb, int trusted){
 #ifdef __linux__
     if(gpu_prefix>0) g_numa_skip_bind=1;   /* prefix slabs = transient upload staging: don't bind (#419) */
 #endif
-    #pragma omp parallel for schedule(dynamic,1)
-    for(int a=0;a<(gpu_prefix?gpu_prefix:npin);a++)
-        expert_load(m,r[a].l,r[a].e,&m->pin[r[a].l][slot_of[a]],1,0);   /* startup pin load; demand=0, never classified */
-#ifdef __linux__
-    g_numa_skip_bind=0;
+    int pre_n = gpu_prefix?gpu_prefix:npin;   /* quanti esperti nella fase "prefisso" */
+    /* #730: quanti caricarne per volta. Il default e' "tutti", che riproduce esattamente
+     * il comportamento precedente. Sotto CUDA_RELEASE_HOST i slab host del prefisso sono
+     * staging TRANSITORIO -- il commento di budget qui sopra lo dice: "prefix RAM is
+     * returned after upload" -- ma erano transitori in AGGREGATO: si caricava tutto il
+     * prefisso in RAM host e solo dopo si liberava un esperto alla volta. Il picco di RSS
+     * host era quindi l'intero CUDA_EXPERT_GB, e su un host con piu' VRAM che RAM (96 GB
+     * di VRAM contro 64 di RAM, #730) l'OOM arriva prima che il primo release parta.
+     * A round, il picco diventa stage*eb e il carico parallelo mantiene la sua banda. */
+    int stage = pre_n;
+#ifdef COLI_CUDA
+    if(g_cuda_enabled && g_cuda_release_host && gpu_prefix>0 && budget>0){
+        /* Tetto di staging: il piu' piccolo tra 4 GB e un ottavo del budget del tier,
+         * mai meno di un esperto (altrimenti il ciclo non avanza) e mai piu' del
+         * prefisso. Un ottavo mantiene i round abbastanza grandi da tenere occupati
+         * i thread del carico parallelo; il tetto assoluto protegge chi ha poca RAM
+         * e un budget enorme, che e' esattamente il caso segnalato. */
+        double cap = 4e9; if(budget/8.0 < cap) cap = budget/8.0;
+        int st = (int)(cap/eb);
+        if(st < 1) st = 1;
+        if(st < stage) stage = st;
+        if(stage < pre_n)
+            fprintf(stderr,"[CUDA] tier staging: %d experts per round (%.1f GB host peak) "
+                           "instead of %d at once (%.1f GB) — CUDA_RELEASE_HOST frees each "
+                           "round before the next (#730)\n",
+                    stage, stage*eb/1e9, pre_n, pre_n*eb/1e9);
+    }
 #endif
-    m->resident_bytes+=(int64_t)(gpu_prefix?gpu_prefix:npin)*eb;
+    for(int base=0; base<pre_n; base+=stage){
+    int hi = base+stage; if(hi>pre_n) hi=pre_n;
+    #pragma omp parallel for schedule(dynamic,1)
+    for(int a=base;a<hi;a++)
+        expert_load(m,r[a].l,r[a].e,&m->pin[r[a].l][slot_of[a]],1,0);   /* startup pin load; demand=0, never classified */
+    m->resident_bytes+=(int64_t)(hi-base)*eb;
 #ifdef COLI_CUDA
     if(g_cuda_enabled && budget>0){
-        int gpu_limit=gpu_prefix?gpu_prefix:npin;
-        for(int a=0;a<gpu_limit && m->gpu_expert_bytes<budget;a++){
+        for(int a=base;a<hi && m->gpu_expert_bytes<budget;a++){
             int li=r[a].l;
             { ESlot *s=&m->pin[li][slot_of[a]];
                 int64_t need=qt_bytes(&s->g)+qt_bytes(&s->u)+qt_bytes(&s->d);
@@ -8133,6 +8159,14 @@ static void pin_load(Model *m, const char *statspath, double gb, int trusted){
                 }
             }
         }
+    }
+#endif
+    }   /* fine del ciclo a round (#730) */
+#ifdef __linux__
+    g_numa_skip_bind=0;
+#endif
+#ifdef COLI_CUDA
+    if(g_cuda_enabled && budget>0){
         fprintf(stderr,"[CUDA] hot expert tier: %d/%d experts, VRAM %.2f GB (budget %.1f GB%s, reserve %.1f GB)\n",
             m->gpu_expert_count,npin,m->gpu_expert_bytes/1e9,
             g_cuda_expert_auto?safe_total/1e9:budget/1e9,


### PR DESCRIPTION
Fixes #730, reported and correctly diagnosed by @mcollinswisc.

## The bug

`pin_fill` loaded the **entire** VRAM-ranked prefix into host RAM in one parallel pass, and only then entered the upload loop that releases each slab:

```c
#pragma omp parallel for schedule(dynamic,1)
for(int a=0;a<(gpu_prefix?gpu_prefix:npin);a++)
    expert_load(...);                        /* ALL of them, into host RAM */

for(int a=0;a<gpu_limit && m->gpu_expert_bytes<budget;a++){
    ...
    if(uploaded && g_cuda_release_host) expert_host_release(m,s);   /* too late */
}
```

So `CUDA_RELEASE_HOST=1` worked exactly as documented and **could not help** — by the time the first release ran, every slab was already resident. **Peak host RSS was the whole `CUDA_EXPERT_GB` budget**, whatever that budget was.

The code's own comments state the intended contract and show the gap:

> *"Load the VRAM-ranked prefix first. Once uploaded its host backing is released before the disjoint RAM-ranked suffix is allocated."*
>
> `npin+=prefix_est;` — *additive: prefix RAM is returned after upload*

Both are true of the prefix **as a whole**. The design treats prefix RAM as transient, and it is — transient in aggregate rather than per expert, and aggregate is the number that has to fit.

It also explains why `RAM_GB=24` and `RSS_GUARD_GB=8` changed nothing for the reporter: those bound the *steady state*, and this peak is a startup transient that no steady-state budget models.

## Why it surfaced now

@mcollinswisc has **more VRAM than system RAM** — 96 GB on an RTX PRO 6000 Blackwell against 64 GB of RAM. Every assumption that host RAM comfortably exceeds the GPU tier quietly breaks in that regime, and it is going to become more common rather than less.

They also reproduced it for everyone else with a cgroup, which is what made this checkable in minutes instead of requiring their hardware:

```sh
systemd-run --user --wait --pipe -p MemoryMax=24G -p MemorySwapMax=0 \
  env SNAP=... COLI_CUDA=1 CUDA_RELEASE_HOST=1 CUDA_EXPERT_GB=40 \
      PIN=/dev/null PIN_FILL=1 PIN_GB=1 "${PWD}/c/colibri" 64 4 4
```

## The fix

Stage in rounds: load a round in parallel, upload it, release it, next. Peak host staging becomes `stage × expert_bytes` instead of the full budget, and the parallel load keeps its bandwidth.

Round size is `min(4 GB, budget/8)`, at least one expert and never more than the prefix. `budget/8` keeps rounds large enough to saturate the loader threads; the absolute cap protects the little-RAM, big-budget case that is the report. When it engages, it says so:

```
[CUDA] tier staging: N experts per round (X GB host peak) instead of M at once
       (Y GB) — CUDA_RELEASE_HOST frees each round before the next (#730)
```

Same bug family as the Inkling expert-cache defect fixed recently: acquiring the whole working set up front when the working set is larger than what fits, where processing in rounds is both correct and bounded.

## Behaviour is unchanged for everyone else

Without `CUDA_RELEASE_HOST`, without CUDA, or with no VRAM prefix, `stage == prefix` and **the loop runs exactly once** — which is the previous code path, statement for statement. The accumulators (`remaining`, `placed_b`, `placed_n`, `gpu_expert_bytes`) already lived outside the loop, so they carry across rounds untouched.

## Verification, and its limit

- Builds clean; **syntax-checks with `-DCOLI_CUDA`**, which the plain build does not compile.
- `make test-c` passes.
- The non-CUDA path is structurally identical with `stage == prefix`.

**Not verified functionally: I have no CUDA hardware.** Compile-level and non-CUDA evidence is what I can offer. @mcollinswisc has the reproduction and can confirm whether the OOM is gone and what the staging line reports; @4ny3l said they were investigating this and may want to review the approach.

One thing I did not change and want to flag: once the VRAM budget fills mid-prefix, later rounds still load experts that will not be uploaded, and they stay as RAM pins. That is the pre-existing behaviour — the old code loaded them too — so it is preserved deliberately rather than fixed silently here.
