### PR TITLE
fix(olmoe): COLI_TEMP channel, and never evict an in-flight slot

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -392,7 +392,10 @@ def env_for_engine(a, arch):
     if arch == "olmoe":
         env["CHAT"] = "1"
         env["MAX_NEW"] = str(ngen_for(a))
-        if a.temp is not None: env["TEMP"] = str(a.temp)
+        # olmoe reads COLI_TEMP like every other engine (line above). Setting the
+        # legacy TEMP alias here also clobbered %TEMP% with "0.7" for every child
+        # of the chat process on Windows — and olmoe never read COLI_TEMP, so the
+        # ONLY working channel was a poisoned system variable (#509's exact shape).
     # --ram reaches the engines that read it. kimi_k3 gained a RAM budget in
     # #855; before that `grep -c RAM_GB c/kimi_k3.c` returned 0, so `coli chat
     # --ram 242` on Kimi K3 set an environment variable nobody looked at and the

--- a/c/olmoe.c
+++ b/c/olmoe.c
@@ -468,7 +468,22 @@ static void expert_get(Model *m, int layer, int eid, Slot **out) {
                 if (lru < 0 || lc->slots[i].used < lc->slots[lru].used) lru = i;
             }
         }
-        if (lru < 0) lru = 0; /* absolute last resort: all in-flight, evict slot 0 */
+        while (lru < 0) {
+            /* EVERY slot is in flight: each buffer is owned by an unlocked pread
+             * in the pilot worker (or a demand load) that will publish into it.
+             * The old last resort (lru=0) stole such a slot mid-load — two writers
+             * racing the same slab, then whichever published last decided the
+             * expert id the resident bytes answered to. Wait for a publish instead
+             * and rescan; in-flight always drains because a load either finishes
+             * or the process is already dead in the water. */
+            pthread_mutex_unlock(&g_pilot_mx);
+            sleep_ms(1);
+            pthread_mutex_lock(&g_pilot_mx);
+            for (int i = 0; i < lc->n; i++) {
+                if (lc->slots[i].eid < 0) continue;
+                if (lru < 0 || lc->slots[i].used < lc->slots[lru].used) lru = i;
+            }
+        }
         s = &lc->slots[lru];
         s->pinned = 0;
     }
@@ -1323,7 +1338,15 @@ int main(int argc, char **argv) {
     }
 
     if (getenv("CHAT")) {   /* interactive mode: bypasses the ref.json harness entirely */
-        g_temp = getenv("TEMP")    ? (float)atof(getenv("TEMP"))    : g_temp;
+        /* #509 convention, same as the GLM engine: COLI_TEMP is the primary channel;
+         * TEMP stays a legacy alias ONLY when it is fully numeric — on Windows and under
+         * ROCm stacks %TEMP% names a directory, and atof("C:\...") == 0.0 would silently
+         * force greedy decoding for every olmoe chat on those hosts. */
+        if (getenv("COLI_TEMP")) g_temp = (float)atof(getenv("COLI_TEMP"));
+        else if (getenv("TEMP") && *getenv("TEMP")) {
+            char *tend; double tv = strtod(getenv("TEMP"), &tend);
+            if (tend != getenv("TEMP") && *tend == '\0') g_temp = (float)tv;
+        }
         g_nuc  = getenv("NUCLEUS") ? (float)atof(getenv("NUCLEUS")) : g_nuc;
         int ctx_cap = getenv("CTX") ? atoi(getenv("CTX")) : 4096;
         if (ctx_cap < 1 || ctx_cap > 4096) {   /* attention()'s sc[4096] score buffer hard-caps this */

--- a/c/tests/test_v4_cli.py
+++ b/c/tests/test_v4_cli.py
@@ -70,7 +70,14 @@ class V4CliTest(unittest.TestCase):
         env = self.cli.env_for_engine(args, "olmoe")
         self.assertEqual(env["CHAT"], "1")
         self.assertEqual(env["MAX_NEW"], "32")
-        self.assertEqual(env["TEMP"], "0.25")
+        # #509 for olmoe: the engine reads COLI_TEMP like every other arch.
+        # The legacy TEMP channel double-poisoned on Windows: it overrode the
+        # child's %TEMP% directory with "0.25", while a real %TEMP% path read
+        # back as atof("C:\...") == 0.0 and silently forced greedy decoding.
+        # env starts from os.environ, so TEMP may be inherited — the launcher
+        # must simply never write the temperature there.
+        self.assertEqual(env["COLI_TEMP"], "0.25")
+        self.assertNotEqual(env.get("TEMP"), "0.25")
 
     def test_olmoe_run_uses_its_engine_and_writes_one_prompt_line(self):
         directory, root = self.make_model("olmoe")


### PR DESCRIPTION
## Two silent-failure fixes in OLMoE — both are GLM-cured defects that never reached the sibling (the recurring shape in this tree)

### 1. Temperature: OLMoE carried #509 after GLM was cured

`olmoe.c` read `TEMP` raw, and the launcher exported `TEMP=<temp>` for olmoe (`coli --temp`):

- On Windows / ROCm stacks `%TEMP%` is a **directory path**; `atof("C:\...")` is `0.0`, so every olmoe chat silently forced **greedy decoding** — with the user setting apparently in effect.
- Conversely, `coli chat --temp 0.7` on olmoe **overwrote the child process's own `%TEMP%` with "0.7"** for anything that honored it downstream.

This is exactly why #509 moved GLM to `COLI_TEMP`. OLMoE now follows the same contract: **`COLI_TEMP` primary, `TEMP` as a legacy alias only when fully numeric** (same full-parse rule as `temp_from_env`). The launcher stops writing `TEMP` for olmoe — `COLI_TEMP` was already set for every arch.

`tests/test_v4_cli.py`'s olmoe block asserted `env["TEMP"] == "0.25"` — it was pinning the poisoning. It now pins the contract (`COLI_TEMP` set, `TEMP` never written by the launcher).

### 2. `expert_get`: the all-in-flight last resort raced the pilot's writer

When every cache slot was reserved (`eid==-1` — a pread physically in progress, usually the pilot's), the eviction fallback did:

```c
if (lru < 0) lru = 0; /* absolute last resort: all in-flight, evict slot 0 */
```

then loaded into that slot's slab **outside the lock** — while the pilot worker was mid-`load_expert_merged` into the same slab. Two writers racing one buffer, and whichever published last decided which expert id the resident bytes answered to → silently wrong weights from cache. It is the one place in the tree contradicting the in-flight exclusion every sibling honors (kimi_k3 keeps the read pending, V4 skips referenced slots, colibri.c marks reservations never-evictable).

The fallback now **waits for an in-flight publish (1 ms poll) and rescans**. The wait always drains: a load either finishes or the host is already dead in the water. Normal-pressure eviction is unchanged — pass 1 (skip pinned+in-flight) and pass 2 (allow pinned, never in-flight) are byte-identical.
