### PR TITLE
fix(cli): stream the model's thinking in chat, dim and boxed (#979)

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -1043,6 +1043,8 @@ def chat_attached(a, base, model_id):
                     for ch in ev.get("choices",[]):
                         d=ch.get("delta",{})
                         rtxt=d.get("reasoning_content")
+                        if rtxt and os.environ.get("COLI_SHOW_THINK","1")=="0":
+                            continue              # thinking nascosto: lo spinner resta a girare
                         if rtxt:
                             # Thinking arrives as its own delta field, and this loop
                             # used to drop it on the floor: `coli run` streamed the

--- a/c/coli
+++ b/c/coli
@@ -1030,7 +1030,7 @@ def chat_attached(a, base, model_id):
         if a.api_key: req.add_header("Authorization", f"Bearer {a.api_key}")
         print(f"\n  {C.teal}◆ colibri{C.r}")
         sp=Spinner("thinking…"); sp.start()
-        md=MDStream("  "); reply=[]; first=True; t0=time.time(); interrupted=False
+        md=MDStream("  "); reply=[]; first=True; t0=time.time(); interrupted=False; think_open=False
         try:
             with urllib.request.urlopen(req) as r:
                 for raw in r:
@@ -1042,8 +1042,27 @@ def chat_attached(a, base, model_id):
                     except ValueError: continue
                     for ch in ev.get("choices",[]):
                         d=ch.get("delta",{})
+                        rtxt=d.get("reasoning_content")
+                        if rtxt:
+                            # Thinking arrives as its own delta field, and this loop
+                            # used to drop it on the floor: `coli run` streamed the
+                            # model's reasoning while `coli chat` silently hid it
+                            # (#979). Render it dim and unformatted — it is the
+                            # model's scratchpad, not the answer — and keep it out
+                            # of the saved reply so history carries content only.
+                            # The keepalive ping reuses this field with "."/"" —
+                            # dim dots read as heartbeat, which is what they are.
+                            if first: sp.stop(); first=False
+                            if not think_open:
+                                think_open=True
+                                sys.stdout.write(f"  {C.dgray}┌ thinking{C.r}\n  {C.dgray}│{C.r} ")
+                            sys.stdout.write(C.dim+rtxt.replace("\n","\n  "+C.dgray+"│"+C.r+" "+C.dim)+C.r)
+                            sys.stdout.flush(); continue
                         txt=d.get("content")
-                        if not txt: continue          # ping/ruolo/reasoning: non è testo
+                        if not txt: continue          # ping/ruolo: non è testo
+                        if think_open:
+                            think_open=False
+                            sys.stdout.write(f"{C.r}\n  {C.dgray}└─{C.r}\n")
                         if first: sp.stop(); first=False
                         md.feed(txt); reply.append(txt)
         except KeyboardInterrupt:
@@ -1065,6 +1084,9 @@ def chat_attached(a, base, model_id):
         except OSError as e:
             sp.stop()
             print(f"\n  {C.yel}[server unreachable: {e}]{C.r}"); break
+        if think_open:                            # stream finito dentro il thinking (interrupt o
+            think_open=False                      # risposta solo-reasoning): chiudi il riquadro
+            sys.stdout.write(f"{C.r}\n  {C.dgray}\u2514\u2500{C.r}\n")
         md.close(); sp.stop()
         if reply: msgs.append({"role":"assistant","content":"".join(reply)})
         else: msgs.pop()                              # turno vuoto: non sporcare la history

--- a/c/tests/test_chat_thinking.py
+++ b/c/tests/test_chat_thinking.py
@@ -74,13 +74,42 @@ def run_chat(base, extra_env):
         args = SimpleNamespace(ngen=32, api_key=None)
         module.chat_attached(args, base, "fake-model")
         os._exit(0)
-    os.write(fd, b"first question\n")
-    time.sleep(1.0)
-    os.write(fd, b"second question\n")
-    time.sleep(1.0)
-    os.write(fd, b":q\n")
+    # Lockstep, not fire-and-forget: writing lines before the child reaches
+    # input() is timing-dependent -- on macOS, libedit's initialization at the
+    # first input() flushes the tty buffer and eats pre-written lines (the
+    # readline activation from #928), while Linux's GNU readline preserves
+    # them. Wait for each marker before typing, like a human would, with a
+    # strictly-advancing cursor so an old prompt can never satisfy a new wait.
     output = b""
-    deadline = time.time() + 15
+    pos = 0
+    deadline = time.time() + 30
+
+    def read_until(needle):
+        nonlocal output, pos
+        while time.time() < deadline:
+            found = output.find(needle, pos)
+            if found >= 0:
+                pos = found + len(needle)
+                return True
+            try:
+                chunk = os.read(fd, 65536)
+            except OSError:
+                return False
+            if not chunk:
+                return False
+            output += chunk
+        return False
+
+    prompt = "\u203a".encode()           # the › of a fresh input box
+    footer = "tok \u00b7".encode()       # the "~N tok ·" reply footer
+    if read_until(prompt):
+        os.write(fd, b"first question\n")
+    read_until(footer)                    # reply finished
+    if read_until(prompt):
+        os.write(fd, b"second question\n")
+    read_until(footer)
+    if read_until(prompt):
+        os.write(fd, b":q\n")
     while time.time() < deadline:
         try:
             chunk = os.read(fd, 65536)

