### PR TITLE
release: ship deepseek_v4 in the archives (#858)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,17 @@ jobs:
           - os: ubuntu-latest
             name: linux
             shell: bash
+            v4: "1"
           - os: macos-latest
             name: macos
             shell: bash
+            # No v4: the engine builds on x86-64 Linux/Windows and aarch64 Linux
+            # only (COLI_V4_SUPPORTED in c/Makefile); the target exits 1 here.
           - os: windows-latest
             name: windows
             # GitHub shells are format strings: 'msys2 {0}', never bare 'msys2'.
             shell: "msys2 {0}"
+            v4: "1"
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -90,11 +94,18 @@ jobs:
             mingw-w64-ucrt-x86_64-binutils
       - if: matrix.os == 'macos-latest'
         run: brew install libomp
+      # "Every engine" was four of five. deepseek-v4's only CI is the Linux
+      # v4-tiny job in check.yml, so the MSYS2 build of that engine had no job
+      # anywhere -- the release tag compiled it on Windows for the first time.
+      # The hyphenated target is appended rather than folded into the loop
+      # because it must not run on macos.
       - name: Build every engine
         run: |
           cd c
           rc=0
-          for t in colibri inkling kimi_k3 olmoe; do
+          ENGINES="colibri inkling kimi_k3 olmoe"
+          if [ "${{ matrix.v4 }}" = "1" ]; then ENGINES="$ENGINES deepseek-v4"; fi
+          for t in $ENGINES; do
             echo "::group::$t"
             make $t || { echo "FAILED: $t"; rc=1; }
             echo "::endgroup::"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,18 @@ jobs:
             name: linux-x86_64
             ext: ""
             make_args: "ARCH=x86-64-v3"
+            v4: "1"
           - os: macos-latest
             name: macos-arm64
             ext: ""
             make_args: ""
+            # No v4: DeepSeek V4 is x86-64 Linux/Windows + aarch64 Linux only
+            # (c/Makefile, COLI_V4_SUPPORTED). Asking for it here fails the build.
           - os: windows-latest
             name: windows-x86_64
             ext: ".exe"
             make_args: ""
+            v4: "1"
             # GitHub shells are format strings: 'msys2 {0}', never bare 'msys2'
             # (the v1.0.0 tag build failed on exactly this). Same as ci.yml.
             shell: "msys2 {0}"
@@ -61,6 +65,23 @@ jobs:
           done
           ls -lh colibri${{ matrix.ext }} inkling${{ matrix.ext }} kimi_k3${{ matrix.ext }} olmoe${{ matrix.ext }}
 
+      # DeepSeek V4 has its own Makefile and its own target name (`deepseek-v4`,
+      # producing `deepseek_v4`), so it never joined the loop above -- and #858 is
+      # the result: v1.5.0 was titled "DeepSeek V4 Flash" and shipped no
+      # deepseek_v4.exe, so `coli web --model .../DeepSeek-V4-Flash` answered
+      # "deepseek-v4 engine is not built" with the release freshly unzipped.
+      #
+      # Separate step rather than another entry in that loop because the engine
+      # builds on x86-64 Linux/Windows and aarch64 Linux only (COLI_V4_SUPPORTED);
+      # on macos-arm64 the target deliberately exits 1, and folding it in would
+      # turn that into a red release build.
+      - name: Build DeepSeek V4 engine
+        if: matrix.v4 == '1'
+        run: |
+          cd c
+          make deepseek-v4 ${{ matrix.make_args }}
+          ls -lh deepseek_v4${{ matrix.ext }}
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -97,6 +118,12 @@ jobs:
           cp c/inkling${{ matrix.ext }} dist/inkling${{ matrix.ext }}
           cp c/kimi_k3${{ matrix.ext }} dist/kimi_k3${{ matrix.ext }}
           cp c/olmoe${{ matrix.ext }} dist/olmoe${{ matrix.ext }}
+          # deepseek_v4 -- underscore, not the hyphen of the make target: engine_for()
+          # looks for "deepseek_v4" next to coli. Guarded, not unconditional, because
+          # the macos-arm64 archive has no such engine to ship (#858).
+          if [ "${{ matrix.v4 }}" = "1" ]; then
+            cp c/deepseek_v4${{ matrix.ext }} dist/deepseek_v4${{ matrix.ext }}
+          fi
           # Kimi K3 ships tiktoken.model, not tokenizer.json; k3_tokenizer.py synthesizes
           # it. Without this the engine is in the archive but `coli chat` still cannot
           # run it -- the second half of #720.
@@ -137,7 +164,12 @@ jobs:
           # a green build, green tests, and an archive with no engine for the model the
           # user actually had. Presence is not enough -- assert they are executable, and
           # that the launcher's own resolver finds them where it looks (next to coli).
-          for e in inkling kimi_k3 olmoe; do
+          SIBLINGS="inkling kimi_k3 olmoe"
+          # deepseek_v4 only where the engine builds (COLI_V4_SUPPORTED); asserting it
+          # unconditionally would fail the macos-arm64 archive for shipping an engine
+          # that platform cannot have.
+          if [ "${{ matrix.v4 }}" = "1" ]; then SIBLINGS="$SIBLINGS deepseek_v4"; fi
+          for e in $SIBLINGS; do
             test -x $e${{ matrix.ext }} || { echo "FAIL: $e missing from archive"; ls -la; exit 1; }
           done
           # Kimi K3 needs tokenizer.json synthesized from tiktoken.model; without this
@@ -149,14 +181,17 @@ jobs:
           # fine. The check was wrong, not the artifact.
           python3 -c "import ast; ast.parse(open('tools/k3_tokenizer.py', encoding='utf-8').read())" \
             || { echo "FAIL: packaged k3_tokenizer.py does not parse"; exit 1; }
-          python3 - <<'PYCHK'
+          # COLI_EXPECT rather than a literal tuple: the list is platform-dependent
+          # now, and one hardcoded list that silently omitted an engine is what #858
+          # was. Keep the expectation in a single place, above.
+          COLI_EXPECT="$SIBLINGS" python3 - <<'PYCHK'
           import os, sys
           exe = ".exe" if os.name == "nt" else ""
-          missing = [n for n in ("inkling", "kimi_k3", "olmoe")
-                     if not os.path.exists(os.path.join(".", n + exe))]
+          expect = os.environ["COLI_EXPECT"].split()
+          missing = [n for n in expect if not os.path.exists(os.path.join(".", n + exe))]
           if missing:
               sys.exit("FAIL: coli would not resolve these next to itself: " + ", ".join(missing))
-          print("OK: every engine is where coli's engine_for() looks for it")
+          print("OK: every engine is where coli's engine_for() looks for it:", " ".join(expect))
           PYCHK
           out=$(python3 coli info 2>&1 || true)
           echo "$out"

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,13 @@ c/inkling
 c/kimi_k3
 c/kimi_k3.exe
 c/olmoe.exe
+# deepseek_v4 and the per-unit objects its amalgamated Makefile leaves behind.
+# The same omission as #858, one file over: every engine is listed here except
+# the one added last, so `make deepseek-v4` left 26 untracked .o files in
+# `git status`.
+c/deepseek_v4
+c/deepseek_v4.exe
+c/COLI_V4_UNIT_*.o
 c/iobench
 c/iobench.exe
 c/tok_test


### PR DESCRIPTION
`v1.5.0` is titled **"DeepSeek V4 Flash"** and the Windows archive contains no `deepseek_v4.exe`. Unzip it, point `coli` at a DeepSeek checkpoint, and you get:

```
deepseek-v4 engine is not built. Run: make -C c deepseek-v4
```

from a release built for that model. Reported by @uvtzxpm, confirmed by @nliaudat — thank you both.

## Cause

The `Build engines` step loops over `colibri inkling kimi_k3 olmoe`. DeepSeek V4 lives in its own Makefile under a hyphenated target (`deepseek-v4`, producing `deepseek_v4`), so it never joined that loop when the engine landed. Same shape as #720, which is why the loop exists at all.

## Why it is not a one-word change

The engine builds on **x86-64 Linux/Windows and aarch64 Linux only** (`COLI_V4_SUPPORTED`, `c/Makefile`). On `macos-arm64` the target deliberately exits 1, so appending it to the loop would turn a documented platform limitation into a red release build.

So it gets a matrix flag:

| platform | `v4` | ships `deepseek_v4` |
|---|---|---|
| linux-x86_64 | `1` | yes |
| windows-x86_64 | `1` | yes |
| macos-arm64 | — | no |

and packaging plus the archive assertions follow that one flag. The binary is copied under `deepseek_v4` — underscore, not the hyphen of the make target — because that is what `coli`'s `engine_for()` looks for next to itself.

The verify step's hardcoded engine tuple now reads the same flag. A second hardcoded list that silently omitted an engine is precisely how a green build shipped an unusable archive twice.

## Checked, not assumed

- `make deepseek-v4 ARCH=x86-64-v3` builds clean here — 302 KB binary
- packaging + both archive assertions simulated for `v4=1` and `v4` unset: the first expects four siblings including `deepseek_v4`, the second three
- **negative control** with the engine deliberately absent: both the shell loop and the python resolver check fail, so the release job goes red on a regression of exactly this bug instead of publishing silently

```
CAUGHT by the shell loop: deepseek_v4 missing from archive
CAUGHT by PYCHK: coli would not resolve these next to itself: deepseek_v4
```

## Also

`.gitignore` lists every engine binary except the one added last, so `make deepseek-v4` left 26 untracked `COLI_V4_UNIT_*.o` files in `git status`. Same omission, one file over.

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)