### PR TITLE
openai_server: use COLI_TEMP as the gateway default temperature

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -1321,6 +1321,7 @@ def cmd_serve(a):
                             "olmoe-colibri" if arch=="olmoe" else
                             "glm-5.2-colibri")
     try:
+        if a.temp is not None: os.environ["COLI_TEMP"] = str(a.temp)
         openai_server.serve(a.model,a.host,a.port,model_id,a.api_key,
               a.cap,ngen_for(a,interactive=True),engine,env_for_engine(a,arch),a.cors_origin,
               a.max_queue,a.queue_timeout,a.kv_slots,allowed_hosts=a.allowed_host)

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -1622,7 +1622,16 @@ def generation_options(body, limit):
         maximum = limit
     temperature = body.get("temperature")
     top_p = body.get("top_p")
-    temperature = 0.7 if temperature is None else temperature
+    if temperature is None:
+        # The launcher publishes --temp through COLI_TEMP (#509, #968). The
+        # gateway must use that value as its request default or the SERVE frame
+        # replaces it with 0.7 before any engine can honor the setting.
+        try:
+            temperature = float(os.environ.get("COLI_TEMP", "0.7"))
+            if not math.isfinite(temperature) or not 0 <= temperature <= 2:
+                temperature = 0.7
+        except ValueError:
+            temperature = 0.7
     top_p = 0.9 if top_p is None else top_p
     if isinstance(maximum, bool) or not isinstance(maximum, int) or maximum < 1:
         raise APIError(400, f"`{maximum_param}` must be a positive integer.", maximum_param)

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -187,6 +187,15 @@ class TemplateTest(unittest.TestCase):
         opts = generation_options({"response_format": {"type": "gbnf", "grammar": "not a grammar ::="}}, 8)
         self.assertEqual(opts[3], "not a grammar ::=")
 
+    def test_coli_temp_is_the_default_for_requests_that_omit_temperature(self):
+        with patch.dict("openai_server.os.environ", {"COLI_TEMP": "0.25"}):
+            self.assertEqual(generation_options({}, 8)[1], 0.25)
+            self.assertEqual(generation_options({"temperature": 0}, 8)[1], 0.0)
+        for invalid in ("malformed", "5", "-1", "nan", "1e999"):
+            with self.subTest(invalid=invalid):
+                with patch.dict("openai_server.os.environ", {"COLI_TEMP": invalid}):
+                    self.assertEqual(generation_options({}, 8)[1], 0.7)
+
     def test_validates_stop_sequences(self):
         self.assertEqual(generation_options({"stop": "END"}, 8)[4], ("END",))
         self.assertEqual(generation_options({"stop": ["ONE", "TWO"]}, 8)[4],


### PR DESCRIPTION
## Summary

- use `COLI_TEMP` as the gateway default when a request omits `temperature`
- seed `COLI_TEMP` from `--temp` in `coli serve`, whose gateway runs in-process and never saw the launcher env
- keep an explicit request temperature authoritative
- fall back to the existing `0.7` when `COLI_TEMP` is absent, malformed, or outside the gateway's 0..2 range

## Problem

The launcher publishes `--temp` through `COLI_TEMP`, following #509 and #968. The API gateway then replaced that value with its own hard-coded `0.7` whenever request JSON omitted `temperature`.

The built-in non-GLM chat client omits the field, so `coli chat --temp 0.25` silently generated at `0.7`. `coli serve` and `coli web` had the same mismatch twice over: the gateway ignored an exported `COLI_TEMP`, and `--temp` never reached the in-process gateway at all because `env_for_engine` builds a copy for the engine child only.

Use `COLI_TEMP` at the point where the gateway chooses a missing request default, and have `cmd_serve` seed it from `--temp` for the in-process gateway. Explicit API values still win, and an env value that would not pass the gateway's own temperature validation falls back to `0.7` instead of failing requests that never sent the parameter.

## Validation

- `python3 -m unittest tests.test_openai_server.TemplateTest.test_coli_temp_is_the_default_for_requests_that_omit_temperature -v`
- `python3 -m py_compile openai_server.py`
- `make check`

The focused test covers the environment default, an explicit request value of zero, and malformed or out-of-range values (`malformed`, `5`, `-1`, `nan`, `1e999`), each falling back to `0.7`. `make check` passed all C tests and 446 Python tests, with 57 dependency or platform skips.
