### PR TITLE
Avoid reserving DSpark cache for unsupported DeepSeek-V4 checkpoints

### DIFF
--- a/c/compat.h
+++ b/c/compat.h
@@ -320,6 +320,12 @@ static inline int compat_setenv(const char *name, const char *value, int overwri
 }
 #define setenv(name,value,overwrite) compat_setenv(name,value,overwrite)
 
+/* --- unsetenv -> SetEnvironmentVariableA(NULL) --- */
+static inline int compat_unsetenv(const char *name){
+    return SetEnvironmentVariableA(name, NULL) ? 0 : -1;
+}
+#define unsetenv(name) compat_unsetenv(name)
+
 /* --- getenv_utf8: read an env var as UTF-8, not through the ANSI codepage ---
  * Plain getenv()/_environ are populated by the CRT from the ANSI-codepage view
  * of the process environment block, not UTF-8. A parent that hands the child a

--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -6319,6 +6319,45 @@ static int v4_dspark_full_wanted(
     return mtp && atoi(mtp) != 0 && draft && atoi(draft) > 0;
 }
 
+/* The native full drafter is a three-stage DSpark profile.  The ordinary
+ * Flash checkpoint exposes only the standard MTP tensors, while the official
+ * DSpark supplement keeps num_nextn_predict_layers=1 and adds these markers.
+ * The full loader remains the authority for detailed dtype/shape validation;
+ * this cheap probe only decides whether its cache should enter the plan. */
+enum {
+    V4_DSPARK_PROFILE_BLOCK = 5,
+    V4_DSPARK_PROFILE_RANK = 256,
+};
+
+static int v4_dspark_full_profile_present(
+    const ColiSafetensorsIndex *index,
+    const ColiDeepSeekV4Config *config) {
+    if (!index || !config) return 0;
+
+    /* Converted checkpoints may omit these optional fields, but an explicit
+     * incompatible profile must not reserve memory for this fixed loader. */
+    if ((config->dspark_block_size > 0 &&
+         config->dspark_block_size != V4_DSPARK_PROFILE_BLOCK) ||
+        (config->dspark_markov_rank > 0 &&
+         config->dspark_markov_rank != V4_DSPARK_PROFILE_RANK))
+        return 0;
+
+    /* Cover the entry projection, middle and final stages, and the distinctive
+     * output heads. v4_ds_load_all() performs the complete validation later. */
+    static const char *profile_tensors[] = {
+        "mtp.0.main_proj.weight", "mtp.0.main_proj.scale",
+        "mtp.1.attn.wq_a.weight", "mtp.1.attn.wq_a.scale",
+        "mtp.2.attn.wq_a.weight", "mtp.2.attn.wq_a.scale",
+        "mtp.2.confidence_head.proj.weight",
+        "mtp.2.markov_head.markov_w1.weight",
+        "mtp.2.markov_head.markov_w2.weight",
+    };
+    for (size_t item = 0;
+         item < sizeof(profile_tensors) / sizeof(profile_tensors[0]); item++)
+        if (!coli_st_find(index, profile_tensors[item])) return 0;
+    return 1;
+}
+
 static uint64_t v4_dspark_full_reserve_bytes(void) {
     double cache = coli_v4_dspark_cache_gb() * 1e9;
     /* The released Flash checkpoint has ~0.56 GiB of resident MTP dense,
@@ -6533,7 +6572,16 @@ int coli_v4_engine_open(ColiV4Engine **output,
         goto fail;
     engine->owns_index = 1;
     const ColiSafetensorsTensor *dspark_w1 = NULL, *dspark_w2 = NULL;
-    int want_full_dspark = v4_dspark_full_wanted(options);
+    int requested_full_dspark = v4_dspark_full_wanted(options);
+    int want_full_dspark = requested_full_dspark &&
+                           v4_dspark_full_profile_present(
+                               engine->target_index, &engine->config);
+    if (requested_full_dspark && !want_full_dspark)
+        fprintf(stderr,
+                "v4_dspark warning=unsupported-checkpoint "
+                "expected_full_profile=3stage actual_mtp_layers=%d; "
+                "continuing-target-only\n",
+                engine->config.num_nextn_predict_layers);
     int want_dspark = !want_full_dspark && v4_dspark_markov_wanted(options);
     if (want_dspark && v4_dspark_markov_probe(engine, &dspark_w1,
                                                &dspark_w2)) {

--- a/c/tests/test_deepseek_v4_dspark_source.py
+++ b/c/tests/test_deepseek_v4_dspark_source.py
@@ -27,6 +27,28 @@ class DeepSeekV4DSparkSourceTest(unittest.TestCase):
         self.assertIn("load=lazy verification=exact-target", self.engine)
         self.assertIn("double total_gb = coli_v4_dspark_cache_gb()", self.drafter)
 
+    def test_full_drafter_does_not_reserve_for_other_mtp_profiles(self):
+        requested = self.engine.index("requested_full_dspark =")
+        supported = self.engine.index(
+            "v4_dspark_full_profile_present(", requested
+        )
+        reserve = self.engine.index(
+            "engine->runtime.dspark_reserve_bytes =", supported
+        )
+        warning = self.engine.index(
+            'warning=unsupported-checkpoint', requested
+        )
+        self.assertLess(requested, supported)
+        self.assertLess(supported, warning)
+        self.assertLess(warning, reserve)
+        self.assertIn("num_nextn_predict_layers", self.engine)
+        self.assertIn("expected_full_profile=3stage", self.engine)
+        self.assertIn("dspark_block_size", self.engine)
+        self.assertIn("mtp.0.main_proj.weight", self.engine)
+        self.assertIn("mtp.1.attn.wq_a.weight", self.engine)
+        self.assertIn("mtp.2.attn.wq_a.weight", self.engine)
+        self.assertIn("mtp.2.markov_head.markov_w1.weight", self.engine)
+
     def test_exact_target_hidden_precedes_full_mtp(self):
         self.assertIn("int full_mtp_ready = 0;", self.engine)
         target = self.engine.index("if (target_token(engine, &state, &next")

--- a/c/tests/test_v4_ownership.c
+++ b/c/tests/test_v4_ownership.c
@@ -284,11 +284,58 @@ static int test_session_tokenizer_freed(void) {
     return 0;
 }
 
+static void restore_setting(const char *name, char *value) {
+    if (value) setenv(name, value, 1);
+    else unsetenv(name);
+    free(value);
+}
+
+static int test_incomplete_full_dspark_profile_not_reserved(void) {
+    char directory[128], error[256];
+    if (make_fixture(directory, sizeof(directory))) return 1;
+
+    const char *draft = getenv("V4_DRAFT");
+    const char *mtp = getenv("V4_MTP");
+    char *saved_draft = draft ? strdup(draft) : NULL;
+    char *saved_mtp = mtp ? strdup(mtp) : NULL;
+    if ((draft && !saved_draft) || (mtp && !saved_mtp) ||
+        setenv("V4_DRAFT", "1", 1) || setenv("V4_MTP", "1", 1)) {
+        restore_setting("V4_DRAFT", saved_draft);
+        restore_setting("V4_MTP", saved_mtp);
+        cleanup_fixture(directory);
+        return 1;
+    }
+
+    coli_v4_test_skip_expert_store_open = 1;
+    ColiV4Engine *engine = NULL;
+    ColiV4EngineOpenOptions options = {.target_model_dir = directory};
+    int result = coli_v4_engine_open(&engine, &options, error, sizeof(error));
+    uint64_t reserved = engine
+        ? engine->runtime.dspark_reserve_bytes : 0;
+    int passed = !result && engine &&
+                 reserved == 0;
+    if (engine) coli_v4_engine_destroy(engine);
+    coli_v4_test_skip_expert_store_open = 0;
+    restore_setting("V4_DRAFT", saved_draft);
+    restore_setting("V4_MTP", saved_mtp);
+    cleanup_fixture(directory);
+    if (!passed) {
+        fprintf(stderr,
+                "incomplete DSpark profile reserved %llu bytes: %s\n",
+                (unsigned long long)reserved,
+                error);
+        return 1;
+    }
+    puts("ownership: incomplete full DSpark profile reserves no cache: ok");
+    return 0;
+}
+
 int main(void) {
     if (test_index_closed_on_expert_fail()) return 1;
     if (test_engine_owns_model_path()) return 1;
     if (test_session_lifetime_accounting()) return 1;
     if (test_session_tokenizer_freed()) return 1;
+    if (test_incomplete_full_dspark_profile_not_reserved()) return 1;
     puts("DeepSeek-V4 ownership tests: ok");
     return 0;
 }


### PR DESCRIPTION
## Summary

- Detect the native three-stage DSpark profile before reserving DSpark memory.
- Avoid reducing the target cache for ordinary `DeepSeek-V4-Flash` checkpoints.
- Preserve compatibility with the official `DeepSeek-V4-Flash-DSpark` checkpoint.
- Add regression coverage for unsupported DSpark profiles.

## Problem

When `V4_DRAFT` and `V4_MTP` were enabled, the engine reserved the full DSpark cache before checking whether the checkpoint contained the required DSpark tensors.

The regular `DeepSeek-V4-Flash` checkpoint contains standard MTP tensors but does not contain the native three-stage DSpark profile. The DSpark loader would fail later, while the resource planner had already reserved approximately 1.17 GiB of memory.

## Implementation

- Separate the requested DSpark mode from the supported checkpoint profile.
- Detect DSpark using distinctive tensors from the entry projection, middle stage, final stage, confidence head, and Markov heads.
- Keep detailed dtype, shape, and expert validation in the existing DSpark loader.
- Continue in target-only mode with zero DSpark reservation when the profile is absent.
- Do not infer DSpark stage count from `num_nextn_predict_layers`; both official Flash and DSpark checkpoints report this field as `1`.

References:

- [DeepSeek-V4-Flash](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash)
- [DeepSeek-V4-Flash-DSpark](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-DSpark)

## Validation

- `make -C c -j16 deepseek-v4`
- DeepSeek-V4 C test suite
- Ownership regression tests
- DSpark source tests
- Real `DeepSeek-V4-Flash` inference under an 8 GiB memory limit