### PR TITLE
deepseek_v4: print the effective OpenMP team when the sizing policy is silent

### DIFF
--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -8889,23 +8889,26 @@ static int v4_serve_main(void) {
  * rationale omp_tune.h records for the spin-wait half of the GLM tuning: a
  * busy team steals cores from the I/O pool). An explicit OMP_NUM_THREADS or
  * COLI_NO_OMP_TUNE=1 wins, exactly like the other engines' tuning. */
-static void v4_omp_reserve_loader_cpus(void) {
-    if (getenv("COLI_NO_OMP_TUNE")) return; /* family-wide kill-switch */
-    if (getenv("OMP_NUM_THREADS")) return;  /* the user already chose */
+static int v4_omp_reserve_loader_cpus(void) {
+    if (getenv("COLI_NO_OMP_TUNE")) return 0; /* family-wide kill-switch */
+    if (getenv("OMP_NUM_THREADS")) return 0;  /* the user already chose */
     int logical = omp_get_max_threads();
     int team = logical - COLI_V4_EXPERT_LOADER_COUNT;
-    if (team < 2) return; /* tiny machine: leave the OpenMP default alone */
+    if (team < 2) return 0; /* tiny machine: leave the OpenMP default alone */
     omp_set_num_threads(team);
     fprintf(stderr, "[OMP] deepseek-v4: %d compute threads (%d logical CPUs "
                     "minus %d expert-loader workers); OMP_NUM_THREADS=<n> "
                     "overrides, COLI_NO_OMP_TUNE=1 disables\n",
             team, logical, COLI_V4_EXPERT_LOADER_COUNT);
+    return 1;
 }
 #endif
 
 int main(int argc, char **argv) {
 #ifdef _OPENMP
-    v4_omp_reserve_loader_cpus();
+    if (!v4_omp_reserve_loader_cpus())
+        fprintf(stderr, "[OMP] deepseek-v4: effective team size %d\n",
+                omp_get_max_threads());
 #endif
     if (getenv("SERVE") && getenv("SERVE")[0] == '1')
         return v4_serve_main();


### PR DESCRIPTION
I added an OpenMP startup diagnostic to the DeepSeek V4 engine for the cases where the team sizing is silent today. `v4_omp_reserve_loader_cpus()` already prints its policy line when it sizes the team, but when `OMP_NUM_THREADS` is set, `COLI_NO_OMP_TUNE=1` is set, or the machine is too small for the reservation, nothing reports what team the engine actually got. This prints `omp_get_max_threads()` on stderr with the existing `[OMP] deepseek-v4:` prefix in exactly those cases, so the default path still prints one line, not two.

The override case matters most on the launcher paths: today both launch funnels set `OMP_NUM_THREADS` before V4 starts, so launcher-driven runs currently start with no OpenMP report at all. With #958, explicit user overrides remain the silent case this line covers.

I kept the launcher and sizing policy unchanged. Built with OpenMP and verified three startups: unset (policy line only), `OMP_NUM_THREADS=3` (effective team 3 reported), and `COLI_NO_OMP_TUNE=1` (effective team reported). The focused DeepSeek V4 C tests pass. I did not run `deepseek-v4-tiny-check`; the change is a print with no numeric path touched.
