### PR TITLE
Kimi K3: run the dense trunk on CUDA during prefill (1.46x prefill, 1.18x end-to-end)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -671,7 +671,7 @@ rans: $(RANSLIB)
 $(RANSLIB): tools/rans_ctypes.c rans.h
 	$(CC) $(CFLAGS) -fPIC -shared $< -o $@ $(LDFLAGS)
 
-cuda-test: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/test_backend_cuda.cu tests/test_ragged_attention.cu tests/test_mxfp4_cuda.cu tests/mxfp4_ref.c
+cuda-test: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/test_backend_cuda.cu tests/test_ragged_attention.cu tests/test_mxfp4_cuda.cu tests/mxfp4_ref.c tests/test_i4g_cuda.cu tests/test_i8_cuda.cu tests/i4g_ref.c
 	@command -v "$(GPUCC)" >/dev/null 2>&1 || { echo "$(GPUCC_NAME) not found" >&2; exit 1; }
 	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/test_backend_cuda.cu -o backend_cuda_test$(EXE) $(ANS_NVCC_LIBS)
 	./backend_cuda_test$(EXE)
@@ -681,8 +681,19 @@ cuda-test: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/test_backen
 	# as C on purpose: quant.h uses _Thread_local, which nvcc's C++ front end
 	# rejects, and re-implementing it for the test would defeat the comparison.
 	$(CC) $(CFLAGS) -c tests/mxfp4_ref.c -o tests/mxfp4_ref.o
-	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/test_mxfp4_cuda.cu tests/mxfp4_ref.o -o mxfp4_cuda_test$(EXE)
+	# -fopenmp on the link line: the CPU reference objects are built with
+	# $(CFLAGS), which has it, but nvcc does not pass it through and the link
+	# fails on GOMP_parallel.
+	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/test_mxfp4_cuda.cu tests/mxfp4_ref.o -o mxfp4_cuda_test$(EXE) -Xcompiler -fopenmp
 	./mxfp4_cuda_test$(EXE)
+	# i4_tiled_f32 (the S>1 path K3_CUDA_DENSE uses) against the same CPU
+	# decoders, for both weight formats it dispatches: fmt=4 grouped int4 and
+	# fmt=1 int8. Same C-reference trick as mxfp4_ref above, same reason.
+	$(CC) $(CFLAGS) -c tests/i4g_ref.c -o tests/i4g_ref.o
+	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/test_i4g_cuda.cu tests/i4g_ref.o -o i4g_cuda_test$(EXE) -Xcompiler -fopenmp
+	./i4g_cuda_test$(EXE)
+	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/test_i8_cuda.cu tests/i4g_ref.o -o i8_cuda_test$(EXE) -Xcompiler -fopenmp
+	./i8_cuda_test$(EXE)
 
 # convenience alias: kernel correctness on AMD (same test, hipcc toolchain)
 hip-test:

--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -455,6 +455,92 @@ __global__ static void w4a16_matmul(float *y,const float *x,const uint8_t *w,
 #endif
 }
 
