### PR TITLE
convert_inkling: support output locking on Windows

### DIFF
--- a/c/tests/test_inkling_converter_lock.py
+++ b/c/tests/test_inkling_converter_lock.py
@@ -1,0 +1,63 @@
+import ast
+import builtins
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+CONVERTER = Path(__file__).resolve().parent.parent / "tools" / "convert_inkling_int4.py"
+ERROR = "ERROR: another converter is already using this output directory."
+
+
+def load_lock_helper():
+    tree = ast.parse(CONVERTER.read_text(encoding="utf-8"), filename=str(CONVERTER))
+    helper = next(node for node in tree.body
+                  if isinstance(node, ast.FunctionDef) and node.name == "acquire_output_lock")
+    namespace = {"os": os, "sys": sys}
+    exec(compile(ast.Module(body=[helper], type_ignores=[]), str(CONVERTER), "exec"), namespace)
+    return namespace["acquire_output_lock"]
+
+
+class InklingConverterLockTest(unittest.TestCase):
+    def setUp(self):
+        self.acquire_output_lock = load_lock_helper()
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+
+    def test_unix_uses_nonblocking_flock(self):
+        fcntl = types.SimpleNamespace(LOCK_EX=2, LOCK_NB=4, flock=mock.Mock())
+        with mock.patch.dict(sys.modules, {"fcntl": fcntl}):
+            lock = self.acquire_output_lock(self.directory.name)
+        self.addCleanup(lock.close)
+        fcntl.flock.assert_called_once_with(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def test_windows_uses_nonblocking_msvcrt_lock(self):
+        msvcrt = types.SimpleNamespace(LK_NBLCK=3, locking=mock.Mock())
+        real_import = builtins.__import__
+
+        def platform_import(name, *args, **kwargs):
+            if name == "fcntl":
+                raise ImportError("fcntl is unavailable")
+            if name == "msvcrt":
+                return msvcrt
+            return real_import(name, *args, **kwargs)
+
+        with mock.patch("builtins.__import__", side_effect=platform_import):
+            lock = self.acquire_output_lock(self.directory.name)
+        self.addCleanup(lock.close)
+        msvcrt.locking.assert_called_once_with(lock.fileno(), msvcrt.LK_NBLCK, 1)
+
+    def test_lock_contention_keeps_existing_error(self):
+        fcntl = types.SimpleNamespace(
+            LOCK_EX=2, LOCK_NB=4, flock=mock.Mock(side_effect=BlockingIOError))
+        with mock.patch.dict(sys.modules, {"fcntl": fcntl}), \
+             self.assertRaisesRegex(SystemExit, ERROR):
+            self.acquire_output_lock(self.directory.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tools/convert_inkling_int4.py
+++ b/c/tools/convert_inkling_int4.py
@@ -223,6 +223,29 @@ AUX_FILES = ["config.json", "tokenizer.json", "tokenizer_config.json",
              "special_tokens_map.json", "chat_template.jinja"]
 
 
+def acquire_output_lock(outdir):
+    lock = open(os.path.join(outdir, ".convert.lock"), "w")
+    try:
+        import fcntl
+    except ImportError:
+        try:
+            import msvcrt
+        except ImportError:
+            return lock
+        try:
+            msvcrt.locking(lock.fileno(), msvcrt.LK_NBLCK, 1)
+        except OSError:
+            lock.close()
+            sys.exit("ERROR: another converter is already using this output directory.")
+    else:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            lock.close()
+            sys.exit("ERROR: another converter is already using this output directory.")
+    return lock
+
+
 def shard_out_name(src):
     m = re.search(r"model-(\d+)-of-\d+\.safetensors$", os.path.basename(src))
     return f"out-{m.group(1)}.safetensors" if m else \
@@ -418,12 +441,7 @@ def main():
     if not a.indir or not a.outdir:
         ap.error("--indir and --outdir required")
     os.makedirs(a.outdir, exist_ok=True)
-    lock = open(os.path.join(a.outdir, ".convert.lock"), "w")
-    import fcntl
-    try:
-        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except OSError:
-        sys.exit("ERROR: another converter is already using this output directory.")
+    lock = acquire_output_lock(a.outdir)
     convert_dir(a.indir, a.outdir, a.xbits, watch=a.watch, delete_src=a.delete_src)
 
 


### PR DESCRIPTION
## Summary

- use `fcntl.flock` when it is available
- fall back to `msvcrt.locking` on native Windows Python
- keep the lock handle alive until conversion exits

## Problem

`convert_inkling_int4.py` imports `fcntl` unconditionally while acquiring its output-directory lock. Native Windows Python does not provide that module, so the converter exits before it can process a shard.

The GLM converter already carries the required platform split. This change gives the Inkling converter the same behavior without changing the lock contract.

## Validation

- `python3 -m unittest tests.test_inkling_converter_lock -v` passed 3 tests on macOS. The suite exercises the Unix `fcntl` path, a simulated native Windows `msvcrt` path, and the existing contention error without importing optional model dependencies.
- `python3 -m py_compile tools/convert_inkling_int4.py` passed on macOS.
- `make check` passed on macOS. The Python suite ran 424 tests with 57 dependency or platform skips, and the C tests passed. The build emitted the existing unused `KV_GB` warning in `tests/test_k3_ram_budget.c`.
- Native Windows execution was not run during implementation. The earlier Windows 10 pc1 audit found that `fcntl` was unavailable, `msvcrt.locking(..., LK_NBLCK, 1)` acquired the converter's empty lock-file shape, and a competing handle received `PermissionError`.