### PR TITLE
Experiment: validate placement and backend residency assumptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,11 @@ c/tiny_inkling/
 
 # Claude Code working directory (agent worktrees, session scratch) — never a repo artifact
 .claude/
+
+# CNRE local experiment outputs (the source tools and methodology are tracked;
+# generated traces, profiles, and result dumps are not repository artifacts).
+cnre-results/
+c/cnre-results/
+*.trace
+*.coli_usage
+.coli_kv*

--- a/c/Makefile.deepseek-v4
+++ b/c/Makefile.deepseek-v4
@@ -62,6 +62,13 @@ V4_OBJS = $(TARGET_OBJS)
 .PHONY: deepseek-v4 deepseek-v4-clean deepseek-v4-test-objs
 deepseek-v4: $(V4_BINARY)
 
+# Vulkan support is currently implemented by the GLM/Kimi sibling engines, not
+# by the amalgamated DeepSeek V4 runtime. Keep `make deepseek-v4 VK=1` from
+# implying that COLI_VULKAN=1 can dispatch V4 work.
+ifeq ($(VK),1)
+$(warning DeepSeek V4 does not currently include a Vulkan backend; VK is ignored)
+endif
+
 $(V4_BINARY): $(V4_OBJS)
 	$(CC) $(V4_OBJS) -o $@ $(LDFLAGS)
 

--- a/c/backend_metal.h
+++ b/c/backend_metal.h
@@ -139,12 +139,13 @@ int coli_metal_resset_stats(double *flush_s);
  *  g/u/d[e]    = pointers to expert e's gate/up/down quantized weights (in RAM slabs)
  *  gs/us/ds[e] = pointers to expert e's scales (per-row or per-group)
  *  fmt         = quant format (shared across experts), including fmt=4 grouped int4.
+ *  group_size  = common fmt=4 group size (0 for non-grouped formats).
  *  xg          = packed activations [total_rows, D]; xoff[e] = row offset of expert e
  *  nr[e]       = rows for expert e; rows[]/rw[] map packed rows back to out positions
  *  out         = [S, D] accumulate target
  * Returns 1 on success, 0 to signal the caller to fall back to the CPU path.
  */
