### PR TITLE
fix(cli): dispatch OLMoE one-shot runs

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -236,6 +236,8 @@ def model_arch(model):
         return "inkling"
     if "kimi" in model_type:
         return "kimi"
+    if "olmoe" in model_type:
+        return "olmoe"
     if "deepseek_v4" in model_type or ("deepseek" in model_type and "v4" in model_type):
         return "deepseek_v4"
     return "glm"
@@ -244,7 +246,7 @@ def engine_for(model):
     arch = model_arch(model)
     if arch == "glm" or os.environ.get("COLI_ENGINE"):
         return GLM
-    name = {"inkling": "inkling", "kimi": "kimi_k3",
+    name = {"inkling": "inkling", "kimi": "kimi_k3", "olmoe": "olmoe",
             "deepseek_v4": "deepseek_v4"}[arch]
     local = os.path.join(HERE, name + _EXE)
     return local if os.path.exists(local) else os.path.join(_LIBEXEC, name + _EXE)
@@ -260,6 +262,7 @@ def need_model(model, engine=None):
     if not os.path.exists(engine):
         arch = model_arch(model)
         target = ("kimi_k3" if arch == "kimi" else "inkling" if arch == "inkling" else
+                  "olmoe" if arch == "olmoe" else
                   "deepseek-v4" if arch == "deepseek_v4" else "colibri")
         sys.exit(f"{C.yel}{target} engine is not built.{C.r} Run: make -C c {target}")
 
@@ -294,6 +297,10 @@ def env_for_engine(a, arch):
                 env.setdefault("OMP_PLACES", "cores")
     if a.ngen: env["NGEN"] = str(a.ngen)
     if a.temp is not None: env["COLI_TEMP"] = str(a.temp)
+    if arch == "olmoe":
+        env["CHAT"] = "1"
+        if a.ngen: env["MAX_NEW"] = str(a.ngen)
+        if a.temp is not None: env["TEMP"] = str(a.temp)
     # --ram reaches the engines that read it. kimi_k3 gained a RAM budget in
     # #855; before that `grep -c RAM_GB c/kimi_k3.c` returned 0, so `coli chat
     # --ram 242` on Kimi K3 set an environment variable nobody looked at and the
@@ -685,7 +692,7 @@ def cmd_build(a):
         sys.exit(f"{C.yel}coli build{C.r} only works from a source checkout (this is an installed copy).\n"
                   f"  Clone https://github.com/JustVugg/colibri and run ./setup.sh, or make -C c colibri.")
     arch=model_arch(a.model) if a.model else "glm"
-    target={"glm":"colibri","inkling":"inkling","kimi":"kimi_k3",
+    target={"glm":"colibri","inkling":"inkling","kimi":"kimi_k3","olmoe":"olmoe",
             "deepseek_v4":"deepseek-v4"}[arch]
     sys.exit(subprocess.call(["make","-C",HERE,target]))
 
@@ -842,6 +849,15 @@ def cmd_run(a):
                 try: os.unlink(prompt_path)
                 except OSError: pass
         sys.exit(result)
+    if arch=="olmoe":
+        # OLMoE has a persistent stdin chat loop but not the gateway's SERVE
+        # protocol yet. Feed exactly one turn and close stdin: the engine emits
+        # the answer and exits cleanly. Keep this scoped to `coli run`; chat/web
+        # remain unavailable until OLMoE implements READY/SUBMIT/DATA/DONE.
+        result=subprocess.run(
+            [engine, str(a.cap if a.cap is not None else 16), "8"],
+            input=prompt+"\n", text=True, env=env_for_engine(a,arch), check=False)
+        sys.exit(result.returncode)
     # template ufficiale GLM-5.2: niente \n dopo i ruoli; <think></think> = risposta diretta (nothink).
     # THINK=1 lascia <think> aperto, stessa convenzione del serve mode (glm.c). EN: THINK=1 leaves
     # <think> open so the engine emits its reasoning block; the default stays nothink.

--- a/c/tests/test_doctor_engine_arch.py
+++ b/c/tests/test_doctor_engine_arch.py
@@ -21,6 +21,7 @@ ARCHES = [
     ("glm-5.2", "colibri"),
     ("inkling", "inkling"),
     ("kimi_k3", "kimi_k3"),
+    ("olmoe", "olmoe"),
 ]
 
 

--- a/c/tests/test_v4_cli.py
+++ b/c/tests/test_v4_cli.py
@@ -50,6 +50,58 @@ class V4CliTest(unittest.TestCase):
         finally:
             directory.cleanup()
 
+    def test_model_arch_selects_olmoe(self):
+        directory, root = self.make_model("olmoe")
+        try:
+            self.assertEqual(self.cli.model_arch(str(root)), "olmoe")
+        finally:
+            directory.cleanup()
+
+    def test_engine_for_selects_olmoe_binary(self):
+        directory, root = self.make_model("olmoe")
+        try:
+            expected = "olmoe.exe" if os.name == "nt" else "olmoe"
+            self.assertEqual(Path(self.cli.engine_for(str(root))).name, expected)
+        finally:
+            directory.cleanup()
+
+    def test_olmoe_environment_enters_chat_mode(self):
+        args = argparse.Namespace(ngen=32, temp=0.25, ram=0, ctx=0)
+        env = self.cli.env_for_engine(args, "olmoe")
+        self.assertEqual(env["CHAT"], "1")
+        self.assertEqual(env["MAX_NEW"], "32")
+        self.assertEqual(env["TEMP"], "0.25")
+
+    def test_olmoe_run_uses_its_engine_and_writes_one_prompt_line(self):
+        directory, root = self.make_model("olmoe")
+        args = argparse.Namespace(
+            model=str(root), prompt=["hello", "world"], ngen=32, ram=0,
+            temp=0.25, ctx=0, cap=None,
+        )
+        captured = {}
+
+        def fake_run(command, **kwargs):
+            captured["command"] = command
+            captured.update(kwargs)
+            return argparse.Namespace(returncode=0)
+
+        try:
+            with mock.patch.object(self.cli, "engine_for", return_value="/engines/olmoe"), \
+                 mock.patch.object(self.cli, "need_model"), \
+                 mock.patch.object(self.cli, "banner"), \
+                 mock.patch("resource_plan.physical_cpu_count", return_value=6), \
+                 mock.patch.object(self.cli.subprocess, "run", side_effect=fake_run):
+                with self.assertRaises(SystemExit) as stopped:
+                    self.cli.cmd_run(args)
+            self.assertEqual(stopped.exception.code, 0)
+            self.assertEqual(captured["command"], ["/engines/olmoe", "16", "8"])
+            self.assertEqual(captured["input"], "hello world\n")
+            self.assertTrue(captured["text"])
+            self.assertEqual(captured["env"]["CHAT"], "1")
+            self.assertEqual(captured["env"]["MAX_NEW"], "32")
+        finally:
+            directory.cleanup()
+
     def test_v4_engine_environment_forwards_ram_and_context(self):
         args = argparse.Namespace(ngen=8, temp=0.0, ram=64, ctx=4096)
         env = self.cli.env_for_engine(args, "deepseek_v4")


### PR DESCRIPTION
## Summary

- classify `model_type: olmoe` as its own architecture instead of silently falling back to GLM
- resolve and build the dedicated `olmoe` binary from the launcher
- make `coli run --model <olmoe>` drive OLMoE's existing stdin chat loop for exactly one prompt
- map `--ngen`, `--temp`, and `--cap` onto the OLMoE interface
- extend doctor and CLI regressions so OLMoE cannot collapse back onto the GLM engine

Closes the `coli run` portion of #879.

## Scope

This intentionally does **not** enable `coli chat`, `coli web`, or `coli serve` for OLMoE. Those commands use `openai_server.py` and require the persistent READY/SUBMIT/DATA/DONE engine protocol, which `olmoe.c` does not implement yet.

`coli run` is complete without that protocol because OLMoE already has a persistent `CHAT=1` stdin loop. The launcher writes one prompt line and closes stdin; OLMoE emits the answer and exits cleanly.

## Root cause

The launcher banner knew about OLMoE, but dispatch did not:

```text
_BANNER_MODELS: olmoe -> OLMoE
model_arch():   olmoe -> glm fallback
engine_for():   glm -> colibri
```

Users therefore saw an accurate `OLMoE · 7B` banner immediately before the GLM engine attempted to load the checkpoint and failed with:

```text
this engine requires n_group=1 (GLM-5.2)
```

Even forcing the `olmoe` binary did not make one-shot generation work, because the engine enters its reference harness unless `CHAT=1` is set.

## Implementation

For an OLMoE model, `coli run` now invokes:

```text
olmoe <cap-or-16> 8
```

with:

```text
SNAP=<model>
CHAT=1
MAX_NEW=<--ngen>
TEMP=<--temp>
```

and sends the joined prompt plus one newline over stdin.

The fixed `8` is the existing OLMoE runtime-quantization default used by its documented working invocation. Converted merged containers already carry int8 expert weights; this does not rewrite model data.

## Tests

Added regressions for:

- `model_arch()` classifying OLMoE
- `engine_for()` selecting `olmoe` / `olmoe.exe`
- `env_for_engine()` entering OLMoE chat mode and forwarding generation controls
- `cmd_run()` executing the OLMoE binary, using default cap 16, and writing exactly one prompt line
- `coli doctor` inspecting the OLMoE binary rather than GLM

The separate release-dispatch suite from #880 was also applied locally to this branch and all four tests pass.

Validation on macOS:

```text
python3 -m unittest tests.test_v4_cli tests.test_doctor_engine_arch tests.test_cli_output
Ran 35 tests in 0.992s
OK

make check
Ran 364 tests in 63.503s
OK (skipped=57)
```

The existing `test_k3_ram_budget.c` unused-constant warning is pre-existing; this Python-only launcher change adds no compiler warnings.