### PR TITLE
feat(plan): discover Windows AMD GPUs without planning against them

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -565,8 +565,15 @@ def env_for(a):
         if (sys.platform == "win32" and a.gpu is None and not a.vram
                 and e.get("COLI_CUDA") != "0"):
             if cuda_binary():
-                from resource_plan import discover_gpus, build_plan, environment_for_plan, format_bytes
-                gpus = discover_gpus()
+                from resource_plan import (discover_gpus, plans_placement, build_plan,
+                                           environment_for_plan, format_bytes)
+                # Auto-enable is an automatic placement decision, so it may only
+                # be made from devices whose free memory is a qualified budget.
+                # A discovered-but-unqualified device (free_bytes None: a Windows
+                # AMD part found through hipInfo) reaches the engine env here
+                # WITHOUT passing through environment_for_plan, so the planner's
+                # own gate cannot cover this path -- filter at the source.
+                gpus = [g for g in discover_gpus() if plans_placement(g)]
                 if gpus:
                     e["COLI_CUDA"]="1"
                     e.setdefault("COLI_GPUS", ",".join(str(g["index"]) for g in gpus))

--- a/c/doctor.py
+++ b/c/doctor.py
@@ -351,7 +351,13 @@ def cuda_linkage(engine_path):
     engine = Path(engine_path)
     if not engine.is_file():
         return {"linked": False, "missing": False}
-    if os.name == "posix":
+    # `sys.platform` alone selects the branch, so a test can exercise the
+    # Windows probe on a POSIX host by faking it. Faking `os.name` instead
+    # would repoint pathlib at Windows semantics and turn the POSIX fixture
+    # path into a WindowsPath that no longer resolves, so `is_file()` above
+    # would return early. On every real host the two agree and this reads
+    # exactly as `os.name == "posix"` did.
+    if os.name == "posix" and sys.platform != "win32":
         try:
             result = subprocess.run(["ldd", str(engine)], capture_output=True, text=True,
                                     timeout=3, check=False)

--- a/c/doctor.py
+++ b/c/doctor.py
@@ -365,18 +365,30 @@ def cuda_linkage(engine_path):
         return {"linked": any("not found" not in line for line in lines),
                 "missing": any("not found" in line for line in lines)}
     if sys.platform == "win32":
-        # Windows CUDA_DLL=1 builds never link libcudart directly: glm.exe loads
-        # coli_cuda.dll at runtime via LoadLibrary (backend_loader.c), so there's no
-        # import-table entry for ldd/dumpbin to see. Detect the COLI_CUDA build via a
-        # marker string baked into glm.c's #ifdef COLI_CUDA block instead, and require
-        # coli_cuda.dll to actually sit next to glm.exe (else CUDA init fails at startup).
+        # Windows DLL-split builds never link the GPU runtime directly: the host
+        # LoadLibrary's its backend at runtime (backend_loader.c), so there's no
+        # import-table entry for ldd/dumpbin to see. Detect the GPU build via a
+        # marker string baked into the engine's #ifdef COLI_CUDA block, then
+        # require the backend artifact to sit next to the executable.
+        #
+        # WHICH artifact is not a guess. backend_loader.c compiles exactly one
+        # basename into the host -- COLI_BACKEND_DLL is "coli_hip.dll" under
+        # COLI_HIP_DLL and "coli_cuda.dll" otherwise -- so the binary states
+        # what it will load and we check for that. Asking for coli_cuda.dll
+        # unconditionally failed a working HIP host (a hard error, not a
+        # warning), and accepting either name would have passed a HIP host that
+        # only had a stray CUDA backend beside it.
         try:
-            built = b"[CUDA] mode: routed experts" in engine.read_bytes()
+            image = engine.read_bytes()
         except OSError:
             return {"linked": False, "missing": False}
-        if not built:
+        if b"[CUDA] mode: routed experts" not in image:
             return {"linked": False, "missing": False}
-        dll_present = (engine.parent / "coli_cuda.dll").is_file()
+        expected = next((name for name in ("coli_hip.dll", "coli_cuda.dll")
+                         if name.encode() in image), None)
+        if expected is None:
+            return {"linked": False, "missing": False}
+        dll_present = (engine.parent / expected).is_file()
         return {"linked": dll_present, "missing": not dll_present}
     return {"linked": False, "missing": False}
 

--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -355,11 +355,15 @@ def _parse_hipinfo(text):
     because the zeros would read as measurements.
 
     ``memInfo.free`` is deliberately NOT carried into ``free_bytes``. hipInfo