--- a/c/tests/test_chat_thinking.py
+++ b/c/tests/test_chat_thinking.py
@@ -1,0 +1,134 @@
+"""#979: `coli chat` must SHOW the model's thinking, and be able to hide it.
+
+The server streams thinking as `reasoning_content` deltas; chat_attached's
+loop used to drop every non-content delta (its comment listed `reasoning`
+among the discards), so `coli run` showed reasoning while `coli chat`
+silently hid it. These tests drive the real chat_attached under a pty
+against a stdlib SSE server:
+
+  1. default: the reasoning text is visible, inside the thinking box;
+  2. COLI_SHOW_THINK=0: the reasoning is absent, the answer still arrives;
+  3. both ways: the assistant history carries `content` only -- the second
+     request's messages must not contain the scratchpad.
+"""
+import importlib.machinery
+import importlib.util
+import json
+import os
+import pty
+import sys
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from types import SimpleNamespace
+
+CLI = Path(__file__).resolve().parent.parent / "coli"
+
+SEEN_MESSAGES = []
+
+
+class FakeSSE(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+        SEEN_MESSAGES.append(body["messages"])
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.end_headers()
+
+        def event(delta):
+            payload = {"choices": [{"index": 0, "delta": delta,
+                                    "finish_reason": None}]}
+            self.wfile.write(b"data: " + json.dumps(payload).encode() + b"\n\n")
+
+        event({"role": "assistant"})
+        event({"reasoning_content": "SCRATCHPAD-ALPHA "})
+        event({"reasoning_content": "SCRATCHPAD-BETA"})
+        event({"content": "ANSWER-GAMMA"})
+        self.wfile.write(b"data: [DONE]\n\n")
+
+
+def run_chat(base, extra_env):
+    """Drive chat_attached in a pty child: two prompts, then quit."""
+    pid, fd = pty.fork()
+    if pid == 0:
+        # Under pytest the inherited sys.stdout is the capture buffer, not
+        # fd 1: coli would see isatty()=False and its output would never
+        # reach the pty. Rebind the std streams to the real descriptors.
+        sys.stdin = os.fdopen(0, "r")
+        sys.stdout = os.fdopen(1, "w", buffering=1)
+        sys.stderr = os.fdopen(2, "w", buffering=1)
+        os.environ.update(extra_env)
+        loader = importlib.machinery.SourceFileLoader("coli_t", str(CLI))
+        spec = importlib.util.spec_from_loader(loader.name, loader)
+        module = importlib.util.module_from_spec(spec)
+        sys.argv = ["coli"]
+        try:
+            loader.exec_module(module)
+        except SystemExit:
+            pass
+        args = SimpleNamespace(ngen=32, api_key=None)
+        module.chat_attached(args, base, "fake-model")
+        os._exit(0)
+    os.write(fd, b"first question\n")
+    time.sleep(1.0)
+    os.write(fd, b"second question\n")
+    time.sleep(1.0)
+    os.write(fd, b":q\n")
+    output = b""
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        try:
+            chunk = os.read(fd, 65536)
+        except OSError:
+            break
+        if not chunk:
+            break
+        output += chunk
+    os.waitpid(pid, 0)
+    return output.decode("utf-8", "replace")
+
+
+class ChatThinkingTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = ThreadingHTTPServer(("127.0.0.1", 0), FakeSSE)
+        threading.Thread(target=cls.server.serve_forever, daemon=True).start()
+        cls.base = f"http://127.0.0.1:{cls.server.server_address[1]}"
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+
+    def setUp(self):
+        SEEN_MESSAGES.clear()
+
+    def test_thinking_is_shown_by_default(self):
+        out = run_chat(self.base, {"COLI_SHOW_THINK": "1"})
+        self.assertIn("SCRATCHPAD-ALPHA", out, "reasoning deltas must render")
+        self.assertIn("thinking", out, "the thinking box must announce itself")
+        self.assertIn("ANSWER-GAMMA", out)
+
+    def test_toggle_hides_thinking(self):
+        out = run_chat(self.base, {"COLI_SHOW_THINK": "0"})
+        self.assertNotIn("SCRATCHPAD-ALPHA", out,
+                         "COLI_SHOW_THINK=0 must suppress the scratchpad")
+        self.assertIn("ANSWER-GAMMA", out, "the answer must still stream")
+
+    def test_history_carries_content_only(self):
+        run_chat(self.base, {"COLI_SHOW_THINK": "1"})
+        self.assertGreaterEqual(len(SEEN_MESSAGES), 2, "need the second request")
+        second = SEEN_MESSAGES[1]
+        assistant = [m for m in second if m["role"] == "assistant"]
+        self.assertTrue(assistant)
+        self.assertEqual(assistant[0]["content"], "ANSWER-GAMMA")
+        self.assertNotIn("SCRATCHPAD", json.dumps(second),
+                         "the scratchpad must never re-enter the context")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tests/test_chat_thinking.py
+++ b/c/tests/test_chat_thinking.py
@@ -15,6 +15,7 @@ import importlib.machinery
 import importlib.util
 import json
 import os
+import subprocess
 import sys
 import threading
 import time
@@ -32,6 +33,26 @@ from types import SimpleNamespace
 CLI = Path(__file__).resolve().parent.parent / "coli"
 
 SEEN_MESSAGES = []
+
+# The child is spawned with fork+EXEC, never bare fork: this test process is
+# multi-threaded (the fake SSE server runs in a thread), and pty.fork() from a
+# multi-threaded process inherits half-held runtime locks -- Python itself
+# warns "use of forkpty() may lead to deadlocks in the child", and on the
+# macOS runner it did exactly that, reliably, until the job timeout.
+BOOTSTRAP = """
+import importlib.machinery, importlib.util, os, sys
+from types import SimpleNamespace
+loader = importlib.machinery.SourceFileLoader("coli_t", os.environ["COLI_TEST_CLI"])
+spec = importlib.util.spec_from_loader(loader.name, loader)
+module = importlib.util.module_from_spec(spec)
+sys.argv = ["coli"]
+try:
+    loader.exec_module(module)
+except SystemExit:
+    pass
+module.chat_attached(SimpleNamespace(ngen=32, api_key=None),
+                     os.environ["COLI_TEST_BASE"], "fake-model")
+"""
 
 
 class FakeSSE(BaseHTTPRequestHandler):
@@ -58,27 +79,16 @@ class FakeSSE(BaseHTTPRequestHandler):
 
 
 def run_chat(base, extra_env):
-    """Drive chat_attached in a pty child: two prompts, then quit."""
-    pid, fd = pty.fork()
-    if pid == 0:
-        # Under pytest the inherited sys.stdout is the capture buffer, not
-        # fd 1: coli would see isatty()=False and its output would never
-        # reach the pty. Rebind the std streams to the real descriptors.
-        sys.stdin = os.fdopen(0, "r")
-        sys.stdout = os.fdopen(1, "w", buffering=1)
-        sys.stderr = os.fdopen(2, "w", buffering=1)
-        os.environ.update(extra_env)
-        loader = importlib.machinery.SourceFileLoader("coli_t", str(CLI))
-        spec = importlib.util.spec_from_loader(loader.name, loader)
-        module = importlib.util.module_from_spec(spec)
-        sys.argv = ["coli"]
-        try:
-            loader.exec_module(module)
-        except SystemExit:
-            pass
-        args = SimpleNamespace(ngen=32, api_key=None)
-        module.chat_attached(args, base, "fake-model")
-        os._exit(0)
+    """Drive chat_attached through a pty slave: two prompts, then quit."""
+    master, slave = pty.openpty()
+    env = dict(os.environ, COLI_TEST_CLI=str(CLI), COLI_TEST_BASE=base,
+               TERM="xterm", **extra_env)
+    child = subprocess.Popen([sys.executable, "-c", BOOTSTRAP],
+                             stdin=slave, stdout=slave, stderr=slave,
+                             env=env, start_new_session=True, close_fds=True)
+    os.close(slave)
+    fd = master
+
     # Lockstep, not fire-and-forget: writing lines before the child reaches
     # input() is timing-dependent -- on macOS, libedit's initialization at the
     # first input() flushes the tty buffer and eats pre-written lines (the
@@ -123,7 +133,12 @@ def run_chat(base, extra_env):
         if not chunk:
             break
         output += chunk
-    os.waitpid(pid, 0)
+    try:
+        child.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        child.kill()
+        child.wait()
+    os.close(master)
     return output.decode("utf-8", "replace")
 
 

--- a/c/tests/test_chat_thinking.py
+++ b/c/tests/test_chat_thinking.py
@@ -15,11 +15,16 @@ import importlib.machinery
 import importlib.util
 import json
 import os
-import pty
 import sys
 import threading
 import time
 import unittest
+
+try:
+    import pty                      # POSIX-only: no termios/pty on Windows.
+    HAVE_PTY = True
+except ImportError:                 # The TUI path under test needs a real
+    HAVE_PTY = False                # terminal; Linux and macOS runners cover it.
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from types import SimpleNamespace
@@ -122,6 +127,7 @@ def run_chat(base, extra_env):
     return output.decode("utf-8", "replace")
 
 
+@unittest.skipUnless(HAVE_PTY, "pty is POSIX-only; covered on Linux/macOS")
 class ChatThinkingTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
The server has always streamed thinking as `reasoning_content` deltas; `chat_attached` dropped every non-content delta — the comment even named `reasoning` among the discards. So `coli run` showed the model reasoning while `coli chat` silently hid it (#979).

Now: reasoning renders **dim inside a light box** (`┌ thinking … └─`), kept out of the saved reply — it is the model's scratchpad, not the answer, so history carries `content` only. The visible-keepalive ping reuses the same field with `"."` and reads as a dim heartbeat inside the box. The box closes on the first content delta, or at stream end for an interrupted thought.

138 launcher/server tests green; syntax-checked; mirrors the fix the reporter's own patched client proved out.

Closes #979 (manual close on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)