### PR TITLE
fix(kimi): guard the Vulkan-only state

### DIFF
--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -252,9 +252,9 @@ static void rmsnorm_(float *out, const float *x, const float *w, int D, float ep
  *    experts enter from freshly-read RAM slots (K3_VK_UP per step) until the
  *    VRAM budget (K3_VK_GB) is reached; resident experts then skip BOTH the
  *    disk read and the CPU matmuls at decode (C==1). */
-static int g_k3_vk=0;                     /* backend live (K3_VK=0 disables) */
 #ifdef COLI_VULKAN
 #include "backend_vulkan.h"
+static int g_k3_vk=0;                     /* backend live (K3_VK=0 disables) */
 typedef struct { void *w1, *w2, *w3; } VkExp;   /* ColiVkTensor* triple */
 static VkExp *g_vkexp; static int64_t g_vkexp_n;
 static int g_vk_upcap=8, g_vk_up_left=0, g_vk_full=0;


### PR DESCRIPTION
## Summary

- declare the Vulkan liveness flag only when Vulkan is compiled in
- keep the ordinary Kimi build warning-free

The non-Vulkan build declared `g_k3_vk` even though every use was compiled out. Apple clang reported it as an unused variable.

## Validation

- `make -s -C c clean && make -s -C c kimi_k3 EXTRA_CFLAGS=-Werror`
- `make check`: all native tests and 447 Python tests passed, with 57 expected skips