### PR TITLE
fix(omp): size GLM threads from physical cores

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -392,7 +392,7 @@ $(file >.build-config,$(BUILD_CONFIG))
 endif
 .build-config: ;
 
-colibri$(EXE): colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h quant.h sample.h kv_persist.h telemetry.h route_trace.h $(CUDA_OBJ) $(METAL_OBJ) $(VK_OBJ) $(VK_SPV) .build-config
+colibri$(EXE): colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h quant.h sample.h kv_persist.h telemetry.h route_trace.h omp_tune.h $(CUDA_OBJ) $(METAL_OBJ) $(VK_OBJ) $(VK_SPV) .build-config
 	$(CC) $(CFLAGS) colibri.c $(CUDA_OBJ) $(METAL_OBJ) $(VK_OBJ) -o colibri$(EXE) $(LDFLAGS)
 
 # Vulkan backend object (plain C + vulkan headers) and its SPIR-V shaders.
@@ -670,6 +670,9 @@ tests/test_pipe_block$(EXE): tests/test_pipe_block.c colibri.c st.h uring.h json
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_pilot_ring$(EXE): tests/test_pilot_ring.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+tests/test_omp_tune$(EXE): tests/test_omp_tune.c omp_tune.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 test-c: $(TEST_BINS)

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -69,6 +69,7 @@
 static inline int omp_get_max_threads(void){ return 1; }
 static inline int omp_get_thread_num(void){ return 0; }
 #endif
+#include "omp_tune.h"
 #ifdef COLI_CUDA
 #include "backend_cuda.h"
 #endif
@@ -8859,6 +8860,13 @@ int main(int argc, char **argv){
         perror("[OMP] execv self-reexec failed, running untuned");
 #endif
     }
+    /* #718: the hot-team block above tunes wake latency but historically left
+     * GLM at libgomp's logical-CPU default.  Memory-bound quantized matmuls can
+     * collapse when SMT siblings share each core, measured 2.3x on a 5950X.
+     * The shared helper already protects kimi_k3/olmoe: apply its independent
+     * physical-core sizing here too.  This must stay after the possible re-exec;
+     * omp_set_num_threads() is a runtime API and needs no second exec. */
+    coli_omp_tune_threads("colibri");
 #ifdef _WIN32
     _setmode(fileno(stdout), O_BINARY);
 #endif

--- a/c/omp_tune.h
+++ b/c/omp_tune.h
@@ -22,6 +22,9 @@
  * Kimi e' il motore piu' disk-bound del progetto (misurato: 6.7% di hit,
  * 891 GB letti per 32 token), cioe' esattamente il regime in cui la seconda
  * meta' fa danno. Aggiungergliela sarebbe stato un peggioramento misurabile.
+ * GLM now calls this same helper after its optional hot-team re-exec, so it
+ * receives the physical-core sizing without changing the independent spin-wait
+ * policy that its existing block controls.
  *
  * PERCHE' QUI NON SERVE IL RE-EXEC.
  * colibri.c si ri-esegue perche' OMP_WAIT_POLICY & co. le legge il COSTRUTTORE
@@ -38,6 +41,7 @@
 #define COLI_OMP_TUNE_H
 
 #include <stdio.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -50,6 +54,33 @@
 #endif
 
 /* Numero di core FISICI, o 0 se non determinabile. Mai un valore inventato. */
+#if defined(_WIN32)
+static int coli_count_windows_physical_cores(const void *buf, DWORD bytes)
+{
+    const char *p = (const char *)buf;
+    const char *end = p + bytes;
+    const size_t header_size = offsetof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
+                                        Processor);
+    int cores = 0;
+
+    while ((size_t)(end - p) >= header_size) {
+        LOGICAL_PROCESSOR_RELATIONSHIP relationship;
+        DWORD record_size;
+        memcpy(&relationship,
+               p + offsetof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, Relationship),
+               sizeof(relationship));
+        memcpy(&record_size,
+               p + offsetof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, Size),
+               sizeof(record_size));
+        if (record_size < header_size || (size_t)(end - p) < record_size)
+            break; /* Reject a zero, truncated, or otherwise malformed record. */
+        if (relationship == RelationProcessorCore) cores++;
+        p += record_size;
+    }
+    return cores;
+}
+#endif
+
 static int coli_physical_cores(void)
 {
 #if defined(_WIN32)
@@ -58,17 +89,9 @@ static int coli_physical_cores(void)
     if (!need) return 0;
     void *buf = malloc(need);
     if (!buf) return 0;
-    int cores = 0;
-    if (GetLogicalProcessorInformationEx(RelationProcessorCore, buf, &need)) {
-        char *p = (char *)buf, *end = p + need;
-        while (p + sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX) <= end) {
-            SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *e =
-                (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *)p;
-            if (!e->Size) break;                 /* mai avanzare di 0: loop infinito */
-            if (e->Relationship == RelationProcessorCore) cores++;
-            p += e->Size;
-        }
-    }
+    int cores = GetLogicalProcessorInformationEx(RelationProcessorCore, buf, &need)
+                    ? coli_count_windows_physical_cores(buf, need)
+                    : 0;
     free(buf);
     return cores;
 
