### PR TITLE
Run the test suite under ASan+UBSan, and fix the clean that hid it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,30 @@ jobs:
         with:
           dockerfile: docker/Dockerfile
           failure-threshold: error
+  # The C suite under AddressSanitizer + UndefinedBehaviorSanitizer.
+  #
+  # Before this the only sanitized code in CI was nothing at all: fuzz-rans has
+  # always built with ASan+UBSan but was never wired to a job, and it covers
+  # rans.h alone. The engine's pointer arithmetic, mmap/pread paths and worker
+  # threads had never been run under a sanitizer here.
+  #
+  # Leak detection is off on purpose -- the engines allocate the tensor index,
+  # parsed config and weight slabs once and use them until exit (st.h calls this
+  # out: "intentionally leaked ... one-time startup parsing"). Reporting those
+  # would bury the findings that matter under noise nobody intends to fix. The
+  # flags live in c/Makefile's test-asan target, not here, so the same command
+  # reproduces it locally.
+  sanitizers:
+    name: Sanitizers (ASan + UBSan)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: C suite under ASan + UBSan
+        run: make -C c test-asan
+      - name: rANS fuzz round-trip (ASan + UBSan)
+        # Already sanitized and already asserting byte identity across every
+        # compiled decode arm; it just had no job to run in.
+        run: make -C c fuzz-rans
 
   engines-all-platforms:
     name: All engines (${{ matrix.name }})

--- a/c/Makefile
+++ b/c/Makefile
@@ -17,6 +17,14 @@ DARWIN := $(findstring darwin,$(TRIPLET))
 LINUX  := $(findstring linux,$(TRIPLET))
 IS_WIN := $(MINGW)$(CYGWIN)
 
+# Appended to every platform's flags, so a caller can add to the build without
+# replacing it. Overriding CFLAGS= on the command line would drop that
+# platform's OpenMP and -march flags, which is how a sanitizer run ends up
+# silently unsanitized. Used by test-asan; also the supported way to pass
+# your own flag: make colibri EXTRA_CFLAGS=-DFOO
+EXTRA_CFLAGS  ?=
+EXTRA_LDFLAGS ?=
+
 # Fallbacks for the rare toolchain that does not answer -dumpmachine: keep the
 # #129 signal (OS=Windows_NT, set in every Windows shell) for Windows, then
 # `uname` for everything else, so no host regresses.
