### PR TITLE
feat(usage): COLI_USAGE_DECAY — give the learned expert history a half-life

### DIFF
--- a/c/route_trace.h
+++ b/c/route_trace.h
@@ -298,8 +298,30 @@ static int64_t rt_load(const char *path){
 }
 
 /* atomic write of the current counters. quiet=0 prints the one-line summary. */
+/* COLI_USAGE_DECAY: the persistent history is a cumulative, never-decayed histogram,
+ * so its responsiveness falls as it grows. Measured on a host with 18.2M recorded
+ * selections: a typical turn contributes ~38k, i.e. it moves the ranking by 0.2%, and
+ * the pinned set can no longer follow a change of workload. Multiplying the counters
+ * by a factor at each save gives the history a half-life in turns (0.99 -> ~69 turns)
+ * while leaving the default (1.0) byte-identical to current behaviour.
+ * Placement only: routing math and outputs are untouched, so the token-exact oracle
+ * is unaffected. Rounding keeps a count of 1 alive -- forgetting targets the large
+ * counters that dominate the ranking, not the long tail. */
+static void rt_decay(void){
+    static double d = -1.0;
+    if(d < 0.0){ const char *e = getenv("COLI_USAGE_DECAY"); d = e ? atof(e) : 1.0;
+                 if(d <= 0.0 || d > 1.0) d = 1.0; }
+    if(d >= 1.0 || !rt_c) return;
+    for(int i = 0; i <= rt_nl; i++){
+        if(!rt_c[i]) continue;
+        for(int e = 0; e < rt_ne; e++)
+            if(rt_c[i][e]) rt_c[i][e] = (unsigned)(rt_c[i][e] * d + 0.5);
+    }
+}
+
 static int rt_save(const char *path, int quiet){
     if(!rt_c || !path || !*path) return 0;
+    rt_decay();
     int64_t tot = 0, nz = 0;
     for(int i = 0; i <= rt_nl; i++){
         if(!rt_c[i]) continue;


### PR DESCRIPTION
`.coli_usage` is a cumulative histogram that is never decayed, so its responsiveness falls as it grows. This adds an opt-in decay factor. **Default 1.0 is byte-identical to current behaviour.**

## Why

Measured on a 4x A6000 host after a day of real use:

| | |
|---|---|
| recorded history | **18,190,000 selections** |
| a typical turn contributes | ~38,000 (0.2 % of the total) |
| turns needed to re-rank the pinned set | ~9,000 |

The learning saturates. Early on, when the history held 58k selections, each conversation mattered; at 18.2M the profile is effectively frozen and can no longer follow a change of workload.

**That matters because a specialised profile is worth roughly 2x on this host.** We hit it by accident: the *same* memory placement measured **5.46 tok/s** when `.coli_usage` had been fitted to one repeated benchmark prompt (240k selections), and **2.78 tok/s** once the history had been diluted to 18.2M mixed selections. We first treated that as a measurement confound; it is the feature working, and then ceasing to work as the history grows.

## What

`rt_decay()` in `route_trace.h`, called from `rt_save()`:

```c
if(rt_c[i][e]) rt_c[i][e] = (unsigned)(rt_c[i][e] * d + 0.5);
```

Half-life in turns: `0.99` → ~69 turns, `0.95` → ~14. Rounding keeps a count of 1 alive, so forgetting targets the large counters that dominate the ranking rather than the long tail.

**Placement only** — routing math and outputs are untouched, so the token-exact oracle is unaffected.

## Validation

Clean build (`make glm`, 0 warnings). Unit test driving `rt_init` + `rt_save` directly:

```
default (unset)        ratio 1.000 · 1.000 · 1.000     unchanged
COLI_USAGE_DECAY=0.5   ratio 0.500 · 0.250 · 0.125     exact halving
COLI_USAGE_DECAY=0.9   ratio 0.900 · 0.810 · 0.729     exactly 0.9^n
invalid (2.0)          ratio 1.000 · 1.000 · 1.000     falls back to 1.0
```

## What I have not done

I have **not** measured the end-to-end effect of a decayed profile on throughput — that needs a controlled workload-switch experiment (fit on domain A, switch to B, measure convergence with and without decay), which is a day of machine time. The 2x figure above is from an accidental A/B, not a designed one. I am happy to run that experiment if you think the feature is worth it, or to leave this as a knob for people who want to try it.

Related: #119 and #175 both concern profile-guided placement; this makes the profile track the current workload rather than the all-time average.

---
*4x RTX A6000, EPYC 7402P, GLM-5.2 int4. Context in #764.*