### PR TITLE
coli: the banner said GLM-5.2 over every model

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -137,12 +137,81 @@ def sprite_lines():
         out.append(row+"\033[0m")
     return out
 
-def banner(sub=""):
+# Display names for the banner, keyed on the RAW model_type -- deliberately not
+# on model_arch(), which returns "glm" for everything it does not recognise.
+# That fallback is right for picking an engine (colibri.c is the general path)
+# and wrong for telling someone what they loaded: it is why the banner said
+# GLM-5.2 over an Inkling, a Kimi K3 and a DeepSeek V4 alike.
+#
+# Parameter counts are the roster's, i.e. the README's, so the two cannot drift
+# apart quietly. A model_type absent from this table is NOT forced into a name
+# here -- it prints its own model_type and its measured geometry instead.
+_BANNER_MODELS = (
+    ("deepseek_v4", "DeepSeek V4 Flash", "284B"),   # before "deepseek": V4 is its own engine
+    ("inkling",     "Inkling",           "975B"),
+    ("kimi",        "Kimi K3",           "2.8T"),
+    ("olmoe",       "OLMoE",             "7B"),
+    ("glm",         "GLM-5.2",           "744B"),
+)
+
+def model_banner_line(model):
+    """Third banner line: what is actually loaded, or the generic tagline.
+
+    Reads config.json and stats the shards. No safetensors headers are parsed:
+    this runs before every command, and a banner may not cost a scan of a
+    400 GB checkpoint.
+    """
+    generic = "GLM-5.2 · 744B MoE · int4 · streaming CPU"
+    if not model:
+        return generic
+    try:
+        with open(os.path.join(model, "config.json"), encoding="utf-8") as f:
+            cfg = json.load(f)
+    except (OSError, ValueError, TypeError):
+        return generic
+    kind = (cfg.get("model_type") or "").lower()
+
+    name, scale = "", ""
+    for key, display, params in _BANNER_MODELS:
+        if key in kind:
+            name, scale = display, params
+            break
+    if not name:
+        # Unknown checkpoint: say so with its own words rather than guess.
+        name = kind or "unknown model"
+
+    bits = [name]
+    if scale:
+        bits.append(f"{scale} MoE" if cfg.get("n_routed_experts") else scale)
+    else:
+        layers, experts = cfg.get("num_hidden_layers"), cfg.get("n_routed_experts")
+        if layers and experts:
+            bits.append(f"{layers}L x {experts}E MoE")
+        elif layers:
+            bits.append(f"{layers} layer")
+    try:
+        size = sum(os.path.getsize(os.path.join(model, x))
+                   for x in os.listdir(model) if x.endswith(".safetensors"))
+        if size >= 1e9:
+            # One decimal below 10 GB so a small checkpoint does not read as
+            # "0 GB"; whole numbers above, where a decimal is noise.
+            bits.append(f"{size/1e9:.1f} GB on disk" if size < 1e10
+                        else f"{size/1e9:.0f} GB on disk")
+        elif size:
+            bits.append(f"{size/1e6:.0f} MB on disk")
+    except OSError:
+        pass
+    return " · ".join(bits)
+
+def banner(sub="", *, model=None):
+    # model= is keyword-only on purpose: banner(sub) is called from a dozen
+    # places and from open PRs, and a second positional argument here would
+    # silently be read as a path.
     sp=sprite_lines()
     txt=[
         f"{C.teal}{C.b}colibri{C.r} {C.dim}v{_version}{C.r}",
         f"{C.dim}tiny engine, immense model{C.r}",
-        f"{C.gray}GLM-5.2 · 744B MoE · int4 · streaming CPU{C.r}",
+        f"{C.gray}{model_banner_line(model)}{C.r}",
         f"{C.dgray}{sub}{C.r}" if sub else "",
         "",
     ]
@@ -577,7 +646,7 @@ def cmd_build(a):
     sys.exit(subprocess.call(["make","-C",HERE,target]))
 
 def cmd_info(a):
-    banner("info")
+    banner("info", model=a.model)
     if not a.model:
         sys.exit(f"{C.yel}no model directory given.{C.r}\n  {NO_MODEL_HINT}")
     cfgp=os.path.join(a.model,"config.json")
@@ -625,7 +694,7 @@ def cmd_plan(a):
     if a.json:
         print(json.dumps(plan,indent=2))
         return
-    banner("plan · Disk / RAM / VRAM")
+    banner("plan · Disk / RAM / VRAM", model=a.model)
     print(textwrap.indent(format_plan(plan),"  "))
     print()
 