@@ -54,7 +62,7 @@ $(warning libomp not found: building single-threaded. For multithreading: brew i
 OMPC    =
 OMPL    =
 endif
-CFLAGS  = -O3 $(OMPC) -Wall -Wextra -Wno-unused-parameter -Wno-misleading-indentation -Wno-unused-function
+CFLAGS  = -O3 $(OMPC) -Wall -Wextra -Wno-unused-parameter -Wno-misleading-indentation -Wno-unused-function $(EXTRA_CFLAGS)
 # Opt-in: ARCH=native appends -mcpu=native (arm64 clang uses -mcpu, not -march),
 # which unlocks the i8mm SMMLA int8/int4 dot kernels in colibri.c. ARCH unset ->
 # no -mcpu, default build byte-identical. Apple clang knows apple-m4 / native.
@@ -66,7 +74,7 @@ else
 CFLAGS += -mcpu=$(ARCH)
 endif
 endif
-LDFLAGS = -lm $(OMPL)
+LDFLAGS = -lm $(OMPL) $(EXTRA_LDFLAGS)
 EXE     =
 else ifneq ($(IS_WIN),)
 # --- Windows 11 x86-64 (MinGW-w64 / MSYS2) ---
@@ -79,12 +87,12 @@ else ifneq ($(IS_WIN),)
 # a v3 build simply compiles out the VNNI path - safe on any x86-64.
 CC      = gcc
 ARCH   ?= x86-64-v3
-CFLAGS  = -D_FILE_OFFSET_BITS=64 -O3 -march=$(ARCH) -fopenmp -Wall -Wextra -Wno-unused-parameter -Wno-misleading-indentation -Wno-unused-function
+CFLAGS  = -D_FILE_OFFSET_BITS=64 -O3 -march=$(ARCH) -fopenmp -Wall -Wextra -Wno-unused-parameter -Wno-misleading-indentation -Wno-unused-function $(EXTRA_CFLAGS)
 # -lpsapi: compat.h calls GetProcessMemoryInfo (rss_gb). It's linked via
 # #pragma comment(lib,"psapi.lib") for MSVC, but MinGW gcc ignores that pragma
 # (warns), so link psapi explicitly or the build fails undefined-reference on
 # modern GCC (e.g. 16.x under UCRT). Harmless where the pragma also resolves it.
-LDFLAGS = -lm -fopenmp -static -lpsapi
+LDFLAGS = -lm -fopenmp -static -lpsapi $(EXTRA_LDFLAGS)
 EXE     = .exe
 else
 ifneq (,$(PPC64))
@@ -94,8 +102,8 @@ ifneq (,$(PPC64))
 # (validated token-exact vs the transformers oracle on a POWER8 S824).
 CC      = gcc
 ARCH   ?= native
-CFLAGS  = -O3 -mcpu=$(ARCH) -fopenmp -pthread -Wall -Wextra -Wno-unused-parameter -Wno-misleading-indentation -Wno-unused-function
-LDFLAGS = -lm -fopenmp -pthread
+CFLAGS  = -O3 -mcpu=$(ARCH) -fopenmp -pthread -Wall -Wextra -Wno-unused-parameter -Wno-misleading-indentation -Wno-unused-function $(EXTRA_CFLAGS)
+LDFLAGS = -lm -fopenmp -pthread $(EXTRA_LDFLAGS)
 EXE     =
 else ifneq (,$(AARCH64))
 # --- Linux / *BSD aarch64 (#631) ---
@@ -128,8 +136,8 @@ ARCHFLAG := -march=$(ARCH)
 else
 ARCHFLAG := -mcpu=$(ARCH)
 endif
-CFLAGS  = -O3 $(ARCHFLAG) -fopenmp -pthread -Wall -Wextra -Wno-unused-parameter -Wno-misleading-indentation -Wno-unused-function
-LDFLAGS = -lm -fopenmp -pthread
+CFLAGS  = -O3 $(ARCHFLAG) -fopenmp -pthread -Wall -Wextra -Wno-unused-parameter -Wno-misleading-indentation -Wno-unused-function $(EXTRA_CFLAGS)
+LDFLAGS = -lm -fopenmp -pthread $(EXTRA_LDFLAGS)
 EXE     =
 else
 # --- Linux / *BSD x86-64 (percorso originale, invariato) ---
@@ -139,8 +147,8 @@ CC      = gcc
 # ARCH=x86-64 -> massima compatibilita' (niente AVX2: usa il path scalare di fallback).
 # -pthread: Linux lo tira dentro via -fopenmp, i *BSD no e le pthread_* non risolvono (#219).
 ARCH   ?= native
-CFLAGS  = -O3 -march=$(ARCH) -fopenmp -pthread -Wall -Wextra -Wno-unused-parameter -Wno-misleading-indentation -Wno-unused-function
-LDFLAGS = -lm -fopenmp -pthread
+CFLAGS  = -O3 -march=$(ARCH) -fopenmp -pthread -Wall -Wextra -Wno-unused-parameter -Wno-misleading-indentation -Wno-unused-function $(EXTRA_CFLAGS)
+LDFLAGS = -lm -fopenmp -pthread $(EXTRA_LDFLAGS)
 EXE     =
 endif
 endif
@@ -991,6 +999,33 @@ bench-omp-grain: tests/bench_omp_grain.c
 	$(CC) $(CFLAGS) $< -o tests/bench_omp_grain $(LDFLAGS)
 	./tests/bench_omp_grain
 
+# --- sanitizers ---------------------------------------------------------
+# The whole C test suite under AddressSanitizer + UndefinedBehaviorSanitizer.
+# Until this target the only sanitized code in the tree was fuzz-rans, which
+# covers rans.h alone -- the engine's 9k lines of pointer arithmetic, mmap/pread
+# and worker threads had never been run under ASan at all.
+#
+# detect_leaks is OFF, deliberately. The engines allocate their tensor index,
+# parsed config and weight slabs once and use them until exit; st.h says as much
+# ("intentionally leaked ... one-time startup parsing"). LeakSanitizer reports
+# every one of those, which would bury the reports that matter -- a
+# heap-buffer-overflow or a use-after-free -- under noise nobody intends to fix.
+# halt_on_error makes the first UB report fail the run instead of scrolling past.
+#
+# -O1: ASan needs frame pointers and readable stacks; -O3 costs signal for speed
+# that a test run does not need.
+ASAN_CFLAGS  = -O1 -g -fno-omit-frame-pointer -fsanitize=address,undefined
+ASAN_LDFLAGS = -fsanitize=address,undefined
+ASAN_ENV     = ASAN_OPTIONS=detect_leaks=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1
+
+# `make clean` first is not optional: tools/clean.py had to be fixed to remove
+# Unix test binaries at all (it globbed only *.exe), and without that step this
+# target re-runs binaries built with the NORMAL flags and reports them clean.
+test-asan:
+	@$(MAKE) clean
+	@$(ASAN_ENV) $(MAKE) test-c EXTRA_CFLAGS="$(ASAN_CFLAGS)" EXTRA_LDFLAGS="$(ASAN_LDFLAGS)"
+	@echo "test-asan: suite clean under ASan + UBSan"
+
 # Local validation: one portable CPU build and dependency-free tests.
 check:
 	$(MAKE) clean
@@ -1035,6 +1070,7 @@ bench: iobench$(EXE)
 
 # Own line: see the TEST_RULES note above on shared .PHONY lines.
 .PHONY: bench-omp-grain
+.PHONY: test-asan
 
 tests/test_kv_prefix$(EXE): tests/test_kv_prefix.c kv_prefix.h
 	$(CC) $(CFLAGS) tests/test_kv_prefix.c -o tests/test_kv_prefix$(EXE) $(LDFLAGS)

--- a/c/tools/clean.py
+++ b/c/tools/clean.py
@@ -11,8 +11,10 @@ import shutil
 # Files (relative to c/) to remove if present.
 FILES = [
     "colibri", "colibri.exe",
+    "inkling", "inkling.exe",
+    "kimi_k3", "kimi_k3.exe",
     "olmoe", "olmoe.exe",
-    "glm", "glm.exe",
+    "glm", "glm.exe",                       # pre-rename name of the colibri engine
     "iobench", "iobench.exe",
     "backend_cuda.o", "backend_loader.o",
     "backend_cuda_test", "backend_cuda_test.exe",
@@ -25,10 +27,24 @@ FILES = [
     "native_quant.o", "native_quant_parallel.o", "native_quant_dual.o",
     "native_quant_batch_avx512.o", "native_quant_fp4_rows16.o",
 ]
-# Test binaries and V4 unit objects match these patterns. Only remove binaries (.exe on Windows,
-# no extension on Unix) — never .c or .py source files.
-ARTIFACT_GLOBS = ["tests/test_*", "COLI_V4_UNIT_*.o"]
-BINARY_EXTENSIONS = {"", ".exe", ".o"}
+# Test binaries and V4 unit objects. The test globs deliberately have no
+# extension: on Unix that is what a built test IS, and matching only
+# "tests/test_*.exe" (as this did) meant `make clean` removed nothing at all on
+# Linux and macOS.
+#
+# That is not a tidiness problem -- it silently invalidates verification. Change a
+# compile flag, run `make clean && make test-c`, and the stale binaries built
+# with the OLD flags are re-run and reported as passing. CONTRIBUTING's
+# `make check` starts with exactly that sequence.
+#
+# KEEP_EXT is the safety rail: a source file must never match. Everything the
+# repo tracks under tests/ carries one of these extensions, and directories
+# (tests/fixtures/) are skipped by the isfile() check. Object files are not in
+# it, so COLI_V4_UNIT_*.o is removed by the same rule rather than a second one.
+ARTIFACT_GLOBS = ["tests/test_*", "tests/bench_*", "tests/fuzz_*",
+                  "COLI_V4_UNIT_*.o"]
+KEEP_EXT = (".c", ".h", ".cc", ".cpp", ".cu", ".mm", ".py", ".txt", ".json",
+            ".md", ".bin", ".sh", ".toml", ".yml", ".yaml")
 # Directories to remove.
 DIRS = ["tests/__pycache__", "build/ownership"]
 
@@ -39,9 +55,12 @@ for f in FILES:
         removed += 1
 for pattern in ARTIFACT_GLOBS:
     for f in glob.glob(pattern):
-        if os.path.isfile(f) and os.path.splitext(f)[1] in BINARY_EXTENSIONS:
-            os.remove(f)
-            removed += 1
+        if not os.path.isfile(f):          # tests/fixtures/ and friends
+            continue
+        if f.endswith(KEEP_EXT):           # never a source file
+            continue
+        os.remove(f)
+        removed += 1
 for d in DIRS:
     if os.path.isdir(d):
         shutil.rmtree(d)


### PR DESCRIPTION
> **Depends on #835.** Verifying this PR turned up a tracked build artifact — `c/tests/bench_omp_grain`, a 16,880-byte ELF committed by my own #808. Once `clean.py` correctly removes extensionless binaries, `make clean` would delete a tracked file and leave every contributor with a dirty tree. #835 untracks it and closes the `bench_*`/`fuzz_*` gap in `.gitignore`. Merge that first; this is harmless after it.

## `make clean` removes nothing on Linux and macOS

```console
$ ls tests/test_* | grep -v '\.' | wc -l
40
$ make clean
clean: removed 0 files/dirs
```

`tools/clean.py` globs `"tests/test_*.exe"`. Its own comment says it means *"(.exe on Windows, no extension on Unix)"* — only the Windows half was ever implemented. The engine binaries (`colibri`, `inkling`, `kimi_k3`) are not in the removal list at all either; it still lists `glm`, the pre-rename name.

**This silently invalidates verification.** Change a compile flag, run `make clean && make test-c`, and the *stale* binaries built with the old flags are re-run and reported as passing. CONTRIBUTING's `make check` opens with exactly that sequence.

It is also how this PR nearly shipped as a lie. My first sanitizer run came back clean — because `clean.py` had left the previous, unsanitized binaries in place and `make` had nothing to rebuild. `nm tests/test_topp | grep asan` was empty. The "zero findings" was the old binaries passing again.

## Nothing in this repo has ever been sanitized in CI

`fuzz-rans` builds with `-fsanitize=address,undefined` and has since it was written — but it is not wired to any job, and it covers `rans.h` alone. The engine's 9k lines of pointer arithmetic, its `mmap`/`pread` paths and its worker threads have never been run under ASan here.

## What this adds

- **`tools/clean.py`** removes Unix test binaries and the four engines. `KEEP_EXT` is the safety rail — a file with a source extension can never match, directories (`tests/fixtures/`) are skipped — because the failure mode of getting this wrong is deleting tracked sources. Rebased on `dev` after #165: `ARTIFACT_GLOBS` now carries `COLI_V4_UNIT_*.o` alongside the test globs, and `BINARY_EXTENSIONS` is gone — `.o` is absent from `KEEP_EXT`, so the existing rail already permits removing it. One allowlist, not two facing opposite directions.
- **`EXTRA_CFLAGS` / `EXTRA_LDFLAGS`**, appended to every platform's flags. The obvious way to build with sanitizers, `make CFLAGS=...`, *replaces* the platform's flags and quietly drops its OpenMP and `-march` settings — a second way to end up with a run that is not what it claims to be. This is also the supported way to pass any one-off flag: `make colibri EXTRA_CFLAGS=-DFOO`.
- **`make -C c test-asan`** — clean, rebuild the suite with `-fsanitize=address,undefined -O1 -g`, run it.
- **CI `sanitizers` job** — that, plus `make fuzz-rans`.

## On leak detection being off

It is off deliberately, and this is the one judgement call worth challenging.

The engines allocate the tensor index, the parsed config and the weight slabs once and use them until exit. `st.h` states the intent directly: *"intentionally leaked ... one-time startup parsing"*. LeakSanitizer reports 9 such sites (`json_parse`, `st_init`, `load_cfg`, `qalloc`). Reporting them would bury the findings that matter — a heap-buffer-overflow, a use-after-free — under noise nobody intends to fix, and a noisy gate gets ignored.

ASan's memory-error checks and all of UBSan stay on. Those are what catch defects. Flip `ASAN_OPTIONS` in the `test-asan` target if you want the leak reports.

## Verification, both directions

A sanitizer job that cannot fail is worse than no job, so I checked it can. With a deliberate 4-int buffer written at index 9 in `tests/test_topp.c`:

| | result |
|---|---|
| `make test-asan` | **`FAILED: tests/test_topp`** |
| `make test-c` | passes, silently |

And with the tree as-is:

- `make test-asan` — suite clean under ASan + UBSan (binaries confirmed linked against libasan, not assumed)
- `make fuzz-rans` — `parsed_ok=1334 refused=3573 decoded_ok=2662 decode_refused=1331`
- `make clean` — 43 artifacts removed, 0 tracked sources touched, `tests/fixtures/` intact
- Normal builds unaffected: four engines warning-free, `make test-c` green

## Cost

The sanitizer job is a full rebuild at `-O1` plus a sanitized run of the suite — a few minutes, on its own job so it does not hold up the fast feedback.

## Not covered

GPU paths (CUDA/Metal/Vulkan) are compile-checked only; sanitizing them needs real hardware, which CI does not have. `test-python` is not run under sanitizers here — it drives the engine binaries, so it would work, but it is a much longer run and belongs in a separate decision about CI budget.

