### PR TITLE
Do not fork an OpenMP team to run one iteration

### DIFF
--- a/c/.gitignore
+++ b/c/.gitignore
@@ -12,6 +12,7 @@ tools/librans_c.so
 tools/librans_c.dylib
 tools/rans_c.dll
 tests/fuzz_rans
+tests/bench_omp_grain
 tests/*.dSYM/
 tests/test_dsa_select
 tests/test_i4_grouped

--- a/c/Makefile
+++ b/c/Makefile
@@ -727,6 +727,18 @@ efficiency-cuda:
 efficiency-report:
 	$(PYTHON) tests/test_efficiency_report.py
 
+
+# What a parallel region costs before its body runs. Backs the `if(S > 1)`
+# clause in the DSA indexer: at decode that region has one iteration, and the
+# fork/join is paid anyway. Not a gate -- a measurement, run it when changing
+# how the engine parallelises.
+#   make -C c bench-omp-grain
+# Honours OMP_NUM_THREADS/OMP_WAIT_POLICY, so measure with the settings the
+# engine actually runs under (omp_tune.h sizes the team to physical cores).
+bench-omp-grain: tests/bench_omp_grain.c
+	$(CC) $(CFLAGS) $< -o tests/bench_omp_grain $(LDFLAGS)
+	./tests/bench_omp_grain
+
 # Local validation: one portable CPU build and dependency-free tests.
 check:
 	$(MAKE) clean
@@ -762,6 +774,9 @@ clean:
 bench: iobench$(EXE)
 	@if [ -n "$(ARGS)" ]; then ./iobench$(EXE) $(ARGS); else echo "built iobench$(EXE) — run: ./iobench$(EXE) <file> <MB> <iters> <threads> <direct 0|1>"; fi
 .PHONY: all colibri glm iq3 rans fuzz-rans cuda-test hip-test gpu-compile cuda-bench cuda-dll portable test-c test-python test check clean install uninstall bench
+
+# Own line: see the TEST_RULES note above on shared .PHONY lines.
+.PHONY: bench-omp-grain
 
 tests/test_kv_prefix$(EXE): tests/test_kv_prefix.c kv_prefix.h
 	$(CC) $(CFLAGS) tests/test_kv_prefix.c -o tests/test_kv_prefix$(EXE) $(LDFLAGS)

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -3370,7 +3370,14 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
                 m->dsa_sel=malloc((size_t)m->dsa_scap*sizeof(int));
                 m->dsa_nsel=malloc((size_t)S*sizeof(int));
             }
-            #pragma omp parallel for schedule(dynamic,1)
+            /* if(S>1): at decode S is 1, so this region has exactly ONE iteration --
+             * and OpenMP still forks and joins the whole team to run it. That is
+             * pure overhead on the hottest path there is: once per layer, per
+             * token, whether or not the body does any work (both early `continue`
+             * branches below are taken on short contexts, and the fork happens
+             * anyway). The clause makes the single-iteration case run inline;
+             * S>1 prefill is untouched, and the results are identical either way. */
+            #pragma omp parallel for schedule(dynamic,1) if(S > 1)
             for(int s=0;s<S;s++){
                 KVState *ks=kvs?kvs[s]:m->kv;
                 int pos=positions?positions[s]:pos_base+s, nk=pos+1;

--- a/c/tests/bench_omp_grain.c
+++ b/c/tests/bench_omp_grain.c
@@ -1,0 +1,101 @@
+/* bench_omp_grain — what a parallel region costs before it does any work.
+ *
+ * The engine wraps work in `#pragma omp parallel for` without asking how much
+ * work is in there. That is right for an expert matmul and wrong for a loop
+ * with one iteration: OpenMP still forks and joins the team, and at decode
+ * (S=1) several of the engine's regions have exactly that shape.
+ *
+ * This measures the floor: a region whose body does nothing measurable, so the
+ * number IS the fork/join cost. Multiply by regions-per-token times layers to
+ * see what it means for a real model.
+ *
+ *   make -C c bench-omp-grain
+ *
+ * Reports nanoseconds per region for the team as configured (OMP_NUM_THREADS),
+ * against the same loop run inline via `if(0)`. Runs long enough that the
+ * difference is not timer noise -- the engine-level tiny-model replay is 15 ms
+ * end to end and cannot resolve this at all.
+ */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+static double now_s(void) {
+    struct timespec t;
+    clock_gettime(CLOCK_MONOTONIC, &t);
+    return (double)t.tv_sec + 1e-9 * (double)t.tv_nsec;
+}
+
+/* Sink the loop body writes to, so neither version can be optimised away. */
+static volatile long g_sink;
+
+/* One iteration per region: the decode shape (S == 1). */
+static double bench_region(long reps, int iters, int parallel) {
+    long acc = 0;
+    double t0 = now_s();
+    for (long r = 0; r < reps; r++) {
+#pragma omp parallel for reduction(+ : acc) if (parallel)
+        for (int i = 0; i < iters; i++) acc += i + r;
+    }
+    double dt = now_s() - t0;
+    g_sink = acc;
+    return dt;
+}
+
+/* Median of n runs: the first is always slower (team not yet warm) and a
+ * scheduler hiccup should not become the headline number. */
+static int cmp_d(const void *a, const void *b) {
+    double x = *(const double *)a, y = *(const double *)b;
+    return x < y ? -1 : x > y ? 1 : 0;
+}
+
+static double median_ns(long reps, int iters, int parallel, int runs) {
+    double *v = malloc((size_t)runs * sizeof(double));
+    if (!v) return -1;
+    for (int k = 0; k < runs; k++) v[k] = bench_region(reps, iters, parallel) / (double)reps * 1e9;
+    qsort(v, (size_t)runs, sizeof(double), cmp_d);
+    double m = v[runs / 2];
+    free(v);
+    return m;
+}
+
+int main(int argc, char **argv) {
+    long reps = argc > 1 ? atol(argv[1]) : 200000;
+    int runs = argc > 2 ? atoi(argv[2]) : 7;
+    if (reps < 1) reps = 1;
+    if (runs < 1) runs = 1;
+
+    int nthreads = 1;
+#ifdef _OPENMP
+#pragma omp parallel
+    {
+#pragma omp master
+        nthreads = omp_get_num_threads();
+    }
+#else
+    printf("built without OpenMP -- nothing to measure\n");
+    return 0;
+#endif
+
+    printf("bench_omp_grain: %ld regions per sample, %d samples, team of %d\n", reps, runs, nthreads);
+    printf("  %-12s %14s %14s %12s\n", "iterations", "parallel (ns)", "inline (ns)", "overhead");
+    for (int iters = 1; iters <= 64; iters *= 8) {
+        double par = median_ns(reps, iters, 1, runs);
+        double seq = median_ns(reps, iters, 0, runs);
+        printf("  %-12d %14.1f %14.1f %11.1fx\n", iters, par, seq, seq > 0 ? par / seq : 0.0);
+    }
+
+    /* The number the engine cares about: one iteration, which is what S=1
+     * decode gives every per-position region. */
+    double one_par = median_ns(reps, 1, 1, runs);
+    double one_seq = median_ns(reps, 1, 0, runs);
+    double cost = one_par - one_seq;
+    printf("\n  fork/join floor: %.0f ns per region (team of %d)\n", cost, nthreads);
+    printf("  a 78-layer model paying this once per layer per token: %.2f ms/token\n", cost * 78.0 / 1e6);
+    return 0;
+}


### PR DESCRIPTION
Draft.

## The change

The DSA indexer's per-position top-k is `#pragma omp parallel for` over `s < S`. **At decode `S` is 1** — the region has exactly one iteration, and OpenMP still forks and joins the whole team to run it. Once per layer, per token.

It happens whether or not the body does any work: both early `continue` branches are taken on short contexts, and the fork precedes them.

```c
#pragma omp parallel for schedule(dynamic,1) if(S > 1)
```

Prefill (`S > 1`) is untouched. A one-iteration parallel region is overhead by construction — this needs no benchmark to justify.

## But it came out of one, and that part is worth reading

Tiny oracle model (5 layers, hidden 128), 15 runs per configuration, median with quartiles:

| `OMP_NUM_THREADS` | tok/s | p25 | p75 |
|---|---|---|---|
| 1 | **17109** | 15573 | 18119 |
| 4 | 10749 | 10650 | 11125 |
| 24 | **1529** | 913 | 1935 |

The distributions do not overlap. **One thread is 11× faster than 24**, and the spread widens with the team — ±8% at one thread, ±34% at twenty-four. That is the same tail the profiler reports as p90 sitting 27% above p50.

A small model on a 24-core host, so the *ratio* does not transfer to a 744B run. What transfers is the shape: **colibri hands every parallel region the full team regardless of how much work it contains**, and there is no notion of a minimum grain anywhere in the tree. PyTorch's `at::parallel_for` takes a `grain_size` for precisely this reason; vLLM's CPU backend carries its own thread-count controls (`VLLM_CPU_OMP_THREADS_BIND`, `VLLM_CPU_NUM_OF_RESERVED_CPU`).

## What this PR deliberately does not do

Fix that properly. A per-region threshold is only honest if it is measured on the model people actually run, and this machine cannot do that: the tiny replay is 0.015 s, and repeated runs of an *unchanged* binary land anywhere from 356 to 3893 tok/s. That noise swamps any single-region effect — I tried, got a plausible-looking +135% median, and threw it away because the quartiles overlapped almost completely.

So this takes only the case that needs no threshold at all: a loop that cannot be parallel. The rest wants the lab machine and a real model.

## The benchmark is included

`make -C c bench-omp-grain` is the tool those numbers come from, and it is in this PR. It runs a region whose body does nothing measurable 200k times and reports a median of samples, so the figure is stable to a few percent instead of the 356..3893 tok/s the engine-level replay gives on an unchanged binary.

On this host (Core Ultra 9 285K, 24 cores, no SMT), with the engine's own OMP settings:

| threads | fork/join per region |
|---|---|
| 4 | 881 ns |
| 8 | 1500 ns |
| 16 | 2498 ns |
| 24 | **12767 ns** |

12.8 µs for a region with one iteration — **1.0 ms/token** on a 78-layer model paying it once per layer, and 149× the cost of the same loop inline.

## A lead this does NOT establish

The 16 → 24 jump is steeper than the trend, and this CPU is hybrid (P-cores + E-cores). That is the effect `omp_tune.h` already avoids **on Apple Silicon**, by counting only performance cores — #707 measured E-cores costing 4.2% of decode there. The Linux path has no equivalent: it dedupes SMT via `thread_siblings_list` and takes every physical core, E-cores included.

So Intel hybrid parts may have exactly the same bug. But this host runs under WSL2, which exposes neither `/sys/devices/system/cpu/types/` nor `cpu_capacity`, so P/E membership is not observable here and **the jump cannot be attributed**. I am flagging it, not claiming it. Anyone on bare metal with a hybrid CPU can settle it with the included benchmark in a minute.

## Verification

Identical output, not merely green:

- teacher-forcing **32/32 positions**, before and after
- the `REPLAY` token sequence is **byte-for-byte the same** before and after
- four engines build warning-free; `make test-c` passes

## Side note that made this measurable at all

These numbers come from `tests/test_inefficiency.py` and its `glm_tiny` fixture. Those 8 tests had never executed on any platform — they looked for `c/glm.exe`, a name that has not existed since the `glm` → `colibri` rename (fixed in #804). With that fix and a generated fixture, 5 of them run for the first time and pass. They are the throughput floor, the disk-wait ceiling, the PROFILE phase assertions and the determinism check — i.e. the harness this kind of work needs.