@@ -677,7 +746,7 @@ def cmd_tune(a):
     a.no_tune_profile=True
     base_env=env_for(a)
     prompt=f"[gMASK]<sop><|user|>{a.prompt}<|assistant|><think></think>"
-    banner("tune · measured execution profile")
+    banner("tune · measured execution profile", model=a.model)
     print(f"  fixed replay: {a.tokens} tokens · {a.repeats} run(s) per candidate")
     print("  only quality-preserving scheduling knobs are eligible\n")
     try:
@@ -706,7 +775,7 @@ def cmd_run(a):
     engine=engine_for(a.model)
     need_model(a.model,engine)
     prompt=" ".join(a.prompt) if a.prompt else sys.exit('usage: coli run "your prompt"')
-    banner("run")
+    banner("run", model=a.model)
     if arch=="deepseek_v4":
         prompt_path=None
         try:
@@ -867,7 +936,7 @@ def cmd_chat(a):
         need_model(a.model,engine)
         model_id=("kimi-k3-colibri" if arch=="kimi" else
                   "inkling-colibri" if arch=="inkling" else "deepseek-v4-colibri")
-        banner(f"chat · {model_id} · local server")
+        banner(f"chat · {model_id} · local server", model=a.model)
         import openai_server
         # --cap rides along so an explicit `coli chat --cap N` reaches the
         # engine (it was silently eaten for years -- disclosed behavior
@@ -897,7 +966,7 @@ def cmd_chat(a):
                 try: p.wait(timeout=10)
                 except subprocess.TimeoutExpired: p.kill()
     need_model(a.model)
-    banner(f"chat · {os.path.basename(a.model)} · ram {a.ram or '-'}GB · topp {a.topp or 'off'}")
+    banner(f"chat · {os.path.basename(a.model)} · ram {a.ram or '-'}GB · topp {a.topp or 'off'}", model=a.model)
     kv_resume_notice(a.model)
     errlog=tempfile.NamedTemporaryFile(mode="w+", suffix=".log", delete=False)
     e=env_for(a); e["SERVE"]="1"

--- a/c/tests/test_cli_output.py
+++ b/c/tests/test_cli_output.py
@@ -134,5 +134,84 @@ class ChatCapForwardingTest(unittest.TestCase):
         self.assertNotIn("--cap", cmd)
 
 
