### PR TITLE
fix(plan): size the expert slot by the widest width the container holds

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -8314,10 +8314,13 @@ static void cap_for_ram(Model *m, double ram_gb, int ebits, int max_ctx){
      * non entra nemmeno nella RAM realmente disponibile misurata all'avvio. */
     if(floored){
         double peak = (double)m->resident_bytes + (double)capmax*nsp*eb + slack;
+        /* eb is printed because it is the one term nobody can check from outside:
+         * every projection here divides by it, so a wrong width is indistinguishable
+         * from a wrong budget in this message (#766). */
         fprintf(stderr,"[RAM_GB=%.1f%s] WARNING: cap=1 is the floor, projected peak %.1f GB is "
-            "%.1f GB OVER the budget (resident %.1f GB + reserve %.1f GB).%s\n",
+            "%.1f GB OVER the budget (resident %.1f GB + reserve %.1f GB, expert %.1f MB).%s\n",
             ram_gb,auto_b?" auto":"",peak/1e9,(peak-ram_gb*1e9)/1e9,
-            m->resident_bytes/1e9,slack/1e9,
+            m->resident_bytes/1e9,slack/1e9,(double)eb/1e6,
             getenv("PIN_GB")?" PIN_GB is inflating the resident set: lower it or drop it.":"");
 #ifdef COLI_CUDA
         /* #686: on a single GPU that also holds host copies of the VRAM tier, the

--- a/c/telemetry.h
+++ b/c/telemetry.h
@@ -10,18 +10,44 @@ static int64_t tbytes(int O,int I,int bits){
     return (int64_t)O*((I+1)/2) + (int64_t)O*4;
 }
 
-static int64_t expert_bytes_probe(Model *m, int ebits){
-    Cfg *c=&m->c; int64_t eb=0; char nm[256];
-    snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.0.gate_proj.weight",c->first_dense);
-    if(st_nbytes(&m->S,nm)>0){
-        const char *suf[3]={"gate_proj","up_proj","down_proj"};
-        for(int k=0;k<3;k++){
-            snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.0.%s.weight",c->first_dense,suf[k]);
-            eb+=st_nbytes(&m->S,nm);
-            snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.0.%s.weight.qs",c->first_dense,suf[k]);
-            int64_t q=st_nbytes(&m->S,nm); if(q>0) eb+=q;
-        }
+/* Container bytes of expert 0 of one layer (weights + .qs scales); 0 if absent. */
+static int64_t expert_bytes_layer(Model *m, int layer){
+    int64_t eb=0; char nm[256];
+    const char *suf[3]={"gate_proj","up_proj","down_proj"};
+    snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.0.gate_proj.weight",layer);
+    if(st_nbytes(&m->S,nm)<=0) return 0;
+    for(int k=0;k<3;k++){
+        snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.0.%s.weight",layer,suf[k]);
+        eb+=st_nbytes(&m->S,nm);
+        snprintf(nm,sizeof(nm),"model.layers.%d.mlp.experts.0.%s.weight.qs",layer,suf[k]);
+        int64_t q=st_nbytes(&m->S,nm); if(q>0) eb+=q;
     }
+    return eb;
+}
+
+/* MAX over the widths the container actually holds, not the first MoE layer.
+ * ws[] slots and the per-layer LRU slabs are reused ACROSS layers, and slab_cap
+ * grows to the largest expert a slot has ever held and is never shrunk (see the
+ * ESlot comment). So on a container that MIXES widths -- int4 routed layers with
+ * an int8 MTP head, which is how GLM-5.2 ships -- every slot ends up costing the
+ * widest one, while probing only c->first_dense reports the narrowest.
+ *
+ * cap_for_ram() divides by this, so the error goes straight into the cap. #766,
+ * measured on 4x A6000 / 251 GiB:
+ *
+ *     layer 3  (int4 routed) 21.23 MB   <- what this used to return
+ *     layer 78 (int8 MTP)    37.79 MB   <- what a slot actually costs
+ *
+ *   --auto-tier -> cap 113 -> 257 GB RSS -> OOM-kill
+ *   113 * 21.23/37.79 = 63.5, and cap 64 is the measured point that survives at
+ *   118 GB. The projection's shape was right; only this constant was wrong.
+ *
+ * nsp += 2 in cap_for_ram() already nods at the MTP row costing double, but that
+ * corrects one row out of nsp; the slabs grow on all of them. */
+static int64_t expert_bytes_probe(Model *m, int ebits){
+    Cfg *c=&m->c;
+    int64_t eb=expert_bytes_layer(m,c->first_dense);
+    if(m->has_mtp){ int64_t mtp=expert_bytes_layer(m,c->n_layers); if(mtp>eb) eb=mtp; }
     if(eb<=0) eb = tbytes(c->moe_inter,c->hidden,ebits)*2 + tbytes(c->hidden,c->moe_inter,ebits);
     return eb;
 }


### PR DESCRIPTION
Closes the diagnosis you asked for in #766 — *"even naming which term is missing would shorten this considerably"*. **No term is missing.** The shape of `cap_for_ram()` is right and one constant in it is wrong by 1.78×.

## The bug

`expert_bytes_probe()` probes expert 0 of `c->first_dense`, the first MoE layer, and returns that size. On a container that **mixes widths** it returns the narrowest one — while a slot actually costs the widest, because `ws[]` slots and the per-layer LRU slabs are reused **across layers** and `slab_cap` grows to the largest expert a slot has ever held and is never shrunk. The `ESlot` comment at `colibri.c:314` already says so:

> gli slot `ws[]` sono riusati **TRA layer** e gli expert **non hanno tutti la stessa taglia** (layer MTP int8 = 2x i layer int4)

`cap_for_ram()` divides by this value, so the error goes straight into the cap.

## Measured, two independent ways

**From the container**, reading the safetensors headers of `mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp`:

| layer | width | expert 0 |
|---|---|---|
| 3 | int4 routed | **21.23 MB** ← what the probe returned |
| 78 | int8 MTP | **37.79 MB** ← what a slot costs |

**From outside**, the two RSS points in #766 on 4× RTX A6000 / 251 GiB:

```
cap  64 -> 118 GB           cap 113 -> 257 GB -> OOM-kill
slope = 139 GB / (49 · 77) = 36.84 MB per slot per layer
```

36.84 against 37.79 is **2.5 %**. Against the 21.23 MB the probe returned it is **1.74×**.

And the corrected projection lands exactly where it should:

```
113 · 21.23/37.79 = 63.5
```

**`cap 64` is the measured point that survives at 118 GB.** Two independent derivations of the same constant, and the corrected formula reproduces the known-good configuration without any term being added.

## What this also settles

- **Nothing in `cap_for_ram()` is super-linear.** Every term is strictly linear in `max_ctx`, and the `slack` decomposition reproduces the 82.8 GB quoted in #768 exactly (`kv_pool_bytes` 47.7 + `kvb_b` 30.1 + `ws_b` 1.3 + page cache 2.5 + activations 1.2). Two points fit a straight line with the wrong slope, not a curve.
- **`nsp += 2` already nods at the MTP row costing double** — but that corrects one row out of `nsp`, while the slabs grow on all of them.

## The change

`expert_bytes_probe()` takes the **max** over the widths the container actually holds — the first MoE layer and, when `has_mtp`, the MTP layer — instead of the first alone. The probe body is factored into `expert_bytes_layer()`; the fallback when no container is present is untouched.

- **Single-width containers: byte-identical.** The max is taken over one value.
- **Mixed-width containers: the cap roughly halves.** That is the direction that keeps the process alive — over-reserving costs cache slots, under-reserving costs the run to `SIGKILL` with no log, which is the failure `cap_for_ram()` exists to prevent (#305).

Second, smaller change: the `cap=1` warning now prints `eb`. It is the one term a user cannot check from outside, so today a wrong width and a wrong budget produce an identical message.

```
[RAM_GB=215.0] WARNING: cap=1 is the floor, projected peak 216.7 GB is 1.7 GB OVER
the budget (resident 132.2 GB + reserve 82.8 GB, expert 37.8 MB).
```

## Testing, and its limits — please read

Builds clean (`make colibri`, clang, `-Wall -Wextra`, no new warnings) on current `dev` at `44d7958`.

**I have not run this on the 4× A6000 host yet.** It is mid-campaign on other measurements as I write, and I would rather send you the reasoning now than sit on it. The specific thing I owe you before this should merge is: `--auto-tier` on that host, confirming it now returns ~64 rather than 113 and that the run survives. I will post that number here.

Two honest caveats:

1. **One checkpoint, one mixed-width layout.** The fit is very good (2.5 % from the container, 1.74× vs 1.78× predicted from the two RSS points) but I have not tested a container whose MTP head is *narrower* than the routed layers, nor one with three widths. The `max` is the safe direction in all of those, but "safe" is not "measured".
2. **The mechanism is inferred from the `ESlot` comment plus the arithmetic**, not from instrumenting `slab_cap` directly. If slabs do *not* in fact grow the way that comment describes, the numbers still say the constant is wrong by 1.74× and this patch still fixes the cap — but my explanation of *why* would be wrong, and the comment I added should be corrected rather than kept.

Happy to hold this until I can post the `--auto-tier` run, if you would rather not have it in the queue in the meantime.
