### PR TITLE
fix(v4): add missing sys/resource.h header for getrusage

### DIFF
--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -1,6 +1,8 @@
 /* Amalgamated deepseek_v4.c — GLM-style source; compile with -DCOLI_V4_UNIT_* per object */
 /* Umbrella API: deepseek_v4.h (included by units) */
 
+#include <sys/resource.h>
+
 #ifdef COLI_V4_UNIT_ST
 /* Shared st.h adapter and V4 tensor materialization helpers. */
 #include "deepseek_v4_internal.h"


### PR DESCRIPTION
Fixes a compilation break on Linux/WSL platforms where struct rusage and getrusage storage layouts are unrecognized.