### PR TITLE
coli: select python.exe from Windows project venvs

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -1372,12 +1372,19 @@ def cmd_web(a):
     print(f"dashboard: {url}  (opens automatically when the engine is ready)")
     cmd_serve(a)
 
+def project_python():
+    if sys.platform == "win32":
+        candidate = os.path.join(HERE, "mio_env", "Scripts", "python.exe")
+    else:
+        candidate = os.path.join(HERE, "mio_env", "bin", "python3")
+    return candidate if os.path.exists(candidate) else sys.executable
+
+
 def cmd_bench(a):
     need_model(a.model)
     banner("bench")
     # python con `tokenizers`: l'ambiente del progetto se c'e', altrimenti quello corrente
-    venv_py = os.path.join(HERE, "mio_env", "Scripts" if sys.platform == "win32" else "bin", "python3")
-    py = venv_py if os.path.exists(venv_py) else sys.executable
+    py = project_python()
     tasks = ",".join(a.tasks) if a.tasks else "hellaswag,arc_challenge,mmlu"
     # dataset mancanti -> li scarica una volta (fetch_benchmarks.py li mette in --data come JSONL)
     missing=[t for t in tasks.split(",") if not os.path.exists(os.path.join(a.data,f"{t}.jsonl"))]
@@ -1410,8 +1417,7 @@ def cmd_convert(a):
         sys.exit(f"{C.yel}no output directory given.{C.r}\n"
                  f"  --model <dir> is where the converted model is written")
     # python con torch/safetensors: l'ambiente del progetto se c'e', altrimenti quello corrente
-    venv_py = os.path.join(HERE, "mio_env", "Scripts" if sys.platform == "win32" else "bin", "python3")
-    py = venv_py if os.path.exists(venv_py) else sys.executable
+    py = project_python()
     base=[py, os.path.join(TOOLS,"convert_fp8_to_int4.py"),
           "--repo", a.repo, "--outdir", a.model, "--ebits", str(a.ebits), "--io-bits", str(a.io_bits),
           "--group-size", str(a.group_size)]

--- a/c/tests/test_launcher_dispatch.py
+++ b/c/tests/test_launcher_dispatch.py
@@ -24,9 +24,12 @@ import importlib.machinery
 import importlib.util
 import json
 import os
+import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 HERE = Path(__file__).resolve().parent.parent
@@ -103,6 +106,59 @@ class LauncherDispatchTest(unittest.TestCase):
         """Guards the whole file: if _BANNER_MODELS is ever renamed or emptied,
         the loops above pass vacuously and this suite proves nothing."""
         self.assertGreaterEqual(len(self.cli._BANNER_MODELS), 5)
+
+
+class ProjectPythonTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cli = load_cli()
+
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+
+    def test_bench_and_convert_use_windows_project_python(self):
+        python = self.root / "mio_env" / "Scripts" / "python.exe"
+        python.parent.mkdir(parents=True)
+        python.write_bytes(b"")
+        data = self.root / "data"
+        data.mkdir()
+        (data / "hellaswag.jsonl").write_text("", encoding="utf-8")
+
+        bench = types.SimpleNamespace(
+            model="model", tasks=["hellaswag"], data=str(data), limit=1, ram=None)
+        convert = types.SimpleNamespace(
+            model="output", repo="repo", ebits=4, io_bits=4,
+            group_size=128, xbits=None, no_mtp=True)
+
+        with mock.patch.object(self.cli, "HERE", str(self.root)), \
+             mock.patch.object(self.cli.sys, "platform", "win32"), \
+             mock.patch.object(self.cli, "need_model"), \
+             mock.patch.object(self.cli, "banner"), \
+             mock.patch.object(self.cli, "env_for", return_value={}), \
+             mock.patch.object(self.cli.subprocess, "call", return_value=0) as call:
+            with self.assertRaisesRegex(SystemExit, "0"):
+                self.cli.cmd_bench(bench)
+            self.assertEqual(call.call_args.args[0][0], str(python))
+
+            call.reset_mock()
+            with self.assertRaisesRegex(SystemExit, "0"):
+                self.cli.cmd_convert(convert)
+            self.assertEqual(call.call_args.args[0][0], str(python))
+
+    def test_posix_project_python_is_unchanged(self):
+        python = self.root / "mio_env" / "bin" / "python3"
+        python.parent.mkdir(parents=True)
+        python.write_bytes(b"")
+        with mock.patch.object(self.cli, "HERE", str(self.root)), \
+             mock.patch.object(self.cli.sys, "platform", "linux"):
+            self.assertEqual(self.cli.project_python(), str(python))
+
+    def test_missing_project_python_falls_back_to_current_interpreter(self):
+        with mock.patch.object(self.cli, "HERE", str(self.root)), \
+             mock.patch.object(self.cli.sys, "platform", "win32"):
+            self.assertEqual(self.cli.project_python(), sys.executable)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- select `mio_env\Scripts\python.exe` on Windows
- keep `mio_env/bin/python3` on POSIX systems
- share the selection logic between `coli bench` and `coli convert`

## Problem

Both commands currently append `python3` after choosing the Windows `Scripts` directory. Standard Windows venvs create `Scripts\python.exe`, so the existence check misses the project environment and silently falls back to the interpreter running `coli`.

That fallback can bypass the environment containing the converter or benchmark dependencies. It also makes the existing comment about preferring the project environment untrue on Windows.

## Validation

- `python3 -m unittest tests.test_launcher_dispatch tests.test_cli_output -v` passed 31 tests on macOS. The launcher test creates a temporary Windows venv layout and verifies that both bench and convert select `Scripts\python.exe`. It also covers the unchanged POSIX path and the missing-venv fallback.
- `python3 -m py_compile coli` passed on macOS.
- `make check` passed on macOS. The Python suite ran 424 tests with 57 dependency or platform skips, and the C tests passed. The build emitted the existing unused `KV_GB` warning in `tests/test_k3_ram_budget.c`.
- Native Windows execution was not run during implementation. The earlier Windows 10 pc1 audit created a standard-library venv that contained `Scripts\python.exe` and did not contain `Scripts\python3`.