### PR TITLE
docs(env): document COLI_PREFILL_CHUNK, and what CUDA_DENSE is worth

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -18,6 +18,7 @@ Format: `VAR` — default — effect.
 |---|---|---|
 | `RAM_GB` | `0` (auto ≈ 88% of free RAM) | RAM budget in GB for the resident/streamed expert working set. Higher → more experts stay hot → higher cache hit rate. |
 | `CTX` | `4096` | Maximum context length (tokens) the KV cache is sized for. |
+| `COLI_PREFILL_CHUNK` | `0` (off) | Run a long prompt through the layers in N-token slices instead of one pass. Every S-scaled activation buffer shrinks from prompt-sized to chunk-sized, which is the remedy when a long prompt exhausts CUDA scratch. Byte-identical output (verified at N=256). Skipped under an active MTP draft. **Cost:** a slice of 512 tokens already routes to essentially every expert of every layer (`P(miss) = (1-topk/n_experts)^N`), so each slice re-reads the whole non-resident expert set -- prefer the largest N that still fits your scratch. |
 | `NGEN` | `256` (engine) | Max tokens to generate before stopping (stop tokens can end sooner). `coli --ngen` defaults to `1024`. |
 | `COLI_TEMP` | `-1` (auto: `1.0` for chat/text, greedy elsewhere) | Sampling temperature. **`COLI_TEMP=0` = greedy/argmax = deterministic.** `TEMP` still works as a deprecated alias, but only if fully numeric: `$TEMP` is the temp-*directory* path on Windows and for the ROCm runtime (#509), so prefer `COLI_TEMP`. |
 | `NUCLEUS` | `0.90` | Nucleus (top-p) mass kept when sampling. Slightly tighter than the official 0.95 because the int4 tail is noisy. |
@@ -154,7 +155,7 @@ See [docs/vulkan.md](vulkan.md). On multi-core boxes also set `COLI_NO_OMP_TUNE=
 |---|---|---|
 | `COLI_CUDA` | off | Enable the CUDA backend. Requires a CUDA build. An explicit `COLI_CUDA=0` disables it **and suppresses the Windows bare-run auto-enable** (before this, Windows "CPU" runs with `COLI_CUDA=0` silently got a VRAM expert tier). The CLI flag `--gpu none` is the canonical hard off-switch on every platform. |
 | `COLI_GPU` / `COLI_GPUS` | unset | Device selection (`auto`, `none`, or a list like `0,1`). Requires `COLI_CUDA=1`. |
-| `CUDA_DENSE` | `0` | Place dense (non-expert) matmuls on the GPU. |
+| `CUDA_DENSE` | `0` | Place dense (non-expert) matmuls on the GPU. Off by default the engine reports `routed experts only (resident dense on CPU)`: on a host where the CPU is the limiter this leaves the dense path of every layer on the CPU while the VRAM tier serves experts only. Measured x2.8 on a 4x A6000 / 24-core host (1.53 -> 4.26 tok/s). |
 | `CUDA_EXPERT_GB` | `0` | VRAM budget (GB) for caching experts on the GPU. |
 | `CUDA_RELEASE_HOST` | auto (`1` if >1 device) | Release host-side copies after upload. |
 | `COLI_CUDA_ATTN` | off | Run S≤4 attention on the GPU. |


### PR DESCRIPTION
Two documentation gaps found while bringing GLM-5.2 up on a 4× A6000 host (#764).

**`COLI_PREFILL_CHUNK` has no entry in `ENVIRONMENT.md`.** It exists only in the comment at `colibri.c:4464`, yet it is the remedy when a long prompt exhausts CUDA scratch under `CUDA_EXPERT_GB=auto` (#767) — a failure whose symptom (`tensor [6144,2048] on device 3 disabled after an error; falling back to CPU`) gives no hint which knob to reach for.

The entry also states its cost, which is not obvious: a 512-token slice already routes to essentially every expert of every layer, since `P(miss) = (1-8/256)^512 ≈ 1e-7`. Each slice therefore re-reads the whole non-resident expert set, so smaller chunks multiply disk traffic rather than reduce work. Measured 2.6–4.3 tok/s prefill at `chunk=512` on an 8,595-token prompt.

**`CUDA_DENSE` has a one-line entry that does not say when it matters.** Off by default the engine reports `routed experts only (resident dense on CPU)`. On a CPU-bound host that leaves the dense path of every layer on the CPU while the VRAM tier serves experts only — measured **×2.8** (1.53 → 4.26 tok/s) on 4× A6000 + a 24-core EPYC. It was by a wide margin the most profitable single setting found on that host, and nothing in the docs suggested to try it.

Docs-only.