### PR TITLE
fix(doctor): name the shard that failed to read

### DIFF
--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -47,7 +47,19 @@ def analyze_model(model):
     dense_bytes = 0
     expert_groups = {}
     for shard in shards:
-        for name, size in _tensor_sizes(shard):
+        try:
+            sizes = list(_tensor_sizes(shard))
+        except OSError as error:
+            # Name the file. An OSError raised by read() on an already-open
+            # stream carries no filename, so `coli doctor` reported bare
+            # "[Errno 5] Input/output error" for a bad sector or a dropped
+            # network mount — indistinguishable from a corrupt download, which
+            # is what the reporter in #191 assumed and re-downloaded 372 GB to
+            # rule out. Which shard failed is the whole diagnosis: one file is
+            # storage, all of them is the mount.
+            raise OSError(error.errno,
+                          f"{error.strerror or error}: {shard}") from error
+        for name, size in sizes:
             match = EXPERT_RE.search(name)
             if match:
                 key = tuple(map(int, match.groups()))


### PR DESCRIPTION
`coli doctor` reported a bare

```
[fail] model.shards    [Errno 5] Input/output error
```

with no indication of **which file**. An `OSError` raised by `read()` on an already-open stream carries no filename, and `doctor.py` prints `str(error)` — so EIO from a bad sector or a dropped network mount looked exactly like a corrupt download.

In #191 the reporter drew that conclusion and **re-downloaded a 372 GB model** to rule it out. It was not the download.

Which shard failed is the whole diagnosis: **one file points at storage, all of them point at the mount.** `analyze_model` now attaches the path:

```
[Errno 5] Input/output error: /mnt/llm/colibri/glm52/model-00042-of-00096.safetensors
```

Errors that already named the file — the `ValueError`s in `_tensor_sizes` for a short or invalid header — are unchanged. 37 resource-plan tests and 28 doctor tests pass.