### PR TITLE
fix(release): read the packaged tokenizer as UTF-8, not the Windows ANSI page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,11 @@ jobs:
           # Kimi K3 needs tokenizer.json synthesized from tiktoken.model; without this
           # script in the archive the engine ships but cannot be driven by coli chat.
           test -f tools/k3_tokenizer.py || { echo "FAIL: k3_tokenizer.py missing from archive"; exit 1; }
-          python3 -c "import ast,sys; ast.parse(open('tools/k3_tokenizer.py').read())" \
+          # encoding='utf-8' explicitly: on Windows open() defaults to the ANSI code
+          # page (cp1252), which cannot decode this UTF-8 file, so the v1.4.0 tag build
+          # failed here with a UnicodeDecodeError while the file itself was perfectly
+          # fine. The check was wrong, not the artifact.
+          python3 -c "import ast; ast.parse(open('tools/k3_tokenizer.py', encoding='utf-8').read())" \
             || { echo "FAIL: packaged k3_tokenizer.py does not parse"; exit 1; }
           python3 - <<'PYCHK'
           import os, sys


### PR DESCRIPTION
The **v1.4.0 tag build failed on `windows-x86_64`**:

```
UnicodeDecodeError: charmap codec cannot decode byte 0x90 in position 5262
FAIL: packaged k3_tokenizer.py does not parse
```

**The file is fine** — valid UTF-8, parses cleanly. The check was wrong: `open()` without an `encoding` argument uses the platform default, which on Windows is the ANSI code page (cp1252), and cp1252 cannot decode a UTF-8 file containing non-ASCII bytes.

Reproduced locally:

```
cp1252: FAILS -> UnicodeDecodeError
utf-8:  ok
```

Mine, introduced with the all-engines packaging in #737, and caught on the very first tag build that exercised it — which is what that verification step exists for, even when the thing it catches is the step itself.

**No broken archive was published**: the job failed before the upload, which is the whole point of verifying the artifact rather than trusting the build.

The three engines and the tokenizer were all packaged correctly; the `test -x` assertions above this line passed. Only the parse check was broken.

One file, workflow only. After this lands, the `v1.4.0` tag needs to be moved onto it so the release job re-runs.