### PR TITLE
test(inkling): enforce cache capacity invariance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,12 @@ jobs:
           # forward); the greedy pass exits non-zero on any mismatch, so this
           # gate fails the moment a shared-code change regresses the engine.
           python3 tools/make_tiny_inkling.py tiny_inkling
-          SNAP=tiny_inkling ./inkling 8 0 tiny_inkling/ref_inkling.json
+          # The oracle at several cache capacities (#784): a capacity-1 cache
+          # exercises eviction on every routed expert, which is where a slot
+          # bookkeeping bug shows up and a capacity-8 run never would.
+          for cap in 1 2 8; do
+            SNAP=tiny_inkling ./inkling "$cap" 0 tiny_inkling/ref_inkling.json
+          done
       - name: KV prefix reuse is token-identical (serve, two turns)
         run: |
           cd c

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -1250,6 +1250,18 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
             for (int j = 0; j < nfill; j++) slot_fill(m, fl[j], fill[j]);
             m->t_fill += now_s() - tf;
         }
+        /* Validate before the CPU/Metal split: either backend must refuse a
+         * cache slot whose weights belong to a different routed expert. */
+        for (int64_t t = base; t < end; t++) {
+            Slot *e = use[t - base];
+            if (!e) continue;                              /* scartato da TOPP */
+            int s = (int)(t / K), kk = (int)(t % K);
+            if (e->eid != idx[(int64_t)s*K + kk]) {
+                fprintf(stderr, "layer %d: cache served expert %d for requested expert %d\n",
+                        layer, e->eid, idx[(int64_t)s*K + kk]);
+                exit(1);
+            }
+        }
         double te = now_s();
 #ifdef COLI_METAL
         if (mxg) {


### PR DESCRIPTION
## Summary

  Add regression coverage for the cache-capacity fix at capacities 1, 2, and 8.

  Add a runtime expert-ID guard so cache mismatches fail clearly instead of using the wrong expert
  weights and producing junk output.

  ## Validation

  - [x] make -C c check
  - [x] CUDA testing not applicable; no CUDA changes
  - [x] Performance validation not applicable; no performance claims

  ## Compatibility

  - [x] The default CPU build remains dependency-free
  - [x] No model files, generated binaries, or benchmark artifacts are included