### PR TITLE
fix(test): build the fp8 e2e harness with -fopenmp on Linux — make check was red

### DIFF
--- a/c/tests/test_fp8_e2e_repack_load.py
+++ b/c/tests/test_fp8_e2e_repack_load.py
@@ -49,6 +49,14 @@ def _cc_flags():
     cflags = ["-O3", "-Wall", "-Wextra", "-Wno-unused-parameter",
               "-Wno-misleading-indentation", "-Wno-unused-function"]
     ldflags = ["-lm"]
+    if sys.platform not in ("darwin", "win32"):
+        # -fopenmp, like the Makefile. Without it every '#pragma omp' in colibri.c
+        # becomes a -Wunknown-pragmas warning (-Wall enables it), and the assertion
+        # below requires an empty stderr -- so on Linux this test failed for a
+        # reason that had nothing to do with what it is testing. macOS gets the
+        # libomp probe just below; Windows/MinGW is left alone.
+        cflags += ["-fopenmp"]
+        ldflags += ["-fopenmp"]
     if sys.platform == "darwin":
         try:
             prefix = subprocess.run(["brew", "--prefix", "libomp"], capture_output=True,


### PR DESCRIPTION
make check is red on Linux on current dev, for a reason that has nothing to do with what the test asserts.

## Cause

`_cc_flags()` in `tests/test_fp8_e2e_repack_load.py` adds `-fopenmp` **only on darwin**. Everywhere else it compiles colibri.c without it, so every `#pragma omp` becomes a `-Wunknown-pragmas` warning — `-Wall` enables that — and the test then asserts stderr is empty:

```
AssertionError: In file included from .../colibri.c:419 ... != ""
: e2e harness build produced warnings (production flags require zero)
quant.h:99: warning: ignoring "#pragma omp parallel" [-Wunknown-pragmas]
```

**The assertion is right.** A production-flags build should be warning-free. The flags simply were not production flags — they were missing the one the Makefile has.

## Fix

Linux and the BSDs get `-fopenmp` like the Makefile does. macOS keeps its existing libomp probe immediately below; Windows/MinGW is left alone.

The test now **passes rather than being weakened**, so it still guards exactly what it was written to guard.

## Notes

Confirmed pre-existing: the identical failure reproduces on unmodified dev, so it is not fallout from anything merged today.

Worth flagging separately: CI Python tests runs `python3 -m unittest discover` on ubuntu-latest and is **green**, while the same suite is red locally. I have not chased why the two disagree — but a test that fails on a contributor Linux box and passes in CI is its own small problem, and this PR removes the instance rather than the class.

make check: 288 tests, OK (skipped=13). One file, test only.