### PR TITLE
cuda: zero-copy expert views on pageable-shared memory (GB10)

### DIFF
--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -1050,6 +1050,18 @@ extern "C" int coli_cuda_mem_info(int device, size_t *free_bytes, size_t *total_
  * GB10, Jetson, integrated GPUs). On these the expert tier and the RAM cache draw
  * from the same pool, so the RAM budget must account for the tier; on a discrete GPU
  * VRAM is a separate pool and this returns 0. */
+/* Le GPU peut-il lire de la memoire pageable (malloc ordinaire) sans aucun
+ * enregistrement ? Vrai sur Grace-Blackwell / GB10, ou CPU et GPU partagent les
+ * tables de pages. Quand c est le cas, cudaHostRegister est non seulement
+ * inutile mais NUISIBLE : il epingle les pages, les rend non evincables, et
+ * fait exploser le budget memoire d un moteur qui recycle ses tampons
+ * (mesure : OOM-kill a 85 Go de RSS). */
+extern "C" int coli_cuda_device_pageable(int device) {
+    cudaDeviceProp prop{};
+    if (cudaGetDeviceProperties(&prop, device) != cudaSuccess) return 0;
+    return prop.pageableMemoryAccess ? 1 : 0;
+}
+
 extern "C" int coli_cuda_device_integrated(int device) {
     cudaDeviceProp prop{};
     if (!cuda_ok(cudaGetDeviceProperties(&prop, device), "device properties")) return 0;
@@ -1098,6 +1110,20 @@ extern "C" int coli_cuda_tensor_upload(ColiCudaTensor **tensor,
                                         const void *weights, const float *scales,
                                         int fmt, int I, int O, int device) {
     if (!tensor) return 0;
+    /* A VIEW must never satisfy a request for a COPY. coli_cuda_tensor_wrap
+     * builds NON-OWNING views onto host slabs (integrated / pageable-shared
+     * memory such as GB10). A view matches on fmt/I/O/device/gs, so the cached
+     * copy check below would accept one and return success WITHOUT allocating
+     * anything: the caller then believes the slot holds a device copy while it
+     * holds a borrowed host pointer. Because a view declares weight_bytes=0,
+     * the expert-tier accounting silently collapses -- measured on GB10, the
+     * tier fell from 3795 experts to 128 and decode from 0.54 to 0.48 tok/s,
+     * which is why wiring the zero-copy path had to be reverted twice.
+     * Dropping a view never touches the host bytes it borrowed. */
+    if (*tensor && !(*tensor)->weights_owned) {
+        coli_cuda_tensor_free(*tensor);
+        *tensor = nullptr;
+    }
     if (*tensor) {
         /* Cached device copy: usable even when the caller's host pointers are
          * gone. CUDA_RELEASE_HOST slots null their host pointers after upload,
@@ -1985,6 +2011,126 @@ extern "C" int coli_cuda_attention_project_ragged(ColiCudaTensor *w,ColiCudaTens
     return cuda_ok(cudaGetLastError(),"ragged attention launch")&&
            cuda_ok(cudaMemcpyAsync(out,dc->y,ob,cudaMemcpyDeviceToHost,dc->stream),"ragged output download")&&
            cuda_ok(cudaStreamSynchronize(dc->stream),"ragged attention synchronize");
+}
+
+/* ---------------------------------------------------------------------------
+ * Zero-copie sur GPU a memoire unifiee (symetrie de la branche Metal).
+ *
+ * La branche Metal enveloppe deja les slabs d'experts streames dans un
+ * MTLBuffer via newBufferWithBytesNoCopy et resout tout pointeur interne en
+ * adresse GPU : sur Apple Silicon, le GPU lit le tampon de streaming EN PLACE.
+ * Rien d'equivalent n'existait cote CUDA parce que, jusqu'aux GPU integres
+ * (Jetson, GB10), "CUDA" impliquait une VRAM separee ou le zero-copie n'a
+ * aucun sens -- il faudrait de toute facon traverser le PCIe.
+ *
+ * Difference de conception avec Metal, et elle est essentielle : Metal se
+ * decide a la COMPILATION (un Mac est toujours unifie), CUDA doit se decider a
+ * l'EXECUTION, car le meme binaire sert des cartes discretes et des puces
+ * integrees. La bascule est donc prop.integrated, deja expose par
+ * coli_cuda_device_integrated(). Sur GPU discret, l'enregistrement est refuse
+ * et l'appelant garde exactement son chemin actuel.
+ * ------------------------------------------------------------------------- */
+
+struct RegisteredSlab { void *base; size_t len; void *dev; };
+static std::vector<RegisteredSlab> g_reg_slabs;
+static std::mutex g_reg_mtx;          /* appele depuis les threads expert_load paralleles */
+
+extern "C" int coli_cuda_slab_register(void *base, size_t len) {
+    if (!base || !len) return 0;
+    if (g_nctx < 1) return 0;
+    if (!coli_cuda_device_integrated(g_ctx[0].device)) return 0;
+    if (!select_ctx(&g_ctx[0])) return 0;
+
+    /* cudaHostRegisterMapped : la page reste celle de l'appelant, on ne fait
+     * qu'en publier une adresse device. Aucune copie, aucune allocation. */
+    if (!cuda_ok(cudaHostRegister(base, len, cudaHostRegisterMapped), "slab register"))
+        return 0;
+    void *dev = nullptr;
+    if (!cuda_ok(cudaHostGetDevicePointer(&dev, base, 0), "slab device pointer")) {
+        cudaHostUnregister(base);
+        return 0;
+    }
+    std::lock_guard<std::mutex> lk(g_reg_mtx);
+    for (auto &s : g_reg_slabs)
+        if (s.base == base) { s.len = len; s.dev = dev; return 1; }   /* re-enregistrement */
+    g_reg_slabs.push_back({base, len, dev});
+    return 1;
+}
+
+extern "C" void coli_cuda_slab_unregister(void *base) {
+    if (!base) return;
+    {
+        std::lock_guard<std::mutex> lk(g_reg_mtx);
+        for (size_t i = 0; i < g_reg_slabs.size(); i++)
+            if (g_reg_slabs[i].base == base) {
+                g_reg_slabs.erase(g_reg_slabs.begin() + i);
+                break;
+            }
+    }
+    /* Hors du verrou : aucun appel CUDA sous le mutex du registre, meme
+     * discipline que la branche Metal. */
+    cudaHostUnregister(base);
+}
+
+/* Resout un pointeur QUELCONQUE a l'interieur d'un slab enregistre en adresse
+ * device, offset compris. Rend nullptr si le pointeur n'appartient a aucun
+ * slab -- l'appelant retombe alors sur le chemin CPU. */
+static void *slab_resolve(const void *p) {
+    std::lock_guard<std::mutex> lk(g_reg_mtx);
+    const uint8_t *q = (const uint8_t*)p;
+    for (auto &s : g_reg_slabs) {
+        const uint8_t *b = (const uint8_t*)s.base;
+        if (q >= b && q < b + s.len)
+            return (uint8_t*)s.dev + (q - b);
+    }
+    return nullptr;
+}
+
+/* Construit une VUE : un ColiCudaTensor qui pointe sur la memoire enregistree
+ * sans la posseder. weights_owned=0 existait deja dans la structure et etait
+ * verifie a la liberation -- c'etait le point d'accroche manquant. Liberer
+ * cette vue ne doit JAMAIS toucher au tampon du moteur. */
+extern "C" int coli_cuda_tensor_wrap(ColiCudaTensor **tensor, const void *host_weights,
+                                     const float *scales, int fmt, int I, int O,
+                                     int device, int gs) {
+    if (!tensor || !host_weights || I < 1 || O < 1) return 0;
+    DeviceContext *ctx = find_ctx(device);
+    if (!ctx || !select_ctx(ctx)) return 0;
+    if (!coli_cuda_device_integrated(device)) return 0;   /* discret : rien a faire ici */
+
+    /* Chemin GB10 : le pointeur hote est deja adressable par le GPU, on le
+     * prend tel quel. Aucun enregistrement, donc aucune page epinglee.
+     * Sinon on retombe sur le registre (cudaHostRegister), utile aux GPU
+     * integres plus anciens qui exigent un mapping explicite. */
+    void *dev = coli_cuda_device_pageable(device)
+                  ? (void*)host_weights
+                  : slab_resolve(host_weights);
+    if (!dev) return 0;                                    /* ni pageable, ni enregistre */
+
+    ColiCudaTensor *t = new (std::nothrow) ColiCudaTensor();
+    if (!t) return 0;
+    t->weights = dev;
+    t->weights_owned = 0;                                  /* VUE : ne pas liberer */
+    t->scales = nullptr;
+    if (scales) {
+        void *ds = coli_cuda_device_pageable(device)
+                     ? (void*)scales
+                     : slab_resolve(scales);
+        if (!ds) { delete t; return 0; }
+        t->scales = (float*)ds;
+    }
+    t->fmt = fmt; t->I = I; t->O = O; t->device = device; t->gs = gs;
+    t->ng = (gs > 0) ? (I + gs - 1) / gs : 0;
+    t->scale_count = (gs > 0) ? (size_t)O * t->ng : (size_t)O;
+    t->weight_bytes = 0;                                   /* pas notre allocation */
+    t->tracked = 0;                                        /* hors comptabilite VRAM */
+    t->ragged_count = 0;
+    *tensor = t;
+    return 1;
+}
+
+extern "C" int coli_cuda_tensor_owns_weights(const ColiCudaTensor *t) {
+    return t ? t->weights_owned : 0;
 }
 
 extern "C" void coli_cuda_tensor_free(ColiCudaTensor *tensor) {

--- a/c/backend_cuda.h
+++ b/c/backend_cuda.h
@@ -145,6 +145,18 @@ COLI_CUDA_DLLEXPORT int coli_cuda_attention_project_ragged(ColiCudaTensor *kv_b,
         const float *const *latent,const float *const *rope,
         const int *lengths,int S,int H,int Q,int R,int V,int K,int max_t,float attention_scale);
 
+
+/* Zero-copie sur GPU integre (symetrie de coli_metal_register). Enregistre une
+ * allocation hote alignee page pour que le GPU la lise EN PLACE, et enveloppe
+ * un pointeur interne en tenseur NON PROPRIETAIRE. Refuse sur GPU discret :
+ * l appelant garde alors son chemin actuel. */
+COLI_CUDA_DLLEXPORT int  coli_cuda_device_pageable(int device);
+COLI_CUDA_DLLEXPORT int  coli_cuda_slab_register(void *base, size_t len);
+COLI_CUDA_DLLEXPORT void coli_cuda_slab_unregister(void *base);
+COLI_CUDA_DLLEXPORT int  coli_cuda_tensor_wrap(ColiCudaTensor **tensor, const void *host_weights,
+                                               const float *scales, int fmt, int I, int O,
+                                               int device, int gs);
+COLI_CUDA_DLLEXPORT int  coli_cuda_tensor_owns_weights(const ColiCudaTensor *tensor);
 COLI_CUDA_DLLEXPORT void coli_cuda_tensor_free(ColiCudaTensor *tensor);
 COLI_CUDA_DLLEXPORT size_t coli_cuda_tensor_bytes(const ColiCudaTensor *tensor);
 COLI_CUDA_DLLEXPORT int coli_cuda_tensor_device(const ColiCudaTensor *tensor);

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -2492,6 +2492,44 @@ static int expert_load_impl(Model *m, int layer, int eid, ESlot *s, int fatal, i
         int fmt=qt_resolve_fmt(tw[k]->name,OO[k],II[k],nb,tq[k]->nbytes,&gs,NULL);   /* routed expert: never stamped */
         qt[k]->fmt=fmt; qt[k]->O=OO[k]; qt[k]->I=II[k]; qt[k]->gs=gs; qt[k]->qf=NULL;
         qt[k]->q8=(int8_t*)(s->slab+pos[k]); qt[k]->q4=s->slab+pos[k]; qt[k]->s=fp[k];
+#ifdef COLI_CUDA
+        /* Expert STREAME : sur un GPU a memoire pageable partagee (GB10), le
+         * tampon hote est DEJA adressable par le GPU -- pas de copie, pas
+         * d enregistrement, pas de page epinglee. On construit donc une vue et
+         * on rend l expert eligible au calcul GPU.
+         *
+         * Le garde `demand` a ete RETIRE : il excluait les chargements PREDITS
+         * par le pilote (PILOT_REAL, demand=0), qui arrivaient donc en RAM sans
+         * vue ET sans copie device -- donc non cuda_eligible, donc calcules sur
+         * CPU. Mesure GB10 : activer PILOT faisait passer la presence de 82,5 a
+         * 88,1 % et l attente disque de 34 a 24 %, mais ressuscitait 914 lignes
+         * d experts sur le CPU (4,4 s) qui mangeaient tout le gain.
+         *
+         * Ce garde etait un contournement du VRAI defaut, desormais corrige a
+         * la source : coli_cuda_tensor_upload acceptait une vue comme reponse a
+         * une demande de copie, ce qui effondrait la comptabilite du palier
+         * (3795 experts -> 128). Une vue ne peut plus satisfaire une copie, donc
+         * le chemin de placement (pin_load, REPIN) obtient toujours sa vraie
+         * copie et remplace la vue de lui-meme.
+         *
+         * Toujours jamais sur un slot adosse a l arene de pin (s->aslab) : ceux-la
+         * sont traites par la passe dediee a la fin de pin_load, apres placement.
+         *
+         * COLI_ZEROCOPY_PREFETCH=0 restaure l ancien comportement (demand=1
+         * seulement) pour un A/B sans recompilation.
+         *
+         * Sur GPU discret coli_cuda_tensor_wrap refuse : l expert reste sur le
+         * chemin CPU, exactement comme avant. */
+        static int zc_prefetch=-1;
+        if(zc_prefetch<0) zc_prefetch=getenv("COLI_ZEROCOPY_PREFETCH")?atoi(getenv("COLI_ZEROCOPY_PREFETCH")):1;
+        if((demand||zc_prefetch) && !s->aslab){
+            qt_cuda_reset(qt[k]);
+            qt[k]->cuda_eligible=0;
+            if(coli_cuda_tensor_wrap(&qt[k]->cuda, s->slab+pos[k], fp[k],
+                                     qt[k]->fmt, qt[k]->I, qt[k]->O, 0, qt[k]->gs))
+                qt[k]->cuda_eligible=1;
+        }
+#endif
     }
     s->eid=eid; return 0;
 }
@@ -2691,6 +2729,31 @@ static int uring_finalize_load(UringBatch *b,int li,int publish_eid){
         int fmt=qt_resolve_fmt(l->tw[k]->name,OO[k],II[k],nb,l->tq[k]->nbytes,&gs,NULL);   /* routed expert: never stamped */
         qt[k]->fmt=fmt; qt[k]->O=OO[k]; qt[k]->I=II[k]; qt[k]->gs=gs; qt[k]->qf=NULL;
         qt[k]->q8=(int8_t*)(s->slab+l->pos[k]); qt[k]->q4=s->slab+l->pos[k]; qt[k]->s=fp[k];
+#ifdef COLI_CUDA
+        /* TROISIEME chemin de chargement, et le seul qui n avait pas la vue
+         * zero-copie. Sur memoire pageable partagee (GB10) le GPU lit deja ces
+         * octets la ou ils sont : sans la vue l expert n est pas cuda_eligible
+         * et retombe sur le CPU.
+         *
+         * Mesure GB10, URING=1 : 13240 lignes d experts sur CPU (41,9 s) et
+         * p50 1106 ms contre 547 ms, alors que la presence restait a 90,8 %.
+         * Le reglage semblait donc nuisible ; il etait simplement non cable.
+         *
+         * Le commentaire ci-dessus -- "qt_resolve_fmt like the other two expert
+         * paths" -- dit que les trois chemins etaient gardes synchronises sur le
+         * FORMAT ; le cablage GPU, lui, n en couvrait qu un.
+         *
+         * Meme garde que dans expert_load_impl : jamais sur un slot adosse a l
+         * arene de pin, ceux-la sont traites apres placement a la fin de
+         * pin_load. Sur GPU discret coli_cuda_tensor_wrap refuse. */
+        if(!s->aslab){
+            qt_cuda_reset(qt[k]);
+            qt[k]->cuda_eligible=0;
+            if(coli_cuda_tensor_wrap(&qt[k]->cuda, s->slab+l->pos[k], fp[k],
+                                     qt[k]->fmt, qt[k]->I, qt[k]->O, 0, qt[k]->gs))
+                qt[k]->cuda_eligible=1;
+        }
+#endif
     }
     if(publish_eid) s->eid=l->eid;
     l->finalized=1; return 0;
@@ -8414,6 +8477,21 @@ static void pin_load(Model *m, const char *statspath, double gb, int trusted){
 #endif
 #ifdef COLI_CUDA
     if(g_cuda_enabled && budget>0){
+        /* Les experts epingles que le placement a laisses SANS copie device
+         * calculaient jusqu ici sur CPU. Sur memoire pageable partagee (GB10)
+         * le GPU lit deja ces octets la ou ils sont : une VUE suffit, et elle
+         * ne coute rien.
+         *
+         * On le fait ICI, apres que le placement a tranche, et non pendant le
+         * chargement : sinon qt_cuda_upload verrait un tenseur "deja en place"
+         * et court-circuiterait sa copie, puis expert_host_release libererait
+         * la memoire sous la vue (mesure : logits non finis des la couche 4).
+         *
+         * L arene de pin est STABLE -- jamais recyclee, jamais liberee tant que
+         * l expert reste epingle -- contrairement aux emplacements de streaming.
+         * Et on ne touche QUE les experts : les tenseurs denses et les
+         * projections d attention gardent leur chemin, leurs tampons hotes
+         * pouvant etre reutilises ailleurs. */
         fprintf(stderr,"[CUDA] hot expert tier: %d/%d experts, VRAM %.2f GB (budget %.1f GB%s, reserve %.1f GB)\n",
             m->gpu_expert_count,npin,m->gpu_expert_bytes/1e9,
             g_cuda_expert_auto?safe_total/1e9:budget/1e9,
@@ -8452,6 +8530,48 @@ static void pin_load(Model *m, const char *statspath, double gb, int trusted){
     if(warm_b<0.0) warm_b=0.0;
     fprintf(stderr,"[PIN] placement: %d VRAM + %d RAM expert (%.1f GB warm) in %.0fs da %s\n",
         m->gpu_expert_count,npin-m->gpu_expert_count,warm_b/1e9,now_s()-t0,statspath);
+#ifdef COLI_CUDA
+    /* Experts epingles laisses SANS copie device : sur memoire pageable
+     * partagee (GB10) le GPU lit deja ces octets la ou ils sont, une VUE
+     * suffit et ne coute rien.
+     *
+     * ICI et pas plus haut : les epingles du palier RAM ne sont charges que
+     * par la boucle juste au-dessus. Place avant elle, la passe ne voyait que
+     * des slots vides (mesure : 8 vues sur 3807 candidats).
+     *
+     * Apres le placement et non pendant le chargement : sinon qt_cuda_upload
+     * verrait un tenseur "deja en place", court-circuiterait sa copie, et
+     * expert_host_release libererait la memoire sous la vue (mesure : logits
+     * non finis des la couche 4).
+     *
+     * Uniquement les EXPERTS : les tenseurs denses et les projections
+     * d attention gardent leur chemin, leurs tampons hotes pouvant etre
+     * reutilises ailleurs. */
+    if(g_cuda_enabled && g_cuda_ndev>0 && m->pin && m->npin &&
+       coli_cuda_device_pageable(g_cuda_devices[0])){
+        int vues=0;
+        for(int L=0; L<=m->c.n_layers; L++){
+            for(int j2=0; j2<m->npin[L]; j2++){
+                ESlot *ps=&m->pin[L][j2];
+                if(ps->eid<0 || !ps->slab) continue;
+                if(ps->g.cuda && ps->u.cuda && ps->d.cuda) continue;   /* vraie copie */
+                QT *q3[3]={&ps->g,&ps->u,&ps->d};
+                int tous=1;
+                for(int k=0;k<3;k++)
+                    if(!q3[k]->cuda &&
+                       !coli_cuda_tensor_wrap(&q3[k]->cuda,q3[k]->q4,q3[k]->s,
+                                              q3[k]->fmt,q3[k]->I,q3[k]->O,0,q3[k]->gs))
+                        tous=0;
+                if(tous && ps->g.cuda && ps->u.cuda && ps->d.cuda){
+                    ps->g.cuda_eligible=ps->u.cuda_eligible=ps->d.cuda_eligible=1;
+                    vues++;
+                }
+            }
+        }
+        if(vues) fprintf(stderr,"[CUDA] %d experts epingles rendus calculables par VUE "
+                                "(zero copie, memoire pageable partagee)\n",vues);
+    }
+#endif
     pin_wire(m);                                   /* inchioda in RAM (no compressione) / wire in RAM (no compression) */
     free(r); free(cnt_l); free(slot_of); free(next);
 }

--- a/c/tests/test_zerocopy.c
+++ b/c/tests/test_zerocopy.c
@@ -1,0 +1,89 @@
+/* Zero-copie CUDA sur memoire unifiee : le GPU doit pouvoir calculer un expert
+ * DEPUIS le tampon hote ou le streaming vient de l ecrire, sans recopie.
+ *
+ * C est la symetrie de ce que fait deja la branche Metal
+ * (newBufferWithBytesNoCopy + registre de slabs). Le test verifie les deux
+ * proprietes qui comptent :
+ *   1. le resultat est celui du chemin CPU (a l epsilon pres) ;
+ *   2. le tenseur ne POSSEDE pas ses poids -- sinon il y a eu copie, et la
+ *      liberation detruirait le tampon de streaming du moteur.
+ *
+ * Sur un GPU discret, prop.integrated vaut 0 : le test s abstient plutot que
+ * d echouer, car le zero-copie n y a pas de sens.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "../quant.h"
+#include "../backend_cuda.h"
+
+static uint32_t graine = 4242u;
+static uint32_t suivant(void){
+    graine ^= graine << 13; graine ^= graine >> 17; graine ^= graine << 5;
+    return graine;
+}
+
+int main(void){
+    int devs[1] = {0};
+    if(!coli_cuda_init(devs, 1)){ printf("  (pas de CUDA) - test ignore\n"); return 0; }
+    /* fmt=6 decode contre le livre de codes E8 : sans lui les noyaux rendent
+     * du bruit (ou zero). Le moteur le publie au demarrage, pas ce test. */
+    if(!coli_cuda_e8_set_grid(e8_grid)){ printf("  ECHEC : publication du livre de codes E8\n"); return 1; }
+    if(!coli_cuda_device_integrated(0)){
+        printf("  (GPU discret : le zero-copie ne s applique pas) — test ignore\n");
+        return 0;
+    }
+
+    const int S = 4, I = 6144, O = 256;
+    int64_t rb = e8_rowbytes(I);
+    size_t taille = ((size_t)O * rb + 16383) & ~(size_t)16383;   /* aligne page, comme Metal */
+
+    void *slab = NULL;
+    if(posix_memalign(&slab, 16384, taille)){ fprintf(stderr, "OOM\n"); return 2; }
+    for(size_t i = 0; i < (size_t)O * rb; i++) ((uint8_t*)slab)[i] = (uint8_t)(suivant() & 0xFF);
+
+    float *x = malloc(sizeof(float) * S * I);
+    float *y_gpu = malloc(sizeof(float) * S * O);
+    float *y_cpu = malloc(sizeof(float) * S * O);
+    for(int i = 0; i < S * I; i++)
+        x[i] = ((float)(suivant() % 2000) - 1000.0f) / 1000.0f;
+
+    /* AUCUN enregistrement : sur GB10 (pageableMemoryAccess=1) le pointeur
+     * hote est deja adressable par le GPU. C est precisement ce qu on teste. */
+    printf("  pageable sans enregistrement : %d\n", coli_cuda_device_pageable(0));
+
+    ColiCudaTensor *t = NULL;
+    if(!coli_cuda_tensor_wrap(&t, slab, NULL, 6 /*fmt E8*/, I, O, 0 /*device*/, 0 /*gs*/)){
+        printf("  ECHEC : impossible d envelopper le slab en tenseur\n"); return 1;
+    }
+    if(coli_cuda_tensor_owns_weights(t)){
+        printf("  ECHEC : le tenseur POSSEDE ses poids — il y a eu copie\n"); return 1;
+    }
+
+    if(!coli_cuda_matmul(&t, y_gpu, x, slab, NULL, 6, S, I, O, 0, 0)){
+        printf("  ECHEC : le calcul CUDA a refuse\n"); return 1;
+    }
+    matmul_e8_neon(y_cpu, x, (const uint8_t*)slab, NULL, S, I, O);
+
+    double pire = 0; int ip = -1;
+    for(int i = 0; i < S * O; i++){
+        double a = y_cpu[i], b = y_gpu[i];
+        double den = fabs(a) > 1e-6 ? fabs(a) : 1e-6;
+        double e = fabs(a - b) / den;
+        if(e > pire){ pire = e; ip = i; }
+    }
+    printf("  ecart GPU/CPU max : %.3e (indice %d)\n", pire, ip);
+
+    coli_cuda_tensor_free(t);
+    /* Le slab doit AVOIR SURVECU a la liberation du tenseur : c est la memoire
+     * du moteur, pas celle du backend. On la relit pour le prouver. */
+    volatile uint8_t sonde = ((uint8_t*)slab)[16];
+    (void)sonde;
+    free(slab);
+
+    if(pire > 1e-3){ printf("  ECHEC : resultat GPU divergent\n"); return 1; }
+    printf("  OK : le GPU a calcule depuis le tampon hote, sans copie\n");
+    return 0;
+}


### PR DESCRIPTION
### What

On integrated devices with `pageableMemoryAccess=1` (GB10 / DGX Spark class: one LPDDR5X pool shared by CPU and GPU), uploading an expert copies bytes the GPU can already read in place — and with `CUDA_RELEASE_HOST` each device copy also keeps a mirror host page, so the same physical bytes are paid twice. Worse: experts that are *not* resident on the device tier fall back to **CPU** compute, a rational choice on a discrete GPU and a pure loss on unified memory.

This PR teaches the CUDA backend non-owning device **views** onto host slabs (`coli_cuda_tensor_wrap`, using the `weights_owned` field already present in dev):

- streamed experts and PILOT-prefetched experts (`demand=0`) compute on the GPU through views — without the `demand=0` case, PILOT resurrected 914 expert rows on the CPU per decode window and gave back its I/O gain; measured after: **routed CPU rows during decode = 0**;
- pinned experts are left without device copies after placement (a view suffices; the pass must run after the RAM-tier load loop and after placement — both other orderings were measured wrong);
- the io_uring loader wires the same view path (it set the format but not the view, so uring loads silently fell back to copies);
- fix in `coli_cuda_tensor_upload`: a view must never satisfy a request for a copy — the cached-copy shortcut matches on fmt/I/O/device, would accept a view, and the view's `weight_bytes=0` then collapses expert-tier accounting (measured: tier fell from 3795 to 128 experts). Latent on dev today, armed the moment anything creates views.

Together with the E8 warp kernels (separate PR), decode p50 on GLM-5.2 E8-IQ3 on GB10 went 1376.6 → 640.9 ms/token (2.15x).

### Known limitation (deliberate)

`COLI_GROUP_ASYNC=1` must stay off while views are in use: the `ESlot` LRU has no reference count, so the async group path can recycle a slot while a GPU read is in flight. Reported with full analysis in #933; the sync path costs ~3.5% of orchestration time. A per-slot refcount is the real fix and is out of scope here.

### Dropped during rebase

An earlier version also changed GPU-tier capacity planning to use routed-expert width; dev's `expert_bytes_row` (#856) already solves that better, so it was dropped.

### Suggestion (no code in this PR)

On devices with `pageableMemoryAccess=1`, the unified behavior could become the **default**: views on, GPU prefill pipeline on, async group path guarded off. Today that requires a combination of env vars that only someone who has done this debugging would know. Happy to send a follow-up PR if there is interest.

### Tests

New `c/tests/test_zerocopy.c`. `make check`: 415 tests OK. Same note as the kernels PR: `cuda-test` exits 1 on GB10 already on a pristine dev checkout (v1.5.0-based builds pass on the same machine/driver) — separate issue to follow.

### Disclosure

Developed with AI assistance (Anthropic Claude), human-reviewed; all figures were measured on the hardware described.
