### PR TITLE
fix(build): compile CUDA backend on glibc >= 2.41

### DIFF
--- a/c/.gitignore
+++ b/c/.gitignore
@@ -3,6 +3,8 @@ glm_tiny/
 olmoe_hf/
 olmoe_i4/
 .build-config
+build/
+COLI_V4_UNIT_*.o
 tests/test_st_mirror
 tests/test_st_pread
 tools/libiq3.so

--- a/c/Makefile
+++ b/c/Makefile
@@ -218,6 +218,14 @@ ifneq ($(IS_WIN),)
 NVCCFLAGS ?= -O3 -std=c++17 $(CUDA_GENCODE) -Xcompiler=-W3
 else
 NVCCFLAGS ?= -O3 -std=c++17 $(CUDA_GENCODE) -Xcompiler=-Wall,-Wextra
+# glibc >= 2.41 declares the C23 math additions (rsqrt/rsqrtf, sinpi/cospi, ...)
+# with __THROW -> noexcept(true), clashing with CUDA's crt/math_functions.h
+# under C++17 (noexcept is part of the function type since C++17). Force-include
+# a compat header that strips __THROW from the host pass; see
+# glibc_c23_math_compat.h. MSVC never sees glibc headers, so Linux-only.
+ifneq ($(LINUX),)
+NVCCFLAGS += -Xcompiler=-include,$(CURDIR)/glibc_c23_math_compat.h
+endif
 endif
 # HIP=1 builds the SAME backend for AMD GPUs via ROCm: backend_cuda.cu is
 # compiled unchanged through backend_gpu_compat.h (one source, two vendors,

--- a/c/glibc_c23_math_compat.h
+++ b/c/glibc_c23_math_compat.h
@@ -22,8 +22,8 @@
 #define COLI_GLIBC_C23_MATH_COMPAT_H
 
 #if defined(__cplusplus) && defined(__linux__)
-#include <sys/cdefs.h> /* glibc's own guards; forces __THROW into existence */
-#if defined(__THROW)
+#include <features.h> /* defines __GLIBC__ on glibc; musl ships one too */
+#if defined(__GLIBC__) && defined(__THROW)
 #undef __THROW
 #define __THROW
 #endif

--- a/c/glibc_c23_math_compat.h
+++ b/c/glibc_c23_math_compat.h
@@ -1,0 +1,32 @@
+// glibc_c23_math_compat.h — glibc >= 2.41 C++17 noexcept clash for CUDA host passes.
+//
+// glibc >= 2.41 (Debian trixie, Ubuntu 26.04, ...) declares the C23 math
+// additions (rsqrt/rsqrtf, sinpi/cospi, ...) via __THROW, which expands to
+// noexcept(true) in C++. CUDA's crt/math_functions.h declares the same
+// functions WITHOUT an exception specification, and since C++17 noexcept is
+// part of the function type, nvcc's host pass fails with:
+//
+//   mathcalls.h: error: exception specification is incompatible with that of
+//   previous function "rsqrt" (declared at ... crt/math_functions.h)
+//
+// This header is force-included into the HOST pass (NVCCFLAGS
+// -Xcompiler=-include, ... on Linux). It strips glibc's __THROW so the C
+// declarations carry no exception specification, matching CUDA's. The device
+// pass is unaffected: -Xcompiler flags never reach nvcc's device frontend,
+// and it includes CUDA's math_functions.h directly.
+//
+// Deliberately Linux-only: Windows builds use MSVC cl.exe, which never sees
+// glibc headers.
+
+#ifndef COLI_GLIBC_C23_MATH_COMPAT_H
+#define COLI_GLIBC_C23_MATH_COMPAT_H
+
+#if defined(__cplusplus) && defined(__linux__)
+#include <sys/cdefs.h> /* glibc's own guards; forces __THROW into existence */
+#if defined(__THROW)
+#undef __THROW
+#define __THROW
+#endif
+#endif /* __cplusplus && __linux__ */
+
+#endif /* COLI_GLIBC_C23_MATH_COMPAT_H */


### PR DESCRIPTION
glibc >= 2.41 (Debian trixie, Ubuntu 26.04, ...) declares the C23 math additions (rsqrt/rsqrtf, sinpi/cospi, ...) via __THROW, which expands to noexcept(true) in C++. CUDA's crt/math_functions.h declares the same functions without an exception specification, and since C++17 noexcept is part of the function type, nvcc's host pass fails with:

  mathcalls.h: error: exception specification is incompatible with that
  of previous function "rsqrt" (declared at ... crt/math_functions.h)

Force-include c/glibc_c23_math_compat.h into the host pass on Linux (NVCCFLAGS -Xcompiler=-include). It strips glibc's __THROW so the C declarations carry no exception specification, matching CUDA's. The device pass is unaffected (-Xcompiler flags never reach nvcc's device frontend).

Also ignore the V4 unit-test artifacts (COLI_V4_UNIT_*.o, build/) that `make test` produces on Linux.