### PR TITLE
cuda: warp-per-row E8 kernels, lattice table in shared memory

### DIFF
--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -587,6 +587,208 @@ __global__ static void grouped_down_e8(float *y,const float *x,const GroupDesc *
     if(!threadIdx.x)y[(size_t)(d.offset+s)*D+o]=p[0];
 }
 
+/* ---- Warp-per-row fmt=6 expert kernels -----------------------------------
+ * The block-per-output kernels above give a whole 256-thread block to ONE
+ * output element. With COLI_E8_SUB=32 only width/32 threads have a sub-block to
+ * decode, and the single float they produce is folded by an 8-round
+ * __syncthreads tree:
+ *
+ *   kernel                    width  sub-blocks  idle threads  bytes/block
+ *   grouped_hidden_e8_dual    6144      192          25 %         4704
+ *   grouped_down_e8           2048       64          75 %          784
+ *
+ * Measured on GB10 / GLM-5.2 decode: 8.3 GB of expert weights per token in
+ * ~425 ms = ~21 GB/s out of the machine's 273 GB/s, with nvidia-smi reporting
+ * 96 % "utilization" at 40 W -- the signature of a kernel that is always
+ * resident and always synchronizing, not one that is short of bandwidth or of
+ * blocks (grouped_down_e8 launches 49152 blocks per layer).
+ *
+ * Here one WARP owns one output row and folds with __shfl_down_sync: no barrier
+ * and no shared memory in the reduction. COLI_E8_WARPS_PER_BLOCK warps share ONE
+ * staged copy of the activation row, so the activation is read from global
+ * memory once per block instead of once per output.
+ *
+ * The shared copy is PADDED to 33 floats per sub-block. Without the pad, lane L
+ * reads sx[L*32+k]: for a fixed k every lane lands on bank (L*32+k)%32 == k%32,
+ * i.e. a 32-WAY bank conflict that would have made the staging slower than the
+ * global reads it replaces. With stride 33 the bank is (L+k)%32 -- all distinct.
+ *
+ * The tail sub-block is zero-filled instead of clamped, so the inner loop is a
+ * fixed 32 iterations: a zero activation contributes nothing to the dot product.
+ *
+ * ACCUMULATION ORDER DIFFERS from the block-tree version (warp-strided, folded
+ * pairwise across 5 shuffle rounds, instead of block-strided folded across 8
+ * shared-memory rounds). Results are therefore NOT bit-identical. This matters:
+ * an E8 dot product is 6144 fp32 terms, and reordering one can flip an argmax on
+ * a marginal token. Both orders must be checked against a DOUBLE precision
+ * reference, never against each other -- a test is never better than its oracle.
+ *
+ * COLI_E8_WARP=0 restores the block-per-output kernels for A/B without a rebuild. */
+#define COLI_E8_WARPS_PER_BLOCK 8
+#define COLI_E8_SPAD (COLI_E8_SUB+1)
+static_assert(COLI_E8_SUB==32,"the >>5 / &31 sub-block indexing below assumes COLI_E8_SUB==32");
+
+static int e8_warp_kernels(void){
+    static int v=-1;
+    if(v<0){ const char *e=std::getenv("COLI_E8_WARP"); v=e?std::atoi(e):1; }
+    return v;
+}
+
+__device__ __forceinline__ float e8_warp_fold(float v){
+    for(int off=16;off;off>>=1) v+=__shfl_down_sync(0xffffffffu,v,off);
+    return v;
+}
+/* Stage one activation row into padded shared memory; zero-fill the tail. */
+__device__ __forceinline__ void e8_stage_x(float *sx,const float *xs,int n,int nsub){
+    for(int i=threadIdx.x;i<n;i+=blockDim.x)
+        sx[(size_t)(i>>5)*COLI_E8_SPAD+(i&31)]=xs[i];
+    for(int i=n+(int)threadIdx.x;i<nsub*COLI_E8_SUB;i+=blockDim.x)
+        sx[(size_t)(i>>5)*COLI_E8_SPAD+(i&31)]=0.f;
+}
+/* Stage the E8 codebook into shared memory, PRE-SCALED by the 0.5 that
+ * e8_expand_sub_dev applies to every magnitude.
+ *
+ * __constant__ memory is built for BROADCAST -- every thread at one address,
+ * one cycle. Here each lane decodes a different sub-block, so the eight
+ * c_e8_grid[idx] lookups per sub-block are 32 DIVERGENT addresses per warp, and
+ * the constant cache serializes them. Shared memory is banked and takes
+ * divergent addresses in one or two cycles, which is the standard remedy.
+ *
+ * Storing floats rather than the packed bytes also removes an int->float
+ * conversion and a multiply PER WEIGHT, and makes the access a natural 4-byte
+ * bank read instead of a byte extract. Cost: 4 KB of shared memory per block. */
+#define COLI_E8_CB_FLOATS 1024
+__device__ __forceinline__ void e8_stage_codebook(float *cb){
+    for(int i=threadIdx.x;i<COLI_E8_CB_FLOATS;i+=blockDim.x)
+        cb[i]=(float)((const uint8_t*)c_e8_grid)[i]*0.5f;
+}
+/* e8_expand_sub_dev with the codebook in shared memory and the parity computed
+ * in one instruction instead of an 8-step serial XOR chain. The odd-parity bit
+ * that closes each group of 8 is the XOR of the 7 explicit sign bits, i.e.
+ * __popc(seven)&1 -- same value, no dependency chain. Numerically identical to
+ * e8_expand_sub_dev term by term. */
+__device__ __forceinline__ void e8_expand_sub_sm(const uint8_t *blk,int ib,float d,
+                                                 float *out,const float *cb){
+    uint32_t word=e8_ld_u32(blk+COLI_E8_QK/4+ib*4);
+    float db=d*(0.5f+(float)((word>>28)&0xF))*0.5f;
+    const uint8_t *idx=blk+ib*8;
+    for(int l=0;l<4;l++){
+        uint32_t seven=(word>>(7*l))&0x7F;
+        uint32_t signs=seven|((uint32_t)(__popc(seven)&1)<<7);
+        const float *g0=cb+(size_t)idx[l*2+0]*4,*g1=cb+(size_t)idx[l*2+1]*4;
+        for(int j=0;j<8;j++){
+            float mag=(j<4?g0[j]:g1[j-4]);
+            out[l*8+j]=((signs>>j)&1)?-mag*db:mag*db;
+        }
+    }
+}
+
+/* One sub-block's contribution to a dot product, summed locally before it joins
+ * the caller's accumulator: 32 terms then one add, instead of 32 adds onto a
+ * running total.
+ *
+ * COLI_E8_ACCS independent accumulators per lane keep the rounding chain short.
+ * Measured against the double reference at GLM-5.2's decode shape (I=6144,
+ * O=2048, tests/test_backend_cuda.cu with T6_I/T6_O/T6_VERBOSE): one accumulator
+ * per lane gave relative_rms 3.94e-07 against the block kernel's 2.72e-07 --
+ * both far inside the 2e-4 limit, but a 45 % regression bought for nothing. A
+ * warp holds 32 lanes over nsub sub-blocks, so one accumulator means a 192-term
+ * chain at D=6144; four means at most 64. This is the same argument that made
+ * the NEON path MORE accurate than the scalar one it replaced: independent
+ * accumulators break the rounding chain of a long single-precision sum. */
+#define COLI_E8_ACCS 4
+static_assert(COLI_E8_QK/COLI_E8_SUB==8,"the sb>>3 / sb&7 block indexing assumes QK/SUB==8");
+__device__ __forceinline__ void e8_dot_sub(const uint8_t *row,int sb,const float *sx,
+                                           const float *cb,float *acc){
+    const uint8_t *blk=row+(size_t)(sb>>3)*COLI_E8_BBYTES;
+    float w[COLI_E8_SUB]; e8_expand_sub_sm(blk,sb&7,e8_fp16(blk+96),w,cb);
+    const float *xv=sx+(size_t)sb*COLI_E8_SPAD;
+    float s=0; for(int k=0;k<COLI_E8_SUB;k++) s+=xv[k]*w[k];
+    *acc+=s;
+}
+
+__global__ static void grouped_hidden_e8_dual_warp(float *gate,const float *x,
+                                                   const GroupDesc *desc,int I,int D){
+    extern __shared__ float sx[];
+    int lane=threadIdx.x&31,w=threadIdx.x>>5;
+    int s=blockIdx.y,c=blockIdx.z;GroupDesc d=desc[c];
+    int nsub=(D+COLI_E8_SUB-1)/COLI_E8_SUB;
+    float *cb=sx+(size_t)nsub*COLI_E8_SPAD;
+    if(s<d.rows) e8_stage_x(sx,x+(size_t)(d.offset+s)*D,D,nsub);
+    e8_stage_codebook(cb);
+    __syncthreads();                       /* one barrier per BLOCK, not per output */
+    if(s>=d.rows) return;
+    int o=blockIdx.x*COLI_E8_WARPS_PER_BLOCK+w; if(o>=I) return;
+    size_t rb=row_bytes(6,D);
+    const uint8_t *gr=(const uint8_t*)d.g+(size_t)o*rb;
+    const uint8_t *ur=(const uint8_t*)d.u+(size_t)o*rb;
+    float g0=0,g1=0,g2=0,g3=0,u0=0,u1=0,u2=0,u3=0;
+    for(int sb=lane;sb<nsub;sb+=32*COLI_E8_ACCS){
+                            e8_dot_sub(gr,sb,   sx,cb,&g0), e8_dot_sub(ur,sb,   sx,cb,&u0);
+        if(sb+32<nsub)      e8_dot_sub(gr,sb+32,sx,cb,&g1), e8_dot_sub(ur,sb+32,sx,cb,&u1);
+        if(sb+64<nsub)      e8_dot_sub(gr,sb+64,sx,cb,&g2), e8_dot_sub(ur,sb+64,sx,cb,&u2);
+        if(sb+96<nsub)      e8_dot_sub(gr,sb+96,sx,cb,&g3), e8_dot_sub(ur,sb+96,sx,cb,&u3);
+    }
+    float ga=(g0+g1)+(g2+g3),ua=(u0+u1)+(u2+u3);
+    ga=e8_warp_fold(ga); ua=e8_warp_fold(ua);
+    if(!lane) gate[(size_t)(d.offset+s)*I+o]=(ga/(1.f+expf(-ga)))*ua;
+}
+
+__global__ static void grouped_down_e8_warp(float *y,const float *x,
+                                            const GroupDesc *desc,int D,int I){
+    extern __shared__ float sx[];
+    int lane=threadIdx.x&31,w=threadIdx.x>>5;
+    int s=blockIdx.y,c=blockIdx.z;GroupDesc d=desc[c];
+    int nsub=(I+COLI_E8_SUB-1)/COLI_E8_SUB;
+    float *cb=sx+(size_t)nsub*COLI_E8_SPAD;
+    if(s<d.rows) e8_stage_x(sx,x+(size_t)(d.offset+s)*I,I,nsub);
+    e8_stage_codebook(cb);
+    __syncthreads();
+    if(s>=d.rows) return;
+    int o=blockIdx.x*COLI_E8_WARPS_PER_BLOCK+w; if(o>=D) return;
+    size_t rb=row_bytes(6,I);
+    const uint8_t *wr=(const uint8_t*)d.d+(size_t)o*rb;
+    float a0=0,a1=0,a2=0,a3=0;
+    for(int sb=lane;sb<nsub;sb+=32*COLI_E8_ACCS){
+                       e8_dot_sub(wr,sb,   sx,cb,&a0);
+        if(sb+32<nsub) e8_dot_sub(wr,sb+32,sx,cb,&a1);
+        if(sb+64<nsub) e8_dot_sub(wr,sb+64,sx,cb,&a2);
+        if(sb+96<nsub) e8_dot_sub(wr,sb+96,sx,cb,&a3);
+    }
+    float sum=(a0+a1)+(a2+a3);
+    sum=e8_warp_fold(sum);
+    if(!lane) y[(size_t)(d.offset+s)*D+o]=sum;
+}
+/* Shared-memory bytes one warp-kernel block needs: the padded activation row
+ * plus the pre-scaled codebook. D=6144 -> (192*33 + 1024)*4 = 29440 B; I=2048 ->
+ * 12544 B. Both inside the 48 KB a block gets without an opt-in call. */
+static size_t e8_warp_smem(int width){
+    int nsub=(width+COLI_E8_SUB-1)/COLI_E8_SUB;
+    return ((size_t)nsub*COLI_E8_SPAD+COLI_E8_CB_FLOATS)*sizeof(float);
+}
+/* The fmt=6 group, on either kernel family. Both call sites (the synchronous
+ * coli_cuda_expert_group and the issue/take split) go through here so the two
+ * cannot drift -- the rotate between the two matmuls is part of the sequence,
+ * not of either kernel. */
+static int e8_group_launch(DeviceContext *ctx,GroupDesc *dev,int I,int D,
+                           int max_rows,int count,int total){
+    if(e8_warp_kernels()){
+        unsigned hb=(unsigned)((I+COLI_E8_WARPS_PER_BLOCK-1)/COLI_E8_WARPS_PER_BLOCK);
+        unsigned ob=(unsigned)((D+COLI_E8_WARPS_PER_BLOCK-1)/COLI_E8_WARPS_PER_BLOCK);
+        dim3 hg(hb,(unsigned)max_rows,(unsigned)count),og(ob,(unsigned)max_rows,(unsigned)count);
+        grouped_hidden_e8_dual_warp<<<hg,256,e8_warp_smem(D),ctx->stream>>>(ctx->gate,ctx->x,dev,I,D);
+        if(!e8_rot_rows_dev(ctx->gate,total,I,ctx->stream))return 0;
+        grouped_down_e8_warp<<<og,256,e8_warp_smem(I),ctx->stream>>>(ctx->y,ctx->gate,dev,D,I);
+        return 1;
+    }
+    dim3 hg((unsigned)I,(unsigned)max_rows,(unsigned)count),
+         og((unsigned)D,(unsigned)max_rows,(unsigned)count);
+    grouped_hidden_e8_dual<<<hg,256,0,ctx->stream>>>(ctx->gate,ctx->x,dev,I,D);
+    if(!e8_rot_rows_dev(ctx->gate,total,I,ctx->stream))return 0;
+    grouped_down_e8<<<og,256,0,ctx->stream>>>(ctx->y,ctx->gate,dev,D,I);
+    return 1;
+}
+
 __device__ static void unpack_s4(uint8_t v,float *lo,float *hi){
     int a=v&15,b=v>>4; *lo=(float)(a&8?a-16:a); *hi=(float)(b&8?b-16:b);
 }
