### PR TITLE
fix(omp): skip the spin-wait tuning on macOS — measured slower (#707)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -9104,9 +9104,21 @@ int main(int argc, char **argv){
      * misurato (#707). */
     if(!getenv("COLI_OMP_TUNED") && !getenv("COLI_NO_OMP_TUNE") &&
        !coli_env_on("COLI_CUDA") && !coli_env_on("COLI_METAL")){
+        /* #707: the spin-wait knobs are measured HARMFUL on macOS / Apple
+         * Silicon with LLVM libomp. Reporter (M1 Max, 32 GB, GLM-5.2 int4):
+         * OMP_WAIT_POLICY=active alone +122% decode, KMP_BLOCKTIME=200 alone
+         * +115%. Reproduced on an M3 16 GB with the OLMoE engine (same libomp
+         * behaviour, smaller scale): wait-only 2.23 tok/s vs ~3.4 baseline
+         * (-34%), block-only 2.54 (-25%). The Linux/FreeBSD re-exec below
+         * never runs on Darwin (libomp's constructor already read the
+         * environment), so these setenvs are inert today -- but keep them OFF
+         * explicitly so a future Darwin exec path cannot apply a measured
+         * regression. The OMP_PROC_BIND/OMP_DYNAMIC pair is noise-level and
+         * stays for all platforms. */
+#ifndef __APPLE__
         setenv("OMP_WAIT_POLICY","active",0);  /* keep the team hot across the tiny per-expert matmul regions */
         setenv("GOMP_SPINCOUNT","200000",0);   /* spin briefly, then yield so long disk waits don't burn a core */
-        /* LLVM libomp (clang builds: FreeBSD cc, macOS, some Linux setups) does not
+        /* LLVM libomp (clang builds: FreeBSD cc, some Linux setups) does not
          * read GOMP_*: with OMP_WAIT_POLICY=active it sets KMP_BLOCKTIME=infinite,
          * so the idle team SPINS FOREVER once generation ends — a serve-mode engine
          * parked on stdin burns ~100% x nthreads (#341, measured 3000% on FreeBSD).
@@ -9114,6 +9126,10 @@ int main(int argc, char **argv){
          * and lets it sleep at the prompt. libgomp ignores KMP_*; overwrite=0 keeps
          * the user's own setting authoritative. */
         setenv("KMP_BLOCKTIME","200",0);
+#else
+        fprintf(stderr,"[OMP] hot-thread tuning skipped on macOS (#707): spin-wait knobs "
+                       "measured slower on Apple Silicon (COLI_NO_OMP_TUNE=1 to skip)\n");
+#endif
         setenv("OMP_PROC_BIND","close",0);     /* pack the team onto adjacent cores for cache locality */
         setenv("OMP_DYNAMIC","FALSE",0);       /* fixed team size: no per-region thread-count churn */
         setenv("COLI_OMP_TUNED","1",1);


### PR DESCRIPTION
Addresses #707 (item 1). Item 2 (team size includes efficiency cores) is already covered by `coli_omp_tune_threads` on dev — the M3 sizes to its 4 P cores, not 8 logical.

**Problem:** `colibri.c`'s hot-thread block set `OMP_WAIT_POLICY=active` / `GOMP_SPINCOUNT` / `KMP_BLOCKTIME=200` on every platform, but the self-re-exec that makes them effective is Linux/FreeBSD-only — on macOS they are inert. That is currently a *good* thing: the #707 measurements show the knobs are a regression on Apple Silicon with LLVM libomp.

**Measurements:**

Reporter (M1 Max, 32 GB, GLM-5.2 int4, from #707):
| condition | vs baseline |
|---|---|
| `OMP_WAIT_POLICY=active` alone | **+122%** decode time |
| `KMP_BLOCKTIME=200` alone | **+115%** |
| `OMP_DYNAMIC=FALSE` | +0.8% (noise) |

Reproduced here on an Apple M3 16 GB, OLMoE int8 (cap 16, TEMP=0, 128-token capped decode — same libomp behaviour, smaller scale):
| condition | tok/s | vs baseline |
|---|---|---|
| baseline (A1/A2/A3) | 3.82 / 3.18 / 3.43 (~3.4 mean) | — |
| `OMP_WAIT_POLICY=active` alone | **2.23** | **-34%** |
| `KMP_BLOCKTIME=200` alone | **2.54** | **-25%** |
| all four knobs | 2.87 / 3.01 | -5% / -25% |

Same direction on both hosts: the spin-wait knobs hurt decode on macOS/libomp.

**Fix** (c/colibri.c): the three spin-wait setenvs are now `#ifndef __APPLE__`, with an explicit `[OMP] hot-thread tuning skipped on macOS (#707)...` note on Darwin — so the intent is explicit, a future Darwin exec path cannot apply a measured regression, and users copying the Linux recipe get told why it is skipped. `OMP_PROC_BIND`/`OMP_DYNAMIC` (noise-level per both measurements) and the #718 physical-core sizing stay for all platforms; Linux/FreeBSD paths are byte-identical (preprocessor-only change).

**Verified:** `make colibri` on macOS — Darwin branch fires (message + `SNAP=<dir>` exit); full `test_*.py` suite 436 tests OK (38 dependency skips).