### PR TITLE
st: retain tensor shapes and shard sizes

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -553,6 +553,9 @@ tests/test_tok_o200k$(EXE): tests/test_tok_o200k.c tok.h tok_unicode.h tok_unico
 tests/test_st_pread$(EXE): tests/test_st_pread.c st.h json.h compat.h
 	$(CC) $(CFLAGS) -DST_PREAD_CHUNK=7 $< -o $@ $(LDFLAGS)
 
+tests/test_st_shape$(EXE): tests/test_st_shape.c st.h json.h compat.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
 tests/test_st$(EXE): tests/test_st.c st.h json.h compat.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 

--- a/c/st.h
+++ b/c/st.h
@@ -24,6 +24,7 @@
  * (KB..pochi MB). Un file crafted che dichiara un hlen enorme causerebbe una
  * malloc gigante prima ancora di leggere: lo respingiamo. */
 #define ST_MAX_HEADER (512ll << 20)
+#define ST_MAX_RANK 8
 
 typedef struct {
     char   *name;
@@ -32,6 +33,8 @@ typedef struct {
     int64_t nbytes;
     int     dtype;     /* 0=BF16 1=F16 2=F32 3=U8/I8 4=F8_E4M3 5=F8_E8M0 6=I64 */
     int64_t numel;
+    int     rank;
+    int64_t shape[ST_MAX_RANK];
 } st_tensor;
 
 typedef struct {
@@ -40,6 +43,7 @@ typedef struct {
     int        fds[512];
     int        dfds[512];  /* gemelli O_DIRECT (aperti pigramente): -2 = non ancora provato */
     char      *paths[512];
+    int64_t    sizes[512];  /* indexed primary shard sizes, parallel to fds/paths */
     int        nfd;
 #define ST_MAX_MIR 4       /* extra read replicas beyond the primary (multi-SSD) */
     int        mfds[ST_MAX_MIR][512];  /* MIRROR: fds of replica copy r+1 (multi-SSD), -1 = absent */
@@ -136,7 +140,10 @@ static int st_open_fd(shards *S, const char *path) {
     for (int i = 0; i < S->nfd; i++) if (!strcmp(S->paths[i], path)) return S->fds[i];
     int fd = open(path, COMPAT_O_RDONLY);
     if (fd < 0) { perror(path); exit(1); }
+    struct stat sb;
+    if (fstat(fd, &sb) != 0) { perror("fstat shard"); close(fd); exit(1); }
     S->paths[S->nfd] = strdup(path); S->fds[S->nfd] = fd;
+    S->sizes[S->nfd] = (int64_t)sb.st_size;
 #ifdef O_DIRECT
     S->dfds[S->nfd] = open(path, COMPAT_O_RDONLY | O_DIRECT);   /* eager: lookup poi thread-safe */
 #elif defined(__APPLE__) || defined(_WIN32)
@@ -467,9 +474,9 @@ static void st_init_multi(shards *S, const char *snap_dir, const char *extra_dir
 
     for (int fi = 0; fi < nf; fi++) {
         int fd = st_open_fd(S, files[fi]);
-        struct stat sst;
-        if (fstat(fd, &sst) != 0) { perror("fstat shard"); exit(1); }
-        int64_t fsz = (int64_t)sst.st_size;
+        int fidx = st_fidx(S, fd);
+        if (fidx < 0) { fprintf(stderr, "%s: indexed shard fd is missing\n", files[fi]); exit(1); }
+        int64_t fsz = S->sizes[fidx];
         uint64_t hlen;
         st_pread_full(fd, &hlen, 8, 0, "pread hlen");
         /* file malevolo/troncato: hlen deve stare nel file dopo gli 8 byte di
@@ -500,7 +507,7 @@ static void st_init_multi(shards *S, const char *snap_dir, const char *extra_dir
              * senza questi guard si dereferenzia NULL (json_get) o si legge
              * off->kids[0/1] oltre i limiti dell'array. */
             if (!dt || dt->t != J_STR || !off || off->t != J_ARR || off->len < 2 ||
-                !shp || shp->t != J_ARR) {
+                !shp || shp->t != J_ARR || shp->len > ST_MAX_RANK) {
                 fprintf(stderr, "%s: tensor '%s' has malformed dtype/data_offsets/shape\n",
                         files[fi], name); exit(1); }
             int64_t a0 = (int64_t)off->kids[0]->num, b0 = (int64_t)off->kids[1]->num;
@@ -517,8 +524,12 @@ static void st_init_multi(shards *S, const char *snap_dir, const char *extra_dir
              * numel*esz==nbytes in st_read_f32, riaprendo l'OOB. */
             int64_t numel = 1; int bad_shape = 0;
             for (int k = 0; k < shp->len; k++) {
-                int64_t d = (int64_t)shp->kids[k]->num;
-                if (d < 0 || (d != 0 && numel > INT64_MAX / d)) { bad_shape = 1; break; }
+                jval *dim = shp->kids[k];
+                if (!dim || dim->t != J_NUM || !isfinite(dim->num) ||
+                    dim->num < 0.0 || dim->num >= ldexp(1.0, 63) ||
+                    floor(dim->num) != dim->num) { bad_shape = 1; break; }
+                int64_t d = (int64_t)dim->num;
+                if (d != 0 && numel > INT64_MAX / d) { bad_shape = 1; break; }
                 numel *= d;
             }
             if (bad_shape) {
@@ -531,8 +542,11 @@ static void st_init_multi(shards *S, const char *snap_dir, const char *extra_dir
                 S->t = nt;
             }
             st_tensor *t = &S->t[S->n++];
+            memset(t, 0, sizeof(*t));
             t->name = strdup(name); t->fd = fd; t->off = data_start + a0;
             t->nbytes = b0 - a0; t->dtype = st_dtype_code(dt->str); t->numel = numel;
+            t->rank = shp->len;
+            for (int k = 0; k < t->rank; k++) t->shape[k] = (int64_t)shp->kids[k]->num;
             /* cross-check the declared element count against the byte span for FLOAT
              * dtypes: st_read_f32 writes `numel` floats (BF16/F16 loop or F32 memcpy)
              * into a caller-sized buffer, so a header with numel != nbytes/esz is an

--- a/c/tests/test_st_pread.c
+++ b/c/tests/test_st_pread.c
@@ -27,7 +27,7 @@ static void write_snap(const char *dir, int truncate_bytes) {
     snprintf(path, sizeof(path), "%s/model.safetensors", dir);
     unsigned char data[96];
     for (int i = 0; i < 96; i++) data[i] = (unsigned char)(i * 7 + 3);
-    const char *hdr = "{\"t\":{\"dtype\":\"U8\",\"shape\":[96],\"data_offsets\":[0,96]}}";
+    const char *hdr = "{\"t\":{\"dtype\":\"U8\",\"shape\":[2,3,16],\"data_offsets\":[0,96]}}";
     uint64_t hlen = strlen(hdr);
     FILE *f = fopen(path, "wb");
     fwrite(&hlen, 8, 1, f);
@@ -45,6 +45,15 @@ int main(void) {
     /* 1) chunk loop: 96-byte tensor read 7 bytes at a time, content exact */
     write_snap(dir, 0);
     shards S; st_init(&S, dir);
+    st_tensor *tensor = st_find(&S, "t");
+    CHECK(tensor != NULL);
+    CHECK(tensor->rank == 3);
+    CHECK(tensor->shape[0] == 2 && tensor->shape[1] == 3 && tensor->shape[2] == 16);
+    CHECK(tensor->shape[3] == 0);
+    CHECK(S.nfd == 1);
+    struct stat indexed_sb;
+    CHECK(fstat(S.fds[0], &indexed_sb) == 0);
+    CHECK(S.sizes[0] == (int64_t)indexed_sb.st_size);
     unsigned char out[96] = {0};
     st_read_raw(&S, "t", out, 0);
     for (int i = 0; i < 96; i++) CHECK(out[i] == (unsigned char)(i * 7 + 3));

--- a/c/tests/test_st_shape.c
+++ b/c/tests/test_st_shape.c
@@ -1,0 +1,156 @@
+/* Safetensors shape validation, including st_init() exit(1) paths.
+ *
+ * st_init() deliberately terminates the process for hostile containers, so
+ * the parent writes one container per case and invokes this same binary in
+ * child mode. This keeps the refusal checks real on Windows as well as POSIX.
+ */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifndef _WIN32
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+#include "../st.h"
+
+#define CHECK(condition) do { \
+    if (!(condition)) { \
+        fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, __LINE__, #condition); \
+        return 1; \
+    } \
+} while (0)
+
+typedef struct {
+    const char *shape;
+    int accept;
+    int rank;
+    int64_t numel;
+    int data_bytes;
+} shape_case;
+
+static const shape_case CASES[] = {
+    {"[2,\"3\"]", 0, 0, 0, 0},
+    {"[2,3.5]", 0, 0, 0, 0},
+    {"[2,-1]", 0, 0, 0, 0},
+    {"[9223372036854775807,2]", 0, 0, 0, 0},
+    {"[4611686018427387904,3]", 0, 0, 0, 0},
+    {"[1,1,1,1,1,1,1,1]", 1, 8, 1, 1},
+    {"[1,1,1,1,1,1,1,1,1]", 0, 0, 0, 0},
+    {"[]", 1, 0, 1, 1},
+    {"[0,4096]", 1, 2, 0, 0},
+};
+
+static int write_case(const char *dir, const shape_case *test) {
+    char path[512];
+    char header[512];
+    snprintf(path, sizeof(path), "%s/model.safetensors", dir);
+    int header_bytes = snprintf(
+        header, sizeof(header),
+        "{\"t\":{\"dtype\":\"U8\",\"shape\":%s,\"data_offsets\":[0,%d]}}",
+        test->shape, test->data_bytes);
+    if (header_bytes < 0 || (size_t)header_bytes >= sizeof(header)) return -1;
+
+    FILE *file = fopen(path, "wb");
+    if (!file) return -1;
+    uint64_t hlen = (uint64_t)header_bytes;
+    unsigned char byte = 0;
+    int failed =
+        fwrite(&hlen, 8, 1, file) != 1 ||
+        fwrite(header, 1, (size_t)header_bytes, file) != (size_t)header_bytes ||
+        (test->data_bytes && fwrite(&byte, 1, 1, file) != 1);
+    if (fclose(file) != 0) failed = 1;
+    return failed ? -1 : 0;
+}
+
+static int child_case(int index, const char *dir) {
+    if (index < 0 || index >= (int)(sizeof(CASES) / sizeof(CASES[0]))) return 90;
+    const shape_case *test = &CASES[index];
+    shards S;
+    st_init(&S, dir);
+
+    /* A refusing case reaching here means st_init() incorrectly accepted it. */
+    if (!test->accept) return 91;
+    st_tensor *tensor = st_find(&S, "t");
+    if (!tensor || tensor->rank != test->rank || tensor->numel != test->numel)
+        return 92;
+    for (int i = 0; i < tensor->rank; i++) {
+        int64_t expected =
+            test->rank == 2 && test->numel == 0 ? (i == 0 ? 0 : 4096) : 1;
+        if (tensor->shape[i] != expected) return 93;
+    }
+    for (int i = tensor->rank; i < ST_MAX_RANK; i++)
+        if (tensor->shape[i] != 0) return 94;
+    return 0;
+}
+
+static int subprocess_exit_code(const char *self, int index, const char *dir) {
+    char command[1536];
+    char error_path[512];
+    snprintf(error_path, sizeof(error_path), "%s/stderr.txt", dir);
+#ifdef _WIN32
+    int n = snprintf(command, sizeof(command),
+                     "call \"%s\" --shape-child %d \"%s\" 2>\"%s\"",
+                     self, index, dir, error_path);
+#else
+    int n = snprintf(command, sizeof(command),
+                     "\"%s\" --shape-child %d \"%s\" 2>\"%s\"",
+                     self, index, dir, error_path);
+#endif
+    if (n < 0 || (size_t)n >= sizeof(command)) return -1;
+    int status = system(command);
+#ifdef _WIN32
+    return status;
+#else
+    if (status < 0 || !WIFEXITED(status)) return -1;
+    return WEXITSTATUS(status);
+#endif
+}
+
+static void remove_case(const char *dir) {
+    char path[512];
+    snprintf(path, sizeof(path), "%s/model.safetensors", dir);
+    remove(path);
+    snprintf(path, sizeof(path), "%s/stderr.txt", dir);
+    remove(path);
+#ifdef _WIN32
+    _rmdir(dir);
+#else
+    rmdir(dir);
+#endif
+}
+
+int main(int argc, char **argv) {
+    if (argc == 4 && !strcmp(argv[1], "--shape-child"))
+        return child_case(atoi(argv[2]), argv[3]);
+
+    CHECK(argc >= 1 && argv[0] && *argv[0]);
+    for (int i = 0; i < (int)(sizeof(CASES) / sizeof(CASES[0])); i++) {
+        char dir[] = "test_st_shape_XXXXXX";
+        CHECK(mkdtemp(dir) != NULL);
+        CHECK(write_case(dir, &CASES[i]) == 0);
+        int code = subprocess_exit_code(argv[0], i, dir);
+        char error_path[512];
+        char error[1024] = {0};
+        snprintf(error_path, sizeof(error_path), "%s/stderr.txt", dir);
+        FILE *error_file = fopen(error_path, "rb");
+        CHECK(error_file != NULL);
+        size_t error_bytes = fread(error, 1, sizeof(error) - 1, error_file);
+        CHECK(!ferror(error_file));
+        fclose(error_file);
+        error[error_bytes] = 0;
+        remove_case(dir);
+        if (CASES[i].accept) {
+            CHECK(code == 0);
+            CHECK(error_bytes == 0);
+        } else {
+            CHECK(code == 1);
+            CHECK(strstr(error, "tensor 't'") != NULL);
+            CHECK(strstr(error, "shape") != NULL);
+        }
+    }
+
+    printf("test_st_shape: hostile dimensions, rank limits, scalar and zero shape: ok\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- retain each safetensors tensor's rank and shape (up to `ST_MAX_RANK=8`)
- retain the indexed size of each primary shard alongside `fds[]` and `paths[]`
- reuse the recorded shard size during indexing instead of discarding the `fstat` result
- reject non-numeric, fractional, negative, overflowing, or over-rank shapes before storing them

## Why

`st_tensor` currently keeps only `numel`, so engines cannot validate the original tensor geometry after indexing. The shard size used for the initial bounds check is also discarded, which prevents later range diagnostics from using the same indexed fact.

This is the shared `st.h` prerequisite discussed on #165. It deliberately does not add the V4 engine, a per-tensor shard field, or model-specific aliases. `sizes[512]` costs 4 KiB once per model index.

## Tests

- `test_st_shape` validates non-numeric, fractional, negative, dimension-bound, product-overflow, and rank>8 refusals in subprocesses on Windows and POSIX
- `test_st_shape` also accepts rank 8, scalar `[]` (`rank=0`, `numel=1`), and zero-element `[0,4096]` shapes with exact stored metadata
- `test_st_pread`, `test_st`, `test_st_mirror`, and `test_ue8m0` pass on Windows/UCRT64
- portable build and all C gates pass under the stages used by `make -C c check`
- Python: 288 tests passed, 32 skipped (`PYTHONUTF8=1` on Windows)

Related: #165