+/* int4 (fmt=2 per-row scale, fmt=4 per-group) x fp32 activations, tiled in
+ * shared memory, accumulated in fp32. No Tensor Cores -- deliberately.
+ *
+ * The first version of this used the WMMA path (w4a16_matmul's fp16 A and B).
+ * It was 13-30x the CPU on K3's dense shapes and its own relative error was a
+ * harmless-looking 2.6e-04, but measured end to end through the 93-layer stack
+ * the prefill logits came out at 5.9% mean / 33% worst relative L2, and 2 of 56
+ * teacher-forced positions changed argmax -- including the last one, which picks
+ * the first generated token. docs/kimi_k3.md predicts exactly this: the AttnRes
+ * mix logits sit ~0.02 apart, so the mix amplifies weight noise. fp16 weights
+ * are not usable here at any speed.
+ *
+ * What actually made the GPU fast was reuse, not fp16: quant_matmul re-reads the
+ * whole weight matrix per batch row, and this reads each weight tile once per 32
+ * rows. Staying in fp32 keeps the arithmetic within rounding of the CPU decoder
+ * and costs only Tensor Core headroom the workload never needed -- the A6000 has
+ * 38.7 TFLOPS of plain fp32 against the CPU's measured ~41 GFLOP/s on these
+ * shapes.
+ *
+ * Tile: 32 batch rows x 64 output cols x 32 k. 256 threads, 8 accumulators each.
+ * The +1 padding on the shared arrays keeps consecutive output columns on
+ * consecutive banks (stride 33 floats, 33 mod 32 = 1); without it every thread
+ * in a warp would hit the same bank on the ws read.
+ *
+ * gs is unconstrained: each element derives its own group from its own k, so a
+ * k-tile straddling two groups reads two scales and is still correct. */
+#define I4T_TM 32
+#define I4T_TN 64
+#define I4T_TK 32
+__global__ static void i4_tiled_f32(float *y,const float *x,const uint8_t *w,
+                                    const float *scale,int M,int K,int N,
+                                    int gs,int ng){
+    __shared__ float xs[I4T_TM][I4T_TK+1];
+    __shared__ float ws[I4T_TN][I4T_TK+1];
+    int tid=threadIdx.x;
+    int n_local=tid&(I4T_TN-1);          /* 64 output columns per block */
+    int m_grp=tid>>6;                    /* 4 groups, each thread covers 8 rows */
+    int m0=blockIdx.y*I4T_TM, n0=blockIdx.x*I4T_TN;
+    int gn=n0+n_local;
+    size_t rb=(size_t)(K+1)/2;
+    float acc[8];
+    #pragma unroll
+    for(int j=0;j<8;j++) acc[j]=0.f;
+
+    for(int k0=0;k0<K;k0+=I4T_TK){
+        for(int z=tid;z<I4T_TM*I4T_TK;z+=256){
+            int m=z>>5,k=z&31,gm=m0+m,gk=k0+k;
+            xs[m][k]=(gm<M&&gk<K)?x[(size_t)gm*K+gk]:0.f;
+        }
+        for(int z=tid;z<I4T_TN*I4T_TK;z+=256){
+            int n=z>>5,k=z&31,gw=n0+n,gk=k0+k;float v=0.f;
+            if(gw<N&&gk<K){
+                uint8_t q=w[(size_t)gw*rb+(gk>>1)];
+                int a=(gk&1)?(q>>4):(q&15);
+                v=(float)(a&8?a-16:a)*(ng>1?scale[(size_t)gw*ng+gk/gs]:scale[gw]);
+            }
+            ws[n][k]=v;
+        }
+        __syncthreads();
+        /* Partial per k-tile, folded into acc once per tile, instead of one
+         * 7168-long serial chain. The CPU decoder sums hierarchically (8-wide
+         * SIMD -> per-group -> per-row); a flat chain drifts from it far more on
+         * real activations than on the uniform data a kernel unit test uses, and
+         * that drift is what the 93-layer stack amplifies. 32-term partials are
+         * finer than the CPU's 64-wide groups, so this is no worse than what it
+         * is being compared against. */
+        float part[8];
+        #pragma unroll
+        for(int j=0;j<8;j++) part[j]=0.f;
+        #pragma unroll
+        for(int kk=0;kk<I4T_TK;kk++){
+            float wv=ws[n_local][kk];
+            #pragma unroll
+            for(int j=0;j<8;j++) part[j]+=xs[m_grp+j*4][kk]*wv;
+        }
+        #pragma unroll
+        for(int j=0;j<8;j++) acc[j]+=part[j];
+        __syncthreads();
+    }
+    #pragma unroll
+    for(int j=0;j<8;j++){
+        int gm=m0+m_grp+j*4;
+        if(gm<M&&gn<N) y[(size_t)gm*N+gn]=acc[j];
+    }
+}
+
 /* Gate and up use the same input.  Eight warps compute both 16x64 projections
  * while sharing the FP32->FP16 conversion of A. */
 __global__ static void w4a16_gate_up(float *gate,float *up,const float *x,
@@ -1342,6 +1428,9 @@ extern "C" int coli_cuda_tensor_update(ColiCudaTensor *tensor,
  * engine's CPU fallbacks and host-rematerialization end-to-end without real
  * hardware faults. Uploads/queries are not gated. Unset: no effect. */
 static long g_gpu_calls;
+/* 0 = follow COLI_CUDA_TC_W4A16_MIN; see coli_cuda_set_tile_min. */
+static int g_tile_min = 0;
+extern "C" void coli_cuda_set_tile_min(int n) { g_tile_min = n > 0 ? n : 0; }
 static int fault_injected(void) {
     const char *fa = std::getenv("COLI_GPU_FAIL_AFTER");
     return fa && g_gpu_calls++ >= std::atol(fa);
@@ -1367,8 +1456,24 @@ extern "C" int coli_cuda_matmul(ColiCudaTensor **tensor,
     size_t xb = (size_t)S * I * sizeof(float), yb = (size_t)S * O * sizeof(float);
     if (!reserve(&ctx->x, &ctx->x_cap, xb) || !reserve(&ctx->y, &ctx->y_cap, yb)) return 0;
     if (!cuda_ok(cudaMemcpy(ctx->x, x, xb, cudaMemcpyHostToDevice), "input upload")) return 0;
-    dim3 grid((unsigned)O, (unsigned)S);
-    quant_matmul<<<grid, 256>>>(ctx->y, ctx->x, t->weights, t->scales, fmt, S, I, O, rb, t->gs, t->ng);
+    /* quant_matmul makes S the grid Y dimension: every row of the batch re-reads
+     * the whole weight matrix from VRAM. That is the right shape at S=1 (decode),
+     * and S copies of the traffic at a prefill chunk size. Above the tile
+     * threshold, switch to i4_tiled_f32, which reads one weight tile per 32
+     * output rows. Same threshold and env var as the expert-group path below, so
+     * there is one knob, not two. */
+    int tc16_min = g_tile_min > 0 ? g_tile_min
+                 : (std::getenv("COLI_CUDA_TC_W4A16_MIN")
+                    ? std::atoi(std::getenv("COLI_CUDA_TC_W4A16_MIN")) : 16);
+    if (S >= tc16_min && (fmt == 2 || (fmt == 4 && t->gs > 0))) {
+        dim3 tg((unsigned)((O + I4T_TN - 1) / I4T_TN), (unsigned)((S + I4T_TM - 1) / I4T_TM));
+        i4_tiled_f32<<<tg, 256>>>(ctx->y, ctx->x, (const uint8_t *)t->weights,
+                                  t->scales, S, I, O,
+                                  fmt == 4 ? t->gs : 1, fmt == 4 ? t->ng : 1);
+    } else {
+        dim3 grid((unsigned)O, (unsigned)S);
+        quant_matmul<<<grid, 256>>>(ctx->y, ctx->x, t->weights, t->scales, fmt, S, I, O, rb, t->gs, t->ng);
+    }
     if (!cuda_ok(cudaGetLastError(), "matmul launch") ||
         !cuda_ok(cudaMemcpy(y, ctx->y, yb, cudaMemcpyDeviceToHost), "output download")) return 0;
     return 1;

--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -1428,7 +1428,11 @@ extern "C" int coli_cuda_tensor_update(ColiCudaTensor *tensor,
  * engine's CPU fallbacks and host-rematerialization end-to-end without real
  * hardware faults. Uploads/queries are not gated. Unset: no effect. */
 static long g_gpu_calls;
-/* 0 = follow COLI_CUDA_TC_W4A16_MIN; see coli_cuda_set_tile_min. */
+/* 0 = tiled dispatch OFF. Opt-in only, and deliberately not defaulted from
+ * COLI_CUDA_TC_W4A16_MIN: coli_cuda_matmul is shared with the GLM engine
+ * (colibri.c), which passes its own S straight through, so a nonzero default
+ * here would silently reroute another model's prefill onto this kernel. The env
+ * var keeps meaning what it always meant for the expert-group path below. */
 static int g_tile_min = 0;
 extern "C" void coli_cuda_set_tile_min(int n) { g_tile_min = n > 0 ? n : 0; }
 static int fault_injected(void) {
@@ -1462,10 +1466,7 @@ extern "C" int coli_cuda_matmul(ColiCudaTensor **tensor,
      * threshold, switch to i4_tiled_f32, which reads one weight tile per 32
      * output rows. Same threshold and env var as the expert-group path below, so
      * there is one knob, not two. */
-    int tc16_min = g_tile_min > 0 ? g_tile_min
-                 : (std::getenv("COLI_CUDA_TC_W4A16_MIN")
-                    ? std::atoi(std::getenv("COLI_CUDA_TC_W4A16_MIN")) : 16);
-    if (S >= tc16_min && (fmt == 2 || (fmt == 4 && t->gs > 0))) {
+    if (g_tile_min > 0 && S >= g_tile_min && (fmt == 2 || (fmt == 4 && t->gs > 0))) {
         dim3 tg((unsigned)((O + I4T_TN - 1) / I4T_TN), (unsigned)((S + I4T_TM - 1) / I4T_TM));
         i4_tiled_f32<<<tg, 256>>>(ctx->y, ctx->x, (const uint8_t *)t->weights,
                                   t->scales, S, I, O,

--- a/c/backend_cuda.h
+++ b/c/backend_cuda.h
@@ -31,6 +31,12 @@ COLI_CUDA_DLLEXPORT int coli_cuda_device_count(void);
 COLI_CUDA_DLLEXPORT int coli_cuda_device_at(int index);
 COLI_CUDA_DLLEXPORT int coli_cuda_mem_info(int device, size_t *free_bytes, size_t *total_bytes);
 COLI_CUDA_DLLEXPORT int coli_cuda_device_integrated(int device);
+/* Minimum batch rows at which coli_cuda_matmul picks the tiled kernel over the
+ * GEMV. Defaults to COLI_CUDA_TC_W4A16_MIN, or 16. Callers that expose their own
+ * knob should set it here rather than putenv()ing the backend's variable, which
+ * would also reach any other engine sharing the process. n < 1 restores the
+ * environment default. */
+COLI_CUDA_DLLEXPORT void coli_cuda_set_tile_min(int n);
 /* device < 0 returns aggregate statistics for all configured devices. */
 COLI_CUDA_DLLEXPORT void coli_cuda_stats(int device, size_t *tensor_count, size_t *tensor_bytes);
 COLI_CUDA_DLLEXPORT void coli_cuda_group_stats(uint64_t *calls, uint64_t *experts, uint64_t *rows,

--- a/c/backend_loader.c
+++ b/c/backend_loader.c
@@ -56,6 +56,7 @@ typedef int            (*fn_device_count)(void);
 typedef int            (*fn_device_at)(int index);
 typedef int            (*fn_mem_info)(int device, size_t *free_bytes, size_t *total_bytes);
 typedef int            (*fn_device_integrated)(int device);
+typedef void           (*fn_set_tile_min)(int n);
 typedef void           (*fn_stats)(int device, size_t *tensor_count, size_t *tensor_bytes);
 typedef void           (*fn_group_stats)(uint64_t *calls, uint64_t *experts, uint64_t *rows,
                                          double *h2d_ms, double *kernel_ms, double *d2h_ms);
@@ -143,6 +144,7 @@ static struct {
     fn_device_at       device_at;
     fn_mem_info        mem_info;
     fn_device_integrated device_integrated;
+    fn_set_tile_min      set_tile_min;
     fn_stats           stats;
     fn_group_stats     group_stats;
     fn_group_stats_device group_stats_device;
@@ -1386,6 +1388,7 @@ static int coli_cuda_load(void){
      * "not integrated" (0), so the RAM-budget correction simply doesn't apply
      * rather than taking the whole GPU backend down over one missing symbol. */
     RESOLVE_OPT(device_integrated, fn_device_integrated)
+    RESOLVE_OPT(set_tile_min, fn_set_tile_min)
     RESOLVE(stats,          fn_stats)
     RESOLVE(group_stats,    fn_group_stats)
     RESOLVE(group_stats_device, fn_group_stats_device)
@@ -1491,6 +1494,13 @@ int coli_cuda_mem_info(int device, size_t *free_bytes, size_t *total_bytes){
 int coli_cuda_device_integrated(int device){
     if(!g_cuda.available || !g_cuda.device_integrated) return 0;
     return g_cuda.device_integrated(device);
+}
+
+/* Optional: a DLL predating the tiled dispatch simply never engages it, which is
+ * the same state as not opting in. Silently doing nothing is correct here. */
+void coli_cuda_set_tile_min(int n){
+    if(!g_cuda.available || !g_cuda.set_tile_min) return;
+    g_cuda.set_tile_min(n);
 }
 
 void coli_cuda_stats(int device, size_t *tensor_count, size_t *tensor_bytes){

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -112,7 +112,8 @@ typedef struct {
 
 /* ---------- RAM-resident weight, quantized at load ---------- */
 typedef struct { int fmt; float *f; int8_t *q8; uint8_t *q4; float *s; int O, I, gs;
-                 void *vk; /* ColiVkTensor* once uploaded (K3_VK); NULL = CPU only */ } W;
+                 void *vk; /* ColiVkTensor* once uploaded (K3_VK); NULL = CPU only */
+                 void *cu; /* ColiCudaTensor* once uploaded (K3_CUDA_DENSE); NULL = CPU */ } W;
 
 typedef struct {                          /* KDA layer */
     W q, k, v, o, g;
@@ -294,11 +295,122 @@ static int w_vk_upload(W *w){
         fmt==1?(const void*)w->q8:(const void*)w->q4,w->s,fmt,w->I,w->O,w->gs);
 }
 #endif
+#ifdef COLI_CUDA
+/* K3_CUDA_DENSE: the dense trunk (attention projections, latent up/down, shared
+ * experts, dense-layer MLP) resident in VRAM, computed with the fp32 shared-memory
+ * tiling above K3_CUDA_TILE_S rows.
+ *
+ * Separate from K3_CUDA because it targets the opposite regime. The routed-expert
+ * CUDA path helps decode; this one only pays during PREFILL, where a chunk gives
+ * the tiles enough rows to amortize reading a weight tile (measured standalone on
+ * one A6000, K3 shapes at S=32: 6-13x the GPU GEMV, which is the clean comparison;
+ * at S=1 the GEMV wins and the tiling loses, hence the row threshold rather than
+ * always-on).
+ *
+ * The trunk is ~36 GB at K3_BITS=4, so it fits one 48 GB card whole. Uploads stop
+ * at K3_CUDA_GB (default: leave 4 GB of headroom) and anything not resident
+ * silently stays on the CPU. */
+static int g_k3_cuda_dense=0;
+static double g_cuda_gb=0;               /* K3_CUDA_GB cap (0 = VRAM minus headroom) */
+static int g_cuda_tile_s=16;             /* K3_CUDA_TILE_S: min rows for the tiled path */
+static long g_cuda_res=0, g_cuda_hit=0, g_cuda_skip=0;
+static double g_cuda_bytes=0;
+static int g_cuda_dev=0;                 /* K3_CUDA_DEV: device for the dense trunk */
+static int g_cuda_verify=0;              /* K3_CUDA_VERIFY: CPU-recompute every dense matmul */
+static double g_cuda_worst=0;            /* worst rel-L2 seen under verify */
+static char g_cuda_worst_at[96]="";
+/* Upload one dense W to VRAM, honoring the K3_CUDA_GB cap. Returns 1 if the
+ * tensor is resident afterwards.
+ *
+ * fmt=0 (f32) is refused rather than converted: it appears only under
+ * K3_BITS=32, which exists for validation against tools/k3_ref.py, and quietly
+ * running that comparison on Tensor Cores in fp16 would defeat its purpose. */
+static int w_cuda_upload(W *w){
+    if(w->cu) return 1;
+    if(w->fmt!=1&&w->fmt!=4) return 0;
+    size_t need=(size_t)w->O*(w->fmt==1?(size_t)w->I:((size_t)w->I+1)/2);
+    size_t ng=w->gs>0?((size_t)w->I+w->gs-1)/w->gs:1;
+    need+=(size_t)w->O*ng*sizeof(float);
+    size_t freeb=0,totb=0;
+    if(!coli_cuda_mem_info(g_cuda_dev,&freeb,&totb)) return 0;
+    double cap=g_cuda_gb>0?g_cuda_gb*1e9:(double)totb-4e9;   /* 4 GB headroom */
+    if(g_cuda_bytes+(double)need>cap||(double)need>(double)freeb-1e9) return 0;
+    int ok = w->gs>0
+        ? coli_cuda_tensor_upload_g((ColiCudaTensor**)&w->cu,
+              w->fmt==1?(const void*)w->q8:(const void*)w->q4,w->s,w->fmt,w->I,w->O,g_cuda_dev,w->gs)
+        : coli_cuda_tensor_upload((ColiCudaTensor**)&w->cu,
+              w->fmt==1?(const void*)w->q8:(const void*)w->q4,w->s,w->fmt,w->I,w->O,g_cuda_dev);
+    if(!ok) return 0;
+    g_cuda_bytes+=(double)need; g_cuda_res++;
+    return 1;
+}
+/* Every dense matmul the prefill path reaches. Order matters: the biggest
+ * matrices go first so a budget too small to hold the trunk still buys the
+ * projections where the tiling pays most. */
+static int layer_cuda_upload(Layer *L, const Cfg *c){
+    int n=0;
+    if(L->kda){ Kda *a=&L->a;
+        n+=w_cuda_upload(&a->q)+w_cuda_upload(&a->k)+w_cuda_upload(&a->v)
+          +w_cuda_upload(&a->o)+w_cuda_upload(&a->g);
+    } else { Mla *ml=&L->m;
+        n+=w_cuda_upload(&ml->qa)+w_cuda_upload(&ml->qb)+w_cuda_upload(&ml->kva)
+          +w_cuda_upload(&ml->o)+w_cuda_upload(&ml->g);
+        /* kvb is consumed row-at-a-time by the MLA absorb (w_addrow), never by
+         * w_matmul, so uploading it would occupy VRAM for nothing. */
+    }
+    if(L->sparse){ Moe *o=&L->moe;
+        n+=w_cuda_upload(&o->lat_down)+w_cuda_upload(&o->lat_up)
+          +w_cuda_upload(&o->sh_gate)+w_cuda_upload(&o->sh_up)+w_cuda_upload(&o->sh_down);
+    } else {
+        n+=w_cuda_upload(&L->d_gate)+w_cuda_upload(&L->d_up)+w_cuda_upload(&L->d_down);
+    }
+    (void)c;
+    return n;
+}
+#endif
 static void w_matmul(float *y, const float *x, const W *w, int S){
 #ifdef COLI_VULKAN
     if(g_k3_vk&&S==1&&w->vk&&
        coli_vk_matmul((ColiVkTensor**)&((W*)w)->vk,y,x,NULL,NULL,w->fmt,1,w->I,w->O,w->gs))
         return;
+#endif
+#ifdef COLI_CUDA
+    /* Prefill only. S is the chunk size at every dense call site, so this engages
+     * for prefill chunks and never for decode, where the CPU is faster than a
+     * tiled kernel running on 1 of 16 tile rows. A refused call (VRAM full, fault
+     * injection, unsupported fmt) falls through to the CPU with y untouched. */
+    if(g_k3_cuda_dense&&w->cu&&S>=g_cuda_tile_s){
+        if(coli_cuda_matmul((ColiCudaTensor**)&((W*)w)->cu,y,x,NULL,NULL,
+                            w->fmt,S,w->I,w->O,g_cuda_dev,w->gs)){
+            g_cuda_hit++;
+            /* K3_CUDA_VERIFY=1: recompute on the CPU and report the worst
+             * disagreement seen, per shape. The kernels agree to ~1e-6 on
+             * synthetic data yet the model's logits move by 5e-3, so the
+             * question is what real weights and activations do to them --
+             * which a unit test on uniform random data cannot answer. */
+            if(g_cuda_verify){
+                float *ref=(float*)malloc((size_t)S*w->O*sizeof(float));
+                if(ref){
+                    if(w->fmt==1) matmul_q(ref,x,w->q8,w->s,S,w->I,w->O);
+                    else          matmul_i4_grouped(ref,x,w->q4,w->s,S,w->I,w->O,w->gs);
+                    double num=0,den=0;
+                    for(int64_t i=0;i<(int64_t)S*w->O;i++){
+                        double d=(double)y[i]-(double)ref[i];
+                        num+=d*d; den+=(double)ref[i]*(double)ref[i];
+                    }
+                    double e=den>0?sqrt(num/den):0;
+                    if(e>g_cuda_worst){
+                        g_cuda_worst=e;
+                        snprintf(g_cuda_worst_at,sizeof(g_cuda_worst_at),
+                                 "fmt=%d S=%d I=%d O=%d gs=%d",w->fmt,S,w->I,w->O,w->gs);
+                    }
+                    free(ref);
+                }
+            }
+            return;
+        }
+        g_cuda_skip++;
+    }
 #endif
     if(w->fmt==0)      matmul(y,x,w->f,S,w->I,w->O);
     else if(w->fmt==1) matmul_q(y,x,w->q8,w->s,S,w->I,w->O);
@@ -551,12 +663,39 @@ static void model_init(Model *m, const char *snap, int n_layers_env){
     g_bits_env = getenv("K3_BITS")!=NULL;
 #ifdef COLI_CUDA
     g_k3_cuda = getenv("K3_CUDA") ? atoi(getenv("K3_CUDA")) : 0;
-    if(g_k3_cuda){
-        int dev0 = 0;
+    g_k3_cuda_dense = getenv("K3_CUDA_DENSE") ? atoi(getenv("K3_CUDA_DENSE")) : 0;
+    if(g_k3_cuda||g_k3_cuda_dense){
+        g_cuda_dev = getenv("K3_CUDA_DEV") ? atoi(getenv("K3_CUDA_DEV")) : 0;
+        /* coli_cuda_matmul_mxfp4 resolves its context with find_ctx(0), so the
+         * routed-expert path only works on device 0. Rather than let it fail
+         * silently back to the CPU, pin the device when both are on. */
+        if(g_k3_cuda && g_cuda_dev != 0){
+            fprintf(stderr,"[K3-CUDA] K3_CUDA=1 requires device 0; ignoring K3_CUDA_DEV=%d\n",
+                    g_cuda_dev);
+            g_cuda_dev = 0;
+        }
+        int dev0 = g_cuda_dev;
         if(!coli_cuda_init(&dev0, 1)){
             fprintf(stderr,"[K3-CUDA] device unavailable -- experts stay on CPU\n");
-            g_k3_cuda = 0;
-        } else fprintf(stderr,"[K3-CUDA] MXFP4 routed experts on device 0 (decode only)\n");
+            g_k3_cuda = 0; g_k3_cuda_dense = 0;
+        } else if(g_k3_cuda) fprintf(stderr,"[K3-CUDA] MXFP4 routed experts on device 0 (decode only)\n");
+    }
+    if(g_k3_cuda_dense){
+        g_cuda_gb = getenv("K3_CUDA_GB") ? atof(getenv("K3_CUDA_GB")) : 0;
+        g_cuda_tile_s = getenv("K3_CUDA_TILE_S") ? atoi(getenv("K3_CUDA_TILE_S")) : 16;
+        g_cuda_verify = getenv("K3_CUDA_VERIFY") ? atoi(getenv("K3_CUDA_VERIFY")) : 0;
+        if(g_cuda_tile_s<1) g_cuda_tile_s=1;
+        /* Keep the engine gate and the backend dispatch on one number. Set it
+         * through the API, not putenv: the backend variable is process-global and
+         * would follow any other engine sharing this process. */
+        coli_cuda_set_tile_min(g_cuda_tile_s);
+        if(g_k3_cuda)
+            fprintf(stderr,"[K3-CUDA] note: K3_CUDA=1 with K3_CUDA_DENSE=1 shares one "
+                           "device; the routed-expert path uploads per call and measured "
+                           "SLOWER than leaving experts on the CPU (8-layer prefill "
+                           "14.9s -> 25.5s). Prefer K3_CUDA=0 unless benchmarking it.\n");
+        /* Uploads happen after the layers load, next to the Vulkan residency
+         * pass -- the weights do not exist yet at this point. */
     }
 #endif
     g_k3_direct = getenv("K3_DIRECT")?atoi(getenv("K3_DIRECT")):1;
@@ -684,6 +823,20 @@ static void model_init(Model *m, const char *snap, int n_layers_env){
         fprintf(stderr,"[K3-VK] resident: %d shared-expert mats (%.1f/%.1f GB); routed MXFP4 tier fills at decode (K3_VK_UP=%d/step, cap %s)\n",
                 nsh,used,budget,g_vk_upcap,g_vk_gb>0?"K3_VK_GB":"driver budget");
       }
+    }
+#endif
+#ifdef COLI_CUDA
+    if(g_k3_cuda_dense){
+        int tried=0;
+        for(int i=0;i<c->n_layers;i++) tried+=layer_cuda_upload(&m->L[i],&m->c);
+        fprintf(stderr,"[K3-CUDA] dense trunk: %ld tensors resident (%.1f GB) on device %d, "
+                       "fp32 tiling at S>=%d\n",
+                g_cuda_res,g_cuda_bytes/1e9,g_cuda_dev,g_cuda_tile_s);
+        (void)tried;
+        if(g_cuda_res==0){
+            fprintf(stderr,"[K3-CUDA] nothing uploaded -- dense stays on CPU\n");
+            g_k3_cuda_dense=0;
+        }
     }
 #endif
     expert_table_init(m);
@@ -1927,6 +2080,17 @@ static void serve_one(Model *m, Tok *T, ServeReq *q){
     if(g_k3_vk) fprintf(stderr,"[K3-VK] routed tier: %ld resident, %ld GPU hits so far\n",
                         g_vk_res,g_vk_hit);
 #endif
+#ifdef COLI_CUDA
+    /* skip counts refused calls that fell back to the CPU: a nonzero value means
+     * the GPU produced none of those outputs, which is the difference between
+     * "tiling is not helping" and "tiling never ran". */
+    if(g_k3_cuda_dense)
+    {   fprintf(stderr,"[K3-CUDA] dense: %ld tiled matmuls, %ld fell back to CPU\n",
+                g_cuda_hit,g_cuda_skip);
+        if(g_cuda_verify) fprintf(stderr,"[K3-CUDA] verify: worst rel_l2 %.3e at %s\n",
+                                  g_cuda_worst,g_cuda_worst_at);
+    }
+#endif
 }
 
 static void serve_loop(Model *m, Tok *T){
@@ -2140,6 +2304,15 @@ int main(int argc, char **argv){
      * precision (#852 -- two decimals of tok/s is one significant digit at the
      * rates this engine runs at). */
     printf("TUNE decode: %d tokens in %.3fs\n", ntok, dt);
+#ifdef COLI_CUDA
+    if(g_k3_cuda_dense){
+        fprintf(stderr,"[K3-CUDA] dense: %ld GPU matmuls, %ld fell back to CPU\n",
+                g_cuda_hit,g_cuda_skip);
+        if(g_cuda_verify)
+            fprintf(stderr,"[K3-CUDA] verify: worst rel_l2 %.3e at %s\n",
+                    g_cuda_worst,g_cuda_worst_at);
+    }
+#endif
     if(m.trace) fclose(m.trace);
     { const char *sv=getenv("USAGE_SAVE");
       if(!(sv && atoi(sv)==0) && g_k3_usage[0])

--- a/c/tests/bench_i4g_cuda.cu
+++ b/c/tests/bench_i4g_cuda.cu
@@ -1,0 +1,76 @@
+/* Throughput of the three ways to do one K3 dense projection at a prefill chunk
+ * size: CPU grouped-int4, GPU GEMV-by-replication, GPU Tensor Core tiling.
+ *
+ * Reports the kernel time AND the time including coli_cuda_matmul's host round
+ * trip, because the API copies x in and y out on every call. If the round trip
+ * dominates, the conclusion is about the API, not the kernel -- the engine would
+ * need activations to stay resident across a layer, which is a much larger
+ * change than swapping a kernel.
+ */
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <ctime>
+#include "../backend_cuda.h"
+
+extern "C" void i4g_ref(float *y, const float *x, const unsigned char *q4,
+                        const float *scale, int S, int I, int O, int gs);
+
+static double now(void) {
+    struct timespec t; clock_gettime(CLOCK_MONOTONIC, &t);
+    return t.tv_sec + t.tv_nsec / 1e9;
+}
+static unsigned long long sd = 0x2545F4914F6CDD1DULL;
+static float rnd(void) {
+    sd = sd * 6364136223846793005ULL + 1442695040888963407ULL;
+    return (float)((sd >> 40) % 2000001) / 1000000.0f - 1.0f;
+}
+
+int main(int argc, char **argv) {
+    int S = argc > 1 ? std::atoi(argv[1]) : 32;
+    int reps = argc > 2 ? std::atoi(argv[2]) : 20;
+    int dev[1] = {0};
+    if (!coli_cuda_init(dev, 1)) { std::fprintf(stderr, "no CUDA device\n"); return 0; }
+
+    struct { const char *nm; int I, O; } shp[] = {
+        {"lat_down 7168->3584", 7168, 3584},
+        {"lat_up   3584->7168", 3584, 7168},
+        {"sh_gate  7168->6144", 7168, 6144},
+        {"kda_qkv  7168->12288", 7168, 12288},
+    };
+    std::printf("S=%d, %d reps, per-call ms (lower is better)\n", S, reps);
+    std::printf("%-22s %10s %10s %10s %8s\n", "shape", "cpu", "gpu-gemv", "gpu-tile", "tile/cpu");
+
+    for (unsigned c = 0; c < sizeof(shp)/sizeof(shp[0]); c++) {
+        int I = shp[c].I, O = shp[c].O, gs = 64;
+        int rb = (I+1)/2, ng = (I+gs-1)/gs;
+        unsigned char *q4 = (unsigned char*)std::malloc((size_t)O*rb);
+        float *scale = (float*)std::malloc((size_t)O*ng*sizeof(float));
+        float *x = (float*)std::malloc((size_t)S*I*sizeof(float));
+        float *y = (float*)std::calloc((size_t)S*O, sizeof(float));
+        for (size_t i = 0; i < (size_t)O*rb; i++) { sd = sd*6364136223846793005ULL+1442695040888963407ULL; q4[i]=(unsigned char)(sd>>40); }
+        for (size_t i = 0; i < (size_t)O*ng; i++) scale[i] = 0.01f;
+        for (size_t i = 0; i < (size_t)S*I; i++) x[i] = rnd();
+
+        i4g_ref(y, x, q4, scale, S, I, O, gs);          /* warm caches/threads */
+        double t0 = now();
+        for (int r = 0; r < reps; r++) i4g_ref(y, x, q4, scale, S, I, O, gs);
+        double tcpu = (now()-t0)/reps*1e3;
+
+        double tg[2];
+        for (int mode = 0; mode < 2; mode++) {
+            setenv("COLI_CUDA_TC_W4A16_MIN", mode ? "1" : "1000000", 1);
+            ColiCudaTensor *t = nullptr;
+            coli_cuda_matmul(&t, y, x, q4, scale, 4, S, I, O, 0, gs);   /* upload once */
+            double s0 = now();
+            for (int r = 0; r < reps; r++)
+                coli_cuda_matmul(&t, y, x, q4, scale, 4, S, I, O, 0, gs);
+            tg[mode] = (now()-s0)/reps*1e3;
+            if (t) coli_cuda_tensor_free(t);
+        }
+        std::printf("%-22s %10.3f %10.3f %10.3f %8.2fx\n",
+                    shp[c].nm, tcpu, tg[0], tg[1], tcpu/tg[1]);
+        std::free(q4); std::free(scale); std::free(x); std::free(y);
+    }
+    return 0;
+}

--- a/c/tests/bench_i4g_cuda.cu
+++ b/c/tests/bench_i4g_cuda.cu
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
 
         double tg[2];
         for (int mode = 0; mode < 2; mode++) {
-            setenv("COLI_CUDA_TC_W4A16_MIN", mode ? "1" : "1000000", 1);
+            coli_cuda_set_tile_min(mode ? 1 : 0);
             ColiCudaTensor *t = nullptr;
             coli_cuda_matmul(&t, y, x, q4, scale, 4, S, I, O, 0, gs);   /* upload once */
             double s0 = now();

--- a/c/tests/i4g_ref.c
+++ b/c/tests/i4g_ref.c
@@ -1,0 +1,18 @@
+/* CPU grouped-int4 (fmt=4) reference for tests/test_i4g_cuda.cu.
+ *
+ * Same reason as tests/mxfp4_ref.c: quant.h declares a `static _Thread_local`,
+ * which nvcc's C++ front end rejects, so the reference is compiled as C and
+ * exposed as one symbol. The point is to compare against the code the engine
+ * actually runs, not a C++-friendly copy that can drift from it. */
+#include "../quant.h"
+
+void i4g_ref(float *y, const float *x, const unsigned char *q4,
+             const float *scale, int S, int I, int O, int gs) {
+    matmul_i4_grouped(y, x, q4, scale, S, I, O, gs);
+}
+
+/* int8 per-row (fmt=1), the format K3's MLA projections use at K3_MLA_BITS=8. */
+void i8_ref(float *y, const float *x, const signed char *q8, const float *scale,
+            int S, int I, int O) {
+    matmul_q(y, x, q8, scale, S, I, O);
+}

--- a/c/tests/logit_cmp.py
+++ b/c/tests/logit_cmp.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Compare two K3_LOGITS dumps position by position.
+
+rel_l2 answers "did the numbers move"; top-1 agreement and the top-2 margin
+answer "would the model have said something else", which is the only question
+that matters for a kernel swap. A change that never flips an argmax is invisible
+in generation; one that flips argmax on a narrow-margin position is not, however
+small its L2.
+
+usage: logit_cmp.py a.bin b.bin [vocab]
+"""
+import sys
+import numpy as np
+
+a_path, b_path = sys.argv[1], sys.argv[2]
+vocab = int(sys.argv[3]) if len(sys.argv) > 3 else 163584
+
+a = np.fromfile(a_path, dtype=np.float32)
+b = np.fromfile(b_path, dtype=np.float32)
+if a.size != b.size:
+    sys.exit(f"size mismatch: {a.size} vs {b.size} floats")
+if a.size % vocab:
+    sys.exit(f"{a.size} floats is not a multiple of vocab {vocab}")
+
+n = a.size // vocab
+a = a.reshape(n, vocab)
+b = b.reshape(n, vocab)
+print(f"{n} positions, vocab {vocab}")
+
+num = np.linalg.norm(a - b, axis=1)
+den = np.linalg.norm(a, axis=1)
+rel = np.where(den > 0, num / np.maximum(den, 1e-30), 0.0)
+
+ta, tb = a.argmax(1), b.argmax(1)
+flips = np.nonzero(ta != tb)[0]
+
+# Margin between top-1 and top-2 on the reference side: a flip where this is tiny
+# is a coin toss the kernel had no real say in.
+part = np.partition(a, -2, axis=1)
+margin = part[:, -1] - part[:, -2]
+
+print(f"rel_l2 per position : mean {rel.mean():.3e}  max {rel.max():.3e}")
+print(f"top-1 agreement     : {n - len(flips)}/{n} ({100.0 * (n - len(flips)) / n:.2f}%)")
+print(f"top-2 margin (ref)  : min {margin.min():.4f}  median {np.median(margin):.4f}")
+if len(flips):
+    print("flipped positions:")
+    for i in flips:
+        print(f"  pos {i:4d}  ref {ta[i]:6d} -> {tb[i]:6d}  "
+              f"ref margin {margin[i]:.5f}  rel_l2 {rel[i]:.3e}")
+else:
+    print("no argmax flips")
+sys.exit(1 if len(flips) else 0)

--- a/c/tests/test_backend_cuda.cu
+++ b/c/tests/test_backend_cuda.cu
@@ -272,7 +272,14 @@ int main(int argc, char **argv) {
         coli_cuda_stats(-1, &c0, &b0);
         ColiCudaTensor *bad = nullptr;
         if (coli_cuda_tensor_upload(&bad, q8, s8, 1, 4, 2, 9999)) return 1;
-        if (coli_cuda_tensor_upload(&bad, q8, s8, 7, 4, 2, d0)) return 1;
+        /* fmt=7 (MXFP4) used to be rejected here. db0c80f taught row_bytes about
+         * it for Kimi K3's experts, so an upload now legitimately succeeds and
+         * the old negative assertion failed the whole suite. Check the new
+         * contract instead, and free it so the `if (bad)` below still means
+         * "no rejected upload left a tensor behind". */
+        ColiCudaTensor *mx = nullptr;
+        if (!coli_cuda_tensor_upload(&mx, q8, s8, 7, 4, 2, d0)) return 1;
+        coli_cuda_tensor_free(mx);
         if (coli_cuda_tensor_upload(&bad, q8, nullptr, 1, 4, 2, d0)) return 1;
         if (coli_cuda_tensor_upload(&bad, nullptr, s8, 1, 4, 2, d0)) return 1;
         if (coli_cuda_tensor_upload(&bad, q8, s8, 1, 1 << 20, 1 << 24, d0)) return 1; /* ~16 TB */

--- a/c/tests/test_i4g_cuda.cu
+++ b/c/tests/test_i4g_cuda.cu
@@ -1,24 +1,16 @@
-/* w4a16_matmul_g (fmt=4 Tensor Core tiling) vs the CPU decoder in quant.h.
+/* i4_tiled_f32 (fmt=4 grouped int4) vs the CPU decoder in quant.h.
  *
- * Two things are under test, and they are not the same thing:
- *
- *  1. Correctness of the new grouped-scale tile indexing. The GEMV kernel
- *     (quant_matmul) and the tiled kernel read the SAME uploaded weights and
- *     scales, so running both against the CPU on identical inputs isolates the
- *     indexing from everything else. COLI_CUDA_TC_W4A16_MIN selects the path,
- *     so one binary exercises both.
- *
- *  2. The precision cost of the tiling. w4a16 puts A and the dequantized B
- *     through fp16 with fp32 accumulate, where the GEMV path stays in fp32.
- *     The tiled error is therefore EXPECTED to be larger, and the test asserts
- *     a bound rather than equality. The bound is not a quality verdict: K3's
- *     AttnRes mix is documented as sensitive to weight noise, so whether this
- *     is acceptable for generation is a logits question, not a kernel question.
+ * Both GPU paths read the SAME uploaded weights and scales, so running the GEMV
+ * and the tiled kernel against the CPU on identical inputs isolates the tiling
+ * from everything else. coli_cuda_set_tile_min() selects between them, so one
+ * binary exercises both -- and using the API rather than the environment is the
+ * point: the tiled dispatch is opt-in precisely so it cannot reach the GLM
+ * engine, which shares coli_cuda_matmul.
  *
  * Shapes are K3's real dense-trunk projections at K3_BITS=4 (gs=64).
  *
  *   nvcc -O3 -std=c++17 -arch=native backend_cuda.cu tests/test_i4g_cuda.cu \
- *        tests/i4g_ref.o -o test_i4g_cuda -lgomp
+ *        tests/i4g_ref.o -o test_i4g_cuda -Xcompiler -fopenmp
  */
 #include <cstdio>
 #include <cstdlib>
@@ -72,9 +64,9 @@ static void case_(const char *label, int S, int I, int O, int gs, double bound) 
     i4g_ref(want, x, q4, scale, S, I, O, gs);
 
     ColiCudaTensor *t = nullptr;
-    setenv("COLI_CUDA_TC_W4A16_MIN", "1000000", 1);           /* force GEMV */
+    coli_cuda_set_tile_min(0);                                /* force GEMV */
     int ok_g = coli_cuda_matmul(&t, gemv, x, q4, scale, 4, S, I, O, 0, gs);
-    setenv("COLI_CUDA_TC_W4A16_MIN", "1", 1);                 /* force tiles */
+    coli_cuda_set_tile_min(1);                                /* force tiles */
     int ok_t = coli_cuda_matmul(&t, tile, x, q4, scale, 4, S, I, O, 0, gs);
 
     if (!ok_g || !ok_t) {

--- a/c/tests/test_i4g_cuda.cu
+++ b/c/tests/test_i4g_cuda.cu
@@ -1,0 +1,128 @@
+/* w4a16_matmul_g (fmt=4 Tensor Core tiling) vs the CPU decoder in quant.h.
+ *
+ * Two things are under test, and they are not the same thing:
+ *
+ *  1. Correctness of the new grouped-scale tile indexing. The GEMV kernel
+ *     (quant_matmul) and the tiled kernel read the SAME uploaded weights and
+ *     scales, so running both against the CPU on identical inputs isolates the
+ *     indexing from everything else. COLI_CUDA_TC_W4A16_MIN selects the path,
+ *     so one binary exercises both.
+ *
+ *  2. The precision cost of the tiling. w4a16 puts A and the dequantized B
+ *     through fp16 with fp32 accumulate, where the GEMV path stays in fp32.
+ *     The tiled error is therefore EXPECTED to be larger, and the test asserts
+ *     a bound rather than equality. The bound is not a quality verdict: K3's
+ *     AttnRes mix is documented as sensitive to weight noise, so whether this
+ *     is acceptable for generation is a logits question, not a kernel question.
+ *
+ * Shapes are K3's real dense-trunk projections at K3_BITS=4 (gs=64).
+ *
+ *   nvcc -O3 -std=c++17 -arch=native backend_cuda.cu tests/test_i4g_cuda.cu \
+ *        tests/i4g_ref.o -o test_i4g_cuda -lgomp
+ */
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cmath>
+#include "../backend_cuda.h"
+
+extern "C" void i4g_ref(float *y, const float *x, const unsigned char *q4,
+                        const float *scale, int S, int I, int O, int gs);
+
+/* Deterministic, so a failure reproduces without carrying a seed file. */
+static unsigned long long g_seed = 0x9E3779B97F4A7C15ULL;
+static float rnd(void) {
+    g_seed = g_seed * 6364136223846793005ULL + 1442695040888963407ULL;
+    return (float)((g_seed >> 40) % 2000001) / 1000000.0f - 1.0f;
+}
+
+/* Relative L2 over the whole output: one bad tile shows up here, whereas a
+ * max-relative on near-zero entries mostly reports cancellation noise. */
+static double rel_l2(const float *got, const float *want, size_t n) {
+    double num = 0, den = 0;
+    for (size_t i = 0; i < n; i++) {
+        double d = (double)got[i] - (double)want[i];
+        num += d * d;
+        den += (double)want[i] * (double)want[i];
+    }
+    return den > 0 ? std::sqrt(num / den) : (num > 0 ? 1.0 : 0.0);
+}
+
+static int fail = 0;
+
+static void case_(const char *label, int S, int I, int O, int gs, double bound) {
+    int rb = (I + 1) / 2, ng = (I + gs - 1) / gs;
+    unsigned char *q4 = (unsigned char *)std::malloc((size_t)O * rb);
+    float *scale = (float *)std::malloc((size_t)O * ng * sizeof(float));
+    float *x = (float *)std::malloc((size_t)S * I * sizeof(float));
+    float *want = (float *)std::calloc((size_t)S * O, sizeof(float));
+    float *gemv = (float *)std::calloc((size_t)S * O, sizeof(float));
+    float *tile = (float *)std::calloc((size_t)S * O, sizeof(float));
+    if (!q4 || !scale || !x || !want || !gemv || !tile) { std::printf("  OOM\n"); fail = 1; return; }
+
+    for (size_t i = 0; i < (size_t)O * rb; i++) {
+        g_seed = g_seed * 6364136223846793005ULL + 1442695040888963407ULL;
+        q4[i] = (unsigned char)(g_seed >> 40);
+    }
+    /* Scales spread over ~2 decades: a per-row-only index would still pass on a
+     * flat scale field, so make the groups actually differ. */
+    for (size_t i = 0; i < (size_t)O * ng; i++) scale[i] = 0.002f * (1.0f + 9.0f * std::fabs(rnd()));
+    for (size_t i = 0; i < (size_t)S * I; i++) x[i] = rnd();
+
+    i4g_ref(want, x, q4, scale, S, I, O, gs);
+
+    ColiCudaTensor *t = nullptr;
+    setenv("COLI_CUDA_TC_W4A16_MIN", "1000000", 1);           /* force GEMV */
+    int ok_g = coli_cuda_matmul(&t, gemv, x, q4, scale, 4, S, I, O, 0, gs);
+    setenv("COLI_CUDA_TC_W4A16_MIN", "1", 1);                 /* force tiles */
+    int ok_t = coli_cuda_matmul(&t, tile, x, q4, scale, 4, S, I, O, 0, gs);
+
+    if (!ok_g || !ok_t) {
+        std::printf("  FAIL %-28s S=%-3d rejected (gemv=%d tiled=%d)\n", label, S, ok_g, ok_t);
+        fail = 1;
+    } else {
+        double eg = rel_l2(gemv, want, (size_t)S * O);
+        double et = rel_l2(tile, want, (size_t)S * O);
+        int bad = !(et <= bound) || !(eg <= 1e-5);
+        std::printf("  %-4s %-28s S=%-3d I=%-5d O=%-5d  gemv %.2e  tiled %.2e  (bound %.0e)\n",
+                    bad ? "FAIL" : "ok", label, S, I, O, eg, et, bound);
+        if (bad) fail = 1;
+    }
+    if (t) coli_cuda_tensor_free(t);
+    std::free(q4); std::free(scale); std::free(x);
+    std::free(want); std::free(gemv); std::free(tile);
+}
+
+int main(void) {
+    int dev[1] = {0};
+    if (!coli_cuda_init(dev, 1)) { std::fprintf(stderr, "no CUDA device - skipped\n"); return 0; }
+
+    /* fp32 throughout, so the tiled path should sit near the GEMV's own 1.8e-07
+     * and differ from the CPU only by summation order. 1e-5 leaves room for that
+     * reordering over K=7168 terms while still failing loudly on a wrong scale
+     * index, which moves entries by whole decades here.
+     *
+     * The predecessor of this kernel used fp16 Tensor Cores and passed at 2.6e-04
+     * against a 1e-3 bound -- and produced 5.9% logit drift with argmax flips on
+     * the real model. Hence the tight bound: a kernel-level number this loose is
+     * not evidence of anything at 93 layers. */
+    const double B = 1e-5;
+    std::printf("fmt=4 grouped int4, fp32 shared-memory tiling vs CPU (gs=64)\n");
+    case_("lat_down 7168->3584",   32, 7168, 3584, 64, B);
+    case_("lat_up   3584->7168",   32, 3584, 7168, 64, B);
+    case_("sh_gate  7168->6144",   32, 7168, 6144, 64, B);
+    case_("kda_qkv  7168->12288",  32, 7168, 12288, 64, B);
+    /* S below/at/above the tile edge: 16 is exactly one tile, 33 forces a
+     * partial tile, 1 is the decode shape the tiled path must still get right
+     * when the threshold is forced down to it. */
+    case_("tile edge S=16",        16, 3584, 3584, 64, B);
+    case_("partial tile S=33",     33, 3584, 3584, 64, B);
+    case_("degenerate S=1",         1, 3584, 3584, 64, B);
+    /* gs=128 straddles nothing; gs=16 makes every k-tile its own group, which is
+     * the indexing most likely to be off by one. */
+    case_("gs=128",                32, 3584, 3584, 128, B);
+    case_("gs=16",                 32, 3584, 3584, 16, B);
+
+    std::printf("%s\n", fail ? "test_i4g_cuda: FAIL" : "test_i4g_cuda: ok");
+    return fail;
+}

--- a/c/tests/test_i8_cuda.cu
+++ b/c/tests/test_i8_cuda.cu
@@ -1,0 +1,73 @@
+/* fmt=1 (int8, per-row scale) on CUDA vs the CPU decoder in quant.h.
+ *
+ * This path was shipped untested by test_i4g_cuda, which only covered fmt=4.
+ * K3's MLA projections are fmt=1 at the default K3_MLA_BITS=8, so K3_CUDA_DENSE
+ * routes 24 layers x 5 tensors through it -- and the dense prefill logits came
+ * out 5% off the CPU with argmax flips even after the int4 kernel was proven
+ * correct to 1e-06. If fmt=1 disagrees, that is the explanation.
+ *
+ *   nvcc -O3 -std=c++17 -arch=native backend_cuda.cu tests/test_i8_cuda.cu \
+ *        tests/i4g_ref.o -o test_i8_cuda -lgomp
+ */
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include "../backend_cuda.h"
+
+extern "C" void i8_ref(float *y, const float *x, const signed char *q8,
+                       const float *scale, int S, int I, int O);
+
+static unsigned long long sd = 0x9E3779B97F4A7C15ULL;
+static float rnd(void) {
+    sd = sd * 6364136223846793005ULL + 1442695040888963407ULL;
+    return (float)((sd >> 40) % 2000001) / 1000000.0f - 1.0f;
+}
+static double rel_l2(const float *a, const float *b, size_t n) {
+    double num = 0, den = 0;
+    for (size_t i = 0; i < n; i++) {
+        double d = (double)a[i] - (double)b[i];
+        num += d * d; den += (double)b[i] * (double)b[i];
+    }
+    return den > 0 ? std::sqrt(num / den) : (num > 0 ? 1.0 : 0.0);
+}
+
+static int fail = 0;
+static void case_(const char *nm, int S, int I, int O) {
+    signed char *q8 = (signed char *)std::malloc((size_t)O * I);
+    float *sc = (float *)std::malloc((size_t)O * sizeof(float));
+    float *x = (float *)std::malloc((size_t)S * I * sizeof(float));
+    float *want = (float *)std::calloc((size_t)S * O, sizeof(float));
+    float *got = (float *)std::calloc((size_t)S * O, sizeof(float));
+    for (size_t i = 0; i < (size_t)O * I; i++) { sd = sd*6364136223846793005ULL+1442695040888963407ULL; q8[i] = (signed char)(sd >> 40); }
+    for (int o = 0; o < O; o++) sc[o] = 0.002f * (1.0f + std::fabs(rnd()));
+    for (size_t i = 0; i < (size_t)S * I; i++) x[i] = rnd();
+
+    i8_ref(want, x, q8, sc, S, I, O);
+    ColiCudaTensor *t = nullptr;
+    int ok = coli_cuda_matmul(&t, got, x, q8, sc, 1, S, I, O, 0, 0);
+    double e = ok ? rel_l2(got, want, (size_t)S * O) : 1.0;
+    int bad = !ok || !(e <= 1e-5);
+    std::printf("  %-4s %-24s S=%-3d I=%-5d O=%-5d  rel_l2 %.3e%s\n",
+                bad ? "FAIL" : "ok", nm, S, I, O, e, ok ? "" : "  (REJECTED)");
+    if (bad) {
+        fail = 1;
+        for (int i = 0; i < 4 && i < S * O; i++)
+            std::printf("        [%d] gpu %.6f  cpu %.6f  ratio %.6f\n",
+                        i, got[i], want[i], want[i] != 0 ? got[i] / want[i] : 0.0);
+    }
+    if (t) coli_cuda_tensor_free(t);
+    std::free(q8); std::free(sc); std::free(x); std::free(want); std::free(got);
+}
+
+int main(void) {
+    int d[1] = {0};
+    if (!coli_cuda_init(d, 1)) { std::fprintf(stderr, "no CUDA device - skipped\n"); return 0; }
+    std::printf("fmt=1 int8 per-row vs CPU\n");
+    case_("mla_qa  7168->1536",  32, 7168, 1536);
+    case_("mla_qb  1536->12288", 32, 1536, 12288);
+    case_("mla_kva 7168->576",   32, 7168, 576);
+    case_("S=1 decode shape",     1, 7168, 1536);
+    case_("S=8 below threshold",  8, 7168, 1536);
+    std::printf("%s\n", fail ? "test_i8_cuda: FAIL" : "test_i8_cuda: ok");
+    return fail;
+}

--- a/c/tools/clean.py
+++ b/c/tools/clean.py
@@ -19,6 +19,8 @@ FILES = [
     "backend_cuda.o", "backend_loader.o",
     "backend_cuda_test", "backend_cuda_test.exe",
     "backend_cuda_bench", "backend_cuda_bench.exe",
+    "i4g_cuda_test", "i4g_cuda_test.exe",
+    "i8_cuda_test", "i8_cuda_test.exe",
     "backend_metal.o", "backend_metal_test",
     "coli_cuda.dll", "coli_cuda.lib", "coli_cuda.exp",
     # hipcc emits an import library, export file and PDB alongside the DLL.

--- a/docs/kimi_k3.md
+++ b/docs/kimi_k3.md
@@ -263,6 +263,18 @@ The MoE line barely moves because only its dense parts are resident; the routed
 experts still stream to the CPU. Batching those per chunk needs a gather/scatter
 over each expert's token subset and is not done here.
 
+Since only prefill moves, the end-to-end win is whatever share of your wall clock
+prefill is. At a balanced mix -- 56-token prompt, 44 generated, sized so prefill
+is ~50% of CPU wall -- the same ABBA measurement gives:
+
+| | prefill | decode | total |
+|---|---|---|---|
+| CPU | 143.8 s | 140.5 s | 284.2 s |
+| `K3_CUDA_DENSE=1` | 100.9 s | 139.7 s | **240.5 s (1.18x)** |
+
+So: ~1.45x on prefill-heavy work (long prompts, RAG, code context), ~1.18x on a
+balanced turn, ~nothing when generating long output from a short prompt.
+
 No Tensor Cores, deliberately. The first version used the fp16 WMMA path and was
 no faster end to end, but see the caveat below.
 

--- a/docs/kimi_k3.md
+++ b/docs/kimi_k3.md
@@ -161,6 +161,11 @@ Judge quantization choices on real-text logits, not synthetic-vector norms.
 | `K3_VK` | 1 | Vulkan tier when built with `make VK=1 kimi_k3` (0 = pure CPU) |
 | `K3_VK_GB` | driver budget | VRAM cap for the Vulkan tier |
 | `K3_VK_UP` | 8 | routed-expert uploads per step (fill-once tier) |
+| `K3_CUDA_DENSE` | 0 | dense trunk resident in VRAM, tiled matmul at prefill (`make CUDA=1 kimi_k3`) |
+| `K3_CUDA_GB` | VRAM − 4 | upload cap for the dense trunk |
+| `K3_CUDA_TILE_S` | 16 | min batch rows for the tiled kernel (below it, the GEMV wins) |
+| `K3_CUDA_DEV` | 0 | device for the dense trunk (forced to 0 when `K3_CUDA=1`) |
+| `K3_CUDA_VERIFY` | 0 | recompute every dense matmul on the CPU, report worst rel-L2 |
 | `K3_DIRECT` | 1 | O_DIRECT expert reads (0 = buffered + WILLNEED) |
 | `K3_IDOT` | 1 | int8-activation expert matmuls (0 = exact-float kernel) |
 | `K3_PIPE` | 1 | overlap expert loads with compute (loader threads) |
@@ -228,6 +233,62 @@ non-streaming `/v1/chat/completions`; `coli web` uses that same API. Reasoning
 is returned as `reasoning_content`, response text as `content`, and
 `<|end_of_msg|>` remains the model-owned stop token. `STOP` and `CANCEL` are
 honoured between generated tokens.
+
+## CUDA dense trunk (`make CUDA=1 kimi_k3`, `K3_CUDA_DENSE=1`)
+
+Prefill only. The dense trunk — attention projections, latent up/down, the shared
+experts, dense-layer MLP — is uploaded to VRAM once at init (~32 GB at
+`K3_BITS=4`, so it fits one 48 GB card whole) and its matmuls run on
+`i4_tiled_f32`, an fp32 shared-memory tiled GEMM for fmt=2/4.
+
+Why a threshold rather than always-on: `quant_matmul` makes the batch the grid Y
+dimension, so each row re-reads the whole weight matrix from VRAM. That is the
+right shape at S=1 and S copies of the traffic at a prefill chunk. The tiled
+kernel reads one weight tile per 32 output rows, which only pays once the chunk
+is wide enough — measured on one A6000, K3 shapes at S=32, the tiling is 6–13x
+the GEMV, and at S=1 the GEMV wins. `K3_CUDA_TILE_S` is that crossover, and
+decode (S=1) therefore never touches the GPU.
+
+Measured on the 93-layer model, 56-token prompt, ABBA-interleaved on an idle box
+(2x A6000, 16-core Ice Lake):
+
+| | CPU | `K3_CUDA_DENSE=1` |
+|---|---|---|
+| prefill | 146.9 s (2.62 s/tok) | **100.4 s (1.79 s/tok)** |
+| attention projections | 40.0 s | 10.8 s |
+| MoE | 119.9 s | 102.4 s |
+| decode | unchanged | unchanged |
+
+The MoE line barely moves because only its dense parts are resident; the routed
+experts still stream to the CPU. Batching those per chunk needs a gather/scatter
+over each expert's token subset and is not done here.
+
+No Tensor Cores, deliberately. The first version used the fp16 WMMA path and was
+no faster end to end, but see the caveat below.
+
+### This path does not reproduce CPU logits, and cannot
+
+Teacher-forced prefill logits differ from the CPU by ~5e-2 relative L2 on the
+93-layer model, with occasional argmax flips on near-tied positions. That is not
+a kernel defect and is not fixable by precision:
+
+- every dense matmul agrees with the CPU decoder to **6.3e-07** on real weights
+  and activations (`K3_CUDA_VERIFY=1`, worst of 156, zero fallbacks);
+- the divergence is **5.6e-03 at 8 layers** and 5.2e-02 at 93 — roughly 3x
+  amplification per layer;
+- fp16 tiling (kernel error 2.6e-04) and fp32 tiling (1.0e-06) both land at ~5%,
+  so a 260x more accurate kernel buys 12%.
+
+The cause is AttnRes: it replaces the residual stream with a softmax mix whose
+scores sit ~0.02 apart, twice per layer, so a near-tie converts a 1e-07
+perturbation into a shifted mixture weight. Merely changing fp32 summation order
+is enough. Controls: CPU vs CPU is bit-identical, GPU vs GPU is bit-identical,
+and uploading without computing is bit-identical — so the harness can tell a real
+difference from noise.
+
+Judge this path on generated text, not on logit equality with the CPU. Measured
+side by side on the same prompt, both produce fluent, correct output; they word
+it differently.
 
 ## Vulkan tier (`make VK=1 kimi_k3`)
 


### PR DESCRIPTION
# Kimi K3: run the dense trunk on CUDA during prefill (1.46x)

`kimi_k3` gated every GPU path to `S == 1` — decode only, with a literal `1` at
each call site. Prefill, which processes 32-token chunks and is where a GPU has
something to work with, never touched one. This adds that path.

## Result

93-layer model, 56-token prompt, `--ngen 4`, ABBA-interleaved on an idle box
(2x RTX A6000, 16-core Xeon Silver 4314). Spread within arms 6% / 3%.

| | CPU | `K3_CUDA_DENSE=1` |
|---|---|---|
| **prefill** | 146.9 s (2.62 s/tok) | **100.4 s (1.79 s/tok)** |
| attention projections | 40.0 s | 10.8 s |
| MoE | 119.9 s | 102.4 s |
| decode | unchanged | unchanged |

MoE barely moves because only its dense parts are resident — the routed experts
still stream to the CPU. Batching those needs a gather/scatter over each
expert's token subset per chunk and is not attempted here.

Only prefill moves, so the end-to-end win is bounded by prefill's share of wall
clock. At a balanced mix — 56-token prompt, 44 generated, sized so prefill is
~50% of CPU wall — the same ABBA measurement gives:

| | prefill | decode | total |
|---|---|---|---|
| CPU | 143.8 s | 140.5 s | 284.2 s |
| `K3_CUDA_DENSE=1` | 100.9 s | 139.7 s | **240.5 s (1.18x)** |

Spread within arms 4.5% / 0.6%. Decode is unchanged at 1.006x, as designed.
Headline by workload: ~1.45x prefill-heavy, ~1.18x balanced, ~nothing for long
generation from a short prompt.

## What changed

**`i4_tiled_f32`** (`backend_cuda.cu`) — fp32 shared-memory tiled GEMM for fmt=2
and fmt=4. `coli_cuda_matmul` previously sent every shape to `quant_matmul`,
which makes the batch the grid Y dimension, so each row re-reads the whole
weight matrix from VRAM. The tiled kernel reads one weight tile per 32 output
rows. On K3's dense shapes at S=32 it is 6–13x the GEMV; at S=1 the GEMV wins,
hence a threshold rather than always-on.

Not Tensor Cores, deliberately. The first version reused the existing `w4a16`
WMMA path; it was no faster end to end, and fp16 weights are a poor trade in
this model. fp32 also drops the sm_70 floor WMMA imposes. The win was weight
reuse, not fp16.

**`K3_CUDA_DENSE`** (`kimi_k3.c`) — the dense trunk (attention projections,
latent up/down, shared experts, dense-layer MLP) is ~32 GB at `K3_BITS=4` and
fits one 48 GB card whole. Uploaded at init, dispatched at `S >= K3_CUDA_TILE_S`.

New env: `K3_CUDA_DENSE`, `K3_CUDA_GB`, `K3_CUDA_TILE_S`, `K3_CUDA_DEV`,
`K3_CUDA_VERIFY`. Default off; documented in `docs/kimi_k3.md`.

**Two pre-existing test breakages** fixed in a separate commit:
`tests/test_backend_cuda.cu:275` asserted fmt=7 uploads are rejected, but
`db0c80f` made them work, so `make cuda-test` failed at the first hurdle with no
diagnostic; and the mxfp4 test's link line lacked `-fopenmp` for its CPU
reference object. Neither is reachable without a CUDA device.

## Correctness

`make cuda-test` green, including two new tests over both dispatched formats,
real K3 shapes, tile edge (S=16), partial tile (S=33), S=1, gs 16/64/128:

```
i4g: tiled 2.5e-07 .. 3.5e-07 vs CPU     i8: 2.7e-07 .. 5.6e-07 vs CPU
```

In situ on the real model, every dense matmul against the CPU decoder
(`K3_CUDA_VERIFY=1`): **worst rel_l2 6.3e-07** across all 156, zero fallbacks.

Degrades rather than fails. Verified at a budget half the trunk: 33 of 78
tensors resident, the rest silently on the CPU, same numerics. `K3_BITS=32`
gives fmt=0, refused on purpose so validation against `tools/k3_ref.py` is not
quietly run in another precision. Repacked containers need no special case —
`w_load` yields fmt=1/fmt=4 either way.

## Known: this does not reproduce CPU logits, and cannot

Teacher-forced prefill logits differ from the CPU by ~5e-2 relative L2 at 93
layers, with occasional argmax flips on near-tied positions (margins ~0.05
against a median of ~1.0). This is not a kernel defect:

- every dense matmul agrees with the CPU to 6.3e-07 on real weights;
- divergence is 5.6e-03 at 8 layers, 5.2e-02 at 93 — ~3x per layer;
- fp16 tiling (kernel error 2.6e-04) and fp32 tiling (1.0e-06) both land at ~5%,
  so a 260x more accurate kernel buys 12%.

AttnRes replaces the residual stream with a softmax mix whose scores sit ~0.02
apart, twice per layer; a near-tie turns a 1e-07 perturbation into a shifted
mixture weight. Changing fp32 summation order at all is sufficient. `docs/`
already warned that the mix "leverages weight noise strongly".

Controls, so this is distinguishable from noise: CPU vs CPU, GPU vs GPU, and
upload-without-compute are each **bit-identical**; so is chunk=1 vs chunk=32.

Judged on output instead: same prompt, 100 tokens, both arms fluent and correct,
worded differently. `tests/logit_cmp.py` reports top-1 agreement and top-2
margin for this kind of check, since L2 alone does not say whether the model
would have said something else.

## Not addressed

- Routed experts at S>1 — the remaining ~102 s of prefill.
- `K3_CUDA=1` together with `K3_CUDA_DENSE=1` works but is a pessimization (the
  routed path uploads per call); both are warned about at startup.
- Single device: the trunk fits one card, so sharding buys nothing.
- Untested through `coli chat/serve/web` (shares the same `w_matmul`), on a
  repacked container, and on `CUDA_ARCH=portable`.