@@ -1557,10 +1759,7 @@ extern "C" int coli_cuda_expert_group(ColiCudaTensor *const *gates,
     int tc_min=getenv("COLI_CUDA_TC_MIN_ROWS")?atoi(getenv("COLI_CUDA_TC_MIN_ROWS")):8;
     for(int c=0;c<count&&tc;c++)tc=rows[c]>=tc_min;
     if(all_e8){
-        dim3 hg((unsigned)I,(unsigned)max_rows,(unsigned)count),og((unsigned)D,(unsigned)max_rows,(unsigned)count);
-        grouped_hidden_e8_dual<<<hg,256,0,ctx->stream>>>(ctx->gate,ctx->x,dev,I,D);
-        if(!e8_rot_rows_dev(ctx->gate,total,I,ctx->stream))return 0;
-        grouped_down_e8<<<og,256,0,ctx->stream>>>(ctx->y,ctx->gate,dev,D,I);
+        if(!e8_group_launch(ctx,dev,I,D,max_rows,count,total)) return 0;
     }else if(all_f8){
         /* fp8-e4m3 groups: silu fused in the dual epilogue, like the w4/g4 duals. */
         dim3 hg((unsigned)I,(unsigned)max_rows,(unsigned)count),og((unsigned)D,(unsigned)max_rows,(unsigned)count);
@@ -1731,11 +1930,7 @@ extern "C" int coli_cuda_expert_group_issue(ColiCudaTensor *const *gates,
                 "expert group issue upload")) return 0;
     if(all_e8){
         GroupDesc *dev=(GroupDesc*)ctx->group_desc;
-        dim3 hg((unsigned)I,(unsigned)max_rows,(unsigned)count);
-        dim3 og((unsigned)D,(unsigned)max_rows,(unsigned)count);
-        grouped_hidden_e8_dual<<<hg,256,0,ctx->stream>>>(ctx->gate,ctx->x,dev,I,D);
-        if(!e8_rot_rows_dev(ctx->gate,total,I,ctx->stream))return 0;
-        grouped_down_e8<<<og,256,0,ctx->stream>>>(ctx->y,ctx->gate,dev,D,I);
+        if(!e8_group_launch(ctx,dev,I,D,max_rows,count,total)) return 0;
     }else if(all_f8){
         /* fp8-e4m3 groups on the async decode path: same kernels as the sync
          * dispatch, silu fused in the dual epilogue. */

--- a/c/tests/test_backend_cuda.cu
+++ b/c/tests/test_backend_cuda.cu
@@ -24,10 +24,20 @@ static int close_enough(const float *got, const float *want, int n) {
     return 1;
 }
 
-static int relative_rms(const float *got,const float *want,int n,float limit){
+static float relative_rms_value(const float *got,const float *want,int n){
     double err=0,ref=0; for(int i=0;i<n;i++){double d=got[i]-want[i];err+=d*d;ref+=(double)want[i]*want[i];}
-    float r=(float)std::sqrt(err/(ref+1e-20));
+    return (float)std::sqrt(err/(ref+1e-20));
+}
+/* T6_VERBOSE=1 prints the measured distance to the double reference even when it
+ * passes. A pass/fail alone cannot answer "which of two kernels is closer", and
+ * that is the only question worth asking when they disagree on an argmax. */
+static int relative_rms_named(const char *what,const float *got,const float *want,int n,float limit){
+    float r=relative_rms_value(got,want,n);
+    if(std::getenv("T6_VERBOSE")) std::fprintf(stderr,"[T6] %-22s relative_rms=%.3e (limit %.1e)\n",what,r,limit);
     if(r>limit){std::fprintf(stderr,"relative RMS %.5f exceeds %.5f\n",r,limit);return 0;} return 1;
+}
+static int relative_rms(const float *got,const float *want,int n,float limit){
+    return relative_rms_named("(unnamed)",got,want,n,limit);
 }
 
 /* ---- fmt=6 (E8/IQ3) --------------------------------------------------------
@@ -134,7 +144,17 @@ static int test_fmt6(int dev) {
         for (int j = 0; j < 4; j++) grid[i][j] = (uint8_t)((i*4 + j) % 17);
     if (!coli_cuda_e8_set_grid(grid)) { std::fprintf(stderr,"e8 grid upload failed\n"); return 0; }
 
-    const int I = 256, O = 128, S = 2;
+    /* Widths are overridable so this oracle -- double accumulation, the same
+     * t6_rot/t6_signs the device mirrors -- can be pointed at a model's REAL
+     * decode shape. It matters for the fmt=6 kernels: at I=256 a dot product is
+     * 8 sub-blocks, so every accumulation order rounds the same way and two
+     * kernels that disagree on a 6144-term sum still both pass here. GLM-5.2:
+     *   T6_I=6144 T6_O=2048 T6_S=1 ./backend_cuda_test
+     * Run it once per COLI_E8_WARP setting to compare the two kernel families
+     * against the double reference -- never against each other. */
+    const int I = std::getenv("T6_I") ? std::atoi(std::getenv("T6_I")) : 256,
+              O = std::getenv("T6_O") ? std::atoi(std::getenv("T6_O")) : 128,
+              S = std::getenv("T6_S") ? std::atoi(std::getenv("T6_S")) : 2;
     int nb = (I + T6_QK - 1) / T6_QK;
     uint8_t *q = (uint8_t*)std::malloc((size_t)O*nb*T6_BB);
     t6_fill(q, I, O);
@@ -156,7 +176,7 @@ static int test_fmt6(int dev) {
     ColiCudaTensor *t6 = nullptr;
     int ok = coli_cuda_matmul(&t6, got, x, q, nullptr, 6, S, I, O, dev, 0);
     if (!ok) { std::fprintf(stderr,"fmt=6 matmul rejected\n"); return 0; }
-    if (!relative_rms(got, want, S*O, 1e-4f)) { std::fprintf(stderr,"fmt=6 matmul mismatch\n"); return 0; }
+    if (!relative_rms_named("fmt6 matmul",got, want, S*O, 1e-4f)) { std::fprintf(stderr,"fmt=6 matmul mismatch\n"); return 0; }
 
     /* --- expert MLP: gate/up, silu, the device-side down rotation, down ---
      * The caller owns the gate/up input rotation (once per layer), so x goes in
@@ -203,14 +223,14 @@ static int test_fmt6(int dev) {
     if (!coli_cuda_expert_mlp(tg6,tu6,td6,got_e,x,S)) {
         std::fprintf(stderr,"fmt=6 expert_mlp rejected\n"); return 0;
     }
-    if (!relative_rms(got_e, want_e, S*I, 2e-4f)) {
+    if (!relative_rms_named("fmt6 expert_mlp",got_e, want_e, S*I, 2e-4f)) {
         std::fprintf(stderr,"fmt=6 expert_mlp mismatch (device-side rotation?)\n"); return 0;
     }
     ColiCudaTensor *eg6[2]={tg6,tg6},*eu6[2]={tu6,tu6},*ed6[2]={td6,td6};
     int erows[2]={1,1};
     float *group_e=(float*)std::malloc((size_t)S*I*sizeof(float));
     if (!coli_cuda_expert_group(eg6,eu6,ed6,erows,2,group_e,x) ||
-        !relative_rms(group_e,want_e,S*I,2e-4f)) {
+        !relative_rms_named("fmt6 expert_group",group_e,want_e,S*I,2e-4f)) {
         std::fprintf(stderr,"fmt=6 expert_group mismatch\n"); return 0;
     }
 


### PR DESCRIPTION
### What

`grouped_hidden_e8_dual` and `grouped_down_e8` used one thread block per output element: `width/32` useful threads out of 256 launched, an 8-stage `__syncthreads` tree to reduce a single float, and per-element lattice lookups through `__constant__` memory. `__constant__` is built for broadcast; here every lane reads a different index, so the constant cache serializes up to 32 accesses per warp. Measured effect on GB10: ~21 GB/s effective weight bandwidth out of 273 available.

This PR replaces them with warp-per-output-row kernels (`__shfl_down_sync` reduction, E8 lattice table in shared memory pre-multiplied by 0.5, activation tile with stride 33 against bank conflicts, sign parity via `__popc`, 4 independent accumulators per lane).

### Measured (GB10, GLM-5.2 E8-IQ3, decode, `nsys cuda_gpu_kern_sum` over 23 forwards)

| step | routed GPU critical path |
|---|---|
| original block kernels | 10.01 s |
| + warp/shuffle reduction | 8.40 s (-16%) |
| + lattice table in shared memory | **1.58 s (-81%)** |

The dominant cost was the serialized `__constant__` cache, not the reduction. End to end: expert matmul 435 → 69 ms/token (~120 GB/s, 44% of peak); a 60-token prompt went 25.72 s → 4.00 s (6.4x).

Precision: a single accumulator regresses RMS vs a float64 oracle by 45%; 4 accumulators restore it (2.796e-07 vs 2.719e-07 for the old block kernel) at identical throughput.

### Tests

`test_backend_cuda.cu` gains parametrable fmt=6 widths (`T6_I`/`T6_O`/`T6_S`) and `T6_VERBOSE=1` RMS output, so both kernel families can be checked against the float64 oracle at real dimensions.

`make check`: 415 tests OK. Note: `make -C c cuda-test CUDA_ARCH=native` currently exits 1 on GB10 **on a pristine dev checkout as well** — a v1.5.0-based build of the same test passes on the same machine and driver, so this looks like a dev-branch regression on sm_121 unrelated to this PR; we can file a separate issue with details.

### Disclosure

Developed with AI assistance (Anthropic Claude), human-reviewed; all figures were measured on the hardware described.
