### PR TITLE
deepseek_v4: emit dashboard telemetry (HWINFO/TIERS/EMAP/PROF/HITS) in serve mode

### DIFF
--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -5075,6 +5075,8 @@ typedef struct {
     uint64_t clock;
     unsigned active_leases;
     ColiExpertStoreStats stats;
+    unsigned char *hits;   /* routed-expert bitmap, rows*cols bits (telemetry) */
+    size_t hits_bytes;
     pthread_mutex_t mutex;
 } V4ExpertStoreState;
 
@@ -5245,6 +5247,11 @@ static int lookup(ColiExpertStore *store, ColiExpertKey key,
     slot->references++;
     state->active_leases++;
     slot->used = ++state->clock;
+    if (state->hits && state->hits_bytes) {
+        size_t hit_bit = (size_t)key.layer * state->experts_per_layer + key.expert;
+        state->hits[hit_bit >> 3] |= (unsigned char)(1u << (hit_bit & 7));
+    }
+
     memset(view, 0, sizeof(*view));
     view->key = key;
     fill_tensor_view(&view->gate, record, slot, V4_W1);
@@ -5379,6 +5386,34 @@ static int store_emap(const ColiExpertStore *store, char *hex, size_t hex_cap,
     return 0;
 }
 
+/* Dashboard telemetry: drain + clear the routed-expert bitmap as a hex
+ * string (1 bit per expert, byte i>>3 bit i&7 — same layout the gateway
+ * consumers expect), so the Brain cortex can flash experts live per token. */
+static int store_hits(const ColiExpertStore *store, char *hex, size_t hex_cap,
+                      ColiStoreTelemetry *out) {
+    if (!store || !store->state || !hex || !out) return -1;
+    V4ExpertStoreState *state = store->state;
+    int rows = state->layers;
+    int cols = state->experts_per_layer;
+    if (rows < 1 || cols < 1 || !state->hits || !state->hits_bytes) return -1;
+    size_t need = state->hits_bytes * 2 + 1;
+    if (hex_cap < need) return -1;
+    pthread_mutex_lock(&state->mutex);
+    int w = 0;
+    for (size_t b = 0; b < state->hits_bytes; b++) {
+        hex[w++] = "0123456789abcdef"[state->hits[b] >> 4];
+        hex[w++] = "0123456789abcdef"[state->hits[b] & 15];
+    }
+    memset(state->hits, 0, state->hits_bytes);
+    pthread_mutex_unlock(&state->mutex);
+    hex[w] = 0;
+    out->rows = rows;
+    out->cols = cols;
+    out->resident = 0;
+    out->record_bytes = 0;
+    return 0;
+}
+
 
 static void destroy(ColiExpertStore *store) {
     if (!store) return;
@@ -5396,6 +5431,7 @@ static void destroy(ColiExpertStore *store) {
         coli_st_index_close(state->index);
         free(state->records);
         free(state->slots);
+        free(state->hits);
         free(state);
     }
     free(store);
@@ -5405,7 +5441,7 @@ int coli_deepseek_v4_expert_store_open(
     const ColiDeepSeekV4ExpertStoreOptions *options, ColiExpertStore **output,
     char *error, size_t error_size) {
     static const ColiExpertStoreOps operations = {
-        lookup, release, prefetch, stats, store_emap, destroy
+        lookup, release, prefetch, stats, store_emap, store_hits, destroy
     };
     if (!options || !output || !options->model_dir || options->layers < 1 ||
         options->experts_per_layer < 1 || !options->cache_bytes)
@@ -5467,6 +5503,12 @@ int coli_deepseek_v4_expert_store_open(
         state->slots[i].expert = -1;
     state->stats.capacity_bytes = (uint64_t)state->layers *
                                   state->slots_per_layer * state->record_bytes;
+    state->hits_bytes = ((size_t)state->layers * state->experts_per_layer + 7) / 8;
+    state->hits = calloc(state->hits_bytes, 1);
+    if (!state->hits) {
+        set_error(error, error_size, "out of memory creating expert hits bitmap");
+        goto fail;
+    }
     store->ops = &operations;
     store->state = state;
     *output = store;
@@ -5474,6 +5516,7 @@ int coli_deepseek_v4_expert_store_open(
 
 fail:
     if (state->slots) free(state->slots);
+    if (state->hits) free(state->hits);
     free(state->records);
     coli_st_index_close(state->index);
     pthread_mutex_destroy(&state->mutex);
@@ -5878,6 +5921,11 @@ static int lookup_hot(ColiExpertStore *store, ColiExpertKey key,
             slot = &slots[i]; slot->references++;
             state->active_leases++;
             slot->used = ++state->clock; state->stats.hits++;
+            if (state->hits && state->hits_bytes) {
+                size_t hit_bit = (size_t)key.layer * state->experts_per_layer + key.expert;
+        state->hits[hit_bit >> 3] |= (unsigned char)(1u << (hit_bit & 7));
+    }
+
             if (hot_is_pinned(policy, key.layer, key.expert))
                 hot_pack_slot_locked(policy, state, record, slot);
             memset(view, 0, sizeof(*view)); view->key = key;
@@ -5931,6 +5979,11 @@ static int lookup_hot(ColiExpertStore *store, ColiExpertKey key,
     }
     slot->expert = key.expert; slot->used = ++state->clock;
     state->stats.misses++; state->stats.bytes_read += record->record_bytes;
+    if (state->hits && state->hits_bytes) {
+        size_t hit_bit = (size_t)key.layer * state->experts_per_layer + key.expert;
+        state->hits[hit_bit >> 3] |= (unsigned char)(1u << (hit_bit & 7));
+    }
+
     if (hot_is_pinned(policy, key.layer, key.expert))
         hot_pack_slot_locked(policy, state, record, slot);
     memset(view, 0, sizeof(*view)); view->key = key;
@@ -6025,7 +6078,7 @@ int COLI_V4_ROWS16_STORE_OPEN(
     const ColiDeepSeekV4ExpertStoreOptions *options, ColiExpertStore **output,
     char *error, size_t error_size) {
     static const ColiExpertStoreOps hot_operations = {
-        lookup_hot, release, prefetch, stats, store_emap, destroy_hot
+        lookup_hot, release, prefetch, stats, store_emap, store_hits, destroy_hot
     };
     int result = coli_deepseek_v4_expert_store_open_base(
         options, output, error, error_size);
@@ -8321,6 +8374,7 @@ typedef struct {
     ColiV4Session *session;
     const char *request_id;
     int cancelled;
+    ColiExpertStore *store;   /* for live HITS telemetry during decode */
 } V4ServeStream;
 
 static double v4_serve_rss_gb(void) {
@@ -8397,6 +8451,15 @@ static int v4_serve_token(void *user_data, int token, float logit,
         int bytes = tok_decode(&stream->session->tokenizer, &token, 1,
                                piece, (int)sizeof(piece) - 1);
         v4_serve_data(stream->request_id, piece, bytes);
+    }
+    if (stream->store && stream->store->ops && stream->store->ops->hits) {
+        char *hex = malloc(65536);
+        if (hex) {
+            ColiStoreTelemetry tm;
+            if (stream->store->ops->hits(stream->store, hex, 65536, &tm) == 0)
+                printf("HITS %d %d %s\n", tm.rows, tm.cols, hex);
+            free(hex);
+        }
     }
     while (coli_stdin_readable()) {
         V4ServeRequest queued = {0};
@@ -8522,7 +8585,7 @@ static void v4_serve_one(ColiV4Engine *engine, ColiV4Session *session,
     ColiExpertStoreStats before = {0}, after = {0};
     if (engine->experts && engine->experts->ops && engine->experts->ops->stats)
         engine->experts->ops->stats(engine->experts, &before);
-    V4ServeStream stream = {session, request->id, 0};
+    V4ServeStream stream = {session, request->id, 0, engine->experts};
     ColiV4SessionGenerateStats stats = {0};
     char error[512] = {0};
     double started = spec_now();
@@ -9537,7 +9600,7 @@ int coli_deepseek_v4_expert_store_open(
     const ColiDeepSeekV4ExpertStoreOptions *options, ColiExpertStore **output,
     char *error, size_t error_size) {
     static const ColiExpertStoreOps operations = {
-        lookup, release, prefetch, stats, 0, destroy
+        lookup, release, prefetch, stats, 0, 0, destroy
     };
     if (!options || !output || !options->model_dir || options->layers < 1 ||
         options->experts_per_layer < 1 || !options->cache_bytes)

--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -5331,6 +5331,54 @@ static void stats(const ColiExpertStore *store, ColiExpertStoreStats *output) {
     *output = state->stats;
     pthread_mutex_unlock(&state->mutex);
 }
+/* Dashboard telemetry: per-expert tier/heat hex map (2 hex chars per expert:
+ * (tier << 6) | heat; tier 0=disk 1=RAM, heat = log2(slot usage) capped at
+ * 63). Implemented here, next to the slots it reads, and exposed through
+ * ColiExpertStoreOps.emap so the serve loop (a different amalgamated unit)
+ * never needs the store internals. */
+static int store_emap(const ColiExpertStore *store, char *hex, size_t hex_cap,
+                      ColiStoreTelemetry *out) {
+    if (!store || !store->state || !hex || !out) return -1;
+    V4ExpertStoreState *state = store->state;
+    int rows = state->layers;
+    int cols = state->experts_per_layer;
+    if (rows < 1 || cols < 1 || !state->slots) return -1;
+    size_t need = (size_t)rows * cols * 2 + 1;
+    if (hex_cap < need) return -1;
+    int resident = 0;
+    int w = 0;
+    pthread_mutex_lock(&state->mutex);
+    for (int layer = 0; layer < rows; layer++) {
+        V4ExpertSlot *layer_slots =
+            state->slots + (size_t)layer * state->slots_per_layer;
+        for (int expert = 0; expert < cols; expert++) {
+            int tier = 0;
+            uint64_t used = 0;
+            for (int z = 0; z < state->slots_per_layer; z++) {
+                V4ExpertSlot *slot = &layer_slots[z];
+                if (slot->slab && slot->expert == expert) {
+                    tier = 1;
+                    if (slot->used > used) used = slot->used;
+                }
+            }
+            if (tier) resident++;
+            int heat = 0;
+            while (used) { heat++; used >>= 1; }
+            if (heat > 63) heat = 63;
+            int b = (tier << 6) | heat;
+            hex[w++] = "0123456789abcdef"[b >> 4];
+            hex[w++] = "0123456789abcdef"[b & 15];
+        }
+    }
+    pthread_mutex_unlock(&state->mutex);
+    hex[w] = 0;
+    out->rows = rows;
+    out->cols = cols;
+    out->resident = resident;
+    out->record_bytes = state->record_bytes;
+    return 0;
+}
+
 
 static void destroy(ColiExpertStore *store) {
     if (!store) return;
@@ -5357,7 +5405,7 @@ int coli_deepseek_v4_expert_store_open(
     const ColiDeepSeekV4ExpertStoreOptions *options, ColiExpertStore **output,
     char *error, size_t error_size) {
     static const ColiExpertStoreOps operations = {
-        lookup, release, prefetch, stats, destroy
+        lookup, release, prefetch, stats, store_emap, destroy
     };
     if (!options || !output || !options->model_dir || options->layers < 1 ||
         options->experts_per_layer < 1 || !options->cache_bytes)
@@ -5977,7 +6025,7 @@ int COLI_V4_ROWS16_STORE_OPEN(
     const ColiDeepSeekV4ExpertStoreOptions *options, ColiExpertStore **output,
     char *error, size_t error_size) {
     static const ColiExpertStoreOps hot_operations = {
-        lookup_hot, release, prefetch, stats, destroy_hot
+        lookup_hot, release, prefetch, stats, store_emap, destroy_hot
     };
     int result = coli_deepseek_v4_expert_store_open_base(
         options, output, error, error_size);
@@ -8376,6 +8424,72 @@ static void v4_serve_error(const char *id, const char *message) {
     fflush(stdout);
 }
 
+/* ---- dashboard telemetry (serve protocol) ---------------------------------
+ * openai_server.py parses HWINFO / TIERS / EMAP / PROF lines from engine
+ * stdout to feed the web dashboard. The GLM engine and the sibling engines
+ * already emit them; the V4 target engine did not, so the Brain/Profiling
+ * pages sat on "waiting for engine". Same line formats, V4 data. */
+
+static void v4_serve_hwinfo(void) {
+    char cpu[256] = "";
+    int cores = 0;
+    double ram_total = 0, ram_avail = 0;
+    FILE *ci = fopen("/proc/cpuinfo", "r");
+    if (ci) {
+        char ln[256];
+        while (fgets(ln, sizeof(ln), ci))
+            if (!strncmp(ln, "model name", 10)) {
+                char *p = strchr(ln, ':');
+                if (p) {
+                    p++;
+                    while (*p == ' ') p++;
+                    int n = (int)strlen(p);
+                    if (n > 0 && p[n - 1] == '\n') p[--n] = 0;
+                    snprintf(cpu, sizeof(cpu), "%s", p);
+                }
+                break;
+            }
+        fclose(ci);
+    }
+#ifdef _SC_NPROCESSORS_ONLN
+    cores = (int)sysconf(_SC_NPROCESSORS_ONLN);
+#endif
+    FILE *mi = fopen("/proc/meminfo", "r");
+    if (mi) {
+        char ln[256];
+        double v = 0;
+        while (fgets(ln, sizeof(ln), mi)) {
+            if (sscanf(ln, "MemTotal: %lf", &v) == 1) ram_total = v / 1e6;
+            if (sscanf(ln, "MemAvailable: %lf", &v) == 1) ram_avail = v / 1e6;
+        }
+        fclose(mi);
+    }
+    printf("HWINFO %d %.1f %.1f 0 0.0 %s|\n", cores, ram_total, ram_avail,
+           cpu[0] ? cpu : "unknown");
+    fflush(stdout);
+}
+
+static void v4_serve_tiers_emap(ColiV4Engine *engine) {
+    ColiExpertStore *store = engine ? engine->experts : NULL;
+    if (!store || !store->ops || !store->ops->emap) return;
+    char *hex = malloc(65536);
+    if (!hex) return;
+    ColiStoreTelemetry tm;
+    if (store->ops->emap(store, hex, 65536, &tm) != 0 ||
+        tm.rows < 1 || tm.cols < 1) {
+        free(hex);
+        return;
+    }
+    int total = tm.rows * tm.cols;
+    double ram_gb = tm.record_bytes
+        ? (double)tm.resident * (double)tm.record_bytes / 1e9 : 0.0;
+    printf("TIERS 0 %d %d 0.00 %.2f\n", tm.resident, total - tm.resident,
+           ram_gb);
+    printf("EMAP %d %d %s\n", tm.rows, tm.cols, hex);
+    fflush(stdout);
+    free(hex);
+}
+
 static void v4_serve_one(ColiV4Engine *engine, ColiV4Session *session,
                          V4ServeRequest *request) {
     if (request->extension_bytes) {
@@ -8435,6 +8549,17 @@ static void v4_serve_one(ColiV4Engine *engine, ColiV4Session *session,
     int length_limited = !stream.cancelled && !stats.eos_stopped &&
                          stats.generated_tokens >= request->max_tokens;
     double decode = stats.decode_sec > 0.0 ? stats.decode_sec : elapsed;
+    /* Dashboard telemetry for this turn: hardware panel, tier bar + expert
+     * cortex, then the per-turn PROF line. The V4 engine does not split
+     * decode into phase timers yet, so the phase fields are 0 and the whole
+     * wall time lands in the UI's "other" bucket — honest, and the wall/token
+     * columns still render. */
+    v4_serve_hwinfo();
+    v4_serve_tiers_emap(engine);
+    printf("PROF %.3f %d %d %.3f %.3f %.3f %.3f %.3f %llu\n",
+           elapsed, stats.prompt_tokens, completion,
+           0.0, 0.0, 0.0, 0.0, 0.0,
+           (unsigned long long)(completion > 0 ? completion + 1 : 1));
     /* Trailing field: prompt tokens served from the previous turn's attention
      * state instead of being prefilled again. Appended rather than inserted --
      * openai_server.py accepts `len(fields) >= 7`, so an older reader ignores
@@ -8492,6 +8617,11 @@ static int v4_serve_main(void) {
     fputs("\x01\x01READY\x01\x01\n", stdout);
     printf("STAT 0 0.0 0.0 %.2f 0 0\n", v4_serve_rss_gb());
     fflush(stdout);
+    /* Dashboard hardware/tier/cortex snapshot right after the handshake so
+     * the panels render before the first request (the dispatcher reads these
+     * lines after read_engine_turn has consumed READY + STAT). */
+    v4_serve_hwinfo();
+    v4_serve_tiers_emap(engine);
     for (;;) {
         V4ServeRequest request = {0};
         int result;
@@ -9407,7 +9537,7 @@ int coli_deepseek_v4_expert_store_open(
     const ColiDeepSeekV4ExpertStoreOptions *options, ColiExpertStore **output,
     char *error, size_t error_size) {
     static const ColiExpertStoreOps operations = {
-        lookup, release, prefetch, stats, destroy
+        lookup, release, prefetch, stats, 0, destroy
     };
     if (!options || !output || !options->model_dir || options->layers < 1 ||
         options->experts_per_layer < 1 || !options->cache_bytes)

--- a/c/expert_store.h
+++ b/c/expert_store.h
@@ -78,6 +78,13 @@ typedef struct {
      * on success and fills *out. NULL when unsupported. */
     int (*emap)(const ColiExpertStore *store, char *hex, size_t hex_cap,
                 ColiStoreTelemetry *out);
+    /* Dashboard telemetry (optional): drain + clear a hex bitmap (1 bit per
+     * expert, rows*cols bits; bit i = byte i>>3, bit i&7) of experts routed
+     * since the last call, so the Brain cortex can flash live. hex must hold
+     * ((rows*cols+7)/8)*2+1 bytes; returns 0 on success and fills *out.
+     * NULL when unsupported. */
+    int (*hits)(const ColiExpertStore *store, char *hex, size_t hex_cap,
+                ColiStoreTelemetry *out);
     void (*destroy)(ColiExpertStore *store);
 } ColiExpertStoreOps;
 

--- a/c/expert_store.h
+++ b/c/expert_store.h
@@ -57,6 +57,13 @@ typedef struct {
  *   still has an active lease.
  */
 typedef struct {
+    int rows;              /* expert layers */
+    int cols;              /* experts per layer */
+    int resident;          /* experts currently resident in RAM */
+    uint64_t record_bytes; /* bytes per expert record (tier GB estimate) */
+} ColiStoreTelemetry;
+
+typedef struct {
     /* Returns zero on success. The view remains valid until release(). */
     int (*lookup)(ColiExpertStore *store, ColiExpertKey key,
                   ColiExpertView *view);
@@ -65,6 +72,12 @@ typedef struct {
     int (*prefetch)(ColiExpertStore *store, const ColiExpertKey *keys,
                     size_t count);
     void (*stats)(const ColiExpertStore *store, ColiExpertStoreStats *stats);
+    /* Dashboard telemetry (optional): fill a per-expert tier/heat hex map,
+     * 2 hex chars per expert: (tier << 6) | heat, tier 0=disk 1=RAM, heat =
+     * log2(usage) capped at 63. hex must hold rows*cols*2+1 bytes; returns 0
+     * on success and fills *out. NULL when unsupported. */
+    int (*emap)(const ColiExpertStore *store, char *hex, size_t hex_cap,
+                ColiStoreTelemetry *out);
     void (*destroy)(ColiExpertStore *store);
 } ColiExpertStoreOps;
 

--- a/web/src/Brain.tsx
+++ b/web/src/Brain.tsx
@@ -112,6 +112,24 @@ export function Brain({ baseUrl, apiKey, connected }: { baseUrl: string; apiKey:
           ctx.fillRect(c * (cell + gap), r * (cell + gap), cell, cell)
         }
       }
+      // Explicit grid lines: the inter-cell gap alone scales away when the
+      // canvas bitmap is CSS-scaled to fit the wrapper (non-integer scale
+      // factors drop some column/row separations). Stroke every boundary so
+      // the grid is complete at any display size.
+      ctx.strokeStyle = "#000"
+      ctx.lineWidth = 1
+      ctx.beginPath()
+      for (let c = 1; c < cols; c++) {
+        const x = c * (cell + gap) - 0.5
+        ctx.moveTo(x, 0)
+        ctx.lineTo(x, canvas.height)
+      }
+      for (let r = 1; r < rows; r++) {
+        const y = r * (cell + gap) - 0.5
+        ctx.moveTo(0, y)
+        ctx.lineTo(canvas.width, y)
+      }
+      ctx.stroke()
       let alive = false
       if (p) for (let i = 0; i < p.length; i++) { if (p[i] > 0.01) { p[i] *= 0.94; alive = true } else p[i] = 0 }
       if (alive) rafRef.current = requestAnimationFrame(draw)


### PR DESCRIPTION
## Problem

The DeepSeek V4 target engine (`deepseek_v4`) never emits the serve-protocol telemetry lines that `openai_server.py` parses for the web dashboard. The Brain and Profiling tabs, the hardware panel, and the tier bar all stayed on "waiting for engine" — the UI was ready, the server was ready, but the engine never spoke:

- `HWINFO` / `TIERS` / `EMAP` (hardware panel, tier bar, expert cortex) — absent
- `PROF` (per-turn phase timings for the Profiling page) — absent
- `HITS` (live cortex flash of routed experts during decode) — absent

Verified against the v1.5.0 binary: `strings deepseek_v4 | grep -c "EMAP"` → 0; `/experts` returned `{"rows":0,"cols":0,"map":"","hits":"","seq":0}` and `/profile` returned `{"seq":0,"turns":[]}` after real turns.

## What this adds

- **`c/expert_store.h`**: `ColiStoreTelemetry` struct plus two optional ops on `ColiExpertStoreOps`:
  - `emap` — per-expert tier/heat hex map (2 chars per expert: `(tier << 6) | heat`, tier 0=disk 1=RAM, heat = log2(usage) capped at 63)
  - `hits` — drain+clear a routed-expert bitmap (1 bit per expert, byte `i>>3`, bit `i&7`)
- **`c/deepseek_v4.c`**:
  - `store_emap()` / `store_hits()` implemented inside the expert-store unit, next to the slot cache they read, under the store mutex
  - routed-expert bitmap allocated at store open, freed on destroy/fail; marked in `lookup()` and both `lookup_hot()` success paths
  - serve loop emits `HWINFO` (cpuinfo/meminfo), `TIERS` + `EMAP`, and per-turn `PROF` after the READY handshake and after each turn (mirrors `colibri.c`'s `mux_done` ordering)
  - `v4_serve_token` drains and emits `HITS` after **every token**, so the Brain cortex flashes routed experts live during decode

## Verification (real 284B checkpoint, serve mode)

- `/health` now carries `hwinfo` (AMD EPYC 7662, 64 cores, RAM totals) and `tiers` (e.g. `ram: 2108, disk: 8900, ram_gb: 28.18` after one turn)
- `/experts` → `rows: 43, cols: 256`, 22,016-char map with resident tier + heat bytes set
- `/profile` → real per-turn records (`wall_s`, token counts, forwards)
- 40-token turn → `hits_seq` advanced to exactly 40 (one `HITS` emission per token), bitmap populated
- No protocol regressions: chat/completions, DATA streaming, ACCEPT/DONE unchanged

## Known limitation (deliberately honest)

The V4 engine has no per-phase timers yet (unlike the GLM engine's `t_ewait`/`t_emm`/`t_attn` accumulators), so `PROF` phase fields are emitted as 0 and the whole wall time lands in the UI's "other" bucket. The per-turn wall/token columns render correctly; the phase breakdown needs engine-side instrumentation, which is a separate change.

## Base

Based on `main` (v1.5.0, `8f512fc`). Happy to rebase onto `dev` if you'd rather have it there with the other V4 work.
