### PR TITLE
.gitignore: the four ownership objects #868 did not reach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ c/olmoe.exe
 c/deepseek_v4
 c/deepseek_v4.exe
 c/COLI_V4_UNIT_*.o
+# ...and the ownership-test objects, which the same Makefile puts in a build/
+# subdirectory (V4_OWN_DIR) rather than next to the sources. #868 caught the
+# twelve in c/, not the four in here, so `make check` still left `?? c/build/`.
+c/build/
 c/iobench
 c/iobench.exe
 c/tok_test


### PR DESCRIPTION
#868 closed most of this. `c/COLI_V4_UNIT_*.o` covers the twelve objects the amalgamated deepseek_v4 Makefile leaves next to the sources. **Four more go somewhere else:**

```make
c/Makefile:895:  V4_OWN_DIR = build/ownership
```

So `make check` also writes `build/ownership/COLI_V4_UNIT_{RUNTIME,CONFIG,ST,NATIVE_QUANT}.o`, which no rule matches:

```console
$ git check-ignore -v c/COLI_V4_UNIT_CONFIG.o
.gitignore:28:c/COLI_V4_UNIT_*.o

$ git check-ignore -v c/build/ownership/COLI_V4_UNIT_ST.o
(no match)
```

On current `dev`, a clean checkout plus `make check` still leaves `?? c/build/` in `git status` — one `git add -A` away from exactly the accident #868 was written to stop, and the one I made on #849 and #800.

`c/build/` wholesale rather than four names: nothing under it is tracked (`git ls-tree -r dev -- c/build/` is empty), it is a build output directory, and naming each object would need editing every time the ownership suite grows.

## One thing worth stating, since it cost me a round trip on #849

**An ignore rule does not untrack what is already committed.** #868 made those twelve objects invisible in `git status` while leaving them in the tree — `git ls-tree` still listed all sixteen on my branch after rebasing onto current `dev`. What removed them was `git rm --cached`, which @JustVugg named in his first comment before the follow-up suggested the rebase would be enough.

Same shape as #835, where `c/.gitignore` already named `tests/bench_omp_grain` and the binary sat tracked regardless. **Ignore rules prevent; they do not clean up.** This PR is prevention only — nothing under `c/build/` is tracked today, so there is nothing here to remove.

Verified both directions: the four objects are ignored after this change, and `git status` on a tree with `c/build/ownership/*.o` present is clean.