### PR TITLE
ci(release): attach to an existing release instead of failing on it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,25 @@ jobs:
           if [ -z "$NOTES" ]; then
             NOTES="Release ${TAG}"
           fi
-          gh release create "$TAG" artifacts/* \
-            --title "colibri ${TAG}" \
-            --notes "$NOTES"
+          # Attach to an existing release rather than failing on it.
+          #
+          # `gh release create` errors with "a release with the same tag name
+          # already exists" whenever the release was published by hand before
+          # the tag build finished -- which is how any release with hand-written
+          # notes happens. v1.5.0 hit exactly that: all three platforms built,
+          # the checksums printed, and then the job went red having attached
+          # nothing, so the release had notes and no downloads until the
+          # artifacts were recovered from that run by hand.
+          #
+          # Uploading is the operation that matters and --clobber makes it
+          # idempotent, so upload when the release exists and write notes only
+          # when creating one. Notes a human already published are never
+          # overwritten by the CHANGELOG fallback.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG already exists — uploading artifacts to it"
+            gh release upload "$TAG" artifacts/* --clobber
+          else
+            gh release create "$TAG" artifacts/* \
+              --title "colibri ${TAG}" \
+              --notes "$NOTES"
+          fi


### PR DESCRIPTION
`gh release create` errors with *"a release with the same tag name already exists"* whenever a human published the release before the tag build finished — which is how any release with hand-written notes happens.

**v1.5.0 hit exactly that.** All three platforms built, `SHA256SUMS` printed, and then the job went red having attached nothing. The release had notes and **no downloads** until the artifacts were pulled out of that run by hand and uploaded — after verifying their checksums against the ones the job had already printed:

```
47102858…  colibri-v1.5.0-linux-x86_64.tar.gz
ad7039d3…  colibri-v1.5.0-macos-arm64.tar.gz
739dc920…  colibri-v1.5.0-windows-x86_64.zip
```

Uploading is the operation that matters and `--clobber` makes it idempotent, so upload when the release exists and create only when it does not. Notes a human already published are never overwritten by the CHANGELOG fallback.

**Separately, and not fixed here:** `CHANGELOG.md` stops at `1.1.1`, four releases back. The note-extraction step has therefore been falling through to `"Release vX.Y.Z"` for a while — worth a follow-up.