### PR TITLE
web: open the dashboard when the engine is ready, however long that takes (#854)

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -1223,13 +1223,30 @@ def cmd_web(a):
     if not getattr(a, "no_browser", False):
         import threading, urllib.request, webbrowser
         def opener():
-            for _ in range(600):                    # the 744B engine takes minutes to load
-                time.sleep(2)
+            # No iteration cap. It used to be `for _ in range(600)` with a 2 s sleep --
+            # a 20-minute budget, sized when "the engine takes minutes to load" meant
+            # GLM. #854 reported Kimi K3 never opening the browser on a 256 GB Windows
+            # box, and the log explains itself: `[K3] init done in 2540.5s`. The thread
+            # gave up 22 minutes before the server first answered /health, so the
+            # message promising it opens automatically was simply false.
+            #
+            # A ceiling here can only ever be wrong in one direction: too low fails
+            # silently on a slow load, too high costs a sleeping daemon thread. The
+            # thread is a daemon, so it cannot outlive the server it is waiting for --
+            # there is nothing for the cap to protect against.
+            waited = 0
+            while True:
+                time.sleep(2); waited += 2
                 try:
-                    urllib.request.urlopen(f"http://{a.host}:{a.port}/health", timeout=2)
-                    webbrowser.open(url); return
+                    urllib.request.urlopen(f"http://{a.host}:{a.port}/health", timeout=5)
                 except OSError:
+                    # Say something once, rather than looking hung. A 93-layer K3 load
+                    # is 40+ minutes and the user has no way to tell waiting from stuck.
+                    if waited == 300:
+                        print(f"still loading; the dashboard will open at {url} when the "
+                              f"engine is ready (Ctrl-C to stop, or --no-browser to skip)")
                     continue
+                webbrowser.open(url); return
         threading.Thread(target=opener, daemon=True).start()
     print(f"dashboard: {url}  (opens automatically when the engine is ready)")
     cmd_serve(a)

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -1910,7 +1910,14 @@ class APIHandler(BaseHTTPRequestHandler):
                              % self.address_string())
             self.close_connection = True
             return
-        except (BrokenPipeError, ConnectionResetError):
+        except ConnectionError:
+            # ConnectionError, not (BrokenPipeError, ConnectionResetError): those two
+            # are SIBLINGS of ConnectionAbortedError under it, so the pair caught the
+            # POSIX spellings and let the Windows one through. #854's log is pages of
+            # `ConnectionAbortedError: [WinError 10053] An established connection was
+            # aborted by the software in your host machine` escaping to socketserver,
+            # from a `coli web` start that was otherwise healthy.
+            #
             # The client hung up mid-response. That is not an error here, it is
             # how HTTP clients behave: `coli chat` polls /health while the model
             # loads and drops each connection as soon as it has its answer, and
@@ -2187,8 +2194,8 @@ class APIHandler(BaseHTTPRequestHandler):
             self._fail(error, request_id)
         except ClientCancelled:
             pass
-        except (BrokenPipeError, ConnectionResetError):
-            pass
+        except ConnectionError:
+            pass                      # same widening as handle_one_request, same reason
         except Exception as error:
             self.log_error("request failed: %s", error)
             try:

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -938,6 +938,47 @@ class ClientHangupTest(unittest.TestCase):
                      timeout=2) as response:
             self.assertEqual(json.load(response)["status"], "ok")
 
