### PR TITLE
st: document st_read_raw's caller contract, and add the capped sibling

### DIFF
--- a/c/st.h
+++ b/c/st.h
@@ -776,12 +776,37 @@ static int64_t st_read_scale_f32(shards *S, const char *name, float *out, int64_
 }
 
 /* legge i byte GREZZI di un tensore (nessuna conversione di dtype): per i pesi gia'
- * quantizzati int4/int8 del nostro container (dtype U8). drop=1 -> fadvise DONTNEED. */
+ * quantizzati int4/int8 del nostro container (dtype U8). drop=1 -> fadvise DONTNEED.
+ *
+ * CALLER CONTRACT: this reads `t->nbytes` -- a length declared by the file header --
+ * into `out`, and has no bound of its own. st_init cannot supply one: it deliberately
+ * skips its numel*esz==nbytes cross-check for dtype 3, because packed quant bytes
+ * legitimately have numel != nbytes. So the caller MUST establish that its destination
+ * is at least t->nbytes before calling. Today all callers do, by three routes:
+ *   - colibri.c sizes the buffer from st_nbytes() itself, and qt_resolve_fmt validates
+ *     both byte counts against [O,I];
+ *   - kimi_k3.c makes the byte count the branch predicate (`if(t->nbytes==O*I ...)`),
+ *     so identifying the format and validating it are the same act;
+ *   - olmoe.c compares against a config-derived want_w and refuses by name.
+ * A new caller with none of those wants st_read_raw_cap below. */
 static void st_read_raw(shards *S, const char *name, void *out, int drop) {
     st_tensor *t = st_find(S, name);
     if (!t) { fprintf(stderr, "missing tensor: %s\n", name); exit(1); }
     st_pread_full(t->fd, out, t->nbytes, t->off, "pread raw");
     if (drop) posix_fadvise(t->fd, t->off, t->nbytes, POSIX_FADV_DONTNEED);
+}
+
+/* st_read_raw with the bound made explicit: `cap` is the byte capacity of `out`, in the
+ * same position and spirit as st_read_f32_cap's element cap. Refuses rather than writing
+ * past the destination, so a caller that has an expected size need not invent its own
+ * check -- and one that has none cannot silently do the wrong thing. */
+static void st_read_raw_cap(shards *S, const char *name, void *out, int64_t cap, int drop) {
+    st_tensor *t = st_find(S, name);
+    if (!t) { fprintf(stderr, "missing tensor: %s\n", name); exit(1); }
+    if (t->nbytes < 0 || t->nbytes > cap) {
+        fprintf(stderr, "%s: tensor declares %lld bytes, destination holds %lld — refusing "
+                "(untrusted container)\n", name, (long long)t->nbytes, (long long)cap); exit(1); }
+    st_read_raw(S, name, out, drop);
 }
 
 /* legge una FETTA di un tensore: n_elems a partire dall'elemento elem_off.

--- a/c/tests/test_st_pread.c
+++ b/c/tests/test_st_pread.c
@@ -49,7 +49,33 @@ int main(void) {
     st_read_raw(&S, "t", out, 0);
     for (int i = 0; i < 96; i++) CHECK(out[i] == (unsigned char)(i * 7 + 3));
 
+    /* 1b) the capped variant passes a read that fits, byte for byte */
+    unsigned char capped[96] = {0};
+    st_read_raw_cap(&S, "t", capped, sizeof(capped), 0);
+    CHECK(memcmp(capped, out, 96) == 0);
+
 #ifndef _WIN32
+    /* 1c) a header declaring more bytes than the destination holds. st_init cannot
+     * catch this for dtype 3 (packed quant bytes legitimately have numel != nbytes),
+     * so the bound has to be the caller's -- st_read_raw_cap makes it one. Runs on
+     * the intact shard: the cap is checked before any pread, so truncation below
+     * would only obscure which refusal fired. */
+    int cap_pipe[2]; CHECK(pipe(cap_pipe) == 0);
+    pid_t cap_pid = fork(); CHECK(cap_pid >= 0);
+    if (cap_pid == 0) {
+        dup2(cap_pipe[1], 2); close(cap_pipe[0]); close(cap_pipe[1]);
+        unsigned char small[64];
+        st_read_raw_cap(&S, "t", small, sizeof(small), 0);   /* 96 > 64: must exit(1) */
+        _exit(42);                                            /* reaching here = bug */
+    }
+    close(cap_pipe[1]);
+    char cap_err[512] = {0};
+    ssize_t cn = read(cap_pipe[0], cap_err, sizeof(cap_err)-1); (void)cn;
+    close(cap_pipe[0]);
+    int cap_status = 0; waitpid(cap_pid, &cap_status, 0);
+    CHECK(WIFEXITED(cap_status) && WEXITSTATUS(cap_status) == 1);
+    CHECK(strstr(cap_err, "destination holds") != NULL);
+
     /* 2) shard truncated AFTER st_init (init validates static bounds, so the
      * pread path only fires when the file shrinks underneath a live handle):
      * child must exit(1) with an honest message, not perror's "Success" */


### PR DESCRIPTION
`st_read_raw` preads a header-declared `t->nbytes` into a caller-sized buffer and has no bound
of its own. `st_init` cannot supply one — it deliberately skips the `numel*esz==nbytes`
cross-check for dtype 3, because packed quant bytes legitimately have `numel != nbytes`. That
skip is correct, and it means the bound has to be the caller's.

I audited all eleven call sites. **All of them establish it**, by three different routes:

- `colibri.c` sizes the destination from `st_nbytes()` itself, and `qt_resolve_fmt` validates
  both byte counts against `[O,I]`;
- `kimi_k3.c` makes the byte count the branch predicate — `if(t->nbytes==(int64_t)O*I && …)` —
  so identifying the format and validating it are one act;
- `olmoe.c` compares against a config-derived `want_w` and refuses by name. Its `SEC` comment
  already describes this exact hazard, so somebody has walked here before.

So this is not a bug report. The gap is that **nothing in `st.h` said any of that**, and a
twelfth caller had nothing to notice.

## What this adds

The contract, written where the function is, naming the three mechanisms so a reader can see
why it is safe today rather than having to reconstruct it from three engines.

And `st_read_raw_cap`, following the file's own `st_read_f32` / `st_read_f32_cap` pattern —
`cap` in the same position, refusing rather than writing past the destination.

**No call site changes.** I started to convert `olmoe.c`'s hand-written check and stopped: it
tests `!=`, an exact geometry match, while a cap tests `>`. Converting would have *weakened* it.
The same is true of the other two mechanisms. So the capped variant has no caller today except
its test — it is there for the next one, and if you would rather not carry an API with no
in-tree user, dropping it and keeping the comment is a reasonable read of this PR.

## Tests

Two cases in `tests/test_st_pread.c`, on its existing fork/`_exit(42)` idiom: a capped read that
fits returns the same bytes as the uncapped one, and one that does not is refused before any
pread. The refusal case runs on the intact shard, before the truncation subtest, so it cannot be
confused with a short-read refusal.

I checked the second case is not decorative by disabling the guard (`if (0)`) and rebuilding: the
test fails at `WEXITSTATUS(cap_status) == 1`, i.e. the child reached the `_exit(42)` that the
comment marks as the bug. Restored, it passes.

## Verification

Built on Linux from a clean clone of `dev` (72ddb67): all four engines `rc=0`, zero errors, and
the warning sets are byte-identical to the pristine tree (kimi_k3's 5 and olmoe's 1 are
pre-existing). `tests/test_st_pread` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
