### PR TITLE
inkling: audio input, Metal expert MoE, and tuned Apple defaults

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -461,8 +461,8 @@ cuda-bench: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/bench_tens
 olmoe$(EXE): olmoe.c st.h json.h compat.h sample.h tok.h tok_unicode.h tok_unicode_o200k.h omp_tune.h
 	$(CC) $(CFLAGS) olmoe.c -o olmoe$(EXE) $(LDFLAGS)
 
-inkling$(EXE): inkling.c st.h json.h compat.h $(INK_CUDA_OBJ)
-	$(CC) $(CFLAGS) inkling.c $(INK_CUDA_OBJ) -o inkling$(EXE) $(LDFLAGS)
+inkling$(EXE): inkling.c st.h json.h compat.h $(INK_CUDA_OBJ) $(METAL_OBJ)
+	$(CC) $(CFLAGS) inkling.c $(INK_CUDA_OBJ) $(METAL_OBJ) -o inkling$(EXE) $(LDFLAGS)
 
 kimi_k3$(EXE): kimi_k3.c st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h omp_tune.h route_trace.h $(VK_OBJ) $(VK_SPV)
 	$(CC) $(CFLAGS) kimi_k3.c $(VK_OBJ) -o kimi_k3$(EXE) $(LDFLAGS)

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -38,6 +38,20 @@
 #include "backend_cuda_ink.h"
 static int g_cuda = 0;
 #endif
+#ifdef COLI_METAL
+/* Apple-GPU expert MoE (opt-in, COLI_METAL=1). Reuses colibri's batched
+ * coli_metal_moe_block: inkling's container int4 (nibble-packed, -8 offset,
+ * per-row scales) is bit-identical to the Metal fmt=2 kernel, and int8 to
+ * fmt=1. Expert slots live in page-aligned per-layer slabs registered once
+ * for zero-copy resolve — unified memory, no upload. Attention and the dense
+ * path stay on the CPU (at high hit rates ~90% of decode is expert matmul). */
+#include "backend_metal.h"
+static int g_metal = 0;
+#endif
+#if defined(__APPLE__)
+#include <mach/mach.h>
+#include <sys/sysctl.h>
+#endif
 
 #define MAXL 256
 
@@ -52,6 +66,7 @@ typedef struct {
     int n_experts, topk, n_shared, moe_inter, dense_inter;
     int eos;
     float eps, route_scale, mup;
+    int audio_tok, mel_bins, mel_vocab;   /* DMel audio input (TMLv0 <|audio|> placeholder) */
     unsigned char local[MAXL];            /* 1 = sliding-window layer */
     unsigned char sparse[MAXL];           /* 1 = MoE layer, 0 = dense MLP */
 } Cfg;