+    def _abort(self, *args):
+        """Windows' spelling of the same disconnect, raised where it really lands.
+
+        In #854's log the traceback runs do_GET -> send_json -> end_headers ->
+        flush_headers -> wfile.write -> sendall, so raising from end_headers
+        reproduces the exact shape on any platform.
+        """
+        raise ConnectionAbortedError(
+            10053, "An established connection was aborted by the software in your "
+                   "host machine")
+
+    def test_windows_aborted_connection_is_not_an_error(self):
+        """ConnectionAbortedError is a SIBLING of BrokenPipeError and
+        ConnectionResetError under ConnectionError, not a subclass of either --
+        so catching the pair caught the POSIX spellings and let the Windows one
+        escape. #854 is pages of WinError 10053 tracebacks from a healthy start.
+        """
+        self.assertFalse(
+            issubclass(ConnectionAbortedError, (BrokenPipeError, ConnectionResetError)),
+            "the old except clause would have covered this; the test proves nothing")
+        with patch.object(APIHandler, "end_headers", self._abort):
+            try:
+                urlopen(f"http://127.0.0.1:{self.server.server_port}/health", timeout=2)
+            except Exception:
+                pass                      # the client sees a broken response; that is fine
+            time.sleep(0.3)
+        self.assertEqual(self.errors, [],
+                         "WinError 10053 surfaced as a server error (#854)")
+
+    def test_the_server_survives_an_aborted_connection(self):
+        """Same as the hangup case: the damage is a lost handler, not the log."""
+        with patch.object(APIHandler, "end_headers", self._abort):
+            try:
+                urlopen(f"http://127.0.0.1:{self.server.server_port}/health", timeout=2)
+            except Exception:
+                pass
+            time.sleep(0.3)
+        with urlopen(f"http://127.0.0.1:{self.server.server_port}/health",
+                     timeout=2) as response:
+            self.assertEqual(json.load(response)["status"], "ok")
+
 
 class StaticServingTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Two defects, both visible in the log @brad-evony posted on #854.

## 1. The browser never opens

`coli web` prints *"opens automatically when the engine is ready"*, then waits in a thread capped at `for _ in range(600)` with a 2 s sleep — a 20-minute budget, written when *"the engine takes minutes to load"* meant GLM.

```
opener budget      600 x 2s = 1200 s = 20.0 min
[K3] init done in             2540.5 s = 42.3 min
```

The thread gave up **22.3 minutes before the server first answered `/health`**. The promise was simply false on a 93-layer Kimi K3 load.

A ceiling here can only be wrong in one direction: too low fails silently, too high costs a sleeping daemon thread that cannot outlive the server it is waiting for. Removed. One line after five minutes now tells the user that waiting is not hanging — on a 40-minute load that is the difference between patience and Ctrl-C.

## 2. Windows disconnects escaped the handler

```python
except (BrokenPipeError, ConnectionResetError):
```

`ConnectionAbortedError` is a **sibling** of those two under `ConnectionError`, not a subclass of either:

| | caught by the pair |
|---|---|
| `BrokenPipeError` | yes |
| `ConnectionResetError` | yes |
| **`ConnectionAbortedError`** | **no** |
| `ConnectionRefusedError` | no |

So the clause caught the POSIX spellings and let the Windows one through, and #854's log is pages of

```
ConnectionAbortedError: [WinError 10053] An established connection was aborted
by the software in your host machine
```

escaping to `socketserver` from a start that was otherwise healthy — which is exactly the noise the original catch existed to remove, just not on the reporter's platform. Both sites now catch `ConnectionError`.

## Tests

`ClientHangupTest` already had the harness: it records what escapes to `socketserver` instead of printing it. #854's traceback runs `do_GET → send_json → end_headers → flush_headers → wfile.write → sendall`, so raising `ConnectionAbortedError` from `end_headers` reproduces the Windows shape on any platform.

The test asserts up front that the *old* clause would not have covered it — otherwise it would pass without proving anything.

**Negative control**, reverting only the except clauses:

```
FAIL: [ConnectionAbortedError(10053, ...)] != [] :
      WinError 10053 surfaced as a server error (#854)
```

127 tests in `test_openai_server` + `test_env_defaults`: OK.

## Not fixed here

@brad-evony's other two — #853 (K3 loads on one thread) and #855 (engine exits mid-session) — are separate, and neither is a symptom of this one. Looking at #855 next; it is the serious one.

Closes #854

🤖 Generated with [Claude Code](https://claude.com/claude-code)