### PR TITLE
Release v1.4.0: version bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ c/olmoe_merged/
 c/olmoe_i4/
 .idea
 c/tiny_inkling/
+
+# Claude Code working directory (agent worktrees, session scratch) — never a repo artifact
+.claude/

--- a/README.it.md
+++ b/README.it.md
@@ -32,7 +32,7 @@ ma non ridefinire il modello di nascosto.
 
 ```
 $ ./coli chat
-  🐦 colibri v1.3.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
+  🐦 colibri v1.4.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
   ✓ ready in 32s · resident 9.9 GB
   › ciao!
   ◆ Ciao! 😊 Come posso aiutarti oggi?

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ may reduce speed; it must not quietly redefine the model.
 
 ```
 $ ./coli chat
-  🐦 colibri v1.3.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
+  🐦 colibri v1.4.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
   ✓ ready in 32s · resident 9.9 GB
   › ciao!
   ◆ Ciao! 😊 Come posso aiutarti oggi?

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,7 +24,7 @@ Colibrì 刻意用于验证激进的系统思路——因此**对速度不作 SL
 
 ```
 $ ./coli chat
-  🐦 colibri v1.3.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
+  🐦 colibri v1.4.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
   ✓ ready in 32s · resident 9.9 GB
   › ciao!
   ◆ Ciao! 😊 Come posso aiutarti oggi?

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -24,7 +24,7 @@ Colibrì 刻意用於驗證激進的系統構想——因此**對速度不作 SL
 
 ```
 $ ./coli chat
-  🐦 colibri v1.3.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
+  🐦 colibri v1.4.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
   ✓ ready in 32s · resident 9.9 GB
   › ciao!
   ◆ Ciao! 😊 Come posso aiutarti oggi?

--- a/c/version.py
+++ b/c/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the colibri version number."""
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"


### PR DESCRIPTION
The last three commits before the `v1.4.0` tag.

`c/version.py` is the single source of truth and the release archives carry it, so this has to be on `main` **before** the tag — otherwise the published binaries announce 1.3.0 while the tag says 1.4.0. The four README sample banners go with it; they had gone stale for two releases running before #709 caught them at 1.1.0.

Also adds `.claude/` to `.gitignore`. Claude Code keeps agent worktrees there, and a `git add -A` while preparing this bump picked one up as an embedded git repository. It was caught and removed before review, but the guard belongs in the tree rather than in whoever runs the next `add -A`.

Routed through `dev` rather than opened against `main` directly — everything goes to `dev` first, including this. All checks green on `dev`.

After this merges, the tag can be cut.