### PR TITLE
Handle SIGTERM, and drop the SA_RESTART that would have made it useless

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -6051,13 +6051,34 @@ static int grammar_draft(GrDraft *g, int *draft, int cap){
  * killing the engine; :more can continue the interrupted answer. Armed only
  * in the serve loops; one-shot runs keep default SIGINT. POSIX only. */
 static volatile sig_atomic_t g_intr=0;
+/* #810: SIGINT and SIGTERM mean different things and cannot share a flag. SIGINT is a
+ * SOFT stop -- it ends the current turn and the serve loop clears g_intr and keeps
+ * serving. SIGTERM is a request to shut down, so it needs a flag the loop does NOT
+ * clear. It sets g_intr too, so the in-flight turn unwinds through the ordinary path
+ * (stats, usage_save, KV append, END sentinel) instead of being torn down. */
+static volatile sig_atomic_t g_shutdown=0;
 #if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
 static void intr_sig(int s){ (void)s; g_intr=1; }
+static void term_sig(int s){ (void)s; g_intr=1; g_shutdown=1; }
 static void intr_install(void){
     struct sigaction sa; memset(&sa,0,sizeof(sa));
     sa.sa_handler=intr_sig; sigemptyset(&sa.sa_mask);
     sa.sa_flags=SA_RESTART;              /* getline/pread non devono vedere EINTR */
     sigaction(SIGINT,&sa,NULL);
+    /* SIGTERM deliberately WITHOUT SA_RESTART. The serve loop blocks in getline()
+     * waiting for the next request, and SA_RESTART would silently resume that read
+     * after the handler ran -- the flag would be set and never looked at again, so
+     * `systemctl stop` would hang until its TimeoutStopSec expired into SIGKILL.
+     * Without it, getline() returns -1/EINTR and the loop exits through its normal
+     * end. The original reason for SA_RESTART was "getline/pread must not see EINTR",
+     * and the pread half no longer applies: every read path retries EINTR itself
+     * (st.h st_pread_full, the mirror loop here, uring.h). getline is the only caller
+     * that needed protecting, and it is precisely the one a shutdown must interrupt.
+     * select() in run_serve_mux is unaffected: it tests `> 0`, so an EINTR return is
+     * just "no input this round" and the next iteration sees the flag. */
+    sa.sa_handler=term_sig;
+    sa.sa_flags=0;
+    sigaction(SIGTERM,&sa,NULL);
 }
 #else
 static void intr_install(void){}
@@ -7302,6 +7323,11 @@ static void run_serve_mux(Model *m, const char *snap){
                                           * via normale di mux_done (DONE+stats+KV coerenti) */
             for(int i=0;i<nctx;i++) if(req[i].active) mux_done(m,&ctx[i],&req[i]);
         }
+        /* #810: SIGTERM. Ordered AFTER the mux_done sweep above on purpose -- the
+         * in-flight requests finish through their normal path first, then the loop
+         * ends. With no active request select() blocks with a NULL timeout, so the
+         * EINTR from an un-restarted SIGTERM is what wakes us to reach this line. */
+        if(g_shutdown) break;
         int active=0; for(int i=0;i<nctx;i++) active+=req[i].active;
         /* Poll stdin for available input without blocking. On POSIX this is
          * select(); on Windows, select() on a pipe handle routes to winsock
@@ -7466,7 +7492,7 @@ static void run_serve(Model *m, const char *snap){
     intr_install();                      /* Ctrl-C = fine turno, non fine processo */
     printf("\x01\x01" "READY" "\x01\x01\n"); printf("STAT 0 0.00 0.0 %.2f\n", rss_gb()); fflush(stdout);
     tiers_emit(m);
-    while((nr=getline(&line,&cap,stdin))>0){
+    while(!g_shutdown && (nr=getline(&line,&cap,stdin))>0){
         g_intr=0;                        /* interruzioni arrivate tra i turni: stantie */
         if(nr>0 && line[nr-1]=='\n') line[--nr]=0;
         if(!strcmp(line,"\x02RESET")){ len=0; first=1; if(m->has_mtp) m->kv_start[m->c.n_layers]=-1;


### PR DESCRIPTION
Closes the engine half of #810. @ThefloorMiner's report and your source diagnosis; the fix is the one you specified, plus the part that turned out to be load-bearing.

## Adding SIGTERM to `intr_install` is not enough

You wrote:

> That is one line in `intr_install` plus **making sure the flag actually breaks the serve read loop** rather than only the generation loop.

That second clause is the whole difficulty, and the obstacle is the flag already there:

```c
sa.sa_flags = SA_RESTART;   /* getline/pread non devono vedere EINTR */
```

`run_serve` blocks in `getline()` waiting for the next request. With `SA_RESTART`, the handler runs, sets the flag, and **the read resumes** — nothing ever looks at the flag again, and the stop hangs until systemd's `TimeoutStopSec` escalates to SIGKILL. Which would have replaced a wrong exit code with a worse failure: the learned cache lost to a kill, exactly what you wanted this fix to protect.

Measured rather than assumed — minimal repro, handler set both ways, signal delivered while blocked in `getline` on a pipe nobody writes to:

```
no-SA_RESTART  getline=-1  errno=Interrupted system call  flag=1
SA_RESTART     still blocked after 2 s                    flag=1
```

`flag=1` in both: the handler ran either way. Only one of them lets the loop notice.

## The comment's other half has expired

`getline/pread non devono vedere EINTR` — the `pread` half no longer applies. Every read path retries `EINTR` itself now:

| | |
|---|---|
| `st.h:267` | `st_pread_full`, added by #331 |
| `colibri.c:2126` | the mirror loop, #236 |
| `uring.h:123` | |

`getline` is the only caller `SA_RESTART` still protects, and it is precisely the one a shutdown must interrupt. So **SIGTERM is installed without it; SIGINT keeps it and is otherwise untouched.**

## The two signals cannot share `g_intr`

SIGINT is a *soft* stop — both serve loops clear `g_intr` and keep serving. Reusing it for SIGTERM would turn Ctrl-C into "quit", a regression in the behaviour you documented as deliberate.

So `g_shutdown` is separate and never cleared, while `term_sig` sets `g_intr` **as well**, so an in-flight turn unwinds through its ordinary path — stats, `usage_save`, KV append, `END` sentinel — rather than being torn down. Both loops then end and reach the existing `if(stats) stats_dump(&m,stats); return 0;`.

Both serve paths covered:

- **`run_serve`** tests `g_shutdown` before blocking again, so a SIGTERM arriving *mid-generation* does not leave it parked in the next `getline`.
- **`run_serve_mux`** breaks **after** its `mux_done` sweep, so in-flight requests finish first. With no active request that loop blocks in `select()` with a NULL timeout, and the `EINTR` from the un-restarted SIGTERM is what wakes it to reach the check. `select` is otherwise unaffected — it tests `> 0`, so `EINTR` reads as "no input this round" and the next iteration sees the flag.

Named `g_shutdown` rather than `g_stop` because `sample.h` already has a `g_stop` token array.

## Verification, and what it does not cover

- signal registration confirmed in the disassembly: `$0x2` → `intr_sig`, `$0xf` → `term_sig`
- `SA_RESTART` mechanism measured above
- clean build, zero warnings, `make test-c` passes

**Not verified end to end.** The engine needs a quantised `SNAP=` directory and this box has only raw safetensors, so I could not run a live `serve` and stop it.

## One thing I could not explain, @ThefloorMiner

Your log shows `code=exited, status=1/FAILURE`. With no handler installed, the default disposition for SIGTERM is *termination by signal*, which systemd records as `code=killed, signal=TERM` — not `exited, status=1`. So something is catching it and returning 1, and it may not be the engine: `coli` is a Python wrapper around the binary, and `KillMode` decides whether systemd signals the wrapper, the engine, or both.

This change is correct regardless — SIGTERM should end the turn cleanly and save the usage history rather than kill the process. But whether it fully removes *your* `status=1` depends on that. **Could you post the unit file?** If the wrapper is the one exiting 1, that is a second fix and it belongs in `coli`, not here.