### PR TITLE
fix(cli): activate readline so UP/DOWN recall previous prompts (#922)

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -26,6 +26,16 @@ Configuration through environment variables or flags (also valid after the subco
 """
 import os, sys, subprocess, argparse, json, time, signal, shutil, threading, re, codecs, tempfile, textwrap, struct
 
+# input() only gets line editing and UP/DOWN history once the readline module
+# has been LOADED — without it the terminal's arrow-key escape sequences are
+# echoed raw into the prompt (#922). Guarded: Windows has no readline module
+# and the console provides its own editing; on FreeBSD Python links libedit,
+# which this activates the same way.
+try:
+    import readline  # noqa: F401 — importing it is the activation
+except ImportError:
+    pass
+
 # The engine mmaps every shard (144+ files); macOS default RLIMIT_NOFILE is 256.
 if sys.platform != "win32":
     try:


### PR DESCRIPTION
`input()` only provides line editing and UP/DOWN history once Python's `readline` module has been loaded — `coli` never imported it, so arrow keys echoed their raw escape sequences into the prompt line, which is exactly what #922 reports on FreeBSD (libedit-backed, same mechanism everywhere).

One guarded import. Windows has no `readline` module and the console provides its own editing (the msvcrt paste path is untouched), hence the guard.

Verified:
- pty harness: type a line, press UP + Enter → the second `input()` returns the first line verbatim (PASS)
- `coli` loads clean with readline active; `tests/test_env_defaults.py` 8/8

Known limitation, stated on the issue: a multi-line pasted block enters history as its first line only — recalling whole pasted blocks is a deeper change and out of scope here.

Closes #922 (manual close needed on merge — `Closes` doesn't fire on non-default-branch merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)