### PR TITLE
test(cuda): fmt=7 is real now — fix the stale negative case (#971)

### DIFF
--- a/c/tests/test_backend_cuda.cu
+++ b/c/tests/test_backend_cuda.cu
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <vector>
 
 #ifdef _WIN32
 /* MSVC has no POSIX setenv/unsetenv */

--- a/c/tests/test_backend_cuda.cu
+++ b/c/tests/test_backend_cuda.cu
@@ -272,13 +272,39 @@ int main(int argc, char **argv) {
         coli_cuda_stats(-1, &c0, &b0);
         ColiCudaTensor *bad = nullptr;
         if (coli_cuda_tensor_upload(&bad, q8, s8, 1, 4, 2, 9999)) return 1;
-        if (coli_cuda_tensor_upload(&bad, q8, s8, 7, 4, 2, d0)) return 1;
+        /* 99, not 7: this line asserted "unknown format must fail" with 7 back
+         * when 7 WAS unknown. db0c80f made fmt=7 (MXFP4) real for Kimi K3's
+         * CUDA tier and the expectation silently inverted -- v1.6.0's first
+         * real-GPU run failed exactly here (#971). Unknown must stay unknown. */
+        if (coli_cuda_tensor_upload(&bad, q8, s8, 99, 4, 2, d0)) return 1;
         if (coli_cuda_tensor_upload(&bad, q8, nullptr, 1, 4, 2, d0)) return 1;
         if (coli_cuda_tensor_upload(&bad, nullptr, s8, 1, 4, 2, d0)) return 1;
+        /* Deliberate ~16 TB ask: the backend PRINTS its out-of-memory line
+         * here and that is the expected outcome, not a swallowed failure --
+         * announce it so the stderr does not read like a bug (#971 round 1). */
+        std::fprintf(stderr, "expecting one out-of-memory line next (deliberate ~16 TB negative case):\n");
         if (coli_cuda_tensor_upload(&bad, q8, s8, 1, 1 << 20, 1 << 24, d0)) return 1; /* ~16 TB */
         if (bad) return 1;
         coli_cuda_stats(-1, &c1, &b1);
         if (c0 != c1 || b0 != b1) return 1;
+        /* fmt=7 is REAL now (db0c80f): a valid MXFP4 upload must succeed.
+         * Smoke, not correctness -- e2m1 nibbles 2/byte, one ue8m0 exponent
+         * per 32 columns; all-zero payload decodes to zeros, which is enough
+         * to prove the format is accepted and accounted. The matmul-level
+         * correctness case mirrors fmt=6's harness and is tracked in #971. */
+        {
+            const int I7 = 64, O7 = 4, NG7 = (I7 + 31) / 32;
+            std::vector<uint8_t> w7((size_t)O7 * ((I7 + 1) / 2), 0);
+            std::vector<uint8_t> s7((size_t)O7 * NG7, 127); /* e8m0 127 = scale 1.0 */
+            ColiCudaTensor *t7 = nullptr;
+            if (!coli_cuda_tensor_upload(&t7, w7.data(),
+                                         reinterpret_cast<const float *>(s7.data()),
+                                         7, I7, O7, d0) || !t7) {
+                std::fprintf(stderr, "fmt=7 (MXFP4) upload rejected -- the format is real since db0c80f\n");
+                return 1;
+            }
+            coli_cuda_tensor_free(t7);
+        }
         /* healthy launch immediately after the failed allocation */
         if (!coli_cuda_matmul(&t8, got, x, nullptr, nullptr, 1, 2, 4, 2, d0, 0) ||
             !close_enough(got, want8, 4)) return 1;


### PR DESCRIPTION
Fixes #971's actual defect: the unknown-format negative case asserted format `7` must fail — written when 7 *was* unknown. `db0c80f` made fmt=7 (MXFP4, Kimi K3's CUDA tier) real, the expectation silently inverted, and v1.6.0's **first execution on real hardware** (the reporter's A6000 — `cuda-test` has no CI) failed on exactly that line.

Three changes:
1. Unknown moves to `99`, which stays unknown, with the history in a comment.
2. **Positive smoke for fmt=7**: a valid MXFP4 upload must be accepted, accounted, freed. (The matmul-correctness harness mirroring fmt=6's stays tracked in #971 — it needs the packing exercised against the CPU reference, best written by someone who can run it.)
3. The deliberate ~16 TB negative case now **announces** its expected out-of-memory line — in 1.5.0 that unannounced stderr read like a swallowed failure and fooled the first responder (me) into a wrong theory before the reporter's second dig found the truth.

**Deliberately untested on GPU here** — no CUDA hardware on this side. @ailabai offered to run it on the A6000 that found the bug ("That would be the best, I guess 8)"), which is more execution coverage than this suite has ever had. The ask: `make cuda-test CUDA=1` on this branch, paste the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)