### PR TITLE
fix: exit cleanly on SIGTERM

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -732,6 +732,9 @@ iobench$(EXE): iobench.c compat.h
 tests/test_serve_sentinel$(EXE): tests/test_serve_sentinel.c compat.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
+tests/test_sigterm$(EXE): tests/test_sigterm.c serve_signal.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
 tests/test_ue8m0$(EXE): tests/test_ue8m0.c st.h json.h compat.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -6043,25 +6043,16 @@ static int grammar_draft(GrDraft *g, int *draft, int cap){
 /* STOP MORBIDO (serve/chat): SIGINT chiude il turno CORRENTE per la stessa via
  * del tetto NGEN (stats, usage_save, KV append, sentinella END tutti normali)
  * invece di uccidere il motore; :more puo' continuare la risposta interrotta.
+ * SIGTERM usa la stessa chiusura morbida, poi termina il serve-loop con successo.
  * Il flag e' armato solo nei serve-loop (intr_install): nei run one-shot e in
- * validazione SIGINT resta il default (morte immediata). Solo POSIX: su
+ * validazione SIGINT/SIGTERM restano default. Solo POSIX: su
  * Windows il comportamento di Ctrl-C non cambia.
  * EN: soft stop (serve/chat): SIGINT ends the CURRENT turn through the same
  * path as the NGEN cap — stats/usage/KV/END sentinel all normal — instead of
- * killing the engine; :more can continue the interrupted answer. Armed only
- * in the serve loops; one-shot runs keep default SIGINT. POSIX only. */
-static volatile sig_atomic_t g_intr=0;
-#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
-static void intr_sig(int s){ (void)s; g_intr=1; }
-static void intr_install(void){
-    struct sigaction sa; memset(&sa,0,sizeof(sa));
-    sa.sa_handler=intr_sig; sigemptyset(&sa.sa_mask);
-    sa.sa_flags=SA_RESTART;              /* getline/pread non devono vedere EINTR */
-    sigaction(SIGINT,&sa,NULL);
-}
-#else
-static void intr_install(void){}
-#endif
+ * killing the engine; :more can continue the interrupted answer. SIGTERM uses
+ * that same soft-stop path, then exits the serve loop successfully. Armed only
+ * in serve loops; one-shot runs keep default SIGINT/SIGTERM. POSIX only. */
+#include "serve_signal.h"
 /* #678: mid-turn STOP/CANCEL for the single-slot speculative serve path. With
  * KV_SLOTS=1 the whole turn runs inside ONE spec_decode call, so run_serve_mux's
  * stdin poll never runs mid-turn and a server-sent STOP (raised when its stop
@@ -7302,6 +7293,7 @@ static void run_serve_mux(Model *m, const char *snap){
                                           * via normale di mux_done (DONE+stats+KV coerenti) */
             for(int i=0;i<nctx;i++) if(req[i].active) mux_done(m,&ctx[i],&req[i]);
         }
+        if(g_term) break;
         int active=0; for(int i=0;i<nctx;i++) active+=req[i].active;
         /* Poll stdin for available input without blocking. On POSIX this is
          * select(); on Windows, select() on a pipe handle routes to winsock
@@ -7311,9 +7303,12 @@ static void run_serve_mux(Model *m, const char *snap){
         int ready=0;
         if(!eof){
 #if defined(__APPLE__) || defined(__linux__) ||	defined(__FreeBSD__)
-            fd_set rfds; FD_ZERO(&rfds); FD_SET(STDIN_FILENO,&rfds);
+            fd_set rfds; FD_ZERO(&rfds);
+            FD_SET(STDIN_FILENO,&rfds); FD_SET(g_term_pipe_r,&rfds);
+            int maxfd=STDIN_FILENO>g_term_pipe_r?STDIN_FILENO:g_term_pipe_r;
             struct timeval tv={0,0}, *ptv=active?&tv:NULL;
-            ready=select(STDIN_FILENO+1,&rfds,NULL,NULL,ptv);
+            ready=select(maxfd+1,&rfds,NULL,NULL,ptv);
+            if(ready>0 && FD_ISSET(g_term_pipe_r,&rfds)){ term_pipe_drain(); ready=0; }
             if(ready>0 && FD_ISSET(STDIN_FILENO,&rfds))
 #elif defined(_WIN32)
             HANDLE ih=(HANDLE)_get_osfhandle(_fileno(stdin));
@@ -7466,7 +7461,8 @@ static void run_serve(Model *m, const char *snap){
     intr_install();                      /* Ctrl-C = fine turno, non fine processo */
     printf("\x01\x01" "READY" "\x01\x01\n"); printf("STAT 0 0.00 0.0 %.2f\n", rss_gb()); fflush(stdout);
     tiers_emit(m);
