### PR TITLE
test: assert the launcher dispatches every engine it ships (#879)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,13 +185,44 @@ jobs:
           # now, and one hardcoded list that silently omitted an engine is what #858
           # was. Keep the expectation in a single place, above.
           COLI_EXPECT="$SIBLINGS" python3 - <<'PYCHK'
-          import os, sys
+          import importlib.machinery, importlib.util, json, os, sys, tempfile
           exe = ".exe" if os.name == "nt" else ""
           expect = os.environ["COLI_EXPECT"].split()
+
+          # 1. the files are here
           missing = [n for n in expect if not os.path.exists(os.path.join(".", n + exe))]
           if missing:
-              sys.exit("FAIL: coli would not resolve these next to itself: " + ", ".join(missing))
-          print("OK: every engine is where coli's engine_for() looks for it:", " ".join(expect))
+              sys.exit("FAIL: engines missing from the archive: " + ", ".join(missing))
+
+          # 2. and coli can actually SELECT them.
+          #
+          # This check used to stop at step 1 and was named "coli would not resolve
+          # these next to itself", which reads as a dispatch check and is not one.
+          # It passed for the whole of v1.5.0 while `coli run --model <olmoe>` sent
+          # the request to the GLM engine, because model_arch() had no olmoe branch
+          # (#879). The binary was in the archive and unusable.
+          #
+          # Presence is not dispatch. Load the packaged launcher, hand it a
+          # config.json per family, and assert where the request would go.
+          loader = importlib.machinery.SourceFileLoader("coli_pkg", "coli")
+          spec = importlib.util.spec_from_loader(loader.name, loader)
+          cli = importlib.util.module_from_spec(spec)
+          loader.exec_module(cli)
+
+          bad = []
+          for model_type, label, _ in cli._BANNER_MODELS:
+              with tempfile.TemporaryDirectory() as d:
+                  with open(os.path.join(d, "config.json"), "w", encoding="utf-8") as f:
+                      json.dump({"model_type": model_type}, f)
+                  open(os.path.join(d, "tokenizer.json"), "w").close()
+                  engine = os.path.basename(cli.engine_for(d))
+                  arch = cli.model_arch(d)
+              if model_type != "glm" and arch == "glm":
+                  bad.append("%s (%s) -> the GLM engine; the banner names a family "
+                             "the launcher cannot dispatch" % (label, model_type))
+          if bad:
+              sys.exit("FAIL: packaged launcher misroutes:\n  " + "\n  ".join(bad))
+          print("OK: every engine is packaged AND coli dispatches to it:", " ".join(expect))
           PYCHK
           out=$(python3 coli info 2>&1 || true)
           echo "$out"

--- a/c/tests/test_launcher_dispatch.py
+++ b/c/tests/test_launcher_dispatch.py
@@ -1,0 +1,109 @@
+"""Every model type the launcher NAMES, the launcher must also DISPATCH.
+
+#879: `coli` printed "OLMoE · 7B" in its banner and then handed the request to
+the GLM engine, because `_BANNER_MODELS` knew about `olmoe` and `model_arch()`
+did not. The engine binary shipped in the release archive the whole time; the
+launcher structurally could not select it.
+
+The release check that was supposed to catch this (#868, "coli would not
+resolve these next to itself") asserted the binary was PRESENT next to `coli`.
+It passed. Presence is not dispatch, and a green test that proves the weaker
+property is worse than no test, because it is read as proving the stronger one.
+
+So the invariant is stated once, here, over the launcher's own table:
+
+    for every model_type in _BANNER_MODELS:
+        model_arch() must classify it, and engine_for() must resolve it to a
+        binary name that is not merely the GLM fallback by accident
+
+It is self-updating. Adding a family to the banner roster without teaching the
+dispatcher about it fails this file, rather than shipping and being found by
+someone who downloaded a release.
+"""
+import importlib.machinery
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent.parent
+CLI = HERE / "coli"
+
+
+def load_cli():
+    loader = importlib.machinery.SourceFileLoader("coli_dispatch_test", str(CLI))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+class LauncherDispatchTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cli = load_cli()
+
+    def _model_dir(self, model_type):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        root = Path(directory.name)
+        (root / "config.json").write_text(
+            json.dumps({"model_type": model_type}), encoding="utf-8")
+        (root / "tokenizer.json").write_text("{}", encoding="utf-8")
+        return str(root)
+
+    def test_every_named_model_type_is_classified(self):
+        """A model_type in the banner roster must not fall through to the
+        `return "glm"` default -- except glm itself, whose default that is."""
+        for model_type, label, _ in self.cli._BANNER_MODELS:
+            with self.subTest(model_type=model_type):
+                arch = self.cli.model_arch(self._model_dir(model_type))
+                if model_type == "glm":
+                    self.assertEqual(arch, "glm")
+                    continue
+                self.assertNotEqual(
+                    arch, "glm",
+                    f"the banner prints {label!r} for model_type {model_type!r} "
+                    f"and model_arch() returns 'glm' -- the launcher names a "
+                    f"family it cannot dispatch (#879)")
+
+    def test_every_named_model_type_resolves_to_a_distinct_engine(self):
+        """Two families must not resolve to the same binary. That is the shape
+        the bug took: everything unrecognised quietly became the GLM engine."""
+        seen = {}
+        for model_type, label, _ in self.cli._BANNER_MODELS:
+            with self.subTest(model_type=model_type):
+                engine = os.path.basename(
+                    self.cli.engine_for(self._model_dir(model_type)))
+                self.assertTrue(engine, f"{label}: engine_for returned nothing")
+                previous = seen.get(engine)
+                self.assertIsNone(
+                    previous,
+                    f"{label} ({model_type}) and {previous} both dispatch to "
+                    f"{engine!r} -- one of them is being misrouted (#879)")
+                seen[engine] = label
+
+    def test_engine_for_has_a_branch_for_every_arch_model_arch_can_return(self):
+        """engine_for() indexes a dict with model_arch()'s return value. A value
+        model_arch can produce and the dict lacks is a KeyError at runtime, on
+        the user's machine, after the banner has already printed."""
+        for model_type, label, _ in self.cli._BANNER_MODELS:
+            with self.subTest(model_type=model_type):
+                try:
+                    self.cli.engine_for(self._model_dir(model_type))
+                except KeyError as error:
+                    self.fail(f"{label}: engine_for raised KeyError({error}) -- "
+                              f"model_arch() classifies this family and the "
+                              f"engine dict has no entry for it")
+
+    def test_the_roster_is_not_empty(self):
+        """Guards the whole file: if _BANNER_MODELS is ever renamed or emptied,
+        the loops above pass vacuously and this suite proves nothing."""
+        self.assertGreaterEqual(len(self.cli._BANNER_MODELS), 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Draft on purpose: this fails on `dev` today, for OLMoE, which is the point.** It goes green when @shujaanazhar's launcher fix for #879 lands.

## The test that should have caught #879 was mine, and it passed

#868 added this to the release verification two days ago:

```python
missing = [n for n in expect if not os.path.exists(...)]
if missing:
    sys.exit("FAIL: coli would not resolve these next to itself: " ...)
```

It is *named* as a dispatch check and it is a file-existence check. It went green on every platform while `coli run --model <olmoe>` sent the request to the GLM engine and died with `this engine requires n_group=1 (GLM-5.2)`.

A green test that proves the weaker property is worse than no test, because the name is what people read — including me, when I wrote it.

## What this adds

`tests/test_launcher_dispatch.py` states the invariant once, over the launcher's **own** roster:

```
for every model_type in _BANNER_MODELS:
    model_arch() must not fall through to the "glm" default (except glm)
    engine_for() must not raise, and must not collide with another family
```

Self-updating by construction: adding a family to the banner without teaching the dispatcher fails at PR time rather than shipping and being found by someone who downloaded a release. There is a guard asserting the roster is non-empty, so the loops cannot pass vacuously if `_BANNER_MODELS` is ever renamed.

The release check now does the same against the **packaged** launcher: it loads `coli` out of the archive, hands it a fabricated `config.json` per family, and asserts where the request would go. Presence is still checked — it is step 1 of 2 rather than the whole thing.

## Current output on `dev`

```
DeepSeek V4 Flash    model_type=deepseek_v4  -> arch=deepseek_v4
Inkling              model_type=inkling      -> arch=inkling
Kimi K3              model_type=kimi         -> arch=kimi
OLMoE                model_type=olmoe        -> arch=glm      <-- #879
GLM-5.2              model_type=glm          -> arch=glm
```

```
AssertionError: 'glm' == 'glm' : the banner prints 'OLMoE' for model_type 'olmoe'
and model_arch() returns 'glm' -- the launcher names a family it cannot dispatch

AssertionError: GLM-5.2 (glm) and OLMoE both dispatch to 'colibri' -- one of them
is being misrouted
```

That is the message a maintainer would have got on the v1.5.0 tag build.

## Division of work

@shujaanazhar traced #879 to the line, found the working invocation, and offered the launcher fix. That is theirs: `c/coli` — `model_arch()`, `engine_for()`, `env_for_engine()`.

This is ours: `.github/workflows/release.yml` plus a new test. **No overlapping files, no conflict, and no need to coordinate beyond merge order.**

Refs #879, #868

🤖 Generated with [Claude Code](https://claude.com/claude-code)