@@ -115,6 +130,8 @@ typedef struct {
     int xq;                               /* experts on disk are a colibri container (U8 + .qs) */
     Wt embed, lm_head;
     float *embed_norm, *final_norm;
+    Wt audio_enc;                         /* [mel_bins*mel_vocab, D] embedding table */
+    float *audio_norm;                    /* audio tower RMSNorm [D]; NULL = no audio */
     Layer *L;
     LCache *cache;
     int64_t rb13, rb2;                    /* container row-bytes (0 = not container) */
@@ -488,6 +505,12 @@ static void load_cfg(Cfg *c, const char *snap) {
     jval *eo = json_get(root,"eos_token_id");
     if (!eo || eo->t != J_NUM) eo = json_get(r,"eos_token_id");
     c->eos = (eo && eo->t == J_NUM) ? (int)eo->num : -1;
+    /* DMel audio: placeholder id at the top level (absent in the shipped
+     * config -> the TMLv0 constant), frame geometry under audio_config */
+    c->audio_tok = (int)jnum(root,"audio_token_id",200023);
+    jval *ac = json_get(root,"audio_config");
+    c->mel_bins  = ac ? (int)jnum(ac,"n_mel_bins",80)     : 80;
+    c->mel_vocab = ac ? (int)jnum(ac,"mel_vocab_size",16) : 16;
     /* real config.json: intermediate_size = MoE, dense_intermediate_size = dense.
      * HF-saved config (post_init applied): intermediate_size = dense, moe_intermediate_size = MoE. */
     jval *dis = json_get(r,"dense_intermediate_size");
@@ -717,10 +740,30 @@ static void model_init(Model *m, const char *snap, int cap, int bits) {
         } else fprintf(stderr, "[cuda] init failed, running on CPU\n");
     }
 #endif
+#ifdef COLI_METAL
+    {   const char *me = getenv("COLI_METAL");
+        if (me && *me == '1' && !getenv("NOGPU")) {
+            if (coli_metal_init()) {
+                g_metal = 1;
+                fprintf(stderr, "[metal] ready — batched expert MoE on the Apple GPU\n");
+            } else fprintf(stderr, "[metal] init failed, running on CPU\n");
+        }
+    }
+#endif
     m->embed      = load_w(m, "model.embed_tokens.weight", 0);
     m->embed_norm = st_has(&m->S,"model.embed_norm.weight") ? load_t(m,"model.embed_norm.weight") : NULL;
     m->final_norm = load_t(m, "model.norm.weight");
     m->lm_head    = load_w(m, "lm_head.weight", 1);
+    /* Inkling's audio "tower" is one embedding table + one RMSNorm. The int4
+     * containers are text-only, so these usually arrive via an audio.safetensors
+     * sidecar dropped in the snapshot dir (st_init indexes every *.safetensors).
+     * Absent tensors = text-only engine, exactly as before. */
+    if (st_has(&m->S, "model.audio.encoder.weight")) {
+        m->audio_enc  = load_w(m, "model.audio.encoder.weight", 0);
+        m->audio_norm = load_t(m, "model.audio.final_norm.weight");
+        fprintf(stderr, "[audio] DMel encoder loaded (%d bins x %d levels -> D=%d)\n",
+                c->mel_bins, c->mel_vocab, D);
+    }
     m->L = calloc(c->n_layers, sizeof(Layer));
     char nm[320];
     for (int i = 0; i < c->n_layers; i++) {
@@ -788,6 +831,33 @@ static void model_init(Model *m, const char *snap, int cap, int bits) {
     }
     m->cache = calloc(c->n_layers, sizeof(LCache));
     for (int i = 0; i < c->n_layers; i++) { m->cache[i].cap = cap; m->cache[i].slots = calloc(cap, sizeof(Slot)); }
+    /* container mode: slot storage is one page-aligned slab per sparse layer
+     * (weights) plus one for the row scales, with every slot's pointers carved
+     * out up front. Slots then recycle their region on eviction — no per-slot
+     * malloc, and (under Metal) each slab registers ONCE for zero-copy GPU
+     * resolve instead of churning register/unregister on every fill. */
+    if (m->xq) {
+        int64_t st13 = m->rb13*2*I, st2 = m->rb2*D;
+        size_t pg = 16384;
+        size_t wlen = ((size_t)cap*(st13+st2) + pg - 1) / pg * pg;
+        size_t slen = ((size_t)cap*(2*I+D)*4 + pg - 1) / pg * pg;
+        for (int i = 0; i < c->n_layers; i++) {
+            if (!c->sparse[i]) continue;
+            void *wsl = NULL, *ssl = NULL;
+            if (posix_memalign(&wsl, pg, wlen) || posix_memalign(&ssl, pg, slen)) {
+                fprintf(stderr, "OOM expert slab layer %d (%zu MB)\n", i, (wlen+slen)>>20); exit(1); }
+            for (int k = 0; k < cap; k++) {
+                Slot *s = &m->cache[i].slots[k];
+                s->p13 = (uint8_t*)wsl + (int64_t)k*(st13+st2);
+                s->p2  = s->p13 + st13;
+                s->s13 = (float*)ssl + (int64_t)k*(2*I+D);
+                s->s2  = s->s13 + 2*I;
+            }
+#ifdef COLI_METAL
+            if (g_metal) { coli_metal_register(wsl, wlen); coli_metal_register(ssl, slen); }
+#endif
+        }
+    }
     /* usage counters; seeded from a previous run's history when present */
     rt_init("inkling", c->n_layers, E);
     for (int i = 0; i < c->n_layers; i++) if (!c->sparse[i]) rt_drop_row(i);
@@ -804,6 +874,14 @@ static double mem_avail_bytes(void) {
     while (fgets(ln, sizeof(ln), f)) if (sscanf(ln, "MemAvailable: %lf", &kb) == 1) break;
     fclose(f);
     return kb * 1024.0;
+#elif defined(__APPLE__)
+    /* free + inactive + purgeable ~ Linux MemAvailable. Without this the auto
+     * cap fell back to 16 experts/layer on a 128 GB Mac. */
+    vm_size_t page = 0; host_page_size(mach_host_self(), &page);
+    vm_statistics64_data_t vs; mach_msg_type_number_t n = HOST_VM_INFO64_COUNT;
+    if (host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info64_t)&vs, &n) != KERN_SUCCESS)
+        return 0;
+    return (double)(vs.free_count + vs.inactive_count + vs.purgeable_count) * page;
 #else
     return 0;
 #endif
@@ -826,9 +904,7 @@ static Slot *slot_acquire(Model *m, int layer, int eid) {
     Slot *s;
     if (lc->n < lc->cap) {
         s = &lc->slots[lc->n++];
-        if (m->xq)              { s->p13 = malloc((size_t)(m->rb13*2*I)); s->p2 = malloc((size_t)(m->rb2*D));
-                                  s->s13 = falloc(2*I); s->s2 = falloc(D);
-                                  if (!s->p13 || !s->p2) { fprintf(stderr,"OOM expert slot\n"); exit(1); } }
+        if (m->xq)              { /* slab-carved at model_init; nothing to allocate */ }
         else if (m->quant_bits) { s->q13 = malloc(n13); s->q2 = malloc(n2);
                                   s->s13 = falloc(2*I); s->s2 = falloc(D);
                                   if (!s->q13 || !s->q2) { fprintf(stderr,"OOM expert slot\n"); exit(1); } }
@@ -1122,6 +1198,21 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
     float *g = falloc(2*I), *u = g + I, *hh = falloc(D);
     int q4 = m->xq && m->rb13*2 == D;   /* packed int4 vs int8 container */
     int64_t npair = (int64_t)S*K;
+#ifdef COLI_METAL
+    /* per-round scratch for the batched GPU submit: pairs grouped by expert,
+     * activations packed in group order. Allocated once per moe() call. */
+    float *mxg = NULL, *mrw = NULL; const void **mgp = NULL, **mup = NULL, **mdp = NULL;
+    const float **mgs = NULL, **mus = NULL, **mds = NULL; Slot **mslot = NULL;
+    int *mxoff = NULL, *mnr = NULL, *mrows = NULL, *mgi = NULL, *mfp = NULL;
+    if (g_metal && m->xq) {
+        mxg = falloc((int64_t)cap*D); mrw = falloc(cap);
+        mgp = malloc(cap*sizeof(void*)); mup = malloc(cap*sizeof(void*)); mdp = malloc(cap*sizeof(void*));
+        mgs = malloc(cap*sizeof(float*)); mus = malloc(cap*sizeof(float*)); mds = malloc(cap*sizeof(float*));
+        mslot = malloc(cap*sizeof(Slot*));
+        mxoff = malloc((cap+1)*sizeof(int)); mnr = malloc(cap*sizeof(int));
+        mrows = malloc(cap*sizeof(int)); mgi = malloc(cap*sizeof(int)); mfp = malloc(cap*sizeof(int));
+    }
+#endif
     for (int64_t base = 0; base < npair; base += cap) {
         int64_t end = base + cap < npair ? base + cap : npair;
         nfill = 0;
@@ -1146,6 +1237,46 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
             m->t_fill += now_s() - tf;
         }
         double te = now_s();
+#ifdef COLI_METAL
+        if (mxg) {
+            /* group this round's (token, expert) pairs by expert and submit ONE
+             * command buffer; the kernel scatter-adds rw*hh into out with the
+             * same accumulate semantics as the CPU loop below. 0 -> CPU. */
+            int nb = 0;
+            for (int64_t t = base; t < end; t++) {
+                Slot *e = use[t - base];
+                if (!e) { mgi[t - base] = -1; continue; }
+                int gi = -1;
+                for (int j = 0; j < nb; j++) if (mslot[j] == e) { gi = j; break; }
+                if (gi < 0) { gi = nb++; mslot[gi] = e; mnr[gi] = 0; }
+                mgi[t - base] = gi; mnr[gi]++;
+            }
+            if (nb) {
+                mxoff[0] = 0;
+                for (int j = 0; j < nb; j++) mxoff[j+1] = mxoff[j] + mnr[j];
+                memcpy(mfp, mxoff, nb*sizeof(int));
+                for (int64_t t = base; t < end; t++) {
+                    int gi = mgi[t - base];
+                    if (gi < 0) continue;
+                    int s = (int)(t / K), kk = (int)(t % K);
+                    int r = mfp[gi]++;
+                    memcpy(mxg + (int64_t)r*D, x + (int64_t)s*D, (size_t)D*sizeof(float));
+                    mrows[r] = s;
+                    mrw[r] = wgt[(int64_t)s*(K+ns) + kk];
+                }
+                for (int j = 0; j < nb; j++) {
+                    Slot *e = mslot[j];
+                    mgp[j] = e->p13; mup[j] = e->p13 + (int64_t)I*m->rb13; mdp[j] = e->p2;
+                    mgs[j] = e->s13; mus[j] = e->s13 + I; mds[j] = e->s2;
+                }
+                if (coli_metal_moe_block(nb, D, I, q4 ? 2 : 1, mgp, mup, mdp, mgs, mus, mds,
+                                         mxg, mxoff, mnr, mrows, mrw, out, S)) {
+                    m->t_expert += now_s() - te;
+                    continue;                              /* round done on the GPU */
+                }
+            } else { m->t_expert += now_s() - te; continue; }
+        }
+#endif
         for (int64_t t = base; t < end; t++) {            /* calcolo + accumulo */
             int s = (int)(t / K), kk = (int)(t % K);
             Slot *e = use[t - base];
@@ -1194,18 +1325,61 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
     }
     free(logits); free(idx); free(keff); free(wgt); free(use); free(fill); free(fl);
     free(g); free(hh);              /* u aliases g+I */
+#ifdef COLI_METAL
+    if (mxg) {
+        free(mxg); free(mrw); free(mgp); free(mup); free(mdp);
+        free(mgs); free(mus); free(mds); free(mslot);
+        free(mxoff); free(mnr); free(mrows); free(mgi); free(mfp);
+    }
+#endif
+}
+
+/* ---------- DMel audio embedding ----------
+ * One frame = mel_bins u8 levels in [0, mel_vocab). Its decoder embedding is
+ * sum_b E[b*mel_vocab + v_b], RMSNorm'd with the audio tower norm (eps is a
+ * literal 1e-6 in the HF audio tower, independent of the text rms_norm_eps).
+ * This row REPLACES the <|audio|> placeholder's text embedding — embed_norm
+ * does not apply, matching masked_scatter in modeling_inkling.py. */
+static void audio_embed_row(Model *m, const uint8_t *frame, float *out, float *tmp) {
+    Cfg *c = &m->c; int D = c->hidden;
+    memset(out, 0, (size_t)D * sizeof(float));
+    for (int b = 0; b < c->mel_bins; b++) {
+        int v = frame[b] < c->mel_vocab ? frame[b] : c->mel_vocab - 1;
+        wt_row_f32(m->audio_enc, (int64_t)(b*c->mel_vocab + v)*D, tmp, D);
+        for (int d = 0; d < D; d++) out[d] += tmp[d];
+    }
+    rmsnorm_row(out, out, m->audio_norm, D, 1e-6f);
+}
+
+/* count <|audio|> placeholders in a token sequence (0 if no audio tower) */
+static int audio_tok_count(Model *m, const int *ids, int n) {
+    if (!m->audio_norm) return 0;
+    int k = 0;
+    for (int i = 0; i < n; i++) k += (ids[i] == m->c.audio_tok);
+    return k;
 }
 
 /* ---------- one forward pass over S new tokens ----------
  * Returns malloc'd logits of the last token (unpadded vocab). If tf_out is
- * non-NULL also writes the per-position argmax (teacher-forcing check). */
-static float *step(Model *m, const int *ids, int S, int pos0, int *tf_out) {
+ * non-NULL also writes the per-position argmax (teacher-forcing check).
+ * dmel: u8 [naud, mel_bins] frames consumed left-to-right by the <|audio|>
+ * placeholder positions in ids (prefill only; decode steps pass NULL). */
+static float *step_mm(Model *m, const int *ids, int S, int pos0, int *tf_out,
+                      const uint8_t *dmel, int naud) {
     Cfg *c = &m->c; int D = c->hidden;
     float *x = falloc((int64_t)S*D);
+    float *arow = (dmel && naud > 0) ? falloc(D) : NULL;
+    int aidx = 0;
     for (int s = 0; s < S; s++) {
+        if (arow && m->audio_norm && ids[s] == c->audio_tok && aidx < naud) {
+            audio_embed_row(m, dmel + (int64_t)aidx*c->mel_bins, x + (int64_t)s*D, arow);
+            aidx++;
+            continue;
+        }
         wt_row_f32(m->embed, (int64_t)ids[s]*D, x + (int64_t)s*D, D);
         if (m->embed_norm) rmsnorm_row(x + (int64_t)s*D, x + (int64_t)s*D, m->embed_norm, D, c->eps);
     }
+    free(arow);
     float *nrm = falloc((int64_t)S*D), *tmp = falloc((int64_t)S*D);
     for (int i = 0; i < c->n_layers; i++) {
         Layer *l = &m->L[i];
@@ -1240,6 +1414,10 @@ static float *step(Model *m, const int *ids, int S, int pos0, int *tf_out) {
     return logit;
 }
 
+static float *step(Model *m, const int *ids, int S, int pos0, int *tf_out) {
+    return step_mm(m, ids, S, pos0, tf_out, NULL, 0);
+}
+
 static void state_reset(Model *m) {
     Cfg *c = &m->c;
     m->kv_len = 0;
@@ -1264,9 +1442,10 @@ static void kv_alloc(Model *m, int max_t) {
 }
 
 /* greedy generation, olmoe.c-style */
-static void generate(Model *m, const int *prompt, int np, int n_new, int *out) {
+static void generate(Model *m, const int *prompt, int np, int n_new, int *out,
+                     const uint8_t *dmel, int naud) {
     for (int i = 0; i < np; i++) out[i] = prompt[i];
-    float *logit = step(m, prompt, np, 0, NULL);
+    float *logit = step_mm(m, prompt, np, 0, NULL, dmel, naud);
     int len = np;
     Cfg *c = &m->c;
     for (int s = 0; s < n_new; s++) {
@@ -1281,16 +1460,24 @@ static void generate(Model *m, const int *prompt, int np, int n_new, int *out) {
 }
 
 /* ---------- interactive prompt mode: greedy, streaming, stop on eos ---------- */
-static void generate_stream(Model *m, Tok *T, const char *prompt, int n_new) {
+static void generate_stream(Model *m, Tok *T, const char *prompt, int n_new,
+                            const uint8_t *dmel, int naud) {
     Cfg *c = &m->c;
     int cap = (int)strlen(prompt) + 16;
     int *ids = malloc(cap * sizeof(int));
     int np = tok_encode(T, prompt, (int)strlen(prompt), ids, cap);
     if (np <= 0) { fprintf(stderr, "empty prompt after tokenization\n"); return; }
+    if (audio_tok_count(m, ids, np) != naud) {
+        fprintf(stderr, "audio frames (%d) do not match <|audio|> placeholders (%d)%s\n",
+                naud, audio_tok_count(m, ids, np),
+                m->audio_norm ? "" : " — snapshot has no audio tensors (audio.safetensors)");
+        free(ids); return;
+    }
     kv_alloc(m, np + n_new + 8);
-    printf("[%d prompt tokens] %s", np, prompt); fflush(stdout);
+    printf("[%d prompt tokens%s] %s", np, naud ? " incl. audio" : "", naud ? "" : prompt);
+    fflush(stdout);
     double t0 = now_s(), t1 = 0;
-    float *logit = step(m, ids, np, 0, NULL);
+    float *logit = step_mm(m, ids, np, 0, NULL, dmel, naud);
     int len = np;
     char buf[512];
     for (int s = 0; s < n_new; s++) {
@@ -1311,6 +1498,14 @@ static void generate_stream(Model *m, Tok *T, const char *prompt, int n_new) {
     printf("\n[prefill %.1fs | %d tokens in %.1fs = %.2f tok/s | RSS %.1f GB]\n",
            t1 - t0, gen, dt, gen > 1 ? (gen-1)/dt : 0.0, rss_gb());
     double wall = now_s() - t0;
+#ifdef COLI_METAL
+    if (g_metal) {
+        uint64_t mok = 0, mfb = 0, mex = 0;
+        coli_metal_moe_counts(&mok, &mfb, &mex);
+        printf("[metal] %llu MoE blocks on GPU, %llu CPU fallbacks, %llu experts\n",
+               (unsigned long long)mok, (unsigned long long)mfb, (unsigned long long)mex);
+    }
+#endif
     printf("[phases] fill %.1fs | expert-mm %.1fs | shared %.1fs | attn %.1fs | other %.1fs\n",
            m->t_fill, m->t_expert, m->t_shared, m->t_attn,
            wall - m->t_fill - m->t_expert - m->t_shared - m->t_attn);
@@ -1378,7 +1573,8 @@ static const char *prompt_reject(int np, int want) {
     return NULL;
 }
 
-typedef struct { char id[64]; int max_tok; float temp, top_p; char *payload; int plen; } SReq;
+typedef struct { char id[64]; int max_tok; float temp, top_p; char *payload; int plen;
+                 uint8_t *audio; int alen; } SReq;   /* raw DMel bytes after the payload */
 #define SRV_QMAX 16
 static SReq g_q[SRV_QMAX]; static int g_qn = 0;
 
@@ -1397,20 +1593,29 @@ static int serve_read_cmd(const char *cur_id) {
     if (sscanf(ln, "%15s %63s", cmd, id) < 2) return 0;
     if (!strcmp(cmd, "CANCEL")) return cur_id && !strcmp(id, cur_id);
     if (!strcmp(cmd, "SUBMIT")) {
-        int slot, plen, max_tok; float temp, top_p;
-        if (sscanf(ln, "%*s %*s %d %d %d %f %f", &slot, &plen, &max_tok, &temp, &top_p) != 5 ||
-            plen < 0 || plen > (1<<22)) { printf("ERROR %s bad submit header\n", id); fflush(stdout); return 0; }
+        int slot, plen, max_tok, alen = 0; float temp, top_p;
+        int nf = sscanf(ln, "%*s %*s %d %d %d %f %f %d", &slot, &plen, &max_tok, &temp, &top_p, &alen);
+        /* 6th field (optional, backward compatible): DMel byte count appended
+         * verbatim after the text payload — frames x mel_bins u8 levels */
+        if (nf < 5 || plen < 0 || plen > (1<<22) || alen < 0 || alen > (1<<26)) {
+            printf("ERROR %s bad submit header\n", id); fflush(stdout); return 0; }
         (void)slot;
         char *pl = malloc((size_t)plen + 1);
         if (fread(pl, 1, (size_t)plen, stdin) != (size_t)plen) { free(pl); return -1; }
-        int nl = fgetc(stdin); (void)nl;
         pl[plen] = 0;
+        uint8_t *au = NULL;
+        if (alen > 0) {
+            au = malloc((size_t)alen);
+            if (fread(au, 1, (size_t)alen, stdin) != (size_t)alen) { free(pl); free(au); return -1; }
+        }
+        int nl = fgetc(stdin); (void)nl;
         if (g_qn < SRV_QMAX) {
             SReq *q = &g_q[g_qn++];
             snprintf(q->id, sizeof(q->id), "%s", id);
             q->max_tok = max_tok; q->temp = temp; q->top_p = top_p;
             q->payload = pl; q->plen = plen;
-        } else { printf("ERROR %s queue full\n", id); fflush(stdout); free(pl); }
+            q->audio = au; q->alen = alen;
+        } else { printf("ERROR %s queue full\n", id); fflush(stdout); free(pl); free(au); }
     }
     return 0;
 }
@@ -1423,13 +1628,21 @@ static void serve_one(Model *m, Tok *T, SReq *q) {
     if (np <= 0) { printf("ERROR %s empty prompt\n", q->id); fflush(stdout); free(ids); return; }
     const char *bad = prompt_reject(np, q->max_tok);
     if (bad) { printf("ERROR %s %s\n", q->id, bad); fflush(stdout); free(ids); return; }
+    /* audio: every <|audio|> placeholder must have exactly one DMel frame */
+    int naud = q->alen / m->c.mel_bins;
+    if (q->alen % m->c.mel_bins != 0 || audio_tok_count(m, ids, np) != naud) {
+        printf("ERROR %s audio frames (%d) do not match <|audio|> placeholders (%d)%s\n",
+               q->id, naud, audio_tok_count(m, ids, np),
+               m->audio_norm ? "" : " — snapshot has no audio tensors");
+        fflush(stdout); free(ids); return;
+    }
     state_reset(m);
     kv_alloc(m, np + q->max_tok + 8);
     double t0 = now_s();
     uint64_t h0 = m->hits, m0 = m->miss;
     /* per-turn phase snapshot for the PROF line (timers accumulate globally) */
     double f0 = m->t_fill, e0 = m->t_expert, s0 = m->t_shared, a0 = m->t_attn;
-    float *logit = step(m, ids, np, 0, NULL);
+    float *logit = step_mm(m, ids, np, 0, NULL, q->audio, naud);
     int len = np, gen = 0, limited = 1, cancelled = 0;
     char buf[512];
     /* repetition-penalty history: prompt tail + emitted tokens, ring of 128 */
@@ -1546,7 +1759,7 @@ static void serve_loop(Model *m, Tok *T) {
         memmove(g_q, g_q+1, (size_t)(--g_qn) * sizeof(SReq));
         serve_one(m, T, &q);
         serve_tiers_emap(m);
-        free(q.payload);
+        free(q.payload); free(q.audio);
     }
 }
 
@@ -1592,15 +1805,32 @@ int main(int argc, char **argv) {
     }
     /* flags: -p "prompt" [-n N] -> generate mode; positional: [cap] [bits] [ref.json] */
     const char *prompt = NULL, *pfile = NULL, *refpath = "ref_inkling.json";
+    const char *audiopath = NULL;
     int cap = -1, bits = 0, n_new = 256, npos = 0, chat = 0;
     for (int i = 1; i < argc; i++) {
         if (!strcmp(argv[i], "-p") && i+1 < argc) prompt = argv[++i];
         else if (!strcmp(argv[i], "-f") && i+1 < argc) pfile = argv[++i];
         else if (!strcmp(argv[i], "-n") && i+1 < argc) n_new = atoi(argv[++i]);
         else if (!strcmp(argv[i], "--chat")) chat = 1;
+        else if (!strcmp(argv[i], "--audio") && i+1 < argc) audiopath = argv[++i];
         else if (npos == 0) { cap = atoi(argv[i]); npos++; }
         else if (npos == 1) { bits = atoi(argv[i]); npos++; }
         else refpath = argv[i];
+    }
+    /* --audio <file>: raw u8 DMel frames, [n_frames, mel_bins] row-major —
+     * what tinkernel-audio / the gateway DSP emit. Implies --chat (the audio
+     * message needs TMLv0 framing to be in distribution). */
+    uint8_t *dmel = NULL; long dmel_bytes = 0;
+    if (audiopath) {
+        FILE *af = fopen(audiopath, "rb");
+        if (!af) { perror(audiopath); return 1; }
+        fseek(af, 0, SEEK_END); dmel_bytes = ftell(af); fseek(af, 0, SEEK_SET);
+        dmel = malloc((size_t)dmel_bytes);
+        if (fread(dmel, 1, (size_t)dmel_bytes, af) != (size_t)dmel_bytes) {
+            fprintf(stderr, "short read on %s\n", audiopath); return 1; }
+        fclose(af);
+        chat = 1;
+        if (!prompt) prompt = "";
     }
     /* --chat: avvolge il prompt nel template di Inkling (sottoinsieme testuale di
      * chat_template.jinja, lo stesso che openai_server.py rende in render_chat_inkling):
@@ -1609,7 +1839,7 @@ int main(int argc, char **argv) {
      * generazione. Senza template un modello instruct riceve testo fuori
      * distribuzione. THINK=<0..1> alza lo sforzo di ragionamento (default 0). */
     char *chat_buf = NULL;
-    if (chat && prompt) {
+    if (chat && prompt && !dmel) {
         const char *eff = getenv("THINK") ? getenv("THINK") : "0";
         size_t need = strlen(prompt) + strlen(eff) + 256;
         chat_buf = malloc(need);
@@ -1618,6 +1848,26 @@ int main(int argc, char **argv) {
                  "<|message_user|><|content_text|>%s<|end_message|>"
                  "<|message_system|><|content_text|>Thinking effort level: %s<|end_message|>"
                  "<|message_model|>", prompt, eff);
+        prompt = chat_buf;
+    } else if (chat && dmel) {
+        /* audio turn, TMLv0 framing (conformant with tml-renderers 0.1.0):
+         * effort system message, optional text user message, then the audio
+         * message — <|content_audio_input|>, one <|audio|> per frame,
+         * <|audio_end|> — and <|message_model|> to hand the turn over.
+         * Frame count is provisional here (mel_bins is read from config.json
+         * at model_init); recomputed below once the model is loaded. */
+        const char *eff = getenv("THINK") ? getenv("THINK") : "0";
+        long nf_guess = dmel_bytes / 80;           /* placeholder emission only */
+        size_t need = strlen(prompt) + strlen(eff) + (size_t)nf_guess*10 + 320;
+        chat_buf = malloc(need);
+        if (!chat_buf) { fprintf(stderr, "OOM chat template\n"); return 1; }
+        char *w = chat_buf;
+        w += sprintf(w, "<|message_system|><|content_text|>Thinking effort level: %s<|end_message|>", eff);
+        if (prompt[0])
+            w += sprintf(w, "<|message_user|><|content_text|>%s<|end_message|>", prompt);
+        w += sprintf(w, "<|message_user|><|content_audio_input|>");
+        for (long i = 0; i < nf_guess; i++) w += sprintf(w, "<|audio|>");
+        sprintf(w, "<|audio_end|><|end_message|><|message_model|>");
         prompt = chat_buf;
     }
     if (cap < 0) cap = (prompt || pfile) ? 0 : 16;   /* generate mode defaults to RAM-sized auto cap */
@@ -1642,7 +1892,13 @@ int main(int argc, char **argv) {
         pins_load(&m, snap);
         char tkp[2048]; snprintf(tkp, sizeof(tkp), "%s/tokenizer.json", snap);
         Tok T; tok_load(&T, tkp);
-        if (prompt) generate_stream(&m, &T, prompt, n_new);
+        if (prompt) {
+            int naud = dmel ? (int)(dmel_bytes / m.c.mel_bins) : 0;
+            if (dmel && dmel_bytes % m.c.mel_bins != 0) {
+                fprintf(stderr, "%s: %ld bytes is not a multiple of mel_bins=%d\n",
+                        audiopath, dmel_bytes, m.c.mel_bins); return 1; }
+            generate_stream(&m, &T, prompt, n_new, dmel, naud);
+        }
         else {   /* -f: one prompt per line, model loaded once, usage accumulates */
             FILE *pf = fopen(pfile, "rb"); if (!pf) { perror(pfile); return 1; }
             char ln[8192]; int np = 0;
@@ -1651,7 +1907,7 @@ int main(int argc, char **argv) {
                 if (!n || ln[0]=='#') continue;
                 printf("\n===== prompt %d =====\n", ++np);
                 state_reset(&m);
-                generate_stream(&m, &T, ln, n_new);
+                generate_stream(&m, &T, ln, n_new, NULL, 0);
             }
             fclose(pf);
         }
@@ -1675,10 +1931,12 @@ int main(int argc, char **argv) {
     fseek(f,0,SEEK_END); long n=ftell(f); fseek(f,0,SEEK_SET);
     char *buf=malloc(n+1); if(fread(buf,1,n,f)!=(size_t)n){} buf[n]=0; fclose(f);
     char *arena=NULL; jval *ref = json_parse(buf, &arena);
-    int np, nfull, ntf;
+    int np, nfull, ntf, ndm;
     int *pids  = read_int_array(ref,"prompt_ids",&np);
     int *full  = read_int_array(ref,"full_ids",&nfull);
     int *tfref = read_int_array(ref,"tf_pred",&ntf);
+    /* optional audio oracle: "dmel" = flattened [n_frames, mel_bins] levels */
+    int *dmint = read_int_array(ref,"dmel",&ndm);
     int ngen = nfull - np;
 
     Model m; model_init(&m, snap, cap, bits);
@@ -1691,10 +1949,19 @@ int main(int argc, char **argv) {
     printf("resident weights loaded in %.1fs | RSS: %.2f GB\n", m.dense_load_s, rss_gb());
     kv_alloc(&m, nfull + 8);
 
+    uint8_t *rdmel = NULL; int rnaud = 0;
+    if (dmint && ndm > 0) {
+        if (ndm % m.c.mel_bins != 0) { fprintf(stderr, "dmel len %d not a multiple of mel_bins %d\n", ndm, m.c.mel_bins); return 1; }
+        rnaud = ndm / m.c.mel_bins;
+        rdmel = malloc((size_t)ndm);
+        for (int i = 0; i < ndm; i++) rdmel[i] = (uint8_t)dmint[i];
+        printf("audio oracle: %d DMel frames x %d bins\n", rnaud, m.c.mel_bins);
+    }
+
     /* pass 1: teacher-forced argmax over the full reference sequence */
     if (tfref && ntf == nfull) {
         int *tf = malloc(nfull * sizeof(int));
-        float *lg = step(&m, full, nfull, 0, tf);
+        float *lg = step_mm(&m, full, nfull, 0, tf, rdmel, rnaud);
         free(lg);
         int ok = 0; for (int i = 0; i < nfull; i++) ok += (tf[i] == tfref[i]);
         printf("teacher-forced argmax: %d/%d match\n", ok, nfull);
@@ -1705,13 +1972,21 @@ int main(int argc, char **argv) {
     /* pass 2: greedy generation, token-for-token vs the oracle */
     int *out = malloc(nfull * sizeof(int));
     double t = now_s();
-    generate(&m, pids, np, ngen, out);
+    generate(&m, pids, np, ngen, out, rdmel, rnaud);
     double dt = now_s() - t;
     int match = 0;
     printf("Reference: "); for (int i=np;i<nfull;i++) printf("%d ", full[i]);
     printf("\nC engine : "); for (int i=np;i<nfull;i++) { printf("%d ", out[i]); if (out[i]==full[i]) match++; }
     printf("\nMatching tokens: %d/%d\n", match, ngen);
     double tot = m.hits + m.miss;
+#ifdef COLI_METAL
+    if (g_metal) {
+        uint64_t mok = 0, mfb = 0, mex = 0;
+        coli_metal_moe_counts(&mok, &mfb, &mex);
+        printf("[metal] %llu MoE blocks on GPU, %llu CPU fallbacks, %llu experts\n",
+               (unsigned long long)mok, (unsigned long long)mfb, (unsigned long long)mex);
+    }
+#endif
     printf("PEAK RSS: %.2f GB | expert cache hit %.1f%% | %.2f tok/s\n",
            rss_gb(), tot?100.0*m.hits/tot:0.0, ngen/dt);
     free(buf); free(arena);

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -743,6 +743,10 @@ static void model_init(Model *m, const char *snap, int cap, int bits) {
 #ifdef COLI_METAL
     {   const char *me = getenv("COLI_METAL");
         if (me && *me == '1' && !getenv("NOGPU")) {
+            /* Residency set ON by default for inkling: without it every MoE
+             * block pays per-buffer useResource churn — measured 0.17 vs 1.76
+             * tok/s decode on Inkling-Small. COLI_METAL_RESSET=0 opts out. */
+            setenv("COLI_METAL_RESSET", "1", 0);
             if (coli_metal_init()) {
                 g_metal = 1;
                 fprintf(stderr, "[metal] ready — batched expert MoE on the Apple GPU\n");
@@ -1204,12 +1208,12 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
     float *mxg = NULL, *mrw = NULL; const void **mgp = NULL, **mup = NULL, **mdp = NULL;
     const float **mgs = NULL, **mus = NULL, **mds = NULL; Slot **mslot = NULL;
     int *mxoff = NULL, *mnr = NULL, *mrows = NULL, *mgi = NULL, *mfp = NULL;
-    /* GPU only when the block is batched: at decode (S==1) a round is topk
-     * pairs of 6-row kernels and the ~135ms dispatch+sync latency swamps the
-     * math — measured 0.14 tok/s on GPU vs 0.63 on CPU for Inkling-Small.
-     * Prefill rounds carry up to `cap` pairs and amortize the launch.
-     * INK_METAL_MIN_S overrides the gate (1 = GPU always, for A/Bs). */
-    int metal_min_s = getenv("INK_METAL_MIN_S") ? atoi(getenv("INK_METAL_MIN_S")) : 2;
+    /* GPU for decode too, now that the residency set is on by default: with
+     * it a decode block runs in ~3ms and measures 1.76 tok/s vs 0.84 on CPU
+     * (Inkling-Small, M-series 128 GB). Without the set the same block paid
+     * ~135ms of useResource churn and CPU won — INK_METAL_MIN_S=2 restores
+     * the prefill-only gate if that regime ever returns. */
+    int metal_min_s = getenv("INK_METAL_MIN_S") ? atoi(getenv("INK_METAL_MIN_S")) : 1;
     if (g_metal && m->xq && S >= metal_min_s) {
         mxg = falloc((int64_t)cap*D); mrw = falloc(cap);
         mgp = malloc(cap*sizeof(void*)); mup = malloc(cap*sizeof(void*)); mdp = malloc(cap*sizeof(void*));
@@ -1786,7 +1790,11 @@ int main(int argc, char **argv) {
      * once (COLI_OMP_TUNED guards the exec; COLI_NO_OMP_TUNE=1 disables).
      * NOT under CUDA — same exception glm.c makes: a spinning 24-thread team
      * starves the CUDA driver during every stream sync. */
-#ifndef COLI_CUDA
+#if !defined(COLI_CUDA) && !defined(__APPLE__)
+    /* NOT on Apple Silicon: the active-spin team steals the shared SoC power
+     * budget (same mechanism as the M5 Max Metal report) and measured strictly
+     * worse on Inkling-Small even for pure-CPU decode — 0.50 vs 0.84 tok/s,
+     * and 2x the prefill. Opt back in with COLI_OMP_TUNED=0 unset + Linux. */
     if (!getenv("COLI_OMP_TUNED") && !getenv("COLI_NO_OMP_TUNE")) {
         setenv("OMP_WAIT_POLICY","active",0);
         setenv("GOMP_SPINCOUNT","200000",0);
@@ -1798,7 +1806,7 @@ int main(int argc, char **argv) {
         perror("[OMP] execv self-reexec failed, running untuned");
 #endif
     }
-#endif  /* !COLI_CUDA */
+#endif  /* !COLI_CUDA && !__APPLE__ */
     const char *snap = getenv("SNAP");
     if (!snap) { fprintf(stderr, "set SNAP=<snapshot directory>\n"); return 1; }
     g_topp = getenv("TOPP") ? (float)atof(getenv("TOPP")) : 0.f;

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -1204,7 +1204,13 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
     float *mxg = NULL, *mrw = NULL; const void **mgp = NULL, **mup = NULL, **mdp = NULL;
     const float **mgs = NULL, **mus = NULL, **mds = NULL; Slot **mslot = NULL;
     int *mxoff = NULL, *mnr = NULL, *mrows = NULL, *mgi = NULL, *mfp = NULL;
-    if (g_metal && m->xq) {
+    /* GPU only when the block is batched: at decode (S==1) a round is topk
+     * pairs of 6-row kernels and the ~135ms dispatch+sync latency swamps the
+     * math — measured 0.14 tok/s on GPU vs 0.63 on CPU for Inkling-Small.
+     * Prefill rounds carry up to `cap` pairs and amortize the launch.
+     * INK_METAL_MIN_S overrides the gate (1 = GPU always, for A/Bs). */
+    int metal_min_s = getenv("INK_METAL_MIN_S") ? atoi(getenv("INK_METAL_MIN_S")) : 2;
+    if (g_metal && m->xq && S >= metal_min_s) {
         mxg = falloc((int64_t)cap*D); mrw = falloc(cap);
         mgp = malloc(cap*sizeof(void*)); mup = malloc(cap*sizeof(void*)); mdp = malloc(cap*sizeof(void*));
         mgs = malloc(cap*sizeof(float*)); mus = malloc(cap*sizeof(float*)); mds = malloc(cap*sizeof(float*));

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -457,6 +457,170 @@ def split_inkling(text):
     return _INK_MARKER.sub("", text), _INK_MARKER.sub("", "".join(reasoning))
 
 
+# ---- Inkling DMel audio input ------------------------------------------------------------
+# Inkling takes audio as discretized log-mel frames ("DMel"): 80 slaney mel
+# bands per 50 ms hop, quantized to 16 levels in log10 [-7, 2]. One frame = one
+# <|audio|> placeholder token; the engine swaps in the frame's embedding at that
+# position. The DSP below matches tml-renderers 0.1.0 (via tinkernel-audio,
+# which is byte-golden against the official wheel): 100 ms periodic-Hann window
+# centered on i*hop with zero edge padding, magnitude-domain mel projection,
+# and a turn-level RMS boost for quiet audio (rms < 0.01).
+
+AUDIO_SAMPLE_RATE = 16_000
+AUDIO_HOP = 800
+AUDIO_WINDOW = 1_600
+AUDIO_MEL_BANDS = 80
+AUDIO_DMEL_LEVELS = 16
+AUDIO_DMEL_MIN, AUDIO_DMEL_MAX = -7.0, 2.0
+AUDIO_RMS_FLOOR = 0.01
+AUDIO_LOG_FLOOR = 1.0e-10
+
+_MEL_FILTERS = None
+
+
+def _np():
+    try:
+        import numpy
+    except ImportError:
+        raise APIError(400, "Audio input needs numpy on the gateway (pip install numpy).",
+                       None, "unsupported_content_type")
+    return numpy
+
+
+def _mel_filters(np):
+    """Slaney mel filter bank, [80, 801], normalization 2/(upper-lower)."""
+    global _MEL_FILTERS
+    if _MEL_FILTERS is not None:
+        return _MEL_FILTERS
+    fft_freqs = np.arange(AUDIO_WINDOW // 2 + 1, dtype=np.float64) * AUDIO_SAMPLE_RATE / AUDIO_WINDOW
+
+    def hz_to_mel(hz):
+        hz = np.asarray(hz, dtype=np.float64)
+        return np.where(hz >= 1000.0, 15.0 + np.log(np.maximum(hz, 1e-30) / 1000.0) / 0.06875177742094912,
+                        hz / 66.66666666666667)
+
+    def mel_to_hz(mel):
+        mel = np.asarray(mel, dtype=np.float64)
+        return np.where(mel >= 15.0, 1000.0 * np.exp(0.06875177742094912 * (mel - 15.0)),
+                        66.66666666666667 * mel)
+
+    max_mel = hz_to_mel(AUDIO_SAMPLE_RATE / 2.0)
+    mel_points = mel_to_hz(np.linspace(0.0, float(max_mel), AUDIO_MEL_BANDS + 2))
+    lower, center, upper = mel_points[:-2], mel_points[1:-1], mel_points[2:]
+    rising = (fft_freqs[None, :] - lower[:, None]) / (center - lower)[:, None]
+    falling = (upper[:, None] - fft_freqs[None, :]) / (upper - center)[:, None]
+    weights = np.maximum(np.minimum(rising, falling), 0.0) * (2.0 / (upper - lower))[:, None]
+    _MEL_FILTERS = weights.astype(np.float32)
+    return _MEL_FILTERS
+
+
+def dmel_encode(samples):
+    """Mono 16 kHz f32 PCM -> u8 DMel bytes, [ceil(n/800), 80] row-major."""
+    np = _np()
+    samples = np.asarray(samples, dtype=np.float32)
+    n = samples.shape[0]
+    if n == 0:
+        raise APIError(400, "Audio clip is empty.", None, "invalid_value")
+    frames = -(-n // AUDIO_HOP)
+    half = AUDIO_WINDOW // 2
+    padded = np.zeros(half + frames * AUDIO_HOP + half, dtype=np.float32)
+    padded[half:half + n] = samples
+    idx = (np.arange(frames)[:, None] * AUDIO_HOP) + np.arange(AUDIO_WINDOW)[None, :]
+    hann = (0.5 - 0.5 * np.cos(2.0 * np.pi * np.arange(AUDIO_WINDOW, dtype=np.float64)
+                               / AUDIO_WINDOW)).astype(np.float32)
+    windows = padded[idx] * hann[None, :]
+    sqmag = np.abs(np.fft.rfft(windows, axis=1)) ** 2                   # [frames, 801]
+    rms = math.sqrt(float(np.sum(samples.astype(np.float64) ** 2)) / n)
+    scale = AUDIO_RMS_FLOOR / rms if 0.0 < rms < AUDIO_RMS_FLOOR else 1.0
+    mag = np.sqrt(np.maximum(sqmag * (scale * scale), AUDIO_LOG_FLOOR)).astype(np.float32)
+    energy = mag @ _mel_filters(np).T                                   # [frames, 80]
+    logmel = np.log10(np.maximum(energy, AUDIO_LOG_FLOOR))
+    norm = np.clip((np.clip(logmel, AUDIO_DMEL_MIN, AUDIO_DMEL_MAX) - AUDIO_DMEL_MIN)
+                   / (AUDIO_DMEL_MAX - AUDIO_DMEL_MIN), 0.0, 1.0)
+    q = np.clip(np.ceil(norm * (AUDIO_DMEL_LEVELS - 1) - 0.5), 0, AUDIO_DMEL_LEVELS - 1)
+    return q.astype(np.uint8).tobytes()
+
+
+def decode_wav_mono16k(data, param):
+    """Minimal RIFF/WAVE reader: PCM16 or float32, any channel count (mixed
+    down), sample rate must already be 16 kHz — resampling belongs at the
+    capture edge, not in the gateway."""
+    import struct as _struct
+    np = _np()
+    if len(data) < 44 or data[:4] != b"RIFF" or data[8:12] != b"WAVE":
+        raise APIError(400, "Audio must be a RIFF/WAVE file.", param, "invalid_value")
+    pos, fmt, raw = 12, None, None
+    while pos + 8 <= len(data):
+        cid, size = data[pos:pos + 4], _struct.unpack_from("<I", data, pos + 4)[0]
+        body = data[pos + 8:pos + 8 + size]
+        if cid == b"fmt ":
+            fmt = _struct.unpack_from("<HHIIHH", body, 0)
+        elif cid == b"data":
+            raw = body
+        pos += 8 + size + (size & 1)
+    if fmt is None or raw is None:
+        raise APIError(400, "WAV file is missing fmt/data chunks.", param, "invalid_value")
+    audio_format, channels, rate, _, _, bits = fmt
+    if audio_format == 0xFFFE:      # WAVE_FORMAT_EXTENSIBLE: trust the bit width
+        audio_format = 3 if bits == 32 else 1
+    if rate != AUDIO_SAMPLE_RATE:
+        raise APIError(400, f"Audio must be {AUDIO_SAMPLE_RATE} Hz (got {rate}). "
+                            "Resample at the capture edge.", param, "invalid_value")
+    if audio_format == 1 and bits == 16:
+        samples = np.frombuffer(raw, dtype="<i2").astype(np.float32) / 32768.0
+    elif audio_format == 3 and bits == 32:
+        samples = np.frombuffer(raw, dtype="<f4").astype(np.float32)
+    else:
+        raise APIError(400, f"Unsupported WAV encoding (format {audio_format}, {bits}-bit); "
+                            "use PCM16 or float32.", param, "invalid_value")
+    if channels > 1:
+        samples = samples[:len(samples) - len(samples) % channels]
+        samples = samples.reshape(-1, channels).mean(axis=1)
+    return samples
+
+
+def inkling_content_segments(content, param, audio_out):
+    """Split OpenAI message content into ordered TMLv0 segments:
+    ("text", str) for merged text runs, ("audio", n_frames) per input_audio
+    part (its DMel bytes appended to audio_out in prompt order)."""
+    if isinstance(content, str):
+        return [("text", content)]
+    if not isinstance(content, list):
+        raise APIError(400, "Message content must be a string or an array of parts.", param)
+    segments = []
+    for index, part in enumerate(content):
+        ptype = part.get("type") if isinstance(part, dict) else None
+        if ptype in ("text", "input_text"):
+            if not isinstance(part.get("text"), str):
+                raise APIError(400, "Text content parts require a string `text` field.",
+                               f"{param}.{index}.text")
+            if segments and segments[-1][0] == "text":
+                segments[-1] = ("text", segments[-1][1] + part["text"])
+            else:
+                segments.append(("text", part["text"]))
+        elif ptype == "input_audio":
+            spec = part.get("input_audio")
+            if not isinstance(spec, dict) or not isinstance(spec.get("data"), str):
+                raise APIError(400, "`input_audio` parts need base64 `data`.",
+                               f"{param}.{index}.input_audio")
+            if spec.get("format", "wav") != "wav":
+                raise APIError(400, "Only WAV audio is supported (mono, 16 kHz, PCM16/float32).",
+                               f"{param}.{index}.input_audio.format", "unsupported_content_type")
+            import base64
+            try:
+                wav = base64.b64decode(spec["data"], validate=True)
+            except Exception:
+                raise APIError(400, "`input_audio.data` is not valid base64.",
+                               f"{param}.{index}.input_audio.data")
+            dmel = dmel_encode(decode_wav_mono16k(wav, f"{param}.{index}.input_audio.data"))
+            audio_out.append(dmel)
+            segments.append(("audio", len(dmel) // AUDIO_MEL_BANDS))
+        else:
+            raise APIError(400, "Unsupported content part type for the Inkling engine.",
+                           f"{param}.{index}", "unsupported_content_type")
+    return segments
+
+
 def render_chat_kimi(messages, enable_thinking=False, reasoning_effort=None, tools=None,
                      tool_choice=None):
     """Validated multi-turn K3 payload for the C engine.
@@ -494,7 +658,7 @@ def render_chat_kimi(messages, enable_thinking=False, reasoning_effort=None, too
 
 
 def render_chat_inkling(messages, enable_thinking=False, reasoning_effort=None, tools=None,
-                        tool_choice=None):
+                        tool_choice=None, audio_out=None):
     """Text-only subset of Inkling's chat_template.jinja: role tokens with
     <|content_text|> parts and <|end_message|> terminators, an assistant
     <|content_model_end_sampling|> after each prior model turn, the
@@ -536,8 +700,20 @@ def render_chat_inkling(messages, enable_thinking=False, reasoning_effort=None, 
             prompt.append(effort_str)
             effort_emitted = True
         raw = message.get("content")
-        text = content_text(raw, f"messages.{index}.content") if raw is not None else ""
-        prompt.append(f"{rtok}<|content_text|>{text}<|end_message|>")
+        if audio_out is not None and role == "user" and isinstance(raw, list):
+            # multipart user content: text runs and audio clips become separate
+            # TMLv0 messages, in part order (a message carries ONE content type).
+            # Each DMel frame is one <|audio|> placeholder; the engine replaces
+            # those embeddings with the frames appended to audio_out.
+            for kind, val in inkling_content_segments(raw, f"messages.{index}.content", audio_out):
+                if kind == "text":
+                    prompt.append(f"{rtok}<|content_text|>{val}<|end_message|>")
+                else:
+                    prompt.append(f"{rtok}<|content_audio_input|>"
+                                  + "<|audio|>" * val + "<|audio_end|><|end_message|>")
+        else:
+            text = content_text(raw, f"messages.{index}.content") if raw is not None else ""
+            prompt.append(f"{rtok}<|content_text|>{text}<|end_message|>")
         if role == "assistant":
             prompt.append("<|content_model_end_sampling|>")
     if not effort_emitted:                       # all-system edge case: fallback
@@ -1339,7 +1515,7 @@ class Engine:
                 self._fail_pending(error)
 
     def generate(self, prompt, max_tokens, temperature, top_p, on_text, cache_slot=0,
-                 cancelled=None, grammar=None, stopped=None, on_accept=None):
+                 cancelled=None, grammar=None, stopped=None, on_accept=None, audio=None):
         if isinstance(cache_slot, bool) or not isinstance(cache_slot, int) or not 0 <= cache_slot < self.kv_slots:
             raise APIError(400, "Invalid cache slot.", "cache_slot")
         payload = prompt.encode("utf-8")
@@ -1348,6 +1524,12 @@ class Engine:
         gpayload = grammar.encode("utf-8") if grammar else b""
         if b"\0" in gpayload:
             raise APIError(400, "NUL bytes are not supported in grammars.", "response_format")
+        # audio (inkling only): the optional 7th SUBMIT field is grammar bytes
+        # for glm and DMel bytes for inkling — the two engines never see the
+        # other's extension, and inkling rejects grammars upstream.
+        apayload = audio or b""
+        if gpayload and apayload:
+            raise APIError(400, "Grammar and audio cannot be combined.", "response_format")
         decoder = codecs.getincrementaldecoder("utf-8")("replace")
 
         def decode(data):
@@ -1366,14 +1548,15 @@ class Engine:
             request_id = str(self.next_request_id)
             self.next_request_id += 1
             self.pending[request_id] = events
+        xpayload = gpayload or apayload
         header = (f"SUBMIT {request_id} {cache_slot} {len(payload)} {max_tokens} "
                   f"{temperature:.8g} {top_p:.8g}"
-                  + (f" {len(gpayload)}" if gpayload else "") + "\n").encode()
+                  + (f" {len(xpayload)}" if xpayload else "") + "\n").encode()
         try:
             with self.write_lock:
                 if self.process.poll() is not None:
                     raise RuntimeError("colibri engine is not running")
-                self.process.stdin.write(header + payload + gpayload + b"\n")
+                self.process.stdin.write(header + payload + xpayload + b"\n")
                 self.process.stdin.flush()
         except Exception:
             with self.pending_lock:
@@ -1766,7 +1949,7 @@ class APIHandler(BaseHTTPRequestHandler):
         return {"type": "error", "error": {"type": error.error_type, "message": error.message}}
 
     def generation(self, body, prompt, request_id, chat, tools=None, tool_choice=None,
-                   enable_thinking=False):
+                   enable_thinking=False, audio=None):
         # COLI_DEBUG tees the engine transaction to stderr: 1 = decoded output stream only,
         # 2 = both sides (rendered prompt + output). render_chat already folds prior turns and
         # tool results into `prompt`, so level 2 is the full conversation the engine saw.
@@ -1821,7 +2004,8 @@ class APIHandler(BaseHTTPRequestHandler):
                 stop_filter = StopFilter(stop_sequences, output.append, ignore_leading_stop)
                 stats = self.server.engine.generate(
                     prompt, maximum, temperature, top_p, stop_filter.feed, cache_slot,
-                    self.client_disconnected, grammar=grammar, stopped=stop_filter.stopped)
+                    self.client_disconnected, grammar=grammar, stopped=stop_filter.stopped,
+                    **({"audio": audio} if audio else {}))
                 stop_filter.finish()
                 text = "".join(output)
                 reasoning = ""
@@ -1990,7 +2174,7 @@ class APIHandler(BaseHTTPRequestHandler):
                 stats = self.server.engine.generate(
                     prompt, maximum, temperature, top_p, stop_filter.feed, cache_slot,
                     lambda: not connected, grammar=grammar, stopped=stop_filter.stopped,
-                    on_accept=start_stream)
+                    on_accept=start_stream, **({"audio": audio} if audio else {}))
                 stop_filter.finish()
                 if think:
                     think.finish()
@@ -2019,7 +2203,7 @@ class APIHandler(BaseHTTPRequestHandler):
                 stats = self.server.engine.generate(
                     prompt, maximum, temperature, top_p, stop_filter.feed, cache_slot,
                     lambda: not connected, grammar=grammar, stopped=stop_filter.stopped,
-                    on_accept=start_stream)
+                    on_accept=start_stream, **({"audio": audio} if audio else {}))
                 stop_filter.finish()
                 if content_split:
                     content_split.close()
@@ -2080,10 +2264,16 @@ class APIHandler(BaseHTTPRequestHandler):
         tool_choice = body.get("tool_choice")
         renderer = (render_chat_inkling if ARCH == "inkling" else
                     render_chat_kimi if ARCH == "kimi" else render_chat)
-        prompt = renderer(body.get("messages"), enable_thinking, reasoning_effort, tools,
-                          tool_choice)
+        audio_clips = [] if ARCH == "inkling" else None
+        if audio_clips is not None:
+            prompt = renderer(body.get("messages"), enable_thinking, reasoning_effort, tools,
+                              tool_choice, audio_out=audio_clips)
+        else:
+            prompt = renderer(body.get("messages"), enable_thinking, reasoning_effort, tools,
+                              tool_choice)
         self.generation(body, prompt, request_id, True, tools, tool_choice,
-                        enable_thinking=enable_thinking)
+                        enable_thinking=enable_thinking,
+                        audio=b"".join(audio_clips) if audio_clips else None)
 
     # ---- Anthropic /v1/messages (#343) ----------------------------------------------------
     ANTHROPIC_STOP = {"stop": "end_turn", "length": "max_tokens", "tool_calls": "tool_use"}

--- a/c/tools/convert_inkling_int4.py
+++ b/c/tools/convert_inkling_int4.py
@@ -83,6 +83,17 @@ def interleave(t: torch.Tensor, dim: int) -> torch.Tensor:
 
 SKIP_PREFIXES = ("model.audio.", "model.visual.", "model.mtp.")
 
+# --keep-audio: the audio tower is one embedding table + one norm (~10 MB bf16
+# on Inkling-Small) and inkling.c consumes it under its original model.audio.*
+# names, so keeping it costs nothing. Vision and MTP stay skipped.
+KEEP_AUDIO = False
+
+
+def skip_name(name):
+    if KEEP_AUDIO and name.startswith("model.audio."):
+        return False
+    return name.startswith(SKIP_PREFIXES)
+
 RENAMES = [
     (r"^model\.llm\.embed\.weight$",      "model.embed_tokens.weight"),
     (r"^model\.llm\.embed_norm\.weight$", "model.embed_norm.weight"),
@@ -120,8 +131,9 @@ F32_RE = re.compile(
 
 def map_name(name):
     """Simple renames only (fused w13 tensors are handled by the shard loop).
-    Returns the mapped name, or None to skip."""
-    if name.startswith(SKIP_PREFIXES):
+    Returns the mapped name, or None to skip. model.audio.* (when kept) maps
+    to itself — the engine loads those names directly."""
+    if skip_name(name):
         return None
     for pat, rep in RENAMES:
         name = re.sub(pat, rep, name)
@@ -168,7 +180,7 @@ def quantize_expert_tensor(f, name, xbits, out, out_name):
 def convert_shard(path, out, xbits):
     with safe_open(path, framework="pt") as f:
         for name in f.keys():
-            if name.startswith(SKIP_PREFIXES):
+            if skip_name(name):
                 continue
             base = map_name(name)
             if name.endswith(".mlp.experts.w13_weight"):
@@ -391,9 +403,14 @@ def main():
     ap.add_argument("--watch", action="store_true",
                     help="poll --indir while the download is still running")
     ap.add_argument("--delete-src", action="store_true")
+    ap.add_argument("--keep-audio", action="store_true",
+                    help="keep model.audio.* (DMel embedding table + norm, ~10 MB) "
+                         "so the engine can take audio input")
     ap.add_argument("--selftest", action="store_true")
     ap.add_argument("--selftest-e2e", nargs=2, metavar=("HFDIR", "OUTBASE"))
     a = ap.parse_args()
+    global KEEP_AUDIO
+    KEEP_AUDIO = a.keep_audio
     if a.selftest:
         selftest(); return
     if a.selftest_e2e:

--- a/c/tools/make_tiny_inkling_audio.py
+++ b/c/tools/make_tiny_inkling_audio.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Build a tiny random-weight MULTIMODAL Inkling fixture for inkling.c audio.
+
+Same idea as make_tiny_inkling.py, but through InklingForConditionalGeneration
+with an audio tower, so the DMel path is validated end to end: placeholder
+tokens in the prompt, per-frame embedding-table lookup, the audio RMSNorm, and
+the masked_scatter splice. ref_inkling.json gains "dmel" (flattened
+[n_frames, n_mel_bins] levels); the C engine must reproduce tf_pred and the
+greedy continuation token-for-token (run with bits=0 for f32-exact experts).
+
+Usage: python3 make_tiny_inkling_audio.py <outdir>
+"""
+import json
+import sys
+
+import torch
+
+try:
+    from transformers import InklingForConditionalGeneration
+    from transformers.models.inkling.configuration_inkling import (
+        InklingAudioConfig,
+        InklingConfig,
+        InklingTextConfig,
+        InklingVisionConfig,
+    )
+except ImportError:
+    sys.exit("transformers has no Inkling support: pip install -U transformers")
+
+AUDIO_TOK = 251        # inside the padded vocab (256), outside unpadded (250)
+AUDIO_BOS = 252
+N_FRAMES = 5
+N_MEL = 8
+MEL_VOCAB = 16
+
+
+def main():
+    out = sys.argv[1] if len(sys.argv) > 1 else "tiny_inkling_audio"
+    torch.manual_seed(0)
+
+    text_cfg = InklingTextConfig(
+        vocab_size=256,
+        unpadded_vocab_size=250,
+        hidden_size=64,
+        num_hidden_layers=8,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        swa_num_attention_heads=4,
+        swa_num_key_value_heads=4,
+        swa_head_dim=16,
+        sliding_window_size=8,
+        d_rel=8,
+        rel_extent=32,
+        log_scaling_n_floor=8,
+        log_scaling_alpha=0.1,
+        local_layer_ids=[0, 1, 2, 3, 4, 6, 7],
+        dense_mlp_idx=2,
+        dense_intermediate_size=96,
+        moe_intermediate_size=32,
+        n_routed_experts=8,
+        num_experts_per_tok=2,
+        n_shared_experts=2,
+        route_scale=2.0,
+        logits_mup_width_multiplier=4.0,
+        max_position_embeddings=4096,
+        eos_token_id=None,
+    )
+    audio_cfg = InklingAudioConfig(
+        n_mel_bins=N_MEL,
+        mel_vocab_size=MEL_VOCAB,
+        text_hidden_size=64,
+    )
+    vision_cfg = InklingVisionConfig(
+        decoder_dmodel=64,
+        patch_size=4,
+        temporal_patch_size=1,
+        n_channels=3,
+        n_layers=2,
+    )
+    cfg = InklingConfig(
+        text_config=text_cfg,
+        audio_config=audio_cfg,
+        vision_config=vision_cfg,
+        audio_token_id=AUDIO_TOK,
+        audio_bos_token_id=AUDIO_BOS,
+    )
+
+    # The vision tower is irrelevant to the audio oracle (and its constructor
+    # trips on tensor-typed dims with tiny configs) — stub it out. The C engine
+    # skips model.visual.* regardless.
+    import transformers.models.inkling.modeling_inkling as _mi
+
+    class _NoVision(torch.nn.Module):
+        def __init__(self, config):
+            super().__init__()
+
+    _mi.InklingVisionModel = _NoVision
+
+    model = InklingForConditionalGeneration(cfg).eval().float()
+
+    g = torch.Generator().manual_seed(7)
+    dmel = torch.randint(0, MEL_VOCAB, (1, N_FRAMES, N_MEL), generator=g)
+
+    prompt = [7, 42, 199, AUDIO_BOS] + [AUDIO_TOK] * N_FRAMES + [3, 88, 154, 21, 60]
+    ids = torch.tensor([prompt], dtype=torch.long)
+    n_new = 24
+
+    with torch.no_grad():
+        gen = model.generate(
+            ids,
+            audio_input_ids=dmel,
+            max_new_tokens=n_new,
+            do_sample=False,
+            use_cache=True,
+        )
+        full = gen[0].tolist()
+        tf = (
+            model(torch.tensor([full], dtype=torch.long), audio_input_ids=dmel)
+            .logits[0]
+            .argmax(-1)
+            .tolist()
+        )
+
+    model.save_pretrained(out, safe_serialization=True)
+    ref = {
+        "prompt_ids": prompt,
+        "full_ids": full,
+        "tf_pred": tf,
+        "dmel": dmel[0].flatten().tolist(),
+    }
+    with open(f"{out}/ref_inkling.json", "w") as f:
+        json.dump(ref, f)
+    print(f"saved tiny multimodal model + ref_inkling.json to {out}/")
+    print("continuation:", full[len(prompt):])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds audio input to Inkling and speeds it up on Apple Silicon: DMel frames in
at `<|audio|>` placeholders, routed-expert matmul on the Metal GPU
(`COLI_METAL=1`, opt-in), and three default changes on `__APPLE__` builds that
come out of a measured knob sweep rather than a guess. Text-only Inkling and
non-Apple builds are unchanged, everything here is `__APPLE__`/`COLI_METAL`
guarded or opt-in.

## Audio input (DMel)

Inkling's audio tower is small on purpose: a `[mel_bins*mel_vocab, D]`
embedding table plus one RMSNorm. A frame's embedding is
`rmsnorm(sum of 80 rows, eps 1e-6)`, and it *replaces* the placeholder's text
embedding rather than adding to it (`embed_norm` doesn't apply), matching
`masked_scatter` in HF's `modeling_inkling.py`. That's the whole audio path,
there's no separate encoder stack to load or run, which is why this lands as
a small patch to `inkling.c` instead of a new subsystem.

The tensors (`model.audio.*`, ~10 MB bf16 on Inkling-Small) load from either a
`--keep-audio` container or an `audio.safetensors` sidecar dropped next to the
snapshot. The sidecar matters for anyone running off a remote/lazy mount:
fetch ~10 MB via HTTP range requests instead of pulling the 532 GB bf16
checkpoint just to get the audio tower. Absent tensors, text-only engine,
nothing changes.

Three entry points land the DMel frames:

- `--audio file.dmel` on the CLI (implies `--chat`, emits TMLv0 audio framing)
- an optional 7th field on the serve wire protocol, carrying raw DMel bytes
- a `"dmel"` array in `ref_inkling.json` for the oracle harness

The 7th SUBMIT field was already reserved (glm uses it for grammar bytes), and
the two engines never see each other's extension, so there was no new framing
to design, just a slot to fill. Frame counts are checked against placeholder
counts up front, a mismatch is a hard error, not a silent skip.

On the gateway side, `input_audio` content parts on `/v1/chat/completions`
now work for Inkling: base64 WAV in, spoken answer out. The WAV decode (PCM16
or float32, mono after mixdown, 16 kHz enforced) and the DMel DSP are a numpy
port, imported lazily so text-only serving stays stdlib-only. The DSP is
validated byte-identical against `tinkernel-audio` (itself byte-golden
against the official `tml-renderers` 0.1.0 wheel) on 7 clips, including a
quiet-audio case that exercises the turn-level RMS boost. The HF processor
skips that boost; `tml-renderers` is what the model actually saw in training,
so that's what this matches.

`tools/make_tiny_inkling_audio.py` adds the multimodal oracle fixture: a
random-init `InklingForConditionalGeneration` with an audio tower, saved in
the native TML layout. The engine reproduces it token-for-token: 38/38
teacher-forced positions, 24/24 greedy.

## Metal expert MoE (`COLI_METAL=1`, opt-in)

Reuses colibri's existing `coli_metal_moe_block` rather than adding a second
GPU kernel. The container's int4 format (nibble-packed, -8 offset, per-row
scales) is already bit-identical to the kernel's `fmt=2` input, so this is
wiring, not new math.

Expert slots move from per-slot mallocs to one page-aligned slab per sparse
layer, registered with the Metal backend once at startup. Eviction reuses the
region instead of unregistering and re-registering, so there's no
`useResource` churn on cache turnover and unified memory stays zero-copy.
That single change is most of the win below, see the defaults section for
why.

Each cache round groups its (token, expert) pairs by expert and submits one
command buffer for the round; a failed submit falls back to the CPU loop for
that round only, so a bad dispatch degrades instead of crashing the run.

## Apple performance defaults

Three defaults change on `__APPLE__` builds, all three came out of the same
10-config sweep (2 reps per config, frozen probe: fixed prompt, cap, and
pins, `USAGE_SAVE=0`) rather than being turned on individually and hoped for:

- **`COLI_METAL_RESSET=1` default.** Without the residency set, each decode
  MoE block pays ~135 ms of per-buffer `useResource` churn to do ~3 ms of
  actual math. With it: decode goes 0.17 -> 1.76 tok/s, a 10x change from one
  registration pattern.
- **OMP active-spin tuning off on Apple.** Measured strictly worse even for
  pure-CPU decode (0.50 -> 0.84 tok/s without the spin) and prefill
  (49.7s -> 24.4s without the spin). Same SoC power-budget mechanism as
  `docs/METAL-M5MAX-PERF-REPORT.md` documented for GLM on the M5 Max: an
  active-spinning CPU team steals clock headroom the GPU needs, and Apple
  Silicon shares that budget across CPU and GPU.
- **GPU decode on by default** (`INK_METAL_MIN_S` 2 -> 1). With the residency
  set in place, GPU decode beats CPU decode 2x, so the old prefill-only gate
  was leaving performance on the table rather than protecting it.

Net effect on the probe: 0.50 tok/s decode / 49.7 s prefill at the old
defaults, 1.75 tok/s / 10.3 s at the new ones. Output tokens are identical
across every config in the sweep, this is a placement change, not a
precision change.

The prefill number matters more than usual for audio: a 5-second clip is
~100 DMel positions, so for audio turns prefill speed counts double compared
to a text-only prompt of the same token length.

Also: `mem_avail_bytes` gets a macOS branch (free + inactive + purgeable
pages), so expert-cache auto-sizing works on macOS instead of falling back to
a fixed 16 experts/layer regardless of how much RAM is actually free.

## Behavioral coverage

| Audio tensors | `COLI_METAL` | Platform | What happens |
|---|---|---|---|
| absent | any | any | text-only engine, byte-identical to before this PR |
| present | off | any | DMel frames replace placeholder embeddings, CPU expert matmul |
| present | on | Apple | same audio path, routed experts run on the Metal GPU via the residency-set slab, per-block CPU fallback on a failed dispatch |
| present | n/a | non-Apple | `COLI_METAL`/Metal code paths aren't compiled in; behaves like the CPU row |

## Validation

`make check` is green (275 Python tests, C unit tests, 0 build warnings). The
tiny multimodal oracle is exact on CPU-f32 and on the container-int4 path
both CPU and Metal. Gateway DSP is byte-identical to `tml-renderers` across
all 7 test clips. Beyond the synthetic fixtures, this also ran live against
the real Inkling-Small 131 GiB int4 container: real speech in, correct
transcripts out, including spoken-number normalization ("seven forty five
PM ... gate B twelve" comes back as "7:45 PM from gate B12").

## Benchmark report

- Commit: `e57083f4ae0b6b8c0fbbd977bee888ce6a3b76c5`
- Hardware: Apple M-series Mac, 128 GB unified memory
- Model/storage: Inkling-Small, 131 GiB int4 container, internal NVMe, warm
  page cache
- Workload: frozen probe (fixed prompt, cap, and pins), `USAGE_SAVE=0` so
  cache-warming doesn't drift the comparison between configs
- Run count: 2 reps per configuration across the 10-config sweep

| | Decode | Prefill |
|---|---|---|
| Old defaults | 0.50 tok/s | 49.7 s |
| New defaults | 1.75 tok/s | 10.3 s |

## How to try it

```sh
# converting yourself: keep the audio tower (adds ~10 MB to the container)
python3 c/tools/convert_inkling_int4.py --indir <bf16> --outdir <snap> --keep-audio

make -C c inkling METAL=1
COLI_METAL=1 SNAP=~/Models/inkling_i4 ./c/inkling --audio turn.dmel -n 128

# gateway: base64 WAV in, spoken answer out
./coli serve --model ~/Models/inkling_i4
curl localhost:8000/v1/chat/completions -d '{
  "model": "inkling-colibri",
  "messages": [{"role": "user", "content": [
    {"type": "input_audio", "input_audio": {"data": "<base64 wav>", "format": "wav"}}
  ]}]
}'
```

Already sitting on a text-only container? The two audio tensors
(`model.audio.encoder.weight`, `model.audio.final_norm.weight`) can be pulled
out of the original checkpoint's shards with HTTP range requests (~10 MB
instead of the 532 GB download) and written as an `audio.safetensors` sidecar
next to the snapshot; `st_init` already indexes every `*.safetensors` in the
directory, so the engine just picks it up.
