### PR TITLE
inkling: size direct-run OpenMP teams with the shared physical-core helper

### DIFF
--- a/c/inkling.c
+++ b/c/inkling.c
@@ -33,6 +33,10 @@
 #endif
 #include "st.h"
 #include "tok.h"
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+#include "omp_tune.h"
 #include "route_trace.h"
 #include "kv_prefix.h"                          /* KV prefix reuse (shared) */                          /* shared routing telemetry (#700) */
 #ifdef COLI_CUDA
@@ -2058,6 +2062,7 @@ int main(int argc, char **argv) {
 #endif
     }
 #endif  /* !COLI_CUDA && !__APPLE__ */
+    coli_omp_tune_threads("inkling");
     const char *snap = getenv("SNAP");
     if (!snap) { fprintf(stderr, "set SNAP=<snapshot directory>\n"); return 1; }
     g_topp = getenv("TOPP") ? (float)atof(getenv("TOPP")) : 0.f;

--- a/c/tests/test_inkling_omp_source.py
+++ b/c/tests/test_inkling_omp_source.py
@@ -1,0 +1,18 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class InklingOpenMPWiringTest(unittest.TestCase):
+    def test_direct_engine_uses_shared_physical_core_sizing(self):
+        source = (ROOT / "inkling.c").read_text(encoding="utf-8")
+        self.assertTrue('#include "omp_tune.h"' in source,
+                        "inkling.c does not include the shared OpenMP sizing helper")
+        self.assertTrue('coli_omp_tune_threads("inkling")' in source,
+                        "Inkling direct execution does not size its OpenMP team")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- size direct Inkling OpenMP teams with the shared physical-core helper
- preserve explicit `OMP_NUM_THREADS` and `COLI_NO_OMP_TUNE`
- add a regression test for the engine wiring

## Problem

The launcher sizes Inkling from physical cores, but the direct engine does not. Inkling's self-reexec block configures wait and affinity policy only, so a documented direct invocation falls back to the OpenMP runtime's logical-CPU count.

That is the sibling of the defect fixed for GLM, Kimi K3, OLMoE, and DeepSeek V4 in the #738, #791, #805, and #897 family. On an SMT system it can schedule both hardware threads of a core onto the same execution resources.

Call `coli_omp_tune_threads()` after Inkling's hot-team re-exec block, the same placement GLM documents (`omp_set_num_threads` is a runtime API and needs no second exec). The helper is inert when the user set `OMP_NUM_THREADS`, when `COLI_NO_OMP_TUNE` is present, when topology is unavailable, or when there is no SMT to avoid.

## Validation

- `python3 -m unittest tests.test_inkling_omp_source -v`
- `make inkling`
- `make tests/test_omp_tune && ./tests/test_omp_tune`
- `make check`

The direct startup path selected 12 physical-core threads instead of 16 logical CPUs on the test system. Both override paths remained silent. This startup proof ran on macOS, where the re-exec block is compiled out, so it cannot exercise the Linux re-exec interaction. The call placement mirrors GLM's documented post-re-exec rule. `make check` passed all C tests and 446 Python tests, with 57 dependency or platform skips.

No model benchmark was run, so this PR makes no Inkling throughput claim.
