### PR TITLE
fix(cli): close the markdown stream before stopping the spinner

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -917,7 +917,7 @@ def chat_attached(a, base, model_id):
         except OSError as e:
             sp.stop()
             print(f"\n  {C.yel}[server unreachable: {e}]{C.r}"); break
-        sp.stop(); md.close()
+        md.close(); sp.stop()
         if reply: msgs.append({"role":"assistant","content":"".join(reply)})
         else: msgs.pop()                              # turno vuoto: non sporcare la history
         el=time.time()-t0


### PR DESCRIPTION
## Problem

In `coli chat` (HTTP mode), the tail of a streaming reply visibly **vanishes the moment the `~N tok · Ns` footer appears** — the answer looks cut off mid-sentence, yet the token count and saved history still include the missing text.

## Root cause

`chat_attached` in `c/coli` called the spinner stop *before* closing the markdown stream:

```python
sp.stop(); md.close()
```

`Spinner.stop()` writes `\r\033[K` (carriage return + erase-to-end-of-line). Since a reply rarely ends with a newline, the cursor still sat on the reply's **last partial line**, so `sp.stop()` erased that whole line. `md.close()` then had nothing to re-print: `MDStream._line()` only emits `line[self.printed:]`, and that text was already marked as printed.

The final partial line of the reply is therefore wiped from the display exactly when the summary prints. `Spinner.stop()` is safe *only* when it runs on a line that is already terminated — the GLM serve chat already used the correct order (`md.close()` before `sp2.stop()`); the HTTP path had it reversed.

## Fix

```python
md.close(); sp.stop()
```

`md.close()` terminates the partial line with a newline first; `sp.stop()` then clears only the empty line and can no longer erase reply text.

Introduced by `8bf4cb9a` ("coli: chat attaches to a running serve").
