### PR TITLE
fix(v4): move hot rows16 packing out of store mutex

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -898,6 +898,16 @@ tests/test_deepseek_v4$(EXE): tests/test_deepseek_v4.c deepseek_v4.c deepseek_v4
 		COLI_V4_UNIT_RESOURCE_PLAN.o COLI_V4_UNIT_PROMPT.o COLI_V4_UNIT_NATIVE_QUANT.o
 	$(CC) $(CFLAGS) $< $(V4_TEST_LINK_OBJS) -o $@ -pthread $(LDFLAGS)
 
+V4_HOT_STORE_TEST_OBJS = \
+	COLI_V4_UNIT_ST.o \
+	COLI_V4_UNIT_EXPERT_STORE_HOT_ROWS16.o \
+	COLI_V4_UNIT_NATIVE_QUANT_ROWS16.o
+
+tests/test_deepseek_v4_hot_store$(EXE): tests/test_deepseek_v4_hot_store.c \
+		deepseek_v4.c deepseek_v4.h Makefile.deepseek-v4.units
+	$(MAKE) -f Makefile.deepseek-v4 ARCH=$(ARCH) $(V4_HOT_STORE_TEST_OBJS)
+	$(CC) $(CFLAGS) $< $(V4_HOT_STORE_TEST_OBJS) -o $@ -pthread $(LDFLAGS)
+
 V4_OWN_DIR = build/ownership
 V4_OWN_CFLAGS = $(CFLAGS) -DCOLI_V4_TEST_HOOKS
 V4_OWNERSHIP_OBJS = \