@@ -95,7 +118,10 @@ static int coli_physical_cores(void)
     while ((e = readdir(d)) && n < 1024) {
         if (strncmp(e->d_name, "cpu", 3) != 0 || e->d_name[3] < '0' || e->d_name[3] > '9')
             continue;
-        char path[256], line[64];
+        /* d_name can be up to 255 bytes; leave enough room for the fixed
+         * sysfs prefix/suffix so -Wformat-truncation stays honest when this
+         * shared helper is compiled into the GLM engine too. */
+        char path[512], line[64];
         snprintf(path, sizeof(path),
                  "/sys/devices/system/cpu/%s/topology/thread_siblings_list", e->d_name);
         FILE *f = fopen(path, "r");
@@ -129,9 +155,9 @@ static void coli_omp_tune_threads(const char *engine)
     if (phys >= logical) return;           /* niente SMT da evitare: silenzio */
 
     omp_set_num_threads(phys);
-    fprintf(stderr, "[OMP] %s: %d thread (core fisici) invece di %d logici — "
-                    "l'SMT dimezza il decode su alcune CPU (#718); "
-                    "OMP_NUM_THREADS=<n> per decidere tu\n",
+    fprintf(stderr, "[OMP] %s: %d physical-core threads instead of %d logical CPUs; "
+                    "SMT can halve decode throughput on some CPUs (#718); "
+                    "set OMP_NUM_THREADS=<n> to override\n",
             engine, phys, logical);
 #else
     (void)engine;

--- a/c/tests/test_omp_tune.c
+++ b/c/tests/test_omp_tune.c
@@ -1,0 +1,112 @@
+/* Physical-core OpenMP sizing (#718).
+ *
+ * The helper is shared by the GLM, Kimi K3, and OLMoE engines.  Exercise its
+ * runtime contract directly: cap an SMT host to physical cores when topology is
+ * available, preserve an explicit OMP_NUM_THREADS override, and honor the
+ * existing COLI_NO_OMP_TUNE kill switch.  Hosts without SMT still validate the
+ * two override paths and correctly leave the OpenMP default unchanged. */
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+#include "../omp_tune.h"
+
+#ifdef _WIN32
+static int test_windows_variable_records(void)
+{
+    const size_t record_size =
+        offsetof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, Processor) +
+        offsetof(PROCESSOR_RELATIONSHIP, GroupMask) + sizeof(GROUP_AFFINITY);
+    unsigned char records[2 * record_size];
+    memset(records, 0, sizeof(records));
+
+    for (int i = 0; i < 2; i++) {
+        unsigned char *record = records + i * record_size;
+        LOGICAL_PROCESSOR_RELATIONSHIP relationship = RelationProcessorCore;
+        DWORD size = (DWORD)record_size;
+        memcpy(record + offsetof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, Relationship),
+               &relationship, sizeof(relationship));
+        memcpy(record + offsetof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX, Size),
+               &size, sizeof(size));
+    }
+    if (coli_count_windows_physical_cores(records, sizeof(records)) != 2) {
+        fprintf(stderr, "Windows variable-sized topology records lost a core\n");
+        return 1;
+    }
+    return 0;
+}
+#endif
+
+static void env_set(const char *name, const char *value)
+{
+#ifdef _WIN32
+    _putenv_s(name, value);
+#else
+    setenv(name, value, 1);
+#endif
+}
+
+static void env_unset(const char *name)
+{
+#ifdef _WIN32
+    _putenv_s(name, "");
+#else
+    unsetenv(name);
+#endif
+}
+
+int main(void)
+{
+#ifndef _OPENMP
+    puts("test_omp_tune: ok (OpenMP unavailable; helper is a no-op)");
+    return 0;
+#else
+    int fail = 0;
+    int logical = omp_get_num_procs();
+    int physical = coli_physical_cores();
+
+#ifdef _WIN32
+    fail |= test_windows_variable_records();
+#endif
+
+    env_unset("OMP_NUM_THREADS");
+    env_unset("COLI_NO_OMP_TUNE");
+    omp_set_num_threads(logical);
+    coli_omp_tune_threads("test");
+    int got = omp_get_max_threads();
+    int want = physical > 0 && physical < logical ? physical : logical;
+    if (got != want) {
+        fprintf(stderr, "default sizing: got %d threads, want %d (physical=%d logical=%d)\n",
+                got, want, physical, logical);
+        fail = 1;
+    }
+
+    int sentinel = logical > 1 ? logical - 1 : 1;
+    omp_set_num_threads(sentinel);
+    env_set("OMP_NUM_THREADS", "7");
+    coli_omp_tune_threads("test");
+    if (omp_get_max_threads() != sentinel) {
+        fprintf(stderr, "explicit OMP_NUM_THREADS override was not preserved\n");
+        fail = 1;
+    }
+    env_unset("OMP_NUM_THREADS");
+
+    omp_set_num_threads(sentinel);
+    env_set("COLI_NO_OMP_TUNE", "1");
+    coli_omp_tune_threads("test");
+    if (omp_get_max_threads() != sentinel) {
+        fprintf(stderr, "COLI_NO_OMP_TUNE kill switch was not preserved\n");
+        fail = 1;
+    }
+    env_unset("COLI_NO_OMP_TUNE");
+
+    if (fail) {
+        puts("test_omp_tune: FAIL");
+        return 1;
+    }
+    printf("test_omp_tune: ok (physical=%d logical=%d)\n", physical, logical);
+    return 0;
+#endif
+}

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -38,7 +38,9 @@ overrides print a warning and proceed.
 
 Auto-tier plans size OpenMP from physical cores and bind workers across cores.
 Memory-bound quantized kernels can regress sharply when SMT siblings compete for
