### PR TITLE
fix(plan): warn when VRAM is already in use

### DIFF
--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -567,6 +567,20 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
         warnings.append("one or more requested GPUs were not detected")
     if gpus and vram_budget < requested_vram:
         warnings.append("VRAM tier was clamped by free VRAM or model expert size")
+    # The plan sizes the hot tier from *free* VRAM, so running it while an engine
+    # instance already holds the GPUs silently produces a tiny tier and a
+    # pessimistic hit rate that describe nothing. That is exactly when a user
+    # reaches for `coli plan` -- before changing a live deployment -- so say so
+    # rather than let the numbers be read as a capacity answer.
+    if gpus:
+        gpu_total = sum(g["total_bytes"] for g in gpus)
+        gpu_free = sum(g["free_bytes"] for g in gpus)
+        if gpu_total and gpu_free < 0.75 * gpu_total:
+            warnings.append(
+                f"{format_bytes(gpu_total - gpu_free)} of VRAM is already in use "
+                f"(only {format_bytes(gpu_free)} of {format_bytes(gpu_total)} free): "
+                "this plan plans against the remainder. Stop the running engine "
+                "for a representative plan.")
     if cold_bytes:
         warnings.append("cold expert misses may reach disk; normal decode speed depends on hit rate")
 


### PR DESCRIPTION
Closes #769.

`coli plan` sizes the hot tier from **free** VRAM. Run on a host where an engine instance already holds the GPUs, it reports a tiny tier and a pessimistic hit rate that describe nothing — with no indication that the output is degraded.

That is precisely when the command gets reached for: before changing a live deployment.

**Measured on a 4× A6000 host with the production engine running** (178 GB VRAM held, 91 % actual expert residency):

```
VRAM   2.6 GB hot tier · ~122 experts · 0:RTX A6000, 1:..., 2:..., 3:...
limit  disk expert misses
hit    46% projected expert residency
```

Those numbers were used, in good faith, as the basis for a capacity decision. They are simply the plan for the 2.3 GB that happened to be free.

**Change:** one warning when less than 75 % of aggregate VRAM is free, naming the figures. Verified against the real `nvidia-smi` state of that host:

```
203.8 GB of VRAM is already in use (only 2.3 GB of 206.1 GB free): this plan
plans against the remainder. Stop the running engine for a representative plan.
```

Uses the `total_bytes`/`free_bytes` already carried by `discover_gpus()`; no new probe. Threshold chosen so a few hundred MB of desktop compositor does not trip it.

Python-only, no build or engine impact.