### PR TITLE
docs: pixel wordmark on the README logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/colibri.svg" width="500" alt="colibrì — tiny engine, immense model">
+  <img src="assets/colibri-logo.svg" width="560" alt="colibrì — tiny engine, immense model">
 </p>
 
 <p align="center">

--- a/assets/colibri-logo.svg
+++ b/assets/colibri-logo.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1236" height="240" viewBox="0 0 1236 240">
+  <title>colibri — tiny engine, immense model</title>
+  <g transform="translate(46 34) scale(1.0)" shape-rendering="crispEdges">
+    <rect x="56" y="0" width="14" height="14" fill="#d75fd7"/>
+    <rect x="70" y="0" width="14" height="14" fill="#d75fd7"/>
+    <rect x="84" y="0" width="14" height="14" fill="#d75fd7"/>
+    <rect x="42" y="14" width="14" height="14" fill="#d75fd7"/>
+    <rect x="56" y="14" width="14" height="14" fill="#d75fd7"/>
+    <rect x="70" y="14" width="14" height="14" fill="#d75fd7"/>
+    <rect x="84" y="14" width="14" height="14" fill="#d75fd7"/>
+    <rect x="98" y="14" width="14" height="14" fill="#d75fd7"/>
+    <rect x="140" y="14" width="14" height="14" fill="#5fd7d7"/>
+    <rect x="56" y="28" width="14" height="14" fill="#d75fd7"/>
+    <rect x="70" y="28" width="14" height="14" fill="#d75fd7"/>
+    <rect x="84" y="28" width="14" height="14" fill="#d75fd7"/>
+    <rect x="98" y="28" width="14" height="14" fill="#d75fd7"/>
+    <rect x="126" y="28" width="14" height="14" fill="#5fd7d7"/>
+    <rect x="140" y="28" width="14" height="14" fill="#5fd7d7"/>
+    <rect x="0" y="42" width="14" height="14" fill="#ff8700"/>
+    <rect x="14" y="42" width="14" height="14" fill="#ff8700"/>
+    <rect x="28" y="42" width="14" height="14" fill="#ff8700"/>
+    <rect x="42" y="42" width="14" height="14" fill="#ff8700"/>
+    <rect x="56" y="42" width="14" height="14" fill="#00afaf"/>
+    <rect x="70" y="42" width="14" height="14" fill="#00afaf"/>
+    <rect x="84" y="42" width="14" height="14" fill="#ffffff"/>
+    <rect x="98" y="42" width="14" height="14" fill="#00afaf"/>
+    <rect x="112" y="42" width="14" height="14" fill="#5fd7d7"/>
+    <rect x="126" y="42" width="14" height="14" fill="#5fd7d7"/>
+    <rect x="56" y="56" width="14" height="14" fill="#00afaf"/>
+    <rect x="70" y="56" width="14" height="14" fill="#00afaf"/>
+    <rect x="84" y="56" width="14" height="14" fill="#00afaf"/>
+    <rect x="98" y="56" width="14" height="14" fill="#00afaf"/>
+    <rect x="112" y="56" width="14" height="14" fill="#00afaf"/>
+    <rect x="126" y="56" width="14" height="14" fill="#5fd7d7"/>
+    <rect x="140" y="56" width="14" height="14" fill="#5fd7d7"/>
+    <rect x="70" y="70" width="14" height="14" fill="#00afaf"/>
+    <rect x="84" y="70" width="14" height="14" fill="#00afaf"/>
+    <rect x="98" y="70" width="14" height="14" fill="#00afaf"/>
+    <rect x="112" y="70" width="14" height="14" fill="#00afaf"/>
+    <rect x="126" y="70" width="14" height="14" fill="#5fd7d7"/>
+    <rect x="140" y="70" width="14" height="14" fill="#5fd7d7"/>
+    <rect x="84" y="84" width="14" height="14" fill="#00afaf"/>
+    <rect x="98" y="84" width="14" height="14" fill="#00afaf"/>
+    <rect x="112" y="84" width="14" height="14" fill="#5fd7d7"/>
+    <rect x="126" y="84" width="14" height="14" fill="#5fd7d7"/>
+    <rect x="98" y="98" width="14" height="14" fill="#00afaf"/>
+    <rect x="112" y="98" width="14" height="14" fill="#5fd7d7"/>
+    <rect x="112" y="112" width="14" height="14" fill="#5fd7d7"/>
+  </g>
+  <g transform="translate(260.0 127.0) scale(15.0000 -15.0000)" shape-rendering="crispEdges" fill="#00afaf"><path transform="translate(0,0)" d="M6 6V4H2V6ZM2 4V0H0V4ZM6 0V-2H2V0Z"/><path transform="translate(9,0)" d="M6 6V-2H0V6ZM2 4V0H4V4Z"/><path transform="translate(18,0)" d="M2 6V0H6V-2H0V6Z"/><path transform="translate(27,0)" d="M6 6V4H4V0H6V-2H0V0H2V4H0V6Z"/><path transform="translate(36,0)" d="M4 6V4H6V-2H0V6ZM2 2V0H4V2Z"/><path transform="translate(45,0)" d="M6 6V2H4V4H2V2H4V0H2V-2H0V6ZM6 0V-2H4V0Z"/><path transform="translate(54,0)" d="M6 6V4H4V0H6V-2H0V0H2V4H0V6Z"/></g>
+  <text x="262" y="196" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+        font-size="26" fill="#808080" font-style="italic">tiny engine, immense model</text>
+</svg>


### PR DESCRIPTION
Opened so it can be looked at in place rather than argued about. **Nothing is deleted** — `assets/colibri.svg` stays tracked and untouched, `site/` still uses it, and only the README's `<img src>` moves. Reverting is one line.

## Why

Two things a rendered side-by-side makes obvious:

**1. The current wordmark has no fixed form.** It is a `<text>` element with

```
font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
```

so it is SF Mono on a Mac, Consolas on Windows, and whatever is installed on Linux — different widths, weights and spacing. We do not actually know what our own logo looks like to most people who open the README.

**2. It mixes two idioms.** A pixel-art hummingbird next to a smooth antialiased typeface. The new wordmark is drawn as vector paths in the same blocky idiom as the bird, so the mark is coherent with itself and renders identically everywhere.

The bird keeps the original palette exactly — `#d75fd7` crest, `#5fd7d7` wing, `#00afaf` body, `#ff8700` beak — and the wordmark takes `#00afaf`, the teal the old `<text>` used. The tagline stays.

## Known, and deliberate for now

**The wordmark reads COLIBRI** — capitals, no grave. The project is *colibrì* everywhere else, including the engine banner (a v1.1.0 tag build once failed on exactly that accent). A pixel grave was drawn and discarded: at this weight it floats above the I and reads as an apostrophe rather than part of the letter. It wants a proper pass, not a quick one. This lands first so the rest can be judged in place.

## Separately, and not fixed here

Both `assets/colibri.svg` and `site/colibri.svg` still carry:

```
GLM-5.2 · 744B MoE · int4 · streaming CPU
```

That is false twice over — five model families now, and CUDA/Metal/Vulkan tiers alongside CPU. Left alone so this PR stays revertable in one line; the replacement (`MoE · int4 · experts streamed from disk`, which does not go stale as engines are added) is ready and can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)