-limited memory channels; explicit `OMP_*` settings always take precedence.
+limited memory channels. The GLM, Kimi K3, and OLMoE engines also apply that
+physical-core cap when launched directly; explicit `OMP_NUM_THREADS` and the
+`COLI_NO_OMP_TUNE` kill switch always take precedence.
 
 > Note (#471): exporting `OMP_PROC_BIND`/`OMP_PLACES` used to interact badly with
 > the engine's one-time OpenMP tuning re-exec on Linux — the re-exec'd image


### PR DESCRIPTION
## Summary

- apply the shared physical-core OpenMP sizing to GLM after its optional hot-team re-exec
- preserve explicit `OMP_NUM_THREADS` and `COLI_NO_OMP_TUNE` overrides
- correctly parse variable-sized Windows processor-topology records
- add a cross-platform runtime regression test and document direct-engine behavior
- widen the Linux sysfs path buffer so the GLM build remains warning-clean

## Why

Finding 1 in #718 measured GLM decode at 0.21 tok/s with 32 SMT threads versus 0.49 tok/s with 16 physical-core threads on a Ryzen 9 5950X. Kimi K3 and OLMoE already use the shared `omp_tune.h` helper, but GLM's separate hot-team tuning still left its worker count at the logical-CPU default.

While validating the change on Windows, `GetLogicalProcessorInformationEx` reported 12 physical cores but the helper counted 11. Its result records are variable-sized; requiring `sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX)` bytes at every iteration skipped the final shorter record. This patch advances by each validated `Size` value and rejects malformed or truncated records.

## Behavior

The automatic cap is silent when it cannot help. An explicit `OMP_NUM_THREADS` setting remains authoritative, and `COLI_NO_OMP_TUNE` remains the kill switch. Hosts without SMT retain the OpenMP default.

## Validation

- `make -C c check`
  - all C test gates passed
  - 275 Python tests passed, 15 skipped
- Linux runtime test: 6 physical cores detected from 12 logical CPUs
- Windows 11 / Ryzen 9 7845HX:
  - full `make colibri.exe ARCH=native` build completed without warnings
  - runtime test detected 12 physical cores from 24 logical CPUs
  - synthetic variable-sized topology-record regression passed
- explicit `OMP_NUM_THREADS` and `COLI_NO_OMP_TUNE` paths passed

No new model-throughput result is claimed by this PR; the performance measurement above is the reporter's result from #718.

Addresses finding 1 in #718.
