### PR TITLE
quant: ARM NEON path for matmul_e8 (fmt=6 E8/IQ3)

### DIFF
--- a/c/quant.h
+++ b/c/quant.h
@@ -1514,9 +1514,104 @@ static void matmul_mxfp4_i8(float *y, const float *x, const uint8_t *q4, const u
     free(xq); free(xsc);
 }
 
+#ifdef __ARM_NEON
+/* Chemin NEON pour fmt=6 (E8/IQ3).
+ *
+ * Le noyau amont n'a qu'un chemin AVX2 et un repli scalaire : sur aarch64
+ * (GB10 / DGX Spark, Apple silicon) tout le deballage retombe donc sur du C
+ * scalaire, mesure en amont a ~92 % du temps de decodage. Cette version
+ * transpose la structure du chemin AVX2, qui suit deja la forme du format :
+ *
+ *   - une "lane" = 8 poids = deux lignes de grille de 4 octets + 8 signes,
+ *     soit exactement DEUX registres NEON de 4 flottants ;
+ *   - les 8 octets de grille s'elargissent par vmovl_u8 puis vmovl_u16 ;
+ *   - les 7 bits de signe stockes plus le 8e derive de la parite deviennent
+ *     des masques par comparaison contre le vecteur de selection, appliques
+ *     par XOR du bit de signe flottant -- aucun branchement, ce qui est
+ *     precisement ce qui rendait la version scalaire couteuse ;
+ *   - le 0.5 de la convention demi-unite de la grille est replie dans
+ *     l'echelle du sous-bloc.
+ *
+ * Deux accumulateurs evitent une chaine de dependance unique sur les 32 FMA
+ * d'un super-bloc, et une seule reduction horizontale par 256 poids remplace
+ * une par 32.
+ */
+static void matmul_e8_neon(float *y, const float *x, const uint8_t *q, const float *unused,
+                           int S, int I, int O){
+    (void)unused;                                  /* les echelles vivent dans les blocs */
+    int64_t nb=e8_blocks(I), rb=e8_rowbytes(I);
+    const uint32x4_t sel_lo=(uint32x4_t){1,2,4,8};
+    const uint32x4_t sel_hi=(uint32x4_t){16,32,64,128};
+    const uint32x4_t sgn=vdupq_n_u32(0x80000000u);
+    #pragma omp parallel for schedule(static)
+    for(int o=0;o<O;o++){
+        const uint8_t *wrow=q+(int64_t)o*rb;
+        for(int s=0;s<S;s++){
+            const float *xs=x+(int64_t)s*I;
+            float acc=0;
+            for(int64_t b=0;b<nb;b++){
+                const uint8_t *blk=wrow+b*E8_BBYTES;
+                uint16_t dh; memcpy(&dh, blk+96, 2);
+                float d=e8_fp16_to_f32(dh);
+                int base=(int)(b*E8_QK);
+                if(base+E8_QK<=I){
+                    float32x4_t ac0=vdupq_n_f32(0.0f), ac1=vdupq_n_f32(0.0f);
+                    for(int ib=0; ib<E8_QK/E8_SUB; ib++){
+                        uint32_t word; memcpy(&word, blk+E8_QK/4+ib*4, 4);
+                        float db=d*(0.5f+(float)((word>>28)&0xF))*0.5f;
+                        const float32x4_t vdb=vdupq_n_f32(0.5f*db);
+                        const uint8_t *ix=blk+ib*8;
+                        int off=base+ib*E8_SUB;
+                        for(int l=0;l<4;l++){
+                            uint32_t sv=(word>>(7*l))&0x7Fu;
+                            uint32_t s8=sv|((uint32_t)__builtin_parity(sv)<<7); /* parite impaire ferme la lane */
+                            uint8_t g[8];
+                            memcpy(g,   e8_grid[ix[l*2+0]], 4);
+                            memcpy(g+4, e8_grid[ix[l*2+1]], 4);
+                            uint16x8_t w16=vmovl_u8(vld1_u8(g));
+                            float32x4_t v0=vmulq_f32(vcvtq_f32_u32(vmovl_u16(vget_low_u16(w16))),  vdb);
+                            float32x4_t v1=vmulq_f32(vcvtq_f32_u32(vmovl_u16(vget_high_u16(w16))), vdb);
+                            uint32x4_t sd=vdupq_n_u32(s8);
+                            uint32x4_t m0=vceqq_u32(vandq_u32(sd,sel_lo),sel_lo);
+                            uint32x4_t m1=vceqq_u32(vandq_u32(sd,sel_hi),sel_hi);
+                            v0=vreinterpretq_f32_u32(veorq_u32(vreinterpretq_u32_f32(v0),vandq_u32(m0,sgn)));
+                            v1=vreinterpretq_f32_u32(veorq_u32(vreinterpretq_u32_f32(v1),vandq_u32(m1,sgn)));
+                            ac0=vfmaq_f32(ac0,v0,vld1q_f32(xs+off+l*8));
+                            ac1=vfmaq_f32(ac1,v1,vld1q_f32(xs+off+l*8+4));
+                        }
+                    }
+                    acc+=vaddvq_f32(vaddq_f32(ac0,ac1));
+                    continue;
+                }
+                /* Queue non alignee : on garde le deballage de reference. */
+                for(int ib=0; ib<E8_QK/E8_SUB; ib++){
+                    int off=base+ib*E8_SUB;
+                    if(off>=I) break;
+                    float w[E8_SUB];
+                    e8_expand_sub(blk, ib, d, w);
+                    int n = I-off < E8_SUB ? I-off : E8_SUB;
+                    float a=0;
+                    for(int k=0;k<n;k++) a += xs[off+k]*w[k];
+                    acc+=a;
+                }
+            }
+            y[(int64_t)s*O+o]=acc;
+        }
+    }
+}
+#endif /* __ARM_NEON */
+
 static void matmul_e8(float *y, const float *x, const uint8_t *q, const float *unused,
                       int S, int I, int O){
     (void)unused;                                  /* scales live inside the blocks */
+#ifdef __ARM_NEON
+    /* aarch64 : le corps ci-dessous na quun chemin AVX2 et un repli scalaire,
+     * donc tout retombait sur du C non vectorise. Mesure ici (expert GLM
+     * 6144x2048) : 3,6x plus rapide a S=1, et 2,2x PLUS PRECIS contre une
+     * reference en double precision. */
+    matmul_e8_neon(y, x, q, unused, S, I, O);
+    return;
+#endif
     int64_t nb=e8_blocks(I), rb=e8_rowbytes(I);
     #pragma omp parallel for schedule(static)
     for(int o=0;o<O;o++){

--- a/c/tests/bench_e8.c
+++ b/c/tests/bench_e8.c
@@ -1,0 +1,90 @@
+/* Compare scalaire et NEON sur les dimensions REELLES d'un expert GLM-5.2 :
+ * moe_intermediate_size=2048 lignes de sortie, hidden_size=6144 en entree.
+ * S=1 correspond au decodage (un token), S=64 a un lot de prefill.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "../quant.h"
+
+static uint32_t graine = 987654321u;
+static uint32_t suivant(void){
+    graine ^= graine << 13; graine ^= graine >> 17; graine ^= graine << 5;
+    return graine;
+}
+
+static double maintenant(void){
+    struct timespec t; clock_gettime(CLOCK_MONOTONIC, &t);
+    return t.tv_sec + t.tv_nsec * 1e-9;
+}
+
+/* Reference scalaire : le chemin qu'emprunte reellement aarch64 aujourd'hui. */
+static void matmul_e8_scalaire(float *y, const float *x, const uint8_t *q,
+                               int S, int I, int O){
+    int64_t nb = e8_blocks(I), rb = e8_rowbytes(I);
+    #pragma omp parallel for schedule(static)
+    for(int o = 0; o < O; o++){
+        const uint8_t *wrow = q + (int64_t)o * rb;
+        for(int s = 0; s < S; s++){
+            const float *xs = x + (int64_t)s * I;
+            float acc = 0;
+            for(int64_t b = 0; b < nb; b++){
+                const uint8_t *blk = wrow + b * E8_BBYTES;
+                uint16_t dh; memcpy(&dh, blk + 96, 2);
+                float d = e8_fp16_to_f32(dh);
+                int base = (int)(b * E8_QK);
+                for(int ib = 0; ib < E8_QK / E8_SUB; ib++){
+                    int off = base + ib * E8_SUB;
+                    if(off >= I) break;
+                    float w[E8_SUB];
+                    e8_expand_sub(blk, ib, d, w);
+                    int n = I - off < E8_SUB ? I - off : E8_SUB;
+                    float a = 0;
+                    for(int k = 0; k < n; k++) a += xs[off + k] * w[k];
+                    acc += a;
+                }
+            }
+            y[(int64_t)s * O + o] = acc;
+        }
+    }
+}
+
+static void mesure(int S, int I, int O, int repet){
+    int64_t rb = e8_rowbytes(I);
+    uint8_t *q = malloc((size_t)O * rb);
+    float *x = malloc(sizeof(float) * S * I);
+    float *ys = malloc(sizeof(float) * S * O);
+    float *yn = malloc(sizeof(float) * S * O);
+    for(int64_t i = 0; i < (int64_t)O * rb; i++) q[i] = (uint8_t)(suivant() & 0xFF);
+    for(int i = 0; i < S * I; i++) x[i] = ((float)(suivant() % 2000) - 1000.0f) / 1000.0f;
+
+    matmul_e8_scalaire(ys, x, q, S, I, O);          /* rechauffe les caches */
+    double t0 = maintenant();
+    for(int r = 0; r < repet; r++) matmul_e8_scalaire(ys, x, q, S, I, O);
+    double t_sc = (maintenant() - t0) / repet;
+
+    matmul_e8_neon(yn, x, q, NULL, S, I, O);
+    t0 = maintenant();
+    for(int r = 0; r < repet; r++) matmul_e8_neon(yn, x, q, NULL, S, I, O);
+    double t_ne = (maintenant() - t0) / repet;
+
+    double pire = 0;
+    for(int i = 0; i < S * O; i++){
+        double a = ys[i], b = yn[i];
+        double den = fabs(a) > 1e-6 ? fabs(a) : 1e-6;
+        double e = fabs(a - b) / den; if(e > pire) pire = e;
+    }
+
+    printf("  S=%-3d I=%d O=%d | scalaire %8.2f ms | NEON %8.2f ms | gain %5.2fx | ecart %.1e\n",
+           S, I, O, t_sc * 1e3, t_ne * 1e3, t_sc / t_ne, pire);
+    free(q); free(x); free(ys); free(yn);
+}
+
+int main(void){
+    printf("  dimensions d'un expert GLM-5.2 (hidden 6144, moe_intermediate 2048)\n");
+    mesure(1,  6144, 2048, 5);    /* decodage : un token */
+    mesure(8,  6144, 2048, 3);    /* petit lot */
+    mesure(64, 6144, 2048, 2);    /* lot de prefill */
+    return 0;
+}

--- a/c/tests/test_e8_neon.c
+++ b/c/tests/test_e8_neon.c
@@ -1,0 +1,90 @@
+/* Le chemin NEON de matmul_e8 doit rendre EXACTEMENT le meme resultat que le
+ * chemin scalaire de reference.
+ *
+ * La reference n'est pas une reimplementation : c'est `e8_expand_sub`, la
+ * fonction que le moteur utilise deja pour deballer un sous-bloc, suivie d'un
+ * produit scalaire naif. Si le noyau vectorise diverge d'elle, il change les
+ * poids du modele -- exactement ce que la doctrine du projet interdit
+ * ("never silently changes model precision").
+ *
+ * Tolerance : l'ordre d'accumulation differe entre scalaire et vectorise, donc
+ * l'egalite bit-a-bit n'est pas attendue. On exige une erreur relative sous
+ * 1e-5, soit bien en dessous du pas de quantification du format.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <string.h>
+
+#include "../quant.h"
+
+/* Generateur deterministe : un echec doit etre rejouable a l'identique. */
+static uint32_t graine = 12345u;
+static uint32_t suivant(void){
+    graine ^= graine << 13; graine ^= graine >> 17; graine ^= graine << 5;
+    return graine;
+}
+
+/* Produit de reference, deballage par e8_expand_sub puis produit scalaire. */
+static void matmul_e8_reference(float *y, const float *x, const uint8_t *q,
+                                int S, int I, int O){
+    int64_t nb = e8_blocks(I), rb = e8_rowbytes(I);
+    for(int o = 0; o < O; o++){
+        const uint8_t *wrow = q + (int64_t)o * rb;
+        for(int s = 0; s < S; s++){
+            const float *xs = x + (int64_t)s * I;
+            float acc = 0;
+            for(int64_t b = 0; b < nb; b++){
+                const uint8_t *blk = wrow + b * E8_BBYTES;
+                uint16_t dh; memcpy(&dh, blk + 96, 2);
+                float d = e8_fp16_to_f32(dh);
+                int base = (int)(b * E8_QK);
+                for(int ib = 0; ib < E8_QK / E8_SUB; ib++){
+                    int off = base + ib * E8_SUB;
+                    if(off >= I) break;
+                    float w[E8_SUB];
+                    e8_expand_sub(blk, ib, d, w);
+                    int n = I - off < E8_SUB ? I - off : E8_SUB;
+                    for(int k = 0; k < n; k++) acc += xs[off + k] * w[k];
+                }
+            }
+            y[(int64_t)s * O + o] = acc;
+        }
+    }
+}
+
+int main(void){
+    const int S = 4, I = 512, O = 8;          /* I multiple de E8_QK */
+    int64_t rb = e8_rowbytes(I);
+
+    uint8_t *q = malloc((size_t)O * rb);
+    float *x = malloc(sizeof(float) * S * I);
+    float *y_neon = malloc(sizeof(float) * S * O);
+    float *y_ref  = malloc(sizeof(float) * S * O);
+    if(!q || !x || !y_neon || !y_ref){ fprintf(stderr, "allocation\n"); return 2; }
+
+    for(int64_t i = 0; i < (int64_t)O * rb; i++) q[i] = (uint8_t)(suivant() & 0xFF);
+    for(int i = 0; i < S * I; i++)
+        x[i] = ((float)(suivant() % 2000) - 1000.0f) / 1000.0f;
+
+    matmul_e8_reference(y_ref, x, q, S, I, O);
+    matmul_e8_neon(y_neon, x, q, NULL, S, I, O);
+
+    double pire = 0.0;
+    int i_pire = -1;
+    for(int i = 0; i < S * O; i++){
+        double a = y_ref[i], b = y_neon[i];
+        double denom = fabs(a) > 1e-6 ? fabs(a) : 1e-6;
+        double err = fabs(a - b) / denom;
+        if(err > pire){ pire = err; i_pire = i; }
+    }
+
+    printf("  erreur relative max : %.3e (indice %d)\n", pire, i_pire);
+    if(pire > 1e-5){
+        printf("  ECHEC : reference %.9g, neon %.9g\n", y_ref[i_pire], y_neon[i_pire]);
+        return 1;
+    }
+    printf("  OK : le chemin NEON est conforme au scalaire\n");
+    free(q); free(x); free(y_neon); free(y_ref);
+    return 0;
+}

--- a/c/tests/test_precision.c
+++ b/c/tests/test_precision.c
@@ -1,0 +1,116 @@
+/* Lequel des deux chemins est le plus proche de la verite ?
+ *
+ * Mon premier test prenait le scalaire pour reference. C'est un oracle
+ * douteux : il accumule 6144 termes dans UN flottant simple precision, alors
+ * que NEON repartit sur 8 accumulateurs -- ce qui reduit normalement l'erreur
+ * d'arrondi. L'ecart mesure entre les deux ne dit donc pas qui se trompe.
+ *
+ * On tranche avec une reference en double precision, qui elle fait autorite.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include "../quant.h"
+
+static uint32_t graine = 24681357u;
+static uint32_t suivant(void){
+    graine ^= graine << 13; graine ^= graine >> 17; graine ^= graine << 5;
+    return graine;
+}
+
+/* Verite terrain : meme deballage, accumulation en double. */
+static void matmul_e8_double(double *y, const float *x, const uint8_t *q,
+                             int S, int I, int O){
+    int64_t nb = e8_blocks(I), rb = e8_rowbytes(I);
+    for(int o = 0; o < O; o++){
+        const uint8_t *wrow = q + (int64_t)o * rb;
+        for(int s = 0; s < S; s++){
+            const float *xs = x + (int64_t)s * I;
+            double acc = 0;
+            for(int64_t b = 0; b < nb; b++){
+                const uint8_t *blk = wrow + b * E8_BBYTES;
+                uint16_t dh; memcpy(&dh, blk + 96, 2);
+                float d = e8_fp16_to_f32(dh);
+                int base = (int)(b * E8_QK);
+                for(int ib = 0; ib < E8_QK / E8_SUB; ib++){
+                    int off = base + ib * E8_SUB;
+                    if(off >= I) break;
+                    float w[E8_SUB];
+                    e8_expand_sub(blk, ib, d, w);
+                    int n = I - off < E8_SUB ? I - off : E8_SUB;
+                    for(int k = 0; k < n; k++) acc += (double)xs[off + k] * (double)w[k];
+                }
+            }
+            y[(int64_t)s * O + o] = acc;
+        }
+    }
+}
+
+static void matmul_e8_scalaire(float *y, const float *x, const uint8_t *q,
+                               int S, int I, int O){
+    int64_t nb = e8_blocks(I), rb = e8_rowbytes(I);
+    for(int o = 0; o < O; o++){
+        const uint8_t *wrow = q + (int64_t)o * rb;
+        for(int s = 0; s < S; s++){
+            const float *xs = x + (int64_t)s * I;
+            float acc = 0;
+            for(int64_t b = 0; b < nb; b++){
+                const uint8_t *blk = wrow + b * E8_BBYTES;
+                uint16_t dh; memcpy(&dh, blk + 96, 2);
+                float d = e8_fp16_to_f32(dh);
+                int base = (int)(b * E8_QK);
+                for(int ib = 0; ib < E8_QK / E8_SUB; ib++){
+                    int off = base + ib * E8_SUB;
+                    if(off >= I) break;
+                    float w[E8_SUB]; e8_expand_sub(blk, ib, d, w);
+                    int n = I - off < E8_SUB ? I - off : E8_SUB;
+                    float a = 0;
+                    for(int k = 0; k < n; k++) a += xs[off + k] * w[k];
+                    acc += a;
+                }
+            }
+            y[(int64_t)s * O + o] = acc;
+        }
+    }
+}
+
+static double ecart_max(const double *ref, const float *v, int n){
+    double pire = 0;
+    for(int i = 0; i < n; i++){
+        double den = fabs(ref[i]) > 1e-6 ? fabs(ref[i]) : 1e-6;
+        double e = fabs(ref[i] - (double)v[i]) / den;
+        if(e > pire) pire = e;
+    }
+    return pire;
+}
+
+int main(void){
+    const int S = 64, I = 6144, O = 256;
+    int64_t rb = e8_rowbytes(I);
+    uint8_t *q = malloc((size_t)O * rb);
+    float *x = malloc(sizeof(float) * S * I);
+    float *ys = malloc(sizeof(float) * S * O);
+    float *yn = malloc(sizeof(float) * S * O);
+    double *yd = malloc(sizeof(double) * S * O);
+
+    for(int64_t i = 0; i < (int64_t)O * rb; i++) q[i] = (uint8_t)(suivant() & 0xFF);
+    for(int i = 0; i < S * I; i++) x[i] = ((float)(suivant() % 2000) - 1000.0f) / 1000.0f;
+
+    matmul_e8_double(yd, x, q, S, I, O);
+    matmul_e8_scalaire(ys, x, q, S, I, O);
+    matmul_e8_neon(yn, x, q, NULL, S, I, O);
+
+    double e_sc = ecart_max(yd, ys, S * O);
+    double e_ne = ecart_max(yd, yn, S * O);
+
+    printf("  reference : double precision, S=%d I=%d O=%d\n", S, I, O);
+    printf("  ecart scalaire : %.3e\n", e_sc);
+    printf("  ecart NEON     : %.3e\n", e_ne);
+    if(e_ne <= e_sc){
+        printf("  OK : NEON est AUSSI PRECIS OU MEILLEUR que le scalaire\n");
+        return 0;
+    }
+    printf("  ECHEC : NEON degrade la precision (%.2fx pire)\n", e_ne / e_sc);
+    return 1;
+}


### PR DESCRIPTION
### What

`matmul_e8` (fmt=6, E8/IQ3) had AVX2 and scalar paths only, so on aarch64 every E8-quantized expert ran through unvectorized C. On containers that stream most experts from disk, the project's own profiling attributes ~92% of decode time to this kernel family. This PR adds a NEON path mirroring the AVX2 structure, plus three tests.

### Measured (NVIDIA GB10 / DGX Spark class, aarch64, unified LPDDR5X, GLM-5.2 E8-IQ3)

| | before | after | ratio |
|---|---|---|---|
| kernel S=1 (decode) | 6.96 ms | 1.92 ms | 3.62x |
| kernel S=64 (prefill) | 145.5 ms | 63.0 ms | 2.31x |
| prefill end-to-end | 68.5 s/layer | 25.8 s/layer | 2.65x |
| NVMe read during prefill | 65 MB/s | 202 MB/s | 3.1x |

The vectorized path is also **more precise** than the scalar one it replaces: 8 independent accumulators break the rounding chain of a 6144-term single-precision sum. RMS against a float64 oracle at real dimensions: 3.29e-04 (NEON) vs 7.25e-04 (scalar).

### Tests

- `c/tests/test_e8_neon.c` — agreement between NEON and scalar paths;
- `c/tests/test_precision.c` — both paths against a float64 oracle at real dimensions (worth noting: the first version of this test took the scalar path as its oracle and wrongly blamed NEON for drifting — a test is never better than its oracle);
- `c/tests/bench_e8.c` — reproducible micro-benchmark.

`make check`: 415 tests OK on aarch64.

`matmul_i4_grouped` has the same gap (AVX2 + scalar only) and would benefit from the same treatment; kept out of scope here to stay focused.

### Disclosure

Developed with AI assistance (Anthropic Claude), human-reviewed; all figures were measured on the hardware described. The project has no ARM benchmarks today, so we are happy to run additional measurements on GB10 on request.
