### PR TITLE
ci: stop running every dev commit twice, and bound every job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,31 @@ name: CI
 
 on:
   pull_request:
-    branches: [dev, main]
+    # dev only, deliberately. The release PR is dev->main, so its head IS dev:
+    # with `main` listed here every push to dev ran the whole matrix TWICE on
+    # one commit -- once for `push`, once for the open release PR -- 36 jobs
+    # where 18 suffice, and the duplicate pair is what filled release PRs with
+    # doubled check names. Check runs attach to the SHA, so the release PR
+    # still displays the push run's results. main carries no required status
+    # checks (its ruleset requires a review), so nothing merge-gating is lost,
+    # and a PR mistargeted at main visibly gets no CI -- which is the signal
+    # that it needs retargeting to dev.
+    branches: [dev]
   push:
     branches: [dev, main]
+
+# Supersede, don't accumulate: a second push to the same ref cancels the first
+# run instead of leaving both to burn runner slots. PR refs and branch refs get
+# distinct groups, so a merge to dev never cancels an unrelated PR.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   engine:
     name: Engine (Linux, CPU)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Build colibri + inkling
@@ -34,6 +51,7 @@ jobs:
   docker:
     name: Container image
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Build the slim image
@@ -70,6 +88,7 @@ jobs:
   sanitizers:
     name: Sanitizers (ASan + UBSan)
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
       - name: C suite under ASan + UBSan
@@ -94,6 +113,7 @@ jobs:
   vulkan:
     name: Vulkan (Lavapipe, software)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Install the Vulkan toolchain and a software driver
@@ -158,6 +178,7 @@ jobs:
             shell: "msys2 {0}"
             v4: "1"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     defaults:
       run:
         shell: ${{ matrix.shell }}
@@ -267,6 +288,7 @@ jobs:
   engine-cuda-syntax:
     name: CUDA syntax check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - name: Install CUDA toolkit (compiler only)
@@ -299,6 +321,7 @@ jobs:
   inkling-oracle:
     name: Inkling oracle (token-exact vs transformers)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -349,6 +372,7 @@ jobs:
   efficiency:
     name: Efficiency suite (tiny oracle)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -384,6 +408,7 @@ jobs:
   engine-hip-syntax:
     name: HIP syntax check
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - name: Free runner disk
@@ -442,6 +467,7 @@ jobs:
     # a CI quirk — pinning tracks what the toolkit actually supports. Revisit when
     # a CUDA release accepts VS 18; -allow-unsupported-compiler would only mask it.
     runs-on: windows-2022
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: MSVC environment (puts cl.exe on PATH for nvcc -ccbin)
@@ -492,6 +518,7 @@ jobs:
   web:
     name: Web UI
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: web
@@ -511,6 +538,7 @@ jobs:
   python:
     name: Python tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
**Measured, on a single commit (`33302b8`): 36 jobs where 18 suffice.**

```
CI     event=pull_request  -> 14 jobs
CI     event=push          -> 14 jobs   <- exact duplicate
check  event=pull_request  ->  4 jobs
check  event=push          ->  4 jobs   <- exact duplicate
```

**Cause**: the release PR is `dev -> main`, so its head *is* `dev`. With `main` listed under `pull_request`, every push to dev fired both events on the same SHA and ran the whole matrix twice. That is half the project's CI wall-clock, and it is also why release PRs show every check name doubled.

Dropping `main` from the PR trigger costs nothing: check runs attach to the **SHA**, so the release PR still displays the push run's results. `main`'s ruleset requires a **review**, not status checks, so nothing merge-gating is lost — and a PR mistargeted at main now visibly gets no CI, which is exactly the signal that it needs retargeting to dev.

Two more gaps, both things `check.yml` has had all along and `ci.yml` never did:

- **`concurrency` + `cancel-in-progress`** — superseded runs were never cancelled; they ran to completion burning slots nobody was waiting on.
- **`timeout-minutes` on all 12 jobs** — #947's macOS job hung *after* its step failed and held one of the five macOS runner slots for ~50 minutes, queueing every other PR behind it. Budgets (15–30) are hang backstops against a measured worst case of ~10 min, not targets.

**No check is removed and no job's content changes.** The same work runs, once instead of twice, with an upper bound.

Held for the maintainer's go-ahead until after the v1.6.0 tag — `release.yml` is a separate file and is untouched either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)