-int coli_metal_moe_block(int nb, int D, int Iinter, int fmt,
+int coli_metal_moe_block(int nb, int D, int Iinter, int fmt, int group_size,
                          const void *const *g, const void *const *u, const void *const *d,
                          const float *const *gs, const float *const *us, const float *const *ds,
                          const float *xg, const int *xoff, const int *nr,
@@ -159,7 +160,7 @@ int coli_metal_moe_block(int nb, int D, int Iinter, int fmt,
  * end returns 0 on GPU fault (caller redoes those experts on CPU).
  */
 typedef struct ColiMetalMoeHandle ColiMetalMoeHandle;
-ColiMetalMoeHandle* coli_metal_moe_block_begin(int nb, int D, int Iinter, int fmt,
+ColiMetalMoeHandle* coli_metal_moe_block_begin(int nb, int D, int Iinter, int fmt, int group_size,
                          const void *const *g, const void *const *u, const void *const *d,
                          const float *const *gs, const float *const *us, const float *const *ds,
                          const float *xg, const int *xoff, const int *nr,

--- a/c/backend_metal.h
+++ b/c/backend_metal.h
@@ -137,12 +137,8 @@ int coli_metal_resset_stats(double *flush_s);
  *
  *  D           = hidden size, Iinter = moe intermediate size
  *  g/u/d[e]    = pointers to expert e's gate/up/down quantized weights (in RAM slabs)
- *  gs/us/ds[e] = pointers to expert e's per-row scales
- *  fmt         = quant format (shared across experts). NOTE: fmt=4 (grouped int4) is
- *                NOT yet supported here -- gates to {1,2} and returns 0 (CPU fallback)
- *                for fmt=4 experts, same as before this stage. Grouped-int4 gained GPU
- *                support in mm_gemv (coli_metal_matmul/coli_metal_gemm/bind_gemv) only;
- *                extending the batched routed-expert path is future work (see PR_BODY.md).
+ *  gs/us/ds[e] = pointers to expert e's scales (per-row or per-group)
+ *  fmt         = quant format (shared across experts), including fmt=4 grouped int4.
  *  xg          = packed activations [total_rows, D]; xoff[e] = row offset of expert e
  *  nr[e]       = rows for expert e; rows[]/rw[] map packed rows back to out positions
  *  out         = [S, D] accumulate target

--- a/c/backend_metal.mm
+++ b/c/backend_metal.mm
@@ -163,7 +163,7 @@ kernel void moe_gemv(device const ulong* waddr [[buffer(0)]], device const ulong
                      device float* yout [[buffer(4)]],
                      constant int& O [[buffer(5)]], constant int& K [[buffer(6)]],
                      constant int& Kin [[buffer(7)]], constant int& fmt [[buffer(8)]],
-                     constant int& NT [[buffer(9)]],
+                     constant int& NT [[buffer(9)]], constant int& GS [[buffer(10)]],
                      uint tg [[threadgroup_position_in_grid]],
                      uint slane [[thread_index_in_simdgroup]],
                      uint sgid [[simdgroup_index_in_threadgroup]]) {
@@ -180,9 +180,9 @@ kernel void moe_gemv(device const ulong* waddr [[buffer(0)]], device const ulong
       float4 w1=float4(float(int(b.z&0xF)-8),float(int(b.z>>4)-8),float(int(b.w&0xF)-8),float(int(b.w>>4)-8));
       acc+=dot(w0,x4[2*c])+dot(w1,x4[2*c+1]); }
     for(int i=K8*8+slane;i<K;i+=32){ uchar b=w[i>>1]; int v=(i&1)?(b>>4):(b&0xF); acc+=float(v-8)*xr[i]; }
-  } else if (fmt == 4) { int rb=(K+1)/2, ng=(K+63)/64; device const uchar* w=(device const uchar*)(waddr[e])+(long)o*rb;
+  } else if (fmt == 4) { int rb=(K+1)/2, ng=(K+GS-1)/GS; device const uchar* w=(device const uchar*)(waddr[e])+(long)o*rb;
     device const float* scales=sc+(long)o*ng;
-    for(int i=slane*2;i<K;i+=64){ uchar b=w[i>>1]; int g=i/64; acc+=float(int(b&0xF)-8)*xr[i]*scales[g]; if(i+1<K) acc+=float(int(b>>4)-8)*xr[i+1]*scales[(i+1)/64]; }
+    for(int i=slane*2;i<K;i+=64){ uchar b=w[i>>1]; int g=i/GS; acc+=float(int(b&0xF)-8)*xr[i]*scales[g]; if(i+1<K) acc+=float(int(b>>4)-8)*xr[i+1]*scales[(i+1)/GS]; }
   } else if (fmt == 6) {                            // E8/IQ3: 98B per 256 weights, scales in-block
     long rb=((long)(K+255)/256)*98;                 // host guards K%256==0 (GLM dims are)
     device const uchar* w=(device const uchar*)(waddr[e])+(long)o*rb;
@@ -1199,12 +1199,13 @@ extern "C" size_t coli_metal_tensor_bytes(const ColiMetalTensor *t) { return t ?
 // if Metal is off or any expert pointer is not in a registered slab.
 // Encode + commit a MoE block (no wait). Writes hh[R,D] into hh_buf. Returns nil on
 // unresolved slab / bad fmt (caller falls back to CPU).
-static id<MTLCommandBuffer> moe_submit(int nb, int D, int Iinter, int fmt,
+static id<MTLCommandBuffer> moe_submit(int nb, int D, int Iinter, int fmt, int group_size,
                          const void *const *g, const void *const *u, const void *const *d,
                          const float *const *gs, const float *const *us, const float *const *ds,
                          const float *xg, const int *xoff, const int *nr, int R,
                          id<MTLBuffer> xg_buf, id<MTLBuffer> gg_buf, id<MTLBuffer> uu_buf, id<MTLBuffer> hh_buf) {
   if (!g_dev || (fmt != 1 && fmt != 2 && fmt != 4 && fmt != 5 && fmt != 6)) return nil;
+  if (fmt == 4 && (group_size <= 0 || group_size > D)) return nil;
   if (fmt == 6) {   /* e8 kernel assumes clean block tiling, and every FWHT tile of the
                      * down input (CPU tiling rule, e8_rot_rows) must fit threadgroup mem */
     if ((D & 255) || (Iinter & 31)) return nil;
@@ -1257,7 +1258,7 @@ static id<MTLCommandBuffer> moe_submit(int nb, int D, int Iinter, int fmt,
     [e setBuffer:wa offset:0 atIndex:0];[e setBuffer:sa offset:0 atIndex:1];[e setBuffer:berow offset:0 atIndex:2];
     [e setBuffer:xin offset:0 atIndex:3];[e setBuffer:y offset:0 atIndex:4];
     [e setBytes:&O length:4 atIndex:5];[e setBytes:&K length:4 atIndex:6];[e setBytes:&Kin length:4 atIndex:7];[e setBytes:&fmt length:4 atIndex:8];
-    [e setBytes:&NT length:4 atIndex:9];
+     [e setBytes:&NT length:4 atIndex:9]; [e setBytes:&group_size length:4 atIndex:10];
     [e dispatchThreadgroups:MTLSizeMake(((size_t)NT+3)/4,1,1) threadsPerThreadgroup:MTLSizeMake(128,1,1)]; };
   gemv(bag,bsg,xg_buf,gg_buf,Iinter,D,D);                     // gate
   gemv(bau,bsu,xg_buf,uu_buf,Iinter,D,D);                     // up
@@ -1309,7 +1310,7 @@ static int moe_finish(id<MTLCommandBuffer> cb, id<MTLBuffer> hh_buf, int nb, int
   return 1;
 }
 
-extern "C" int coli_metal_moe_block(int nb, int D, int Iinter, int fmt,
+extern "C" int coli_metal_moe_block(int nb, int D, int Iinter, int fmt, int group_size,
                          const void *const *g, const void *const *u, const void *const *d,
                          const float *const *gs, const float *const *us, const float *const *ds,
                          const float *xg, const int *xoff, const int *nr,
@@ -1322,7 +1323,7 @@ extern "C" int coli_metal_moe_block(int nb, int D, int Iinter, int fmt,
     g_gg = ensure(g_gg,&g_gg_cap,(size_t)R*Iinter*4);
     g_uu = ensure(g_uu,&g_uu_cap,(size_t)R*Iinter*4);
     g_hh = ensure(g_hh,&g_hh_cap,(size_t)R*D*4);
-    id<MTLCommandBuffer> cb = moe_submit(nb,D,Iinter,fmt,g,u,d,gs,us,ds,xg,xoff,nr,R,g_xg,g_gg,g_uu,g_hh);
+    id<MTLCommandBuffer> cb = moe_submit(nb,D,Iinter,fmt,group_size,g,u,d,gs,us,ds,xg,xoff,nr,R,g_xg,g_gg,g_uu,g_hh);
     if (!cb) return 0;
     return moe_finish(cb,g_hh,nb,R,D,rows,rw,out);
   }
@@ -1335,7 +1336,7 @@ struct ColiMetalMoeHandle {
   std::vector<int> rows; std::vector<float> rwv;
   int nb, R, D;
 };
-extern "C" ColiMetalMoeHandle* coli_metal_moe_block_begin(int nb, int D, int Iinter, int fmt,
+extern "C" ColiMetalMoeHandle* coli_metal_moe_block_begin(int nb, int D, int Iinter, int fmt, int group_size,
                          const void *const *g, const void *const *u, const void *const *d,
                          const float *const *gs, const float *const *us, const float *const *ds,
                          const float *xg, const int *xoff, const int *nr,
@@ -1347,7 +1348,7 @@ extern "C" ColiMetalMoeHandle* coli_metal_moe_block_begin(int nb, int D, int Iin
     id<MTLBuffer> bgg=[g_dev newBufferWithLength:(size_t)R*Iinter*4 options:g_res_opts];
     id<MTLBuffer> buu=[g_dev newBufferWithLength:(size_t)R*Iinter*4 options:g_res_opts];
     id<MTLBuffer> bhh=[g_dev newBufferWithLength:(size_t)R*D*4 options:g_res_opts];
-    id<MTLCommandBuffer> cb = moe_submit(nb,D,Iinter,fmt,g,u,d,gs,us,ds,xg,xoff,nr,R,bxg,bgg,buu,bhh);
+    id<MTLCommandBuffer> cb = moe_submit(nb,D,Iinter,fmt,group_size,g,u,d,gs,us,ds,xg,xoff,nr,R,bxg,bgg,buu,bhh);
     if (!cb) return nullptr;
     ColiMetalMoeHandle *h = new ColiMetalMoeHandle();
     h->cb=cb; h->hh=bhh; h->rows.assign(rows,rows+R); h->rwv.assign(rw,rw+R);

--- a/c/backend_metal.mm
+++ b/c/backend_metal.mm
@@ -154,7 +154,8 @@ kernel void mm_gemv(device const uchar* w      [[buffer(0)]],   // raw weight by
 }
 
 // Batched bindless expert GEMV: each row gr belongs to expert erow[gr], whose weight and
-// scale live at gpuAddresses waddr[e]/saddr[e] (zero-copy in the RAM slab). fmt 1=i8, 2=i4.
+// scale live at gpuAddresses waddr[e]/saddr[e] (zero-copy in the RAM slab). fmt 1=i8,
+// 2=i4, 4=grouped i4.
 // One SIMDGROUP per output row, 4 rows/threadgroup, 8-value loads: measured 1.5-2.1x over
 // one-threadgroup-per-row with uchar2 loads (358-389 GB/s on engine-like block shapes).
 kernel void moe_gemv(device const ulong* waddr [[buffer(0)]], device const ulong* saddr [[buffer(1)]],
@@ -179,6 +180,9 @@ kernel void moe_gemv(device const ulong* waddr [[buffer(0)]], device const ulong
       float4 w1=float4(float(int(b.z&0xF)-8),float(int(b.z>>4)-8),float(int(b.w&0xF)-8),float(int(b.w>>4)-8));
       acc+=dot(w0,x4[2*c])+dot(w1,x4[2*c+1]); }
     for(int i=K8*8+slane;i<K;i+=32){ uchar b=w[i>>1]; int v=(i&1)?(b>>4):(b&0xF); acc+=float(v-8)*xr[i]; }
+  } else if (fmt == 4) { int rb=(K+1)/2, ng=(K+63)/64; device const uchar* w=(device const uchar*)(waddr[e])+(long)o*rb;
+    device const float* scales=sc+(long)o*ng;
+    for(int i=slane*2;i<K;i+=64){ uchar b=w[i>>1]; int g=i/64; acc+=float(int(b&0xF)-8)*xr[i]*scales[g]; if(i+1<K) acc+=float(int(b>>4)-8)*xr[i+1]*scales[(i+1)/64]; }
   } else if (fmt == 6) {                            // E8/IQ3: 98B per 256 weights, scales in-block
     long rb=((long)(K+255)/256)*98;                 // host guards K%256==0 (GLM dims are)
     device const uchar* w=(device const uchar*)(waddr[e])+(long)o*rb;
@@ -216,7 +220,7 @@ kernel void moe_gemv(device const ulong* waddr [[buffer(0)]], device const ulong
     for(int i=K8*8+slane;i<K;i+=32) acc+=float(w[i])*xr[i];
   }
   acc=simd_sum(acc);
-  if(slane==0) yout[row] = (fmt==6||fmt==5) ? acc : acc*sc[o];   // fmt 6: in-block scales; fmt 5: none
+  if(slane==0) yout[row] = (fmt==6||fmt==5||fmt==4) ? acc : acc*sc[o];   // grouped scales are folded per group
 }
 
 // fmt=6 activation rotation for the GPU-resident down-projection input: one FWHT
@@ -1200,7 +1204,7 @@ static id<MTLCommandBuffer> moe_submit(int nb, int D, int Iinter, int fmt,
                          const float *const *gs, const float *const *us, const float *const *ds,
                          const float *xg, const int *xoff, const int *nr, int R,
                          id<MTLBuffer> xg_buf, id<MTLBuffer> gg_buf, id<MTLBuffer> uu_buf, id<MTLBuffer> hh_buf) {
-  if (!g_dev || (fmt != 1 && fmt != 2 && fmt != 5 && fmt != 6)) return nil;
+  if (!g_dev || (fmt != 1 && fmt != 2 && fmt != 4 && fmt != 5 && fmt != 6)) return nil;
   if (fmt == 6) {   /* e8 kernel assumes clean block tiling, and every FWHT tile of the
                      * down input (CPU tiling rule, e8_rot_rows) must fit threadgroup mem */
     if ((D & 255) || (Iinter & 31)) return nil;

--- a/c/backend_vulkan.c
+++ b/c/backend_vulkan.c
@@ -295,7 +295,18 @@ int coli_vk_init(const char *spv_path) {
     if (!nd) { fprintf(stderr, "[VK] no devices\n"); return 0; }
     VkPhysicalDevice devs[8]; if (nd > 8) nd = 8;
     vkEnumeratePhysicalDevices(G.inst, &nd, devs);
-    // Prefer a real GPU over a CPU/software device (llvmpipe) on multi-adapter hosts:
+    // Prefer a real GPU over a CPU/software device (llvmpipe) on multi-adapter hosts.
+    // COLI_VK_DEV selects the primary physical-device enumeration index; this
+    // makes multi-GPU and Intel/AMD hybrid systems diagnosable and reproducible.
+    const char *requested = getenv("COLI_VK_DEV");
+    if (requested && *requested) {
+        char *end = NULL; long index = strtol(requested, &end, 10);
+        if (*end || index < 0 || index >= (long)nd) {
+            fprintf(stderr, "[VK] invalid COLI_VK_DEV=%s (devices=%u)\n", requested, nd);
+            return 0;
+        }
+        G.phys = devs[index];
+    } else {
     // discrete > integrated > virtual > other/cpu. Falls back to devs[0] if all equal.
     G.phys = devs[0];
     int bestrank = -1;
@@ -306,6 +317,7 @@ int coli_vk_init(const char *spv_path) {
                    p.deviceType == VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU    ? 2 :
                    p.deviceType == VK_PHYSICAL_DEVICE_TYPE_OTHER          ? 1 : 0; // CPU last
         if (rank > bestrank) { bestrank = rank; G.phys = devs[i]; }
+    }
     }
 
     uint32_t nq = 0;

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -4253,19 +4253,21 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
          * batch's rows all share s, so this is one FWHT per token in practice. The down
          * input is rotated on-GPU by moe_fwht inside moe_submit. */
         int is_miss[64]={0}; ColiMetalMoeHandle *mh=NULL;
-        int cpu_res=1, cpu_miss=1, mh_shared=0, nbb=0, Rtot=0, mfmt=-1, sh_in=0;
+         int cpu_res=1, cpu_miss=1, mh_shared=0, nbb=0, Rtot=0, mfmt=-1, mgs=0, sh_in=0;
         const void *MG[65],*MU[65],*MD[65]; const float *MGS[65],*MUS[65],*MDS[65];
         int xoffb[65],nrb[65];
         float *mxg=NULL; int *mrows=NULL; float *mrw=NULL;
         /* subset builder: experts with is_miss==WANTMISS (+ shared expert when TRY_SH) */
         #define MB_BUILD(WANTMISS, TRY_SH) do{ \
-            nbb=0; Rtot=0; mfmt=-1; sh_in=0; \
+             nbb=0; Rtot=0; mfmt=-1; mgs=0; sh_in=0; \
             for(int j=0;j<nb;j++){ if(is_miss[j]!=(WANTMISS)) continue; \
                 int eid=uniq[base+j]; ESlot *e=use[j]; int cnt=0; \
                 for(int s=0;s<S;s++) for(int kk=0;kk<keff[s];kk++) \
                     if(idxs[(int64_t)s*K+kk]==eid){ cnt++; break; } \
                 if(!cnt) continue; \
-                if(mfmt<0) mfmt=e->g.fmt; \
+                 if(mfmt<0){ mfmt=e->g.fmt; mgs=e->g.gs; } \
+                 if(mfmt!=-2 && (e->g.fmt!=mfmt || (mfmt==4 && (e->g.gs!=mgs || e->u.gs!=mgs || e->d.gs!=mgs)))) mfmt=-2; \
+                 if(mfmt==-2) continue; \
                 MG[nbb]=e->g.fmt==1?(const void*)e->g.q8:(const void*)e->g.q4; \
                 MU[nbb]=e->u.fmt==1?(const void*)e->u.q8:(const void*)e->u.q4; \
                 MD[nbb]=e->d.fmt==1?(const void*)e->d.q8:(const void*)e->d.q4; \
@@ -4273,8 +4275,9 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                 xoffb[nbb]=Rtot; nrb[nbb]=cnt; Rtot+=cnt; nbb++; \
             } \
             if(TRY_SH){ int shf = mfmt<0 ? l->sh_gate.fmt : mfmt; \
-                if(c->n_shared==1 && sI==I && l->sh_gate.fmt==shf && l->sh_up.fmt==shf && l->sh_down.fmt==shf){ \
-                    if(mfmt<0) mfmt=shf; \
+                if(c->n_shared==1 && sI==I && l->sh_gate.fmt==shf && l->sh_up.fmt==shf && l->sh_down.fmt==shf && \
+                   (shf!=4 || (l->sh_gate.gs==mgs && l->sh_up.gs==mgs && l->sh_down.gs==mgs))){ \
+                     if(mfmt<0){ mfmt=shf; mgs=l->sh_gate.gs; } \
                     MG[nbb]=shf==1?(const void*)l->sh_gate.q8:(const void*)l->sh_gate.q4; \
                     MU[nbb]=shf==1?(const void*)l->sh_up.q8  :(const void*)l->sh_up.q4; \
                     MD[nbb]=shf==1?(const void*)l->sh_down.q8:(const void*)l->sh_down.q4; \
@@ -4295,13 +4298,14 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
             mxg=falloc((int64_t)(nb+1)*S*D);
             mrows=xalloc((size_t)(nb+1)*S*sizeof(int),"moe mrows"); mrw=xalloc((size_t)(nb+1)*S*sizeof(float),"moe mrw");
             MB_BUILD(0, base==0 && !g_pre_sh);
+            if(mfmt==-2) nbb=0; /* incompatible grouped metadata: retain CPU correctness */
             if(nbb>0){
                 double t0=now_s();
                 if(mfmt==6) metal_stage_rot_e8(mxg,mrows,Rtot,D);
-                mh=coli_metal_moe_block_begin(nbb,D,I,mfmt,MG,MU,MD,MGS,MUS,MDS,mxg,xoffb,nrb,mrows,mrw);
+                 mh=coli_metal_moe_block_begin(nbb,D,I,mfmt,mgs,MG,MU,MD,MGS,MUS,MDS,mxg,xoffb,nrb,mrows,mrw);
                 m->t_emm += now_s()-t0;
                 if(mh){ cpu_res=0; mh_shared=sh_in; }
-            } else cpu_res=0;
+            } else if(mfmt!=-2) cpu_res=0;
         }
 #endif
         /* Expert loads run HERE, after the resident-experts GPU submit above: under METAL the
@@ -4358,12 +4362,13 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                 for(int q=0;q<nmiss;q++) pipe_wait(q);
                 m->t_ewait += now_s()-tw; }
             MB_BUILD(1, 0);                                   /* missed experts, now loaded */
+            if(mfmt==-2) nbb=0; /* incompatible grouped metadata: retain CPU correctness */
             if(nbb>0){
                 double t0=now_s();
                 if(mfmt==6) metal_stage_rot_e8(mxg,mrows,Rtot,D);
-                if(coli_metal_moe_block(nbb,D,I,mfmt,MG,MU,MD,MGS,MUS,MDS,mxg,xoffb,nrb,mrows,mrw,out,S)) cpu_miss=0;
+                 if(coli_metal_moe_block(nbb,D,I,mfmt,mgs,MG,MU,MD,MGS,MUS,MDS,mxg,xoffb,nrb,mrows,mrw,out,S)) cpu_miss=0;
                 m->t_emm += now_s()-t0;
-            } else cpu_miss=0;
+            } else if(mfmt!=-2) cpu_miss=0;
             if(mh){ double t0=now_s();
                 if(coli_metal_moe_block_end(mh,out)){ if(mh_shared) shared_on_gpu=1; }
                 else cpu_res=1;

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -9321,7 +9321,7 @@ int main(int argc, char **argv){
     if(getenv("COLI_METAL") && atoi(getenv("COLI_METAL"))){
         g_metal_enabled = coli_metal_init();
         if(!g_metal_enabled){ fprintf(stderr,"[METAL] backend requested but not available\n"); return 2; }
-        fprintf(stderr,"[METAL] mode: batched routed experts on GPU (unified-memory zero-copy)\n");
+        fprintf(stderr,"[METAL] device initialized; routed expert dispatch is format-dependent\n");
         if(getenv("COLI_METAL_SPIN") && atoi(getenv("COLI_METAL_SPIN"))){ coli_metal_spin_start(); fprintf(stderr,"[METAL] keep-alive spinner ON\n"); }
         if(getenv("COLI_METAL_GEMM_MIN")) g_metal_gemm_min=atoi(getenv("COLI_METAL_GEMM_MIN"));
     }

--- a/c/doctor.py
+++ b/c/doctor.py
@@ -468,20 +468,22 @@ def run_doctor(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0, *,
         selected_gpus = [gpu for gpu in detected_gpus if gpu["index"] in wanted]
 
     if gpu_indices == []:
-        checks.append(_check("accelerator.cuda", "skip", "GPU use was explicitly disabled"))
+        checks.append(_check("accelerator.gpu", "skip", "GPU use was explicitly disabled"))
     elif gpu_indices is not None and len(selected_gpus) != len(set(gpu_indices)):
-        checks.append(_check("accelerator.cuda", "fail", "one or more requested GPUs were not detected",
+        checks.append(_check("accelerator.gpu", "fail", "one or more requested GPUs were not detected",
                              requested=gpu_indices, detected=[gpu["index"] for gpu in detected_gpus]))
     elif selected_gpus and linkage.get("missing"):
-        checks.append(_check("accelerator.cuda", "fail", "CUDA runtime library is missing"))
+        checks.append(_check("accelerator.gpu", "fail", "GPU runtime library is missing"))
     elif selected_gpus and linkage.get("linked"):
-        checks.append(_check("accelerator.cuda", "pass", "CUDA engine and devices are available",
-                             devices=[gpu["index"] for gpu in selected_gpus]))
+        checks.append(_check("accelerator.gpu", "pass", "GPU engine and devices are available",
+                             devices=[gpu["index"] for gpu in selected_gpus],
+                             unified=any(gpu.get("unified_memory", False)
+                                         for gpu in selected_gpus)))
     elif selected_gpus:
-        checks.append(_check("accelerator.cuda", "warn", "NVIDIA GPU detected but the engine is CPU-only",
+        checks.append(_check("accelerator.gpu", "warn", "GPU detected but the engine is CPU-only",
                              devices=[gpu["index"] for gpu in selected_gpus]))
     else:
-        checks.append(_check("accelerator.cuda", "skip", "no NVIDIA GPU detected; CPU path is available"))
+        checks.append(_check("accelerator.gpu", "skip", "no supported GPU detected; CPU path is available"))
 
     try:
         plan = build_plan(model, ram_gb, context, gpu_indices, vram_gb,

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -1331,7 +1331,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
             }
         }
         sxoff[ns] = ns*S;
-        sh_h = coli_metal_moe_block_begin(ns, D, I, 5, sgp, sup, sdp,
+        sh_h = coli_metal_moe_block_begin(ns, D, I, 5, 0, sgp, sup, sdp,
                                           sscale, sscale, sscale,
                                           sxg, sxoff, snr, srows, srw);
         free(srows);
@@ -1414,7 +1414,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
                  * the round; shared_done stays set either way. */
                 if (base + cap >= npair && !sh_h) {
                     ColiMetalMoeHandle *h = coli_metal_moe_block_begin(
-                        nb, D, I, q4 ? 2 : 1, mgp, mup, mdp, mgs, mus, mds,
+                        nb, D, I, q4 ? 2 : 1, 0, mgp, mup, mdp, mgs, mus, mds,
                         mxg, mxoff, mnr, mrows, mrw);
                     if (h) {
                         double ts = now_s();
@@ -1428,7 +1428,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
                         te = now_s();                      /* fault: CPU redo below */
                     }
                 }
-                if (coli_metal_moe_block(nb, D, I, q4 ? 2 : 1, mgp, mup, mdp, mgs, mus, mds,
+                if (coli_metal_moe_block(nb, D, I, q4 ? 2 : 1, 0, mgp, mup, mdp, mgs, mus, mds,
                                          mxg, mxoff, mnr, mrows, mrw, out, S)) {
                     m->t_expert += now_s() - te;
                     continue;                              /* round done on the GPU */

--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -586,25 +586,28 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
         safe_vram += usable
         gpu_plan.append(dict(gpu, reserve_bytes=reserve, usable_bytes=usable))
     requested_vram = int(vram_gb * GB) if vram_gb > 0 else safe_vram
+    requested_vram_before_clamp = requested_vram
+    unified_pool = max(0, available_memory - info["dense_bytes"] - runtime_bytes)
     if unified:
         # Unified devices expose one physical pool to CUDA and the host. Do not
-        # let an auto/explicit VRAM tier consume pages that the RAM tier also
-        # believes are available.
-        unified_pool = max(0, available_memory - info["dense_bytes"] - runtime_bytes)
+        # let an expert tier consume pages that the RAM tier also believes are
+        # available. Dense/runtime reservations are shared exactly once below.
         requested_vram = min(requested_vram, unified_pool)
-    vram_budget = min(requested_vram, safe_vram, info["expert_bytes"])
+    vram_limit = unified_pool if unified else safe_vram
+    vram_budget = min(requested_vram, vram_limit, info["expert_bytes"])
     vram_experts = int(vram_budget // typical) if typical else 0
     hot_bytes = min(info["expert_bytes"], vram_experts * typical)
     warnings = []
     if unified:
-        ram_available = max(0, available_memory - vram_budget)
-        requested_ram = int(ram_gb * GB) if ram_gb > 0 else int(ram_available * 0.88)
-        ram_budget = min(requested_ram, ram_available)
-        if requested_ram > ram_available:
-            warnings = [
+        requested_ram = int(ram_gb * GB) if ram_gb > 0 else int(available_memory * 0.88)
+        requested_ram_experts = max(0, requested_ram - info["dense_bytes"] - runtime_bytes)
+        ram_expert_bytes = min(requested_ram_experts,
+                               max(0, unified_pool - vram_budget))
+        ram_budget = info["dense_bytes"] + runtime_bytes + ram_expert_bytes
+        if requested_ram_experts > ram_expert_bytes:
+            warnings.append(
                 f"RAM budget clamped from {format_bytes(requested_ram)} to "
-                f"{format_bytes(ram_budget)} because the GPU shares physical memory"
-            ]
+                f"{format_bytes(ram_budget)} because the GPU shares physical memory")
     else:
         ram_budget = int(ram_gb * GB) if ram_gb > 0 else int(available_memory * 0.88)
     if ram_budget < 4 * GB:
@@ -620,8 +623,8 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
         warnings.append("RAM budget cannot hold one expert slot per sparse layer")
     if gpu_indices is not None and len(gpus) != len(set(gpu_indices)):
         warnings.append("one or more requested GPUs were not detected")
-    if gpus and vram_budget < requested_vram:
-        warnings.append("VRAM tier was clamped by free VRAM or model expert size")
+    if gpus and vram_budget < requested_vram_before_clamp:
+        warnings.append("VRAM tier was clamped by free VRAM, shared memory, or model expert size")
     if unified:
         warnings.append(
             "GPU and RAM share one physical memory pool; budgets were jointly constrained")

--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -73,6 +73,7 @@ def analyze_model(model):
     per_layer = {layer: int(statistics.median(sizes)) for layer, sizes in layer_sizes.items()}
     per_cap_bytes = sum(per_layer.values())
     typical_expert_bytes = int(statistics.median(per_layer.values())) if per_layer else 0
+    max_expert_bytes = max(per_layer.values(), default=0)
     model_bytes = sum(shard.stat().st_size for shard in shards)
     return {
         "path": str(model),
@@ -83,6 +84,8 @@ def analyze_model(model):
         "expert_count": len(expert_groups),
         "expert_layers": len(per_layer),
         "typical_expert_bytes": typical_expert_bytes,
+        "max_expert_bytes": max_expert_bytes,
+        "expert_bytes_by_layer": per_layer,
         "per_cap_bytes": per_cap_bytes,
         "config": config,
     }
@@ -278,9 +281,12 @@ def _discover_nvidia_gpus():
                 free = memory_available() // (1024 * 1024)
             except (OSError, AttributeError):
                 total = free = 0
-        devices.append({"index": index, "name": fields[1],
+        name = fields[1]
+        unified = any(token in name.lower() for token in ("gb10", "jetson", "grace blackwell"))
+        devices.append({"index": index, "name": name,
                         "total_bytes": total * 1024 * 1024,
-                        "free_bytes": free * 1024 * 1024})
+                        "free_bytes": free * 1024 * 1024,
+                        "unified_memory": unified})
     return devices
 
 
@@ -327,7 +333,8 @@ def _discover_amd_gpus():
         free = max(total - used, 0)
         name = (row.get(name_col) or "").strip() if name_col else ""
         devices.append({"index": index, "name": name or f"AMD GPU {index}",
-                        "total_bytes": total, "free_bytes": free})
+                        "total_bytes": total, "free_bytes": free,
+                        "unified_memory": False})
     return devices
 
 
@@ -377,11 +384,17 @@ def physical_cpu_count():
         except (OSError, ValueError, AttributeError) as error:
             _physical_cores_warn(f"Windows core probe failed: {error}")
     if sys.platform == "darwin":
-        # macOS has no lscpu. sysctl reports physical cores directly, and on
-        # Apple Silicon hw.physicalcpu counts P+E cores with no SMT sibling to
-        # dedupe. Without this branch the lscpu probe below fails and every run
-        # prints a spurious over-subscription warning on a machine that cannot
-        # over-subscribe.
+        # Apple Silicon's performance cores pace barriered expert matmuls. The
+        # physical count includes efficiency cores, which is not the useful
+        # OpenMP team size for this workload.
+        try:
+            result = subprocess.run(["sysctl", "-n", "hw.perflevel0.logicalcpu"],
+                                    text=True, capture_output=True, check=True, timeout=5)
+            cores = int(result.stdout.strip())
+            if cores > 0:
+                return cores
+        except (OSError, ValueError, subprocess.SubprocessError):
+            pass
         try:
             result = subprocess.run(["sysctl", "-n", "hw.physicalcpu"], text=True,
                                     capture_output=True, check=True, timeout=5)
@@ -553,22 +566,17 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
         wanted = set(gpu_indices)
         gpus = [gpu for gpu in gpus if gpu["index"] in wanted]
 
-    ram_budget = int(ram_gb * GB) if ram_gb > 0 else int(available_memory * 0.88)
-    if ram_budget < 4 * GB:
-        ram_budget = 8 * GB
+    unified = any(gpu.get("unified_memory", False) for gpu in gpus)
     typical = info["typical_expert_bytes"]
+    max_expert = info["max_expert_bytes"] or typical
     layers = int(cfg.get("num_hidden_layers") or 0) + 1
     kv_bytes = layers * context * (int(cfg.get("kv_lora_rank") or 0) +
                                    int(cfg.get("qk_rope_head_dim") or 0)) * 4
     kv_buffer = context * int(cfg.get("num_attention_heads") or 0) * (
         int(cfg.get("qk_nope_head_dim") or 0) + int(cfg.get("v_head_dim") or 0)) * 4
-    runtime_bytes = int(1.2 * GB + 2.5 * GB + 64 * typical + kv_bytes + kv_buffer)
-    cache_bytes = max(0, ram_budget - info["dense_bytes"] - runtime_bytes)
+    runtime_bytes = int(1.2 * GB + 2.5 * GB + 64 * max_expert + kv_bytes + kv_buffer)
     per_cap = info["per_cap_bytes"]
     configured_experts = int(cfg.get("n_routed_experts") or 0)
-    cap = int(cache_bytes // per_cap) if per_cap else 0
-    if configured_experts:
-        cap = min(cap, configured_experts)
 
     reserve = 2 * GB
     gpu_plan = []
@@ -578,21 +586,45 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
         safe_vram += usable
         gpu_plan.append(dict(gpu, reserve_bytes=reserve, usable_bytes=usable))
     requested_vram = int(vram_gb * GB) if vram_gb > 0 else safe_vram
-    # VRAM-resident experts do not need duplicate RAM backing: the checkpoint is
-    # their recovery source. RAM is therefore an independent warm compute tier.
+    if unified:
+        # Unified devices expose one physical pool to CUDA and the host. Do not
+        # let an auto/explicit VRAM tier consume pages that the RAM tier also
+        # believes are available.
+        unified_pool = max(0, available_memory - info["dense_bytes"] - runtime_bytes)
+        requested_vram = min(requested_vram, unified_pool)
     vram_budget = min(requested_vram, safe_vram, info["expert_bytes"])
     vram_experts = int(vram_budget // typical) if typical else 0
     hot_bytes = min(info["expert_bytes"], vram_experts * typical)
+    warnings = []
+    if unified:
+        ram_available = max(0, available_memory - vram_budget)
+        requested_ram = int(ram_gb * GB) if ram_gb > 0 else int(ram_available * 0.88)
+        ram_budget = min(requested_ram, ram_available)
+        if requested_ram > ram_available:
+            warnings = [
+                f"RAM budget clamped from {format_bytes(requested_ram)} to "
+                f"{format_bytes(ram_budget)} because the GPU shares physical memory"
+            ]
+    else:
+        ram_budget = int(ram_gb * GB) if ram_gb > 0 else int(available_memory * 0.88)
+    if ram_budget < 4 * GB:
+        ram_budget = 8 * GB if not unified else max(0, ram_budget)
+    cache_bytes = max(0, ram_budget - info["dense_bytes"] - runtime_bytes)
+    cap = int(cache_bytes // per_cap) if per_cap else 0
+    if configured_experts:
+        cap = min(cap, configured_experts)
     warm_bytes = min(max(0, info["expert_bytes"] - hot_bytes), cache_bytes)
     cold_bytes = max(0, info["expert_bytes"] - hot_bytes - warm_bytes)
 
-    warnings = []
     if cap < 1:
         warnings.append("RAM budget cannot hold one expert slot per sparse layer")
     if gpu_indices is not None and len(gpus) != len(set(gpu_indices)):
         warnings.append("one or more requested GPUs were not detected")
     if gpus and vram_budget < requested_vram:
         warnings.append("VRAM tier was clamped by free VRAM or model expert size")
+    if unified:
+        warnings.append(
+            "GPU and RAM share one physical memory pool; budgets were jointly constrained")
     # The plan sizes the hot tier from *free* VRAM, so running it while an engine
     # instance already holds the GPUs silently produces a tiny tier and a
     # pessimistic hit rate that describe nothing. That is exactly when a user
@@ -640,8 +672,9 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
                    "quality_preserving": policy != "experimental-fast"},
         "model": {key: value for key, value in info.items() if key != "config"},
         "cpu": {"physical_cores": _resolve_physical_cores(physical_cpus),
-                "sockets": max(1, int(cpu_sockets)),
-                "thread_policy": "physical-cores"},
+                 "sockets": max(1, int(cpu_sockets)),
+                 "thread_policy": "physical-cores"},
+        "memory": {"unified": unified, "available_bytes": available_memory},
         "tiers": {
             "disk": {"role": "cold-backing", "model_bytes": info["model_bytes"],
                      "available_bytes": available_disk, "cold_expert_bytes": cold_bytes},

--- a/c/tests/test_backend_contract.py
+++ b/c/tests/test_backend_contract.py
@@ -1,0 +1,34 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class BackendContractTests(unittest.TestCase):
+    def test_deepseek_v4_build_does_not_claim_vulkan_support(self):
+        source = (ROOT / "Makefile.deepseek-v4").read_text(encoding="utf-8")
+        runtime = (ROOT / "deepseek_v4.c").read_text(encoding="utf-8")
+        self.assertNotIn("COLI_VULKAN", runtime)
+        self.assertIn("does not currently include a Vulkan backend", source)
+
+    def test_metal_batched_moe_accepts_grouped_int4(self):
+        source = (ROOT / "backend_metal.mm").read_text(encoding="utf-8")
+        header = (ROOT / "backend_metal.h").read_text(encoding="utf-8")
+        self.assertIn("fmt != 4", source)
+        self.assertIn("fmt == 4", source)
+        self.assertIn("including fmt=4 grouped int4", header)
+
+    def test_metal_moe_grouped_shader_has_per_group_scale_path(self):
+        source = (ROOT / "backend_metal.mm").read_text(encoding="utf-8")
+        self.assertIn("device const float* scales", source)
+        self.assertIn("i/64", source)
+
+    def test_vulkan_primary_device_can_be_selected(self):
+        source = (ROOT / "backend_vulkan.c").read_text(encoding="utf-8")
+        self.assertIn('getenv("COLI_VK_DEV")', source)
+        self.assertIn("invalid COLI_VK_DEV", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tests/test_backend_contract.py
+++ b/c/tests/test_backend_contract.py
@@ -22,7 +22,7 @@ class BackendContractTests(unittest.TestCase):
     def test_metal_moe_grouped_shader_has_per_group_scale_path(self):
         source = (ROOT / "backend_metal.mm").read_text(encoding="utf-8")
         self.assertIn("device const float* scales", source)
-        self.assertIn("i/64", source)
+        self.assertIn("i/GS", source)
 
     def test_vulkan_primary_device_can_be_selected(self):
         source = (ROOT / "backend_vulkan.c").read_text(encoding="utf-8")

--- a/c/tests/test_backend_metal.mm
+++ b/c/tests/test_backend_metal.mm
@@ -256,7 +256,7 @@ static int run_fp8_gemm_gate(const char *name) {
 // up with no routed expert already fixing `mfmt`, it would submit the WRONG pointer
 // (q4, NULL/stale for an fmt=8 tensor whose weights live in q8) tagged as fmt=8.
 // This is safe ANYWAY, but only incidentally: moe_submit() (backend_metal.mm) gates
-// `fmt != 1 && fmt != 2` as its very FIRST statement, before any of g/u/d/gs/us/ds is
+// unsupported formats as its very FIRST statement, before any of g/u/d/gs/us/ds is
 // dereferenced or even resolve()'d -- so an fmt=8 submission is refused before the
 // bad pointer would ever be read, no matter what garbage MB_BUILD packed into it. This
 // test uses deliberately-invalid weight/scale pointers (never dereferenced if the gate
@@ -317,6 +317,37 @@ static int run_moe(const std::vector<int>& nrv, const char* name) {
   printf("  %-22s R=%d nerr=%.2e  %s\n", name, R, nerr, pass?"ok":"*** MISMATCH");
   for(int e=0;e<nb;e++){ coli_metal_unregister(slab[e]); coli_metal_unregister(fslab[e]); free(slab[e]); free(fslab[e]); }
   return pass?0:1;
+}
+
+static int run_moe_grouped(const std::vector<int>& nrv, const char* name) {
+  const int D=6144, I=2048, gs=64, fmt=4; int rb=(D+1)/2, nb=(int)nrv.size();
+  int R=0; std::vector<int> xoff(nb),nr(nrv); for(int e=0;e<nb;e++){ xoff[e]=R; R+=nr[e]; }
+  std::vector<void*> slabs(nb), scales(nb); std::vector<const void*> g(nb),u(nb),d(nb);
+  std::vector<const float*> sg(nb),su(nb),sd(nb);
+  size_t wb=roundpg((size_t)I*rb*2+(size_t)D*rb), sb=roundpg((size_t)I*((D+gs-1)/gs)*sizeof(float)*2+(size_t)D*((I+gs-1)/gs)*sizeof(float));
+  srand(9090+nb);
+  for(int e=0;e<nb;e++){
+    posix_memalign(&slabs[e],16384,wb); posix_memalign(&scales[e],16384,sb);
+    auto* w=(uint8_t*)slabs[e]; for(size_t i=0;i<(size_t)I*rb*2+(size_t)D*rb;i++) w[i]=(uint8_t)(rand()&0xFF);
+    auto* s=(float*)scales[e]; size_t ns=sb/sizeof(float); for(size_t i=0;i<ns;i++) s[i]=0.01f+(rand()%50)/50000.f;
+    g[e]=w; u[e]=w+(size_t)I*rb; d[e]=w+(size_t)I*rb*2;
+    sg[e]=s; su[e]=s+(size_t)I*((D+gs-1)/gs); sd[e]=su[e]+(size_t)I*((D+gs-1)/gs);
+    coli_metal_register(slabs[e],wb); coli_metal_register(scales[e],sb);
+  }
+  std::vector<float> x((size_t)R*D); for(float& v:x) v=((rand()%2000)-1000)/1000.f;
+  std::vector<int> rows(R,0); std::vector<float> rw(R,1.f);
+  std::vector<float> ref((size_t)D,0), gg(I),uu(I),hh(D);
+  for(int e=0;e<nb;e++) for(int r=0;r<nr[e];r++){
+    const float* xr=&x[(size_t)(xoff[e]+r)*D];
+    for(int o=0;o<I;o++){ float a=0; for(int k=0;k<D;k++){ uint8_t b=((const uint8_t*)g[e])[(size_t)o*rb+(k>>1)]; int v=(k&1)?(b>>4):(b&0xF); a+=(float)(v-8)*xr[k]*sg[e][(size_t)o*((D+gs-1)/gs)+(k/gs)]; } gg[o]=a; }
+    for(int o=0;o<I;o++){ float a=0; for(int k=0;k<D;k++){ uint8_t b=((const uint8_t*)u[e])[(size_t)o*rb+(k>>1)]; int v=(k&1)?(b>>4):(b&0xF); a+=(float)(v-8)*xr[k]*su[e][(size_t)o*((D+gs-1)/gs)+(k/gs)]; } uu[o]=a; }
+    for(int o=0;o<I;o++){ float v=gg[o]; gg[o]=(v/(1.f+expf(-v)))*uu[o]; }
+    for(int o=0;o<D;o++){ float a=0; for(int k=0;k<I;k++){ uint8_t b=((const uint8_t*)d[e])[(size_t)o*((I+1)/2)+(k>>1)]; int v=(k&1)?(b>>4):(b&0xF); a+=(float)(v-8)*gg[k]*sd[e][(size_t)o*((I+gs-1)/gs)+(k/gs)]; } ref[o]+=a; }
+  }
+  std::vector<float> out((size_t)D,0); int ok=coli_metal_moe_block(nb,D,I,fmt,g.data(),u.data(),d.data(),sg.data(),su.data(),sd.data(),x.data(),xoff.data(),nr.data(),rows.data(),rw.data(),out.data(),1);
+  double err=0,scale=0; for(int i=0;i<D;i++){err=fmax(err,fabs(out[i]-ref[i]));scale=fmax(scale,fabs(ref[i]));}
+  for(int e=0;e<nb;e++){coli_metal_unregister(slabs[e]);coli_metal_unregister(scales[e]);free(slabs[e]);free(scales[e]);}
+  int pass=ok&&err/(scale+1e-9)<1e-4; printf("  %-22s grouped nerr=%.2e  %s\n",name,err/(scale+1e-9),pass?"ok":"*** MISMATCH"); return pass?0:1;
 }
 
 // ---- fmt=6 (E8/IQ3) moe_block vs the engine's own scalar decoder ----
@@ -678,6 +709,7 @@ int main(void) {
   printf("Metal batched moe_block tests:\n");
   fail |= run_moe({1,1,1,1,1,1,1,1}, "moe decode nb=8");
   fail |= run_moe({3,1,4,2,1,5},     "moe ragged nb=6");
+  fail |= run_moe_grouped({1,1,1,1}, "grouped-int4 moe nb=4");
   printf("Metal fmt=6 (E8/IQ3) moe_block tests:\n");
   fail |= run_moe_e8({1,1,1,1,1,1,1,1}, "e8 decode nb=8");
   fail |= run_moe_e8({3,1,4,2,1,5},     "e8 ragged nb=6");

--- a/c/tests/test_backend_metal.mm
+++ b/c/tests/test_backend_metal.mm
@@ -269,7 +269,7 @@ static int run_fp8_moe_gate(const char *name) {
   const float *gs[1] = {(const float*)bad}, *us[1] = {(const float*)bad}, *ds[1] = {(const float*)bad};
   float xg[8]={0}, out[8]={0}, rw[1]={1.0f};
   int xoff[1]={0}, nr[1]={1}, rows[1]={0};
-  int rc = coli_metal_moe_block(1, 8, 8, FP8, g, u, d, gs, us, ds, xg, xoff, nr, rows, rw, out, 1);
+  int rc = coli_metal_moe_block(1, 8, 8, FP8, 0, g, u, d, gs, us, ds, xg, xoff, nr, rows, rw, out, 1);
   int ok = (rc == 0);
   printf("  %-42s rc=%d (expect 0/CPU-fallback)  %s\n", name, rc, ok?"ok":"*** MISMATCH (should have refused)");
   return ok?0:1;
@@ -310,7 +310,7 @@ static int run_moe(const std::vector<int>& nrv, const char* name) {
     float* os=&refout[(size_t)rows[gr]*D]; for(int o=0;o<D;o++) os[o]+=rw[gr]*hh[o];
   }
   std::vector<float> gout((size_t)S*D,0.f);
-  int ok = coli_metal_moe_block(nb,D,I,fmt,g.data(),u.data(),d.data(),gs.data(),us.data(),ds.data(),
+  int ok = coli_metal_moe_block(nb,D,I,fmt,0,g.data(),u.data(),d.data(),gs.data(),us.data(),ds.data(),
                                 xg.data(),xoff.data(),nr.data(),rows.data(),rw.data(),gout.data(),S);
   double maxabs=0,ymax=0; for(size_t i=0;i<gout.size();i++){ maxabs=fmax(maxabs,fabs(gout[i]-refout[i])); ymax=fmax(ymax,fabs(refout[i])); }
   double nerr=maxabs/(ymax+1e-9); int pass = ok && nerr<1e-4;
@@ -319,8 +319,8 @@ static int run_moe(const std::vector<int>& nrv, const char* name) {
   return pass?0:1;
 }
 
-static int run_moe_grouped(const std::vector<int>& nrv, const char* name) {
-  const int D=6144, I=2048, gs=64, fmt=4; int rb=(D+1)/2, nb=(int)nrv.size();
+static int run_moe_grouped(const std::vector<int>& nrv, int gs, const char* name) {
+  const int D=6144, I=2048, fmt=4; int rb=(D+1)/2, nb=(int)nrv.size();
   int R=0; std::vector<int> xoff(nb),nr(nrv); for(int e=0;e<nb;e++){ xoff[e]=R; R+=nr[e]; }
   std::vector<void*> slabs(nb), scales(nb); std::vector<const void*> g(nb),u(nb),d(nb);
   std::vector<const float*> sg(nb),su(nb),sd(nb);
@@ -344,7 +344,7 @@ static int run_moe_grouped(const std::vector<int>& nrv, const char* name) {
     for(int o=0;o<I;o++){ float v=gg[o]; gg[o]=(v/(1.f+expf(-v)))*uu[o]; }
     for(int o=0;o<D;o++){ float a=0; for(int k=0;k<I;k++){ uint8_t b=((const uint8_t*)d[e])[(size_t)o*((I+1)/2)+(k>>1)]; int v=(k&1)?(b>>4):(b&0xF); a+=(float)(v-8)*gg[k]*sd[e][(size_t)o*((I+gs-1)/gs)+(k/gs)]; } ref[o]+=a; }
   }
-  std::vector<float> out((size_t)D,0); int ok=coli_metal_moe_block(nb,D,I,fmt,g.data(),u.data(),d.data(),sg.data(),su.data(),sd.data(),x.data(),xoff.data(),nr.data(),rows.data(),rw.data(),out.data(),1);
+  std::vector<float> out((size_t)D,0); int ok=coli_metal_moe_block(nb,D,I,fmt,gs,g.data(),u.data(),d.data(),sg.data(),su.data(),sd.data(),x.data(),xoff.data(),nr.data(),rows.data(),rw.data(),out.data(),1);
   double err=0,scale=0; for(int i=0;i<D;i++){err=fmax(err,fabs(out[i]-ref[i]));scale=fmax(scale,fabs(ref[i]));}
   for(int e=0;e<nb;e++){coli_metal_unregister(slabs[e]);coli_metal_unregister(scales[e]);free(slabs[e]);free(scales[e]);}
   int pass=ok&&err/(scale+1e-9)<1e-4; printf("  %-22s grouped nerr=%.2e  %s\n",name,err/(scale+1e-9),pass?"ok":"*** MISMATCH"); return pass?0:1;
@@ -395,7 +395,7 @@ static int run_moe_e8(const std::vector<int>& nrv, const char* name) {
   std::vector<float> xg_gpu(xg);
   for(int gr=0;gr<R;gr++) e8_rot_rows(&xg_gpu[(size_t)gr*D],1,D);
   std::vector<float> gout((size_t)S*D,0.f);
-  int ok = coli_metal_moe_block(nb,D,I,fmt,g.data(),u.data(),d.data(),gs.data(),us.data(),ds.data(),
+  int ok = coli_metal_moe_block(nb,D,I,fmt,0,g.data(),u.data(),d.data(),gs.data(),us.data(),ds.data(),
                                 xg_gpu.data(),xoff.data(),nr.data(),rows.data(),rw.data(),gout.data(),S);
   double maxabs=0,ymax=0; for(size_t i=0;i<gout.size();i++){ maxabs=fmax(maxabs,fabs(gout[i]-refout[i])); ymax=fmax(ymax,fabs(refout[i])); }
   double nerr=maxabs/(ymax+1e-9); int pass = ok && nerr<1e-4;
@@ -709,7 +709,8 @@ int main(void) {
   printf("Metal batched moe_block tests:\n");
   fail |= run_moe({1,1,1,1,1,1,1,1}, "moe decode nb=8");
   fail |= run_moe({3,1,4,2,1,5},     "moe ragged nb=6");
-  fail |= run_moe_grouped({1,1,1,1}, "grouped-int4 moe nb=4");
+  fail |= run_moe_grouped({1,1,1,1}, 64, "grouped-int4 moe g64 nb=4");
+  fail |= run_moe_grouped({1,2,1}, 32, "grouped-int4 moe g32 ragged");
   printf("Metal fmt=6 (E8/IQ3) moe_block tests:\n");
   fail |= run_moe_e8({1,1,1,1,1,1,1,1}, "e8 decode nb=8");
   fail |= run_moe_e8({3,1,4,2,1,5},     "e8 ragged nb=6");

--- a/c/tests/test_doctor.py
+++ b/c/tests/test_doctor.py
@@ -86,7 +86,7 @@ class DoctorTest(unittest.TestCase):
         self.assertEqual(report["mode"], "standard")
         self.assertEqual(report["status"], "ok")
         self.assertIsNotNone(report["plan"])
-        self.assertEqual(checks["accelerator.cuda"]["status"], "skip")
+        self.assertEqual(checks["accelerator.gpu"]["status"], "skip")
         self.assertEqual(checks["memory.ram"]["status"], "pass")
         self.assertEqual(checks["model.shards"]["details"]["shards"], 1)
         self.assertEqual(exit_code(report), 0)
@@ -122,7 +122,7 @@ class DoctorTest(unittest.TestCase):
 
     def test_requested_missing_gpu_is_a_failure(self):
         report = self.report(gpu_indices=[1])
-        check = self.checks_by_id(report)["accelerator.cuda"]
+        check = self.checks_by_id(report)["accelerator.gpu"]
 
         self.assertEqual(check["status"], "fail")
         self.assertEqual(check["details"], {"requested": [1], "detected": []})
@@ -132,11 +132,19 @@ class DoctorTest(unittest.TestCase):
         gpu = {"index": 0, "name": "fixture", "total_bytes": 12 * GB,
                "free_bytes": 10 * GB}
         report = self.report(gpu_indices=None, gpus=[gpu])
-        check = self.checks_by_id(report)["accelerator.cuda"]
+        check = self.checks_by_id(report)["accelerator.gpu"]
 
         self.assertEqual(check["status"], "warn")
         self.assertEqual(report["status"], "warning")
         self.assertEqual(exit_code(report), 0)
+
+    def test_gpu_check_uses_backend_neutral_identifier(self):
+        gpu = {"index": 0, "name": "Intel Arc B570", "total_bytes": 10 * GB,
+               "free_bytes": 9 * GB}
+        report = self.report(gpu_indices=None, gpus=[gpu])
+        checks = self.checks_by_id(report)
+        self.assertIn("accelerator.gpu", checks)
+        self.assertNotIn("accelerator.cuda", checks)
 
     def test_missing_cuda_runtime_is_a_failure(self):
         gpu = {"index": 0, "name": "fixture", "total_bytes": 12 * GB,
@@ -145,8 +153,8 @@ class DoctorTest(unittest.TestCase):
                              linkage={"linked": False, "missing": True})
 
         self.assertEqual(
-            self.checks_by_id(report)["accelerator.cuda"]["summary"],
-            "CUDA runtime library is missing",
+            self.checks_by_id(report)["accelerator.gpu"]["summary"],
+            "GPU runtime library is missing",
         )
         self.assertEqual(report["status"], "error")
 

--- a/c/tests/test_residency_sim.py
+++ b/c/tests/test_residency_sim.py
@@ -1,0 +1,351 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+TOOLS = Path(__file__).resolve().parent.parent / "tools"
+sys.path.insert(0, str(TOOLS))
+import residency_sim as sim
+
+
+class TraceParserTest(unittest.TestCase):
+    def test_batch_rows_keep_union_order_and_selection_multiplicity(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "trace.txt"
+            path.write_text(
+                "0 0 3 7:0.6000 2:0.4000\n"
+                "0 1 3 2:0.7000 9:0.3000\n"
+                "1 0 4 1:1.0000\n",
+                encoding="utf-8",
+            )
+            events = sim.parse_trace(path)
+        self.assertEqual(events, [
+            sim.AccessEvent(3, (7, 2, 9), (7, 2, 2, 9), 0, str(path)),
+            sim.AccessEvent(4, (1,), (1,), 1, str(path)),
+        ])
+
+    def test_multiple_calls_to_same_layer_remain_separate_events(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "trace.txt"
+            path.write_text("0 0 3 1:1.0000\n1 0 3 2:1.0000\n", encoding="utf-8")
+            events = sim.parse_trace(path)
+        self.assertEqual([event.experts for event in events], [(1,), (2,)])
+
+    def test_noncontiguous_group_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "trace.txt"
+            path.write_text(
+                "0 0 3 1:1.0000\n1 0 4 2:1.0000\n0 1 3 3:1.0000\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "noncontiguous"):
+                sim.parse_trace(path)
+
+    def test_kimi_style_constant_call_ids_are_rejected(self):
+        events = [
+            sim.AccessEvent(0, (1,), call=0),
+            sim.AccessEvent(1, (2,), call=0),
+            sim.AccessEvent(2, (3,), call=0),
+        ]
+        with self.assertRaisesRegex(ValueError, "lacks advancing GLM call ids"):
+            sim.validate_glm_trace(events, Path("kimi.trace"))
+
+    def test_glm_call_ids_advance_across_layer_wraps(self):
+        events = [
+            sim.AccessEvent(0, (1,), call=0),
+            sim.AccessEvent(1, (2,), call=1),
+            sim.AccessEvent(2, (3,), call=2),
+            sim.AccessEvent(0, (4,), call=3),
+            sim.AccessEvent(1, (5,), call=4),
+        ]
+        sim.validate_glm_trace(events, Path("glm.trace"))
+
+    def test_glm_call_ids_must_start_at_zero_and_advance_at_wrap(self):
+        invalid = (
+            [sim.AccessEvent(0, (1,), call=1)],
+            [sim.AccessEvent(0, (1,), call=0), sim.AccessEvent(1, (2,), call=1),
+             sim.AccessEvent(0, (3,), call=1)],
+        )
+        for events in invalid:
+            with self.subTest(events=events), self.assertRaisesRegex(
+                    ValueError, "lacks advancing GLM call ids"):
+                sim.validate_glm_trace(events, Path("glm.trace"))
+
+    def test_rows_must_start_at_zero_and_be_contiguous(self):
+        invalid = (
+            "0 1 3 7:1.0000\n",
+            "0 0 3 7:1.0000\n0 2 3 8:1.0000\n",
+        )
+        for text in invalid:
+            with self.subTest(text=text), tempfile.TemporaryDirectory() as tmp:
+                path = Path(tmp) / "trace.txt"
+                path.write_text(text, encoding="utf-8")
+                with self.assertRaisesRegex(ValueError, "expected row"):
+                    sim.parse_trace(path)
+
+    def test_malformed_or_nonfinite_gate_is_rejected_with_location(self):
+        invalid = ("0 0 3 bad\n", "0 0 3 7:nan\n", "0 0 3 7:1:2\n")
+        for text in invalid:
+            with self.subTest(text=text), tempfile.TemporaryDirectory() as tmp:
+                path = Path(tmp) / "trace.txt"
+                path.write_text(text, encoding="utf-8")
+                with self.assertRaisesRegex(ValueError, r"trace\.txt:1"):
+                    sim.parse_trace(path)
+
+
+class SpecificationTest(unittest.TestCase):
+    def test_manifest_separates_resident_and_read_bytes(self):
+        traces = [[sim.AccessEvent(3, (0, 1))]]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "manifest.json"
+            path.write_text(json.dumps({"layers": {"3": {
+                "resident_bytes": 123,
+                "read_bytes": 456,
+                "felt_miss_us": 45.5,
+                "max_experts": 9,
+            }}}), encoding="utf-8")
+            specs = sim.load_specs(traces, path, 1.0, 1.0)
+        self.assertEqual(specs[3], sim.LayerSpec(123, 456, 45.5, 9))
+
+    def test_manifest_bounds_are_required_for_observed_layers_and_experts(self):
+        traces = [[sim.AccessEvent(3, (9,))]]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "manifest.json"
+            path.write_text(json.dumps({"layers": {"3": {
+                "resident_bytes": 123,
+                "max_experts": 9,
+            }}}), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "exceeds manifest bound"):
+                sim.load_specs(traces, path, 1.0, 1.0)
+
+    def test_default_felt_cost_uses_read_bytes(self):
+        traces = [[sim.AccessEvent(0, (0,))]]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "manifest.json"
+            path.write_text(json.dumps({"layers": {"0": {
+                "resident_bytes": 10,
+                "read_bytes": 1_000_000_000,
+                "max_experts": 1,
+            }}}), encoding="utf-8")
+            specs = sim.load_specs(traces, path, 2.0, 0.5)
+        self.assertEqual(specs[0].felt_miss_us, 250_000)
+
+    def test_manifest_layers_absent_from_traces_do_not_consume_budget(self):
+        traces = [[sim.AccessEvent(0, (0,))]]
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "manifest.json"
+            path.write_text(json.dumps({"layers": {
+                "0": {"resident_bytes": 10, "max_experts": 1},
+                "1": {"resident_bytes": 10, "max_experts": 1},
+            }}), encoding="utf-8")
+            specs = sim.load_specs(traces, path, 1.0, 1.0)
+        self.assertEqual(set(specs), {0})
+
+    def test_profile_costs_extracts_aggregate_felt_wait(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "profile.out"
+            path.write_text(
+                "[PROF] expert I/O: 38.178 GB fetched | 525.0 loads/token | "
+                "7.2s read service / 1.4s felt wait\n",
+                encoding="utf-8",
+            )
+            costs = sim.profile_costs([path])
+        self.assertEqual(costs["loads"], 525)
+        self.assertEqual(costs["felt_wait_seconds"], 1.4)
+        self.assertAlmostEqual(costs["felt_us_per_load"], 2666.6666667)
+
+
+class PolicyBehaviorTest(unittest.TestCase):
+    def specs(self):
+        return {0: sim.LayerSpec(1, 4, 10, 100)}
+
+    def events(self, sequence):
+        return [sim.AccessEvent(0, (expert,), (expert,)) for expert in sequence]
+
+    def test_lru_known_sequence_and_read_bytes(self):
+        stats = sim.run_policy("lru", {0: 2}, self.specs(),
+                               self.events([1, 2, 1, 3, 1, 2]))
+        self.assertEqual((stats.hits, stats.misses), (2, 4))
+        self.assertEqual(stats.bytes_read, 16)
+        self.assertEqual(stats.felt_wait_us, 40)
+
+    def test_frequency_admission_rejects_scan_pollution(self):
+        warm = [0, 1] * 20
+        sequence = warm[:]
+        for cold in range(2, 22):
+            sequence.extend([cold, 0, 1])
+        lru = sim.run_policy("lru", {0: 2}, self.specs(), self.events(sequence))
+        frequency = sim.run_policy(
+            "frequency", {0: 2}, self.specs(), self.events(sequence))
+        self.assertGreater(frequency.hits, lru.hits)
+        self.assertLess(frequency.misses, lru.misses)
+        self.assertGreater(frequency.rejected_admissions, 0)
+
+    def test_training_uses_row_selection_multiplicity(self):
+        event = sim.AccessEvent(0, (7, 8), (7, 7, 7, 8))
+        counts = sim.training_counts([[event]])
+        self.assertEqual(counts[0], {7: 3, 8: 1})
+
+    def test_training_counts_seed_frequency_and_half_pinned_policies(self):
+        learned = {0: {7: 100, 8: 50, 9: 1}}
+        first = self.events([7, 8])
+        frequency = sim.run_policy(
+            "frequency", {0: 2}, self.specs(), first, learned)
+        pinned = sim.run_policy(
+            "half-pinned", {0: 2}, self.specs(), first, learned)
+        self.assertEqual(frequency.hits, 2)
+        self.assertEqual(frequency.seeded_objects, 2)
+        self.assertEqual(pinned.hits, 1)
+        self.assertEqual(pinned.seeded_objects, 1)
+
+    def test_slru_protects_reused_objects_from_one_hit_scan(self):
+        warm = [0, 1] * 20
+        sequence = warm + sum(([cold, 0, 1] for cold in range(2, 22)), [])
+        lru = sim.run_policy("lru", {0: 3}, self.specs(), self.events(sequence))
+        slru = sim.run_policy("slru", {0: 3}, self.specs(), self.events(sequence))
+        self.assertGreaterEqual(slru.hits, lru.hits)
+
+    def test_lru_promotes_between_64_expert_blocks(self):
+        event = sim.AccessEvent(0, tuple(range(65)) + (0,))
+        stats = sim.run_policy("lru", {0: 64}, self.specs(), [event])
+        self.assertEqual(stats.hits, 1)
+        self.assertEqual(stats.misses, 65)
+
+
+class AllocationTest(unittest.TestCase):
+    def test_uniform_allocation_respects_resident_bytes(self):
+        specs = {
+            0: sim.LayerSpec(10, 100, 1, 8),
+            1: sim.LayerSpec(20, 100, 1, 8),
+        }
+        caps = sim.uniform_capacities(specs, 95)
+        self.assertEqual(caps, {0: 3, 1: 3})
+        self.assertEqual(sim.capacity_bytes(caps, specs), 90)
+
+    def test_dynamic_budget_uses_exact_policy_replay(self):
+        specs = {
+            0: sim.LayerSpec(1, 1, 1, 8),
+            1: sim.LayerSpec(1, 1, 10, 8),
+        }
+        trace = [[
+            *[sim.AccessEvent(0, (expert,)) for expert in [0, 1, 2, 3] * 20],
+            *[sim.AccessEvent(1, (expert,)) for expert in [0, 1] * 40],
+        ]]
+        counts = sim.training_counts(trace)
+        caps = sim.dynamic_capacities(trace, specs, 4, "lru", counts)
+        self.assertGreater(caps[1], caps[0])
+        self.assertLessEqual(sim.capacity_bytes(caps, specs), 4)
+
+    def test_training_traces_are_independent_cold_runs(self):
+        specs = {0: sim.LayerSpec(1, 1, 1, 4)}
+        traces = [
+            [sim.AccessEvent(0, (1,))],
+            [sim.AccessEvent(0, (1,))],
+        ]
+        wait = sim._training_wait(traces, {0: 0}, specs, "lru", {})
+        self.assertEqual(wait, 2)
+
+    def test_shifted_heldout_dynamic_lru_regression_is_visible(self):
+        train, evaluation, specs, budget = sim.synthetic_trace("shifted")
+        result = sim.analyze(train, evaluation, specs, budget, ["lru"])
+        uniform = result["results"]["uniform"]["lru"]["aggregate"]
+        dynamic = result["results"]["dynamic-lru"]["lru"]["aggregate"]
+        self.assertGreater(dynamic["felt_wait_us"], uniform["felt_wait_us"])
+
+
+class DecisionGateTest(unittest.TestCase):
+    def result(self, category_waits):
+        def payload(values):
+            total = sum(values)
+            return {
+                "aggregate": {"felt_wait_us": total},
+                "traces": [{"felt_wait_us": value} for value in values],
+            }
+
+        return {"results": {
+            "uniform": {
+                "lru": payload([100, 100, 100]),
+                "frequency": payload(category_waits),
+            },
+            "dynamic-frequency": {
+                "frequency": payload([70, 70, 70]),
+            },
+        }}
+
+    def test_gate_equal_weights_categories_and_rejects_worst_regression(self):
+        categories = ["chat", "chat", "code"]
+        gate = sim.decision_gate(self.result([80, 80, 104]), categories)
+        frequency = next(
+            row for row in gate["candidates"]
+            if row["allocation"] == "uniform" and row["policy"] == "frequency")
+        self.assertAlmostEqual(frequency["category_mean_gain"], 0.08)
+        self.assertAlmostEqual(frequency["worst_category_gain"], -0.04)
+        self.assertFalse(frequency["pass"])
+        dynamic = next(
+            row for row in gate["candidates"]
+            if row["allocation"] == "dynamic-frequency")
+        self.assertTrue(dynamic["pass"])
+
+    def test_trace_categories_strip_numeric_replicates_or_use_explicit_names(self):
+        traces = [
+            [sim.AccessEvent(0, (0,), source="/tmp/chat_1.trace")],
+            [sim.AccessEvent(0, (0,), source="/tmp/chat_2.trace")],
+            [sim.AccessEvent(0, (0,), source="/tmp/code-1.trace")],
+        ]
+        self.assertEqual(sim.trace_categories(traces), ["chat", "chat", "code"])
+        self.assertEqual(
+            sim.trace_categories(traces, ["a", "b", "c"]), ["a", "b", "c"])
+        with self.assertRaisesRegex(ValueError, "one value per"):
+            sim.trace_categories(traces, ["a"])
+
+    def test_layer_specific_sensitivity_can_invalidate_candidate(self):
+        train, evaluation, specs, budget = sim.synthetic_trace("stationary")
+        sensitivity = sim.sensitivity_analysis(
+            train, evaluation, specs, budget, ["lru", "frequency"],
+            ["stationary"], [0.5, 1.0, 1.5])
+        frequency = next(
+            row for row in sensitivity["candidates"]
+            if row["allocation"] == "uniform" and row["policy"] == "frequency")
+        self.assertEqual(len(frequency["outcomes"]), 1 + 2 * len(specs))
+        self.assertTrue(any(
+            outcome["scenario"] == "layer-1-x0.5"
+            for outcome in frequency["outcomes"]))
+
+    def test_replay_cache_preserves_full_replay_metrics(self):
+        train, evaluation, specs, budget = sim.synthetic_trace("stationary")
+        counts = sim.training_counts(train)
+        capacities = sim.uniform_capacities(specs, budget)
+        cached = sim.evaluate(
+            evaluation, capacities, specs, ["lru", "frequency"], counts)
+        for policy in ("lru", "frequency"):
+            direct = sim.PolicyStats()
+            for trace in evaluation:
+                direct.add(sim.run_policy(policy, capacities, specs, trace, counts))
+            self.assertEqual(cached[policy]["aggregate"], direct.report())
+
+    def test_combined_category_suite_applies_worst_category_guard(self):
+        train, evaluation, specs, budget, categories = sim.synthetic_category_suite()
+        result = sim.analyze(train, evaluation, specs, budget, ["lru", "frequency"])
+        gate = sim.decision_gate(result, categories)
+        frequency = next(
+            candidate for candidate in gate["candidates"]
+            if candidate["allocation"] == "uniform"
+            and candidate["policy"] == "frequency")
+        self.assertGreater(frequency["category_mean_gain"], 0.10)
+        self.assertLess(frequency["worst_category_gain"], -0.03)
+
+    def test_synthetic_budget_sweep_exposes_robust_and_fragile_regions(self):
+        rows = sim.synthetic_budget_sweep(["lru", "frequency"], [2, 8])
+        frequency = {
+            row["budget_mb"]: row
+            for row in rows
+            if row["allocation"] == "dynamic-frequency"
+        }
+        self.assertTrue(frequency[2]["pass_sensitivity"])
+        self.assertFalse(frequency[8]["pass_sensitivity"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tests/test_resource_plan.py
+++ b/c/tests/test_resource_plan.py
@@ -203,6 +203,28 @@ class ResourcePlanTest(unittest.TestCase):
         self.assertIn("clamped", plan["warnings"][0])
         self.assertIn("0:test-gpu", format_plan(plan))
 
+    def test_unified_memory_uses_one_shared_pool(self):
+        gpus = [{"index": 0, "name": "NVIDIA GB10", "total_bytes": 130 * GB,
+                 "free_bytes": 128 * GB, "unified_memory": True}]
+        plan = build_plan(self.model, ram_gb=100, vram_gb=65,
+                          available_memory=121 * GB, available_disk=1,
+                          gpus=gpus, physical_cpus=8, cpu_sockets=1)
+        ram = plan["tiers"]["ram"]["budget_bytes"]
+        vram = plan["tiers"]["vram"]["budget_bytes"]
+        self.assertTrue(plan["memory"]["unified"])
+        self.assertLessEqual(ram + vram + plan["model"]["dense_bytes"], 121 * GB)
+        self.assertTrue(any("share one physical memory" in warning
+                            for warning in plan["warnings"]))
+
+    def test_nvidia_unified_device_is_marked_from_name(self):
+        output = "0, NVIDIA GB10, 130000, 120000\n"
+        with mock.patch("resource_plan.subprocess.run",
+                        return_value=subprocess.CompletedProcess(
+                            args=[], returncode=0, stdout=output, stderr="")):
+            from resource_plan import _discover_nvidia_gpus
+            devices = _discover_nvidia_gpus()
+        self.assertTrue(devices[0]["unified_memory"])
+
     def test_auto_tier_thread_count_uses_physical_cores(self):
         # End-to-end for #325: build_plan + environment_for_plan must export the
         # physical (not logical SMT) core count as OMP_NUM_THREADS. The original
@@ -508,6 +530,15 @@ class PhysicalCpuCountTest(unittest.TestCase):
              mock.patch("resource_plan.os.cpu_count", return_value=None), \
              mock.patch("sys.stderr"):
             self.assertEqual(physical_cpu_count(), 1)
+
+    def test_apple_silicon_prefers_performance_cores(self):
+        def sysctl(command, **kwargs):
+            value = "8\n" if command[-1] == "hw.perflevel0.logicalcpu" else "10\n"
+            return subprocess.CompletedProcess(args=command, returncode=0,
+                                               stdout=value, stderr="")
+        with mock.patch("resource_plan.subprocess.run", side_effect=sysctl), \
+             mock.patch.object(sys, "platform", "darwin"):
+            self.assertEqual(physical_cpu_count(), 8)
 
 
 if __name__ == "__main__":

--- a/c/tools/residency_sim.py
+++ b/c/tools/residency_sim.py
@@ -1,0 +1,1177 @@
+#!/usr/bin/env python3
+"""Offline GLM expert-residency policy simulator.
+
+The simulator consumes Colibri ROUTE_TRACE output without loading a model. It
+replays GLM's routed-expert unions through bounded per-layer caches and compares
+placement policies under the same expert-residency byte budget. It deliberately
+models demand residency only: no speculative reads, routing changes, or token
+semantics are involved.
+
+ROUTE_TRACE lines have this form (one row per token position and MoE call):
+
+    <call> <row> <layer> <expert>:<gate> ...
+
+Rows sharing one contiguous (call, layer) group are a runtime batch. The parser
+retains both the first-seen expert union for demand replay and per-row selection
+counts for training startup residents.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import statistics
+from collections import Counter, OrderedDict, defaultdict
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+EXPERT_FIELD = re.compile(r"^(\d+):([^:]+)$")
+
+
+@dataclass(frozen=True)
+class AccessEvent:
+    layer: int
+    experts: tuple[int, ...]
+    selections: tuple[int, ...] = ()
+    call: int | None = None
+    source: str = ""
+
+    def selection_counts(self) -> Counter[int]:
+        return Counter(self.selections or self.experts)
+
+
+@dataclass(frozen=True)
+class LayerSpec:
+    resident_bytes: int
+    read_bytes: int
+    felt_miss_us: float
+    max_experts: int
+
+
+@dataclass
+class PolicyStats:
+    requests: int = 0
+    hits: int = 0
+    misses: int = 0
+    bytes_read: int = 0
+    felt_wait_us: float = 0.0
+    admissions: int = 0
+    rejected_admissions: int = 0
+    evictions: int = 0
+    seeded_objects: int = 0
+
+    def add(self, other: "PolicyStats") -> None:
+        for field in self.__dataclass_fields__:
+            setattr(self, field, getattr(self, field) + getattr(other, field))
+
+    def report(self) -> dict:
+        accesses = self.hits + self.misses
+        return {
+            **asdict(self),
+            "accesses": accesses,
+            "hit_rate": self.hits / accesses if accesses else 1.0,
+        }
+
+
+def _build_event(key, union, selections, source):
+    if key is None or not union:
+        return None
+    return AccessEvent(key[1], tuple(union), tuple(selections), key[0], source)
+
+
+def parse_trace(path: Path) -> list[AccessEvent]:
+    """Parse contiguous GLM ROUTE_TRACE call groups into demand-union events."""
+    events = []
+    key = None
+    union: list[int] = []
+    known: set[int] = set()
+    selections: list[int] = []
+    seen_keys: set[tuple[int, int]] = set()
+    next_row = 0
+    last_call = -1
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        fields = raw.split()
+        if not fields:
+            continue
+        if len(fields) < 4:
+            raise ValueError(f"{path}:{lineno}: expected call row layer expert:gate ...")
+        try:
+            call, row, layer = map(int, fields[:3])
+        except ValueError as error:
+            raise ValueError(f"{path}:{lineno}: invalid call/row/layer") from error
+        if call < 0 or row < 0 or layer < 0:
+            raise ValueError(f"{path}:{lineno}: negative call/row/layer")
+        next_key = (call, layer)
+        if next_key != key:
+            event = _build_event(key, union, selections, str(path))
+            if event:
+                events.append(event)
+            if next_key in seen_keys:
+                raise ValueError(f"{path}:{lineno}: noncontiguous call/layer group {next_key}")
+            if call < last_call:
+                raise ValueError(f"{path}:{lineno}: call id moved backwards")
+            seen_keys.add(next_key)
+            key = next_key
+            union = []
+            known = set()
+            selections = []
+            next_row = 0
+            last_call = call
+        if row != next_row:
+            raise ValueError(
+                f"{path}:{lineno}: expected row {next_row} in call/layer group, got {row}")
+        next_row += 1
+        for value in fields[3:]:
+            match = EXPERT_FIELD.fullmatch(value)
+            if not match:
+                raise ValueError(f"{path}:{lineno}: invalid expert field {value!r}")
+            expert = int(match.group(1))
+            try:
+                gate = float(match.group(2))
+            except ValueError as error:
+                raise ValueError(f"{path}:{lineno}: invalid gate in {value!r}") from error
+            if not math.isfinite(gate):
+                raise ValueError(f"{path}:{lineno}: non-finite gate in {value!r}")
+            selections.append(expert)
+            if expert not in known:
+                known.add(expert)
+                union.append(expert)
+    event = _build_event(key, union, selections, str(path))
+    if event:
+        events.append(event)
+    return events
+
+
+def validate_glm_trace(events: Sequence[AccessEvent], path: Path) -> None:
+    if not events or any(event.call is None for event in events):
+        return
+    calls = [event.call for event in events]
+    if calls[0] != 0 or any(
+            call != previous + 1 for previous, call in zip(calls, calls[1:])):
+        raise ValueError(
+            f"{path}: trace lacks advancing GLM call ids; unsupported engine or corrupt trace")
+
+
+def read_traces(paths: Sequence[Path]) -> list[list[AccessEvent]]:
+    traces = [parse_trace(path) for path in paths]
+    if not traces or any(not trace for trace in traces):
+        raise ValueError("every trace must contain at least one routing event")
+    for path, trace in zip(paths, traces):
+        validate_glm_trace(trace, path)
+    return traces
+
+
+def load_specs(
+    traces: Sequence[Sequence[AccessEvent]],
+    manifest: Path,
+    read_gbps: float,
+    felt_fraction: float,
+) -> dict[int, LayerSpec]:
+    if not math.isfinite(read_gbps) or read_gbps <= 0:
+        raise ValueError("read GB/s must be positive and finite")
+    if not math.isfinite(felt_fraction) or not 0 <= felt_fraction <= 1:
+        raise ValueError("felt fraction must be finite and in [0,1]")
+    document = json.loads(manifest.read_text(encoding="utf-8"))
+    if not isinstance(document, dict) or not isinstance(document.get("layers"), dict):
+        raise ValueError("manifest.layers must be an object")
+    specs = {}
+    for raw_layer, raw_spec in document["layers"].items():
+        try:
+            layer = int(raw_layer)
+        except (TypeError, ValueError) as error:
+            raise ValueError(f"invalid manifest layer {raw_layer!r}") from error
+        if layer < 0 or not isinstance(raw_spec, dict):
+            raise ValueError(f"invalid layer {raw_layer!r} specification")
+        try:
+            resident_bytes = int(raw_spec["resident_bytes"])
+            read_bytes = int(raw_spec.get("read_bytes", resident_bytes))
+            max_experts = int(raw_spec["max_experts"])
+            default_felt = (read_bytes / (read_gbps * 1e9) * 1e6 * felt_fraction)
+            felt = float(raw_spec.get("felt_miss_us", default_felt))
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError(f"invalid layer {layer} specification") from error
+        if (resident_bytes <= 0 or read_bytes <= 0 or max_experts <= 0 or
+                felt < 0 or not math.isfinite(felt)):
+            raise ValueError(f"invalid layer {layer} specification")
+        specs[layer] = LayerSpec(resident_bytes, read_bytes, felt, max_experts)
+    observed = defaultdict(set)
+    for trace in traces:
+        for event in trace:
+            observed[event.layer].update(event.experts)
+    for layer, experts in observed.items():
+        if layer not in specs:
+            raise ValueError(f"trace layer {layer} is absent from manifest")
+        invalid = [expert for expert in experts if expert >= specs[layer].max_experts]
+        if invalid:
+            raise ValueError(f"trace layer {layer} expert {min(invalid)} exceeds manifest bound")
+    return {layer: spec for layer, spec in specs.items() if layer in observed}
+
+
+def uniform_capacities(specs: dict[int, LayerSpec], budget_bytes: int) -> dict[int, int]:
+    """Allocate equal slot counts per layer, bounded by each layer's expert count."""
+    if budget_bytes < 0:
+        raise ValueError("budget must be non-negative")
+    capacities = {layer: 0 for layer in specs}
+    used = 0
+    while True:
+        cost = sum(spec.resident_bytes for layer, spec in specs.items()
+                   if capacities[layer] < spec.max_experts)
+        if cost <= 0 or used + cost > budget_bytes:
+            break
+        for layer, spec in specs.items():
+            if capacities[layer] < spec.max_experts:
+                capacities[layer] += 1
+                used += spec.resident_bytes
+    return capacities
+
+
+class BasePolicy:
+    def __init__(self, capacities, specs, learned_counts=None):
+        self.capacities = capacities
+        self.specs = specs
+        self.learned_counts = learned_counts or {}
+        self.stats = PolicyStats()
+
+    def lookup(self, layer: int, expert: int) -> bool:
+        raise NotImplementedError
+
+    def observe(self, layer: int, expert: int, hit: bool) -> None:
+        pass
+
+    def admit_batch(self, layer: int, misses: Sequence[int]) -> None:
+        raise NotImplementedError
+
+    def access(self, event: AccessEvent) -> None:
+        # GLM resolves/promotes at most 64 experts at a time.
+        for start in range(0, len(event.experts), 64):
+            misses = []
+            spec = self.specs[event.layer]
+            for expert in event.experts[start:start + 64]:
+                self.stats.requests += 1
+                hit = self.lookup(event.layer, expert)
+                self.observe(event.layer, expert, hit)
+                if hit:
+                    self.stats.hits += 1
+                else:
+                    self.stats.misses += 1
+                    self.stats.bytes_read += spec.read_bytes
+                    self.stats.felt_wait_us += spec.felt_miss_us
+                    misses.append(expert)
+            self.admit_batch(event.layer, misses)
+
+
+class LRUPolicy(BasePolicy):
+    def __init__(self, capacities, specs, learned_counts=None):
+        super().__init__(capacities, specs, learned_counts)
+        self.cache: dict[int, OrderedDict[int, None]] = defaultdict(OrderedDict)
+
+    def lookup(self, layer, expert):
+        cache = self.cache[layer]
+        if expert not in cache:
+            return False
+        cache.move_to_end(expert)
+        return True
+
+    def admit_batch(self, layer, misses):
+        capacity = self.capacities.get(layer, 0)
+        if capacity <= 0:
+            self.stats.rejected_admissions += len(misses)
+            return
+        selected = list(misses[-capacity:])
+        self.stats.rejected_admissions += len(misses) - len(selected)
+        cache = self.cache[layer]
+        for expert in reversed(selected):
+            if expert in cache:
+                cache.move_to_end(expert)
+                continue
+            while len(cache) >= capacity:
+                cache.popitem(last=False)
+                self.stats.evictions += 1
+            cache[expert] = None
+            self.stats.admissions += 1
+
+
+class LFUPolicy(BasePolicy):
+    """Always-admit LFU with per-layer periodic decay and recency ties."""
+    def __init__(self, capacities, specs, learned_counts=None,
+                 decay_interval=4096, decay=0.5):
+        super().__init__(capacities, specs, learned_counts)
+        self.resident: dict[int, set[int]] = defaultdict(set)
+        self.frequency: dict[int, Counter[int]] = defaultdict(Counter)
+        self.last: dict[int, dict[int, int]] = defaultdict(dict)
+        self.clock: Counter[int] = Counter()
+        self.decay_interval = decay_interval
+        self.decay = decay
+        for layer, capacity in capacities.items():
+            counts = Counter(self.learned_counts.get(layer, {}))
+            self.frequency[layer].update(counts)
+            ranked = sorted(counts, key=lambda expert: (-counts[expert], expert))[:capacity]
+            self.resident[layer].update(ranked)
+            self.stats.seeded_objects += len(ranked)
+
+    def lookup(self, layer, expert):
+        return expert in self.resident[layer]
+
+    def observe(self, layer, expert, hit):
+        self.clock[layer] += 1
+        if self.decay_interval and self.clock[layer] % self.decay_interval == 0:
+            for candidate in list(self.frequency[layer]):
+                self.frequency[layer][candidate] *= self.decay
+                if self.frequency[layer][candidate] < 0.5:
+                    del self.frequency[layer][candidate]
+        self.frequency[layer][expert] += 1
+        self.last[layer][expert] = self.clock[layer]
+
+    def _victim(self, layer):
+        return min(self.resident[layer],
+                   key=lambda expert: (self.frequency[layer][expert],
+                                       self.last[layer].get(expert, 0), expert))
+
+    def admit_batch(self, layer, misses):
+        capacity = self.capacities.get(layer, 0)
+        if capacity <= 0:
+            self.stats.rejected_admissions += len(misses)
+            return
+        resident = self.resident[layer]
+        for expert in misses:
+            if expert in resident:
+                continue
+            if len(resident) >= capacity:
+                resident.remove(self._victim(layer))
+                self.stats.evictions += 1
+            resident.add(expert)
+            self.stats.admissions += 1
+
+
+class SLRUPolicy(BasePolicy):
+    """Segmented LRU: one-hit objects enter probation; reused objects are protected."""
+    def __init__(self, capacities, specs, learned_counts=None, protected_fraction=0.5):
+        super().__init__(capacities, specs, learned_counts)
+        self.protected_fraction = protected_fraction
+        self.probation: dict[int, OrderedDict[int, None]] = defaultdict(OrderedDict)
+        self.protected: dict[int, OrderedDict[int, None]] = defaultdict(OrderedDict)
+
+    def _limits(self, layer):
+        capacity = self.capacities.get(layer, 0)
+        if capacity <= 1:
+            return capacity, 0
+        protected = min(capacity - 1, max(1, int(capacity * self.protected_fraction)))
+        return capacity - protected, protected
+
+    def lookup(self, layer, expert):
+        protected = self.protected[layer]
+        probation = self.probation[layer]
+        if expert in protected:
+            protected.move_to_end(expert)
+            return True
+        if expert not in probation:
+            return False
+        del probation[expert]
+        probation_limit, protected_limit = self._limits(layer)
+        if protected_limit:
+            while len(protected) >= protected_limit:
+                demoted, _ = protected.popitem(last=False)
+                probation[demoted] = None
+                while len(probation) > probation_limit:
+                    probation.popitem(last=False)
+                    self.stats.evictions += 1
+            protected[expert] = None
+        else:
+            probation[expert] = None
+        return True
+
+    def admit_batch(self, layer, misses):
+        capacity = self.capacities.get(layer, 0)
+        probation_limit, _protected_limit = self._limits(layer)
+        if capacity <= 0:
+            self.stats.rejected_admissions += len(misses)
+            return
+        probation = self.probation[layer]
+        protected = self.protected[layer]
+        for expert in misses:
+            if expert in probation or expert in protected:
+                continue
+            probation[expert] = None
+            self.stats.admissions += 1
+            while len(probation) > probation_limit:
+                probation.popitem(last=False)
+                self.stats.evictions += 1
+
+
+class FrequencyAdmissionPolicy(BasePolicy):
+    """Decayed-frequency admission: demand may execute without polluting cache."""
+    def __init__(self, capacities, specs, learned_counts=None,
+                 decay_interval=4096, decay=0.5, hysteresis=0.10):
+        super().__init__(capacities, specs, learned_counts)
+        self.resident: dict[int, set[int]] = defaultdict(set)
+        self.frequency: dict[int, Counter[int]] = defaultdict(Counter)
+        self.last: dict[int, dict[int, int]] = defaultdict(dict)
+        self.clock: Counter[int] = Counter()
+        self.decay_interval = decay_interval
+        self.decay = decay
+        self.hysteresis = hysteresis
+        for layer, capacity in capacities.items():
+            counts = Counter(self.learned_counts.get(layer, {}))
+            self.frequency[layer].update(counts)
+            ranked = sorted(counts, key=lambda expert: (-counts[expert], expert))[:capacity]
+            self.resident[layer].update(ranked)
+            self.stats.seeded_objects += len(ranked)
+
+    def lookup(self, layer, expert):
+        return expert in self.resident[layer]
+
+    def observe(self, layer, expert, hit):
+        self.clock[layer] += 1
+        if self.decay_interval and self.clock[layer] % self.decay_interval == 0:
+            for candidate in list(self.frequency[layer]):
+                self.frequency[layer][candidate] *= self.decay
+                if self.frequency[layer][candidate] < 0.5:
+                    del self.frequency[layer][candidate]
+        self.frequency[layer][expert] += 1
+        self.last[layer][expert] = self.clock[layer]
+
+    def _victim(self, layer):
+        return min(self.resident[layer],
+                   key=lambda expert: (self.frequency[layer][expert],
+                                       self.last[layer].get(expert, 0), expert))
+
+    def admit_batch(self, layer, misses):
+        capacity = self.capacities.get(layer, 0)
+        if capacity <= 0:
+            self.stats.rejected_admissions += len(misses)
+            return
+        resident = self.resident[layer]
+        for expert in misses:
+            if expert in resident:
+                continue
+            if len(resident) < capacity:
+                resident.add(expert)
+                self.stats.admissions += 1
+                continue
+            victim = self._victim(layer)
+            if (self.frequency[layer][expert] <=
+                    self.frequency[layer][victim] * (1 + self.hysteresis)):
+                self.stats.rejected_admissions += 1
+                continue
+            resident.remove(victim)
+            resident.add(expert)
+            self.stats.evictions += 1
+            self.stats.admissions += 1
+
+
+class HalfPinnedLRUPolicy(BasePolicy):
+    """Synthetic half-capacity frequency pins plus adaptive LRU."""
+    def __init__(self, capacities, specs, learned_counts=None, pin_fraction=0.5):
+        super().__init__(capacities, specs, learned_counts)
+        self.pins: dict[int, set[int]] = defaultdict(set)
+        self.cache: dict[int, OrderedDict[int, None]] = defaultdict(OrderedDict)
+        self.adaptive_capacity = {}
+        for layer, capacity in capacities.items():
+            pin_count = min(capacity, int(capacity * pin_fraction))
+            counts = self.learned_counts.get(layer, {})
+            ranked = sorted(counts, key=lambda expert: (-counts[expert], expert))[:pin_count]
+            self.pins[layer].update(ranked)
+            self.adaptive_capacity[layer] = capacity - len(ranked)
+            self.stats.seeded_objects += len(ranked)
+
+    def lookup(self, layer, expert):
+        if expert in self.pins[layer]:
+            return True
+        cache = self.cache[layer]
+        if expert not in cache:
+            return False
+        cache.move_to_end(expert)
+        return True
+
+    def admit_batch(self, layer, misses):
+        capacity = self.adaptive_capacity.get(layer, 0)
+        if capacity <= 0:
+            self.stats.rejected_admissions += len(misses)
+            return
+        selected = list(misses[-capacity:])
+        self.stats.rejected_admissions += len(misses) - len(selected)
+        cache = self.cache[layer]
+        for expert in reversed(selected):
+            if expert in self.pins[layer] or expert in cache:
+                continue
+            while len(cache) >= capacity:
+                cache.popitem(last=False)
+                self.stats.evictions += 1
+            cache[expert] = None
+            self.stats.admissions += 1
+
+
+POLICIES = {
+    "lru": LRUPolicy,
+    "half-pinned": HalfPinnedLRUPolicy,
+    "lfu": LFUPolicy,
+    "slru": SLRUPolicy,
+    "frequency": FrequencyAdmissionPolicy,
+}
+
+
+def training_counts(traces):
+    counts: dict[int, Counter[int]] = defaultdict(Counter)
+    for trace in traces:
+        for event in trace:
+            counts[event.layer].update(event.selection_counts())
+    return dict(counts)
+
+
+def run_policy(policy_name, capacities, specs, trace, learned_counts=None):
+    policy = POLICIES[policy_name](capacities, specs, learned_counts)
+    for event in trace:
+        policy.access(event)
+    return policy.stats
+
+
+class LayerReplayCache:
+    """Memoize exact per-layer replays; all implemented policies are layer-local."""
+    def __init__(self, traces, specs, learned_counts=None, base=None):
+        self.traces = traces
+        self.specs = specs
+        self.learned_counts = learned_counts or {}
+        self.layer_traces = {
+            layer: [[event for event in trace if event.layer == layer] for trace in traces]
+            for layer in specs
+        }
+        self.cache = base.cache if base is not None else {}
+
+    def layer_stats(self, policy_name, layer, capacity, trace_index):
+        key = (policy_name, layer, capacity, trace_index)
+        if key not in self.cache:
+            self.cache[key] = run_policy(
+                policy_name,
+                {layer: capacity},
+                {layer: self.specs[layer]},
+                self.layer_traces[layer][trace_index],
+                {layer: self.learned_counts.get(layer, {})},
+            )
+        return self.cache[key]
+
+    def trace_stats(self, policy_name, capacities, specs, trace_index):
+        combined = PolicyStats()
+        felt_wait_us = 0.0
+        for layer, spec in specs.items():
+            stats = self.layer_stats(
+                policy_name, layer, capacities.get(layer, 0), trace_index)
+            combined.add(stats)
+            felt_wait_us += stats.misses * spec.felt_miss_us
+        combined.felt_wait_us = felt_wait_us
+        return combined
+
+    def layer_wait(self, policy_name, layer, capacity, specs):
+        misses = sum(
+            self.layer_stats(policy_name, layer, capacity, trace_index).misses
+            for trace_index in range(len(self.traces))
+        )
+        return misses * specs[layer].felt_miss_us
+
+
+class ScaledReplayCache(LayerReplayCache):
+    def __init__(self, base, specs):
+        super().__init__(base.traces, specs, base.learned_counts, base=base)
+
+
+def evaluate(
+    traces,
+    capacities,
+    specs,
+    policies,
+    learned_counts=None,
+    replay_cache=None,
+) -> dict:
+    replay_cache = replay_cache or LayerReplayCache(traces, specs, learned_counts)
+    result = {}
+    for policy_name in policies:
+        aggregate = PolicyStats()
+        per_trace = []
+        for trace_index, trace in enumerate(traces):
+            stats = replay_cache.trace_stats(
+                policy_name, capacities, specs, trace_index)
+            aggregate.add(stats)
+            per_trace.append({
+                "source": trace[0].source if trace else "",
+                **stats.report(),
+            })
+        result[policy_name] = {"aggregate": aggregate.report(), "traces": per_trace}
+    return result
+
+
+def capacity_bytes(capacities, specs):
+    return sum(capacities.get(layer, 0) * spec.resident_bytes
+               for layer, spec in specs.items())
+
+
+def scale_specs(specs, felt_scale, target_layer=None):
+    if felt_scale <= 0 or not math.isfinite(felt_scale):
+        raise ValueError("felt scale must be positive and finite")
+    return {
+        layer: LayerSpec(
+            spec.resident_bytes,
+            spec.read_bytes,
+            (spec.felt_miss_us * felt_scale
+             if target_layer is None or layer == target_layer else spec.felt_miss_us),
+            spec.max_experts,
+        )
+        for layer, spec in specs.items()
+    }
+
+
+def trace_categories(traces, category_names=None):
+    if category_names is not None:
+        if len(category_names) != len(traces):
+            raise ValueError("--eval-category requires one value per --eval trace")
+        return list(category_names)
+    categories = []
+    for trace in traces:
+        source = Path(trace[0].source).stem if trace and trace[0].source else "trace"
+        match = re.match(r"^(.*?)(?:[_-]\d+)?$", source)
+        categories.append(match.group(1) or source)
+    return categories
+
+
+def profile_costs(log_paths):
+    """Extract per-layer felt costs from PROF logs when layer telemetry exists.
+
+    Current GLM PROF output reports aggregate felt wait, so return the aggregate
+    cost-per-miss fallback and leave per-layer calibration to a future layer
+    telemetry field.
+    """
+    waits = []
+    loads = []
+    for path in log_paths or ():
+        text = Path(path).read_text(encoding="utf-8")
+        for line in text.splitlines():
+            match = re.search(r"([0-9.]+)s read service / ([0-9.]+)s felt wait", line)
+            load_match = re.search(r"\| ([0-9]+(?:\.[0-9]+)?) loads/token", line)
+            if match:
+                waits.append(float(match.group(2)))
+            if load_match:
+                loads.append(float(load_match.group(1)))
+    return {
+        "logs": [str(path) for path in log_paths or ()],
+        "felt_wait_seconds": sum(waits),
+        "loads": sum(loads),
+        "felt_us_per_load": (sum(waits) * 1e6 / sum(loads) if loads else None),
+        "scope": "aggregate; GLM PROF does not expose layer-level felt wait",
+    }
+
+
+def decision_gate(result, categories, minimum_gain=0.10, maximum_regression=0.03):
+    """Compare every candidate with uniform LRU using equal-weight categories."""
+    if not 0 <= minimum_gain < 1 or maximum_regression < 0:
+        raise ValueError("invalid decision-gate thresholds")
+    baseline_payload = result["results"].get("uniform", {}).get("lru")
+    if not baseline_payload:
+        raise ValueError("decision gate requires policy lru")
+    if len(baseline_payload["traces"]) != len(categories):
+        raise ValueError("category count does not match evaluation traces")
+
+    baseline_by_category: dict[str, float] = defaultdict(float)
+    category_trace_counts: Counter[str] = Counter(categories)
+    for category, stats in zip(categories, baseline_payload["traces"]):
+        baseline_by_category[category] += stats["felt_wait_us"]
+    rows = []
+    for allocation, policies in result["results"].items():
+        for policy, payload in policies.items():
+            if allocation == "uniform" and policy == "lru":
+                continue
+            candidate_by_category: dict[str, float] = defaultdict(float)
+            for category, stats in zip(categories, payload["traces"]):
+                candidate_by_category[category] += stats["felt_wait_us"]
+            category_changes = {}
+            for category in sorted(baseline_by_category):
+                baseline = baseline_by_category[category]
+                candidate = candidate_by_category[category]
+                change = ((baseline - candidate) / baseline
+                          if baseline else (0.0 if candidate == 0 else -math.inf))
+                category_changes[category] = {
+                    "baseline_felt_wait_us": baseline,
+                    "candidate_felt_wait_us": candidate,
+                    "gain": change,
+                    "traces": category_trace_counts[category],
+                }
+            gains = [entry["gain"] for entry in category_changes.values()]
+            mean_gain = statistics.fmean(gains)
+            worst_gain = min(gains)
+            aggregate_baseline = baseline_payload["aggregate"]["felt_wait_us"]
+            aggregate_candidate = payload["aggregate"]["felt_wait_us"]
+            aggregate_gain = ((aggregate_baseline - aggregate_candidate) / aggregate_baseline
+                              if aggregate_baseline else 0.0)
+            row = {
+                "allocation": allocation,
+                "policy": policy,
+                "aggregate_gain": aggregate_gain,
+                "category_mean_gain": mean_gain,
+                "worst_category_gain": worst_gain,
+                "categories": category_changes,
+            }
+            row["pass"] = mean_gain >= minimum_gain and worst_gain >= -maximum_regression
+            rows.append(row)
+    rows.sort(key=lambda row: (
+        not row["pass"], -row["worst_category_gain"],
+        -row["category_mean_gain"], row["allocation"], row["policy"]))
+    return {
+        "baseline": {"allocation": "uniform", "policy": "lru"},
+        "minimum_category_mean_gain": minimum_gain,
+        "maximum_category_regression": maximum_regression,
+        "candidates": rows,
+    }
+
+
+def sensitivity_analysis(
+    train,
+    evaluation,
+    specs,
+    budget_bytes,
+    policies,
+    categories,
+    felt_scales,
+    minimum_gain=0.10,
+    maximum_regression=0.03,
+    sensitivity_layers=None,
+):
+    learned_counts = training_counts(train)
+    # Admission and hit/miss behavior is unchanged by a felt-cost scale within
+    # one layer. Reuse the exact replay curves across perturbations and only
+    # reweight their misses when optimizing dynamic capacity.
+    train_cache = LayerReplayCache(train, specs, learned_counts)
+    evaluation_cache = LayerReplayCache(evaluation, specs, learned_counts)
+    perturbations = [("baseline", None, 1.0)]
+    perturbations.extend(
+        (f"layer-{layer}-x{felt_scale:g}", layer, felt_scale)
+        for layer in (sorted(specs) if sensitivity_layers is None
+                      else sorted(set(sensitivity_layers)))
+        if layer in specs
+        for felt_scale in felt_scales
+        if felt_scale != 1.0
+    )
+    scenarios = []
+    for name, layer, felt_scale in perturbations:
+        scenario_specs = scale_specs(specs, felt_scale, layer)
+        scenario_train_cache = ScaledReplayCache(train_cache, scenario_specs)
+        scenario_evaluation_cache = ScaledReplayCache(evaluation_cache, scenario_specs)
+        result = analyze(
+            train, evaluation, scenario_specs, budget_bytes, policies,
+            learned_counts, scenario_train_cache, scenario_evaluation_cache)
+        scenarios.append({
+            "name": name,
+            "layer": layer,
+            "felt_scale": felt_scale,
+            "gate": decision_gate(
+                result, categories, minimum_gain, maximum_regression),
+        })
+    candidates: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    for scenario in scenarios:
+        for candidate in scenario["gate"]["candidates"]:
+            candidates[(candidate["allocation"], candidate["policy"])].append({
+                "scenario": scenario["name"],
+                "felt_scale": scenario["felt_scale"],
+                "pass": candidate["pass"],
+                "category_mean_gain": candidate["category_mean_gain"],
+                "worst_category_gain": candidate["worst_category_gain"],
+            })
+    robust = []
+    for (allocation, policy), outcomes in candidates.items():
+        robust.append({
+            "allocation": allocation,
+            "policy": policy,
+            "pass_all_scales": all(outcome["pass"] for outcome in outcomes),
+            "outcomes": outcomes,
+        })
+    robust.sort(key=lambda row: (not row["pass_all_scales"], row["allocation"], row["policy"]))
+    return {"scenarios": scenarios, "candidates": robust}
+
+
+def _training_wait(traces, capacities, specs, policy_name, learned_counts):
+    return sum(run_policy(policy_name, capacities, specs, trace, learned_counts).felt_wait_us
+               for trace in traces)
+
+
+def dynamic_capacities(
+    traces,
+    specs,
+    budget_bytes,
+    policy_name,
+    learned_counts,
+    replay_cache=None,
+):
+    """Greedily allocate slots using exact cold-trace replay for one policy."""
+    if budget_bytes < 0:
+        raise ValueError("budget must be non-negative")
+    capacities = {layer: 0 for layer in specs}
+    used = 0
+    replay_cache = replay_cache or LayerReplayCache(traces, specs, learned_counts)
+    layer_waits = {
+        layer: replay_cache.layer_wait(policy_name, layer, 0, specs)
+        for layer in specs
+    }
+    while True:
+        best = None
+        for layer, spec in specs.items():
+            current = capacities[layer]
+            # Exact replay is retained for every candidate, but scanning every
+            # slot is prohibitively expensive on a 256-expert x 75-layer model.
+            # These fixed breakpoints expose the useful capacity regions while
+            # keeping the offline sweep bounded and deterministic.
+            targets = {1, 2, 4, 8, 16, 32, 48, 64, 96, 128, 160, 192, 256}
+            targets.add(spec.max_experts)
+            for trace_index in range(len(traces)):
+                sequence = replay_cache.layer_traces[layer][trace_index]
+                unique = len({expert for event in sequence for expert in event.experts})
+                targets.add(min(spec.max_experts, unique))
+            targets = {target for target in targets
+                       if current < target <= spec.max_experts}
+            for target in sorted(targets):
+                if target <= current:
+                    continue
+                added_bytes = (target - current) * spec.resident_bytes
+                if used + added_bytes > budget_bytes:
+                    break
+                wait = replay_cache.layer_wait(policy_name, layer, target, specs)
+                benefit = layer_waits[layer] - wait
+                candidate = (benefit / added_bytes, benefit, -added_bytes,
+                             -layer, layer, target, wait, added_bytes)
+                if best is None or candidate > best:
+                    best = candidate
+        if best is None or best[1] <= 0:
+            break
+        (_ratio, _benefit, _neg_bytes, _neg_layer, layer, target,
+         layer_wait, added_bytes) = best
+        capacities[layer] = target
+        layer_waits[layer] = layer_wait
+        used += added_bytes
+    return capacities
+
+
+def analyze(
+    train,
+    evaluation,
+    specs,
+    budget_bytes,
+    policies,
+    learned_counts=None,
+    train_cache=None,
+    evaluation_cache=None,
+):
+    learned_counts = learned_counts or training_counts(train)
+    train_cache = train_cache or LayerReplayCache(train, specs, learned_counts)
+    evaluation_cache = evaluation_cache or LayerReplayCache(
+        evaluation, specs, learned_counts)
+    uniform = uniform_capacities(specs, budget_bytes)
+    output = {
+        "budget_bytes": budget_bytes,
+        "specs": {str(k): asdict(v) for k, v in sorted(specs.items())},
+        "allocations": {},
+        "results": {},
+    }
+    output["allocations"]["uniform"] = {
+        "capacities": {str(k): v for k, v in sorted(uniform.items())},
+        "resident_bytes": capacity_bytes(uniform, specs),
+    }
+    output["results"]["uniform"] = evaluate(
+        evaluation, uniform, specs, policies, learned_counts, evaluation_cache)
+    for policy in policies:
+        capacities = dynamic_capacities(
+            train, specs, budget_bytes, policy, learned_counts, train_cache)
+        name = f"dynamic-{policy}"
+        output["allocations"][name] = {
+            "capacities": {str(k): v for k, v in sorted(capacities.items())},
+            "resident_bytes": capacity_bytes(capacities, specs),
+        }
+        output["results"][name] = evaluate(
+            evaluation, capacities, specs, [policy], learned_counts, evaluation_cache)
+    return output
+
+
+def print_report(result):
+    print(f"expert_budget={result['budget_bytes']} bytes")
+    print("allocation policy hit_rate misses bytes_read felt_wait_ms evictions rejected seeded")
+    for allocation, policies in result["results"].items():
+        caps = result["allocations"][allocation]["capacities"]
+        resident = result["allocations"][allocation]["resident_bytes"]
+        print(f"capacities[{allocation}]={caps} resident_bytes={resident}")
+        for policy, payload in policies.items():
+            stats = payload["aggregate"]
+            print(f"{allocation:18} {policy:11} {stats['hit_rate']:8.2%} "
+                  f"{stats['misses']:7d} {stats['bytes_read']:12d} "
+                  f"{stats['felt_wait_us']/1000:12.3f} "
+                  f"{stats['evictions']:9d} {stats['rejected_admissions']:8d} "
+                  f"{stats['seeded_objects']:6d}")
+
+
+def print_gate(gate):
+    print("decision_gate baseline=uniform/lru "
+          f"min_mean_gain={gate['minimum_category_mean_gain']:.1%} "
+          f"max_regression={gate['maximum_category_regression']:.1%}")
+    print("allocation policy verdict category_mean worst_category aggregate")
+    for candidate in gate["candidates"]:
+        verdict = "PASS" if candidate["pass"] else "FAIL"
+        print(f"{candidate['allocation']:18} {candidate['policy']:11} {verdict:7} "
+              f"{candidate['category_mean_gain']:13.2%} "
+              f"{candidate['worst_category_gain']:14.2%} "
+              f"{candidate['aggregate_gain']:9.2%}")
+
+
+def synthetic_trace(kind: str):
+    specs = {
+        0: LayerSpec(1_000_000, 1_000_000, 1000.0, 16),
+        1: LayerSpec(1_000_000, 1_000_000, 4000.0, 16),
+        2: LayerSpec(2_000_000, 2_000_000, 2000.0, 16),
+    }
+    budget = 8_000_000
+
+    def events(layer, sequence):
+        return [AccessEvent(layer, (expert,), (expert,), None, kind) for expert in sequence]
+
+    hot0 = [0, 1, 0, 2, 0, 1, 0, 3] * 100
+    hot1 = [0, 1, 0, 2, 0, 3, 0, 1, 4, 0, 2, 0] * 100
+    burst2 = sum(([0, 1] * 8 + [cold] for cold in range(2, 12)), []) * 20
+    train_trace = events(0, hot0) + events(1, hot1) + events(2, burst2)
+    if kind == "stationary":
+        eval_trace = events(0, hot0[:400]) + events(1, hot1[:600]) + events(2, burst2[:400])
+    elif kind == "shifted":
+        shifted1 = list(range(16)) * 40
+        shifted0 = [7, 8] * 300
+        eval_trace = events(0, shifted0) + events(1, shifted1) + events(2, burst2[:300])
+    else:
+        raise ValueError(kind)
+    return [train_trace], [eval_trace], specs, budget
+
+
+def synthetic_category_suite():
+    """Two-category transfer check: one stationary and one shifted workload."""
+    stationary_train, stationary_eval, specs, budget = synthetic_trace("stationary")
+    _shifted_train, shifted_eval, _shifted_specs, _shifted_budget = synthetic_trace("shifted")
+    return (
+        stationary_train,
+        [stationary_eval[0], shifted_eval[0]],
+        specs,
+        budget,
+        ["stationary", "shifted"],
+    )
+
+
+def synthetic_budget_sweep(policies, budgets_mb=(2, 4, 6, 8, 10, 12, 16, 24, 32)):
+    train, evaluation, specs, _budget, categories = synthetic_category_suite()
+    rows = []
+    for budget_mb in budgets_mb:
+        budget_bytes = budget_mb * 1_000_000
+        result = analyze(train, evaluation, specs, budget_bytes, policies)
+        gate = decision_gate(result, categories)
+        sensitivity = sensitivity_analysis(
+            train, evaluation, specs, budget_bytes, policies, categories,
+            [0.5, 1.0, 1.5])
+        robust = {
+            (row["allocation"], row["policy"]): row["pass_all_scales"]
+            for row in sensitivity["candidates"]
+        }
+        for candidate in gate["candidates"]:
+            if candidate["pass"]:
+                rows.append({
+                    "budget_mb": budget_mb,
+                    "allocation": candidate["allocation"],
+                    "policy": candidate["policy"],
+                    "category_mean_gain": candidate["category_mean_gain"],
+                    "worst_category_gain": candidate["worst_category_gain"],
+                    "pass_sensitivity": robust[
+                        (candidate["allocation"], candidate["policy"])],
+                })
+    return rows
+
+
+def command_demo(args):
+    for scenario in ("stationary", "shifted"):
+        train, evaluation, specs, budget = synthetic_trace(scenario)
+        print(f"\n=== {scenario} ===")
+        result = analyze(train, evaluation, specs, budget, args.policies)
+        print_report(result)
+        if "lru" in args.policies:
+            print_gate(decision_gate(result, [scenario]))
+    if "lru" in args.policies:
+        train, evaluation, specs, budget, categories = synthetic_category_suite()
+        print("\n=== combined category-held-out gate ===")
+        result = analyze(train, evaluation, specs, budget, args.policies)
+        print_gate(decision_gate(result, categories))
+        sensitivity = sensitivity_analysis(
+            train, evaluation, specs, budget, args.policies, categories,
+            [0.5, 1.0, 1.5])
+        print("sensitivity " + " ".join(
+            f"{row['allocation']}/{row['policy']}="
+            f"{'PASS' if row['pass_all_scales'] else 'FAIL'}"
+            for row in sensitivity["candidates"]))
+        sweep = synthetic_budget_sweep(args.policies)
+        print("\n=== synthetic budget operating regions ===")
+        print("budget_mb allocation policy category_mean worst_category sensitivity")
+        for row in sweep:
+            print(f"{row['budget_mb']:9d} {row['allocation']:18} {row['policy']:11} "
+                  f"{row['category_mean_gain']:13.2%} "
+                  f"{row['worst_category_gain']:14.2%} "
+                  f"{'PASS' if row['pass_sensitivity'] else 'FAIL'}")
+
+
+def _real_inputs(args):
+    train_paths = [path.resolve() for path in args.train]
+    eval_paths = [path.resolve() for path in args.eval]
+    if len(set(train_paths)) != len(train_paths):
+        raise ValueError("duplicate path in --train")
+    if len(set(eval_paths)) != len(eval_paths):
+        raise ValueError("duplicate path in --eval")
+    overlap = set(train_paths) & set(eval_paths)
+    if overlap:
+        raise ValueError(f"train/eval paths overlap: {sorted(map(str, overlap))[0]}")
+    try:
+        train_identities = [(path.stat().st_dev, path.stat().st_ino) for path in train_paths]
+        eval_identities = [(path.stat().st_dev, path.stat().st_ino) for path in eval_paths]
+    except OSError:
+        train_identities = []
+        eval_identities = []
+    if len(set(train_identities)) != len(train_identities):
+        raise ValueError("duplicate file in --train")
+    if len(set(eval_identities)) != len(eval_identities):
+        raise ValueError("duplicate file in --eval")
+    if set(train_identities) & set(eval_identities):
+        raise ValueError("train/eval paths refer to the same file")
+    train = read_traces(train_paths)
+    evaluation = read_traces(eval_paths)
+    specs = load_specs(train + evaluation, args.manifest,
+                       args.read_gbps, args.felt_fraction)
+    return train, evaluation, specs
+
+
+def command_run(args):
+    train, evaluation, specs = _real_inputs(args)
+    if args.max_training_events:
+        train = [trace[:args.max_training_events] for trace in train]
+        if any(not trace for trace in train):
+            raise ValueError("--max-training-events removed every event from a trace")
+    budget = int(args.expert_budget_gb * 1e9)
+    result = analyze(train, evaluation, specs, budget, args.policies)
+    print_report(result)
+    categories = trace_categories(evaluation, args.eval_category)
+    gate = decision_gate(result, categories, args.minimum_gain, args.maximum_regression)
+    print_gate(gate)
+    sensitivity = sensitivity_analysis(
+        train, evaluation, specs, budget, args.policies, categories,
+        args.felt_scales, args.minimum_gain, args.maximum_regression,
+        args.sensitivity_layers)
+    costs = profile_costs(args.prof_log)
+    print("sensitivity " + " ".join(
+        f"{row['allocation']}/{row['policy']}="
+        f"{'PASS' if row['pass_all_scales'] else 'FAIL'}"
+        for row in sensitivity["candidates"]))
+    if args.json_out:
+        document = {
+            "result": result,
+            "categories": categories,
+            "profile_costs": costs,
+            "gate": gate,
+            "sensitivity": sensitivity,
+        }
+        args.json_out.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+
+
+def command_sweep(args):
+    train, evaluation, specs = _real_inputs(args)
+    if args.max_training_events:
+        train = [trace[:args.max_training_events] for trace in train]
+        if any(not trace for trace in train):
+            raise ValueError("--max-training-events removed every event from a trace")
+    categories = trace_categories(evaluation, args.eval_category)
+    costs = profile_costs(args.prof_log)
+    results = []
+    for budget_gb in args.expert_budgets:
+        result = analyze(train, evaluation, specs, int(budget_gb * 1e9), args.policies)
+        results.append({
+            "expert_budget_gb": budget_gb,
+            "result": result,
+            "profile_costs": costs,
+            "gate": decision_gate(
+                result, categories, args.minimum_gain, args.maximum_regression),
+            "sensitivity": sensitivity_analysis(
+                train, evaluation, specs, int(budget_gb * 1e9), args.policies,
+                categories, args.felt_scales, args.minimum_gain,
+                args.maximum_regression, args.sensitivity_layers),
+        })
+    for entry in results:
+        print(f"\n=== expert budget {entry['expert_budget_gb']:g} GB ===")
+        print_report(entry["result"])
+        print_gate(entry["gate"])
+        print("sensitivity " + " ".join(
+            f"{row['allocation']}/{row['policy']}="
+            f"{'PASS' if row['pass_all_scales'] else 'FAIL'}"
+            for row in entry["sensitivity"]["candidates"]))
+    if args.json_out:
+        args.json_out.write_text(json.dumps({"sweeps": results}, indent=2) + "\n",
+                                 encoding="utf-8")
+
+
+def add_real_trace_arguments(parser):
+    parser.add_argument("--train", type=Path, nargs="+", required=True)
+    parser.add_argument("--eval", type=Path, nargs="+", required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--read-gbps", type=float, default=3.0)
+    parser.add_argument("--felt-fraction", type=float, default=1.0)
+    parser.add_argument("--felt-scales", type=float, nargs="+", default=[0.5, 1.0, 1.5])
+    parser.add_argument("--eval-category", action="append")
+    parser.add_argument("--minimum-gain", type=float, default=0.10)
+    parser.add_argument("--maximum-regression", type=float, default=0.03)
+    parser.add_argument("--max-training-events", type=int, default=0,
+                        help="limit events per training trace for a quick smoke run")
+    parser.add_argument("--sensitivity-layer", dest="sensitivity_layers",
+                        type=int, action="append",
+                        help="limit cost sensitivity to selected layers")
+    parser.add_argument("--prof-log", type=Path, action="append", default=[],
+                        help="GLM PROF=1 log used for aggregate cost calibration")
+    parser.add_argument("--policies", nargs="+", choices=tuple(POLICIES),
+                        default=list(POLICIES))
+    parser.add_argument("--json-out", type=Path)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    demo = sub.add_parser("demo", help="run deterministic stationary/shifted fixtures")
+    demo.add_argument("--policies", nargs="+", choices=tuple(POLICIES),
+                      default=list(POLICIES))
+    demo.set_defaults(func=command_demo)
+
+    run = sub.add_parser("run", help="simulate real GLM ROUTE_TRACE files")
+    add_real_trace_arguments(run)
+    run.add_argument("--expert-budget-gb", type=float, required=True)
+    run.set_defaults(func=command_run)
+
+    sweep = sub.add_parser("sweep", help="compare policies over expert RAM budgets")
+    add_real_trace_arguments(sweep)
+    sweep.add_argument("--expert-budgets", type=float, nargs="+", required=True)
+    sweep.set_defaults(func=command_sweep)
+    args = parser.parse_args()
+    budgets = ([args.expert_budget_gb] if hasattr(args, "expert_budget_gb")
+               else getattr(args, "expert_budgets", []))
+    if any(value <= 0 or not math.isfinite(value) or value > 1e9 for value in budgets):
+        parser.error("expert budget values must be positive, finite, and <= 1e9 GB")
+    if hasattr(args, "felt_scales") and any(
+            value <= 0 or not math.isfinite(value) for value in args.felt_scales):
+        parser.error("--felt-scales values must be positive and finite")
+    if hasattr(args, "minimum_gain") and not 0 <= args.minimum_gain < 1:
+        parser.error("--minimum-gain must be in [0,1)")
+    if hasattr(args, "maximum_regression") and args.maximum_regression < 0:
+        parser.error("--maximum-regression must be non-negative")
+    if hasattr(args, "max_training_events") and args.max_training_events < 0:
+        parser.error("--max-training-events must be non-negative")
+    if hasattr(args, "policies") and "lru" not in args.policies:
+        parser.error("--policies must include lru as the decision-gate baseline")
+    try:
+        args.func(args)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        parser.error(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -177,6 +177,7 @@ Per-drive byte counts are reported in a `MIRROR:` stats line. Combine with `DIRE
 | Variable | Default | Effect |
 |---|---|---|
 | `COLI_VULKAN` | off | Enable the Vulkan backend. Requires a `make VK=1` build; fails at startup (no silent fallback) if libvulkan or the compiled shaders are missing. |
+| `COLI_VK_DEV` | unset | Select the primary Vulkan physical-device enumeration index. Without it, the backend prefers a discrete GPU, then integrated/virtual devices. |
 | `COLI_VK_SHADERS` | auto | Path to the compiled `qmatmul.spv` **or** the directory holding the `.spv` set; the other shaders are found next to it. Unset: `shaders/` next to the binary, then CWD-relative `shaders/qmatmul.spv`. |
 | `COLI_VK_EXPERTS` | `320` | Pinned VRAM expert tier size: top-N experts by `.coli_usage` heat uploaded once at startup and served from VRAM with no RAM slot or disk read. `0` disables the tier (experts stay on the CPU path). ~19 MB VRAM per int4 expert. |
 | `COLI_VK_DENSE` | `0` | Run the resident dense matmuls (attention projections, shared expert) on the GPU. |

--- a/docs/experiments/cnre-offline-simulator.md
+++ b/docs/experiments/cnre-offline-simulator.md
@@ -1,0 +1,281 @@
+# CNRE Phase 0: offline residency-policy simulator
+
+This experiment supports [Discussion #884](https://github.com/JustVugg/colibri/discussions/884).
+It does not modify an engine or claim a runtime speedup. It replays existing
+`ROUTE_TRACE` files through bounded expert caches so weak policies can be
+rejected before changing inference code or renting hardware.
+
+## Scope
+
+`c/tools/residency_sim.py` currently models the main GLM CPU-routing path:
+
+- first-seen expert unions for each contiguous `(call, layer)` batch;
+- promotion between GLM's 64-expert working-set blocks;
+- separate per-layer resident footprint, read bytes, and felt miss cost;
+- a fixed expert-residency RAM budget, excluding the rest of process RAM;
+- equal slots per layer versus policy-specific, trace-trained layer budgets;
+- GLM LRU, synthetic half-capacity pins + LRU, decayed LFU, segmented LRU,
+  and decayed-frequency admission.
+
+The half-pinned and alternative admission policies are experiments, not exact
+reproductions of current GLM startup pins or live `REPIN`.
+
+The tool does **not** model new prefetch reads, routing substitutions, GPU
+kernels, NUMA effects, page-cache interference, lock contention, startup read
+cost, or actual tok/s. A predicted reduction in felt wait is a gate for a
+runtime A/B, not the result of one.
+
+Current GLM also read-aheads the next 64-expert block while computing the
+current block. The simulator preserves block promotion semantics but does not
+model this existing overlap. Long-prefill felt-wait estimates are therefore
+conservative and must be checked with lower `felt_fraction` sensitivity.
+
+Kimi K3 traces are not currently safe input because that engine emits routes
+without advancing the trace call ID. Inkling and OLMoE initialize routing
+telemetry but do not currently emit route records. Their cache traversal also
+differs from GLM, so each needs an explicit engine profile before inclusion.
+
+## Trace contract
+
+The input is the engine's current `ROUTE_TRACE` stream:
+
+```text
+<call> <row> <layer> <expert>:<gate> ...
+```
+
+Rows sharing one contiguous `(call, layer)` group are one runtime batch. The
+simulator unions their expert IDs in first-seen order for demand I/O, while
+retaining per-row selection multiplicity to train startup residents like
+`.coli_usage` counts. It rejects malformed fields, missing/reordered rows,
+non-advancing call IDs, and repeated noncontiguous call groups rather than
+silently merging a broken trace.
+
+Use a clean environment and deterministic, placement-neutral GLM trace
+collection. In particular, unset `EXPERT_BUDGET` and `ABLATE_*`; the former is
+applied after tracing and would make the trace differ from executed demand.
+Record `COLI_PREFILL_CHUNK`, because it changes batch boundaries.
+
+For a large model, place the model and traces on the instance's local scratch
+volume rather than the root disk. On DigitalOcean's H200 image this is commonly
+`/dev/vdc1`, mounted at `/mnt/scratch`; verify with `lsblk` and `findmnt` before
+using it. The scratch volume is ephemeral and must not be treated as durable
+storage.
+
+```sh
+env -i PATH="$PATH" HOME="$HOME" \
+  DRAFT=0 MTP=0 TOPP=0 TOPK=0 CACHE_ROUTE=0 \
+  PILOT=0 PILOT_REAL=0 REPIN=0 TEMP=0 \
+  ROUTE_TRACE=trace.txt \
+  SNAP=/path/to/model PROMPT="..." NGEN=128 ./colibri 64 4 8
+```
+
+Training traces and held-out evaluation traces must be separate files. The CLI
+rejects identical resolved paths. Use one file per cold process run; policy
+state is intentionally reset between files.
+
+## Manifest and cost calibration
+
+A manifest with fixed model geometry is required. Inferring `max_experts` from
+held-out IDs would leak evaluation data and understate dimensions when a valid
+expert did not happen to route.
+
+```json
+{
+  "layers": {
+    "3": {
+      "resident_bytes": 18915328,
+      "read_bytes": 75661312,
+      "felt_miss_us": 2400.0,
+      "max_experts": 256
+    }
+  }
+}
+```
+
+Manifest rows that are absent from all supplied traces are ignored. This keeps
+disabled MTP rows from consuming only the uniform baseline's budget.
+
+`resident_bytes` consumes the expert cache budget. `read_bytes` counts demand
+I/O and may differ when a source tensor is transformed into a smaller resident
+representation. If `felt_miss_us` is omitted, it defaults to:
+
+```text
+read_bytes / (read_gbps * 1e9) * 1e6 * felt_fraction
+```
+
+`felt_fraction` is the fraction of read service not hidden by concurrent
+compute. Caching a 20 ms read that is fully overlapped does not remove 20 ms
+from token latency.
+
+## Commands
+
+Run deterministic fixtures:
+
+```sh
+cd c
+python3 tools/residency_sim.py demo
+python3 -m unittest tests.test_residency_sim
+```
+
+Evaluate a fixed expert-cache budget:
+
+```sh
+python3 tools/residency_sim.py run \
+  --train traces/chat_train.trace traces/code_train.trace \
+  --eval traces/chat_heldout_1.trace traces/code_heldout_1.trace \
+  --eval-category chat --eval-category code \
+  --manifest glm-residency.json \
+  --expert-budget-gb 32 \
+  --read-gbps 3.0 \
+  --felt-fraction 0.7 \
+  --felt-scales 0.5 1.0 1.5 \
+  --sensitivity-layer 3 --sensitivity-layer 30 --sensitivity-layer 60 \
+  --prof-log /mnt/scratch/logs/trace/coding_eval.out \
+  --json-out cnre-32gb.json
+```
+
+Sweep expert-cache capacities:
+
+```sh
+python3 tools/residency_sim.py sweep \
+  --train traces/chat_train.trace traces/code_train.trace \
+  --eval traces/chat_heldout_1.trace traces/code_heldout_1.trace \
+  --eval-category chat --eval-category code \
+  --manifest glm-residency.json \
+  --expert-budgets 8 16 24 32 48 64 \
+  --read-gbps 3.0 \
+  --felt-fraction 0.7 \
+  --json-out cnre-sweep.json
+```
+
+JSON preserves model specs, every allocation, per-trace source paths and
+metrics, and each complete sweep result. This is enough to compute category
+regressions outside the simulator without parsing human output.
+
+`--policies` must include `lru`, because every decision is measured against the
+uniform-LRU baseline. Both `run` and every point in `sweep` report nominal and
+layer-cost-sensitivity verdicts.
+
+`--prof-log` stores the aggregate `PROF=1` felt-wait calibration in the JSON.
+Current GLM logs expose aggregate, not per-layer, felt wait; this is provenance
+and a global calibration check, not a claim of layer-specific measurement.
+
+`run` also applies the Phase-0 decision gate directly. Categories receive equal
+weight regardless of their number or length of traces. A candidate passes only
+when its category-mean felt-wait gain is at least 10% and its worst category is
+not more than 3% slower than uniform LRU. If `--eval-category` is omitted, the
+tool derives categories by stripping a final numeric replicate from file names,
+for example `chat_2.trace` -> `chat`.
+
+Sensitivity reruns the complete training allocation and held-out evaluation
+after scaling each layer's felt miss cost independently. `--felt-scales 0.5 1
+1.5` therefore tests the baseline plus low/high cost perturbations for every
+active layer. Uniformly scaling every layer would leave policy rankings and
+percentage gains unchanged and is not a useful robustness test.
+
+For a large model, use a representative cost sample first, for example
+`--sensitivity-layer 3 --sensitivity-layer 30 --sensitivity-layer 60`. The
+default all-layer sensitivity is intentionally thorough but can be expensive
+because it recomputes policy-specific capacity allocation for every perturbation.
+
+## Deterministic fixtures
+
+The built-in stationary workload is intentionally cacheable and demonstrates
+scan resistance. The shifted held-out workload deliberately changes its hot
+set and demonstrates that training-seeded residents and dynamic layer budgets
+can overfit. Exact fixture numbers are printed by `demo` and asserted only where
+they encode an invariant; they are not evidence about real Colibri workloads.
+
+`demo` then evaluates both fixtures as equal-weight categories in one decision
+gate. This is deliberately stricter than averaging all accesses: a large
+stationary win cannot hide a shifted-category regression beyond 3%. In the
+current fixture, uniform frequency admission fails that guard (`-4.76%` in the
+shifted category). Dynamic frequency admission narrowly passes the nominal
+gate (`+4.27%` worst category) but fails the layer-by-layer felt-cost
+sensitivity check at that 8 MB budget.
+
+The final demo table sweeps synthetic expert budgets from 2 to 32 MB. It shows
+that robustness is an operating region rather than a policy-wide property. For
+example, dynamic frequency admission is robust in the deliberately constrained
+2-6 MB fixture, fragile at 8-12 MB, and robust again at larger toy budgets. These
+transitions are artifacts of the fixture, but they demonstrate why real traces
+must be swept across realistic RAM budgets rather than evaluated at one point.
+
+## Phase-0 decision gate
+
+Advance to runtime telemetry or an opt-in cache policy only if category-held-out
+real traces show:
+
+```text
+at least 10% lower predicted felt wait
+no principal held-out category worse by more than 3%
+bounded churn and exact expert-cache byte-budget compliance
+the result survives conservative miss-cost sensitivity
+```
+
+The expert-cache budget does not establish whole-process RAM compliance. A
+runtime implementation must additionally account for dense weights, KV state,
+working-set slabs, scratch, page cache, and OS reserve. A negative result is a
+completed experiment and should be published.
+
+## Data still needed
+
+The repository does not currently contain complete GLM routing traces. The
+first useful campaign needs:
+
+1. GLM-5.2 training and held-out traces from coding, chat, multilingual,
+   reasoning, and long-context prompts.
+2. Matching `PROF=1` logs or a per-layer felt-cost manifest.
+3. Exact commit, model/container identity, DRAFT/sampling settings, cache state,
+   prefill chunk, and frozen `.coli_usage` snapshot.
+4. Separate instrumentation fixes and engine profiles before Kimi K3, Inkling,
+   or OLMoE data is interpreted by this simulator.
+
+No server is required to run the simulator. A model-capable machine is needed
+only to collect missing traces and later validate a policy end to end.
+
+## H200 pilot result
+
+The first real-trace campaign ran on a DigitalOcean H200 instance using the
+gs64 GLM container at revision
+`95bb5f03e3e0ca16b4c711394d0461fa86a3cfcb`. The model occupied 429.3 GB on the
+5 TB local scratch volume. The machine had 24 physical CPU cores, 247 GB RAM,
+and 143.8 GiB H200 VRAM.
+
+The collection produced eight training traces and five held-out traces across
+coding, chat, reasoning, multilingual, and long-context prompts. These are
+small pilot traces, not a production benchmark corpus.
+
+At expert-cache budgets of 120, 160, and 200 GB, the offline simulator reported:
+
+```text
+budget   candidate             mean held-out gain   worst category
+120 GB   uniform frequency          +39.91%             +34.84%
+120 GB   dynamic frequency          +40.45%             +35.41%
+160 GB   uniform frequency          +53.35%             +49.92%
+160 GB   dynamic frequency          +54.50%             +50.66%
+200 GB   uniform frequency          +65.31%             +62.64%
+200 GB   dynamic frequency          +66.29%             +63.07%
+```
+
+All frequency candidates passed the nominal category gate and the sampled
+layer-cost sensitivity at layers 3, 30, and 60. LRU dynamic allocation did not
+meet the 10% gate, with approximately 0.0-0.4% gain.
+
+The runtime pilot is the necessary qualification. With `RAM_GB=120`, `PIPE=0`
+measured 1.66 tok/s at 57.2% hit; with `RAM_GB=200`, it measured 1.31 tok/s at
+73.5% hit. Enabling the existing `PIPE=1` overlap reached 2.00 tok/s at the
+same 57.2% hit. This means hit rate alone is not a performance result: I/O
+overlap, disk service, and compute contention materially change tok/s.
+
+Across the five held-out `PROF=1` logs, the aggregate runtime instrumentation
+reported 19.6 seconds of felt wait over 2,625 loads, or approximately 7.47 ms
+per load. This is a whole-run calibration signal, not a per-layer cost: the
+current GLM profile does not attribute felt wait to individual layers.
+
+No runtime frequency-admission policy was implemented in this pilot. The
+current GLM cache admits every demand miss in `moe()` and promotes the bounded
+tail of each 64-expert block. An unrecognized `COLI_CACHE_ADMISSION` variable
+therefore has no effect. This is intentional: the real-trace evidence is strong
+enough to justify a narrowly scoped opt-in prototype, but not enough to claim a
+runtime win or to make a misleading A/B number part of the RFC.


### PR DESCRIPTION
## Summary

This PR is the local-first Phase 0 and placement-contract work requested before a runtime CNRE admission policy is considered. It combines the offline residency simulator with small fixes that make placement accounting, backend selection, and fallback claims more truthful.

It does not add an external cache service, change routing, add prefetch, or change model outputs by policy. It also does not yet implement a runtime frequency-admission policy.

## Why These Changes Are Connected

Several reports describe the same user-visible failure family: the plan says that a GPU/cache tier is available, but the actual execution falls back to CPU/disk, or the computed budget omits a memory term and fails later.

Related reports:

- #887: Intel Vulkan/DeepSeek V4 reports CPU/storage execution instead of GPU use.
- #892: Vulkan residency is absent from Brain Map/telemetry.
- #813: Metal advertises routed-expert GPU execution but rejects the published fmt=4 gs64 container.
- #585: grouped-int4 Metal attention/backend support remains the broader follow-up.
- #759 and #653: RAM/VRAM accounting on unified-memory devices.
- #766 and #767: planner/runtime memory projection and prompt-dependent fallback.
- #687: lazy CUDA tensor uploads can disable GPU work after the expert tier consumes the card.
- #856: mixed expert widths caused an observed cache-capacity regression, fixed in #869.
- #885: a related v1.5 residency under-utilization report remains under investigation.
- #848: Kimi Vulkan tier fill was gated by RAM misses, fixed in #877.
- #662: AMD/ROCm discovery is the precedent for backend-neutral accelerator discovery.
- #783: Kimi CUDA is not implemented and should not be implied by generic GPU flags.

## Implemented

### Offline simulator

- Strict GLM ROUTE_TRACE parsing and validation.
- First-seen batch unions plus per-row selection multiplicity.
- GLM 64-expert block promotion semantics.
- LRU, LFU/frequency admission, SLRU, and synthetic pin policies.
- Uniform and policy-specific dynamic capacity allocation.
- Held-out category gate: at least 10% mean gain and no category worse than 3%.
- Layer-specific felt-cost sensitivity.
- JSON output retaining specs, allocations, trace sources, gates, and sensitivity.
- 29 focused simulator/backend tests.

### Placement accounting

- `resource_plan.py` now records per-layer expert widths and maximum width.
- Shared working-set sizing uses maximum expert width instead of median width.
- Unified-memory fixtures constrain RAM and VRAM against one physical pool.
- Explicit RAM requests are reported when clamped by a shared GPU pool.
- `doctor` reports a backend-neutral `accelerator.gpu` check instead of calling every device CUDA.
- Apple Silicon planning prefers performance-core count when available.

### Backend truthfulness

- `COLI_VK_DEV` selects the primary Vulkan physical-device enumeration index for reproducible multi-GPU/hybrid testing.
- DeepSeek V4's Makefile warns that it has no Vulkan backend instead of implying that `VK=1` enables one.
- Metal batched routed MoE accepts grouped int4 and carries the group size into the shader.
- Metal grouped MoE tests cover g64 and g32 ragged execution.
- Metal startup wording now says that device initialization is format-dependent rather than promising universal routed-expert dispatch.

## Real-trace evidence

Before this PR, a DigitalOcean H200 pilot collected 13 GLM-5.2 traces: 8 train and 5 held-out across coding, chat, reasoning, multilingual, and long-context prompts.

The simulator predicted the following held-out felt-wait gains against uniform LRU:

| Expert budget | Candidate | Mean gain | Worst category |
|---:|---|---:|---:|
| 120 GB | Uniform frequency | +39.91% | +34.84% |
| 120 GB | Dynamic frequency | +40.45% | +35.41% |
| 160 GB | Uniform frequency | +53.35% | +49.92% |
| 160 GB | Dynamic frequency | +54.50% | +50.66% |
| 200 GB | Uniform frequency | +65.31% | +62.64% |
| 200 GB | Dynamic frequency | +66.29% | +63.07% |

These are offline predictions, not runtime speedup claims. The pilot also showed why backend and overlap telemetry must be correct: `RAM_GB=120, PIPE=0` measured 1.66 tok/s at 57.2% hit, while `RAM_GB=120, PIPE=1` measured 2.00 tok/s at the same hit rate. Hit rate alone is not the objective.

## Verification

- Full Python suite: `407 passed, 57 skipped`.
- `make metal-test`: passed, including grouped-int4 batched MoE.
- Focused planner/doctor/backend tests: passed.
- `python3 -m py_compile`: passed.
- `git diff --check`: passed.

## Scope and follow-up

The simulator and methodology are intentionally included so the next runtime policy can be measured against the real held-out gate rather than selected on synthetic or in-sample wins.

The next PR should be a separate, small, GLM-only opt-in admission policy with no routing change, no new prefetch, fixed memory budget, and ABBA measurements for tok/s, p50/p99 latency, felt wait, physical bytes, admissions, rejections, evictions, migration bytes, and output identity.

The Intel Vulkan report in #887 still needs hardware confirmation. This PR improves device selection and removes misleading generic CUDA wording, but it does not claim DeepSeek V4 Vulkan support that the engine does not currently implement.
