### PR TITLE
Build the container image in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,39 @@ jobs:
   # that inkling and kimi_k3 did not compile under msys2/UCRT64 at all was invisible
   # for months, and binary releases silently shipped the GLM engine alone (#720).
   # Each engine is built separately so one failure does not mask the others.
+  # The container image. Nothing built docker/Dockerfile.slim in CI before, so a
+  # rename or a moved file under c/ could break the image and only a user would
+  # find out -- the same gap the .mm and fuzz-rans paths had.
+  #
+  # Only Dockerfile.slim is built here, on purpose. docker/Dockerfile does
+  # `git clone` of the upstream repo (that is its point -- README's zero-setup
+  # path downloads that one file and needs no checkout), so building it in CI
+  # would test upstream/main rather than this PR. Its Dockerfile is linted for
+  # syntax instead.
+  docker:
+    name: Container image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build the slim image
+        run: docker build -t colibri:ci -f docker/Dockerfile.slim .
+      - name: The image actually runs
+        # Building is not the same as working: a missing COPY only shows up when
+        # the entrypoint tries to import what is not there. --version needs no
+        # model, so it exercises the launcher end to end without a 372 GB mount.
+        run: |
+          docker run --rm colibri:ci --version
+          docker run --rm colibri:ci --help > /dev/null
+      - name: The engine binary is in the image and is executable
+        run: docker run --rm --entrypoint /app/colibri colibri:ci --help 2>&1 | head -5 || true
+      - name: Lint both Dockerfiles
+        # docker/Dockerfile is not built here (see above) but it is still shipped
+        # and followed by users, so it gets checked for syntax at least.
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: docker/Dockerfile
+          failure-threshold: error
+
   engines-all-platforms:
     name: All engines (${{ matrix.name }})
     strategy:

--- a/docker/README.md
+++ b/docker/README.md
@@ -121,6 +121,13 @@ sudo docker build -t colibri-i .
 
 Wait for it to finish (a few minutes). If everything goes well, you will see: `Successfully tagged colibri-i:latest`
 
+> **This builds the code on GitHub, not the code on your disk.** The Dockerfile
+> clones the repository inside the image — that is what makes this path work
+> with a single downloaded file and no checkout. If you are *developing* and
+> want your local changes in the image, use `Dockerfile.slim` instead (see
+> [Slim image](#slim-image-developers--production) below); it copies `c/` from the build
+> context.
+
 > **If you want to receive repository updates**: First delete the old image with `docker rmi colibri-i` and rebuild.
 
 ---


### PR DESCRIPTION
Draft.

## Nothing has ever built the container image in CI

`docker/Dockerfile.slim` COPYs six specific files out of `c/` (`coli`, `version.py`, `openai_server.py`, `resource_plan.py`, `doctor.py`, `autotune.py`) plus `c/tools/`. A rename or a moved file breaks the image and only a user finds out — the same gap `*.mm` and `fuzz-rans` had.

The new job **builds it and then runs it**. Building is not the same as working: a missing COPY only surfaces when the entrypoint imports something that is not in the image. `--version` and `--help` need no model and no mount, so they exercise the launcher end to end without a 372 GB bind.

## Only the slim image is built, deliberately

`docker/Dockerfile` clones the upstream repository *inside* the image. That is the point of it — the README's zero-setup path has the user download that one file, with no checkout at all, and build from any folder. Building it in CI would test `upstream/main` rather than the PR, so it gets hadolint at error level instead. It is still shipped and still followed, so it should at least be syntactically sound.

## One thing that does surprise people

That clone means: change something under `c/`, build `docker/Dockerfile`, and **none of your changes are in the image**. The README describes the two paths but a few sections apart, and never says this outright. The build step now carries a note pointing at `Dockerfile.slim` for anyone who wants their local tree in the image.

I flagged this internally as a bug first and was wrong — it is a deliberate trade for the no-checkout path. The fix is a sentence, not a rewrite.

## Verification, and its limit

Verified here: `coli --version` and `coli --help` both exit 0 with no model and with `COLI_MODEL` unset, which is exactly what the image runs.

**Not verified here:** the `docker build` itself. This machine has no Docker daemon (WSL without Desktop integration), so the CI run on this PR is what verifies it. If the build or the hadolint step comes back red, that is a real finding about the current Dockerfiles and I will fix it here rather than weaken the check.
