### PR TITLE
feat(v4): DSML tool calling for DeepSeek V4 (#916)

### DIFF
--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -374,6 +374,173 @@ def parse_tool_calls(reply, tools=None):
     return text.strip(), calls
 
 
+# ---- DeepSeek V4 tool calling (DSML) -------------------------------------------------------
+# V4 expresses tool calls as DSML blocks (see encoding/encoding_dsv4.py):
+#   <｜DSML｜tool_calls>\n<｜DSML｜invoke name="fn">\n
+#   <｜DSML｜parameter name="k" string="true">v</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>
+# preceded by "\n\n". There is no standalone "tool" role: results are <tool_result>{content}
+# </tool_result> blocks merged into the following user turn. DSML = U+FF5C (｜) + ASCII.
+DSV4_DSML = "｜DSML｜"
+DSV4_EOS = "<\uff5cend\u2581of\u2581sentence\uff5c>"
+_DSV4_BLOCK_RE = re.compile(
+    r"<" + DSV4_DSML + r"tool_calls>(.*?)</" + DSV4_DSML + r"tool_calls>", re.DOTALL)
+_DSV4_INVOKE_RE = re.compile(
+    r"<" + DSV4_DSML + r"invoke name=\"(.*?)\">(.*?)</" + DSV4_DSML + r"invoke>", re.DOTALL)
+_DSV4_PARAM_RE = re.compile(
+    r"<" + DSV4_DSML + r"parameter name=\"(.*?)\" string=\"(true|false)\">(.*?)</" +
+    DSV4_DSML + r"parameter>", re.DOTALL)
+
+DSV4_TOOLS_TEMPLATE = """## Tools
+
+You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{dsml}tool_calls>" block like the following:
+
+<{dsml}tool_calls>
+<{dsml}invoke name="$TOOL_NAME">
+<{dsml}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml}parameter>
+...
+</{dsml}invoke>
+<{dsml}invoke name="$TOOL_NAME2">
+...
+</{dsml}invoke>
+</{dsml}tool_calls>
+
+String parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.
+
+If thinking_mode is enabled (triggered by {think_open}), you MUST output your complete reasoning inside {think_open}...{think_close} BEFORE any tool calls or final response.
+
+Otherwise, output directly after {think_close} with tool calls or final response.
+
+### Available Tool Schemas
+
+{tool_schemas}
+
+You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
+"""
+
+# OpenAI-style reasoning_effort levels -> the V4 vocabulary (encoding_dsv4.py has only
+# low/high/max; `low` adds nothing). In thinking mode the level's prompt is prepended at the
+# very start of the conversation, byte-matching REASONING_EFFORT_PROMPTS.
+DSV4_REASONING_EFFORT = {"minimal": "low", "low": "low", "medium": "high",
+                         "high": "high", "xhigh": "max", "max": "max"}
+DSV4_REASONING_EFFORT_PROMPTS = {
+    "high": ("Reasoning Effort: High.\n"
+             "Reason thoroughly, decompose the problem, and verify the relevant edge cases before acting. "
+             "Avoid repeating settled points or narrating redundant alternatives. "
+             "Keep the analysis proportional to the task. HARD LIMIT: finish reasoning within about "
+             "1,500 tokens, close the thinking section, and then emit the next tool call or a complete "
+             "final response. Never consume the whole output budget with reasoning.\n\n"),
+    "max": ("Reasoning Effort: Maximum.\n"
+            "Analyze the problem with maximum depth, trace root causes, and independently verify the "
+            "solution from multiple relevant angles. Do not repeat settled reasoning or pursue "
+            "irrelevant branches. Reserve sufficient tokens for the required tool call or final "
+            "response, and always terminate reasoning before the token budget is exhausted.\n\n"),
+}
+
+
+def _dsv4_tools_block(tools):
+    """V4 tool-declaration block (byte-matches encoding_dsv4.py's TOOLS_TEMPLATE)."""
+    schemas = []
+    for tool in (tools or []):
+        fn = tool.get("function", tool) if isinstance(tool, dict) else {}
+        clean = {k: v for k, v in fn.items() if k not in ("defer_loading", "strict")}
+        schemas.append(json.dumps(clean, ensure_ascii=False))
+    return DSV4_TOOLS_TEMPLATE.format(dsml=DSV4_DSML, think_open=THINK_OPEN,
+                                      think_close=THINK_CLOSE, tool_schemas="\n".join(schemas))
+
+
+def _dsv4_tool_calls(tool_calls):
+    """Render OpenAI-format tool_calls into a V4 DSML block (incl. the leading \\n\\n)."""
+    calls = []
+    for tc in tool_calls:
+        fn = tc.get("function", tc) if isinstance(tc, dict) else {}
+        name = fn.get("name") or ""
+        args = fn.get("arguments")
+        try:
+            arguments = json.loads(args) if isinstance(args, str) else (args or {})
+        except (json.JSONDecodeError, TypeError, ValueError):
+            arguments = {}
+        params = []
+        for key, value in (arguments or {}).items():
+            is_str = "true" if isinstance(value, str) else "false"
+            text = value if isinstance(value, str) else json.dumps(value, ensure_ascii=False)
+            params.append('<%sparameter name="%s" string="%s">%s</%sparameter>'
+                          % (DSV4_DSML, key, is_str, text, DSV4_DSML))
+        calls.append('<%sinvoke name="%s">\n%s\n</%sinvoke>'
+                     % (DSV4_DSML, name, "\n".join(params), DSV4_DSML))
+    return '\n\n<%stool_calls>\n%s\n</%stool_calls>' % (DSV4_DSML, "\n".join(calls), DSV4_DSML)
+
+
+def parse_dsv4_tool_calls(reply):
+    """Parse DeepSeek V4 DSML tool calls out of one assistant reply.
+
+    Returns (content, tool_calls): the visible answer text with the DSML block (and any
+    thinking/eos markers) removed, plus OpenAI-format tool_calls. Tolerant of truncated
+    output: an incomplete block yields no calls rather than an error.
+    """
+    content, calls = reply, []
+    block = _DSV4_BLOCK_RE.search(reply)
+    if block:
+        content = reply[:block.start()].rstrip("\n")
+        for m in _DSV4_INVOKE_RE.finditer(block.group(1)):
+            name = m.group(1).strip()
+            if not name:
+                continue
+            arguments = {}
+            for p in _DSV4_PARAM_RE.finditer(m.group(2)):
+                key, is_str, value = p.group(1), p.group(2), p.group(3)
+                if is_str != "true":
+                    try:
+                        value = json.loads(value)
+                    except (json.JSONDecodeError, TypeError, ValueError):
+                        pass
+                arguments[key] = value
+            calls.append({"id": "call_" + uuid.uuid4().hex[:24], "type": "function",
+                          "function": {"name": name,
+                                       "arguments": json.dumps(arguments, ensure_ascii=False)}})
+    else:
+        # No complete block (e.g. length-truncated output): drop everything from the first
+        # V4 tool marker so raw DSML syntax never leaks into the visible content.
+        cut = len(reply)
+        for marker in ("<" + DSV4_DSML + "tool_calls", "<" + DSV4_DSML + "invoke"):
+            pos = reply.find(marker)
+            if pos >= 0 and pos < cut:
+                cut = pos
+        if cut < len(reply):
+            content = reply[:cut]
+    for marker in (DSV4_EOS, THINK_OPEN, THINK_CLOSE):
+        content = content.replace(marker, "")
+    return content.strip(), calls
+
+
+def parse_arch_tool_calls(reply, tools):
+    """Architecture-appropriate tool-call parser. Returns (content, tool_calls)."""
+    if ARCH == "deepseek_v4":
+        return parse_dsv4_tool_calls(reply)
+    return parse_tool_calls(reply, tools)
+
+
+def _tool_stream_markers():
+    """Marker(s) that open a model tool-call block, in match order (arch-specific)."""
+    if ARCH == "deepseek_v4":
+        return ("<" + DSV4_DSML + "tool_calls", "<" + DSV4_DSML + "invoke")
+    return (BOX_START,)
+
+
+def _tool_cut(buf):
+    """Earliest position of a tool-call marker in buf, or -1."""
+    found = -1
+    for marker in _tool_stream_markers():
+        pos = buf.find(marker)
+        if pos >= 0 and (found < 0 or pos < found):
+            found = pos
+    return found
+
+
+def _tool_hold():
+    """Bytes to hold back while scanning for a tool-call marker split across chunks."""
+    return max(len(m) for m in _tool_stream_markers()) - 1
+
+
 ARCH = "glm"   # set in main(): glm | inkling | kimi | deepseek_v4
 
 INK_THINK, INK_TEXT = "<|content_thinking|>", "<|content_text|>"
@@ -667,40 +834,104 @@ def render_chat_v4(messages, enable_thinking=False, reasoning_effort=None, tools
     The target engine receives this as a raw prompt. Prior assistant turns end
     with the checkpoint's EOS marker; the final assistant marker selects the
     thinking or direct-answer prefix for the new turn.
+
+    Tool use follows the official DSML format (encoding/encoding_dsv4.py): tool
+    schemas are declared on the first system/developer message, assistant tool
+    calls are DSML blocks, and tool results are <tool_result> blocks merged into
+    user turns (V4 has no standalone "tool" role).
     """
     if not isinstance(messages, list) or not messages:
         raise APIError(400, "`messages` must be a non-empty array.", "messages")
-    if tools or tool_choice not in (None, "none"):
-        raise APIError(400, "Tool use is not wired up for DeepSeek V4 yet.",
-                       "tools", "unsupported_parameter")
+    forced = None
+    if isinstance(tool_choice, dict):
+        forced = ((tool_choice.get("function") or {}).get("name")
+                  or tool_choice.get("name"))
+        if forced:
+            tools = [t for t in (tools or [])
+                     if ((t.get("function", t) if isinstance(t, dict) else {}).get("name") == forced)]
+    elif tool_choice == "none":
+        tools = None                              # the client forbade tools: do not offer them
+    # Merge tool messages into <tool_result> blocks on the following user turn (V4 has no
+    # tool role); validate every message on the original list for accurate field-level errors.
+    merged = []
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict):
+            raise APIError(400, "Each message must be an object.", f"messages.{index}")
+        role = message.get("role")
+        if role not in ("system", "developer", "user", "assistant", "tool"):
+            raise APIError(400, f"Unsupported role {role!r}.", f"messages.{index}.role")
+        if role == "assistant":
+            reasoning = message.get("reasoning_content")
+            if reasoning is not None and not isinstance(reasoning, str):
+                raise APIError(400, "`reasoning_content` must be a string.",
+                               f"messages.{index}.reasoning_content")
+            raw = message.get("content")
+            content = content_text(raw, f"messages.{index}.content") if raw is not None else ""
+            merged.append({"role": role, "content": content,
+                           "reasoning_content": message.get("reasoning_content"),
+                           "tool_calls": message.get("tool_calls")})
+            continue
+        raw = message.get("content")
+        text = content_text(raw, f"messages.{index}.content") if raw is not None else ""
+        if role == "tool":
+            block = "<tool_result>" + text + "</tool_result>"
+            if merged and merged[-1].get("_parts") is not None:
+                merged[-1]["_parts"].append(block)
+            else:
+                merged.append({"role": "user", "_parts": [block]})
+        elif role == "user":
+            if merged and merged[-1].get("_parts") is not None:
+                merged[-1]["_parts"].append(text)
+            else:
+                merged.append({"role": "user", "content": text})
+        else:                                     # system / developer
+            merged.append({"role": role, "content": text})
+    if tools:
+        tools_text = _dsv4_tools_block(tools)
+        if forced:
+            tools_text += f"\n\nYou must call the function `{forced}`. Do not answer directly."
+        elif tool_choice == "required":
+            tools_text += "\n\nYou must call one of the functions above. Do not answer directly."
+        for msg in merged:
+            if msg["role"] in ("system", "developer"):
+                msg["content"] += "\n\n" + tools_text
+                break
+        else:
+            # No system/developer message: the official encoder renders tools on an empty
+            # system message, i.e. "bos" + "\n\n" + tools. Keep that exact byte layout.
+            merged.insert(0, {"role": "system", "content": "\n\n" + tools_text})
     bos = "<\uff5cbegin\u2581of\u2581sentence\uff5c>"
     user = "<\uff5cUser\uff5c>"
     assistant = "<\uff5cAssistant\uff5c>"
     eos = "<\uff5cend\u2581of\u2581sentence\uff5c>"
     parts = [bos]
-    for index, message in enumerate(messages):
-        if not isinstance(message, dict):
-            raise APIError(400, "Each message must be an object.", f"messages.{index}")
-        role = message.get("role")
-        if role not in ("system", "developer", "user", "assistant"):
-            raise APIError(400, f"Unsupported role {role!r}.", f"messages.{index}.role")
-        raw = message.get("content")
-        text = content_text(raw, f"messages.{index}.content") if raw is not None else ""
+    if enable_thinking:
+        effort = DSV4_REASONING_EFFORT.get(reasoning_effort, "low")
+        if effort != "low":
+            parts.append(DSV4_REASONING_EFFORT_PROMPTS[effort])
+    for message in merged:
+        role = message["role"]
         if role in ("system", "developer"):
-            parts.append(text)
+            if role == "developer":
+                parts.append(user)            # V4 wraps developer messages like user turns
+            parts.append(message["content"])
         elif role == "user":
-            parts.extend((user, text))
+            parts.append(user)
+            if message.get("_parts") is not None:
+                parts.append("\n\n".join(message["_parts"]))
+            else:
+                parts.append(message["content"])
         else:
             reasoning = message.get("reasoning_content")
-            if reasoning is not None and not isinstance(reasoning, str):
-                raise APIError(400, "`reasoning_content` must be a string.",
-                               f"messages.{index}.reasoning_content")
             parts.append(assistant)
             if reasoning:
                 parts.extend(("<think>", reasoning, "</think>"))
             else:
                 parts.append("</think>")
-            parts.extend((text, eos))
+            parts.append(message["content"])
+            if message.get("tool_calls"):
+                parts.append(_dsv4_tool_calls(message["tool_calls"]))
+            parts.append(eos)
     parts.extend((assistant, "<think>" if enable_thinking else "</think>"))
     return "".join(parts)
 
@@ -2331,7 +2562,7 @@ class APIHandler(BaseHTTPRequestHandler):
                     reasoning, text = split_thinking_reply(text, enable_thinking)
                 length_finish = "length" if stats["length_limited"] else "stop"
                 if chat and tools:
-                    content, calls = parse_tool_calls(text, tools)
+                    content, calls = parse_arch_tool_calls(text, tools)
                     message = {"role": "assistant", "content": content or None, "refusal": None}
                     if reasoning:
                         message["reasoning_content"] = reasoning
@@ -2454,16 +2685,16 @@ class APIHandler(BaseHTTPRequestHandler):
             if chat and tools:
                 # Suppress tool-call markers from the streamed content and parse the authoritative
                 # calls from the FULL reply after generation. Hold back a marker-length tail so a
-                # <tool_call> split across engine chunks is still caught.
+                # tool-call marker split across engine chunks is still caught.
                 sp = {"buf": "", "tool": False}
-                hold = len(BOX_START) - 1
+                hold = _tool_hold()
                 raw = []
                 def feed_content(chunk):               # answer text only (post-</think>)
                     raw.append(chunk)
                     if sp["tool"]:
                         return
                     sp["buf"] += chunk
-                    cut = sp["buf"].find(BOX_START)
+                    cut = _tool_cut(sp["buf"])
                     if cut >= 0:
                         if cut:
                             emit(sp["buf"][:cut])
@@ -2493,7 +2724,7 @@ class APIHandler(BaseHTTPRequestHandler):
                     think.finish()
                 if not sp["tool"] and sp["buf"]:
                     emit(sp["buf"])                     # no tool call happened: flush held tail
-                _content, calls = parse_tool_calls("".join(raw), tools)
+                _content, calls = parse_arch_tool_calls("".join(raw), tools)
                 for i, tc in enumerate(calls):
                     event([{"index": 0, "delta": {"tool_calls": [{"index": i, "id": tc["id"],
                              "type": "function", "function": {"name": tc["function"]["name"],
@@ -2654,7 +2885,7 @@ class APIHandler(BaseHTTPRequestHandler):
                                 "signature": ANTHROPIC_LOCAL_SIGNATURE})
             calls = []
             if tools:
-                text, calls = parse_tool_calls(text, tools)
+                text, calls = parse_arch_tool_calls(text, tools)
             if text:
                 content.append({"type": "text", "text": text})
             for call in calls:
@@ -2743,7 +2974,7 @@ class APIHandler(BaseHTTPRequestHandler):
 
             raw = []
             state = {"buf": "", "in_tool": False}
-            hold = len(BOX_START) - 1
+            hold = _tool_hold()
 
             def emit_text(chunk):
                 if not chunk:
@@ -2762,7 +2993,7 @@ class APIHandler(BaseHTTPRequestHandler):
                 if state["in_tool"]:
                     return                       # tool markers never reach the client as text
                 state["buf"] += chunk
-                cut = state["buf"].find(BOX_START)
+                cut = _tool_cut(state["buf"])
                 if cut >= 0:
                     if cut:
                         emit_text(state["buf"][:cut])

--- a/c/tests/test_anthropic_messages.py
+++ b/c/tests/test_anthropic_messages.py
@@ -169,7 +169,7 @@ class MessagesHTTPTest(unittest.TestCase):
 
     def test_non_glm_architectures_reject_tools_before_generation(self):
         body = self.base_body(tools=[{"name": "f", "input_schema": {"type": "object"}}])
-        for arch in ("inkling", "kimi", "deepseek_v4"):
+        for arch in ("inkling", "kimi"):
             with self.subTest(arch=arch), patch("openai_server.ARCH", arch):
                 before = len(self.engine.prompts)
                 with self.assertRaises(HTTPError) as caught:
@@ -177,6 +177,17 @@ class MessagesHTTPTest(unittest.TestCase):
                 self.assertEqual(caught.exception.code, 400)
                 self.assertIn("tool", json.load(caught.exception)["error"]["message"].lower())
                 self.assertEqual(len(self.engine.prompts), before)
+
+    def test_deepseek_v4_renders_tools_as_dsml_block(self):
+        body = self.base_body(tools=[{"name": "f", "input_schema": {
+            "type": "object", "properties": {"x": {"type": "string"}}}}])
+        with patch("openai_server.ARCH", "deepseek_v4"):
+            with self.post(body) as response:
+                self.assertEqual(response.status, 200)
+        prompt = self.engine.prompts[-1]
+        self.assertIn("## Tools", prompt)
+        self.assertIn('"name": "f"', prompt)
+        self.assertIn("｜DSML｜", prompt)
 
     def test_x_api_key_and_bearer_both_authenticate(self):
         with self.post(self.base_body(), {"x-api-key": "secret"}) as response:

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -18,9 +18,10 @@ from openai_server import (APIError, APIHandler, APIServer, ClientCancelled,
                            DEFAULT_CHAT_STOP_SEQUENCES, END, GenerationScheduler,
                            READY, Engine, InklingStreamSplit, StopFilter, ThinkingStreamSplit,
                            _engine_error, cap_for_arch, conversation_cache_slot, model_arch,
-                           generation_options, parse_tool_calls, read_engine_turn,
-                           render_chat, render_chat_kimi, render_chat_olmoe, serve,
-                           split_thinking_reply, stop_policy, tune_child_env)
+                           generation_options, parse_tool_calls, parse_dsv4_tool_calls,
+                           read_engine_turn, render_chat, render_chat_kimi, render_chat_olmoe,
+                           render_chat_v4, _dsv4_tool_calls, serve, split_thinking_reply,
+                           stop_policy, tune_child_env)
 
 
 class FakeEngine:
@@ -1124,6 +1125,101 @@ class ToolArgumentTypeTest(unittest.TestCase):
         args = self._args("<tool_call>lookup_order"
                           "<arg_key>extra</arg_key><arg_value>7</arg_value></tool_call>")
         self.assertEqual(args["extra"], 7)
+
+
+class DeepSeekV4ToolCallTest(unittest.TestCase):
+    """DeepSeek V4 (#916): DSML tool blocks. Schemas render into the first system/developer
+    message, assistant tool_calls render as <｜DSML｜invoke> blocks, tool results merge into
+    user turns as <tool_result>, and model output parses back into OpenAI tool_calls."""
+
+    DSML = "｜DSML｜"
+    WEATHER = [{"type": "function", "function": {
+        "name": "get_weather", "description": "current weather",
+        "parameters": {"type": "object", "properties": {
+            "city": {"type": "string"}, "days": {"type": "integer"}},
+            "required": ["city"]}}}]
+    CALL = [{"id": "call_1", "type": "function", "function": {
+        "name": "get_weather",
+        "arguments": json.dumps({"city": "Paris", "days": 3})}}]
+
+    def test_tools_declared_on_first_system_message(self):
+        prompt = render_chat_v4([{"role": "system", "content": "Be brief."},
+                                 {"role": "user", "content": "Weather?"}], tools=self.WEATHER)
+        self.assertLess(prompt.index("Be brief."), prompt.index("## Tools"))
+        self.assertIn(f'"{self.WEATHER[0]["function"]["name"]}"', prompt)
+        self.assertTrue(prompt.startswith("<｜begin▁of▁sentence｜>"))
+
+    def test_tools_prepended_when_no_system_message(self):
+        prompt = render_chat_v4([{"role": "user", "content": "hi"}], tools=self.WEATHER)
+        # The official encoder renders tools on an empty system message: bos + "\n\n" + tools.
+        self.assertTrue(prompt.startswith("<｜begin▁of▁sentence｜>\n\n## Tools"))
+
+    def test_tool_choice_none_suppresses_declaration(self):
+        prompt = render_chat_v4([{"role": "user", "content": "hi"}],
+                                tools=self.WEATHER, tool_choice="none")
+        self.assertNotIn("## Tools", prompt)
+
+    def test_developer_message_is_wrapped_in_user_token(self):
+        # encoding_dsv4.py wraps developer content in <｜User｜>; system stays bare.
+        prompt = render_chat_v4([{"role": "developer", "content": "Be terse."},
+                                 {"role": "user", "content": "hi"}], tools=self.WEATHER)
+        self.assertIn("<｜User｜>Be terse.", prompt)
+        self.assertNotIn("<｜User｜>## Tools", prompt)
+
+    def test_thinking_mode_prepends_effort_prompt(self):
+        # encoding_dsv4.py prepends the level prompt after BOS in thinking mode.
+        prompt = render_chat_v4([{"role": "user", "content": "hi"}], enable_thinking=True,
+                                reasoning_effort="high")
+        self.assertTrue(prompt.startswith("<｜begin▁of▁sentence｜>Reasoning Effort: High."))
+        self.assertTrue(prompt.endswith("<｜Assistant｜><think>"))
+        # V4-native level names work too; low adds nothing.
+        self.assertTrue(render_chat_v4([{"role": "user", "content": "hi"}],
+                                       enable_thinking=True, reasoning_effort="max").startswith(
+            "<｜begin▁of▁sentence｜>Reasoning Effort: Maximum."))
+        self.assertFalse(render_chat_v4([{"role": "user", "content": "hi"}],
+                                        enable_thinking=True, reasoning_effort="low").startswith(
+            "<｜begin▁of▁sentence｜>Reasoning Effort:"))
+
+    def test_assistant_tool_calls_render_as_dsml(self):
+        prompt = render_chat_v4([{"role": "user", "content": "Paris?"},
+                                 {"role": "assistant", "content": None,
+                                  "tool_calls": self.CALL}])
+        self.assertIn(f'<{self.DSML}invoke name="get_weather">', prompt)
+        self.assertIn(f'<{self.DSML}parameter name="city" string="true">Paris</{self.DSML}parameter>',
+                      prompt)
+        self.assertIn(f'<{self.DSML}parameter name="days" string="false">3</{self.DSML}parameter>',
+                      prompt)
+        self.assertTrue(prompt.endswith("</think>"))
+
+    def test_tool_results_merge_into_one_user_turn(self):
+        prompt = render_chat_v4([{"role": "user", "content": "Paris?"},
+                                 {"role": "assistant", "content": None, "tool_calls": self.CALL},
+                                 {"role": "tool", "tool_call_id": "call_1", "content": "21c"},
+                                 {"role": "tool", "tool_call_id": "call_1", "content": "sunny"},
+                                 {"role": "user", "content": "And London?"}])
+        self.assertEqual(prompt.count("<｜User｜>"), 2)
+        self.assertIn("<tool_result>21c</tool_result>", prompt)
+        self.assertIn("<tool_result>sunny</tool_result>", prompt)
+        self.assertIn("And London?", prompt)
+
+    def test_parse_dsml_reply_to_openai_tool_calls(self):
+        raw = (f"Here you go.\n\n<{self.DSML}tool_calls>\n"
+               f"<{self.DSML}invoke name=\"get_weather\">\n"
+               f"<{self.DSML}parameter name=\"city\" string=\"true\">Paris</{self.DSML}parameter>\n"
+               f"<{self.DSML}parameter name=\"days\" string=\"false\">3</{self.DSML}parameter>\n"
+               f"</{self.DSML}invoke>\n</{self.DSML}tool_calls><｜end▁of▁sentence｜>")
+        content, calls = parse_dsv4_tool_calls(raw)
+        self.assertEqual(content, "Here you go.")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["function"]["name"], "get_weather")
+        self.assertEqual(json.loads(calls[0]["function"]["arguments"]),
+                         {"city": "Paris", "days": 3})
+
+    def test_parse_truncated_block_leaks_no_markers(self):
+        content, calls = parse_dsv4_tool_calls("Almost.\n\n<｜DSML｜tool_calls><｜DSML｜invoke na")
+        self.assertEqual(calls, [])
+        self.assertEqual(content, "Almost.")
+        self.assertNotIn("DSML", content)
 
 
 class EngineErrorFrameTest(unittest.TestCase):

--- a/c/tests/test_v4_cli.py
+++ b/c/tests/test_v4_cli.py
@@ -208,14 +208,26 @@ class V4CliTest(unittest.TestCase):
             "<\uff5cUser\uff5c>Again<\uff5cAssistant\uff5c><think>",
         )
 
-    def test_openai_renderer_rejects_unwired_tools(self):
+    def test_openai_renderer_scaffolds_v4_tools(self):
         import openai_server
 
-        with self.assertRaises(openai_server.APIError):
-            openai_server.render_chat_v4(
-                [{"role": "user", "content": "hello"}],
-                tools=[{"type": "function"}],
-            )
+        prompt = openai_server.render_chat_v4(
+            [{"role": "user", "content": "hello"}],
+            tools=[{"type": "function", "function": {
+                "name": "get_weather",
+                "description": "current weather",
+                "parameters": {"type": "object", "properties": {
+                    "city": {"type": "string"}}, "required": ["city"]}}}],
+        )
+        self.assertIn("## Tools", prompt)
+        self.assertIn('"get_weather"', prompt)
+        # Sanity: tool_choice="none" suppresses the declaration.
+        no_tools = openai_server.render_chat_v4(
+            [{"role": "user", "content": "hello"}],
+            tools=[{"type": "function", "function": {"name": "get_weather"}}],
+            tool_choice="none",
+        )
+        self.assertNotIn("## Tools", no_tools)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #916.

Wire the official DeepSeek-V4 DSML tool format (`encoding/encoding_dsv4.py`) into the OpenAI and Anthropic paths. Tool use was previously rejected for `deepseek_v4` with `"Tool use is not wired up for DeepSeek V4 yet."`

## What this adds

- `render_chat_v4` now accepts `tools`/`tool_choice`: schemas render via the official `## Tools` block onto the first system/developer message (or an empty system message, byte-matching the encoder). Assistant `tool_calls` render as `<｜DSML｜tool_calls>`/`invoke`/`parameter` blocks, and tool results merge into user turns as `<tool_result>` blocks (V4 has no standalone tool role).
- `reasoning_effort` is honored in thinking mode by prepending the official `REASONING_EFFORT_PROMPTS` (high/max) after BOS; developer messages are wrapped in `<｜User｜>` per the encoder.
- New tolerant `parse_dsv4_tool_calls` maps DSML `string=true|false` params back to OpenAI `tool_calls`, drops the block and thinking/EOS markers from content, and cuts at the first DSML marker when output is length-truncated so raw syntax never leaks.
- `parse_arch_tool_calls` dispatches the 3 parse sites; streaming suppression (OpenAI + Anthropic SSE) uses arch-aware tool markers.

## Verification

- Byte-equivalence against the checkpoint's `encoding_dsv4.py`: 8 render cases, 5 parse cases.
- Unit tests: `test_openai_server` 131 OK, `test_anthropic_messages` 27 OK.
- Live tool-call round trip on the GPU engine.

GLM path unchanged.
