### PR TITLE
v4: support arm64 macOS — one mach branch, the rest was already portable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,20 @@ jobs:
       # check.yml, Windows was first exercised at the release tag). The tiny
       # oracle is the token-exactness gate: it fails on any numerical or I/O
       # divergence, which is exactly what a platform port can break.
+      #
+      # The check target REGENERATES the fixture (--force) before comparing,
+      # so it needs the same pinned torch/transformers the Linux v4-tiny job
+      # installs -- without them the step dies in generation, not in the
+      # oracle (round 2 of this PR measured exactly that).
+      - uses: actions/setup-python@v5
+        if: matrix.os == 'macos-latest'
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: c/tools/requirements-deepseek-v4-tiny.txt
+      - name: Install pinned tiny-fixture dependencies (macOS)
+        if: matrix.os == 'macos-latest'
+        run: python -m pip install -r c/tools/requirements-deepseek-v4-tiny.txt
       - name: DeepSeek V4 tiny oracle (macOS)
         if: matrix.os == 'macos-latest'
         run: make -C c deepseek-v4-tiny-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,11 @@ jobs:
           - os: macos-latest
             name: macos
             shell: bash
-            # No v4: the engine builds on x86-64 Linux/Windows and aarch64 Linux
-            # only (COLI_V4_SUPPORTED in c/Makefile); the target exits 1 here.
+            # arm64 macOS joined COLI_V4_SUPPORTED: compat.h carries the
+            # platform differences (fadvise/F_RDADVISE, O_DIRECT/F_NOCACHE)
+            # and the token-exact tiny oracle below is the acceptance gate.
+            v4: "1"
+
           - os: windows-latest
             name: windows
             # GitHub shells are format strings: 'msys2 {0}', never bare 'msys2'.
@@ -190,6 +193,15 @@ jobs:
             echo "::endgroup::"
           done
           exit $rc
+
+      # macOS is the newest COLI_V4_SUPPORTED platform and the only one whose
+      # engine coverage lives solely in this job (Linux has the v4-tiny job in
+      # check.yml, Windows was first exercised at the release tag). The tiny
+      # oracle is the token-exactness gate: it fails on any numerical or I/O
+      # divergence, which is exactly what a platform port can break.
+      - name: DeepSeek V4 tiny oracle (macOS)
+        if: matrix.os == 'macos-latest'
+        run: make -C c deepseek-v4-tiny-check
 
       # The Windows backend-DLL loader contract (c/tests/test_backend_loader.py)
       # had no CI anywhere: the `python` job below is Linux-only, where these

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,10 @@ jobs:
             name: macos-arm64
             ext: ""
             make_args: ""
-            # No v4: DeepSeek V4 is x86-64 Linux/Windows + aarch64 Linux only
-            # (c/Makefile, COLI_V4_SUPPORTED). Asking for it here fails the build.
+            # arm64 macOS joined COLI_V4_SUPPORTED; the archive verify step
+            # asserts the engine is present and dispatchable like the others.
+            v4: "1"
+
           - os: windows-latest
             name: windows-x86_64
             ext: ".exe"

--- a/c/Makefile
+++ b/c/Makefile
@@ -340,8 +340,11 @@ CUDA_OBJ  =
 
 # DeepSeek V4 is a separate x86-64/aarch64 runtime. Portable infrastructure
 # tests run everywhere; the engine and token-exact fixture run on x86-64
-# Linux/Windows and aarch64 Linux. SIMD fast paths are gated per-feature
-# inside the sources, so a plain armv8-a build stays correct.
+# Linux/Windows, aarch64 Linux, and arm64 macOS. SIMD fast paths are gated
+# per-feature inside the sources, so a plain armv8-a build stays correct.
+# macOS portability rides compat.h (posix_fadvise -> F_RDADVISE, O_DIRECT ->
+# F_NOCACHE via st.h's direct twins) plus a mach branch for available memory;
+# the token-exact tiny fixture is the acceptance gate on the macos runner.
 COLI_V4_SUPPORTED :=
 ifneq (,$(X86_64))
 ifneq (,$(IS_WIN)$(LINUX))
