### PR TITLE
ci: run focused Python tests on native Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,3 +518,22 @@ jobs:
           python-version: '3.12'
       - name: Python test suite
         run: cd c && python3 -m unittest discover -s tests -p 'test_*.py'
+
+  windows-python-focused:
+    name: Python tests (Windows focused)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Converter and launcher tests
+        shell: pwsh
+        run: |
+          cd c
+          $suites = @(
+            'tests.test_launcher_dispatch'
+            'tests.test_inkling_converter_lock'
+            'tests.test_convert_positioned_write'
+          )
+          python -m unittest -v @suites


### PR DESCRIPTION
## Summary

I added a focused `windows-latest` job that runs the launcher dispatch, Inkling converter lock, and positioned-write test modules with Python 3.12.

The fixes for Windows project-venv selection, Inkling output locking, and positioned shard writes have all merged into `dev`. Their regression test modules are present on the current base, so the workflow invokes all three directly without file-existence guards.

## Why

Current CI can exercise the Windows branches through mocks, while the unmocked runs use Unix interpreters. This job complements that coverage by running the suites with native Windows CPython. In that environment, `fcntl` is genuinely absent, `os.pwrite` is unavailable, and the Windows CRT performs newline translation unless files are opened in binary mode.

This gives the platform-specific behavior real-interpreter coverage while keeping the Windows job limited to the relevant suites.

## Verification

I rebased the change onto current `dev` and ran each module locally. All 13 tests passed: 7 launcher dispatch tests, 3 Inkling lock tests, and 3 positioned-write tests.
