### PR TITLE
The VRAM expert tier could only be fed by disk reads

### DIFF
--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -1212,7 +1212,16 @@ static void experts_apply_union(Model *m, int li, int nu, const int *uids,
                 m->t_eload+=now_s()-t0;
             }
 #ifdef COLI_VULKAN
-            if(g_k3_vk&&qof[j]>=0) vk_expert_try_upload(m,li,uids[base+j],use[j]);
+            /* #848: offer EVERY expert used this layer, not only the ones that just
+             * came off disk. qof[j]>=0 means "this was a RAM-cache miss", which is the
+             * right gate for the readiness wait above and the wrong one here: it made
+             * the VRAM tier reachable only through disk reads, so the fill stopped the
+             * moment the RAM cache went warm and never resumed. K3_VK_GB was then a cap
+             * that could not be reached rather than the thing that stopped the fill.
+             * Re-offering a resident expert is nearly free -- vk_expert_try_upload
+             * returns on `v->w1` before it touches the per-step quota -- and it reads
+             * only s->buf, which an LRU slot and a ws[] slot populate identically. */
+            if(g_k3_vk) vk_expert_try_upload(m,li,uids[base+j],use[j]);
 #endif
             int f=pfirst[base+j];
             for(int p2=0;p2<pcnt[base+j];p2++){


### PR DESCRIPTION
Closes the fill path in #848. @JustVugg confirmed the diagnosis against `dev` and asked if I wanted to take it; this is that.

## The one-line version

```c
-if(g_k3_vk && qof[j]>=0) vk_expert_try_upload(m,li,uids[base+j],use[j]);
+if(g_k3_vk)              vk_expert_try_upload(m,li,uids[base+j],use[j]);
```

`qof[j] >= 0` means *"this expert was a RAM-cache miss"*. That is the correct gate for the pipelined readiness wait immediately above it — only a slot being loaded from disk can be un-ready. It is the wrong gate here, because it made the VRAM tier reachable **only through disk reads**.

So the fill had a deadline nobody designed: it closed the moment the RAM cache went warm and never reopened. `K3_VK_GB` stopped being the thing that ends the fill and became a ceiling that could not be reached — @Limalski's 4360 MB is simply wherever the tier happened to be when his misses stopped, which is why `K3_VK_GB=2` and `=3` worked and `=5` and above did not.

## Why re-offering resident experts is safe

Both points I flagged as unverified when I first posted the diagnosis, now checked:

**It is nearly free.** `vk_expert_try_upload` returns on `if(v->w1) return;` **before** it reaches `g_vk_up_left--`, so an expert already in VRAM costs one pointer test and does not consume the per-step upload quota. The "do not re-offer the same expert every token" concern is already handled by the existing early return.

**The slot is the same kind of object either way.** I had said the hit path hands it a slot with different lifetime and ownership. That was over-cautious:

```c
typedef struct { int eid; uint8_t *buf, *base; uint64_t used; int pinned; } Slot;
```

`LCache` holds `Slot *s` and the working set is `Slot ws[64]` — one type, one `buf` layout, both populated by `expert_read`. And `vk_expert_try_upload` touches only `s->buf`; `coli_vk_tensor_ensure` copies into VRAM and keeps no pointer to it, so nothing outlives the call.

## Verification

- default build clean; `-DCOLI_VULKAN` syntax build clean
- `make test-c` passes
- the three `-Wunused-variable` warnings in the default build are pre-existing — checked against `dev`'s `kimi_k3.c`, identical before and after

**Not verified on hardware.** I have no Vulkan GPU, and neither does @JustVugg. @Limalski's box is the only thing that can confirm it end to end.

@Limalski — the check is your original repro: `K3_VK_GB=8` with everything else unchanged. The tier should now keep filling past 4360 MB until it actually reaches 8 GB or the driver budget, instead of freezing when your cache goes warm. The diagnostic @JustVugg suggested (`K3_EXPERT_GB=2` on **unpatched** code, to make misses never stop) is still worth running if you have the time, because it confirms the mechanism independently of whether this patch is correct.
