### PR TITLE
fix(server): reach a public bind from a browser — --allowed-host '*' (#990)

### DIFF
--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -2318,12 +2318,25 @@ class APIHandler(BaseHTTPRequestHandler):
         name = name.strip().lower()
         allowed = set(self.LOOPBACK_HOSTS)
         allowed.update(self.server.allowed_hosts)          # #597: operator-trusted reverse-proxy names
+        # A wildcard is an explicit operator opt-out of the guard, for the case
+        # the guard cannot serve: a container/LAN bind reached by an IP or DNS
+        # name the server cannot predict (#990 -- Docker port-map, the browser
+        # sends the host's address, which the container never knows). The guard
+        # protects a LOOPBACK bind from a malicious page; once bound to 0.0.0.0
+        # the exposure is already chosen, so `*` adds no risk that bind did not.
+        if "*" in allowed:
+            return
         try:
             allowed.add(str(self.server.server_address[0]).strip("[]").lower())
         except Exception:
             pass
         if name not in allowed:
-            raise APIError(403, "Host header not allowed.", None, "forbidden")
+            raise APIError(
+                403,
+                "Host header %r not allowed. Add it with --allowed-host %s "
+                "(or COLI_ALLOWED_HOSTS), or --allowed-host '*' to accept any "
+                "host when the bind is already public." % (name or "(empty)", name or "<host>"),
+                None, "forbidden")
 
     def read_json(self):
         try:
@@ -3126,6 +3139,9 @@ def serve(model, host="127.0.0.1", port=8000, model_id="glm-5.2-colibri", api_ke
             print("refusing to bind %s beyond localhost without COLI_API_KEY set "
                   "(set COLI_ALLOW_INSECURE_BIND=1 to override)" % host, file=sys.stderr)
             sys.exit(1)
+    if allowed_hosts and "*" in allowed_hosts:
+        print("WARNING: --allowed-host '*' accepts ANY Host header "
+              "(DNS-rebinding guard disabled)", file=sys.stderr)
     origins = DEFAULT_CORS_ORIGINS if cors_origins is None else tuple(cors_origins)
     # Bind before starting the 744B engine. A stale/occupied port must fail in
     # milliseconds rather than loading hundreds of GB and leaking a child.

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -1464,6 +1464,31 @@ class AllowedHostsTest(unittest.TestCase):
         server = self._make_server(allowed_hosts=("proxy.example.ts.net",))
         self.assertEqual(self._get_models(server.server_port, "evil.example.com"), 403)
 
+    def test_wildcard_accepts_any_host(self):
+        # #990: a Docker/LAN bind reached by an unpredictable IP. The wildcard is
+        # an explicit operator opt-out, so ANY host passes -- but loopback and a
+        # real name still work, i.e. it widens rather than replaces.
+        server = self._make_server(allowed_hosts=("*",))
+        port = server.server_port
+        self.assertEqual(self._get_models(port, "10.20.30.40:36873"), 200)
+        self.assertEqual(self._get_models(port, "colibri.example.com"), 200)
+        self.assertEqual(self._get_models(port, "localhost"), 200)
+
+    def test_rejection_message_names_the_host_and_the_fix(self):
+        server = self._make_server()
+        conn = http.client.HTTPConnection("127.0.0.1", server.server_port, timeout=2)
+        try:
+            conn.putrequest("GET", "/v1/models", skip_host=True)
+            conn.putheader("Host", "myserver.lan:36873")
+            conn.endheaders()
+            resp = conn.getresponse()
+            body = resp.read().decode()
+        finally:
+            conn.close()
+        self.assertEqual(resp.status, 403)
+        self.assertIn("myserver.lan", body)          # the offending host, so the user can copy it
+        self.assertIn("--allowed-host", body)        # and how to fix it
+
 
 class ThinkingSplitUnitTest(unittest.TestCase):
     """#597 item 4: the GLM reasoning splitter, incl. mkelcb's cross-chunk cases."""

--- a/docker/README.md
+++ b/docker/README.md
@@ -520,6 +520,24 @@ docker run --rm -p 5000:5000 -v /nvme/glm52_i4:/model colibri \
     serve --host 0.0.0.0 --model-id glm-5.2 --ram 24
 ```
 
+**Reaching it from another machine (or `coli web`).** Binding `--host 0.0.0.0`
+is not enough: the server has a DNS-rebinding guard that only trusts the Host
+header for loopback and its own bind address, so a browser pointed at
+`http://<server-ip>:<port>` gets `403 Host header not allowed`. Behind Docker's
+port mapping the container cannot know the address the browser will send, so
+tell it what to accept — the exact name/IP, or `*` when the bind is already
+deliberately public:
+
+```bash
+docker run --rm -p 36873:8000 -e COLI_ALLOW_INSECURE_BIND=1 \
+    -v /nvme/glm52_i4:/model colibri \
+    web --host 0.0.0.0 --allowed-host '*'
+```
+
+`--allowed-host '*'` disables the guard (it warns at startup); prefer an
+explicit `--allowed-host my-server.lan` when you know the name. This is a
+LAN-exposure decision, hence opt-in alongside `COLI_ALLOW_INSECURE_BIND=1`.
+
 The entrypoint is `coli`, so the first argument is the subcommand (`info`,
 `chat`, `serve`, `run`, `plan`, `doctor`) — no `./coli` prefix. The container
 runs as UID 1000, so the model directory must be readable by that user


### PR DESCRIPTION
**#990: `coli web --host 0.0.0.0` in Docker answers `403 Host header not allowed`** when reached from another machine. The DNS-rebinding guard trusts the Host header only for loopback and the bind address; behind port mapping the browser sends the host's real IP/name, which the container can't predict — and the 403 gave no hint how to fix it.

Three changes:
- **`--allowed-host '*'`** accepts any Host — an explicit operator opt-out for the case the guard cannot serve. The guard protects a *loopback* bind from a malicious page; once bound to `0.0.0.0` the exposure is already chosen, so the wildcard adds no risk the bind did not. Warns at startup, like `COLI_ALLOW_INSECURE_BIND`.
- **The 403 now names the offending host and prints the exact `--allowed-host` line** to fix it (the reporter had no way to know the flag existed).
- **docker/README** documents reaching the dashboard from another machine.

Verified over the real server with a spoofed Host header: external IP → 403 by default (message names it), 200 with the exact host or `*`, loopback unaffected. Regression tests for the wildcard and the message; 135 server tests green.

Closes #990 (manual close on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)