### PR TITLE
[WIP] Vulkan stats

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -2152,6 +2152,14 @@ static int expert_load_impl(Model *m, int layer, int eid, ESlot *s, int fatal, i
      * expert re-uploads instead of computing with the old expert's tensors. */
     if(s->eid!=eid){
         if(s->g.vk_eligible) g_vk_resident--;
+        if(s->g.vk || s->u.vk || s->d.vk) {
+            int64_t b = 0;
+            if(s->g.vk) b += coli_vk_tensor_bytes(s->g.vk);
+            if(s->u.vk) b += coli_vk_tensor_bytes(s->u.vk);
+            if(s->d.vk) b += coli_vk_tensor_bytes(s->d.vk);
+            m->gpu_expert_count--;
+            m->gpu_expert_bytes -= b;
+        }
         qt_vk_reset(&s->g); qt_vk_reset(&s->u); qt_vk_reset(&s->d);
     }
 #endif
@@ -7654,7 +7662,10 @@ static void vk_registry_fill(Model *m){
             fprintf(stderr,"[VK] expert tier: VRAM full after %d experts\n",g_vk_reg_n);
             break;
         }
-        bytes+=coli_vk_tensor_bytes(slot[0])+coli_vk_tensor_bytes(slot[1])+coli_vk_tensor_bytes(slot[2]);
+        int64_t actual = coli_vk_tensor_bytes(slot[0])+coli_vk_tensor_bytes(slot[1])+coli_vk_tensor_bytes(slot[2]);
+        bytes+=actual;
+        m->gpu_expert_bytes+=actual;
+        m->gpu_expert_count++;
         g_vk_reg_n++;
     }
     coli_vk_alloc_priority(0.75f);               /* back to the dense/default class */
@@ -7692,7 +7703,10 @@ static void vk_registry_fill(Model *m){
                 fprintf(stderr,"[VK] dev2 tier: VRAM full after %d experts\n",g_vk_reg_n2);
                 break;
             }
-            bytes2+=coli_vk_tensor_bytes(slot[0])+coli_vk_tensor_bytes(slot[1])+coli_vk_tensor_bytes(slot[2]);
+            int64_t actual = coli_vk_tensor_bytes(slot[0])+coli_vk_tensor_bytes(slot[1])+coli_vk_tensor_bytes(slot[2]);
+            bytes2+=actual;
+            m->gpu_expert_bytes+=actual;
+            m->gpu_expert_count++;
             g_vk_reg_n2++;
         }
         fprintf(stderr,"[VK] dev2 tier: %d experts resident (%.2f GB VRAM, %.1fs, next-%d of history)\n",

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -459,6 +459,9 @@ static inline int vk_reg_served(int layer,int eid){
     if(!g_vk_reg || layer<0 || layer>=g_vk_reg_NL || eid<0 || eid>=g_vk_reg_E) return 0;
     return g_vk_reg[((size_t)layer*g_vk_reg_E+eid)*3] != NULL;
 }
+int coli_vk_reg_has(int layer, int eid) {
+    return vk_reg_served(layer, eid);
+}
 static int g_vk_dense;        /* COLI_VK_DENSE=1: run the resident dense matmuls (attention
                                * projections + shared expert) on Vulkan too */
 static int g_vk_budget2;      /* COLI_VK_EXPERTS2: dev2 expert-tier cap (with COLI_VK_DEV2) */

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -1472,11 +1472,19 @@ class Engine:
                         events.put(("done", stats))
                 elif kind == "HWINFO" and len(fields) >= 7:
                     parts = " ".join(fields[6:]).split("|")
+                    gpu_name = parts[1].strip() if len(parts)>1 else ""
+                    if "vulkan" in gpu_name.lower():
+                        backend = "vulkan"
+                    elif int(fields[4]) > 0:
+                        backend = "cuda"
+                    else:
+                        backend = "cpu"
                     self.hwinfo = {"cores": int(fields[1]), "ram_total_gb": float(fields[2]),
                                    "ram_avail_gb": float(fields[3]), "gpus": int(fields[4]),
                                    "vram_total_gb": float(fields[5]),
                                    "cpu": parts[0].strip() if len(parts)>0 else "",
-                                   "gpu": parts[1].strip() if len(parts)>1 else ""}
+                                   "gpu": gpu_name,
+                                   "backend": backend}
                 elif kind == "EMAP" and len(fields) == 4:
                     self.emap = {"rows": int(fields[1]), "cols": int(fields[2]), "map": fields[3]}
                 elif kind == "HITS" and len(fields) == 4:

--- a/c/telemetry.h
+++ b/c/telemetry.h
@@ -96,7 +96,7 @@ static void hwinfo_emit(Model *m){
     hw_probe(cpu,sizeof(cpu),&cores,&ram_total,&ram_avail);
     int ngpu=0; double vram_total=0;
     char gpu_name[128]="";
-#ifdef COLI_CUDA
+#if defined(COLI_CUDA)
     ngpu=g_cuda_ndev; vram_total=m->gpu_expert_bytes/1e9;
     for(int i=0;i<g_cuda_ndev;i++){
         size_t fr=0,to=0; coli_cuda_mem_info(g_cuda_devices[i],&fr,&to);
@@ -104,6 +104,17 @@ static void hwinfo_emit(Model *m){
     }
     if(g_cuda_ndev>0)
         snprintf(gpu_name,sizeof(gpu_name),"CUDA device x%d",g_cuda_ndev);
+#elif defined(COLI_VULKAN)
+    ngpu = (coli_vk_available() ? 1 : 0) + (coli_vk_dev2_available() ? 1 : 0);
+    vram_total = m->gpu_expert_bytes / 1e9;
+    double used, budget;
+    if (coli_vk_available() && coli_vk_mem_budget(&used, &budget)) {
+        vram_total = budget;
+        if (coli_vk_dev2_available() && coli_vk_mem_budget2(&used, &budget)) {
+            vram_total += budget;
+        }
+    }
+    if(ngpu > 0) snprintf(gpu_name, sizeof(gpu_name), "Vulkan device x%d", ngpu);
 #endif
     printf("HWINFO %d %.1f %.1f %d %.1f %s|%s\n",
         cores,ram_total,ram_avail,ngpu,vram_total,cpu,gpu_name);

--- a/c/telemetry.h
+++ b/c/telemetry.h
@@ -136,6 +136,10 @@ static void tiers_emit(Model *m){
     fflush(stdout);
 }
 
+#ifdef COLI_VULKAN
+int coli_vk_reg_has(int layer, int eid);
+#endif
+
 static void emap_emit(Model *m){
     Cfg *c=&m->c;
     int rows=0;
@@ -151,10 +155,12 @@ static void emap_emit(Model *m){
             int tier=0;
             ESlot *P=m->pin[i];
             for(int z=0;z<m->npin[i];z++) if(P[z].eid==e){
-#ifdef COLI_CUDA
-                tier = P[z].g.cuda?2:1;
-#else
                 tier = 1;
+#ifdef COLI_CUDA
+                if (P[z].g.cuda) tier = 2;
+#endif
+#ifdef COLI_VULKAN
+                if (coli_vk_reg_has(i, e)) tier = 2;
 #endif
                 break; }
             if(!tier && m->ecache && m->ecache[i])

--- a/c/telemetry.h
+++ b/c/telemetry.h
@@ -117,9 +117,7 @@ static void tiers_emit(Model *m){
     int pinned=0,lru=0;
     for(int i=0;i<=c->n_layers;i++){ pinned+=m->npin?m->npin[i]:0; lru+=m->ecn?m->ecn[i]:0; }
     int vram=0; double vram_gb=0;
-#ifdef COLI_CUDA
     vram=m->gpu_expert_count; vram_gb=m->gpu_expert_bytes/1e9;
-#endif
     int ram=pinned-vram+lru; if(ram<0) ram=0;
     int disk=total-vram-ram; if(disk<0) disk=0;
     double eb=(double)expert_bytes_probe(m,m->ebits);

--- a/c/tests/test_inefficiency.py
+++ b/c/tests/test_inefficiency.py
@@ -86,6 +86,28 @@ def _cuda_available() -> bool:
 
 @unittest.skipUnless(_engine_present(), _skip_reason() or "glm.exe + glm_tiny required")
 class TinyEfficiencyTest(unittest.TestCase):
+
+    def test_vulkan_telemetry_parses(self):
+        from tools import diag_harness, efficiency
+        stdout = ""
+        stderr = """
+[VK] ready: AMD Radeon RX 7900 XTX
+[VK] dev2 ready: AMD Radeon RX 7900 XTX
+[VK] dev2 tier: 12 hot experts resident (15.5 GB VRAM)
+[VK] dense preloaded: 4 tensors, 2.3 GB VRAM
+"""
+        metrics = diag_harness.extract_metrics(stdout, stderr)
+        vk_devices = metrics.get('vk_devices', [])
+        self.assertEqual(len(vk_devices), 2)
+        self.assertEqual(metrics['vk_tier']['resident'], 12)
+        self.assertEqual(metrics['vk_tier']['vram_gb'], 15.5)
+        self.assertEqual(metrics['vk_dense']['tensors'], 4)
+        
+        parsed = efficiency.parse_run(stdout, stderr)
+        self.assertTrue(parsed['vk']['enabled'])
+        self.assertEqual(parsed['vk']['expert_count'], 12)
+        self.assertEqual(parsed['vk']['expert_gb'], 15.5)
+        self.assertEqual(parsed['vk']['resident_tensors'], 4)
     """Asserted regression tests on the resident tiny model. Gates CI."""
 
     def _run(self, **overlay):

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -413,6 +413,32 @@ class FakeProcess:
 
 
 class DispatcherTest(unittest.TestCase):
+
+    def test_parses_hwinfo_backends(self):
+        def respond(process, frame):
+            pass
+        process = FakeProcess(respond)
+        with patch("openai_server.subprocess.Popen", return_value=process):
+            engine = Engine("glm", "model", kv_slots=2)
+            
+        # The engine spawns a thread running _dispatch_stdout automatically!
+        # Just feed the data and then wait for it to process.
+        process.stdout.feed(b"HWINFO 32 197.0 153.3 1 30.6 CPU|Vulkan device x1\n")
+        import time
+        time.sleep(0.1)
+        self.assertEqual(engine.hwinfo["backend"], "vulkan")
+
+        process.stdout.feed(b"HWINFO 32 197.0 153.3 2 30.6 CPU|CUDA device x2\n")
+        time.sleep(0.1)
+        self.assertEqual(engine.hwinfo["backend"], "cuda")
+
+        process.stdout.feed(b"HWINFO 32 197.0 153.3 0 0.0 CPU|\n")
+        time.sleep(0.1)
+        self.assertEqual(engine.hwinfo["backend"], "cpu")
+        engine.close()
+
+
+
     def test_dispatches_interleaved_requests_by_id(self):
         submitted = []
 

--- a/c/tools/diag_harness.py
+++ b/c/tools/diag_harness.py
@@ -112,6 +112,10 @@ RX = {
     "cuda_mode":     (re.compile(r"\[CUDA\] mode: (.+)"),                 lambda m: m.group(1)),
     "cuda_tier":     (re.compile(r"CUDA expert tier: (\d+) resident experts \(([\d.]+) GB\)"),
                       lambda m: {"resident":int(m.group(1)),"vram_gb":float(m.group(2))}),
+    "vk_tier":       (re.compile(r"\[VK\] (?:dev2 |expert )tier: (\d+) (?:hot )?experts resident \(([\d.]+) GB VRAM\)"),
+                      lambda m: {"resident": int(m.group(1)), "vram_gb": float(m.group(2))}),
+    "vk_dense":      (re.compile(r"\[VK\] dense preloaded: (\d+) tensors, ([\d.]+) GB VRAM"),
+                      lambda m: {"tensors": int(m.group(1)), "vram_gb": float(m.group(2))}),
     # stderr: TOKENS dump (line 4010-4012)
     "tokens_dump":   (re.compile(r"^\[TOKENS\] (\d+) generated:(.*)$", re.MULTILINE),
                       lambda m: [int(x) for x in m.group(2).split()]),
@@ -148,6 +152,12 @@ def extract_metrics(stdout: str, stderr: str) -> dict:
         cuda_devs.append({"id":int(m.group(1)),"name":m.group(2).strip(),
                           "vram_gb":float(m.group(3)),"sm":f"{m.group(4)}.{m.group(5)}"})
     if cuda_devs: metrics["cuda_devices"] = cuda_devs
+    # Multiple Vulkan devices
+    vk_devs = []
+    for m in re.finditer(r"\[VK\] (?:dev(\d+) )?ready: ([^,\n]+)", text_err):
+        dev_id = int(m.group(1)) if m.group(1) else 0
+        vk_devs.append({"id": dev_id, "name": m.group(2).strip()})
+    if vk_devs: metrics["vk_devices"] = vk_devs
     # Multiple progress checkpoints — collect the full curve
     progress = []
     for m in RX["progress_tps"][0].finditer(text_err):
@@ -333,6 +343,7 @@ class DiagnosticHarness:
             "cap_final": metrics.get("cap_ok"),
             "cuda_devices": metrics.get("cuda_devices", []),
             "cuda_mode": metrics.get("cuda_mode"),
+            "vk_devices": metrics.get("vk_devices", []),
         }
         # Print summary
         print(f"  load time:    {result['load_secs']:.2f}s" if result['load_secs'] else "  load time:    FAILED")
@@ -349,6 +360,8 @@ class DiagnosticHarness:
             print(f"  cache cap:    {result['cache_cap_requested']}")
         for d in result['cuda_devices']:
             print(f"  GPU {d['id']}:       {d['name']}, {d['vram_gb']:.1f} GB, sm_{d['sm']}")
+        for d in result.get('vk_devices', []):
+            print(f"  VK GPU {d['id']}:    {d['name']}")
         if rc != 0 and rc != -1:
             print(f"  WARNING: engine returned rc={rc}")
         self.results["phases"]["system"] = result
@@ -435,6 +448,7 @@ class DiagnosticHarness:
             "mtp_counts": metrics.get("mtp_acc_cnt"),
             "spec_tok_per_fw": metrics.get("spec_tok_per_fw"),
             "cuda_tier": metrics.get("cuda_tier"),
+            "vk_tier": metrics.get("vk_tier"),
             "progress_curve": metrics.get("progress_curve", []),
         }
         # Print the PROFILE breakdown
@@ -455,6 +469,9 @@ class DiagnosticHarness:
         if result.get('cuda_tier'):
             ct = result['cuda_tier']
             print(f"    CUDA tier: {ct['resident']} experts, {ct['vram_gb']:.1f} GB VRAM")
+        if result.get('vk_tier'):
+            vt = result['vk_tier']
+            print(f"    VK tier:   {vt['resident']} experts, {vt['vram_gb']:.1f} GB VRAM")
         # Show generated text preview
         if text:
             print(f"\n  GENERATED TEXT (first 200 chars):")
@@ -588,6 +605,8 @@ class DiagnosticHarness:
                 lines += [f"- Cache cap: {s['cap_final']}"]
             for d in s.get("cuda_devices", []):
                 lines += [f"- GPU {d['id']}: {d['name']}, {d['vram_gb']:.1f} GB, sm_{d['sm']}"]
+            for d in s.get("vk_devices", []):
+                lines += [f"- VK GPU {d['id']}: {d['name']}"]
             lines.append("")
         # Smoke
         if "smoke" in phases:

--- a/c/tools/efficiency.py
+++ b/c/tools/efficiency.py
@@ -84,6 +84,10 @@ CUDA_RESIDENT_RE = re.compile(
     r"\[CUDA\] resident set:\s+(\d+)\s+tensors,\s+([0-9.]+)\s+GB\s+VRAM"
 )
 
+VK_DEVICE_RE = re.compile(r"\[VK\] (?:dev\d+\s+)?ready:\s+([^,\n]+)")
+VK_TIER_RE = re.compile(r"\[VK\] (?:dev2\s+|expert\s+)tier:\s+(\d+)\s+(?:hot\s+)?experts resident\s+\(([0-9.]+)\s+GB\s+VRAM")
+VK_DENSE_RE = re.compile(r"\[VK\] dense preloaded:\s+(\d+)\s+tensors,\s+([0-9.]+)\s+GB\s+VRAM")
+
 # "PREFILL (teacher-forcing) C vs oracle: 11/32 positions | 1700.4 pos/s"  (TF=1 mode, stdout)
 TF_MATCH_RE = re.compile(r"PREFILL \(teacher-forcing\).*:\s+(\d+)/(\d+)\s+positions")
 
@@ -204,7 +208,7 @@ def parse_run(stdout: str, stderr: str = "") -> dict:
 
     Raises RuntimeError only if the core throughput line is missing — everything
     else is optional and absent on some run modes (e.g. [PROF] needs PROF=1,
-    CUDA tier needs gpu_expert_count>0).
+    CUDA/VK tier needs gpu_expert_count>0).
     """
     out = dict(
         tok_s=None, hit_pct=None, profile=None, profile_sum=None,
@@ -361,6 +365,20 @@ def parse_run(stdout: str, stderr: str = "") -> dict:
             ("h2d_ms", "kernel_ms", "d2h_ms"),
             (float(m.group(1)), float(m.group(2)), float(m.group(3)))))
     out["cuda"] = cuda
+
+    vk = dict(enabled=False, expert_count=None, expert_gb=None,
+              resident_tensors=None, resident_gb=None)
+    if VK_DEVICE_RE.search(blob):
+        vk["enabled"] = True
+    m = VK_TIER_RE.search(blob)
+    if m:
+        vk["expert_count"] = int(m.group(1))
+        vk["expert_gb"] = float(m.group(2))
+    m = VK_DENSE_RE.search(blob)
+    if m:
+        vk["resident_tensors"] = int(m.group(1))
+        vk["resident_gb"] = float(m.group(2))
+    out["vk"] = vk
 
     m = TF_MATCH_RE.search(stdout)
     if m:

--- a/plan-vulkan-stats.md
+++ b/plan-vulkan-stats.md
@@ -1,0 +1,133 @@
+ Diagnosis: Why VRAM is misreported under Vulkan                                                                                       
+                                                                                                                                       
+ The VRAM telemetry pipeline has two layers — the C engine emits HWINFO/TIERS lines, the Python server parses them into hwinfo/tiers   
+ JSON, and the web client renders that JSON. Every layer is wired exclusively to the CUDA backend's data sources; the Vulkan backend   
+ tracks the same information in separate globals that nothing reads.                                                                   
+                                                                                                                                       
+ Concretely, in c/telemetry.h:                                                                                                         
+                                                                                                                                       
+ - hwinfo_emit() reads g_cuda_ndev, coli_cuda_mem_info(), and m->gpu_expert_bytes — all under #ifdef COLI_CUDA. Under COLI_VULKAN,     
+   ngpu stays 0, vram_total stays 0, and gpu_name stays "".                                                                            
+ - tiers_emit() sets vram/vram_gb from m->gpu_expert_count/m->gpu_expert_bytes, again only under #ifdef COLI_CUDA. But the Vulkan tier 
+   never writes those fields — it tracks residency in g_vk_reg_n / g_vk_reg_n2 and a local bytes accumulator inside vk_registry_fill() 
+    (colibri.c:7604-7665), with no propagation to m->gpu_expert_*.                                                                     
+ - emap_emit() marks a slot as VRAM-tier (tier=2) only when P[z].g.cuda is set — a CUDA-only struct field.                             
+                                                                                                                                       
+ Downstream consumers inherit the blank:                                                                                               
+                                                                                                                                       
+ - c/openai_server.py faithfully parses whatever HWINFO/TIERS the engine emits, so it ships zeros to the web client.                   
+ - web/src/App.tsx then shows "0× GPU / 0 GB VRAM" and an all-RAM tier bar even when the Vulkan tier is live with hundreds of resident 
+   experts.                                                                                                                            
+ - c/tools/diag_harness.py and c/tools/efficiency.py parse only [CUDA] … GB VRAM and CUDA expert tier: … log lines — the Vulkan [VK] … 
+    lines are invisible to them.                                                                                                       
+                                                                                                                                       
+ The Vulkan backend already has the needed primitives: coli_vk_mem_budget() / coli_vk_mem_budget2() report device-local heap           
+ usage/budget via VK_EXT_memory_budget, coli_vk_tensor_bytes() reports per-tensor VRAM, and G.dev/G2.dev know their physical-device    
+ properties. The work is purely plumbing.                                                                                              
+                                                                                                                                       
+ ────────────────────────────────────────────────────────────────────────────────                                                      
+                                                                                                                                       
+ Plan, ranked easiest → hardest                                                                                                        
+                                                                                                                                       
+ Each item is self-contained and can land independently; later items benefit from earlier ones but don't strictly require them.        
+                                                                                                                                       
+ ### 1. (Easiest) Engine: emit m->gpu_expert_* from the Vulkan tier                                                                    
+                                                                                                                                       
+ File: c/colibri.c, inside vk_registry_fill() (around line 7604-7685).                                                                 
+                                                                                                                                       
+ What: After each successful coli_vk_tensor_ensure for a dev0 expert, increment m->gpu_expert_count and add coli_vk_tensor_bytes() of  
+ the three tensors to m->gpu_expert_bytes; do the same for dev2 into the same fields (or a paired gpu_expert_count2/bytes2 if you want 
+ per-device fidelity — but merging is simpler and sufficient for tiers). On coli_vk_tensor_free/slot reuse (line 2151-2154),           
+ decrement. On full tier teardown, zero them.                                                                                          
+                                                                                                                                       
+ Why easiest: It's a local edit in one function plus its mirror in the free path. m->gpu_expert_* already exists, is backend-neutral   
+ storage, and is already read by tiers_emit(). Once written, TIERS vram/vram_gb starts working under Vulkan with zero telemetry-h      
+ changes (the #ifdef COLI_CUDA guard in tiers_emit must be relaxed to #if defined(COLI_CUDA) || defined(COLI_VULKAN) — one-line        
+ change).                                                                                                                              
+                                                                                                                                       
+ Risk: The dev2 case double-counts if you're not careful; decide whether gpu_expert_* is "dev0" or "all devices" and document it.      
+ Recommend: all devices (matches how g_cuda_ndev multiplies).                                                                          
+                                                                                                                                       
+ ────────────────────────────────────────────────────────────────────────────────                                                      
+                                                                                                                                       
+ ### 2. (Easy) telemetry.h: make hwinfo_emit Vulkan-aware                                                                              
+                                                                                                                                       
+ File: c/telemetry.h, hwinfo_emit() (lines 96-110).                                                                                    
+                                                                                                                                       
+ What: Add a #ifdef COLI_VULKAN branch mirroring the CUDA one: set ngpu to the count of Vulkan devices brought up (g_vk_dev_count,     
+ currently inferred from coli_vk_available() + coli_vk_dev2_available() — add a small counter if needed), set vram_total via           
+ coli_vk_mem_budget() (budget field), and set gpu_name to e.g. "Vulkan device xN" or the p.deviceName from the [VK] ready line (cache  
+ it in a static). Relax the guard to #if defined(COLI_CUDA) || defined(COLI_VULKAN).                                                   
+                                                                                                                                       
+ Why easy: coli_vk_mem_budget() already returns total device-local budget in GB; hw_probe already handles the CPU/RAM half. Just add   
+ the parallel branch.                                                                                                                  
+                                                                                                                                       
+ Risk: VK_EXT_memory_budget may be absent on some drivers — coli_vk_mem_budget() returns 0 and vram_total falls back to 0. That's      
+ acceptable and honest (it's "budget unavailable"), but consider a fallback to the heap size from vkGetPhysicalDeviceMemoryProperties  
+ (non-EXT, always available) for the total field, reserving the budget/used split for the dynamic TIERS line.                          
+                                                                                                                                       
+ ────────────────────────────────────────────────────────────────────────────────                                                      
+                                                                                                                                       
+ ### 3. (Easy) telemetry.h: make emap_emit mark Vulkan-resident slots                                                                  
+                                                                                                                                       
+ File: c/telemetry.h, emap_emit() (lines 139-160).                                                                                     
+                                                                                                                                       
+ What: The tier = P[z].g.cuda ? 2 : 1 decision is CUDA-only. The Vulkan residency is tracked via vk_reg_at(layer,eid) / vk_reg_has()   
+ (colibri.c:454-460). Expose a tiny coli_vk_reg_has(layer,eid) (or reuse the existing vk_reg_has via a declaration) and, in emap_emit, 
+ set tier=2 when either the CUDA flag or the Vulkan registry reports residency. Relax the #ifdef COLI_CUDA to include COLI_VULKAN.     
+                                                                                                                                       
+ Why easy: One new predicate call per slot; the registry lookup already exists.                                                        
+                                                                                                                                       
+ Risk: vk_reg_at/vk_reg_has are static in colibri.c — either make them non-static and declare them in backend_vulkan.h (or a small     
+ vulkan_telemetry.h), or add a public coli_vk_reg_has() wrapper. Prefer the wrapper to keep the registry's storage private.            
+                                                                                                                                       
+ ────────────────────────────────────────────────────────────────────────────────                                                      
+                                                                                                                                       
+ ### 4. (Medium) openai_server.py: no code change needed, but verify field stability                                                   
+                                                                                                                                       
+ File: c/openai_server.py (lines 1473-1501).                                                                                           
+                                                                                                                                       
+ What: The parser already reads vram_total_gb, vram, vram_gb generically — no change required once items 1-2 land. The only action is  
+ a regression check: confirm the engine still emits HWINFO/TIERS with the same field count under COLI_VULKAN=1 builds, and that        
+ vram_total_gb is no longer 0 when a Vulkan device is present.                                                                         
+                                                                                                                                       
+ Why medium and not "nothing": It's a verification/test task, not an edit — but if field semantics shift (e.g., you add vram_used_gb   
+ or a backend tag), the parser and the TS types in web/src/lib/api.ts (lines 27-39) must be updated in lockstep. Decide the schema up  
+ front in item 2.                                                                                                                      
+                                                                                                                                       
+ ────────────────────────────────────────────────────────────────────────────────                                                      
+                                                                                                                                       
+ ### 5. (Medium) Web client: distinguish the backend and label it                                                                      
+                                                                                                                                       
+ Files: web/src/lib/api.ts (types), web/src/App.tsx (line 262), web/src/i18n/*.ts.                                                     
+                                                                                                                                       
+ What: Today hwinfo.gpu is a free-form string and the GPU row says N× GPU / N GB VRAM. Add an optional hwinfo.backend?: "cuda" |       
+ "vulkan" | "cpu" field (sourced from a new HWINFO field — see item 2) and surface it in the UI, e.g. Vulkan GPU / CUDA GPU, so a user 
+ running Vulkan isn't told their VRAM is fine while seeing "0× GPU" (which is the current bug's user-facing symptom). Add i18n keys    
+ (hwinfo.backendVulkan, etc.) in all four locale files.                                                                                
+                                                                                                                                       
+ Why medium: Pure additive TS + UI work, no engine coordination, but touches four locale files and the type contract. Independent of   
+ items 1-3 at the code level, but only useful once they land.                                                                          
+                                                                                                                                       
+ Risk: Breaking the HealthResponse shape for older engine builds — make every new field optional with ?.                               
+                                                                                                                                       
+ ────────────────────────────────────────────────────────────────────────────────                                                      
+                                                                                                                                       
+ ### 6. (Medium) Diagnostic tools: parse [VK] log lines                                                                                
+                                                                                                                                       
+ Files: c/tools/diag_harness.py (lines 109-160, 351, 590), c/tools/efficiency.py (lines 74-90).                                        
+                                                                                                                                       
+ What: Add regexes mirroring the CUDA ones for the Vulkan lines that already exist in stderr:                                          
+ - [VK] ready: <name>, … — device name (backend_vulkan.c:443)                                                                          
+ - [VK] expert tier: <N> hot experts resident (<GB> GB VRAM … (colibri.c:7662)                                                         
+ - [VK] dev2 ready: <name> … (colibri.c:1031)                                                                                          
+ - [VK] dense preloaded: <N> tensors, <GB> GB VRAM … (colibri.c:7600)                                                                  
+                                                                                                                                       
+ Then efficiency.py's "GPU tier needs gpu_expert_count>0" gate (line 207) should accept the Vulkan resident count too, and             
+ diag_harness.py's GPU summary section should print a Vulkan tier: row alongside the CUDA one.                                         
+                                                                                                                                       
+ Why medium: Mechanical regex+display work, but two files with distinct output formats and the efficiency report has a gating          
+ predicate that must be generalized. No engine changes — the log lines already exist.                                                  
+                                                                                                                                       
+ Risk: The [VK] lines were written for humans, not machines; if field formats drift you'll need to update regexes. Consider adding a   
+ machine-stable VKSTAT <N> <GB> stdout line in a follow-up (see item 8).

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -259,7 +259,7 @@ export default function App() {
           <div className="section-title"><Activity className="size-3.5" /> {t("sidebar.runtime")}</div>
           {health?.hwinfo ? <div className="hw-panel">
             {health.hwinfo.cpu ? <div className="hw-row"><Cpu className="size-3.5" /><span>{health.hwinfo.cpu}</span></div> : null}
-            {health.hwinfo.gpus > 0 ? <div className="hw-row"><MonitorDot className="size-3.5" /><span>{health.hwinfo.gpus}× GPU<small>{health.hwinfo.vram_total_gb.toFixed(0)} GB VRAM</small></span></div> : null}
+            {health.hwinfo.gpus > 0 || health.hwinfo.backend === "vulkan" ? <div className="hw-row"><MonitorDot className="size-3.5" /><span>{Math.max(1, health.hwinfo.gpus)}× {health.hwinfo.backend === "vulkan" ? t("hwinfo.backendVulkan") : health.hwinfo.backend === "cuda" ? t("hwinfo.backendCuda") : "GPU"}<small>{health.hwinfo.vram_total_gb.toFixed(0)} GB VRAM</small></span></div> : null}
             <div className="hw-row"><MemoryStick className="size-3.5" /><span>{health.hwinfo.ram_total_gb.toFixed(0)} GB RAM<small>{health.hwinfo.ram_avail_gb.toFixed(0)} GB free</small></span></div>
             <div className="hw-row"><HardDrive className="size-3.5" /><span>{health.hwinfo.cores} cores</span></div>
           </div> : null}

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -32,6 +32,10 @@ const en: Record<string, string> = {
   "dashboard.prompt": "prompt",
   "dashboard.completion": "completion",
 
+  "hwinfo.backendVulkan": "Vulkan GPU",
+  "hwinfo.backendCuda": "CUDA GPU",
+  "hwinfo.backendCpu": "CPU",
+
   // sidebar — tiers
   "tier.vram": "VRAM",
   "tier.ram": "RAM",

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -28,6 +28,10 @@ const it: Record<string, string> = {
   "dashboard.prompt": "prompt",
   "dashboard.completion": "completion",
 
+  "hwinfo.backendVulkan": "GPU Vulkan",
+  "hwinfo.backendCuda": "GPU CUDA",
+  "hwinfo.backendCpu": "CPU",
+
   "tier.vram": "VRAM",
   "tier.ram": "RAM",
   "tier.disk": "Disco",

--- a/web/src/i18n/zh-CN.ts
+++ b/web/src/i18n/zh-CN.ts
@@ -28,6 +28,10 @@ const zhCN: Record<string, string> = {
   "dashboard.prompt": "提示词",
   "dashboard.completion": "补全",
 
+  "hwinfo.backendVulkan": "Vulkan GPU",
+  "hwinfo.backendCuda": "CUDA GPU",
+  "hwinfo.backendCpu": "CPU",
+
   "tier.vram": "VRAM",
   "tier.ram": "RAM",
   "tier.disk": "磁盘",

--- a/web/src/i18n/zh-TW.ts
+++ b/web/src/i18n/zh-TW.ts
@@ -28,6 +28,10 @@ const zhTW: Record<string, string> = {
   "dashboard.prompt": "提示詞",
   "dashboard.completion": "補全",
 
+  "hwinfo.backendVulkan": "Vulkan GPU",
+  "hwinfo.backendCuda": "CUDA GPU",
+  "hwinfo.backendCpu": "CPU",
+
   "tier.vram": "VRAM",
   "tier.ram": "RAM",
   "tier.disk": "磁碟",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -39,6 +39,7 @@ export interface HwinfoHealth {
   vram_total_gb: number
   cpu: string
   gpu: string
+  backend?: "cuda" | "vulkan" | "cpu"
 }
 
 export interface HealthResponse {


### PR DESCRIPTION
## Summary

This is a placeholder PR for implementing the same statistic features that exists for cuda, but for vulkan. More specificaly the vmem and the expert recidents when runing the web ui.

## Validation

- [ ] `make -C c check`
- [ ] CUDA changes were tested with `make -C c cuda-test` (if applicable)
- [ ] Performance claims include hardware, commands, and repeatable measurements

## Compatibility

- [ ] The default CPU build remains dependency-free
- [ ] No model files, generated binaries, or benchmark artifacts are included