+class BannerModelLineTest(unittest.TestCase):
+    """The banner's third line must describe the model that is loaded.
+
+    It said "GLM-5.2 · 744B MoE · int4 · streaming CPU" for every checkpoint,
+    because model_arch() answers "glm" for anything it does not recognise --
+    the right default for choosing an engine, and a wrong statement of fact.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        loader = SourceFileLoader("coli_banner_under_test", str(CLI))
+        spec = importlib.util.spec_from_loader(loader.name, loader)
+        cls.coli = importlib.util.module_from_spec(spec)
+        loader.exec_module(cls.coli)
+
+    def make_model(self, config, shard_bytes=0):
+        directory = Path(tempfile.mkdtemp(prefix="coli-banner-"))
+        self.addCleanup(lambda: __import__("shutil").rmtree(directory, ignore_errors=True))
+        (directory / "config.json").write_text(json.dumps(config), encoding="utf-8")
+        if shard_bytes:
+            with open(directory / "model-00001.safetensors", "wb") as shard:
+                shard.truncate(shard_bytes)   # sparse: costs no disk
+        return directory
+
+    def line(self, config, shard_bytes=0):
+        return self.coli.model_banner_line(str(self.make_model(config, shard_bytes)))
+
+    def test_each_engine_names_itself(self):
+        for model_type, expected in (
+            ("glm5_moe", "GLM-5.2"),
+            ("inkling", "Inkling"),
+            ("kimi_k3", "Kimi K3"),
+            ("deepseek_v4", "DeepSeek V4 Flash"),
+            ("olmoe", "OLMoE"),
+        ):
+            with self.subTest(model_type=model_type):
+                line = self.line({"model_type": model_type, "n_routed_experts": 8})
+                self.assertTrue(line.startswith(expected), line)
+
+    def test_deepseek_v4_is_not_read_as_glm(self):
+        """The regression this exists for: a non-GLM checkpoint said GLM-5.2."""
+        line = self.line({"model_type": "deepseek_v4", "n_routed_experts": 256})
+        self.assertNotIn("GLM", line)
+        self.assertNotIn("744B", line)
+
+    def test_unknown_model_states_its_own_type(self):
+        """No forcing into the roster: an unknown checkpoint speaks for itself."""
+        line = self.line({"model_type": "qwen3_moe", "num_hidden_layers": 48,
+                          "n_routed_experts": 128})
+        self.assertIn("qwen3_moe", line)
+        self.assertIn("48L x 128E", line)
+        self.assertNotIn("GLM", line)
+
+    def test_missing_model_type_does_not_invent_one(self):
+        line = self.line({"num_hidden_layers": 32})
+        self.assertIn("unknown model", line)
+        self.assertNotIn("GLM-5.2", line)
+
+    def test_no_model_keeps_the_generic_tagline(self):
+        self.assertIn("GLM-5.2", self.coli.model_banner_line(None))
+
+    def test_unreadable_model_falls_back_instead_of_raising(self):
+        """`coli info` banners before validating the path; it must not crash."""
+        self.assertIn("GLM-5.2", self.coli.model_banner_line("/nonexistent/xyz"))
+
+    def test_size_is_reported_without_rounding_to_zero(self):
+        small = self.line({"model_type": "olmoe"}, shard_bytes=4_200_000_000)
+        self.assertIn("4.2 GB on disk", small)
+        large = self.line({"model_type": "glm5_moe"}, shard_bytes=372_000_000_000)
+        self.assertIn("372 GB on disk", large)
+        tiny = self.line({"model_type": "olmoe"}, shard_bytes=3_000_000)
+        self.assertIn("MB on disk", tiny)
+
+    def test_model_is_keyword_only(self):
+        """banner(sub, x) must not read x as a path: other PRs add arguments."""
+        with self.assertRaises(TypeError):
+            self.coli.banner("run", True)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`coli chat`, `run`, `info`, `plan` and `tune` all printed the same third banner line whatever you loaded:

```
GLM-5.2 · 744B MoE · int4 · streaming CPU
```

Start a chat with Inkling, Kimi K3, OLMoE or the new DeepSeek V4 engine and the banner still said GLM-5.2 · 744B. With four engines in the tree and a fifth arriving, that is no longer a cosmetic detail — it is the first thing the TUI tells you, and it was false four times out of five.

## Where the wrongness actually lives

Not in `banner()`. In what `banner()` would have had to ask:

```python
def model_arch(model):
    ...
    return "glm"          # every unrecognised model_type lands here
```

That default is **right for its job**. `colibri.c` is the general engine, so an unknown checkpoint should be offered to it rather than refused. It is simply the wrong answer to a different question — *what did the user load* — and the banner needs that one.

So `model_banner_line()` reads the raw `model_type` and leaves the dispatch in `model_arch()` untouched. No engine-selection behaviour changes.

## What it prints now

```
GLM-5.2 · 744B MoE · 372 GB on disk
Inkling · 975B MoE · 469 GB on disk
Kimi K3 · 2.8T MoE · 1.1 TB on disk
DeepSeek V4 Flash · 284B MoE · 167 GB on disk
OLMoE · 7B MoE · 4.2 GB on disk
qwen3_moe · 48L x 128E MoE · 61 GB on disk        ← not in the roster
```

Three decisions worth stating, because each one is a place where it would have been easy to lie:

**Parameter counts come from the README roster.** Same numbers, one source; they cannot drift apart without someone noticing.

**An unrecognised `model_type` is not forced into a name.** It prints its own type and the geometry measured from its own config. Guessing "GLM-5.2" for a Qwen checkpoint is exactly the bug being fixed, and inventing a nicer-looking wrong answer is not an improvement over the old one.

**A model with no `config.json`, or an unreadable path, keeps the original tagline.** `coli info` banners *before* it validates the model directory, so this had to be safe on a bad path — there is a test for it.

## Cost

Size is measured by `stat`-ing the shards. No safetensors headers are parsed: a banner runs before every command and may not cost a scan of a 400 GB checkpoint. The whole line is one `config.json` read plus one `stat` per shard.

## For the other PRs that touch `banner()`

#825 and #670 both change `banner("run")` into `banner("run", <cuda flag>)`, positionally. `model=` here is therefore **keyword-only**, so a second positional argument raises `TypeError` rather than being silently read as a path. `test_model_is_keyword_only` pins that.

Whichever of us lands second gets a trivial one-line conflict instead of a banner that tries to open `True` as a directory.

## Tests

Eight new cases in `tests/test_cli_output.py`, run with the existing suite (16/16 green):

- every engine names itself
- **the regression itself** — a `deepseek_v4` config must not produce a line containing `GLM` or `744B`
- an unknown `model_type` states its own type and its measured geometry
- a config with no `model_type` says `unknown model` rather than inventing one
- no model, and an unreadable path, both keep the generic tagline without raising
- sizes do not round to `0 GB` on a small checkpoint
- `model=` is keyword-only
