### PR TITLE
fix(api): cancel a generation that disconnects before the first frame (#908)

### DIFF
--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -1723,7 +1723,21 @@ class Engine:
                     on_accept(info)
 
         while True:
-            kind, value = events.get()
+            try:
+                kind, value = events.get(timeout=0.05)
+            except queue.Empty:
+                # #908: cancelled() is only polled in the "data" branch, so a
+                # client that disconnects before the engine's first DATA frame
+                # (it is still prefilling) never cancels: the CANCEL never went
+                # out, the turn ran to its token limit, and this thread stayed
+                # blocked until the engine emitted something. Poll the callback
+                # while idle so a pre-first-frame disconnect cancels too.
+                if not cancel_sent and not stop_sent and cancelled and cancelled():
+                    cancel_sent = True
+                    with self.write_lock:
+                        self.process.stdin.write(f"CANCEL {request_id}\n".encode())
+                        self.process.stdin.flush()
+                continue
             if kind == "accept":
                 if accepted:
                     raise RuntimeError("engine sent a duplicate ACCEPT frame")

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -601,6 +601,50 @@ class DispatcherTest(unittest.TestCase):
         self.assertEqual(output, ["x"])
         self.assertEqual(process.writes[-1].split(), [b"CANCEL", request_id])
 
+    def test_cancels_generation_before_first_frame(self):
+        # #908: a client that disconnects while the engine is still prefilling
+        # (no DATA frame has arrived) must cancel too. cancelled() used to be
+        # polled only in the "data" branch, so the CANCEL never went out and
+        # the turn ran to its token limit while this thread stayed blocked.
+        # The fake engine emits nothing until it sees CANCEL -- exactly the
+        # pre-first-frame regime -- and must still get one.
+        request_id = None
+
+        def respond(process, frame):
+            nonlocal request_id
+            fields = frame.split()
+            if fields[0] == b"SUBMIT":
+                request_id = fields[1]
+            elif fields[0] == b"CANCEL":
+                self.assertEqual(fields[1], request_id)
+                process.stdout.feed(b"ERROR " + request_id + b" CANCELLED\n")
+
+        process = FakeProcess(respond)
+        with patch("openai_server.subprocess.Popen", return_value=process):
+            engine = Engine("glm", "model")
+        flag = {"cancelled": False}
+        outcome = []
+
+        def generate():
+            try:
+                engine.generate("hello", 8, 0.7, 0.9, lambda _: None,
+                                cancelled=lambda: flag["cancelled"])
+            except ClientCancelled:
+                outcome.append("cancelled")
+
+        thread = threading.Thread(target=generate)
+        thread.start()
+        for _ in range(200):
+            if any(frame.startswith(b"SUBMIT") for frame in process.writes):
+                break
+            time.sleep(0.01)
+        flag["cancelled"] = True
+        thread.join(timeout=2)
+        self.assertFalse(thread.is_alive())
+        engine.close()
+        self.assertEqual(outcome, ["cancelled"])
+        self.assertEqual(process.writes[-1].split(), [b"CANCEL", request_id])
+
     def test_stops_generation_through_successful_done_path(self):
         request_id = None
 


### PR DESCRIPTION
Fixes #908 — the pre-first-token half of the disconnect spin, per the mechanism @terrizoaguimor pinned down in the thread.

**Root cause:** `Engine.generate()` only polled the `cancelled()` callback in the `kind == "data"` branch. A client that disconnects while the engine is still prefilling (before the first `DATA` frame) therefore never sent `CANCEL <id>` — the engine kept generating to its token limit and the generate thread stayed blocked in `events.get()` until the engine emitted something.

**Fix** (c/openai_server.py): the wait loop now uses `events.get(timeout=0.05)` and, while idle, polls `cancelled()`; a pre-first-frame disconnect sends the same `CANCEL <id>` the data branch would have, and the loop resolves via the engine's `CANCELLED` error exactly as before. `stopped()`/decode behavior is untouched; the idle poll costs nothing on the happy path (frames still return immediately).

**Regression test** (c/tests/test_openai_server.py): submit to `FakeProcess`, flip `cancelled()` to true before any `ACCEPT`/`DATA` frame, assert `CANCEL <id>` is written and the generate thread unblocks with `ClientCancelled` — model-free, mirroring the existing post-first-frame cancel test.

**Verified:** `test_openai_server.py` 123/123 ok; full `test_*.py` suite 430 tests OK (35 dependency skips).