### PR TITLE
v4: max_tokens is a ceiling — clamp to context instead of rejecting (#975)

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -1003,7 +1003,7 @@ def chat_attached(a, base, model_id):
     its KV slots reuse the conversation prefix, so a continued chat skips
     re-prefill too. The engine byte-protocol stays untouched — this is plain
     OpenAI SSE over localhost, stdlib only."""
-    import urllib.request
+    import urllib.request, urllib.error
     print(f"  {C.grn}✦ attached{C.r} {C.dim}to {base} · model {model_id} · the engine stays warm after you quit{C.r}")
     print(f"  {C.dim}type and press Enter · Ctrl-C stops the answer · :reset starts a new conversation · :q exits{C.r}\n")
     msgs=[]
@@ -1048,6 +1048,20 @@ def chat_attached(a, base, model_id):
                         md.feed(txt); reply.append(txt)
         except KeyboardInterrupt:
             interrupted=True                          # il server annulla la richiesta alla disconnessione
+        except urllib.error.HTTPError as e:
+            # HTTPError IS-A OSError: without this arm a 4xx/5xx fell into the
+            # branch below and read as "server unreachable" — hiding the API's
+            # own explanation of what was wrong with the request (#975: a V4
+            # CONTEXT_EXCEEDED 400 took a screenshot to diagnose instead of a
+            # sentence). The body is OpenAI-shaped; show its message.
+            sp.stop()
+            try:
+                detail=json.loads(e.read().decode("utf-8","replace")).get("error",{}).get("message","")
+            except Exception:
+                detail=""
+            print(f"\n  {C.yel}[the server rejected the request: HTTP {e.code}"
+                  f"{' — '+detail if detail else ''}]{C.r}")
+            msgs.pop(); continue                      # la richiesta non è mai partita: togli il turno e riprova
         except OSError as e:
             sp.stop()
             print(f"\n  {C.yel}[server unreachable: {e}]{C.r}"); break

--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -8744,11 +8744,20 @@ static void v4_serve_one(ColiV4Engine *engine, ColiV4Session *session,
     if (prompt_count < 1 || prompt_count > session->max_prompt_tokens ||
         prompt_count + 1 > context) {
         /* The PROMPT does not fit (or leaves no room for a single generated
-         * token) -- that is the only honest CONTEXT_EXCEEDED. */
+         * token) -- that is the only honest CONTEXT_EXCEEDED.
+         *
+         * Format contract: the gateway parses `CONTEXT_EXCEEDED <used>
+         * <limit>` as bare positional numbers (openai_server.py, matching
+         * the GLM engine's emission). The previous key=value fields were
+         * interpolated verbatim into the client-facing message, which told
+         * #975's reporter his "maximum context length is requested=16384"
+         * -- the request, not the capacity, which never appeared at all. */
+        int prompt_capacity = session->max_prompt_tokens < context - 1
+                                  ? session->max_prompt_tokens
+                                  : context - 1;
         char message[256];
-        snprintf(message, sizeof(message),
-                 "CONTEXT_EXCEEDED prompt_tokens=%d requested=%d capacity=%d",
-                 prompt_count, request->max_tokens, context);
+        snprintf(message, sizeof(message), "CONTEXT_EXCEEDED %d %d",
+                 prompt_count, prompt_capacity);
         v4_serve_error(request->id, message);
         return;
     }

--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -8742,13 +8742,28 @@ static void v4_serve_one(ColiV4Engine *engine, ColiV4Session *session,
                                   session->max_prompt_tokens + 16);
     int context = engine->runtime.context_tokens;
     if (prompt_count < 1 || prompt_count > session->max_prompt_tokens ||
-        prompt_count + request->max_tokens > context) {
+        prompt_count + 1 > context) {
+        /* The PROMPT does not fit (or leaves no room for a single generated
+         * token) -- that is the only honest CONTEXT_EXCEEDED. */
         char message[256];
         snprintf(message, sizeof(message),
                  "CONTEXT_EXCEEDED prompt_tokens=%d requested=%d capacity=%d",
                  prompt_count, request->max_tokens, context);
         v4_serve_error(request->id, message);
         return;
+    }
+    /* max_tokens is a CEILING, not a target (#260/#382): generation ends at
+     * EOS either way, so an oversized budget is clamped to what the context
+     * can hold -- the same semantics the GLM serve path has had since #260.
+     * Rejecting instead made `coli chat`'s interactive default (16384) a
+     * guaranteed 400 on every first message of a fresh V4 chat (#975). */
+    if (request->max_tokens > context - prompt_count) {
+        fprintf(stderr,
+                "[V4] max_tokens %d clamped to %d (context %d - prompt %d); "
+                "raise CTX for longer answers\n",
+                request->max_tokens, context - prompt_count, context,
+                prompt_count);
+        request->max_tokens = context - prompt_count;
     }
     printf("ACCEPT %s %d\n", request->id, prompt_count);
     fflush(stdout);

--- a/docs/deepseek-v4.md
+++ b/docs/deepseek-v4.md
@@ -71,6 +71,10 @@ python ./coli serve --model /path/to/DeepSeek-V4-Flash --ram 32
 python ./coli web --model /path/to/DeepSeek-V4-Flash --ram 32
 ```
 
+Generation length: `--ngen` is a ceiling, not a target — answers end at EOS.
+If the ceiling exceeds what the context window can hold, the engine clamps it
+and says so on stderr; raise `CTX` for genuinely longer answers.
+
 V4 chat uses native model markers. Native serving currently supports greedy
 generation and one active KV slot; tools and grammar are rejected. Requests
 re-prefill their context, while the process, weights, dense tensors, head, and


### PR DESCRIPTION
First user-facing bug of v1.6.0 — reported 4 hours after the release by its first Windows V4 chat user, fixed the same day.

**Mechanism** (verified, not guessed): `coli chat` raises the generation ceiling to 16384 by design (#260); the V4 serve path required `prompt + max_tokens <= context`, and with the default CTX of 4096 that made **every first message of a fresh V4 chat a guaranteed 400**. `coli run` worked because its default is 1024.

**Two fixes, one per layer:**
- **Engine**: `max_tokens` is a ceiling, not a target — clamp to `context - prompt` with a stderr notice (same semantics the GLM serve path has had since #260). `CONTEXT_EXCEEDED` remains for the only honest case: a prompt that does not fit.
- **TUI**: `HTTPError` IS-A `OSError`, so every 4xx/5xx read as "server unreachable" and the API's own explanation was discarded — which is why #975 needed a screenshot instead of a sentence. A dedicated arm prints the response body's message and drops the failed turn so the user can retry.

**Verified on the real V4-Flash checkpoint** with the exact failing request (max_tokens=16384):

```
[V4] max_tokens 16384 clamped to 4091 (context 4096 - prompt 5); raise CTX for longer answers
ACCEPT r1 5
->  Paris
```

`make deepseek-v4-tiny-check` stays token-exact; `docs/deepseek-v4.md` documents the ceiling semantics.

Closes #975 (manual close on merge — dev is not the default branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)