### PR TITLE
test(cuda): link the MXFP4 OpenMP reference

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -325,6 +325,9 @@ endif
 GPUCC      = $(NVCC)
 GPUFLAGS   = $(NVCCFLAGS)
 GPUCC_NAME = nvcc (set CUDA_HOME or NVCC)
+# tests/mxfp4_ref.c is compiled by $(CC) with OpenMP. Its object therefore
+# needs the host OpenMP runtime when the GPU compiler performs the final link.
+GPU_OMP_LINK = -Xcompiler=-fopenmp
 # PYTHON is a HOST tool (clean/test-c/test-python run it on the build machine),
 # so key it off the host, NOT $(IS_WIN) — which is derived from the *target*
 # triple ($(CC) -dumpmachine). Otherwise a cross build (make CC=x86_64-w64-
@@ -435,6 +438,7 @@ CUDA_OBJ   = backend_cuda.o
 GPUCC      = $(HIPCC)
 GPUFLAGS   = $(HIPCCFLAGS)
 GPUCC_NAME = hipcc (set ROCM_HOME or HIPCC)
+GPU_OMP_LINK = -fopenmp
 # rocWMMA needs matrix cores (MFMA gfx908+ / WMMA gfx11xx); on these archs its
 # headers static_assert (ROCm/TheRock#1944). Compile the WMMA paths out and
 # let backend_gpu_compat.h fall back via COLI_GPU_HAS_WMMA=0. The flag must
@@ -681,7 +685,7 @@ cuda-test: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/test_backen
 	# as C on purpose: quant.h uses _Thread_local, which nvcc's C++ front end
 	# rejects, and re-implementing it for the test would defeat the comparison.
 	$(CC) $(CFLAGS) -c tests/mxfp4_ref.c -o tests/mxfp4_ref.o
-	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/test_mxfp4_cuda.cu tests/mxfp4_ref.o -o mxfp4_cuda_test$(EXE)
+	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/test_mxfp4_cuda.cu tests/mxfp4_ref.o -o mxfp4_cuda_test$(EXE) $(GPU_OMP_LINK)
 	./mxfp4_cuda_test$(EXE)
 
 # convenience alias: kernel correctness on AMD (same test, hipcc toolchain)

--- a/c/setup.sh
+++ b/c/setup.sh
@@ -7,6 +7,9 @@ cd "$(dirname "$0")"
 echo "🐦 colibrì — setup"
 
 UNAME_S=$(uname -s)
+OMP_PROBE=".colibri-omp-probe-$$"
+cleanup_omp_probe() { rm -f "$OMP_PROBE" "$OMP_PROBE.exe"; }
+trap cleanup_omp_probe EXIT
 
 # 1) dipendenze
 command -v make >/dev/null || { echo "make is missing"; exit 1; }
@@ -21,14 +24,16 @@ Darwin)
 MINGW*|MSYS*)
     command -v gcc  >/dev/null || { echo "gcc is missing (MinGW-w64). Install: pacman -S mingw-w64-x86_64-gcc make"; exit 1; }
     echo "  gcc: $(gcc -dumpversion) · MinGW-w64"
-    echo -n "  OpenMP: "; echo 'int main(){return 0;}' | gcc -fopenmp -xc - -o /tmp/_omp 2>/dev/null && echo ok || { echo "libgomp is missing (pacman -S mingw-w64-x86_64-gcc)"; exit 1; }
+    echo -n "  OpenMP: "; echo 'int main(){return 0;}' | gcc -fopenmp -xc - -o "$OMP_PROBE" 2>/dev/null && echo ok || { echo "libgomp is missing (pacman -S mingw-w64-x86_64-gcc)"; exit 1; }
     ;;
 *)
     command -v gcc  >/dev/null || { echo "gcc is missing (for example: sudo apt install build-essential)"; exit 1; }
     echo "  gcc: $(gcc -dumpversion) · $(nproc) core"
-    echo -n "  OpenMP: "; echo 'int main(){return 0;}' | gcc -fopenmp -xc - -o /tmp/_omp 2>/dev/null && echo ok || { echo "libgomp is missing"; exit 1; }
+    echo -n "  OpenMP: "; echo 'int main(){return 0;}' | gcc -fopenmp -xc - -o "$OMP_PROBE" 2>/dev/null && echo ok || { echo "libgomp is missing"; exit 1; }
     ;;
 esac
+cleanup_omp_probe
+trap - EXIT
 
 # 2) build: nativa (veloce, per QUESTA macchina). Per un binario da distribuire: make portable
 echo "  building (ARCH=${ARCH:-native})…"

--- a/c/tests/test_cuda_test_makefile.py
+++ b/c/tests/test_cuda_test_makefile.py
@@ -1,0 +1,46 @@
+"""Build-contract checks for the real-GPU MXFP4 correctness test."""
+import subprocess
+import unittest
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent.parent
+
+
+def cuda_test_recipe(*variables):
+    result = subprocess.run(
+        ["make", "-Bn", "cuda-test",
+         "TRIPLET=x86_64-unknown-linux-gnu", *variables],
+        cwd=HERE, text=True, capture_output=True, check=False, timeout=120)
+    return result.stdout + result.stderr
+
+
+def mxfp4_link_line(recipe):
+    return next(
+        (line for line in recipe.splitlines()
+         if "tests/test_mxfp4_cuda.cu" in line and " -o " in line),
+        "")
+
+
+class CudaTestMakefileTest(unittest.TestCase):
+    def test_nvcc_links_the_cpu_oracle_openmp_runtime(self):
+        line = mxfp4_link_line(cuda_test_recipe("CUDA=1", "NVCC=nvcc"))
+        self.assertTrue(line, "no MXFP4 CUDA link command in dry-run recipe")
+        self.assertIn("-Xcompiler=-fopenmp", line)
+
+    def test_hipcc_links_the_cpu_oracle_openmp_runtime(self):
+        line = mxfp4_link_line(cuda_test_recipe(
+            "HIP=1", "HIP_ARCH=gfx1100", "HIPCC=hipcc"))
+        self.assertTrue(line, "no MXFP4 HIP link command in dry-run recipe")
+        self.assertIn("-fopenmp", line)
+        self.assertNotIn("-Xcompiler=-fopenmp", line)
+
+    def test_setup_openmp_probe_does_not_require_tmp(self):
+        setup = (HERE / "setup.sh").read_text(encoding="utf-8")
+        self.assertNotIn("/tmp/_omp", setup)
+        self.assertIn('OMP_PROBE=".colibri-omp-probe-$$"', setup)
+        self.assertIn('rm -f "$OMP_PROBE" "$OMP_PROBE.exe"', setup)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- link the MXFP4 CPU oracle OpenMP runtime in the CUDA and HIP test binaries
- keep the setup OpenMP probe in the writable source directory
- add dry-run checks for both GPU compiler recipes

Issue #971 reached the MXFP4 correctness test on an A6000, then failed to link `omp_get_num_threads`, `omp_get_thread_num`, and `GOMP_parallel`. The host compiler builds the oracle with OpenMP, but the final GPU compiler command did not link the matching host runtime.

## Validation

- `python3 -m unittest c.tests.test_cuda_test_makefile -v`
- `bash -n c/setup.sh`
- `make -C c check`: all C tests and 450 Python tests passed, with 57 expected skips

I could not run `make -C c cuda-test` on this machine because it has no CUDA runtime or GPU. Actual CUDA execution is unverified.