### PR TITLE
docs: acknowledge inference research foundations

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,30 @@ releasing frontier-class weights in the open — **Z.ai** (GLM), **Moonshot AI**
 contributor who benchmarked, bisected, replicated an atlas run, or sent a patch.
 This project is proof of what open weights make possible.
 
+The project's expert placement, compression, and routing experiments also build
+on ideas and evidence from the following open research and systems work:
+
+- [REAP](https://github.com/CerebrasResearch/reap) and
+  [EASY-EP](https://github.com/RUCAIBox/EASYEP) for output-aware and
+  domain-specific expert importance.
+- [SERE](https://github.com/JL-Cheng/SERE) for similarity-based expert
+  re-routing, and [ReMoE](https://github.com/BUAA-OSCAR/ReMoE) for
+  cache-locality-aware router fine-tuning.
+- [MC-SMoE](https://github.com/UNITES-Lab/MC-SMoE) for routing-guided expert
+  merging and compression.
+- [MoBE](https://github.com/inclusionAI/MoBE) and
+  [D²-MoE](https://github.com/lliai/D2MoE) for shared expert bases and
+  low-rank expert deltas.
+- [HybriMoE](https://github.com/PKU-SEC-Lab/HybriMoE) for hybrid CPU/GPU expert
+  scheduling, [ScMoE](https://arxiv.org/abs/2404.05019) for overlapping expert
+  communication with computation, and
+  [OD-MoE](https://arxiv.org/abs/2512.03927) for distributed on-demand expert
+  loading.
+- [vLLM](https://github.com/vllm-project/vllm),
+  [llama.cpp](https://github.com/ggml-org/llama.cpp), and
+  [kTransformers](https://github.com/kvcache-ai/ktransformers) for the open
+  inference systems and expert-offload work that make comparisons reproducible.
+
 ## License
 
 Apache 2.0. GLM-5.2 weights are released by Z.ai under MIT.

--- a/README.md
+++ b/README.md
@@ -544,6 +544,28 @@ on ideas and evidence from the following open research and systems work:
   [kTransformers](https://github.com/kvcache-ai/ktransformers) for the open
   inference systems and expert-offload work that make comparisons reproducible.
 
+The engine also stands on concrete engineering work, not only ideas. Each of
+these is used or reimplemented in the tree today:
+
+- [safetensors](https://github.com/huggingface/safetensors) — the container
+  every engine reads (`c/st.h`), including its fp8 and I64 dtypes.
+- [tiktoken](https://github.com/openai/tiktoken) — `c/tok.h` reimplements its
+  `byte_pair_encode` exactly, merging the adjacent pair whose concatenation has
+  the lowest vocab id, so a tiktoken-derived vocabulary needs no merges list.
+- [llama.cpp](https://github.com/ggml-org/llama.cpp) — the GBNF grammar subset
+  in `c/grammar.h` follows its syntax and its set-of-stacks PDA, and the Metal
+  path borrows its `newBufferWithBytesNoCopy` residency trick.
+- [vLLM](https://github.com/vllm-project/vllm) — the reference for output
+  semantics the engine matches position by position (e.g. where the final norm
+  lands relative to the LM head).
+- [transformers](https://github.com/huggingface/transformers) — the oracle:
+  CI reproduces a random-init model token for token against it.
+- [DietGPU](https://github.com/facebookresearch/dietgpu) — the GPU ANS codec
+  behind the experimental compressed expert tier (`COLI_ANS`).
+- [rocWMMA](https://github.com/ROCm/rocWMMA) — the HIP backend maps CUDA's
+  `nvcuda::wmma` fragment/mma_sync API onto it (`c/backend_gpu_compat.h`), which
+  is what lets one .cu source compile for both vendors.
+
 ## License
 
 Apache 2.0. GLM-5.2 weights are released by Z.ai under MIT.


### PR DESCRIPTION
## Summary

Acknowledge the open research and inference-system projects that informed Colibri experiments in expert placement, routing, compression, heterogeneous scheduling, and expert offload.

This is intentionally separate from the experiment closeout PR so the README change remains small and independently reviewable.