### PR TITLE
v1.4.0 hotfix: read the packaged tokenizer as UTF-8 (unblocks the Windows archive)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,11 @@ jobs:
           # Kimi K3 needs tokenizer.json synthesized from tiktoken.model; without this
           # script in the archive the engine ships but cannot be driven by coli chat.
           test -f tools/k3_tokenizer.py || { echo "FAIL: k3_tokenizer.py missing from archive"; exit 1; }
-          python3 -c "import ast,sys; ast.parse(open('tools/k3_tokenizer.py').read())" \
+          # encoding='utf-8' explicitly: on Windows open() defaults to the ANSI code
+          # page (cp1252), which cannot decode this UTF-8 file, so the v1.4.0 tag build
+          # failed here with a UnicodeDecodeError while the file itself was perfectly
+          # fine. The check was wrong, not the artifact.
+          python3 -c "import ast; ast.parse(open('tools/k3_tokenizer.py', encoding='utf-8').read())" \
             || { echo "FAIL: packaged k3_tokenizer.py does not parse"; exit 1; }
           python3 - <<'PYCHK'
           import os, sys


### PR DESCRIPTION
The `v1.4.0` tag build failed on `windows-x86_64`, so **no archives were published** — the `release` job was skipped because one platform failed, which is the behaviour we want.

```
UnicodeDecodeError: charmap codec cannot decode byte 0x90 in position 5262
FAIL: packaged k3_tokenizer.py does not parse
```

**The file was fine.** The check was wrong: `open()` without an `encoding` uses the platform default, which on Windows is cp1252, and cp1252 cannot decode a UTF-8 file. Mine, introduced with the all-engines packaging in #737, and caught on the first tag build that exercised it.

**Linux and macOS built and verified cleanly**, so the four-engine packaging itself works — 863 KB, all engines present and executable, the launcher resolver satisfied.

After this merges, the `v1.4.0` tag moves onto it and the release job re-runs. No version bump: the shipped content is identical, and nothing was ever published under the old tag.