### PR TITLE
docs: register int4-rans256-g0 in FORMATS.md; registry parity for ordinal-less rows

### DIFF
--- a/c/tests/test_formats_registry.py
+++ b/c/tests/test_formats_registry.py
@@ -26,6 +26,16 @@ Parity rules:
      explicitly ("no in-tree name string" -- the MXFP4 row's marker), so
      a new registry row can't silently claim a name the reader won't
      recognize.
+  3. ORDINAL-LESS rows (a non-numeric ordinal cell such as "*(none)*" --
+     the int4-rans256-g0 row's convention for a merged, stamp-identified
+     format with no engine consumer) are rows too, not parse noise:
+     their NAME must be unique across the whole table (an ordinal-less
+     row silently shadowing a numbered row's name is exactly the
+     stamp-string collision this registry exists to prevent); the name
+     must NOT appear in FMT_NAMES (a compiled name means the format HAS
+     an ordinal and the row must carry it); and the row must declare
+     "no public ordinal" explicitly, the ordinal-less analogue of rule
+     2's say-so marker.
 """
 import os
 import re
@@ -49,29 +59,53 @@ def parse_fmt_names(path):
 
 
 def parse_doc_rows(path):
+    """Returns (numeric_rows, ordinal_less_rows).
+
+    numeric_rows: {ordinal: (first_backticked_name, name_cell)} as before.
+    ordinal_less_rows: [(ordinal_cell, first_backticked_name, full_line)]
+    for table rows whose ordinal cell is NOT a plain integer. To qualify,
+    a line must still look like a registry row, not a header/separator or
+    prose table elsewhere in the doc: at least 5 '|'-separated cells and a
+    backticked token in the name (second) cell.
+    """
     rows = {}
+    ordinal_less = []
     with open(path, encoding="utf-8") as f:
         lines = f.readlines()
     for line in lines:
         m = re.match(r"\|\s*\*{0,2}(\d+)\*{0,2}\s*\|\s*(.+)$", line)
-        if not m:
+        if m:
+            ordinal = int(m.group(1))
+            name_cell = m.group(2).split("|")[0]
+            first_tick = re.search(r"`([^`]+)`", name_cell)
+            rows[ordinal] = (first_tick.group(1) if first_tick else None,
+                             name_cell)
             continue
-        ordinal = int(m.group(1))
-        name_cell = m.group(2).split("|")[0]
-        first_tick = re.search(r"`([^`]+)`", name_cell)
-        rows[ordinal] = (first_tick.group(1) if first_tick else None, name_cell)
-    return rows
+        if not line.startswith("|"):
+            continue
+        cells = line.strip().strip("|").split("|")
+        if len(cells) < 5:
+            continue
+        name_tick = re.search(r"`([^`]+)`", cells[1])
+        if not name_tick:
+            continue  # header row / separator / non-registry table
+        ordinal_less.append((cells[0].strip(), name_tick.group(1), line))
+    return rows, ordinal_less
 
 
 class RegistryParityTest(unittest.TestCase):
     def setUp(self):
         self.c_names = parse_fmt_names(COLIBRI_C)
-        self.doc_rows = parse_doc_rows(FORMATS_MD)
+        self.doc_rows, self.ordinal_less = parse_doc_rows(FORMATS_MD)
         # plausibility floors: an anchor drift must fail HERE, loudly.
         self.assertGreaterEqual(len(self.c_names), 8,
                                 "FMT_NAMES parse found suspiciously few entries")
         self.assertGreaterEqual(len(self.doc_rows), 9,
                                 "FORMATS.md table parse found suspiciously few rows")
+        self.assertGreaterEqual(len(self.doc_rows) + len(self.ordinal_less), 10,
+                                "FORMATS.md parse lost the ordinal-less rows "
+                                "(int4-rans256-g0 landed as one; if every row is "
+                                "numbered again, update this floor deliberately)")
 
     def test_every_c_name_matches_its_doc_row(self):
         for fmt, name in sorted(self.c_names.items()):
@@ -90,6 +124,36 @@ class RegistryParityTest(unittest.TestCase):
                           f"FORMATS.md row fmt={fmt} ('{doc_name}') has no FMT_NAMES entry "
                           f"and is not marked 'no in-tree name string' -- a tool stamping "
                           f"this documented name would be refused as unrecognized")
+
+    def test_names_are_unique_across_all_rows(self):
+        seen = {}
+        numbered = [(f"fmt={fmt}", doc_name)
+                    for fmt, (doc_name, _cell) in sorted(self.doc_rows.items())
+                    if doc_name is not None]
+        unnumbered = [(f"ordinal cell {oc!r}", name)
+                      for oc, name, _line in self.ordinal_less]
+        for where, name in numbered + unnumbered:
+            self.assertNotIn(name, seen,
+                             f"registry NAME '{name}' appears twice ({seen.get(name)} "
+                             f"and {where}) -- the name column IS the stamp identity; "
+                             f"two rows may never share it")
+            seen[name] = where
+
+    def test_ordinal_less_rows_do_not_claim_a_compiled_name(self):
+        compiled = set(self.c_names.values())
+        for oc, name, _line in self.ordinal_less:
+            self.assertNotIn(name, compiled,
+                             f"ordinal-less row ({oc!r}) names '{name}', which IS in "
+                             f"FMT_NAMES -- a compiled name has an ordinal, and its row "
+                             f"must carry that number, not '{oc}'")
+
+    def test_ordinal_less_rows_declare_no_public_ordinal(self):
+        for oc, name, line in self.ordinal_less:
+            self.assertIn("no public ordinal", line,
+                          f"ordinal-less row '{name}' ({oc!r}) does not declare "
+                          f"'no public ordinal' -- rule 3's say-so marker: a row with "
+                          f"no number must state that the number's absence is "
+                          f"deliberate and what its identity rests on instead")
 
 
 if __name__ == "__main__":

--- a/docs/FORMATS.md
+++ b/docs/FORMATS.md
@@ -35,7 +35,9 @@ discussion separate from the CPU+Metal implementation.
 
 ## Known formats
 
-Every row below is verified against this PR pair's current restack: the
+Every row below is verified against this PR pair's current restack (the
+ordinal-less `int4-rans256-g0` row, which landed later, instead states its
+own verification anchor in its sources bullet): the
 stamp+registry series (#529) stacked directly on the fp8-passthrough series
 (#528), which is in turn based on dev `292ed4c` (post-#465, post-#457
 Metal grouped-GEMV merge, post-#705 Vulkan/Kimi-K3 MXFP4 merge) — no
@@ -65,9 +67,14 @@ the bytes alone say.
 | 6 | `e8-iq3-lattice` (E8/IQ3 lattice) | `O*ceil(I/256)*98` bytes (98-byte self-contained super-blocks: E8 lattice indices + parity signs + fp16 super-scales; `E8_QK=256`, `E8_BBYTES=98`) | none as a separate array — scales live **inside** the super-blocks; the `.qs` sidecar is a single-float tag (`ns==4` is the loader's discriminator). NOTE: stores `W@Q` (block-diagonal FWHT rotation) — activations must be rotated before the kernel | **stable, upstream** — [#465](https://github.com/JustVugg/colibri/pull/465) MERGED 2026-07-21 | dev `dce7012` |
 | 7 | `mxfp4` (no in-tree name string — dev has no stamp feature) | `O*ceil(I/2)` bytes (e2m1 nibbles, 2 packed values/byte — same nibble packing as fmt=2/4) | in the **container**: 1 **UE8M0** byte (u8 power-of-two exponent) per **group** of `gs=32` inputs; expanded to 1 `f32` per group at Vulkan upload (`c/kimi_k3.c`'s `mx4_scale` loop — the shader is float-only). Host gate: `gs >= 8 && gs % 8 == 0` (`c/backend_vulkan.c`) | **stable, upstream** — Kimi K3 native routed-expert tier, **Vulkan backend only** (`c/backend_vulkan.c`, `c/shaders/qmatmul.comp`); NOT a CPU/`QT` format — `qt_resolve_fmt` never returns 7 and the Metal backend refuses it | merged [#676](https://github.com/JustVugg/colibri/issues/676)/[#705](https://github.com/JustVugg/colibri/pull/705) |
 | **8** | `fp8-e4m3-b128` | `O*I` × 1 byte (`q8`, raw e4m3, byte-identical layout to fmt=1) | a **declared property**, not one fixed layout — see "Scale encoding is a declared property" below. **f32** (1 per 128×128 block, `ceil(O/128)*ceil(I/128)` entries) is IMPLEMENTED; **UE8M0** (1 byte/block, same block grid) is RECOGNIZED and refused by name, not yet implemented | **this PR pair** — CPU/Metal/repack/collision-refusal on `fmt7/fp8-passthrough`, this stamp+registry PR stacked on top; developed under the PRIVATE ORDINAL BLOCK as `fmt=100`; assigned fmt=7 by the maintainer on #524, renumbered to **fmt=8** after #705 merged claiming 7 for MXFP4 while this pair was open (see "ID assignment" below) | `fmt7/fp8-passthrough` (PR 1) |
+| *(none)* | `int4-rans256-g0` | **data-dependent** — an opaque `U8` blob (safetensors dtype `U8`, shape `[record_len]`; the tensor keeps its original logical name) holding the chunk record of `docs/int4-rans256-g0.md`: u64 `n_symbols` + u64 `packed_bytes` + `N+1` u32 stream offsets + `N=256` concatenated single-state rANS streams (`RANS_NSTREAMS=256`, `c/rans.h`) that losslessly entropy-code the source tensor's packed int4 bytes — byte-exact reconstruction, ~0.76 of the source packed bytes on the GLM-5.2 full-corpus census. **No `expected_bytes(O,I)` formula exists**, so byte-arithmetic inference is structurally impossible for this format: the `__metadata__["colibri.fmt"]` stamp naming `int4-rans256-g0` is **MANDATORY**, and the shared decode table ships once per shard in `__metadata__["colibri.int4-rans256-g0.table"]` | per-row **f32** `.qs` sidecar, raw and unchanged from the source `int4-row`-geometry container (`O` entries) | **merged, offline tools only** — codec `c/rans.h`, writer `c/tools/repack_rans.py`, validator `c/tools/rans_verify.py`. **No engine DECODE path exists** (no compiled `fmt` constant anywhere, not even a private-block one; `qt_resolve_fmt` has no branch for it), so it holds **no public ordinal** — and none can be claimed before engine code consuming the format (the ladder's PR 2 loader/CPU-decode stage) first merges into dev: this row's gloss on the "ID assignment" rule below, for a format with nothing to compile a number into. The engine is NOT inert against repacked shards, though: discovery-time stamp ingest and load-time byte-arithmetic inference both run, and the routed-expert load sites — this format's entire target population — pass `stamped_name=NULL`, so the MANDATORY stamp is **not consulted there today**. Pointing the current engine at a repacked directory is **unsupported** (typical outcome: a named refusal from the byte-arithmetic mismatch); the stamp becomes load-bearing only when PR 2 wires stamp-gated dispatch **ahead of** inference, exactly as the format spec warns (depth: sources bullet below) | merged [#671](https://github.com/JustVugg/colibri/pull/671) (dev `a3a5a75`) |
 
 With fmt 0–8 all assigned, the next free public ordinal is **9** — per the
 convention below it isn't claimed here; an ID is only settled at merge.
+(`int4-rans256-g0`'s row above claims none either: a stamp-identified
+container format with no engine consumer has nothing to compile an ordinal
+into, and its row exists so name-collision scans find it — exactly what
+this registry is for.)
 
 **ID assignment.** An ordinal is claimed by the first merge into dev that
 ships it — there is no reservation mechanism, and an assignment made on an
@@ -129,6 +136,36 @@ pair's current restack, base dev `292ed4c`):
   override that default — see "The metadata stamp" below for the exact
   rule in both cases. FMT_NAMES table (name string <-> fmt int):
   `c/colibri.c:1316`.
+- **no ordinal** (`int4-rans256-g0`, merged tools-only tier — line numbers
+  at dev `7fb1159`, post-#671 merge `a3a5a75`, not at this PR pair's
+  restack base) — codec + record reader/writer: `c/rans.h`
+  (`RANS_NSTREAMS 256`, `c/rans.h:93`; the record layout in the file-header
+  comment, `c/rans.h:17-34`; that same header names its engine consumer
+  "a future engine decode stage", `c/rans.h:4` — the format's own statement
+  that none exists yet). Identity constants: `c/tools/rans_format.py:40-46`
+  (`FORMAT_NAME = "int4-rans256-g0"`; `METADATA_KEY = "colibri.fmt"` — the
+  same key/shape as the fmt=8 stamp convention below, but MANDATORY here
+  rather than a cross-check, because there is no byte arithmetic to fall
+  back on; `TABLE_KEY = "colibri.int4-rans256-g0.table"`). Writer
+  `c/tools/repack_rans.py` (deterministic; verifies every record byte-exact
+  before writing); validator `c/tools/rans_verify.py` (TRUST-VERIFY-REFUSE,
+  named refusal classes in its module docstring). Full specification:
+  `docs/int4-rans256-g0.md`. Engine-interaction status, stated precisely
+  (why the ordinal column is empty, and what still runs): `qt_resolve_fmt`
+  (`c/colibri.c:1374`) has no branch that returns this format, and
+  `c/colibri.c`/`c/quant.h`/`c/st.h` contain no reference to it — no
+  decode path, hence no ordinal. But a repacked shard is not invisible to
+  the engine: `st_fmt_stamp_ingest` (`c/st.h:317`, called from
+  `st_init_multi`'s discovery loop) parses its mandatory `colibri.fmt`
+  stamp map at container-discovery time, and the three routed-expert load
+  sites — exactly this format's target population — resolve formats by
+  byte arithmetic alone with `stamped_name=NULL` (`c/colibri.c:2217`,
+  `c/colibri.c:2386`, `c/colibri.c:2580`, each marked
+  `/* routed expert: never stamped */`), so the stamp is never consulted
+  where it would matter most. A future consumer must wire stamp-gated
+  dispatch AHEAD of that inference — `docs/int4-rans256-g0.md`'s
+  "THE STAMP IS MANDATORY" section states why that ordering is
+  load-bearing.
 
 ## Scale encoding is a declared property (fmt=8)
 

--- a/docs/int4-rans256-g0.md
+++ b/docs/int4-rans256-g0.md
@@ -4,10 +4,11 @@ Status: format specification + offline tools, PR 1 of a 3-PR ladder. This PR
 adds the codec (`c/rans.h`), the repack/verify tools
 (`c/tools/repack_rans.py`, `c/tools/rans_verify.py`) and this document —
 **no engine code paths change**. PR 2 (loader + CPU decode on expert load)
-and PR 3 (Metal batched decode) build on it. A registry row is *proposed*
-here, not claimed: the format's identity is the NAME string
-`int4-rans256-g0`; the numeric `fmt` ordinal is left for the maintainer to
-assign whenever a registry (FORMATS.md) lands.
+and PR 3 (Metal batched decode) build on it. The format's identity is the
+NAME string `int4-rans256-g0`; its registry row has since landed in
+FORMATS.md with ordinal *(none)* — no numeric `fmt` ordinal exists or is
+claimed before engine code consuming the format (PR 2) first merges into
+dev (see "Registry row (landed)" below).
 
 ## What it is, in one paragraph
 
@@ -235,8 +236,17 @@ integrity** — these exact bytes came from that mint run; container
 engine-side load check ships with the consumer PR. The record wire format
 is untouched by all of this: the manifest is a sidecar file.
 
-## Proposed registry row
+## Registry row (landed)
+
+The registry row this section originally *proposed* now exists in
+`docs/FORMATS.md` (the authoritative copy — this table is a summary):
 
 | ordinal | name | weight bytes | scale layout | status |
 |---|---|---|---|---|
-| *(maintainer-assigned)* | `int4-rans256-g0` | data-dependent (chunk record above; **stamp mandatory**) | per-row `F32` `.qs`, raw (unchanged from int4-row) | proposed, offline tools only |
+| *(none)* | `int4-rans256-g0` | data-dependent (chunk record above; **stamp mandatory**) | per-row `F32` `.qs`, raw (unchanged from int4-row) | merged, offline tools only |
+
+The ordinal cell reads *(none)*, not *(maintainer-assigned)*: with no
+engine decode path there is nothing to compile an ordinal into, so — as
+the FORMATS.md row glosses the registry's ID-assignment rule — no public
+ordinal is claimed before engine code consuming the format (this ladder's
+PR 2) first merges into dev.


### PR DESCRIPTION
*Authored by Fable 5 in Claude Code, analysis in partnership with @monotophic.*

Registers `int4-rans256-g0` — the entropy-coded container format that merged
with #671's offline tools — in `docs/FORMATS.md`, and extends the registry
parity test so rows like it are inside the safety net.

**Scope and audience:** this changes no runtime behavior and affects no one's
tok/s. It's coordination infrastructure for format authors — the registry
exists because ordinal collisions happened twice in one month (#465 vs fmt=6;
#705 vs #528 on fmt=7, which cost a 191-reference renumber), and with CUDA
work now building on registered formats (#817), name/ordinal coordination is
load-bearing rather than hypothetical. Two concrete protections ship here:
the collision safety net now actually sees ordinal-less rows (it previously
skipped them — a colliding row passed CI green), and anyone who runs the #671
repack tools gets an explicit statement that pointing today's engine at a
repacked directory is unsupported, with the failure mode named instead of
discovered.

**The row claims no public ordinal, deliberately.** The format has no engine
decode path today (`qt_resolve_fmt` has no branch for it; no compiled `fmt`
constant exists anywhere, not even a private-block one — its identity is the
mandatory `__metadata__["colibri.fmt"]` stamp). Per this registry's own "ID
assignment" rule, an ordinal is claimed by the first merge into dev that ships
it; the row reads that as *ships engine code consuming it* for a
stamp-identified format — stated in the row as its own clarifying gloss, since
there is nothing to compile a number into until the ladder's PR 2 (engine
decode stage) lands. The "next free public ordinal is 9" statement stays true.

**Registry parity coverage** (`c/tests/test_formats_registry.py`): the parser
previously recognized only numeric-ordinal rows, so an ordinal-less row was
invisible to the collision checks this registry exists for. It now parses both
populations and enforces three rules on ordinal-less rows: name uniqueness
across the whole table, no claiming a compiled `FMT_NAMES` name, and an
explicit "no public ordinal" declaration. Verified to bite: an injected
colliding row fails all three tests by name.

**Two known constraints, disclosed for the future decode stage** (both
pre-existing, neither introduced or resolved here; the row's wording reflects
them):
1. The mandatory stamp is not consulted on the routed-expert load paths — the
   format's entire target population — which pass `stamped_name=NULL`
   (`c/colibri.c:2217/2386/2580`). Stamp-gated dispatch must be wired ahead of
   byte-arithmetic inference when the decode stage lands, exactly as
   `docs/int4-rans256-g0.md`'s "THE STAMP IS MANDATORY" section warns.
2. `ST_FMT_STAMP_MAX` (4096, per this doc's own scan-bound section) is sized
   for hundreds of stamped tensors; a full-corpus routed-expert repack needs
   tens of thousands of stamp entries. The decode-stage PR must raise the
   bound or restructure the map before full-corpus repacks are loadable.

**Shared-namespace scan** (per this registry's convention): dev HEAD `7fb1159`
has no rans row and no fmt=9 claim; all 51 open PRs enumerated 2026-08-04 —
none touch `docs/FORMATS.md`, claim a format ordinal, or use rans naming.

| Requirement | Decisive evidence |
|---|---|
| Every factual cell true at its stated anchor | Each carries a `file:line` citation at dev `7fb1159` — checkable in-tree |
| Ordinal-less rows now inside the parity net | Injected colliding row → 3 named test failures; real doc → 5/5 green |
| Nothing else regresses | `make check` green: C battery 0 failures, Python 304 tests OK |

<details><summary>Verification detail</summary>

- Cross-doc consistency: `docs/int4-rans256-g0.md`'s registry stub updated in
  the same PR to match the landed row (it previously said ordinal
  *(maintainer-assigned)*, status "proposed").
- Table structure: all rows column-count-consistent in both edited docs.
- The parity suite's plausibility floor now counts both row populations, so a
  parser drift that loses ordinal-less rows fails loudly rather than
  silently shrinking coverage.
- Independent blind fact-check re-derived every row cell against
  `git show 7fb1159:<file>` with zero discrepancies before this was opened.

</details>