--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -5733,6 +5733,7 @@ typedef struct V4HotPolicy {
     uint64_t *layer_requests;
     int *pins;
     unsigned char *packed;
+    pthread_mutex_t *pack_mutexes;
     uint64_t packed_slots;
     uint64_t history_total;
     int history_seeded;
@@ -6019,16 +6020,23 @@ static int hot_pack_matrix(ColiTensorView *view, unsigned char *scratch) {
 #endif
 }
 
-/* state->mutex is held and the slot has at least one reference. */
-static int hot_pack_slot_locked(V4HotPolicy *policy,
-                                V4ExpertStoreState *state,
-                                const V4ExpertRecord *record,
-                                V4ExpertSlot *slot) {
+/* The caller holds a lease on slot.  The per-slot mutex keeps other leases
+ * from observing the in-place layout conversion, without serializing them
+ * behind unrelated expert loads. */
+static int hot_prepare_slot(V4HotPolicy *policy,
+                            V4ExpertStoreState *state,
+                            const V4ExpertRecord *record,
+                            V4ExpertSlot *slot, int should_pack) {
 #ifndef COLI_FP4_ROWS16_KERNEL
-    (void)policy; (void)state; (void)record; (void)slot; return -1;
+    (void)policy; (void)state; (void)record; (void)slot; (void)should_pack;
+    return -1;
 #else
     size_t slot_index = hot_slot_index(state, slot);
-    if (policy->packed[slot_index]) return 0;
+    pthread_mutex_lock(&policy->pack_mutexes[slot_index]);
+    if (!should_pack || policy->packed[slot_index]) {
+        pthread_mutex_unlock(&policy->pack_mutexes[slot_index]);
+        return 0;
+    }
     ColiTensorView gate, down, up;
     fill_tensor_view(&gate, record, slot, V4_W1);
     fill_tensor_view(&down, record, slot, V4_W2);
@@ -6046,9 +6054,12 @@ static int hot_pack_slot_locked(V4HotPolicy *policy,
                  hot_pack_matrix(&up, scratch);
     free(scratch);
     if (!result) {
+        pthread_mutex_lock(&state->mutex);
         policy->packed[slot_index] = 1;
         policy->packed_slots++;
+        pthread_mutex_unlock(&state->mutex);
     }
+    pthread_mutex_unlock(&policy->pack_mutexes[slot_index]);
     return result;
 #endif
 }
@@ -6112,8 +6123,13 @@ static int lookup_hot(ColiExpertStore *store, ColiExpertKey key,
             slot = &slots[i]; slot->references++;
             state->active_leases++;
             slot->used = ++state->clock; state->stats.hits++;
-            if (hot_is_pinned(policy, key.layer, key.expert))
-                hot_pack_slot_locked(policy, state, record, slot);
+            /* Existing row-major leases may still read this slab.  Defer an
+             * in-place conversion until this lookup owns the only lease. */
+            int should_pack = hot_is_pinned(policy, key.layer, key.expert) &&
+                slot->references == 1;
+            pthread_mutex_unlock(&state->mutex);
+            hot_prepare_slot(policy, state, record, slot, should_pack);
+            pthread_mutex_lock(&state->mutex);
             memset(view, 0, sizeof(*view)); view->key = key;
             hot_fill_view(&view->gate, record, slot, V4_W1, policy, state);
             hot_fill_view(&view->down, record, slot, V4_W2, policy, state);
@@ -6165,8 +6181,11 @@ static int lookup_hot(ColiExpertStore *store, ColiExpertKey key,
     }
     slot->expert = key.expert; slot->used = ++state->clock;
     state->stats.misses++; state->stats.bytes_read += record->record_bytes;
-    if (hot_is_pinned(policy, key.layer, key.expert))
-        hot_pack_slot_locked(policy, state, record, slot);
+    int should_pack = hot_is_pinned(policy, key.layer, key.expert) &&
+        slot->references == 1;
+    pthread_mutex_unlock(&state->mutex);
+    hot_prepare_slot(policy, state, record, slot, should_pack);
+    pthread_mutex_lock(&state->mutex);
     memset(view, 0, sizeof(*view)); view->key = key;
     hot_fill_view(&view->gate, record, slot, V4_W1, policy, state);
     hot_fill_view(&view->down, record, slot, V4_W2, policy, state);
@@ -6182,8 +6201,9 @@ static void destroy_hot(ColiExpertStore *store) {
     V4HotPolicy *policy = *link;
     if (policy) *link = policy->next;
     pthread_mutex_unlock(&hot_policies_mutex);
+    V4ExpertStoreState *state = store ? store->state : NULL;
     if (policy) {
-        hot_usage_save(policy, store ? store->state : NULL);
+        hot_usage_save(policy, state);
         fprintf(stderr, "v4_rows16 packed_slots=%llu\n",
                 (unsigned long long)policy->packed_slots);
         fprintf(stderr,
@@ -6198,6 +6218,12 @@ static void destroy_hot(ColiExpertStore *store) {
                 (unsigned long long)__atomic_load_n(
                     &v4_direct_payload_bytes, __ATOMIC_RELAXED));
         free(policy->history_path);
+        if (policy->pack_mutexes && state) {
+            size_t slots = (size_t)state->layers * state->slots_per_layer;
+            for (size_t i = 0; i < slots; i++)
+                pthread_mutex_destroy(&policy->pack_mutexes[i]);
+        }
+        free(policy->pack_mutexes);
         free(policy->packed); free(policy->pins);
         free(policy->layer_requests); free(policy->usage); free(policy);
     }
@@ -6295,14 +6321,19 @@ int COLI_V4_ROWS16_STORE_OPEN(
         (size_t)state->layers, sizeof(*policy->layer_requests));
     if (policy) policy->pins = malloc(pins * sizeof(*policy->pins));
     if (policy) policy->packed = calloc(slots, sizeof(*policy->packed));
+    if (policy) policy->pack_mutexes = calloc(
+        slots, sizeof(*policy->pack_mutexes));
     if (!policy || !policy->usage || !policy->layer_requests ||
-        !policy->pins || !policy->packed) {
+        !policy->pins || !policy->packed || !policy->pack_mutexes) {
+        free(policy ? policy->pack_mutexes : NULL);
         free(policy ? policy->packed : NULL); free(policy ? policy->pins : NULL);
         free(policy ? policy->layer_requests : NULL);
         free(policy ? policy->usage : NULL); free(policy);
         destroy(*output); *output = NULL;
         return set_error(error, error_size, "out of memory creating hot policy");
     }
+    for (size_t i = 0; i < slots; i++)
+        pthread_mutex_init(&policy->pack_mutexes[i], NULL);
     for (size_t i = 0; i < pins; i++) policy->pins[i] = -1;
     policy->store = *output; policy->pin_count = pin_count;
     policy->history_path = hot_history_path(options->model_dir);

--- a/c/tests/test_deepseek_v4_hot_store.c
+++ b/c/tests/test_deepseek_v4_hot_store.c
@@ -1,0 +1,187 @@
+#include "../compat.h"
+#include "../deepseek_v4_internal.h"
+#include "../native_quant_fp4_rows16.h"
+
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifndef COLI_FP4_ROWS16_KERNEL
+int main(void) {
+    puts("SKIP DeepSeek-V4 hot ExpertStore tests: rows16 kernel unavailable");
+    return 0;
+}
+#else
+
+enum {
+    HOT_EXPERTS = 7,
+    HOT_MATRICES = 3,
+    HOT_ROWS = 16,
+    HOT_PACKED_COLUMNS = 64,
+    HOT_SCALE_BYTES = HOT_ROWS * 4,
+    HOT_WEIGHT_BYTES = HOT_ROWS * HOT_PACKED_COLUMNS,
+    HOT_RECORD_BYTES = HOT_MATRICES * (HOT_SCALE_BYTES + HOT_WEIGHT_BYTES),
+    HOT_WORKERS = 8,
+    HOT_LOOKUPS_PER_WORKER = 100
+};
+
+static int write_all(int fd, const void *data, size_t length) {
+    const unsigned char *bytes = data;
+    while (length) {
+        ssize_t count = write(fd, bytes, length);
+        if (count <= 0) return -1;
+        bytes += count;
+        length -= (size_t)count;
+    }
+    return 0;
+}
+
+static int append_json(char *header, size_t capacity, size_t *used,
+                       const char *format, ...) {
+    va_list arguments;
+    va_start(arguments, format);
+    int written = vsnprintf(header + *used, capacity - *used, format,
+                            arguments);
+    va_end(arguments);
+    if (written < 0 || (size_t)written >= capacity - *used) return -1;
+    *used += (size_t)written;
+    return 0;
+}
+
+static int write_hot_fixture(const char *path) {
+    char header[8192];
+    size_t used = 0;
+    uint64_t offset = 0;
+    if (append_json(header, sizeof(header), &used, "{") != 0) return -1;
+    for (int expert = 0; expert < HOT_EXPERTS; expert++) {
+        for (int matrix = 1; matrix <= HOT_MATRICES; matrix++) {
+            uint64_t end = offset + HOT_SCALE_BYTES;
+            if (append_json(
+                    header, sizeof(header), &used,
+                    "\"layers.0.ffn.experts.%d.w%d.scale\":{"
+                    "\"dtype\":\"F8_E8M0\",\"shape\":[16,4],"
+                    "\"data_offsets\":[%llu,%llu]},",
+                    expert, matrix, (unsigned long long)offset,
+                    (unsigned long long)end) != 0)
+                return -1;
+            offset = end;
+        }
+        for (int matrix = 1; matrix <= HOT_MATRICES; matrix++) {
+            uint64_t end = offset + HOT_WEIGHT_BYTES;
+            if (append_json(
+                    header, sizeof(header), &used,
+                    "\"layers.0.ffn.experts.%d.w%d.weight\":{"
+                    "\"dtype\":\"I8\",\"shape\":[16,64],"
+                    "\"data_offsets\":[%llu,%llu]},",
+                    expert, matrix, (unsigned long long)offset,
+                    (unsigned long long)end) != 0)
+                return -1;
+            offset = end;
+        }
+    }
+    if (!used || header[used - 1] != ',') return -1;
+    header[used - 1] = '}';
+
+    unsigned char payload[HOT_EXPERTS * HOT_RECORD_BYTES];
+    for (size_t i = 0; i < sizeof(payload); i++)
+        payload[i] = (unsigned char)(i * 31u + 7u);
+    uint64_t header_length = used;
+    int fd = open(path, O_CREAT | O_TRUNC | O_WRONLY | COMPAT_O_BINARY, 0600);
+    if (fd < 0) return -1;
+    int result = write_all(fd, &header_length, sizeof(header_length)) ||
+                 write_all(fd, header, used) ||
+                 write_all(fd, payload, sizeof(payload));
+    close(fd);
+    return result ? -1 : 0;
+}
+
+typedef struct {
+    ColiExpertStore *store;
+    int failed;
+} HotLookupWorker;
+
+static void *lookup_hot_expert(void *argument) {
+    HotLookupWorker *worker = argument;
+    for (int i = 0; i < HOT_LOOKUPS_PER_WORKER; i++) {
+        ColiExpertView view;
+        if (coli_expert_lookup(worker->store, (ColiExpertKey){0, 0}, &view) ||
+            view.gate.block_rows != 16 || view.down.block_rows != 16 ||
+            view.up.block_rows != 16) {
+            worker->failed = 1;
+            return NULL;
+        }
+        coli_expert_release(worker->store, &view);
+    }
+    return NULL;
+}
+
+int main(void) {
+    char directory[] = "colibri-v4-hot-store-XXXXXX";
+    char path[256], usage_path[256], error[256];
+    if (!mkdtemp(directory)) { perror("mkdtemp"); return 1; }
+    snprintf(path, sizeof(path), "%s/model.safetensors", directory);
+    snprintf(usage_path, sizeof(usage_path), "%s/.coli_usage", directory);
+    if (write_hot_fixture(path) != 0) {
+        perror("write_hot_fixture");
+        unlink(path); rmdir(directory);
+        return 1;
+    }
+
+    ColiDeepSeekV4ExpertStoreOptions options = {
+        directory, 1, HOT_EXPERTS, HOT_EXPERTS * HOT_RECORD_BYTES, -1, 2
+    };
+    ColiExpertStore *store = NULL;
+    if (coli_deepseek_v4_expert_store_open(&options, &store,
+                                            error, sizeof(error)) != 0) {
+        fprintf(stderr, "%s\n", error);
+        unlink(path); rmdir(directory);
+        return 1;
+    }
+
+    ColiExpertView held = {0}, deferred = {0}, initial = {0};
+    int failed = coli_expert_lookup(store, (ColiExpertKey){0, 0}, &held) ||
+        held.gate.block_rows != 1 || held.down.block_rows != 1 ||
+        held.up.block_rows != 1 ||
+        coli_expert_lookup(store, (ColiExpertKey){0, 0}, &deferred) ||
+        deferred.gate.block_rows != 1 || deferred.down.block_rows != 1 ||
+        deferred.up.block_rows != 1;
+    coli_expert_release(store, &deferred);
+    coli_expert_release(store, &held);
+    if (!failed)
+        failed = coli_expert_lookup(store, (ColiExpertKey){0, 0}, &initial) ||
+            initial.gate.block_rows != 16 || initial.down.block_rows != 16 ||
+            initial.up.block_rows != 16;
+    coli_expert_release(store, &initial);
+
+    pthread_t threads[HOT_WORKERS];
+    HotLookupWorker workers[HOT_WORKERS];
+    memset(workers, 0, sizeof(workers));
+    for (int i = 0; !failed && i < HOT_WORKERS; i++) {
+        workers[i].store = store;
+        if (pthread_create(&threads[i], NULL, lookup_hot_expert, &workers[i])) {
+            failed = 1;
+            for (int joined = 0; joined < i; joined++)
+                pthread_join(threads[joined], NULL);
+            break;
+        }
+    }
+    if (!failed)
+        for (int i = 0; i < HOT_WORKERS; i++) {
+            pthread_join(threads[i], NULL);
+            failed |= workers[i].failed;
+        }
+
+    store->ops->destroy(store);
+    unlink(path);
+    unlink(usage_path);
+    rmdir(directory);
+    if (failed) return 1;
+    puts("DeepSeek-V4 hot ExpertStore tests: ok");
+    return 0;
+}
+#endif


### PR DESCRIPTION
## Summary
- Move rows16 packing behind a per-slot preparation mutex instead of the store-wide mutex.
- Convert in place only while the requesting lease is exclusive; an existing row-major view keeps its layout until a later lookup can safely repack the slot.
- Publish the packed state under the store mutex, so consumers of the same slot wait while unrelated expert loads continue.
- Add a hot-store regression test that verifies deferred conversion and concurrent packed lookups; it is part of `make check`.

## Validation
- `make check`
- `make tests/test_deepseek_v4_hot_store && ./tests/test_deepseek_v4_hot_store`

Resolves #900