### PR TITLE
fix: correct CNRE cost and capacity accounting

### DIFF
--- a/c/tests/test_residency_sim.py
+++ b/c/tests/test_residency_sim.py
@@ -147,14 +147,62 @@ class SpecificationTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "profile.out"
             path.write_text(
-                "[PROF] expert I/O: 38.178 GB fetched | 525.0 loads/token | "
+                "[PROF] expert I/O: 38.178 GB fetched | "
+                "hit 42.9% (100 pin + 125 lru / 300 load) | 525.0 loads/token | "
                 "7.2s read service / 1.4s felt wait\n",
                 encoding="utf-8",
             )
             costs = sim.profile_costs([path])
-        self.assertEqual(costs["loads"], 525)
+        self.assertEqual(costs["physical_misses"], 300)
+        self.assertEqual(costs["requests_per_token"], [525.0])
+        self.assertTrue(costs["complete"])
+        self.assertEqual(costs["records"], 1)
         self.assertEqual(costs["felt_wait_seconds"], 1.4)
-        self.assertAlmostEqual(costs["felt_us_per_load"], 2666.6666667)
+        self.assertAlmostEqual(costs["felt_us_per_physical_miss"], 4666.6666667)
+
+    def test_profile_costs_without_physical_misses_is_not_calibrated(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "profile.out"
+            path.write_text(
+                "[PROF] legacy | 525.0 loads/token | "
+                "7.2s read service / 1.4s felt wait\n",
+                encoding="utf-8",
+            )
+            costs = sim.profile_costs([path])
+        self.assertIsNone(costs["physical_misses"])
+        self.assertEqual(costs["requests_per_token"], [])
+        self.assertFalse(costs["complete"])
+        self.assertIsNone(costs["felt_us_per_physical_miss"])
+
+    def test_profile_costs_require_a_complete_record_from_every_log(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            complete = Path(tmp) / "complete.out"
+            empty = Path(tmp) / "empty.out"
+            complete.write_text(
+                "[PROF] expert I/O: 1 GB fetched | "
+                "hit 50.0% (1 pin + 1 lru / 2 load) | 4.0 loads/token | "
+                "0.2s read service / 0.1s felt wait\n",
+                encoding="utf-8",
+            )
+            empty.write_text("engine stopped before PROF output\n", encoding="utf-8")
+            costs = sim.profile_costs([complete, empty])
+        self.assertFalse(costs["complete"])
+        self.assertIsNone(costs["physical_misses"])
+        self.assertIsNone(costs["felt_us_per_physical_miss"])
+
+    def test_profile_costs_distinguish_zero_misses_from_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "profile.out"
+            path.write_text(
+                "[PROF] expert I/O: 0 GB fetched | "
+                "hit 100.0% (1 pin + 1 lru / 0 load) | 2.0 loads/token | "
+                "0.0s read service / 0.0s felt wait\n",
+                encoding="utf-8",
+            )
+            costs = sim.profile_costs([path])
+        self.assertTrue(costs["complete"])
+        self.assertEqual(costs["physical_misses"], 0)
+        self.assertIsNone(costs["felt_us_per_physical_miss"])
 
 
 class PolicyBehaviorTest(unittest.TestCase):
@@ -237,6 +285,85 @@ class AllocationTest(unittest.TestCase):
         caps = sim.dynamic_capacities(trace, specs, 4, "lru", counts)
         self.assertGreater(caps[1], caps[0])
         self.assertLessEqual(sim.capacity_bytes(caps, specs), 4)
+
+    def test_dynamic_budget_evaluates_intermediate_capacity(self):
+        specs = {0: sim.LayerSpec(1, 1, 1, 4)}
+        sequence = [0, 1, 2, 0, 1, 2, 3] * 20
+        traces = [[sim.AccessEvent(0, (expert,)) for expert in sequence]]
+        counts = sim.training_counts(traces)
+        self.assertEqual(
+            sim.run_policy("lru", {0: 0}, specs, traces[0], counts).misses, 140)
+        self.assertEqual(
+            sim.run_policy("lru", {0: 2}, specs, traces[0], counts).misses, 140)
+        self.assertEqual(
+            sim.run_policy("lru", {0: 3}, specs, traces[0], counts).misses, 80)
+        caps = sim.dynamic_capacities(traces, specs, 3, "lru", counts)
+        self.assertEqual(caps, {0: 3})
+        result = sim.analyze(traces, traces, specs, 3, ["lru"], counts)
+        self.assertEqual(result["allocations"]["dynamic-lru"]["unused_bytes"], 0)
+
+    def test_frontier_matches_exhaustive_greedy_on_small_specs(self):
+        specs = {
+            0: sim.LayerSpec(2, 1, 1, 5),
+            1: sim.LayerSpec(3, 1, 4, 5),
+        }
+        traces = [[
+            *[sim.AccessEvent(0, (expert,)) for expert in [0, 1, 2, 0, 1, 3] * 4],
+            *[sim.AccessEvent(1, (expert,)) for expert in [0, 1, 0, 2, 0, 1] * 4],
+        ]]
+        counts = sim.training_counts(traces)
+
+        def exhaustive(policy, scenario_specs, budget):
+            capacities = {layer: 0 for layer in scenario_specs}
+            cache = sim.LayerReplayCache(traces, scenario_specs, counts)
+            waits = {
+                layer: cache.layer_wait(policy, layer, 0, scenario_specs)
+                for layer in scenario_specs
+            }
+            used = 0
+            while True:
+                best = None
+                for layer, spec in scenario_specs.items():
+                    current = capacities[layer]
+                    for target in range(current + 1, spec.max_experts + 1):
+                        added = (target - current) * spec.resident_bytes
+                        if used + added > budget:
+                            break
+                        wait = cache.layer_wait(policy, layer, target, scenario_specs)
+                        benefit = waits[layer] - wait
+                        candidate = (benefit / added, benefit, -added, -layer,
+                                     layer, target, wait, added)
+                        if best is None or candidate > best:
+                            best = candidate
+                if best is None or best[1] <= 0:
+                    break
+                _, _, _, _, layer, target, wait, added = best
+                capacities[layer] = target
+                waits[layer] = wait
+                used += added
+            return capacities
+
+        for policy in ("lru", "half-pinned", "frequency"):
+            for felt_scale in (0.1, 0.2, 1.0, 3.5):
+                scaled = sim.scale_specs(specs, felt_scale, target_layer=0)
+                for budget in range(1, 26):
+                    with self.subTest(
+                            policy=policy, felt_scale=felt_scale, budget=budget):
+                        self.assertEqual(
+                            sim.dynamic_capacities(
+                                traces, scaled, budget, policy, counts),
+                            exhaustive(policy, scaled, budget),
+                        )
+
+    def test_allocation_reports_unusable_budget_remainder(self):
+        specs = {0: sim.LayerSpec(2, 1, 1, 1)}
+        traces = [[sim.AccessEvent(0, (0,))]]
+        result = sim.analyze(traces, traces, specs, 3, ["lru"])
+        self.assertEqual(result["allocations"]["uniform"]["unused_bytes"], 1)
+        # A one-access training trace has no reuse benefit, so the dynamic
+        # allocator intentionally buys no residency and exposes all 3 bytes as
+        # unused rather than hiding the remainder.
+        self.assertEqual(result["allocations"]["dynamic-lru"]["unused_bytes"], 3)
 
     def test_training_traces_are_independent_cold_runs(self):
         specs = {0: sim.LayerSpec(1, 1, 1, 4)}
@@ -337,7 +464,7 @@ class DecisionGateTest(unittest.TestCase):
         self.assertLess(frequency["worst_category_gain"], -0.03)
 
     def test_synthetic_budget_sweep_exposes_robust_and_fragile_regions(self):
-        rows = sim.synthetic_budget_sweep(["lru", "frequency"], [2, 8])
+        rows = sim.synthetic_budget_sweep(["lru", "frequency"], [2, 8, 12])
         frequency = {
             row["budget_mb"]: row
             for row in rows
@@ -345,6 +472,7 @@ class DecisionGateTest(unittest.TestCase):
         }
         self.assertTrue(frequency[2]["pass_sensitivity"])
         self.assertFalse(frequency[8]["pass_sensitivity"])
+        self.assertTrue(frequency[12]["pass_sensitivity"])
 
 
 if __name__ == "__main__":

--- a/c/tools/residency_sim.py
+++ b/c/tools/residency_sim.py
@@ -535,11 +535,13 @@ class LayerReplayCache:
         self.traces = traces
         self.specs = specs
         self.learned_counts = learned_counts or {}
-        self.layer_traces = {
+        self.layer_traces = base.layer_traces if base is not None else {
             layer: [[event for event in trace if event.layer == layer] for trace in traces]
             for layer in specs
         }
         self.cache = base.cache if base is not None else {}
+        self.miss_cache = base.miss_cache if base is not None else {}
+        self.frontier_cache = base.frontier_cache if base is not None else {}
 
     def layer_stats(self, policy_name, layer, capacity, trace_index):
         key = (policy_name, layer, capacity, trace_index)
@@ -565,11 +567,40 @@ class LayerReplayCache:
         return combined
 
     def layer_wait(self, policy_name, layer, capacity, specs):
-        misses = sum(
-            self.layer_stats(policy_name, layer, capacity, trace_index).misses
-            for trace_index in range(len(self.traces))
-        )
-        return misses * specs[layer].felt_miss_us
+        return self.layer_misses(policy_name, layer, capacity) * specs[layer].felt_miss_us
+
+    def layer_misses(self, policy_name, layer, capacity):
+        key = (policy_name, layer, capacity)
+        if key not in self.miss_cache:
+            self.miss_cache[key] = sum(
+                self.layer_stats(policy_name, layer, capacity, trace_index).misses
+                for trace_index in range(len(self.traces))
+            )
+        return self.miss_cache[key]
+
+    def allocation_target(self, policy_name, layer, current, affordable, spec):
+        """Best exact target up to ``affordable``, cached by current capacity."""
+        key = (policy_name, layer, current, spec.resident_bytes,
+               spec.max_experts, spec.felt_miss_us)
+        if key not in self.frontier_cache:
+            maximum = spec.max_experts
+            frontier = [None] * (maximum + 1)
+            current_wait = (self.layer_misses(policy_name, layer, current)
+                            * spec.felt_miss_us)
+            best_key = None
+            best_target = None
+            for target in range(current + 1, maximum + 1):
+                added_bytes = (target - current) * spec.resident_bytes
+                target_wait = (self.layer_misses(policy_name, layer, target)
+                               * spec.felt_miss_us)
+                benefit = current_wait - target_wait
+                candidate = (benefit / added_bytes, benefit, -added_bytes, target)
+                if best_key is None or candidate > best_key:
+                    best_key = candidate
+                    best_target = target
+                frontier[target] = best_target
+            self.frontier_cache[key] = frontier
+        return self.frontier_cache[key][affordable]
 
 
 class ScaledReplayCache(LayerReplayCache):
@@ -643,21 +674,40 @@ def profile_costs(log_paths):
     telemetry field.
     """
     waits = []
-    loads = []
+    physical_misses = []
+    requests_per_token = []
+    complete = bool(log_paths)
+    records = 0
     for path in log_paths or ():
         text = Path(path).read_text(encoding="utf-8")
+        path_records = 0
         for line in text.splitlines():
+            if "[PROF] expert I/O:" not in line:
+                continue
+            records += 1
+            path_records += 1
             match = re.search(r"([0-9.]+)s read service / ([0-9.]+)s felt wait", line)
-            load_match = re.search(r"\| ([0-9]+(?:\.[0-9]+)?) loads/token", line)
-            if match:
-                waits.append(float(match.group(2)))
-            if load_match:
-                loads.append(float(load_match.group(1)))
+            miss_match = re.search(r"\([^)]*/\s*([0-9]+) loads?\)", line)
+            request_match = re.search(r"\| ([0-9]+(?:\.[0-9]+)?) loads/token", line)
+            if not match or not miss_match or not request_match:
+                complete = False
+                continue
+            waits.append(float(match.group(2)))
+            physical_misses.append(int(miss_match.group(1)))
+            requests_per_token.append(float(request_match.group(1)))
+        if not path_records:
+            complete = False
+    miss_count = sum(physical_misses) if complete and records else None
     return {
         "logs": [str(path) for path in log_paths or ()],
         "felt_wait_seconds": sum(waits),
-        "loads": sum(loads),
-        "felt_us_per_load": (sum(waits) * 1e6 / sum(loads) if loads else None),
+        "physical_misses": miss_count,
+        "requests_per_token": requests_per_token,
+        "records": records,
+        "complete": complete,
+        "felt_us_per_physical_miss": (
+            sum(waits) * 1e6 / miss_count
+            if complete and miss_count else None),
         "scope": "aggregate; GLM PROF does not expose layer-level felt wait",
     }
 
@@ -735,13 +785,18 @@ def sensitivity_analysis(
     minimum_gain=0.10,
     maximum_regression=0.03,
     sensitivity_layers=None,
+    learned_counts=None,
+    train_cache=None,
+    evaluation_cache=None,
+    baseline_result=None,
 ):
-    learned_counts = training_counts(train)
+    learned_counts = learned_counts or training_counts(train)
     # Admission and hit/miss behavior is unchanged by a felt-cost scale within
     # one layer. Reuse the exact replay curves across perturbations and only
     # reweight their misses when optimizing dynamic capacity.
-    train_cache = LayerReplayCache(train, specs, learned_counts)
-    evaluation_cache = LayerReplayCache(evaluation, specs, learned_counts)
+    train_cache = train_cache or LayerReplayCache(train, specs, learned_counts)
+    evaluation_cache = evaluation_cache or LayerReplayCache(
+        evaluation, specs, learned_counts)
     perturbations = [("baseline", None, 1.0)]
     perturbations.extend(
         (f"layer-{layer}-x{felt_scale:g}", layer, felt_scale)
@@ -754,11 +809,14 @@ def sensitivity_analysis(
     scenarios = []
     for name, layer, felt_scale in perturbations:
         scenario_specs = scale_specs(specs, felt_scale, layer)
-        scenario_train_cache = ScaledReplayCache(train_cache, scenario_specs)
-        scenario_evaluation_cache = ScaledReplayCache(evaluation_cache, scenario_specs)
-        result = analyze(
-            train, evaluation, scenario_specs, budget_bytes, policies,
-            learned_counts, scenario_train_cache, scenario_evaluation_cache)
+        if name == "baseline" and baseline_result is not None:
+            result = baseline_result
+        else:
+            scenario_train_cache = ScaledReplayCache(train_cache, scenario_specs)
+            scenario_evaluation_cache = ScaledReplayCache(evaluation_cache, scenario_specs)
+            result = analyze(
+                train, evaluation, scenario_specs, budget_bytes, policies,
+                learned_counts, scenario_train_cache, scenario_evaluation_cache)
         scenarios.append({
             "name": name,
             "layer": layer,
@@ -815,30 +873,21 @@ def dynamic_capacities(
         best = None
         for layer, spec in specs.items():
             current = capacities[layer]
-            # Exact replay is retained for every candidate, but scanning every
-            # slot is prohibitively expensive on a 256-expert x 75-layer model.
-            # These fixed breakpoints expose the useful capacity regions while
-            # keeping the offline sweep bounded and deterministic.
-            targets = {1, 2, 4, 8, 16, 32, 48, 64, 96, 128, 160, 192, 256}
-            targets.add(spec.max_experts)
-            for trace_index in range(len(traces)):
-                sequence = replay_cache.layer_traces[layer][trace_index]
-                unique = len({expert for event in sequence for expert in event.experts})
-                targets.add(min(spec.max_experts, unique))
-            targets = {target for target in targets
-                       if current < target <= spec.max_experts}
-            for target in sorted(targets):
-                if target <= current:
-                    continue
-                added_bytes = (target - current) * spec.resident_bytes
-                if used + added_bytes > budget_bytes:
-                    break
-                wait = replay_cache.layer_wait(policy_name, layer, target, specs)
-                benefit = layer_waits[layer] - wait
-                candidate = (benefit / added_bytes, benefit, -added_bytes,
-                             -layer, layer, target, wait, added_bytes)
-                if best is None or candidate > best:
-                    best = candidate
+            affordable = min(
+                spec.max_experts,
+                current + (budget_bytes - used) // spec.resident_bytes,
+            )
+            if affordable <= current:
+                continue
+            target = replay_cache.allocation_target(
+                policy_name, layer, current, affordable, spec)
+            added_bytes = (target - current) * spec.resident_bytes
+            wait = replay_cache.layer_wait(policy_name, layer, target, specs)
+            benefit = layer_waits[layer] - wait
+            candidate = (benefit / added_bytes, benefit, -added_bytes,
+                          -layer, layer, target, wait, added_bytes)
+            if best is None or candidate > best:
+                best = candidate
         if best is None or best[1] <= 0:
             break
         (_ratio, _benefit, _neg_bytes, _neg_layer, layer, target,
@@ -874,6 +923,8 @@ def analyze(
         "capacities": {str(k): v for k, v in sorted(uniform.items())},
         "resident_bytes": capacity_bytes(uniform, specs),
     }
+    output["allocations"]["uniform"]["unused_bytes"] = (
+        budget_bytes - output["allocations"]["uniform"]["resident_bytes"])
     output["results"]["uniform"] = evaluate(
         evaluation, uniform, specs, policies, learned_counts, evaluation_cache)
     for policy in policies:
@@ -884,6 +935,8 @@ def analyze(
             "capacities": {str(k): v for k, v in sorted(capacities.items())},
             "resident_bytes": capacity_bytes(capacities, specs),
         }
+        output["allocations"][name]["unused_bytes"] = (
+            budget_bytes - output["allocations"][name]["resident_bytes"])
         output["results"][name] = evaluate(
             evaluation, capacities, specs, [policy], learned_counts, evaluation_cache)
     return output
@@ -895,7 +948,9 @@ def print_report(result):
     for allocation, policies in result["results"].items():
         caps = result["allocations"][allocation]["capacities"]
         resident = result["allocations"][allocation]["resident_bytes"]
-        print(f"capacities[{allocation}]={caps} resident_bytes={resident}")
+        unused = result["allocations"][allocation]["unused_bytes"]
+        print(f"capacities[{allocation}]={caps} resident_bytes={resident} "
+              f"unused_bytes={unused}")
         for policy, payload in policies.items():
             stats = payload["aggregate"]
             print(f"{allocation:18} {policy:11} {stats['hit_rate']:8.2%} "
@@ -1051,7 +1106,12 @@ def command_run(args):
         if any(not trace for trace in train):
             raise ValueError("--max-training-events removed every event from a trace")
     budget = int(args.expert_budget_gb * 1e9)
-    result = analyze(train, evaluation, specs, budget, args.policies)
+    learned_counts = training_counts(train)
+    train_cache = LayerReplayCache(train, specs, learned_counts)
+    evaluation_cache = LayerReplayCache(evaluation, specs, learned_counts)
+    result = analyze(
+        train, evaluation, specs, budget, args.policies, learned_counts,
+        train_cache, evaluation_cache)
     print_report(result)
     categories = trace_categories(evaluation, args.eval_category)
     gate = decision_gate(result, categories, args.minimum_gain, args.maximum_regression)
@@ -1059,7 +1119,8 @@ def command_run(args):
     sensitivity = sensitivity_analysis(
         train, evaluation, specs, budget, args.policies, categories,
         args.felt_scales, args.minimum_gain, args.maximum_regression,
-        args.sensitivity_layers)
+        args.sensitivity_layers, learned_counts, train_cache, evaluation_cache,
+        result)
     costs = profile_costs(args.prof_log)
     print("sensitivity " + " ".join(
         f"{row['allocation']}/{row['policy']}="
@@ -1084,9 +1145,15 @@ def command_sweep(args):
             raise ValueError("--max-training-events removed every event from a trace")
     categories = trace_categories(evaluation, args.eval_category)
     costs = profile_costs(args.prof_log)
+    learned_counts = training_counts(train)
+    train_cache = LayerReplayCache(train, specs, learned_counts)
+    evaluation_cache = LayerReplayCache(evaluation, specs, learned_counts)
     results = []
     for budget_gb in args.expert_budgets:
-        result = analyze(train, evaluation, specs, int(budget_gb * 1e9), args.policies)
+        budget_bytes = int(budget_gb * 1e9)
+        result = analyze(
+            train, evaluation, specs, budget_bytes, args.policies,
+            learned_counts, train_cache, evaluation_cache)
         results.append({
             "expert_budget_gb": budget_gb,
             "result": result,
@@ -1094,9 +1161,10 @@ def command_sweep(args):
             "gate": decision_gate(
                 result, categories, args.minimum_gain, args.maximum_regression),
             "sensitivity": sensitivity_analysis(
-                train, evaluation, specs, int(budget_gb * 1e9), args.policies,
+                train, evaluation, specs, budget_bytes, args.policies,
                 categories, args.felt_scales, args.minimum_gain,
-                args.maximum_regression, args.sensitivity_layers),
+                args.maximum_regression, args.sensitivity_layers,
+                learned_counts, train_cache, evaluation_cache, result),
         })
     for entry in results:
         print(f"\n=== expert budget {entry['expert_budget_gb']:g} GB ===")

--- a/docs/experiments/cnre-offline-simulator.md
+++ b/docs/experiments/cnre-offline-simulator.md
@@ -148,17 +148,27 @@ python3 tools/residency_sim.py sweep \
   --json-out cnre-sweep.json
 ```
 
-JSON preserves model specs, every allocation, per-trace source paths and
-metrics, and each complete sweep result. This is enough to compute category
-regressions outside the simulator without parsing human output.
+JSON preserves model specs, every allocation, resident and unused budget bytes,
+per-trace source paths and metrics, and each complete sweep result. This is
+enough to compute category regressions outside the simulator without parsing
+human output. Dynamic allocation evaluates every feasible per-layer capacity.
+Exact replay curves and per-layer frontiers are cached by current capacity and
+reused across nominal and sensitivity runs, so fixed breakpoints are
+unnecessary and cannot hide a useful intermediate capacity.
 
 `--policies` must include `lru`, because every decision is measured against the
 uniform-LRU baseline. Both `run` and every point in `sweep` report nominal and
 layer-cost-sensitivity verdicts.
 
 `--prof-log` stores the aggregate `PROF=1` felt-wait calibration in the JSON.
-Current GLM logs expose aggregate, not per-layer, felt wait; this is provenance
-and a global calibration check, not a claim of layer-specific measurement.
+The denominator is the physical miss count from the `N load` field;
+`loads/token` is retained separately as `requests_per_token` and is never
+treated as a count. Every requested log must contain at least one complete
+expert-I/O record; otherwise the calibration is marked incomplete. A legacy
+log without the physical count has
+`felt_us_per_physical_miss=null`. Current GLM logs expose aggregate, not
+per-layer, felt wait; this is provenance and a global calibration check, not a
+claim of layer-specific measurement.
 
 `run` also applies the Phase-0 decision gate directly. Categories receive equal
 weight regardless of their number or length of traces. A candidate passes only
@@ -191,13 +201,14 @@ gate. This is deliberately stricter than averaging all accesses: a large
 stationary win cannot hide a shifted-category regression beyond 3%. In the
 current fixture, uniform frequency admission fails that guard (`-4.76%` in the
 shifted category). Dynamic frequency admission narrowly passes the nominal
-gate (`+4.27%` worst category) but fails the layer-by-layer felt-cost
+gate (`-1.72%` worst category) but fails the layer-by-layer felt-cost
 sensitivity check at that 8 MB budget.
 
 The final demo table sweeps synthetic expert budgets from 2 to 32 MB. It shows
 that robustness is an operating region rather than a policy-wide property. For
 example, dynamic frequency admission is robust in the deliberately constrained
-2-6 MB fixture, fragile at 8-12 MB, and robust again at larger toy budgets. These
+2-6 MB fixture, fragile at 8-10 MB, and robust again from 12 MB in this toy
+fixture. These
 transitions are artifacts of the fixture, but they demonstrate why real traces
 must be swept across realistic RAM budgets rather than evaluated at one point.
 
@@ -246,7 +257,8 @@ The collection produced eight training traces and five held-out traces across
 coding, chat, reasoning, multilingual, and long-context prompts. These are
 small pilot traces, not a production benchmark corpus.
 
-At expert-cache budgets of 120, 160, and 200 GB, the offline simulator reported:
+At expert-cache budgets of 120, 160, and 200 GB, the original offline simulator
+reported:
 
 ```text
 budget   candidate             mean held-out gain   worst category
@@ -260,7 +272,9 @@ budget   candidate             mean held-out gain   worst category
 
 All frequency candidates passed the nominal category gate and the sampled
 layer-cost sensitivity at layers 3, 30, and 60. LRU dynamic allocation did not
-meet the 10% gate, with approximately 0.0-0.4% gain.
+meet the 10% gate, with approximately 0.0-0.4% gain. The dynamic rows predate
+exhaustive capacity evaluation and must be re-derived from the original traces;
+the uniform rows do not use that allocator.
 
 The runtime pilot is the necessary qualification. With `RAM_GB=120`, `PIPE=0`
 measured 1.66 tok/s at 57.2% hit; with `RAM_GB=200`, it measured 1.31 tok/s at
@@ -268,10 +282,13 @@ measured 1.66 tok/s at 57.2% hit; with `RAM_GB=200`, it measured 1.31 tok/s at
 same 57.2% hit. This means hit rate alone is not a performance result: I/O
 overlap, disk service, and compute contention materially change tok/s.
 
-Across the five held-out `PROF=1` logs, the aggregate runtime instrumentation
-reported 19.6 seconds of felt wait over 2,625 loads, or approximately 7.47 ms
-per load. This is a whole-run calibration signal, not a per-layer cost: the
-current GLM profile does not attribute felt wait to individual layers.
+An earlier version of this document described 19.6 seconds of felt wait over
+2,625 loads, or 7.47 ms per load. The value 2,625 was a sum of `loads/token`
+rates, not a count of physical misses, so that calibration is withdrawn. The
+corrected parser uses the physical `N load` field. The ephemeral pilot logs are
+not in the repository, so no corrected aggregate is claimed here. Even after
+recalculation this remains a whole-run signal: the current GLM profile does not
+attribute felt wait to individual layers.
 
 No runtime frequency-admission policy was implemented in this pilot. The
 current GLM cache admits every demand miss in `moe()` and promotes the bounded


### PR DESCRIPTION
## Summary

Fix the two offline-simulator defects accepted in #924 and #925.

### Physical miss calibration

`profile_costs()` now reads the physical `N load` count from the runtime `[PROF] expert I/O` record. `loads/token` remains available separately as `requests_per_token`; it is no longer treated as a count.

Calibration is atomic per requested log: every file must contribute at least one complete expert-I/O record, and malformed or missing records produce an explicitly incomplete result rather than a partial calibration. Explicit zero misses remain distinguishable from a missing count.

### Exact dynamic capacity allocation

The dynamic allocator now considers every feasible per-layer capacity, so an omitted intermediate point such as capacity 3 cannot be hidden behind fixed breakpoints. Exact replay miss curves and per-layer target frontiers are cached and shared across nominal runs, sensitivity scenarios and every point in a sweep.

The optimized selector is checked against the original exhaustive greedy algorithm across multiple policies, decimal felt-cost scales and budgets. Allocations also report `unused_bytes`, making profitable or structurally unusable budget remainders visible.

### Evidence corrections

The methodology document withdraws the H200 `7.47 ms/load` calibration because its denominator was a sum of rates, not physical misses. The ephemeral logs are unavailable, so no replacement number is invented. Historical dynamic rows are marked for re-derivation; uniform rows do not depend on the dynamic allocator. Deterministic fixture claims were regenerated.

## Validation

```sh
cd c
PYTHONDONTWRITEBYTECODE=1 python3 -B -m unittest discover -s tests -p "test_*.py"
python3 -B tools/residency_sim.py demo --policies lru frequency
```

Result: 414 tests passed, 54 skipped.

Closes #924.
Closes #925.