### PR TITLE
fix(download): fail when checkpoint remains incomplete

### DIFF
--- a/c/download_fp8.py
+++ b/c/download_fp8.py
@@ -4,7 +4,7 @@ Usage: python download_fp8.py
        python download_fp8.py --parallel 4
        python download_fp8.py --source hf  (force HuggingFace)
 """
-import os, sys, time, threading, argparse, subprocess
+import os, time, threading, argparse, subprocess
 
 REPO_MS = "ZhipuAI/GLM-5.2-FP8"        # ModelScope
 REPO_HF = "zai-org/GLM-5.2-FP8"        # HuggingFace
@@ -78,6 +78,10 @@ def download_file_curl(fn, base_url, expected_size):
         return True
     return False
 
+def shard_complete(path, expected_size):
+    return (os.path.exists(path)
+            and (expected_size <= 0 or os.path.getsize(path) == expected_size))
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--parallel", type=int, default=3)
@@ -100,12 +104,20 @@ def main():
         except Exception as e:
             print(f"{C.yel}failed ({e}){C.r}")
             if args.source == "ms":
-                print("ModelScope failed and --source ms was set. Exiting."); return
+                print("ModelScope failed and --source ms was set. Exiting."); return 1
+
+    if not shards and args.source == "ms":
+        print(f"{C.yel}No checkpoint shards found on ModelScope. Exiting.{C.r}")
+        return 1
 
     if not shards:
+        use_ms = False
         print(f"{C.dim}Using HuggingFace...{C.r}", end=" ", flush=True)
         shards, sizes = get_shard_list_hf()
         print(f"{C.grn}✓{C.r} {len(shards)} shards found")
+    if not shards:
+        print(f"{C.yel}No checkpoint shards found. Exiting.{C.r}")
+        return 1
 
     total = len(shards)
     total_bytes = sum(sizes.values())
@@ -121,13 +133,15 @@ def main():
                 if use_ms: download_file_ms(fn)
                 else: download_file_hf(fn)
             except Exception: pass
+    missing_meta = [fn for fn in meta_files
+                    if not os.path.isfile(os.path.join(DEST, fn))]
 
     # Build work queue
     todo = []
     done_set = set()
     for fn in shards:
         outpath = os.path.join(DEST, fn)
-        if os.path.exists(outpath) and os.path.getsize(outpath) == sizes.get(fn, 0):
+        if shard_complete(outpath, sizes.get(fn, 0)):
             done_set.add(fn)
         else:
             todo.append(fn)
@@ -142,7 +156,10 @@ def main():
     print()
 
     if not todo:
-        print(f"{C.grn}✓ All shards already downloaded!{C.r}\n"); return
+        if missing_meta:
+            print(f"{C.yel}Missing metadata: {', '.join(missing_meta)}{C.r}")
+            return 1
+        print(f"{C.grn}✓ All shards already downloaded!{C.r}\n"); return 0
 
     lock = threading.Lock()
     completed = list(done_set)
@@ -215,17 +232,21 @@ def main():
     for t in threads: t.join()
 
     print()
-    final = sum(1 for fn in shards
-                if os.path.exists(os.path.join(DEST, fn))
-                and os.path.getsize(os.path.join(DEST, fn)) == sizes.get(fn, 0))
-    if final == total:
+    final = sum(1 for fn in shards if shard_complete(
+        os.path.join(DEST, fn), sizes.get(fn, 0)))
+    if final == total and not missing_meta:
         print(f"{C.grn}{'='*50}")
         print(f"  ✓ All {total} shards downloaded!{C.r}\n")
+        return 0
     else:
         print(f"{C.yel}  {final}/{total} complete, {total-final} remaining{C.r}")
-        print(f"  Re-run to resume.\n")
+        if missing_meta:
+            print(f"  Missing metadata: {', '.join(missing_meta)}")
+        print("  Re-run to resume.\n")
+        return 1
 
 if __name__ == "__main__":
-    try: main()
+    try: raise SystemExit(main())
     except KeyboardInterrupt:
         print(f"\n\n{C.yel}Interrupted. Re-run to resume — no data lost.{C.r}\n")
+        raise SystemExit(130)

--- a/c/tests/test_download_fp8.py
+++ b/c/tests/test_download_fp8.py
@@ -1,0 +1,94 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+import download_fp8
+
+
+class DownloadExitStatusTests(unittest.TestCase):
+    META_FILES = ("config.json", "tokenizer.json", "tokenizer_config.json",
+                  "generation_config.json", "model.safetensors.index.json")
+
+    def run_main(self, dest, *args):
+        with mock.patch.object(download_fp8, "DEST", dest), \
+             mock.patch.object(sys, "argv", ["download_fp8.py", *args]):
+            return download_fp8.main()
+
+    def test_failed_shard_returns_nonzero(self):
+        manifest = (["model-00001.safetensors"],
+                    {"model-00001.safetensors": 4})
+        with tempfile.TemporaryDirectory() as dest, \
+             mock.patch.object(download_fp8, "get_shard_list_hf",
+                               return_value=manifest), \
+             mock.patch.object(download_fp8, "download_file_hf",
+                               side_effect=RuntimeError("offline")), \
+             mock.patch.object(download_fp8.time, "sleep"):
+            self.assertEqual(self.run_main(dest, "--source", "hf"), 1)
+
+    def test_explicit_modelscope_failure_returns_nonzero(self):
+        with tempfile.TemporaryDirectory() as dest, \
+             mock.patch.object(download_fp8, "get_shard_list_ms",
+                               side_effect=RuntimeError("offline")):
+            self.assertEqual(self.run_main(dest, "--source", "ms"), 1)
+
+    def test_explicit_modelscope_empty_manifest_does_not_fall_back(self):
+        with tempfile.TemporaryDirectory() as dest, \
+             mock.patch.object(download_fp8, "get_shard_list_ms",
+                               return_value=([], {})), \
+             mock.patch.object(download_fp8, "get_shard_list_hf") as hf:
+            self.assertEqual(self.run_main(dest, "--source", "ms"), 1)
+            hf.assert_not_called()
+
+    def test_auto_empty_modelscope_manifest_uses_huggingface(self):
+        name = "model-00001.safetensors"
+        manifest = ([name], {name: 4})
+        with tempfile.TemporaryDirectory() as dest, \
+             mock.patch.object(download_fp8, "get_shard_list_ms",
+                               return_value=([], {})), \
+             mock.patch.object(download_fp8, "get_shard_list_hf",
+                               return_value=manifest), \
+             mock.patch.object(download_fp8, "download_file_ms") as ms:
+            def download(fn):
+                with open(os.path.join(dest, fn), "wb") as out:
+                    out.write(b"data" if fn == name else b"")
+            with mock.patch.object(download_fp8, "download_file_hf",
+                                   side_effect=download):
+                self.assertEqual(self.run_main(dest), 0)
+            ms.assert_not_called()
+
+    def test_complete_manifest_returns_zero(self):
+        name = "model-00001.safetensors"
+        manifest = ([name], {name: 4})
+        with tempfile.TemporaryDirectory() as dest, \
+             open(os.path.join(dest, name), "wb") as shard:
+            shard.write(b"data")
+            shard.flush()
+            for metadata in self.META_FILES:
+                open(os.path.join(dest, metadata), "wb").close()
+            with mock.patch.object(download_fp8, "get_shard_list_hf",
+                                   return_value=manifest), \
+                 mock.patch.object(download_fp8, "download_file_hf"):
+                self.assertEqual(self.run_main(dest, "--source", "hf"), 0)
+
+    def test_missing_metadata_returns_nonzero(self):
+        name = "model-00001.safetensors"
+        with tempfile.TemporaryDirectory() as dest:
+            with open(os.path.join(dest, name), "wb") as shard:
+                shard.write(b"data")
+            manifest = ([name], {name: 4})
+            with mock.patch.object(download_fp8, "get_shard_list_hf",
+                                   return_value=manifest), \
+                 mock.patch.object(download_fp8, "download_file_hf"):
+                self.assertEqual(self.run_main(dest, "--source", "hf"), 1)
+
+    def test_empty_manifest_returns_nonzero(self):
+        with tempfile.TemporaryDirectory() as dest, \
+             mock.patch.object(download_fp8, "get_shard_list_hf",
+                               return_value=([], {})):
+            self.assertEqual(self.run_main(dest, "--source", "hf"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- return a nonzero status when shard retries are exhausted or metadata is missing
- return zero only for a complete checkpoint
- keep `--source ms` from silently falling back to Hugging Face
- switch automatic downloads to Hugging Face when ModelScope returns an empty manifest
- return 130 on Ctrl-C

The downloader could print that shards were still missing and exit successfully. Automation could then continue with an incomplete checkpoint.

## Validation

- `python3 -m unittest tests.test_download_fp8 -v`
- `python3 -m py_compile download_fp8.py tests/test_download_fp8.py`
- `python3 -m pyflakes download_fp8.py tests/test_download_fp8.py`
- `make check`: all native tests and 454 Python tests passed, with 57 expected skips