### PR TITLE
fix(pilot): free the recency sentinel when a speculative load fails

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -5157,7 +5157,14 @@ static void pilot_realload(Model *m, int layer, int eid){
         dst->used=(uint64_t)__atomic_add_fetch(&m->eclock,1,__ATOMIC_RELAXED);  /* eid gia' reale (expert_load); timbra used fresco */
         atomic_fetch_add_explicit(&g_pilot_loads,1,memory_order_relaxed);
     } else {
-        dst->eid=-1;                                    /* load fallito: libera la prenotazione (slot resta in ecn ma nascosto, riusabile) */
+        /* load fallito: libera la prenotazione. LO SLOT VA ANCHE RIPORTATO A used=0:
+         * la prenotazione lo aveva marcato used=(uint64_t)-1 ("in carica", mai vittima),
+         * e lasciarlo cosi' lo rendeva invisibile agli hit ma ULTIMO in ogni scan LRU —
+         * mai evictable: ogni speculazione fallita (disco lento, errore I/O transitorio)
+         * sottraeva ~19MB di cache in modo permanente e silenzioso. used=0 e' la stessa
+         * convenzione "slot vergine" di rss_guard: diventa la PRIMA vittima, non l'ultima. */
+        dst->eid=-1;
+        dst->used=0;
         atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);
     }
     g_pilot_inflight[layer]--;


### PR DESCRIPTION
## The bug

`pilot_realload` reserves its LRU slot with `used=(uint64_t)-1` — the "in load, never evict me" sentinel — and stamps a fresh `used` on success. The **failure** path reset only `eid=-1`:

```c
dst->used=(uint64_t)-1;   /* sentinel: never LRU-evictable while loading */
...
} else {
    dst->eid=-1;          /* freed... except `used` stayed UINT64_MAX */
```

A slot in that state is:
- **invisible to hits** (`eid==-1` matches nothing),
- **last in every demand-path LRU victim scan** (`min used` wins; `UINT64_MAX` never is),
- so **never reclaimable by the demand path**. Every failed speculative load permanently removed one ~19 MB slot from the effective expert cache. Failures cluster exactly where they should hurt least: slow/flaky drives, transient I/O errors, `O_DIRECT` fallbacks — the same scenarios the mirror machinery exists for. The bleed is silent: `ecn` still counts the slot, the stats lines show nothing.

## The fix

Reset `used=0` next to `eid=-1` — the same "virgin slot" convention `rss_guard`'s in-place free already uses (`eid=-1, used=0`, "primo"): a failed slot becomes the *first* eviction candidate and the first slot the pilot itself reuses (`eid==-1` scan hits it too). The URING arm never set the sentinel, so it is unchanged.

Placement/cache only: routing, tokens, and the load path are untouched; the token-exact oracle gates the rest.