@@ -349,7 +352,7 @@ COLI_V4_SUPPORTED := 1
 endif
 endif
 ifneq (,$(AARCH64))
-ifneq (,$(LINUX))
+ifneq (,$(LINUX)$(DARWIN))
 COLI_V4_SUPPORTED := 1
 endif
 endif

--- a/c/Makefile.deepseek-v4
+++ b/c/Makefile.deepseek-v4
@@ -1,6 +1,8 @@
-# DeepSeek V4 amalgamation build — x86-64/aarch64 Linux and Windows/MSYS2 only.
-# Uses GNU ld -Wl,--wrap and gcc -march; do not invoke from macOS/PowerPC
-# `make check` (the parent Makefile gates COLI_V4_SUPPORTED).
+# DeepSeek V4 amalgamation build — x86-64/aarch64 Linux, Windows/MSYS2, and
+# arm64 macOS. (An earlier version of this header claimed GNU-ld --wrap as a
+# hard dependency; nothing here has used --wrap for a while, and macOS
+# portability rides compat.h: posix_fadvise -> F_RDADVISE, O_DIRECT ->
+# F_NOCACHE.) The parent Makefile gates COLI_V4_SUPPORTED.
 
 ifeq ($(OS),Windows_NT)
 IS_WIN := 1
@@ -19,10 +21,14 @@ else ifeq ($(UNAME_S),Linux)
 ifneq (,$(filter x86_64 amd64 aarch64 arm64,$(UNAME_M)))
 COLI_V4_OK := 1
 endif
+else ifeq ($(UNAME_S),Darwin)
+ifneq (,$(filter arm64,$(UNAME_M)))
+COLI_V4_OK := 1
+endif
 endif
 
 ifneq ($(COLI_V4_OK),1)
-$(error Makefile.deepseek-v4 supports only x86-64/aarch64 Linux and Windows/MSYS2)
+$(error Makefile.deepseek-v4 supports x86-64/aarch64 Linux, Windows/MSYS2, and arm64 macOS)
 endif
 
 ifneq ($(IS_WIN),)

--- a/c/Makefile.deepseek-v4
+++ b/c/Makefile.deepseek-v4
@@ -36,6 +36,29 @@ CFLAGS = -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -O3 -march=$(ARCH) -fopenmp \
 	-DCOLI_V4_EXPERIMENTAL_DUAL_EXPERT_LOADER
 LDFLAGS = -lm -fopenmp -static -pthread
 V4_BINARY := deepseek_v4.exe
+else ifeq ($(UNAME_S),Darwin)
+# Apple clang has no bundled OpenMP runtime: use Homebrew libomp when its
+# artifacts are actually present, else build single-threaded (pragmas are
+# ignored). No -march: NEON is baseline on arm64 and the per-feature gates in
+# the sources do the rest. Mirrors the parent Makefile's Darwin block.
+CC = clang
+OMPDIR := $(shell brew --prefix libomp 2>/dev/null)
+ifneq ($(and $(OMPDIR),$(wildcard $(OMPDIR)/include/omp.h),$(wildcard $(OMPDIR)/lib/libomp.*)),)
+OMPC = -Xclang -fopenmp -I$(OMPDIR)/include
+OMPL = -L$(OMPDIR)/lib -lomp
+else
+$(warning libomp not found: building deepseek_v4 single-threaded. brew install libomp)
+OMPC =
+OMPL =
+endif
+CFLAGS = -D_GNU_SOURCE -O3 $(OMPC) -pthread -include pthread.h \
+	-Wall -Wextra -Wno-unused-parameter \
+	-Wno-misleading-indentation -Wno-unused-function \
+	-DCOLI_V4_MAX_PIN_SLOTS_PER_LAYER=16 \
+	-DCOLI_V4_PIN_RAMP_REQUESTS=24 \
+	-DCOLI_V4_EXPERIMENTAL_DUAL_EXPERT_LOADER
+LDFLAGS = -lm $(OMPL) -pthread
+V4_BINARY := deepseek_v4
 else
 CC = gcc
 ARCH ?= native

--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -668,12 +668,30 @@ static int multiply_u64(uint64_t a, uint64_t b, uint64_t *output) {
     return 0;
 }
 