-    while((nr=getline(&line,&cap,stdin))>0){
+    while(!g_term && (nr=getline(&line,&cap,stdin))>0){
+        if(g_term) break;
         g_intr=0;                        /* interruzioni arrivate tra i turni: stantie */
         if(nr>0 && line[nr-1]=='\n') line[--nr]=0;
         if(!strcmp(line,"\x02RESET")){ len=0; first=1; if(m->has_mtp) m->kv_start[m->c.n_layers]=-1;

--- a/c/serve_signal.h
+++ b/c/serve_signal.h
@@ -1,0 +1,84 @@
+#ifndef COLI_SERVE_SIGNAL_H
+#define COLI_SERVE_SIGNAL_H
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static volatile sig_atomic_t g_intr=0, g_term=0;
+
+#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
+
+#include <fcntl.h>
+#include <unistd.h>
+
+/*
+ * SIGINT remains a turn-only soft stop. SIGTERM requests the same soft stop,
+ * then exits the serve loop through its normal usage/KV cleanup path.
+ *
+ * Keep SA_RESTART for both signals: model reads may run on any engine thread
+ * and must not acquire new EINTR behavior during shutdown. A nonblocking
+ * self-pipe wakes the mux input select even when another thread gets SIGTERM.
+ */
+static int g_term_pipe_r=-1;
+static volatile sig_atomic_t g_term_pipe_w=-1;
+
+static void intr_sig(int s){ (void)s; g_intr=1; }
+
+static void term_sig(int s){
+    int saved_errno=errno;
+    (void)s;
+    g_intr=1;
+    g_term=1;
+    if(g_term_pipe_w>=0){
+        unsigned char wake=1;
+        ssize_t wake_result=write((int)g_term_pipe_w,&wake,1);
+        (void)wake_result;
+    }
+    errno=saved_errno;
+}
+
+static int term_pipe_init(void){
+    if(g_term_pipe_r>=0) return 0;
+    int fds[2];
+    if(pipe(fds)!=0) return -1;
+    int flags=fcntl(fds[1],F_GETFL,0);
+    if(flags<0 || fcntl(fds[1],F_SETFL,flags|O_NONBLOCK)<0 ||
+       fcntl(fds[0],F_SETFD,FD_CLOEXEC)<0 ||
+       fcntl(fds[1],F_SETFD,FD_CLOEXEC)<0){
+        int saved_errno=errno;
+        close(fds[0]); close(fds[1]);
+        errno=saved_errno;
+        return -1;
+    }
+    g_term_pipe_r=fds[0];
+    g_term_pipe_w=fds[1];
+    return 0;
+}
+
+static void intr_install(void){
+    if(term_pipe_init()!=0){ perror("SIGTERM wake pipe"); exit(1); }
+    struct sigaction sa; memset(&sa,0,sizeof(sa));
+    sa.sa_handler=intr_sig; sigemptyset(&sa.sa_mask);
+    sa.sa_flags=SA_RESTART;
+    if(sigaction(SIGINT,&sa,NULL)!=0){ perror("sigaction(SIGINT)"); exit(1); }
+    sa.sa_handler=term_sig;
+    if(sigaction(SIGTERM,&sa,NULL)!=0){ perror("sigaction(SIGTERM)"); exit(1); }
+}
+
+static void term_pipe_drain(void){
+    unsigned char wake;
+    ssize_t wake_result=read(g_term_pipe_r,&wake,1);
+    (void)wake_result;
+}
+
+#else
+
+/* Windows behavior is intentionally unchanged; systemd/SIGTERM is POSIX-only. */
+static void intr_install(void){}
+
+#endif
+
+#endif

--- a/c/tests/test_sigterm.c
+++ b/c/tests/test_sigterm.c
@@ -1,0 +1,121 @@
+#include <stdio.h>
+
+#ifdef _WIN32
+
+int main(void){
+    puts("test_sigterm: skipped (POSIX-only)");
+    return 0;
+}
+
+#else
+
+#include <pthread.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include "../serve_signal.h"
+
+static int fails;
+
+static void check(int cond,const char *what){
+    printf("  %s %s\n",cond?"ok  ":"FAIL",what);
+    if(!cond) fails++;
+}
+
+static int child_exited_zero(pid_t pid){
+    for(int i=0;i<200;i++){
+        int status=0;
+        pid_t got=waitpid(pid,&status,WNOHANG);
+        if(got==pid) return WIFEXITED(status)&&WEXITSTATUS(status)==0;
+        if(got<0) return 0;
+        usleep(10000);
+    }
+    kill(pid,SIGKILL);
+    waitpid(pid,NULL,0);
+    return 0;
+}
+
+static void *send_sigterm(void *unused){
+    (void)unused;
+    usleep(50000);
+    raise(SIGTERM);
+    return NULL;
+}
+
+static char *source_text(void){
+    FILE *f=fopen("colibri.c","rb");
+    if(!f) return NULL;
+    if(fseek(f,0,SEEK_END)!=0){ fclose(f); return NULL; }
+    long n=ftell(f);
+    if(n<0 || fseek(f,0,SEEK_SET)!=0){ fclose(f); return NULL; }
+    char *text=malloc((size_t)n+1);
+    if(!text){ fclose(f); return NULL; }
+    size_t got=fread(text,1,(size_t)n,f);
+    fclose(f);
+    text[got]=0;
+    return got==(size_t)n?text:(free(text),NULL);
+}
+
+static int occurrences(const char *text,const char *needle){
+    int count=0;
+    for(const char *p=text;(p=strstr(p,needle));p+=strlen(needle)) count++;
+    return count;
+}
+
+int main(void){
+    struct sigaction sa;
+    intr_install();
+
+    check(sigaction(SIGTERM,NULL,&sa)==0,"SIGTERM disposition is readable");
+    check(sa.sa_handler==term_sig,"SIGTERM uses the graceful-stop handler");
+    check((sa.sa_flags&SA_RESTART)!=0,"SIGTERM preserves SA_RESTART for model I/O");
+
+    g_intr=0; g_term=0;
+    raise(SIGINT);
+    check(g_intr==1 && g_term==0,"SIGINT remains a turn-only soft stop");
+
+    int input[2];
+    check(pipe(input)==0,"idle-shutdown fixture pipe opens");
+    pid_t pid=fork();
+    if(pid==0){
+        close(input[1]);
+        if(dup2(input[0],STDIN_FILENO)<0) _exit(10);
+        close(input[0]);
+        g_intr=0; g_term=0;
+        pthread_t sender;
+        if(pthread_create(&sender,NULL,send_sigterm,NULL)!=0) _exit(11);
+        fd_set rfds; FD_ZERO(&rfds);
+        FD_SET(STDIN_FILENO,&rfds); FD_SET(g_term_pipe_r,&rfds);
+        int maxfd=STDIN_FILENO>g_term_pipe_r?STDIN_FILENO:g_term_pipe_r;
+        int ready=select(maxfd+1,&rfds,NULL,NULL,NULL);
+        pthread_join(sender,NULL);
+        _exit(ready>0 && FD_ISSET(g_term_pipe_r,&rfds) &&
+              g_intr==1 && g_term==1 ? 0 : 12);
+    }
+    close(input[0]);
+    check(pid>0 && child_exited_zero(pid),
+          "worker-thread SIGTERM wakes mux select and exits zero");
+    close(input[1]);
+
+    char *source=source_text();
+    check(source!=NULL,"engine source is readable by the regression test");
+    if(source){
+        check(strstr(source,"#include \"serve_signal.h\"")!=NULL,
+              "engine uses the tested signal module");
+        check(occurrences(source,"if(g_term) break;")>=2,
+              "both serve loops have a termination gate");
+        check(strstr(source,"FD_SET(g_term_pipe_r,&rfds)")!=NULL,
+              "mux select watches the SIGTERM wake pipe");
+        check(strstr(source,"fread(raw,1,(size_t)sub.bytes,stdin)")!=NULL,
+              "mux payload framing remains on the existing stdio path");
+        free(source);
+    }
+
+    printf("test_sigterm: %s\n",fails?"FAILED":"ok");
+    return fails?1:0;
+}
+
+#endif


### PR DESCRIPTION
Fixes #810.

  SIGTERM now wakes the mux loop through a POSIX self-pipe, runs the existing soft-stop cleanup, and
  exits with status 0. SIGINT behavior, request framing, Windows behavior, and dependencies remain
  unchanged.

  Adds a regression test for worker-thread SIGTERM delivery and clean exit.

  ## Validation

  - [x ] make -C c check
  - [x] CUDA testing not applicable
  - [x] No performance claims

  Full C tests passed on Ubuntu. The focused regression and CPU build passed on macOS.

  Manual test on Ubuntu/Acer using three terminals:

  Terminal 1:

```
  systemctl --user start colibri-810.service
  journalctl --user -fu colibri-810.service
```

  Terminal 2:

```
  python3 - <<'PY' >/tmp/request.json
  import json
  print(json.dumps({
      "model": "glm-tiny",
      "messages": [{"role": "user", "content": "Keep generating output. " * 200}],
      "max_tokens": 4096,
      "stream": True
  }))
  PY
```

```
  curl -N -H 'Content-Type: application/json' \
    --data-binary @/tmp/request.json \
    http://127.0.0.1:8765/v1/chat/completions
```

  Terminal 3, while the request is streaming:

```
  systemctl --user stop colibri-810.service
  systemctl --user show colibri-810.service \
    -p Result -p ExecMainStatus -p ActiveState
```

  Observed:

```
  finish_reason: stop
  data: [DONE]
  Result=success
  ExecMainStatus=0
  ActiveState=inactive
```

  Usage and KV state were persisted. No timeout or SIGKILL occurred.

  ## Compatibility

  - [x] The default CPU build remains dependency-free
  - [x] No model files, generated binaries, or benchmark artifacts are included