### PR TITLE
fix(msys2): use UTF-8 prompt file for DeepSeek V4

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -941,7 +941,7 @@ def cmd_run(a):
         prompt_path=None
         try:
             cmd=[engine,os.path.abspath(a.model)]
-            if sys.platform=="win32":
+            if sys.platform in ("win32", "msys", "cygwin"):
                 with tempfile.NamedTemporaryFile(
                         mode="w",encoding="utf-8",newline="",delete=False,
                         prefix="coli-v4-prompt-",suffix=".txt") as stream:


### PR DESCRIPTION
## Summary

Fix UTF-8 prompt handling for DeepSeek V4 when Colibrì is run under Windows/MSYS2.

Under MSYS2 UCRT64, Python reports:

    sys.platform == "cygwin"

The DeepSeek V4 launcher currently uses the UTF-8 `--prompt-file` path only when:

    sys.platform == "win32"

As a result, under MSYS2 the prompt is passed directly through `argv`, which can corrupt non-ASCII input such as Ukrainian/Cyrillic text.

The smallest fix is to use the existing UTF-8 prompt-file path for MSYS2/Cygwin as well:

    - if sys.platform=="win32":
    + if sys.platform in ("win32", "msys", "cygwin"):

Tested on Windows with MSYS2 UCRT64 and DeepSeek-V4-Flash-0731.

Before the change:

    python ./coli run \
      --model /c/models/DeepSeek-V4-Flash-0731 \
      --ram 32 \
      "Привіт! Відповідай українською."

The model received corrupted input.

Running the DeepSeek V4 engine directly with `--prompt-file` handled the same UTF-8 prompt correctly. After this change, `coli run` also handles Ukrainian UTF-8 prompts correctly.

## Validation

- [x] `make -C c check`
- [ ] CUDA changes were tested with `make -C c cuda-test` (if applicable)
- [ ] Performance claims include hardware, commands, and repeatable measurements

Manual validation:
- Windows
- MSYS2 UCRT64
- DeepSeek-V4-Flash-0731
- Verified Ukrainian/Cyrillic UTF-8 prompt handling before and after the change

No CUDA changes or performance claims are included in this PR.

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included