-    does report it, and on the validated gfx1151 host it reported 89.24 GB
-    "100% free" while Windows itself had 59.3 GiB of physical memory actually
-    available -- the same pages, counted twice, ~30 GB apart. Qualifying that
-    relationship is a later slice; until then the value is observed and
-    discarded, and ``free_bytes`` stays None. See plans_placement().
+    does report it, but on integrated hardware it has not been qualified as a
+    budget. On the validated gfx1151 host, four controlled rebooted sessions
+    varying the firmware shared-memory limit reported the same 76.79 GiB total
+    at the ~6, ~32 and ~64 GB settings -- about 12.8x the configured limit at
+    the minimum -- and 93.00 GiB only at the ~123 GB maximum, with
+    Windows-visible memory unchanged throughout. What that figure permits, and
+    at what cost to the host, is a later slice; until then the value is
+    observed and discarded, and ``free_bytes`` stays None. See
+    plans_placement().
     """
     blocks = []
     current = None
@@ -463,8 +467,9 @@ def plans_placement(gpu):
     discrete card's free VRAM *is* the budget. It is ``None`` for a device that
     exists and is worth reporting but whose free memory has not been qualified
     as a Colibri budget -- today, a Windows AMD part found through hipInfo,
-    where the runtime's free figure describes the same physical pages the host
-    RAM tier is already counting.
+    where the GPU and the host draw on one physical pool and the relationship
+    between the runtime's free figure and host-available memory has not been
+    measured.
 
     ``None`` is deliberately distinct from ``0``. Zero is a measurement ("the
     card is full") and keeps every behaviour it has always had. ``None`` says

--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -338,6 +338,26 @@ def _discover_amd_gpus():
     return devices
 
 
+def plans_placement(gpu):
+    """Whether a discovered device's memory is qualified to drive placement.
+
+    Discovery is a fact; a placement budget is a policy decision, and the two
+    are not the same thing. ``free_bytes`` normally carries both, because a
+    discrete card's free VRAM *is* the budget. It is ``None`` for a device that
+    exists and is worth reporting but whose free memory has not been qualified
+    as a Colibri budget -- today, a Windows AMD part found through hipInfo,
+    where the runtime's free figure describes the same physical pages the host
+    RAM tier is already counting.
+
+    ``None`` is deliberately distinct from ``0``. Zero is a measurement ("the
+    card is full") and keeps every behaviour it has always had. ``None`` says
+    "not measured in a way this planner may spend", which is a different claim
+    and must not silently collapse into the other -- hence ``is not None``
+    rather than a truthiness test.
+    """
+    return gpu.get("free_bytes") is not None
+
+
 def _physical_cores_warn(message):
     """Visibility for a mis-detected core count: a silent "1" here becomes
     OMP_NUM_THREADS=1 and pins the whole run to a single core (#325). Emit on
@@ -566,7 +586,13 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
         wanted = set(gpu_indices)
         gpus = [gpu for gpu in gpus if gpu["index"] in wanted]
 
-    unified = any(gpu.get("unified_memory", False) for gpu in gpus)
+    # Every discovered device is reported; only the ones whose free memory is a
+    # qualified budget may steer placement. Keeping the two lists apart is what
+    # stops "a GPU exists" from being read as "a GPU should be used" -- see
+    # plans_placement().
+    planning_gpus = [gpu for gpu in gpus if plans_placement(gpu)]
+
+    unified = any(gpu.get("unified_memory", False) for gpu in planning_gpus)
     typical = info["typical_expert_bytes"]
     max_expert = info["max_expert_bytes"] or typical
     layers = int(cfg.get("num_hidden_layers") or 0) + 1
@@ -582,7 +608,7 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
     gpu_plan = []
     safe_vram = 0
     for gpu in gpus:
-        usable = max(0, gpu["free_bytes"] - reserve)
+        usable = max(0, gpu["free_bytes"] - reserve) if plans_placement(gpu) else 0
         safe_vram += usable
         gpu_plan.append(dict(gpu, reserve_bytes=reserve, usable_bytes=usable))
     requested_vram = int(vram_gb * GB) if vram_gb > 0 else safe_vram
@@ -623,8 +649,14 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
         warnings.append("RAM budget cannot hold one expert slot per sparse layer")
     if gpu_indices is not None and len(gpus) != len(set(gpu_indices)):
         warnings.append("one or more requested GPUs were not detected")
-    if gpus and vram_budget < requested_vram_before_clamp:
+    if planning_gpus and vram_budget < requested_vram_before_clamp:
         warnings.append("VRAM tier was clamped by free VRAM, shared memory, or model expert size")
+    for gpu in gpus:
+        if not plans_placement(gpu):
+            warnings.append(
+                f"GPU {gpu['index']} ({gpu['name']}) was detected but its free memory is "
+                "not qualified as a placement budget on this platform; it is reported "
+                "only and drives no automatic tier")
     if unified:
         warnings.append(
             "GPU and RAM share one physical memory pool; budgets were jointly constrained")
@@ -633,9 +665,9 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
     # pessimistic hit rate that describe nothing. That is exactly when a user
     # reaches for `coli plan` -- before changing a live deployment -- so say so
     # rather than let the numbers be read as a capacity answer.
-    if gpus:
-        gpu_total = sum(g["total_bytes"] for g in gpus)
-        gpu_free = sum(g["free_bytes"] for g in gpus)
+    if planning_gpus:
+        gpu_total = sum(g["total_bytes"] for g in planning_gpus)
+        gpu_free = sum(g["free_bytes"] for g in planning_gpus)
         if gpu_total and gpu_free < 0.75 * gpu_total:
             warnings.append(
                 f"{format_bytes(gpu_total - gpu_free)} of VRAM is already in use "
@@ -652,11 +684,11 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
     if cold_bytes:
         bottleneck = "disk expert misses"
         bottleneck_class = "disk"
-    elif warm_bytes and gpus:
+    elif warm_bytes and planning_gpus:
         bottleneck = "CPU expert tail and GPU compute"
         bottleneck_class = "mixed"
     elif projected_hit >= 0.99:
-        if gpus:
+        if planning_gpus:
             bottleneck = "GPU compute and interconnect"
         else:
             bottleneck = "CPU expert compute (fully resident)"
@@ -665,7 +697,7 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
         bottleneck = "CPU expert compute and RAM bandwidth"
         bottleneck_class = "memory"
 
-    tune = _auto_tune(bottleneck_class, projected_hit, gpus, cpu_sockets,
+    tune = _auto_tune(bottleneck_class, projected_hit, planning_gpus, cpu_sockets,
                       plan_has_metal=False)
     probe_state, probe_gbs = ssd_probe_state(info["path"])
 
@@ -736,7 +768,9 @@ def environment_for_plan(plan, env=None, cuda_enabled=True):
     result.setdefault("RAM_GB", f"{ram['budget_bytes'] / GB:.3f}")
 
     vram = plan["tiers"]["vram"]
-    devices = [device["index"] for device in vram["devices"]]
+    # Report every device, but only name the placement-qualified ones to the
+    # engine: COLI_GPU/COLI_GPUS is an instruction, not an inventory.
+    devices = [device["index"] for device in vram["devices"] if plans_placement(device)]
     if not cuda_enabled or not devices or vram["budget_bytes"] <= 0:
         return result
     if result.get("COLI_CUDA", "1") == "0":
@@ -770,11 +804,16 @@ def format_plan(plan):
              f"cap {tiers['ram']['cache_slots_per_layer']}/layer"]
     vram = tiers["vram"]
     if vram["devices"]:
-        names = ", ".join(f"{gpu['index']}:{gpu['name']}" for gpu in vram["devices"])
+        names = ", ".join(
+            f"{gpu['index']}:{gpu['name']}"
+            + ("" if plans_placement(gpu) else " (identity only)")
+            for gpu in vram["devices"])
         lines.append(f"VRAM   {format_bytes(vram['budget_bytes'])} hot tier · "
                      f"~{vram['expert_capacity']} experts · {names}")
     else:
-        lines.append("VRAM   no NVIDIA device detected · CPU path")
+        # Backend-neutral, matching the accelerator wording #903 settled on:
+        # an AMD or Intel host that finds nothing is not "no NVIDIA device".
+        lines.append("VRAM   no supported GPU detected · CPU path")
     if plan.get("ssd_probe_gbs") is not None:
         lines.append(f"ssd    {plan['ssd_probe_gbs']:.1f} GB/s F_NOCACHE (cached probe, #379)")
     elif plan.get("ssd_probe_state") in SSD_PROBE_PENDING:

--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -290,12 +290,129 @@ def _discover_nvidia_gpus():
     return devices
 
 
+_HIPINFO_UNITS = {"B": 1, "KB": 1024, "MB": 1024 ** 2,
+                  "GB": 1024 ** 3, "TB": 1024 ** 4}
+
+
+def _hipinfo_executable():
+    """Locate hipInfo.exe, preferring the runtime Colibri will actually bind.
+
+    rocm-smi does not exist on Windows -- neither the HIP SDK installer nor a
+    source build ships it -- so the rocm-smi probe below finds nothing there and
+    every Windows AMD host planned CPU-only. hipInfo.exe is what both shipped
+    SDKs do provide, and it sits in the same directory as amdhip64_7.dll.
+
+    Lookup order, and why:
+
+    1. ``COLI_HIP_RUNTIME_DIR`` -- the directory the loader binds the HIP
+       runtime from (docs/windows.md). hipInfo lives beside amdhip64_7.dll
+       there, so its answer describes the runtime the engine will actually
+       load.
+    2. ``HIP_PATH``\\bin -- the SDK root the Windows HIP SDK installer sets, and
+       the same variable c/Makefile derives HIP_SDK_ROOT from.
+    3. ``PATH``.
+
+    The order is the point on a host carrying more than one HIP install: a
+    stale ambient HIP_PATH must not describe the hardware through a runtime the
+    engine is not going to bind. No install location is hardcoded.
+    """
+    if sys.platform != "win32":
+        return None
+    candidates = []
+    runtime_dir = os.environ.get("COLI_HIP_RUNTIME_DIR")
+    if runtime_dir:
+        candidates.append(Path(runtime_dir.strip('"')) / "hipInfo.exe")
+    hip_path = os.environ.get("HIP_PATH")
+    if hip_path:
+        candidates.append(Path(hip_path.strip('"')) / "bin" / "hipInfo.exe")
+    for candidate in candidates:
+        try:
+            if candidate.is_file():
+                return candidate
+        except OSError:
+            continue
+    found = shutil.which("hipInfo")
+    return Path(found) if found else None
+
+
+def _hipinfo_bytes(value):
+    """``"89.39 GB"`` -> bytes, or None. hipInfo divides by 1024 (it prints a
+    65536-byte shared block as ``64.00 KB``), so the units are binary."""
+    match = re.match(r"([0-9.]+)\s*([KMGT]?B)\b", (value or "").strip())
+    if not match:
+        return None
+    try:
+        return int(float(match.group(1)) * _HIPINFO_UNITS[match.group(2)])
+    except (ValueError, KeyError, OverflowError):
+        return None
+
+
+def _parse_hipinfo(text):
+    """Devices from hipInfo output, one block per ``device#`` line.
+
+    A block that does not carry both a name and a total is dropped rather than
+    completed with zeros: a half-trusted device is worse than no device,
+    because the zeros would read as measurements.
+
+    ``memInfo.free`` is deliberately NOT carried into ``free_bytes``. hipInfo
+    does report it, and on the validated gfx1151 host it reported 89.24 GB
+    "100% free" while Windows itself had 59.3 GiB of physical memory actually
+    available -- the same pages, counted twice, ~30 GB apart. Qualifying that
+    relationship is a later slice; until then the value is observed and
+    discarded, and ``free_bytes`` stays None. See plans_placement().
+    """
+    blocks = []
+    current = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("device#"):
+            index = stripped[len("device#"):].strip()
+            current = {"index": int(index)} if index.isdigit() else None
+            if current is not None:
+                blocks.append(current)
+            continue
+        if current is None:
+            continue
+        key, sep, value = line.partition(":")
+        if sep:
+            current[key.strip()] = value.strip()
+    devices = []
+    for block in blocks:
+        name = block.get("Name", "")
+        total = _hipinfo_bytes(block.get("memInfo.total")
+                               or block.get("totalGlobalMem"))
+        if not name or not total:
+            continue
+        devices.append({"index": block["index"], "name": name,
+                        "arch": block.get("gcnArchName", ""),
+                        "total_bytes": total,
+                        "free_bytes": None,
+                        "unified_memory": block.get("isIntegrated") == "1"})
+    return devices
+
+
+def _discover_amd_gpus_windows():
+    hipinfo = _hipinfo_executable()
+    if hipinfo is None:
+        return []
+    try:
+        result = subprocess.run([str(hipinfo)], text=True, capture_output=True,
+                                check=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return []
+    return _parse_hipinfo(result.stdout)
+
+
 def _discover_amd_gpus():
-    """ROCm/HIP discovery via rocm-smi (#662). Absent on non-AMD hosts, so this
-    returns [] there. rocm-smi --showmeminfo vram reports BYTES (unlike nvidia-smi's
-    MiB), so no unit scaling. Column names drift across ROCm versions, so match them
-    by substring rather than position. VERIFY on AMD hardware (labelled
-    hardware-owner-needed) -- authored without a ROCm host to test against."""
+    """ROCm/HIP discovery. Windows goes through hipInfo (see above); everywhere
+    else through rocm-smi (#662), which is absent on non-AMD hosts so this
+    returns [] there. rocm-smi --showmeminfo vram reports BYTES (unlike
+    nvidia-smi's MiB), so no unit scaling. Column names drift across ROCm
+    versions, so match them by substring rather than position. The rocm-smi
+    branch remains VERIFY-on-AMD-hardware (labelled hardware-owner-needed) --
+    authored without a ROCm host to test against."""
+    if sys.platform == "win32":
+        return _discover_amd_gpus_windows()
     command = ["rocm-smi", "--showmeminfo", "vram", "--showproductname", "--csv"]
     try:
         result = subprocess.run(command, text=True, capture_output=True, check=True, timeout=5)

--- a/c/tests/test_doctor.py
+++ b/c/tests/test_doctor.py
@@ -177,8 +177,12 @@ class DoctorTest(unittest.TestCase):
         return engine
 
     def _win_linkage(self, engine):
-        with mock.patch.object(sys, "platform", "win32"), \
-             mock.patch.object(os, "name", "nt"):
+        # Only sys.platform is faked. Faking os.name as well would make
+        # pathlib build a WindowsPath from the POSIX fixture path, which does
+        # not resolve on Linux/macOS, so cuda_linkage would bail at its
+        # is_file() guard before reaching the backend-marker logic and every
+        # assertion below would compare against a false negative.
+        with mock.patch.object(sys, "platform", "win32"):
             return cuda_linkage(engine)
 
     def test_windows_cuda_host_accepts_its_own_backend(self):

--- a/c/tests/test_doctor.py
+++ b/c/tests/test_doctor.py
@@ -8,7 +8,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from doctor import exit_code, format_doctor, run_doctor
+from doctor import cuda_linkage, exit_code, format_doctor, run_doctor
 from resource_plan import GB
 
 
@@ -160,6 +160,73 @@ class DoctorTest(unittest.TestCase):
 
     # #379: doctor surfaces the cached F_NOCACHE probe read-only (S4) -- it
     # never re-measures storage itself, only reflects what colibri.c already wrote.
+    # --- Windows backend-artifact linkage ---------------------------------
+    # c/backend_loader.c compiles exactly one backend basename into the host:
+    # COLI_BACKEND_DLL is "coli_hip.dll" under COLI_HIP_DLL and "coli_cuda.dll"
+    # otherwise. So the binary states which artifact it will LoadLibrary, and
+    # doctor can check for that one instead of assuming CUDA. This validates the
+    # host/artifact contract only -- it says nothing about the runtime binding
+    # or about any GPU actually computing.
+
+    def _win_engine(self, backend_dll, artifacts=()):
+        engine = self.root / "colibri.exe"
+        engine.write_bytes(b"...[CUDA] mode: routed experts..."
+                           + backend_dll.encode() + b"...")
+        for artifact in artifacts:
+            (self.root / artifact).write_bytes(b"")
+        return engine
+
+    def _win_linkage(self, engine):
+        with mock.patch.object(sys, "platform", "win32"), \
+             mock.patch.object(os, "name", "nt"):
+            return cuda_linkage(engine)
+
+    def test_windows_cuda_host_accepts_its_own_backend(self):
+        engine = self._win_engine("coli_cuda.dll", ["coli_cuda.dll"])
+        self.assertEqual(self._win_linkage(engine),
+                         {"linked": True, "missing": False})
+
+    def test_windows_hip_host_accepts_its_own_backend(self):
+        engine = self._win_engine("coli_hip.dll", ["coli_hip.dll"])
+        self.assertEqual(self._win_linkage(engine),
+                         {"linked": True, "missing": False})
+
+    def test_windows_hip_host_is_not_satisfied_by_the_cuda_backend(self):
+        engine = self._win_engine("coli_hip.dll", ["coli_cuda.dll"])
+        self.assertEqual(self._win_linkage(engine),
+                         {"linked": False, "missing": True})
+
+    def test_windows_cuda_host_is_not_satisfied_by_the_hip_backend(self):
+        engine = self._win_engine("coli_cuda.dll", ["coli_hip.dll"])
+        self.assertEqual(self._win_linkage(engine),
+                         {"linked": False, "missing": True})
+
+    def test_windows_missing_backend_artifact_still_fails(self):
+        engine = self._win_engine("coli_hip.dll")
+        self.assertEqual(self._win_linkage(engine),
+                         {"linked": False, "missing": True})
+
+    def test_windows_cpu_only_engine_is_not_a_gpu_build(self):
+        engine = self.root / "colibri.exe"
+        engine.write_bytes(b"a plain CPU build with no backend loader")
+        self.assertEqual(self._win_linkage(engine),
+                         {"linked": False, "missing": False})
+
+    def test_hip_host_with_its_backend_reports_gpu_available(self):
+        # End-to-end: the same host that previously reported a hard error
+        # ("GPU runtime library is missing") now passes, with #903's
+        # backend-neutral wording preserved.
+        engine = self._win_engine("coli_hip.dll", ["coli_hip.dll"])
+        report = self.report(gpu_indices=None, engine_path=engine,
+                             gpus=[{"index": 0, "name": "AMD Radeon(TM) 8060S Graphics",
+                                    "total_bytes": 78 * GB, "free_bytes": None,
+                                    "unified_memory": True}],
+                             linkage=self._win_linkage(engine))
+        check = self.checks_by_id(report)["accelerator.gpu"]
+        self.assertEqual(check["status"], "pass")
+        self.assertNotIn("CUDA", check["summary"])
+        self.assertNotIn("NVIDIA", check["summary"])
+
     def test_ssd_probe_check_skips_when_not_yet_cached(self):
         checks = self.checks_by_id(self.report())
         self.assertEqual(checks["storage.ssd_probe"]["status"], "skip")

--- a/c/tests/test_env_defaults.py
+++ b/c/tests/test_env_defaults.py
@@ -132,6 +132,20 @@ class CudaAutoEnableTest(unittest.TestCase):
         self.assertNotIn("COLI_GPUS", e)
         self.assertNotIn("CUDA_EXPERT_GB", e)
 
+    def test_win32_does_not_auto_enable_an_unqualified_gpu(self):
+        # A device whose free memory is not qualified as a placement budget
+        # (free_bytes is None -- a Windows AMD part found through hipInfo) is
+        # discovered and worth reporting, but auto-enable is an automatic
+        # placement decision and must not be made from it. Bare `coli chat`
+        # stays on the CPU path, exactly as if nothing had been found.
+        identity_only = {"index": 0, "name": "AMD Radeon(TM) 8060S Graphics",
+                         "arch": "gfx1151", "total_bytes": 78 * 1024 ** 3,
+                         "free_bytes": None, "unified_memory": True}
+        e = self._env_for("win32", cuda=True, gpus=[identity_only])
+        self.assertNotIn("COLI_CUDA", e)
+        self.assertNotIn("COLI_GPUS", e)
+        self.assertNotIn("CUDA_EXPERT_GB", e)
+
     def test_win32_cpu_build_stays_silent(self):
         # No coli_cuda.dll (cuda=False) -> CPU build, nothing GPU-related emitted.
         e = self._env_for("win32", cuda=False, gpus=[self._fake_gpu()])

--- a/c/tests/test_resource_plan.py
+++ b/c/tests/test_resource_plan.py
@@ -225,6 +225,111 @@ class ResourcePlanTest(unittest.TestCase):
             devices = _discover_nvidia_gpus()
         self.assertTrue(devices[0]["unified_memory"])
 
+    # --- identity-only devices -------------------------------------------
+    # A device can be discovered without its free memory being qualified as a
+    # Colibri placement budget. That is the state of a Windows AMD device found
+    # through hipInfo: the runtime may well report a free figure, but on an
+    # integrated part it describes the same physical pages the host RAM tier is
+    # already counting. Until a later slice qualifies that relationship, such a
+    # device carries free_bytes=None -- "unknown for planning", which is NOT the
+    # same claim as free_bytes=0 ("measured, and none is free").
+
+    def _identity_only_gpu(self):
+        return {"index": 0, "name": "AMD Radeon(TM) 8060S Graphics",
+                "total_bytes": 78 * GB, "free_bytes": None,
+                "unified_memory": True}
+
+    def test_identity_only_gpu_is_planned_without_a_free_memory_value(self):
+        plan = build_plan(self.model, ram_gb=16, available_memory=32 * GB,
+                          available_disk=1, gpus=[self._identity_only_gpu()],
+                          physical_cpus=8, cpu_sockets=1)
+        # It is still reported: the hardware exists and the user should see it.
+        names = [gpu["name"] for gpu in plan["tiers"]["vram"]["devices"]]
+        self.assertIn("AMD Radeon(TM) 8060S Graphics", names)
+        text = format_plan(plan)
+        self.assertIn("8060S", text)
+        # ...and the reader is told why it earns no tier, rather than being
+        # left to read "0.0 GB hot tier" as "the card is full".
+        self.assertIn("identity only", text)
+        self.assertTrue(any("not qualified as a placement budget" in warning
+                            for warning in plan["warnings"]))
+        # But it buys no tier.
+        self.assertEqual(plan["tiers"]["vram"]["budget_bytes"], 0)
+        self.assertEqual(plan["tiers"]["vram"]["expert_capacity"], 0)
+
+    def test_plan_wording_is_backend_neutral_without_a_gpu(self):
+        plan = build_plan(self.model, ram_gb=16, available_memory=32 * GB,
+                          available_disk=1, gpus=[], physical_cpus=8,
+                          cpu_sockets=1)
+        text = format_plan(plan)
+        self.assertIn("no supported GPU detected", text)
+        self.assertNotIn("NVIDIA", text)
+
+    def test_identity_only_gpu_decides_nothing_a_cpu_only_host_would_not(self):
+        gpu_plan = build_plan(self.model, ram_gb=16, available_memory=32 * GB,
+                              available_disk=1, gpus=[self._identity_only_gpu()],
+                              physical_cpus=8, cpu_sockets=1)
+        cpu_plan = build_plan(self.model, ram_gb=16, available_memory=32 * GB,
+                              available_disk=1, gpus=[], physical_cpus=8,
+                              cpu_sockets=1)
+        # Presence alone must not reclassify the bottleneck or move DRAFT.
+        self.assertEqual(gpu_plan["bottleneck_class"], cpu_plan["bottleneck_class"])
+        self.assertNotEqual(gpu_plan["bottleneck_class"], "mixed")
+        self.assertEqual(gpu_plan["tune"].get("DRAFT"), cpu_plan["tune"].get("DRAFT"))
+        # Nor may it switch on the resident pipeline.
+        self.assertNotIn("COLI_CUDA_PIPE", gpu_plan["tune"])
+        # The strongest statement of the contract: for the same inputs, the
+        # recommended environment is byte-identical to the CPU-only host's.
+        # PIN_GB=all may legitimately appear in BOTH -- that is the no-GPU
+        # residency advice (_auto_tune, `not has_gpu`), not a VRAM-derived
+        # budget -- so equality is the assertion, not absence.
+        env = environment_for_plan(gpu_plan, {"PIN": "stats.txt"})
+        cpu_env = environment_for_plan(cpu_plan, {"PIN": "stats.txt"})
+        self.assertEqual(env, cpu_env)
+        self.assertNotIn("COLI_CUDA_PIPE", env)
+        self.assertNotIn("COLI_CUDA", env)
+        self.assertNotIn("COLI_GPU", env)
+        self.assertNotIn("CUDA_EXPERT_GB", env)
+        self.assertNotEqual(env.get("PIN_GB"), f"{gpu_plan['tiers']['vram']['budget_bytes'] / GB:.3f}")
+
+    def test_identity_only_gpu_does_not_claim_vram_is_in_use(self):
+        # The "already in use" warning divides free by total. With no qualified
+        # free value there is nothing to divide, and telling the user to stop a
+        # running engine would be a fabricated diagnosis.
+        plan = build_plan(self.model, ram_gb=16, available_memory=32 * GB,
+                          available_disk=1, gpus=[self._identity_only_gpu()],
+                          physical_cpus=8, cpu_sockets=1)
+        self.assertFalse(any("already in use" in warning
+                             for warning in plan["warnings"]))
+
+    def test_measured_zero_free_memory_still_plans_as_before(self):
+        # free_bytes=0 is a MEASUREMENT, not the unqualified state, and keeps
+        # every behaviour it had: the tier is empty because the card is full,
+        # the pipeline knob is still offered, and the in-use warning still fires.
+        gpus = [{"index": 0, "name": "full-gpu", "total_bytes": 12 * GB,
+                 "free_bytes": 0}]
+        plan = build_plan(self.model, ram_gb=16, available_memory=32 * GB,
+                          available_disk=1, gpus=gpus, physical_cpus=8,
+                          cpu_sockets=1)
+        self.assertEqual(plan["tiers"]["vram"]["budget_bytes"], 0)
+        self.assertEqual(plan["tune"]["COLI_CUDA_PIPE"]["value"], "1")
+        self.assertTrue(any("already in use" in warning
+                            for warning in plan["warnings"]))
+
+    def test_mixed_fleet_plans_only_the_qualified_device(self):
+        gpus = [self._identity_only_gpu(),
+                {"index": 1, "name": "discrete", "total_bytes": 12 * GB,
+                 "free_bytes": 10 * GB}]
+        plan = build_plan(self.model, ram_gb=16, available_memory=32 * GB,
+                          available_disk=1, gpus=gpus, physical_cpus=8,
+                          cpu_sockets=1)
+        env = environment_for_plan(plan)
+        # The qualified card earns a tier; the unqualified one must not be
+        # named to the engine as a placement target.
+        self.assertGreater(plan["tiers"]["vram"]["budget_bytes"], 0)
+        self.assertEqual(env.get("COLI_GPU"), "1")
+        self.assertNotIn("COLI_GPUS", env)
+
     def test_auto_tier_thread_count_uses_physical_cores(self):
         # End-to-end for #325: build_plan + environment_for_plan must export the
         # physical (not logical SMT) core count as OMP_NUM_THREADS. The original

--- a/c/tests/test_resource_plan.py
+++ b/c/tests/test_resource_plan.py
@@ -253,9 +253,6 @@ class ResourcePlanTest(unittest.TestCase):
         self.assertIn("identity only", text)
         self.assertTrue(any("not qualified as a placement budget" in warning
                             for warning in plan["warnings"]))
-        # But it buys no tier.
-        self.assertEqual(plan["tiers"]["vram"]["budget_bytes"], 0)
-        self.assertEqual(plan["tiers"]["vram"]["expert_capacity"], 0)
 
     def test_plan_wording_is_backend_neutral_without_a_gpu(self):
         plan = build_plan(self.model, ram_gb=16, available_memory=32 * GB,
@@ -264,6 +261,9 @@ class ResourcePlanTest(unittest.TestCase):
         text = format_plan(plan)
         self.assertIn("no supported GPU detected", text)
         self.assertNotIn("NVIDIA", text)
+        # But it buys no tier.
+        self.assertEqual(plan["tiers"]["vram"]["budget_bytes"], 0)
+        self.assertEqual(plan["tiers"]["vram"]["expert_capacity"], 0)
 
     def test_identity_only_gpu_decides_nothing_a_cpu_only_host_would_not(self):
         gpu_plan = build_plan(self.model, ram_gb=16, available_memory=32 * GB,
@@ -329,6 +329,172 @@ class ResourcePlanTest(unittest.TestCase):
         self.assertGreater(plan["tiers"]["vram"]["budget_bytes"], 0)
         self.assertEqual(env.get("COLI_GPU"), "1")
         self.assertNotIn("COLI_GPUS", env)
+
+    # --- Windows AMD discovery through hipInfo ----------------------------
+    # Captured from hipInfo.exe shipped with the Windows HIP SDK (TheRock and
+    # ROCm 7.1 both emit this layout). Trimmed to the fields the parser reads
+    # plus a few it must ignore; the "89.39 GB" spellings are verbatim, and
+    # hipInfo divides by 1024 (it prints a 65536-byte shared block as 64.00 KB).
+    HIPINFO_INTEGRATED = """\
+--------------------------------------------------------------------------------
+device#                           0
+Name:                             AMD Radeon(TM) 8060S Graphics
+pciBusID:                         196
+totalGlobalMem:                   89.39 GB
+sharedMemPerBlock:                64.00 KB
+isIntegrated:                     1
+gcnArchName:                      gfx1151
+peers:
+non-peers:                        device#0
+
+memInfo.total:                    89.39 GB
+memInfo.free:                     89.24 GB (100%)
+"""
+
+    HIPINFO_DISCRETE = """\
+--------------------------------------------------------------------------------
+device#                           0
+Name:                             AMD Radeon RX 7900 XTX
+totalGlobalMem:                   24.00 GB
+isIntegrated:                     0
+gcnArchName:                      gfx1100
+
+memInfo.total:                    24.00 GB
+memInfo.free:                     23.50 GB (97%)
+"""
+
+    def _run_hipinfo(self, stdout, returncode=0):
+        """Discover with hipInfo located and returning `stdout`."""
+        from resource_plan import _discover_amd_gpus
+        completed = subprocess.CompletedProcess(args=[], returncode=returncode,
+                                                stdout=stdout, stderr="")
+        with mock.patch.object(sys, "platform", "win32"), \
+             mock.patch("resource_plan._hipinfo_executable",
+                        return_value=Path("C:/sdk/bin/hipInfo.exe")), \
+             mock.patch("resource_plan.subprocess.run", return_value=completed):
+            return _discover_amd_gpus()
+
+    def test_windows_integrated_amd_device_is_identity_only(self):
+        devices = self._run_hipinfo(self.HIPINFO_INTEGRATED)
+        self.assertEqual(len(devices), 1)
+        gpu = devices[0]
+        self.assertEqual(gpu["index"], 0)
+        self.assertEqual(gpu["name"], "AMD Radeon(TM) 8060S Graphics")
+        self.assertEqual(gpu["arch"], "gfx1151")
+        self.assertTrue(gpu["unified_memory"])
+        self.assertEqual(gpu["total_bytes"], int(89.39 * 1024 ** 3))
+        # The whole point of the slice: hipInfo DID report free memory, and it
+        # deliberately did not become a planning budget.
+        self.assertIsNone(gpu["free_bytes"])
+
+    def test_windows_positive_hipinfo_free_memory_never_becomes_a_budget(self):
+        # Belt and braces on the regression that matters most: the fixture says
+        # 89.24 GB free (100%), so any leak of that number into planning would
+        # show up as a non-zero VRAM tier here.
+        self.assertIn("memInfo.free", self.HIPINFO_INTEGRATED)
+        devices = self._run_hipinfo(self.HIPINFO_INTEGRATED)
+        plan = build_plan(self.model, ram_gb=16, available_memory=32 * GB,
+                          available_disk=1, gpus=devices, physical_cpus=8,
+                          cpu_sockets=1)
+        self.assertEqual(plan["tiers"]["vram"]["budget_bytes"], 0)
+        self.assertNotIn("COLI_CUDA_PIPE", plan["tune"])
+        self.assertNotIn("CUDA_EXPERT_GB", environment_for_plan(plan))
+
+    def test_windows_discrete_amd_device_is_not_marked_unified(self):
+        devices = self._run_hipinfo(self.HIPINFO_DISCRETE)
+        self.assertEqual(len(devices), 1)
+        self.assertFalse(devices[0]["unified_memory"])
+        self.assertEqual(devices[0]["arch"], "gfx1100")
+        # Windows AMD free memory is unqualified for every part in this slice,
+        # discrete included: we have no discrete Windows AMD host to qualify it
+        # against, and guessing is what this slice exists to avoid.
+        self.assertIsNone(devices[0]["free_bytes"])
+
+    HIPINFO_SECOND_DEVICE = """\
+--------------------------------------------------------------------------------
+device#                           1
+Name:                             AMD Radeon RX 7900 XTX
+totalGlobalMem:                   24.00 GB
+isIntegrated:                     0
+gcnArchName:                      gfx1100
+
+memInfo.total:                    24.00 GB
+memInfo.free:                     23.50 GB (97%)
+"""
+
+    def test_windows_parses_every_complete_device_block(self):
+        devices = self._run_hipinfo(self.HIPINFO_INTEGRATED
+                                    + self.HIPINFO_SECOND_DEVICE)
+        self.assertEqual([gpu["index"] for gpu in devices], [0, 1])
+        self.assertEqual([gpu["unified_memory"] for gpu in devices], [True, False])
+        self.assertEqual([gpu["free_bytes"] for gpu in devices], [None, None])
+
+    def test_windows_without_hipinfo_reports_no_device(self):
+        from resource_plan import _discover_amd_gpus
+        with mock.patch.object(sys, "platform", "win32"), \
+             mock.patch("resource_plan._hipinfo_executable", return_value=None):
+            self.assertEqual(_discover_amd_gpus(), [])
+
+    def test_windows_hipinfo_failure_invents_nothing(self):
+        from resource_plan import _discover_amd_gpus
+        with mock.patch.object(sys, "platform", "win32"), \
+             mock.patch("resource_plan._hipinfo_executable",
+                        return_value=Path("C:/sdk/bin/hipInfo.exe")), \
+             mock.patch("resource_plan.subprocess.run",
+                        side_effect=subprocess.CalledProcessError(1, "hipInfo")):
+            self.assertEqual(_discover_amd_gpus(), [])
+
+    def test_windows_incomplete_device_block_is_not_half_trusted(self):
+        # A block that names a device but reports no memory must produce no
+        # record at all rather than one with fabricated zeros.
+        partial = ("--------------------------------------------------------\n"
+                   "device#                           0\n"
+                   "Name:                             AMD Radeon(TM) 8060S Graphics\n"
+                   "isIntegrated:                     1\n")
+        self.assertEqual(self._run_hipinfo(partial), [])
+        headless = ("--------------------------------------------------------\n"
+                    "device#                           0\n"
+                    "totalGlobalMem:                   89.39 GB\n"
+                    "memInfo.total:                    89.39 GB\n")
+        self.assertEqual(self._run_hipinfo(headless), [])
+
+    def test_hipinfo_lookup_prefers_the_colibri_runtime_over_a_stale_install(self):
+        # This machine has had two Windows HIP installs at once. The engine
+        # binds the runtime COLI_HIP_RUNTIME_DIR names, and hipInfo sits beside
+        # amdhip64_7.dll in that same directory, so its answer describes the
+        # runtime that will actually be used. An ambient HIP_PATH pointing at a
+        # different SDK must not win.
+        from resource_plan import _hipinfo_executable
+        with tempfile.TemporaryDirectory() as root:
+            chosen = Path(root) / "therock" / "bin"
+            stale = Path(root) / "sdk" / "bin"
+            for directory in (chosen, stale):
+                directory.mkdir(parents=True)
+                (directory / "hipInfo.exe").write_bytes(b"")
+            env = {"COLI_HIP_RUNTIME_DIR": str(chosen),
+                   "HIP_PATH": str(stale.parent)}
+            with mock.patch.object(sys, "platform", "win32"), \
+                 mock.patch.dict(os.environ, env, clear=False):
+                self.assertEqual(_hipinfo_executable(), chosen / "hipInfo.exe")
+            # With no Colibri-specific runtime selected, the SDK root is used.
+            with mock.patch.object(sys, "platform", "win32"), \
+                 mock.patch.dict(os.environ, {"HIP_PATH": str(stale.parent)}, clear=True):
+                self.assertEqual(_hipinfo_executable(), stale / "hipInfo.exe")
+
+    def test_linux_amd_discovery_still_uses_rocm_smi(self):
+        from resource_plan import _discover_amd_gpus
+        output = ("device,Card Series,VRAM Total Memory (B),VRAM Total Used Memory (B)\n"
+                  "card0,Instinct MI300X,68719476736,8589934592\n")
+        completed = subprocess.CompletedProcess(args=[], returncode=0,
+                                                stdout=output, stderr="")
+        with mock.patch.object(sys, "platform", "linux"), \
+             mock.patch("resource_plan.subprocess.run",
+                        return_value=completed) as run:
+            devices = _discover_amd_gpus()
+        self.assertEqual(run.call_args[0][0][0], "rocm-smi")
+        self.assertEqual(devices[0]["total_bytes"], 68719476736)
+        self.assertEqual(devices[0]["free_bytes"], 68719476736 - 8589934592)
+        self.assertFalse(devices[0]["unified_memory"])
 
     def test_auto_tier_thread_count_uses_physical_cores(self):
         # End-to-end for #325: build_plan + environment_for_plan must export the

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -418,22 +418,34 @@ measurement.
 `memInfo.total` and `memInfo.free`. Colibri records the identity, marks
 `isIntegrated: 1` as unified memory, and takes the total.
 
-It deliberately does **not** use `memInfo.free` as a placement budget. On the
-validated gfx1151 host, `hipInfo` reported:
+It deliberately does **not** use `memInfo.free` as a placement budget, because
+on this hardware that figure has not been qualified as one.
 
-```
-memInfo.total:                    89.39 GB
-memInfo.free:                     89.24 GB (100%)
-```
+The Armoury Crate firmware setting on the validated host exposes a
+*shared-memory allocation* limit. Four controlled observations, each in its own
+rebooted session with everything else held constant, gave:
 
-while Windows itself had **59.3 GiB** of physical memory actually available.
-Those are the same physical pages counted twice, about 30 GB apart, on a part
-where the GPU and the host share one pool. Spending the HIP figure as a VRAM
-budget would authorise an expert tier the machine cannot back — and the RAM
-tier is being sized from that same memory at the same time.
+| Armoury shared-memory limit | `memInfo.total` | `memInfo.free` | Windows visible |
+|---|---|---|---|
+| ~6 GB (UI minimum) | 76.79 GiB | 76.63 GiB | 127.15 GiB |
+| ~32 GB | 76.79 GiB | 76.63 GiB | 127.15 GiB |
+| ~64 GB | 76.79 GiB | 76.63 GiB | 127.15 GiB |
+| ~123 GB (UI maximum) | 93.00 GiB | 92.84 GiB | 127.15 GiB |
 
-So such a device is carried as **identity only**: free memory is *unknown for
-planning*, which is not the same claim as "zero bytes are free". `coli plan`
+Three settings spanning a twentyfold range produced the same reading; only the
+maximum differed. At the ~6 GB minimum the reported total was roughly **12.8×
+the configured limit**. Windows-visible physical memory was unchanged in all
+four runs, as was the 0.50 GiB dedicated frame buffer the driver reports.
+
+So the reported figure is not a simple function of the setting, and no
+slider-to-HIP-memory mapping is assumed here. Nor is it dedicated VRAM: on an
+integrated part the GPU and the host draw on one physical pool, and how much of
+what HIP advertises can actually be spent — and at what cost to the host — has
+not been measured. Sizing an expert tier from it would be a guess.
+
+Such a device is therefore carried as **identity only**: free memory is
+*unknown for planning*, which is not the same claim as "zero bytes are free".
+`coli plan`
 shows it, marked `(identity only)`, with a warning naming it, and:
 
 - the VRAM tier stays at 0
@@ -447,8 +459,8 @@ fabricated in place of a measurement.
 None of this prevents you from running on the GPU. Every environment variable
 in this document still works exactly as documented — this governs only what
 Colibri will turn on *by itself*. Qualifying a safe automatic budget on shared
-memory needs measurement on real hardware, and that is deliberately left to a
-later change rather than guessed at here.
+memory needs allocation measurements on real hardware, and that is deliberately
+left to a later change rather than guessed at here.
 
 A discrete Windows AMD card is marked `unified_memory: false` from
 `isIntegrated: 0`, but is also carried as identity-only for now: there is no

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -383,6 +383,78 @@ not been validated on hardware here.
 **CUDA is unaffected.** A `CUDA_DLL=1` host ignores `COLI_HIP_RUNTIME_DIR`
 entirely and keeps its existing `coli_cuda.dll` search behaviour unchanged.
 
+### How `coli plan` and `coli doctor` see an AMD GPU here
+
+`rocm-smi` is a Linux tool. Neither the Windows HIP SDK installer nor a source
+build ships it, so the ROCm discovery path used everywhere else finds nothing on
+Windows and every AMD host planned as if it had no GPU at all.
+
+**Windows AMD discovery therefore goes through `hipInfo.exe`**, which both
+shipped SDKs do provide, in the same directory as `amdhip64_7.dll`. It comes
+from the HIP environment you already installed to build the backend — no extra
+Python package, no third-party dependency.
+
+Colibri looks for it in this order, and stops at the first hit:
+
+1. **`COLI_HIP_RUNTIME_DIR`** — the directory you already point at the HIP
+   runtime. `hipInfo.exe` sits beside `amdhip64_7.dll` there, so its answer
+   describes *the runtime the engine will actually bind*.
+2. **`%HIP_PATH%\bin`** — the SDK root the HIP SDK installer sets, and the same
+   variable the Makefile derives `HIP_SDK_ROOT` from.
+3. **`PATH`**.
+
+The order matters if you have more than one HIP install, which is common: a
+stale machine-wide `HIP_PATH` should not describe your hardware through a
+runtime the engine is not going to load. No install location is hardcoded.
+
+If `hipInfo.exe` cannot be found, or fails, or prints a device block missing a
+name or a memory total, discovery reports **no device**. It never invents one,
+and never completes a partial block with zeros — a zero would read as a
+measurement.
+
+#### Reported, but not planned against — and why
+
+`hipInfo` reports the device name, `gcnArchName`, `isIntegrated`, and **both**
+`memInfo.total` and `memInfo.free`. Colibri records the identity, marks
+`isIntegrated: 1` as unified memory, and takes the total.
+
+It deliberately does **not** use `memInfo.free` as a placement budget. On the
+validated gfx1151 host, `hipInfo` reported:
+
+```
+memInfo.total:                    89.39 GB
+memInfo.free:                     89.24 GB (100%)
+```
+
+while Windows itself had **59.3 GiB** of physical memory actually available.
+Those are the same physical pages counted twice, about 30 GB apart, on a part
+where the GPU and the host share one pool. Spending the HIP figure as a VRAM
+budget would authorise an expert tier the machine cannot back — and the RAM
+tier is being sized from that same memory at the same time.
+
+So such a device is carried as **identity only**: free memory is *unknown for
+planning*, which is not the same claim as "zero bytes are free". `coli plan`
+shows it, marked `(identity only)`, with a warning naming it, and:
+
+- the VRAM tier stays at 0
+- no `CUDA_EXPERT_GB`, `PIN_GB`, `COLI_GPU` or `COLI_CUDA` is recommended
+- `COLI_CUDA_PIPE` is not switched on
+- the bottleneck is classified exactly as it would be on a CPU-only host
+
+No system-RAM figure is substituted for the missing value either; nothing is
+fabricated in place of a measurement.
+
+None of this prevents you from running on the GPU. Every environment variable
+in this document still works exactly as documented — this governs only what
+Colibri will turn on *by itself*. Qualifying a safe automatic budget on shared
+memory needs measurement on real hardware, and that is deliberately left to a
+later change rather than guessed at here.
+
+A discrete Windows AMD card is marked `unified_memory: false` from
+`isIntegrated: 0`, but is also carried as identity-only for now: there is no
+discrete Windows AMD host in this validation set, and the same guess would be
+just as unqualified there.
+
 ### Putting model tensors on the GPU — and checking that it happened
 
 `COLI_CUDA=1` initialises the backend. It does **not**, on its own, put a single


### PR DESCRIPTION
## Summary

**Device discovery does not imply planning eligibility.**

- Windows AMD discovery currently depends on `rocm-smi`, which is not available through the Windows HIP environment used by this path. Windows AMD hosts were therefore planned as if no GPU had been discovered: nothing in `coli plan`, "no supported GPU detected", and `--gpu N` failing on working hardware.
- This change uses `hipInfo.exe` for Windows AMD identity reporting: device name, architecture, integrated flag and reported total memory.
- Integrated Windows AMD devices are reported with `free_bytes=None`. They remain visible to reporting while being excluded from automatic placement until a qualified free-memory budget exists.
- The Windows launcher uses the same placement-eligibility predicate, and doctor checks the backend artifact the host was built to load.

Design background: Discussion #857. This PR does not close it.

### Why

Discovery is a fact; a placement budget is a policy decision, and the planner had no way to separate them: `free_bytes` was mandatory and numeric, and every consumer read "a GPU is present" as "a GPU may be planned against". That reading stops holding when the GPU and the host draw on one physical pool.

`free_bytes` may now be `None`, meaning "not qualified as a budget on this platform". It is deliberately distinct from `0`, which is a measurement ("the card is full"); `plans_placement()` tests `is not None` rather than truthiness so the two cannot collapse. Existing devices with numeric `free_bytes` retain their current planning semantics.

### Implementation

**1. Discovery** — `_discover_amd_gpus()` gains a Windows branch. `hipInfo.exe` is located from `COLI_HIP_RUNTIME_DIR`, then `%HIP_PATH%\bin`, then `PATH`, stopping at the first hit; the Colibri-specific runtime directory leads because it names the runtime the loader will bind, and a host may carry more than one HIP install. No install location is hardcoded, and no new dependency is introduced — hipInfo comes from the HIP environment already required to build the backend. A block missing a name or a memory total yields no device rather than one completed with zeros, and missing, failing or unparsable hipInfo yields no device at all. The Linux `rocm-smi` path is untouched.

**2. Planning boundary** — only devices whose free memory is qualified reach the VRAM budget, the shared-pool `unified` flag, `_auto_tune`, the bottleneck classification, the "VRAM already in use" warning, and the `COLI_GPU`/`COLI_GPUS` device list. Everything discovered still reaches reporting, marked `(identity only)` with a warning naming it. The launcher has a separate auto-enable path that writes `COLI_CUDA`/`COLI_GPUS` before `environment_for_plan()` is consulted, so it filters through the same predicate rather than a second local rule.

**3. Doctor** — the Windows probe required `coli_cuda.dll` regardless of what the host was built to load, so a working HIP install reported "GPU runtime library is missing", which is a `fail` and makes the whole report `error`. `backend_loader.c` compiles exactly one basename into the host (`COLI_BACKEND_DLL`), so the binary states which artifact it will load and doctor now checks for that one. A CUDA host still requires `coli_cuda.dll`; a HIP host requires `coli_hip.dll`; neither is satisfied by the other.

## Validation

- [x] `make -C c check` — 508 tests, OK, 52 skipped, exit code 0
- [ ] CUDA changes were tested with `make -C c cuda-test` (if applicable) — N/A, no CUDA or C code is changed
- [x] Performance claims include hardware, commands, and repeatable measurements — N/A, no performance claim is made

On the local MSYS2 GCC 16.1 toolchain the check also emits existing compiler warnings from unchanged C test translation units; this PR changes no C or header files.

Targeted owner run:

```
python -m unittest tests.test_env_defaults tests.test_resource_plan tests.test_doctor
  -> 98 tests, OK
```

Twenty-three tests were added to three existing owners; no new test file. The contract is reviewable without AMD hardware:

- CPU-only and no-GPU behaviour unchanged
- numeric-`free_bytes` devices retain existing planning behaviour, including `free_bytes=0`
- an identity-only device produces an environment byte-identical to the CPU-only host's
- Windows hipInfo parsing: integrated, discrete, multi-device, absent, non-zero exit, incomplete block, lookup precedence
- Linux `rocm-smi` discovery preserved
- doctor accepts each host's own backend and rejects the other's
- launcher auto-enable regression, both directions

Physical validation on AMD Radeon 8060S / gfx1151, Windows. Four controlled observations, each in its own rebooted session, varying the firmware shared-memory setting:

| shared-memory setting | HIP total | Windows visible |
|---|---|---|
| ~6 GB | 76.79 GiB | 127.15 GiB |
| ~32 GB | 76.79 GiB | 127.15 GiB |
| ~64 GB | 76.79 GiB | 127.15 GiB |
| ~123 GB | 93.00 GiB | 127.15 GiB |

The static HIP values are not a qualified direct budget for the tested shared-memory setting.

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included
- Linux AMD, Windows NVIDIA and CPU-only behavior is covered by regression tests; no macOS-specific path is changed

### Not in this PR

Automatic Windows AMD shared-memory budgeting; dynamic allocation qualification; performance tuning; zero-copy claims; routed-expert placement; KV work; the Windows `memory_available()` fix; HIP-aware `cuda_binary()`.

No performance improvement or automatic Windows AMD placement is claimed. The change enables truthful discovery while deliberately withholding automatic placement until a qualified free-memory budget exists.
