### PR TITLE
deepseek_v4: honor CTX in the generate CLI

### DIFF
--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -7387,7 +7387,8 @@ static void v4_cli_usage(FILE *stream, const char *program) {
         "  --oracle FILE        validate against an oracle JSON fixture\n"
         "  --teacher-forcing N  oracle: compare top-1 on N prompt positions\n"
         "  --greedy N           oracle: compare N greedy continuation tokens\n"
-        "  --record-oracle FILE write greedy tokens + tf_pred to JSON\n",
+        "  --record-oracle FILE write greedy tokens + tf_pred to JSON\n"
+        "  CTX=N (environment)  context window in tokens (default: 4096)\n",
         program, program, program);
 }
 
@@ -8617,6 +8618,9 @@ int main(int argc, char **argv) {
             .target_model_dir = cli.model_dir,
             .no_dspark = cli.no_dspark,
             .pin_slots_per_layer = -1,
+            /* Same contract as v4_serve_main: CTX sets the session plan;
+             * unset or invalid falls back to the engine default (4096). */
+            .context_tokens = getenv("CTX") ? atoi(getenv("CTX")) : 0,
         };
         if (cli.memory_gib > 0.0)
             open_opts.memory_limit_bytes =

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -16,6 +16,7 @@ what follows, but the sister engines read their own:
 | `kimi_k3` | `c/kimi_k3.c` | the `K3_*` family — see [Kimi K3 engine](#kimi-k3-engine-kimi_k3) |
 | `inkling` | `c/inkling.c` | `INK_*`, plus `CTX_MAX`, `PIN_N`, `REP_PEN`, `GPU_DEV`, `NOGPU` — see [Inkling engine](#inkling-engine-inkling) |
 | `olmoe` | `c/olmoe.c` | `HOT`, `WIDE`, `SMOOTH`, `CONF_LIMIT`, `MAX_NEW`, `CHAT`, `EXPERT_DROP`, `WARMUP` — see [OLMoE engine](#olmoe-engine-olmoe) |
+| `deepseek_v4` | `c/deepseek_v4.c` | `CTX` — context window in tokens (default 4096), honored by both the CLI and `SERVE` mode |
 
 Setting an `INK_*` variable while running `colibri` does nothing, and vice
 versa; nothing warns you about it. A few variables are genuinely shared because


### PR DESCRIPTION
## Summary

The one-shot CLI always opens the engine without a context size, so the session plans 4,096 tokens no matter what: `CTX` is read only by `v4_serve_main`, and a longer prompt is refused with `V4 prompt must encode to between 1 and 4096 tokens` even when the user asked for a larger window. Nothing documents this: `docs/ENVIRONMENT.md` lists no DeepSeek V4 variables at all.

The smallest change that solves it: read `CTX` in the generate path with the same contract as serve mode (unset or invalid falls back to the engine default of 4096), mention the variable in the usage text, and give the engine a row in the `ENVIRONMENT.md` engine table.

Verified on a real DeepSeek-V4-Flash weights directory (Ryzen 7 6800H, 32 GB, Ubuntu 26.04, gcc 15.2.0):

- `CTX=131072` makes the memory plan react (expert cache shrinks by the compressed-KV cost, about 1.6 GiB at 128K), and a prompt longer than 4,096 tokens is accepted and prefills.
- `CTX` unset produces the same plan as before the patch.
- `CTX=2048` with a 3.2K-token prompt is refused with the configured limit: `between 1 and 2048 tokens`.

## Validation

- [x] `make check` on the patched tree (Linux x86-64): 373 tests, OK (52 skipped)
- [ ] CUDA changes were tested with `make -C c cuda-test` (not applicable; CPU-only change)
- [x] Performance claims include hardware, commands, and repeatable measurements (no performance claims; behavior probes above)

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included
