### PR TITLE
fix(api): reasoning_effort rendered Max for every level except high

### DIFF
--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -782,7 +782,18 @@ def render_chat(messages, enable_thinking=False, reasoning_effort=None, tools=No
         raise APIError(400, "`messages` must be a non-empty array.", "messages")
     prompt = ["[gMASK]<sop>"]
     if enable_thinking:
-        effort = "High" if reasoning_effort == "high" else "Max"
+        # The endpoint accepts none/minimal/low/medium/high/xhigh, and this used
+        # to render every one of them except "high" as Max -- so a client asking
+        # for `minimal` got more reasoning than one asking for `high`, and the
+        # mapping was not even monotonic (#809). On a single machine that is not
+        # a cosmetic mismatch: unrequested reasoning spends the token budget
+        # before the answer starts.
+        #
+        # GLM-5.2's template takes a word here, not a number, so the levels map
+        # onto the ones it understands, in order. `none` cannot appear: it turns
+        # thinking off upstream and never reaches this branch.
+        effort = {"minimal": "Low", "low": "Low", "medium": "Medium",
+                  "high": "High", "xhigh": "Max"}.get(reasoning_effort, "High")
         prompt.append(f"<|system|>Reasoning Effort: {effort}")
     forced = None
     if isinstance(tool_choice, dict):

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -1748,5 +1748,44 @@ class ConnectionLimitTest(unittest.TestCase):
                          "dripping connections were never reclaimed")
 
 
+class ReasoningEffortTest(unittest.TestCase):
+    """render_chat mapped every level except "high" onto Max (#809).
+
+    The endpoint accepts none/minimal/low/medium/high/xhigh. Four of the five
+    that enable thinking rendered Max, so a client asking for `minimal` got
+    more reasoning than one asking for `high` -- and on a single machine
+    unrequested reasoning spends the token budget before the answer starts.
+    """
+
+    MESSAGES = [{"role": "user", "content": "hi"}]
+
+    def effort(self, level):
+        import re
+        text = render_chat(self.MESSAGES, enable_thinking=True,
+                           reasoning_effort=level)
+        found = re.search(r"Reasoning Effort: (\w+)", text)
+        return found.group(1) if found else None
+
+    def test_levels_are_distinct_and_ordered(self):
+        rendered = [self.effort(l) for l in
+                    ("minimal", "low", "medium", "high", "xhigh")]
+        rank = {"Low": 0, "Medium": 1, "High": 2, "Max": 3}
+        scores = [rank[r] for r in rendered]
+        self.assertEqual(scores, sorted(scores), rendered)
+        self.assertLess(scores[0], scores[-1],
+                        "minimal and xhigh render the same effort")
+
+    def test_minimal_is_not_max(self):
+        """The reported symptom, pinned on its own."""
+        self.assertNotEqual(self.effort("minimal"), "Max")
+        self.assertNotEqual(self.effort("low"), "Max")
+        self.assertNotEqual(self.effort("medium"), "Max")
+
+    def test_thinking_off_emits_no_effort_line(self):
+        text = render_chat(self.MESSAGES, enable_thinking=False,
+                           reasoning_effort="xhigh")
+        self.assertNotIn("Reasoning Effort", text)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The endpoint accepts `none/minimal/low/medium/high/xhigh`. `render_chat` did:

```python
effort = "High" if reasoning_effort == "high" else "Max"
```

So four of the five levels that enable thinking rendered **Max**, and the mapping was not even monotonic — a client asking for `minimal` got *more* reasoning than one asking for `high`.

| requested | before | after |
|---|---|---|
| `minimal` | **Max** | Low |
| `low` | **Max** | Low |
| `medium` | **Max** | Medium |
| `high` | High | High |
| `xhigh` | **Max** | Max |

On a single machine this is not cosmetic. Unrequested reasoning spends the token budget before the answer starts — the same effect behind #814, where a user concluded the model could not reason at all because `THINK` was off. This is the opposite failure: asking for less produced the most.

GLM-5.2's template takes a word rather than a number, so the levels map onto the ones it understands, in order. `none` cannot reach this branch — it turns thinking off upstream.

**Three tests**, including the reported symptom pinned on its own: the levels are ordered and distinct, `minimal`/`low`/`medium` are specifically not `Max`, and thinking-off still emits no effort line. Full suite: 117 green.

Reported by @ThefloorMiner.

Closes #809