### PR TITLE
docs(experiments): GLM-5.2 on 4x RTX A6000 (Ampere) + EPYC 7402P

### DIFF
--- a/docs/experiments/glm52-4xa6000-2026-08-02.md
+++ b/docs/experiments/glm52-4xa6000-2026-08-02.md
@@ -10,6 +10,13 @@ experiment set does not cover (6×5090 Blackwell, Metal M5 Max, Strix Halo, 9950
 Its main contribution is not a throughput number, however: it is a **methodological finding
 that invalidates naive A/B benchmarking on this engine** (§6).
 
+> **Version and revision notice.** The §4 configuration matrix was measured on
+> `ecade075` (2026-07-30); `dev` was already 185 commits ahead. Two of its conclusions have
+> since been **retracted and replaced with controlled measurements** — the prefill I/O claim
+> in §5 and the CPU-fallback claim of issue #776. Both retractions are stated inline where
+> the original claim stood, rather than removed, because the way each was reached is the
+> useful part. §5–§8 were re-measured under the snapshot/restore protocol of §3.
+
 ---
 
 ## 1. Hardware
@@ -47,6 +54,26 @@ Median reported. RSS and VRAM sampled after load.
 > **Caveat (important):** two measurement clients running concurrently against the same
 > engine produce erratic results (0.43–1.04 tok/s) because the engine serialises requests.
 > Any concurrent measurement must be discarded.
+
+**Amended protocol, used for §5–§8.** The above is not sufficient on this engine, because
+`.coli_usage` carries state across restarts (§6). Every measurement from §5 onward adds:
+
+```sh
+cp -f "$MODEL/.coli_usage" snapshot          # once, before the campaign
+# ... then, before every single configuration:
+systemctl stop colibri && sleep 35           # VRAM is not released immediately
+cp -f snapshot "$MODEL/.coli_usage"          # restore the profile byte-for-byte
+systemctl start colibri
+```
+
+Two further rules learned the hard way, both of which produced a wrong published claim:
+
+1. **Never read cumulative log counters as current state.** Count matching lines *before* and
+   *after* the window under test and report the difference — a long-lived log file will
+   otherwise attribute months of history to the current configuration.
+2. **Never sample during a cold start.** Loading 429 GB takes minutes, during which GPU
+   utilisation is legitimately 0 % and one layer may take 45 s. A sample taken there
+   describes the loader, not the engine.
 
 ## 4. Configuration matrix (9 configs, same session, ~1 h)
 
@@ -100,9 +127,9 @@ Sampled during decode, after tuning:
 CPU↔GPU round trips, tiny matmuls at S=1 — not any single bandwidth. This explains both the
 failure of batching and the uselessness of maximising memory.
 
-### Prefill is a different regime entirely
+### Prefill is a different regime — but not for the reason stated in the first draft
 
-Decode activates 8 of 256 experts per layer; consecutive tokens reuse them, so the learned
+Decode activates 8 of 256 experts per layer and consecutive tokens reuse them, so the learned
 pinned set covers them. Prefill does not:
 
 ```
@@ -110,19 +137,42 @@ P(an expert is missed by N tokens) = (1 − 8/256)^N
 P(512) ≈ 1e-7        P(8595) ≈ e^-273
 ```
 
-**A 512-token slice already touches every expert of every layer.** Prefill therefore gets no
-benefit from caching: it pays the non-resident fraction of the *entire model*, once per slice.
+A 512-token slice does touch every expert of every layer. **The first version of this report
+then drew a conclusion that the arithmetic does not support** — that prefill therefore
+*re-reads* the non-resident model once per slice. It does not: the cache retains what a slice
+loaded, so the sweep is paid **once**, not once per slice. Issue #153 measures this directly
+on a Zen 5 + 5090 host — when the prompt doubles, disk time stays **flat** (19.4 s → 21.2 s)
+while attention doubles (49.2 s → 118.0 s). Prefill is attention-bound, not I/O-bound.
 
-Measured: **2.6–4.3 tok/s prefill** at `--ctx 262144` with `COLI_PREFILL_CHUNK=512` — i.e.
-35–55 minutes before first token on an 8,595-token prompt. Raising the chunk to 2048 reduces
-the number of full-model sweeps from 17 to 5.
+`COLI_PREFILL_CHUNK` still matters, but for the other reason: at chunk 512 the per-slice fixed
+costs and the `kvb_all` reconstruction dominate. Raising it to 2048 is worth taking.
 
-During prefill **only one GPU is active** (100 % / 200 W) while the other three sit at
-0 % / ~80 W: aggregate PCIe and compute budget is unused while the engine waits on expert
-loads.
+Controlled prefill measurements on this host, `.coli_usage` snapshotted and restored before
+each level, ~1,190-token prompt:
 
-Prefix caching itself works correctly in steady state (`prefix 8556/8562 token, prefill 6`):
-the prefill cost is paid once per conversation, not per turn.
+| `CTX` | prefill | decode | VRAM OOM messages |
+|---|---|---|---|
+| 32,768 | 198 tok/s | 1.56 tok/s | 0 |
+| 65,536 | 170 | 1.42 (−9 %) | 0 |
+| 98,304 | 198 | 1.33 (−15 %) | 0 |
+| 131,072 | 170 | **1.20** (−23 %) | 0 |
+| 196,608 | 148 | 1.03 (−34 %) | 0 |
+
+**No cliff up to 196,608**, and prefill never leaves the 148–198 tok/s band. The earlier
+figure of 2.6–4.3 tok/s prefill belongs to `--ctx 262144` *with `RAM_GB=215`* — a level at
+which the engine collapses the expert cache to `cap=1` (see §7). It is a property of that
+one over-committed configuration, not of long context in general.
+
+**Recommended: `CTX=131072`** — four times the context for −23 % decode, prefill unchanged.
+
+> An earlier revision of this report, and issue #776, claimed prefill attention silently falls
+> back to CPU when VRAM is full of experts. **That was wrong and has been retracted.** The
+> evidence was `out of memory` counts read cumulatively from the top of a long log file and a
+> GPU sample taken *during a cold start*. The controlled sweep above shows zero new OOM
+> messages at every level.
+
+Prefix caching works correctly in steady state (`prefix 8556/8562 token, prefill 6`): the
+prefill cost is paid once per conversation, not per turn.
 
 ## 6. **The finding that invalidates naive A/B benchmarking**
 
@@ -162,6 +212,32 @@ bandwidth differential accounts for ~1.3 ms of the 77 ms per-token gap — under
 let contributors report the metric that actually decides placement trade-offs instead of
 reporting occupied gigabytes.
 
+### The protocol that was missing, and what it shows
+
+Snapshot `.coli_usage`, restore it byte-for-byte before every configuration, warm up on a
+fixed corpus, then measure. Three placements under that protocol:
+
+| | placement | VRAM / RAM (GB) | tok/s |
+|---|---|---|---|
+| A | VRAM-heavy | 188 / 200 | 2.81 |
+| B | balanced (= the config that once measured 5.46) | 176 / 205 | 2.78 |
+| C | RAM-heavy | 176 / **235** | **3.51** |
+
+**A and B are indistinguishable** (2.81 vs 2.78): moving 12 GB between the tiers changes
+nothing. **C wins by 25 %** — it is the *RAM budget* that matters, not the split.
+
+**The 5.46 tok/s figure is not reproducible, and now we know why.** Configuration B is
+byte-for-byte the one that produced it. Under a controlled profile it gives 2.78. The
+difference is not the machine: it is *specialisation*. On the day of the 5.46 measurement
+`.coli_usage` held 240 k selections from one repeated prompt; it now holds 18.2 M from mixed
+real use. **A specialised profile is worth ≈ ×2** — the mechanism works, then stops working
+as the history dilutes it.
+
+That is the motivation for `COLI_USAGE_DECAY` (merged in #780): a typical turn contributes
+~38 k selections against a recorded history of 18.19 M — **0.2 %** — so recent workload can
+no longer move the pinned set. An opt-in geometric decay applied at save time restores the
+profile's ability to track what the machine is actually being asked to do.
+
 ## 7. Context vs residency trade-off
 
 ```
@@ -170,14 +246,23 @@ required    = 407 (experts) + 83 (KV @262144) + 12 (dense) + 10 (OS) = 512 GB
 deficit                                                              =  69 GB
 ```
 
-At `--ctx 32768` the KV costs 11 GB and everything fits. Measured: **5.46 tok/s at 32768 vs
-0.86 tok/s at 262144**. The engine reports the collapse itself:
+At `--ctx 32768` the KV costs 11 GB and everything fits. The uncontrolled session measured
+5.46 tok/s at 32768 against 0.86 at 262144; **only the second half of that pair survives
+re-measurement** — see §5 for the controlled curve and §6 for why 5.46 is not reproducible.
+What is solid is the failure mode at 262144, which the engine reports itself:
 
 ```
 [RAM_GB=215.0] WARNING: cap=1 is the floor, projected peak 216.7 GB is 1.7 GB OVER
 the budget (resident 132.2 GB + reserve 82.8 GB).
 PIN_GB is inflating the resident set: lower it or drop it.
 ```
+
+`cap=1` means one cached expert slot per layer: every one of the 8 experts a token needs is a
+disk read. That is the collapse — and it is a **budget** failure, not a context failure. It
+was measured at `RAM_GB=215`; the controlled sweep at `RAM_GB=235` reaches 196,608 with no
+collapse at all. The honest statement is therefore: *long context costs decode throughput
+smoothly (−34 % at 6× the context) until the expert cache is squeezed to its floor, at which
+point it falls off a cliff.*
 
 ### KV cache size
 
@@ -202,7 +287,49 @@ Comparison on the same model and same latent attention: llama.cpp with `-ctk f16
 262,144. That is 83 % of the 69 GB deficit above: with an fp16 KV and no `kvb_all`, long
 context and full expert residency would be simultaneously reachable on this host.
 
-## 8. Build notes (Linux, CUDA)
+## 8. What the learned routing profile actually looks like
+
+`.coli_usage` after real use: **19,324 experts across 76 layers, 18,189,640 recorded
+selections**. The placement heuristics assume a hot minority; the measured distribution
+does not have one.
+
+| top % of experts | count | share of selections |
+|---|---|---|
+| 1 % | 194 | 6.8 % |
+| 5 % | 967 | 19.6 % |
+| 10 % | 1,933 | 30.6 % |
+| 25 % | 4,831 | 53.4 % |
+| 50 % | 9,662 | 78.0 % |
+
+**This is not a power law.** Under one, the top 1 % would carry 30–50 % of traffic; it carries
+6.8 %. The max/median ratio is only 18.7, and **no expert is ever unused** — the router's
+`noaux_tc` load-balancing bias is doing its job, which is precisely what defeats hot/cold
+tiering.
+
+Consequences for placement, same profile:
+
+| VRAM tier | % of model | accesses captured | vs random placement |
+|---|---|---|---|
+| 8,288 experts | 42.9 % | 72.1 % | ×1.68 |
+| 6,000 | 31.0 % | 60.5 % | ×1.95 |
+| 4,000 | 20.7 % | 47.8 % | ×2.31 |
+
+Heat-based pinning works, but with **sharply diminishing returns**: each additional gigabyte
+captures less than the one before. This is the direct explanation for §6 — fine-tuning the
+VRAM/RAM split produces noise because the underlying distribution is nearly flat.
+
+And the uniform per-layer cap the engine already applies is close to optimal:
+
+| strategy, equal budget of 8,288 experts | accesses captured |
+|---|---|
+| uniform cap (109/layer — what the engine does) | 71.5 % |
+| global top-k across all layers | 72.1 % |
+
+**0.6 points.** A global ranking is not worth its complexity here. The lever that pays is not
+*which* experts are pinned — it is how many fit, and how well the profile matches the current
+workload (§6).
+
+## 9. Build notes (Linux, CUDA)
 
 `nvcc` 12.6 + gcc 13 fails with `identifier "_Float32" is undefined`;
 `-allow-unsupported-compiler` produces 100 errors. The `BUILD-cuda-glibc241.md` recipe works
@@ -217,24 +344,28 @@ make glm CUDA=1 CUDA_ARCH=sm_86 CUDA_HOME=~/cuda13
 The web dashboard needs Node ≥ 20.12 (`styleText` from `node:util`); Ubuntu 24.04 ships
 18.19, so `npm run build` fails on a stock install.
 
-## 9. Final configuration
+## 10. Final configuration
 
 ```sh
-CTX=32768                  # 262144 measured 0.86 tok/s decode, 2.9 tok/s prefill
+CTX=32768                  # 131072 also fine: −23 % decode, prefill unchanged (§5)
 COLI_CUDA=1
 COLI_GPUS=0,1,2,3
 CUDA_DENSE=1               # ×2.8 — the decisive lever
 COLI_CUDA_ATTN=1
 COLI_CUDA_PIPE=2
 COLI_CUDA_TC_W4A16=1
-CUDA_EXPERT_GB=188         # NOT "auto" — see issue on prefill scratch
+CUDA_EXPERT_GB=176         # NOT "auto" — see issue on prefill scratch
 PIN=auto
 PIN_GB=all
-RAM_GB=200
+RAM_GB=235                 # +25 % over 205 under a controlled profile (§6)
 DIRECT=1
 PIPE=1                     # no URING, no PILOT* — +26 % on this host
 COLI_PREFILL_CHUNK=2048
 ```
+
+`MemoryMax=238G` on the systemd unit: at `RAM_GB=235` the engine's own accounting excludes
+allocations the kernel still charges to the cgroup, and the OOM killer arrives before the
+engine's internal cap does.
 
 Operational notes: the engine does not release VRAM immediately on stop — restarting within
 ~30 s fails with `Failed with result 'exit-code'` (`Restart=on-failure` recovers). And

--- a/docs/experiments/glm52-4xa6000-2026-08-02.md
+++ b/docs/experiments/glm52-4xa6000-2026-08-02.md
@@ -504,7 +504,72 @@ llama.cpp splits by *layer count*, not by bytes, and MoE layers weigh ~4.6 GB ag
 hundred MB for dense ones, so an even layer split is a wildly uneven byte split. Re-running
 with the cursor pulled back.
 
-## 13. Build notes (Linux, CUDA)
+## 13. Tuning campaign: 2.35 -> 3.64 tok/s
+
+Everything above measures the engine as configured. This section is what changed the
+number. Same protocol throughout: `.coli_usage` restored byte-for-byte before every
+condition, `CTX=32768`, 64 tokens greedy, `PROF=1`.
+
+| | tok/s | CPU expert read | `route_agree` | `swap` |
+|---|---|---|---|---|
+| baseline (48 threads, no CACHE_ROUTE) | 2.35 | 22.66 GB/s | — | — |
+| `OMP_NUM_THREADS=24` | 2.70 | 23.49 | — | — |
+| `+ CACHE_ROUTE=1 ROUTE_M=16 ROUTE_J=1` | 3.59 | 32.98 | 99.1 % | 0.9 % |
+| `+ CUDA_EXPERT_GB=188` | **3.64** | 32.98 | 99.1 % | 0.9 % |
+
+**+55 %, from three settings.** Two of them are documented nowhere a user would look.
+
+### `OMP_NUM_THREADS` (see #805)
+
+Never set on Linux. The C-side OMP block sets `OMP_WAIT_POLICY` and `GOMP_SPINCOUNT`
+but not the thread count, and skips itself entirely under CUDA — so libgomp falls back
+to `nproc`, the **logical** count. On this 24c/48t host that is a 2x over-subscription:
+
+| threads | CPU expert read | decode | per thread |
+|---|---|---|---|
+| 4 | 6.48 GB/s | 1.28 tok/s | 1.62 GB/s |
+| 16 | 23.97 | 2.63 | 1.49 |
+| **24 (physical)** | **30.10** | **2.90** | 1.25 |
+| 48 (logical) | 17.35 | 2.06 | **0.36** |
+
+Near-linear to the physical core count, then collapse. **~1.4 GB/s per Zen 2 core is the
+ceiling of this kernel**, and 24 cores x 1.4 = 34 GB/s is where the host sits — so the
+8-channel DDR4-2400's ~85 GB/s is unreachable here. The CPU expert path is compute-bound
+per core, not memory-bound. That single fact sets the machine's ceiling (below).
+
+### `CACHE_ROUTE` (see #811)
+
+The largest lever, and off by default. Parameters barely matter — `M` 12/16/24 all land
+within 1 %, because at 45.6 % residency the resident experts that outrank the true top-8
+are already inside rank 12. `J=0` and `ROUTE_ALPHA` likewise. **The defaults are right;
+the only real decision is on/off.**
+
+### `CUDA_EXPERT_GB`
+
+| requested | tok/s | VRAM actually used | VRAM OOM |
+|---|---|---|---|
+| 176 | 3.55 | 175.98 GB | 0 |
+| 182 | 3.63 | 181.99 | 0 |
+| **188** | **3.64** | **182.99** | 0 |
+| 190 | 3.62 | 182.99 | 0 |
+
+The tier saturates at ~183 GB regardless of what is asked. Worth +2.6 % over 176, with
+no errors at any level.
+
+### Where the ceiling is
+
+At 3.64 tok/s a token takes 275 ms, of which the CPU-side expert read is ~200 ms:
+
+```
+6.6 GB non-resident per token / 32.98 GB/s = 200 ms  (73 % of the token)
+```
+
+Since ~1.4 GB/s per core is a per-core compute limit and all 24 are in use, that term
+cannot be reduced by tuning. **The realistic ceiling for this host is ~4.5 tok/s.** Going
+beyond it requires changing the arithmetic, not the configuration: more VRAM (386 GB of
+experts against 192 GB installed), or a narrower quantization.
+
+## 14. Build notes (Linux, CUDA)
 
 `nvcc` 12.6 + gcc 13 fails with `identifier "_Float32" is undefined`;
 `-allow-unsupported-compiler` produces 100 errors. The `BUILD-cuda-glibc241.md` recipe works
@@ -519,24 +584,57 @@ make glm CUDA=1 CUDA_ARCH=sm_86 CUDA_HOME=~/cuda13
 The web dashboard needs Node ≥ 20.12 (`styleText` from `node:util`); Ubuntu 24.04 ships
 18.19, so `npm run build` fails on a stock install.
 
-## 14. Final configuration
+## 15. Final configuration
 
 ```sh
-CTX=32768                  # 131072 also fine: −23 % decode, prefill unchanged (§5)
+CTX=32768
 COLI_CUDA=1
 COLI_GPUS=0,1,2,3
-CUDA_DENSE=1               # ×2.8 — the decisive lever
+CUDA_DENSE=1                # x2.8 -- the decisive lever before the campaign below
 COLI_CUDA_ATTN=1
 COLI_CUDA_PIPE=2
 COLI_CUDA_TC_W4A16=1
-CUDA_EXPERT_GB=176         # NOT "auto" — see issue on prefill scratch
+COLI_CUDA_ATTN_SHARD=1      # +9 % with PIPE_SHARD; measured separately in §10
+COLI_CUDA_PIPE_SHARD=1
+CUDA_EXPERT_GB=188          # NOT "auto"; tier saturates at ~183 GB anyway (§13)
+OMP_NUM_THREADS=24          # PHYSICAL cores. +15 %; never set on Linux (#805)
+CACHE_ROUTE=1               # +33 % at 99.1 % routing agreement (#811)
+ROUTE_M=16
+ROUTE_J=1
 PIN=auto
-PIN_GB=all
-RAM_GB=235                 # +25 % over 205 under a controlled profile (§6)
+PIN_GB=150                  # NOT "all" -- see below
+RAM_GB=235
+COLI_USAGE_DECAY=0.9        # bounds the learned history (#780) -- see below
 DIRECT=1
-PIPE=1                     # no URING, no PILOT* — +26 % on this host
+PIPE=1                      # no URING, no PILOT* -- +26 % on this host
 COLI_PREFILL_CHUNK=2048
 ```
+
+`MemoryMax=238G` on the systemd unit: at `RAM_GB=235` the engine's own accounting excludes
+allocations the kernel still charges to the cgroup.
+
+### `PIN_GB=all` is not a safe steady state
+
+The report originally recommended it. After two days of ordinary use the engine **refused
+to start**:
+
+```
+[USAGE] expert history: 26,437,320 selections
+[PIN]   placement: 4661 VRAM + 5497 RAM expert (207.7 GB warm)
+[RAM]   refusing to start: projected peak 315.0 GB exceeds the 258.2 GB available
+```
+
+Nothing was reconfigured. `PIN=auto` seeds from `.coli_usage`, which grows monotonically —
+here 18.2 M -> 26.4 M selections — so with `PIN_GB=all` the pinned set grows with it:
+184.8 GB, then 207.7 GB. A working configuration stops working by itself.
+
+Two things fix it, and both belong in a recommended config: **bound `PIN_GB`**, and set
+**`COLI_USAGE_DECAY`**, which exists for exactly this and which nothing points a user
+toward when they hit the wall.
+
+Worth noting that the refusal itself is the correct behaviour and is new: before #793 the
+projection under-counted the slot width, so the same configuration would have started and
+been OOM-killed mid-generation (#305, #766).
 
 `MemoryMax=238G` on the systemd unit: at `RAM_GB=235` the engine's own accounting excludes
 allocations the kernel still charges to the cgroup, and the OOM killer arrives before the

--- a/docs/experiments/glm52-4xa6000-2026-08-02.md
+++ b/docs/experiments/glm52-4xa6000-2026-08-02.md
@@ -144,10 +144,49 @@ attention breakdown:  projection/RoPE      4.592 s
                       output projection    6.261 s
 ```
 
-**Attention is 64 % of decode; expert compute is 19 %; disk is 5 %.** This reorders every
-placement question in this report. Expert residency, tiering and pinning together govern
-under a fifth of the time — a *perfect* expert placement, costing zero, would buy at most
-~19 %.
+> **Read that with the caveat below.** The run above generated ~750 tokens. Fresh runs at
+> the same `CTX` but **64 generated tokens** invert the ranking: `expert-matmul` 46 %,
+> attention 26 %. The attention share grows with the KV as the answer gets longer, so
+> "attention is 64 % of decode" is true of a long generation and misleading as a general
+> statement. Both numbers are reported here rather than one being deleted, because the
+> *dependence on generation length* is the finding.
+
+At 64 generated tokens, `CTX=32768`, best configuration (S3 below), 29.76 s total:
+
+| | | share |
+|---|---|---|
+| expert-matmul | 13.75 s | 46.2 % |
+| attention | 7.80 s | 26.2 % |
+| disk wait | 3.94 s | 13.3 % |
+| other | 4.26 s | 14.3 % |
+
+and with `PROF=1`, the breakdown that matters most:
+
+```
+P0-EXEC: routed CPU 10.967s / 19.67 GB/s (10158 row) | routed GPU critical 1.666s
+         | router 1.809s | residual P2P 0.000s / 0 hop | orchestration 2.449s
+```
+
+### The number that sets the ceiling on this host
+
+**The CPU-side routed expert path sustains 19.67 GB/s.** This host's 8-channel DDR4-2400
+sustains ~85 GB/s. The path therefore uses **23 % of available memory bandwidth**, which is
+the quantified form of the "4–5 cores of 24 busy" observation above.
+
+That single figure caps the machine, independently of everything else in this report:
+
+```
+expert weights touched per token = 8 experts × 20.1 MB × 75 layers = 12.1 GB
+of which non-resident (54.4 %)                                    =  6.6 GB
+
+at 19.67 GB/s (measured)  → 333 ms/token →  3.0 tok/s   ← the ceiling today
+at 85 GB/s (DDR4 saturated) →  77 ms/token → 13.0 tok/s   ← the hard ceiling
+```
+
+Everything else — placement, tiering, pinning, context, KV width — is bounded above by
+those two lines. Whether the 19.67 GB/s is a broken parallelisation or simply what 4–5
+cores can pull is an open question with a cheap answer (an `OMP_NUM_THREADS` sweep watching
+that same counter), and it is the single most valuable measurement still outstanding.
 
 Two consequences worth stating plainly:
 
@@ -403,7 +442,69 @@ That re-test needs a copy-heavy prompt and, unlike this one, needs the acceptanc
 logged. This run did not capture it (`acceptance: not reported` in all three conditions),
 which is a defect of the harness, not of the engine.
 
-## 10. Build notes (Linux, CUDA)
+## 10. Two flags, and a hypothesis of mine that did not survive
+
+`COLI_CUDA_ATTN_SHARD` and `COLI_CUDA_PIPE_SHARD` had never been measured separately. A
+service carrying both ran at 1.70 tok/s while a one-shot run without them ran at 1.14 — a
+49 % gap I attributed to the flags, reasoning that a layer's attention tensors land on one
+device via the round-robin at `colibri.c:1691`, so one GPU works while three wait.
+
+Measured, four conditions, `.coli_usage` restored before each:
+
+| | tok/s | |
+|---|---|---|
+| S0 · neither | 1.97 | — |
+| S1 · `ATTN_SHARD` only | 2.05 | +4.1 % |
+| S2 · `PIPE_SHARD` only | 2.06 | +4.6 % |
+| **S3 · both** | **2.15** | **+9.1 %** |
+
+**+9 %, not +49 %.** Both flags are worth having and they compose, but they do not explain
+the gap I invoked them for. That gap was an artefact: the 1.14 run generated ~750 tokens
+(an `NGEN` that did not take effect — the engine ran to EOS) against 64 here, and attention
+grows with the KV. I was comparing two different generation lengths and calling the
+difference a flag.
+
+## 11. Determinism on 4 GPUs
+
+Six identical requests, `temperature 0`, production configuration:
+
+```
+6 runs -> 1 distinct output   (338 bytes, md5 e86d393c506f, all six)
+```
+
+**Token-identical.** Cross-device FP reduction order does not drift on this host, which
+makes byte-for-byte comparison a usable acceptance test for changes to the CUDA path —
+relevant to #399, where the CUDA follow-up was to be gated on exactly such a check.
+
+## 12. Against llama.cpp, same model, same class of disk
+
+`unsloth/GLM-5.2-GGUF UD-IQ4_NL` (348 GB, 9 shards) on `nvme0n1`; colibri's container on
+`nvme1n1`. **Both are KINGSTON SNV2S1000G**, so there is no disk asymmetry. Same prompts,
+same wall-clock method, colibri stopped and the page cache dropped before each run.
+
+| | prefill | decode | VRAM |
+|---|---|---|---|
+| **llama.cpp** `-cmoe` (all experts in RAM) | **239 tok/s** | **1.58 tok/s** | **26 GB** |
+| **colibri** production config | 198 tok/s | 1.56 tok/s | 176 GB |
+
+**llama.cpp matches colibri's decode and beats its prefill by 20 %, using 26 GB of VRAM
+against 176.** And that is llama.cpp's *least* favourable configuration — `-cmoe` keeps
+every expert on the CPU and leaves the four GPUs almost entirely unused.
+
+This is not a like-for-like architectural comparison: colibri places individual experts and
+llama.cpp cannot, because GGUF fuses all 256 experts of a layer into one `ffn_*_exps`
+tensor. The point is narrower and harder to argue with — **on this host, the per-expert
+placement machinery is not currently buying anything over keeping the experts in RAM and
+letting the CPU read them.** Which is consistent with §5: the limiter is the 19.67 GB/s
+CPU-side read, and both engines are subject to it.
+
+Two configurations that would have let llama.cpp use its VRAM failed to load, for a
+reason worth recording: `-ncmoe 45` requested a **73 GB** buffer on a 48 GB card.
+llama.cpp splits by *layer count*, not by bytes, and MoE layers weigh ~4.6 GB against a few
+hundred MB for dense ones, so an even layer split is a wildly uneven byte split. Re-running
+with the cursor pulled back.
+
+## 13. Build notes (Linux, CUDA)
 
 `nvcc` 12.6 + gcc 13 fails with `identifier "_Float32" is undefined`;
 `-allow-unsupported-compiler` produces 100 errors. The `BUILD-cuda-glibc241.md` recipe works
@@ -418,7 +519,7 @@ make glm CUDA=1 CUDA_ARCH=sm_86 CUDA_HOME=~/cuda13
 The web dashboard needs Node ≥ 20.12 (`styleText` from `node:util`); Ubuntu 24.04 ships
 18.19, so `npm run build` fails on a stock install.
 
-## 11. Final configuration
+## 14. Final configuration
 
 ```sh
 CTX=32768                  # 131072 also fine: −23 % decode, prefill unchanged (§5)

--- a/docs/experiments/glm52-4xa6000-2026-08-02.md
+++ b/docs/experiments/glm52-4xa6000-2026-08-02.md
@@ -1,0 +1,242 @@
+# GLM-5.2 on 4× RTX A6000 (Ampere) + EPYC 7402P — 2026-08-02
+
+**Engine:** colibri v1.3.0, commit `ecade075cfc2eae684097ea7de5570c3786ce199`
+**Model:** `mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp` — 142 shards, 429.3 GB on disk
+**Build:** `make glm CUDA=1 CUDA_ARCH=sm_86 CUDA_HOME=<cuda13>` (see *Build notes* below)
+
+This report adds an **Ampere multi-GPU + pre-AVX-512 CPU** data point, which the existing
+experiment set does not cover (6×5090 Blackwell, Metal M5 Max, Strix Halo, 9950X3D+5090).
+
+Its main contribution is not a throughput number, however: it is a **methodological finding
+that invalidates naive A/B benchmarking on this engine** (§6).
+
+---
+
+## 1. Hardware
+
+| | |
+|---|---|
+| CPU | AMD EPYC 7402P — Zen 2, 24c/48t, socket SP3, **AVX2, no AVX-512**, single NUMA node |
+| RAM | 8×32 GB DDR4-**2400** (native speed grade), 8/8 slots populated — 263.8 GB / 251.6 GiB, ~153 GB/s |
+| GPU | 4× RTX A6000 48 GB (sm_86), all at **PCIe Gen4 x16**, driver 580.173.02 |
+| NVMe A | Gen4-capable drive negotiated at **PCIe 3.0 x4** → `/` |
+| NVMe B | same model, negotiated at **PCIe 3.0 x2** → model directory |
+| OS | Ubuntu 24.04, kernel 6.8.0-136 |
+
+Note: the GPUs negotiate Gen4 x16 while both NVMe sit on Gen3 links — a slot/routing
+limitation, not a drive limitation.
+
+## 2. Storage baseline
+
+`fio --direct=1`, and `iobench` (19 MB blocks = expert-sized, O_DIRECT):
+
+| | NVMe A (x4) | NVMe B (x2) |
+|---|---|---|
+| seq read 1M QD8 | 3232 MB/s | — |
+| randread 4k QD1 | 9,880 IOPS / 0.090 ms | 4,605 IOPS / 0.207 ms |
+| randread 4k QD32 ×4 | 167,098 IOPS | 46,482 IOPS (saturated) |
+| **randread 4M QD4** | **2619 MB/s / 5.79 ms** | **1521 MB/s / 10.44 ms** |
+| `iobench` 19M, 16 threads | **2.86 GB/s / 7.0 ms per expert** | 1.60 GB/s / 12.2 ms |
+
+## 3. Protocol
+
+Full service restart → wait for API → 1 warm-up generation → **5 measured generations**.
+Fixed prompt, greedy (`COLI_TEMP=0`), `max_tokens=64`, **single client**, `--ctx 32768`.
+Median reported. RSS and VRAM sampled after load.
+
+> **Caveat (important):** two measurement clients running concurrently against the same
+> engine produce erratic results (0.43–1.04 tok/s) because the engine serialises requests.
+> Any concurrent measurement must be discarded.
+
+## 4. Configuration matrix (9 configs, same session, ~1 h)
+
+| | Configuration | tok/s | RSS | VRAM |
+|---|---|---|---|---|
+| E1 | D1 + `RAM_GB=205` | **5.46** | 190 GB | 177 GB |
+| D1 | C2 minus `URING`/`PILOT*` | 5.38 | 176 GB | 177 GB |
+| D4 | C2 + `RAM_GB=205` | 4.45 | 190 GB | 177 GB |
+| D2/D3/D5 | +`TC_INT4` / +explicit `OMP close` / no `CUDA_PIPE` | 4.30 | 176 GB | 177 GB |
+| C2 | C1 + `CUDA_DENSE=1` | 4.26 | 176 GB | 177 GB |
+| C0 | starting point (`cap 64`, fixed VRAM, no `PIN`) | 1.53 | 99 GB | 171 GB |
+| C1 | max RAM/VRAM, **without** `CUDA_DENSE` | 1.41 | 176 GB | 188 GB |
+| — | `SERVE_BATCH=1`, `KV_SLOTS=4`, 1/2/4 concurrent | 1.32 / 1.51 / 1.46 | 151 GB | — |
+
+### Only two levers actually moved the number
+
+**`CUDA_DENSE=1` — ×2.8 (1.53 → 4.26).** By default the engine reports
+`[CUDA] mode: routed experts only (resident dense on CPU)`. On a CPU-bound host the dense
+path of all 78 layers runs on the CPU while 192 GB of VRAM serve experts only. This flag is
+**not mentioned in the public README**; it was the single most profitable setting found.
+
+**Removing `URING` + `PILOT` + `PILOT_REAL` + `PILOT_TWO` — +26 % (4.26 → 5.38).** These
+hide disk latency. Once experts are resident the disk reads **0 MB/s during decode**, so the
+prefetch/overlap machinery only consumes CPU — the scarce resource. `DIRECT=1 PIPE=1` kept.
+
+### Neutral (±1 %, within noise)
+
+`COLI_CUDA_TC_INT4` (the W4A4 path needs ≥16 rows per expert; S=1 decode provides one),
+explicit `OMP_PROC_BIND=close` (the engine already sets it), and removing `COLI_CUDA_PIPE`
+(its decode gate is already device-count aware on 4 devices).
+
+### Counter-intuitive results
+
+1. **Maximising RAM+VRAM *degrades* when the dense path stays on CPU**: C1 (176 GB RSS,
+   188 GB VRAM) → 1.41 tok/s vs C0 (99 GB RSS) → 1.53.
+2. **Gains do not compose.** `RAM_GB` 190→205 is worth +4.5 % on the C2 base but only
+   +1.5 % once `URING`/`PILOT` are removed — both targeted the same residual disk misses.
+3. **Concurrency does not scale throughput**: 1.32 / 1.51 / 1.46 tok/s aggregate at 1/2/4.
+
+## 5. Where the bottleneck actually is
+
+Sampled during decode, after tuning:
+
+| | before (C0) | after (D1) |
+|---|---|---|
+| CPU | 638 % | 292–490 % (4–5 cores of 24) |
+| GPU | 2 % / 80 W | 20–22 % / 131 W |
+| Disk | 6 MB/s | **0 MB/s** |
+
+**Nothing is saturated.** The limiter is serialisation latency — 78 sequential layers,
+CPU↔GPU round trips, tiny matmuls at S=1 — not any single bandwidth. This explains both the
+failure of batching and the uselessness of maximising memory.
+
+### Prefill is a different regime entirely
+
+Decode activates 8 of 256 experts per layer; consecutive tokens reuse them, so the learned
+pinned set covers them. Prefill does not:
+
+```
+P(an expert is missed by N tokens) = (1 − 8/256)^N
+P(512) ≈ 1e-7        P(8595) ≈ e^-273
+```
+
+**A 512-token slice already touches every expert of every layer.** Prefill therefore gets no
+benefit from caching: it pays the non-resident fraction of the *entire model*, once per slice.
+
+Measured: **2.6–4.3 tok/s prefill** at `--ctx 262144` with `COLI_PREFILL_CHUNK=512` — i.e.
+35–55 minutes before first token on an 8,595-token prompt. Raising the chunk to 2048 reduces
+the number of full-model sweeps from 17 to 5.
+
+During prefill **only one GPU is active** (100 % / 200 W) while the other three sit at
+0 % / ~80 W: aggregate PCIe and compute budget is unused while the engine waits on expert
+loads.
+
+Prefix caching itself works correctly in steady state (`prefix 8556/8562 token, prefill 6`):
+the prefill cost is paid once per conversation, not per turn.
+
+## 6. **The finding that invalidates naive A/B benchmarking**
+
+A configuration **identical in memory placement** to the best result above
+(VRAM 178 GB, RAM 190 GB) measured **2.56 tok/s instead of 5.46**, with no memory parameter
+changed.
+
+The hidden variable is `.coli_usage`, the persistent learned routing profile that seeds the
+pinned hot store at startup:
+
+| Moment | Recorded selections |
+|---|---|
+| first start | 58,240 |
+| end of the 9-config matrix (~1 h later) | 238,840 |
+| after a day of real conversational use | **17,697,640** |
+
+The pinned set had re-tuned itself onto the real workload, so the synthetic benchmark prompt
+became out-of-distribution for the cache.
+
+**Consequences for anyone benchmarking this engine:**
+
+- `.coli_usage` **persists across restarts** and grows monotonically. Two configurations
+  measured hours apart are not comparable, even with identical flags.
+- `CONTRIBUTING.md` asks for a *warm-up policy*, but warm-up alone is insufficient: the
+  profile must be **snapshotted and restored** before each configuration under test.
+- Absolute numbers in this report should be read as *within-session rankings*, not as
+  portable throughput figures. The 9-config matrix ran back-to-back in one hour on one
+  prompt, so its ordering is internally consistent; cross-session comparisons are not.
+
+Two hypotheses were formed and then refuted by this: "total residency governs throughput"
+(refuted: 98 % residency measured *slower* than 91 %) and "VRAM residency governs throughput"
+(refuted by the identical-placement result). An arithmetic check also shows the VRAM/RAM
+bandwidth differential accounts for ~1.3 ms of the 77 ms per-token gap — under 2 %.
+
+**Suggested engine-side fix:** expose per-tier access counts (VRAM / RAM / disk hits) through
+`/profile` in a scriptable form. The dashboard displays hit rate; making it queryable would
+let contributors report the metric that actually decides placement trade-offs instead of
+reporting occupied gigabytes.
+
+## 7. Context vs residency trade-off
+
+```
+available   = 192 GB VRAM + 251 GB RAM                              = 443 GB
+required    = 407 (experts) + 83 (KV @262144) + 12 (dense) + 10 (OS) = 512 GB
+deficit                                                              =  69 GB
+```
+
+At `--ctx 32768` the KV costs 11 GB and everything fits. Measured: **5.46 tok/s at 32768 vs
+0.86 tok/s at 262144**. The engine reports the collapse itself:
+
+```
+[RAM_GB=215.0] WARNING: cap=1 is the floor, projected peak 216.7 GB is 1.7 GB OVER
+the budget (resident 132.2 GB + reserve 82.8 GB).
+PIN_GB is inflating the resident set: lower it or drop it.
+```
+
+### KV cache size
+
+MLA stores `kv_lora_rank 512 + rope 64 = 576` values per token per layer, ×78 layers =
+44,928 values/token.
+
+| dtype | per token | @262,144 |
+|---|---|---|
+| fp32 | 179.7 KB | **47.1 GB** |
+| fp16 | 89.9 KB | 23.6 GB |
+| int8 | 44.9 KB | 11.8 GB |
+
+The engine reports **47.7 GB**, i.e. fp32 — confirmed at `colibri.c:2277`
+(`...*kvl*4`). On top of that, `kvb_all` at `colibri.c:2766` allocates
+`Tk × H×(qk_nope+v_head) = Tk × 28,672` floats = 114.7 KB **per context position**, i.e.
+**30.1 GB** at 262,144 — matching the reported `kvb 30.1`. That buffer materialises the full
+per-head K/V, which is what MLA exists to avoid; `colibri.c:2568` already notes the
+alternative cost `O(T·kv_lora)` instead of `O(T·H·(nope+vh))`.
+
+Comparison on the same model and same latent attention: llama.cpp with `-ctk f16` uses
+**0.098 MB/token** vs colibri's **0.316 MB/token** — **×3.2**, i.e. ~57 GB avoidable at
+262,144. That is 83 % of the 69 GB deficit above: with an fp16 KV and no `kvb_all`, long
+context and full expert residency would be simultaneously reachable on this host.
+
+## 8. Build notes (Linux, CUDA)
+
+`nvcc` 12.6 + gcc 13 fails with `identifier "_Float32" is undefined`;
+`-allow-unsupported-compiler` produces 100 errors. The `BUILD-cuda-glibc241.md` recipe works
+and needs no root if the prefix is a user directory:
+
+```sh
+micromamba create -y -p ~/cuda13 -c nvidia -c conda-forge cuda-nvcc=13 cuda-cudart-dev=13
+ln -sfn ~/cuda13/lib ~/cuda13/lib64
+make glm CUDA=1 CUDA_ARCH=sm_86 CUDA_HOME=~/cuda13
+```
+
+The web dashboard needs Node ≥ 20.12 (`styleText` from `node:util`); Ubuntu 24.04 ships
+18.19, so `npm run build` fails on a stock install.
+
+## 9. Final configuration
+
+```sh
+CTX=32768                  # 262144 measured 0.86 tok/s decode, 2.9 tok/s prefill
+COLI_CUDA=1
+COLI_GPUS=0,1,2,3
+CUDA_DENSE=1               # ×2.8 — the decisive lever
+COLI_CUDA_ATTN=1
+COLI_CUDA_PIPE=2
+COLI_CUDA_TC_W4A16=1
+CUDA_EXPERT_GB=188         # NOT "auto" — see issue on prefill scratch
+PIN=auto
+PIN_GB=all
+RAM_GB=200
+DIRECT=1
+PIPE=1                     # no URING, no PILOT* — +26 % on this host
+COLI_PREFILL_CHUNK=2048
+```
+
+Operational notes: the engine does not release VRAM immediately on stop — restarting within
+~30 s fails with `Failed with result 'exit-code'` (`Restart=on-failure` recovers). And
+`coli plan` computes against *currently free* VRAM, so its output is meaningless while an
+engine instance is running.

--- a/docs/experiments/glm52-4xa6000-2026-08-02.md
+++ b/docs/experiments/glm52-4xa6000-2026-08-02.md
@@ -127,6 +127,44 @@ Sampled during decode, after tuning:
 CPU↔GPU round trips, tiny matmuls at S=1 — not any single bandwidth. This explains both the
 failure of batching and the uselessness of maximising memory.
 
+### And the engine's own profiler says where the latency goes
+
+External sampling could not attribute the time; the engine's per-phase counters can.
+`CTX=8192`, 48 tokens generated, greedy:
+
+```
+expert-disk    2.345 s   ( 4.8 %)   service 2.345 s / wait 2.046 s
+expert-matmul  9.074 s   (18.6 %)
+attention     31.264 s   (64.2 %)   including kvb 0.000 s
+lm_head        0.000 s
+other          5.987 s   (12.3 %)
+
+attention breakdown:  projection/RoPE      4.592 s
+                      score-softmax-value 20.398 s   (41.9 % of total)
+                      output projection    6.261 s
+```
+
+**Attention is 64 % of decode; expert compute is 19 %; disk is 5 %.** This reorders every
+placement question in this report. Expert residency, tiering and pinning together govern
+under a fifth of the time — a *perfect* expert placement, costing zero, would buy at most
+~19 %.
+
+Two consequences worth stating plainly:
+
+- **`CUDA_DENSE=1` being worth ×2.8 (§4) now has an explanation.** It moves the dense and
+  attention tensors onto the GPU. It was the decisive lever because it was the only one
+  aimed at the phase that dominates.
+- **`kvb 0.000 s`** — during decode the absorbed path runs and `kvb_all` is never built.
+  The 30.1 GB of §7 is a *prefill-only, transient* allocation that `cap_for_ram()`
+  nevertheless reserves permanently at every context length.
+
+`score-softmax-value` does not currently make arithmetic sense and is **not** presented here
+as a finding. At `CTX=8192` with a ~40-position KV cache it moves ~7 MB per token and spends
+425 ms doing it — about 17 MB/s, three orders of magnitude below this host's memory
+bandwidth. Either the counter attributes waiting time to attention, or there is a degenerate
+path at S=1. Resolving it needs a controlled repeat, which is the next measurement rather
+than a claim.
+
 ### Prefill is a different regime — but not for the reason stated in the first draft
 
 Decode activates 8 of 256 experts per layer and consecutive tokens reuse them, so the learned
@@ -329,7 +367,43 @@ And the uniform per-layer cap the engine already applies is close to optimal:
 *which* experts are pinned — it is how many fit, and how well the profile matches the current
 workload (§6).
 
-## 9. Build notes (Linux, CUDA)
+## 9. Self-speculation (`DRAFT`) is not worth enabling here — on this workload
+
+`--auto-tier` forces `DRAFT=0` on this host. That decision was made against a plan with 46 %
+residency, and the configuration has since improved a lot, so it was worth re-testing.
+Same protocol, `.coli_usage` restored before each condition, two warm-ups then three
+measurements:
+
+| | mean |
+|---|---|
+| `DRAFT=0` (what `--auto-tier` imposes) | **1.70 tok/s** |
+| `DRAFT=3` | 0.85 tok/s (−50 %) |
+| `DRAFT=3` + `COLI_CUDA_MTP=1` | 0.96 tok/s (−44 %) |
+
+**`--auto-tier` is right.** Verifying up to 4 positions in one forward widens the per-layer
+expert union from 8 to as many as 32, and on this workload nothing is accepted in return.
+
+**The scope of that result is narrower than it looks, and the distinction matters.**
+`DRAFT=n` is not the MTP head — `colibri.c:944` describes it as *"n token auto-speculati per
+forward via n-gram lookup"*, and `colibri.c:6000` as lossless self-speculation whose
+candidates come **from the context**; the MTP head is only the fallback when the n-gram
+lookup returns nothing (`colibri.c:6093`). It is speculation by *copying*.
+
+The prompt used here asks for three advantages of expert routing and generates 64 tokens of
+entirely novel prose. There is nothing in the context to copy, so the lookup could never
+succeed — this measures the cost of speculation on its structural worst case. The honest
+conclusion is therefore:
+
+> On novel text generation, `DRAFT>0` costs 2× and returns nothing, and disabling it by
+> default is correct. It is **untested here on the workloads this technique targets** —
+> code editing, summarisation, translation, structured output — where long spans are copied
+> from the context.
+
+That re-test needs a copy-heavy prompt and, unlike this one, needs the acceptance rate
+logged. This run did not capture it (`acceptance: not reported` in all three conditions),
+which is a defect of the harness, not of the engine.
+
+## 10. Build notes (Linux, CUDA)
 
 `nvcc` 12.6 + gcc 13 fails with `identifier "_Float32" is undefined`;
 `-allow-unsupported-compiler` produces 100 errors. The `BUILD-cuda-glibc241.md` recipe works
@@ -344,7 +418,7 @@ make glm CUDA=1 CUDA_ARCH=sm_86 CUDA_HOME=~/cuda13
 The web dashboard needs Node ≥ 20.12 (`styleText` from `node:util`); Ubuntu 24.04 ships
 18.19, so `npm run build` fails on a stock install.
 
-## 10. Final configuration
+## 11. Final configuration
 
 ```sh
 CTX=32768                  # 131072 also fine: −23 % decode, prefill unchanged (§5)


### PR DESCRIPTION
Adds `docs/experiments/glm52-4xa6000-2026-08-02.md`, following the convention of the existing 6x5090 report.

Engine v1.3.0 at commit `ecade075cfc2eae684097ea7de5570c3786ce199`, CUDA build `sm_86`, model `mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp`.

**Why this host is worth documenting:** the existing experiment set covers 6x5090 Blackwell, Metal M5 Max, Strix Halo and a 9950X3D+5090 box. This adds **Ampere multi-GPU on a pre-AVX-512 CPU** (EPYC 7402P, Zen 2, DDR4-2400), which behaves quite differently.

### Findings

- **`CUDA_DENSE=1` is worth x2.8** on a CPU-bound host (1.53 -> 4.26 tok/s). With the dense path on CPU, 192 GB of VRAM serve experts only while the CPU is the limiter. The flag does not appear in the public README.
- **Removing `URING`/`PILOT*` gains +26%.** Once experts are resident the disk reads 0 MB/s during decode, so the prefetch/overlap machinery only consumes the scarce resource.
- **Prefill is a different regime.** A 512-token slice already touches every expert of every layer, since `P(miss) = (1-8/256)^512 ~ 1e-7`. Chunked prefill therefore multiplies full-model sweeps instead of reducing work. Only one GPU is active during prefill.
- **KV cost.** Measured 0.316 MB/token vs 0.098 for llama.cpp `-ctk f16` on the same checkpoint (x3.2). Detailed in a separate issue.

### The part I would most like reviewed

Section 6 documents a **methodological problem affecting any A/B benchmark on this engine**: `.coli_usage` persists across restarts and grows monotonically. A configuration *identical in memory placement* measured **5.46 then 2.56 tok/s** after the learned profile re-tuned onto a different workload (240k -> 17.7M recorded selections).

`CONTRIBUTING.md` asks for a warm-up policy, but warm-up alone is insufficient: the profile needs to be snapshotted and restored per configuration. The report is explicit that its own numbers are **within-session rankings, not portable throughput**, and two hypotheses formed during the session are documented as refuted.

Suggested follow-up: expose per-tier access counts (VRAM/RAM/disk hits) via `/profile` in a scriptable form, so contributors can report the metric that actually decides placement trade-offs.

Docs-only change: no build, no test impact.