### PR TITLE
fix(kimi): allocate state after prefix miss

### DIFF
--- a/c/.gitignore
+++ b/c/.gitignore
@@ -27,3 +27,4 @@ tests/test_int3
 tests/test_int3_load
 tests/test_tok_o200k
 tests/test_pipe_block
+tests/test_kimi_request_state

--- a/c/Makefile
+++ b/c/Makefile
@@ -1038,3 +1038,6 @@ bench: iobench$(EXE)
 
 tests/test_kv_prefix$(EXE): tests/test_kv_prefix.c kv_prefix.h
 	$(CC) $(CFLAGS) tests/test_kv_prefix.c -o tests/test_kv_prefix$(EXE) $(LDFLAGS)
+
+tests/test_kimi_request_state$(EXE): tests/test_kimi_request_state.c kimi_k3.c kv_prefix.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h omp_tune.h route_trace.h
+	$(CC) $(NOCUDA_CFLAGS) tests/test_kimi_request_state.c $(VK_OBJ) -o tests/test_kimi_request_state$(EXE) $(NOCUDA_LDFLAGS)

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -1569,6 +1569,18 @@ static void model_state_reset(Model *m){
     m->Lc=NULL; m->Rc=NULL; m->max_t=0;
 }
 
+/* Decide reuse before changing the state it describes. A miss discards the
+ * old recurrent/KV state first and allocates a fresh target; a hit grows the
+ * existing target while preserving its prefix. The old order allocated first,
+ * then reset on the inevitable first-request miss, leaving Lc/Rc NULL when
+ * MLA prefill immediately indexed them (#855). */
+static int prepare_request_state(Model *m, const int *ids, int np, int max_t){
+    int reuse=kv_prefix_reuse(&m->kvp,ids,np);
+    if(!reuse) model_state_reset(m);
+    kv_alloc(m,max_t);
+    return reuse;
+}
+
 static int serve_stdin_readable(void){
     /* Windows non ha fd_set/select in questa forma: la build falliva del tutto.
      * La versione portabile (con i fix #139/#195) vive in compat.h, incluso via st.h. */
@@ -1639,13 +1651,12 @@ static void serve_one(Model *m, Tok *T, ServeReq *q){
      * the conversation, and every replayed position pulled its experts off
      * disk again. When this prompt begins with the sequence the state already
      * holds, that state IS the state at that position: keep it and prefill
-     * only the tail. This is why kv_alloc above must run FIRST and must keep
-     * its buffers: growing them discards the positions fed[] describes.
+     * only the tail. The reuse decision must happen BEFORE a miss resets that
+     * state; allocation then either starts fresh or grows the preserved state.
      * At least one new token is required, since the state cannot be rewound.
      * Either the reused positions are token-identical or nothing is reused;
      * the emitted tokens are unchanged in both cases. */
-    kv_alloc(m,np+q->max_tok+8);
-    int reuse=kv_prefix_reuse(&m->kvp, ids, np);
+    int reuse=prepare_request_state(m,ids,np,np+q->max_tok+8);
     if(getenv("K3_PREFIX_LOG")){
         /* Report the decision either way, with the state behind a "no".
          * "It did not get faster" is otherwise the same observation as
@@ -1659,7 +1670,6 @@ static void serve_one(Model *m, Tok *T, ServeReq *q){
                     (m->kvp.len>0 && m->kvp.len<np) ? " (diverged)" : "");
         fflush(stderr);
     }
-    if(!reuse) model_state_reset(m);
     int chunk=getenv("K3_CHUNK")?atoi(getenv("K3_CHUNK")):32;
     if(chunk<1) chunk=1; if(chunk>512) chunk=512;
     double t0=now_s(), a0=m->t_attn, e0=m->t_moe, d0=m->t_eload, h0=m->t_head;

--- a/c/tests/test_kimi_request_state.c
+++ b/c/tests/test_kimi_request_state.c
@@ -1,0 +1,69 @@
+/* Kimi serve request-state sequencing regression (#855).
+ *
+ * A first request has no reusable prefix. The broken path allocated Lc/Rc,
+ * observed that miss, reset the model, and entered MLA prefill with both arrays
+ * NULL. Exercise the production helper with tiny fabricated layers: first
+ * request, growing reuse, and a divergent request that must reset then allocate. */
+#define main kimi_k3_main_unused
+#include "../kimi_k3.c"
+#undef main
+
+static int failures;
+#define CHECK(cond, ...) do { if(!(cond)){ \
+    fprintf(stderr,"FAIL %s:%d: ",__FILE__,__LINE__); \
+    fprintf(stderr,__VA_ARGS__); fputc('\n',stderr); failures++; } } while(0)
+
+static void init_model(Model *m){
+    memset(m,0,sizeof(*m));
+    m->c.n_layers=2; m->c.kv_lora=3; m->c.qk_rope=2;
+    m->c.kda_heads=1; m->c.kda_hd=1; m->c.kda_proj=1; m->c.conv_k=1;
+    m->L=calloc((size_t)m->c.n_layers,sizeof(Layer));
+    m->L[0].kda=1;                                  /* recurrent row: no Lc/Rc */
+    m->kstate=calloc((size_t)m->c.n_layers,sizeof(float*));
+    m->cwq=calloc((size_t)m->c.n_layers,sizeof(float*));
+    m->cwk=calloc((size_t)m->c.n_layers,sizeof(float*));
+    m->cwv=calloc((size_t)m->c.n_layers,sizeof(float*));
+    m->kstate[0]=calloc(1,sizeof(float));
+    m->cwq[0]=calloc(1,sizeof(float)); m->cwk[0]=calloc(1,sizeof(float));
+    m->cwv[0]=calloc(1,sizeof(float));
+}
+
+static void free_model(Model *m){
+    model_state_reset(m); kv_prefix_free(&m->kvp);
+    free(m->kstate[0]); free(m->cwq[0]); free(m->cwk[0]); free(m->cwv[0]);
+    free(m->kstate); free(m->cwq); free(m->cwk); free(m->cwv); free(m->L);
+}
+
+int main(void){
+    Model m; init_model(&m);
+    const int first[]={1,2,3};
+    int reuse=prepare_request_state(&m,first,3,8);
+    CHECK(reuse==0,"first request reused %d tokens",reuse);
+    CHECK(m.Lc&&m.Rc,"first request left cache pointer arrays NULL");
+    CHECK(m.Lc[1]&&m.Rc[1],"first request left MLA cache rows NULL");
+    CHECK(m.max_t==8&&m.kvp.cap==8,"first allocation max_t=%d prefix cap=%d",m.max_t,m.kvp.cap);
+
+    kv_prefix_record(&m.kvp,first,0,3);
+    float *old_l=m.Lc[1], *old_r=m.Rc[1];
+    for(int i=0;i<9;i++) old_l[i]=(float)(i+1);
+    for(int i=0;i<6;i++) old_r[i]=(float)(20+i);
+    const int extended[]={1,2,3,4};
+    reuse=prepare_request_state(&m,extended,4,12);
+    CHECK(reuse==3,"extended request reused %d tokens, want 3",reuse);
+    CHECK(m.Lc&&m.Rc&&m.Lc[1]&&m.Rc[1],"growing reuse lost MLA cache");
+    CHECK(m.Lc[1]!=old_l&&m.Rc[1]!=old_r,"grow did not replace undersized storage");
+    for(int i=0;i<9;i++) CHECK(m.Lc[1][i]==(float)(i+1),"Lc prefix changed at %d",i);
+    for(int i=0;i<6;i++) CHECK(m.Rc[1][i]==(float)(20+i),"Rc prefix changed at %d",i);
+
+    const int divergent[]={1,9,3,4};
+    reuse=prepare_request_state(&m,divergent,4,10);
+    CHECK(reuse==0,"divergent request reused %d tokens",reuse);
+    CHECK(m.Lc&&m.Rc&&m.Lc[1]&&m.Rc[1],"divergent reset was not followed by allocation");
+    CHECK(m.max_t==10&&m.kvp.cap==10&&m.kvp.len==0,
+          "fresh state max_t=%d cap=%d len=%d",m.max_t,m.kvp.cap,m.kvp.len);
+
+    free_model(&m);
+    if(failures){ fprintf(stderr,"kimi request state: %d failure(s)\n",failures); return 1; }
+    puts("kimi request state: ok");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- decide Kimi KV-prefix reuse before mutating the state described by the prefix record
- reset a missed/divergent state before allocating the request target, so first-request MLA prefill always has valid `Lc`/`Rc` storage
- preserve the existing grow-and-copy path when an extended prompt reuses a previous prefix
- add a model-free native regression covering first request, reuse with growth, and divergence

Closes #855.

## Root cause

Kimi serve currently prepares a request in this order:

```c
kv_alloc(m, np + max_tokens + 8);
int reuse = kv_prefix_reuse(&m->kvp, ids, np);
if (!reuse) model_state_reset(m);
```

The first request necessarily has no prefix to reuse. `kv_alloc()` allocates `m->Lc` and `m->Rc`, then `model_state_reset()` immediately frees them and sets both outer arrays to `NULL`. Prefill starts next, and the first MLA layer indexes:

```c
m->Lc[li]
m->Rc[li]
```

That makes the first non-KDA layer dereference a null outer pointer and terminates the engine. The gateway then reports the symptom from #855:

```text
request failed: colibri engine exited unexpectedly
```

This ordering arrived with Kimi prefix reuse in `d14b09d`, which is in v1.5.0 but not v1.4.0.

## Fix

The new `prepare_request_state()` helper establishes one ordering invariant:

```text
decide reuse -> reset on miss -> allocate/grow -> prefill
```

- First request or divergent prompt: clear the old recurrent/KV state, then allocate fresh storage.
- Extending prompt: keep the existing state and let `kv_alloc()` grow `Lc`/`Rc` while copying the recorded prefix.

No tokenization, routing, sampling, cache capacity, or model math changes.

## Tests

`c/tests/test_kimi_request_state.c` includes the production Kimi state helpers with tiny fabricated KDA/MLA layers and verifies:

- the first request returns a miss but leaves both `Lc`/`Rc` arrays and MLA rows allocated
- an extending prompt reuses the recorded prefix
- growing `Lc`/`Rc` preserves every prefix value
- a divergent prompt resets the prefix and allocates a fresh target rather than leaving null storage

Validation run locally on macOS:

```text
make tests/test_kimi_request_state && ./tests/test_kimi_request_state
kimi request state: ok

make check
Ran 355 tests in 68.752s
OK (skipped=52)
```

`kimi_k3` also builds successfully. The existing non-Vulkan build still emits its pre-existing unused `g_k3_vk` warning; this change adds no new warnings.