### PR TITLE
docs: `coli serve` carries the dashboard too, and say so for headless hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,8 +400,8 @@ COLI_MODEL=/nvme/glm52_i4 ./coli plan     # inspect the planned VRAM/RAM/disk pl
 COLI_MODEL=/nvme/glm52_i4 ./coli doctor   # read-only readiness check
 COLI_MODEL=/nvme/glm52_i4 ./coli doctor --deep  # strict tensors/shards/index/mirror preflight
 COLI_MODEL=/nvme/glm52_i4 ./coli tune     # measure and save this machine's fastest safe execution profile
-./coli web  --model /nvme/glm52_i4        # API + web dashboard on one port
-./coli serve --model /nvme/glm52_i4       # OpenAI-compatible API only
+./coli web  --model /nvme/glm52_i4        # API + dashboard, and opens a browser
+./coli serve --model /nvme/glm52_i4       # API + dashboard, no browser (headless)
 ```
 
 On Windows the same commands work with `python coli chat --model D:\glm52_i4`.
@@ -424,9 +424,9 @@ COLI_MODEL=/nvme/glm52_i4      ./coli chat        # TUI
 COLI_MODEL=/nvme/inkling_i4    ./coli chat
 COLI_MODEL=/nvme/kimi_k3       ./coli chat
 
-./coli web --model /nvme/inkling_i4               # API + dashboard, same port
+./coli web --model /nvme/inkling_i4               # API + dashboard, opens a browser
 ./coli web --model /nvme/kimi_k3
-./coli serve --model /nvme/inkling_i4             # API only
+./coli serve --model /nvme/inkling_i4             # API + dashboard, no browser
 ```
 
 For the non-GLM engines `coli chat` starts the gateway locally and attaches the

--- a/docs/api.md
+++ b/docs/api.md
@@ -222,6 +222,11 @@ cd web && npm install && npm run build   # once
 ./coli web --model <model-dir>
 ```
 
+`coli web` differs from `coli serve` only in opening a browser — both serve the
+dashboard on the same port. On a headless host (no display, often no GPU at all)
+use `coli serve`, or `coli web --no-browser`, and point a browser at it from
+another machine. Nothing in the dashboard needs a desktop session on the host.
+
 What you get:
 
 - **Chat** with live metrics: a flashing token counter while generating, then


### PR DESCRIPTION
The README described `coli serve` as "OpenAI-compatible API only" in two command blocks, and
`docs/api.md` documented the dashboard only under `coli web`. Neither matches the code:
`openai_server.py` resolves `web/dist` itself and calls `serve_static()` unconditionally for any
path outside `/v1/` and `/health`, so `serve` carries the dashboard too. `coli web` differs only
by starting a thread that opens a browser once `/health` answers.

The wording matters more than the inaccuracy does. In #191 @centralware reported stopping at
something that read as *"colibri will open the window in the desktop"*, on machines that are
"almost all headless, no video card even installed" — which is the deployment target. A reader
who believes the dashboard needs `coli web`, and that `coli web` needs a display, concludes the
whole project needs a desktop session. Nothing in the code says that, and nothing in the docs
said otherwise.

So: the two command comments now distinguish the commands by the thing that actually differs,
and the dashboard section says the headless path out loud. It also mentions `--no-browser`,
which today exists in the argparse help and nowhere else in the documentation.

Docs only — no code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
