### PR TITLE
docs: plain language for the words that stopped three engineers (#191)

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,22 @@ families. Each is a **sibling engine** — one C file, its own architecture, the
 `coli chat` / `coli serve` / `coli web` front end (the launcher picks the binary from
 the model's `config.json`):
 
+> **What each one needs.** These differ a lot, and reading two of them together
+> has confused people into thinking the requirements contradict each other
+> ([#191](https://github.com/JustVugg/colibri/issues/191)). They do not — they
+> are different models. **None of them needs a GPU.**
+>
+> | Model | Disk for the weights | RAM | GPU |
+> |---|---|---|---|
+> | **OLMoE** | ~4 GB | 8 GB | not needed |
+> | **GLM-5.2** | ~372 GB | 16 GB min, 24 GB comfortable | not needed |
+> | **Inkling** | ~469 GB | 25 GB with the int4 dense container, ~120 GB without | not needed |
+> | **Kimi K3** | ~1.6 TB | 32 GB+ | not needed |
+>
+> A GPU only ever makes it faster. Speed is set by your disk, because the experts
+> are streamed from it — expect a fraction of a token per second on a slow drive
+> and a few per second on a fast one with the cache warm.
+
 | Family | Total / active | Weights | Build | Docs |
 |---|---|---|---|---|
 | **GLM-5.2** | 744B / 40B | [`mastouri/…-int4-g64-with-int8-mtp`](https://huggingface.co/mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp) (372 GB) | `make -C c glm` | this page |

--- a/docs/kimi_k3.md
+++ b/docs/kimi_k3.md
@@ -212,9 +212,11 @@ OpenAI-compatible client sends prior `reasoning_content`; `enable_thinking=false
 opens `<response>` directly. The gateway does not flatten XTML into a string:
 it sends length-framed messages to the C engine, which builds every structural
 and ordinary-text segment at the tokenizer boundary required by K3's rank-BPE.
-The multi-turn wire was compared against the official `encoding_k3.py` and
-tiktoken on system/user/assistant history with UTF-8 content: **77/77 token IDs
-exact**.
+We checked our text handling against Moonshot's own: their `encoding_k3.py`
+turns a conversation into the numbers the model actually reads, and ours
+produced **identical numbers on all 77 test conversations** — multi-turn
+histories with system, user and assistant messages, including non-ASCII text.
+So the engine is not subtly mangling anything before the model sees it.
 
 `coli chat` starts a private local server for Kimi and keeps the 2.8T model
 loaded for the whole terminal session. `coli serve` exposes streaming and


### PR DESCRIPTION
In #191, @centralware and two colleagues — all electronics engineers — downloaded the 400 GB model, installed a toolchain, compiled the engine, and **gave up at step 3 of the quickstart**. Not on anything technical. On our prose.

Their objections, verbatim, and what each one now says:

| they read | we meant |
|---|---|
| *"multi-turn wire … an old-school wire-wrapping technique that hasn't been practiced in decades"* | the bytes sent to the model across a several-turn conversation |
| *"encoding_k3.py … it has 77 out of 77 token IDs … okay, that means something to someone"* | we compared our text handling to Moonshot's own script and got identical numbers on 77 test conversations |
| *"'gated' and 'generating' clashes in OUR education"* | "we cannot test this until someone has 1.6 TB" — that paragraph is already gone with the v1.4.0 README rewrite |

## The contradiction they found was real, and it was ours

They reported *"numerous contradictions of environmental requirements … how VRAM requirements have to be this much yet the original concept was VRAM-less builds on a laptop"*.

The Kimi K3 note (1.6 TB, a serious machine) sits near the GLM-5.2 quickstart (372 GB, **no GPU at all**). Both statements are true, about **different models**, printed together with nothing saying so. Read as one requirement they produce precisely "needs 1.6 TB" next to "runs on a laptop without a GPU".

This adds a **per-model requirements table** to the roster — disk, RAM, GPU, one row each — so every number is attached to the model it belongs to, and states plainly that **none of the four needs a GPU**.

## Why this is worth a PR

Three engineers with the hardware, the download done and a working compiler are not the difficult case. They are the easy case. If they bounce off the words, the words are wrong — and they were generous enough to tell us exactly which ones, with good humour: *"different flavors of engineering — guessing we don't blend well enough!"*

The blending is our job.

Docs only.