+#ifdef __APPLE__
+#include <mach/mach.h>
+#endif
+
 uint64_t coli_v4_os_available_memory(void) {
 #ifdef _WIN32
     MEMORYSTATUSEX status;
     memset(&status, 0, sizeof(status));
     status.dwLength = sizeof(status);
     return GlobalMemoryStatusEx(&status) ? (uint64_t)status.ullAvailPhys : 0;
+#elif defined(__APPLE__)
+    /* No /proc and no _SC_AVPHYS_PAGES on macOS. "Available" is what the
+     * kernel could hand out without swapping: free + inactive pages -- the
+     * same approximation Activity Monitor reports, and the closest analogue
+     * of Linux's MemAvailable (which also counts reclaimable cache). */
+    mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+    vm_statistics64_data_t vm;
+    vm_size_t page = 0;
+    if (host_statistics64(mach_host_self(), HOST_VM_INFO64,
+                          (host_info64_t)&vm, &count) == KERN_SUCCESS &&
+        host_page_size(mach_host_self(), &page) == KERN_SUCCESS && page)
+        return ((uint64_t)vm.free_count + (uint64_t)vm.inactive_count) *
+               (uint64_t)page;
+    return 0;
 #else
     FILE *stream = fopen("/proc/meminfo", "r");
     if (stream) {

--- a/c/tools/requirements-deepseek-v4-tiny.txt
+++ b/c/tools/requirements-deepseek-v4-tiny.txt
@@ -1,4 +1,8 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.13.0+cpu
+# The +cpu local-version tag exists only in the Linux wheels of the CPU index;
+# macOS wheels are CPU-only by construction and carry the plain version.
+# Same pin either way -- the environment markers pick the spelling per OS.
+torch==2.13.0+cpu; sys_platform == "linux"
+torch==2.13.0; sys_platform == "darwin"
 transformers==5.14.1
 safetensors==0.8.0

--- a/c/tools/requirements-deepseek-v4-tiny.txt
+++ b/c/tools/requirements-deepseek-v4-tiny.txt
@@ -1,8 +1,8 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-# The +cpu local-version tag exists only in the Linux wheels of the CPU index;
-# macOS wheels are CPU-only by construction and carry the plain version.
-# Same pin either way -- the environment markers pick the spelling per OS.
-torch==2.13.0+cpu; sys_platform == "linux"
+# The +cpu local-version tag exists in the Linux and Windows wheels of the CPU
+# index; macOS wheels are CPU-only by construction and carry the plain
+# version. Same pin either way -- the marker picks the spelling per OS.
+torch==2.13.0+cpu; sys_platform != "darwin"
 torch==2.13.0; sys_platform == "darwin"
 transformers==5.14.1
 safetensors==0.8.0


### PR DESCRIPTION
DeepSeek V4 was gated off macOS, but the stated reasons had expired:

- the `Makefile.deepseek-v4` header claimed a GNU-ld `--wrap` dependency — **nothing uses `--wrap` anymore** (zero `__wrap_`/`__real_` symbols, zero flags);
- the engine's Linux-isms already route through `compat.h`, because every unit includes `deepseek_v4_internal.h → st.h → compat.h`: `posix_fadvise` → `F_RDADVISE`, `O_DIRECT` → `F_NOCACHE` via the direct twins.

**The one real gap** was `coli_v4_os_available_memory()`: `/proc/meminfo` with a `sysconf(_SC_AVPHYS_PAGES)` fallback, and macOS has neither. New `__APPLE__` branch uses mach `host_statistics64` (free + inactive pages — the closest analogue of MemAvailable).

Build side: Darwin arm64 gate + a toolchain branch mirroring the parent Makefile's Darwin block (clang, Homebrew libomp when actually present, single-threaded fallback, no `-march`).

**Acceptance is behavioural**: the macos CI job now builds the engine and runs `make deepseek-v4-tiny-check` — the token-exact oracle — on the runner itself. If the port diverges numerically or in I/O, this PR goes red, not a user's Mac. `release.yml` packages and asserts `deepseek_v4` in the macos-arm64 archive like every other engine.

Linux verified unaffected locally: clean build, tiny-check token-exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)