### PR TITLE
fix(supervisor): stop only its own converter

### DIFF
--- a/c/scripts/supervisor.sh
+++ b/c/scripts/supervisor.sh
@@ -18,18 +18,50 @@ flock -n 9 || { echo "a supervisor is already running; exiting"; exit 1; }
 log(){ echo "[$(date +%H:%M:%S)] $*"; }
 
 start_conv(){
-    cd "$CODE"
+    cd "$CODE" || { log "cannot enter $CODE"; return 1; }
     nohup python3 tools/convert_fp8_to_int4.py --repo zai-org/GLM-5.2-FP8 \
         --outdir "$DIR" --ebits 4 --io-bits 8 >> "$CONVLOG" 2>&1 &
+    conv_pid=$!
     log "converter started (PID $!)"
+}
+
+# Match only a converter that owns this supervisor's output directory. A global
+# pgrep/pkill also sees conversions for other models and can stop all of them
+# when this one finishes or stalls.
+find_conv_pid(){
+    local cmdline pid arg i saw_script saw_outdir
+    local -a argv
+    for cmdline in /proc/[0-9]*/cmdline; do
+        pid=${cmdline#/proc/}; pid=${pid%/cmdline}
+        [ "$pid" = "$$" ] && continue
+        [ -r "$cmdline" ] || continue
+        argv=()
+        while IFS= read -r -d '' arg; do argv+=("$arg"); done < "$cmdline"
+        saw_script=0; saw_outdir=0
+        for ((i=0; i<${#argv[@]}; i++)); do
+            case "${argv[i]}" in */convert_fp8_to_int4.py|convert_fp8_to_int4.py) saw_script=1;; esac
+            if [ "${argv[i]}" = "--outdir" ] && [ "${argv[i+1]:-}" = "$DIR" ]; then
+                saw_outdir=1
+            fi
+        done
+        if [ "$saw_script" -eq 1 ] && [ "$saw_outdir" -eq 1 ]; then
+            echo "$pid"
+            return
+        fi
+    done
 }
 
 last_size=-1; stall=0
 while :; do
     done_n=$(ls "$DIR"/out-*.safetensors 2>/dev/null | wc -l)
-    if [ "$done_n" -ge "$TOTAL" ]; then log "DONE: $done_n/$TOTAL shards. Exiting."; pkill -f convert_fp8 2>/dev/null; exit 0; fi
+    conv_pid=$(find_conv_pid)
+    if [ "$done_n" -ge "$TOTAL" ]; then
+        log "DONE: $done_n/$TOTAL shards. Exiting."
+        [ -z "$conv_pid" ] || kill "$conv_pid" 2>/dev/null
+        exit 0
+    fi
 
-    if ! pgrep -f convert_fp8 >/dev/null; then
+    if [ -z "$conv_pid" ]; then
         log "converter is not running ($done_n/$TOTAL): starting it"
         start_conv; last_size=-1; stall=0; sleep 20; continue
     fi
@@ -41,7 +73,7 @@ while :; do
             stall=$((stall+30))
             if [ "$stall" -ge "$STALL_S" ]; then
                 log "download stalled for ${stall}s at $((size/1000000)) MB ($done_n/$TOTAL): restarting the converter"
-                pkill -f convert_fp8; sleep 5
+                kill "$conv_pid" 2>/dev/null; sleep 5
                 start_conv; last_size=-1; stall=0
             fi
         else

--- a/c/tests/test_supervisor_scope.py
+++ b/c/tests/test_supervisor_scope.py
@@ -1,0 +1,61 @@
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+C_DIR = Path(__file__).resolve().parents[1]
+SUPERVISOR = C_DIR / "scripts" / "supervisor.sh"
+
+
+@unittest.skipUnless(
+    sys.platform.startswith("linux") and shutil.which("flock") and Path("/proc").is_dir(),
+    "the conversion supervisor targets Linux/WSL",
+)
+class SupervisorScopeTests(unittest.TestCase):
+    def test_completion_stops_only_its_own_converter(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            script = root / "convert_fp8_to_int4.py"
+            script.write_text("import time\ntime.sleep(60)\n", encoding="utf-8")
+            own_dir = root / "own model"
+            other_dir = root / "other model"
+            own_dir.mkdir()
+            other_dir.mkdir()
+
+            own = subprocess.Popen([
+                sys.executable, str(script), "--repo", "repo", "--outdir", str(own_dir)
+            ])
+            other = subprocess.Popen([
+                sys.executable, str(script), "--repo", "repo", "--outdir", str(other_dir)
+            ])
+            try:
+                for _ in range(50):
+                    cmdline = Path(f"/proc/{own.pid}/cmdline")
+                    if cmdline.exists() and b"convert_fp8_to_int4.py" in cmdline.read_bytes():
+                        break
+                    time.sleep(0.02)
+                env = os.environ.copy()
+                env.update({"COLI_MODEL": str(own_dir), "TOTAL_SHARDS": "0"})
+                result = subprocess.run(
+                    ["bash", str(SUPERVISOR)], cwd=C_DIR, env=env,
+                    text=True, capture_output=True, timeout=10, check=False,
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                own.wait(timeout=5)
+                self.assertIsNone(other.poll(),
+                                  "the supervisor stopped another model's converter")
+            finally:
+                for process in (own, other):
+                    if process.poll() is None:
+                        process.terminate()
+                    process.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- find the converter that owns this supervisor's exact output directory
- stop or restart only that converter
- handle model paths containing spaces

The supervisor used global `pgrep` and `pkill` patterns. Finishing or stalling one model conversion could stop a separate conversion running on the same host.

## Validation

- Linux behavior test passed in a local Python 3.12 container with two concurrent converters
- `bash -n c/scripts/supervisor.sh`
- `shellcheck -S error c/scripts/supervisor.sh`
- `make check`: all native tests and 448 Python tests passed, with 58 expected skips

The Linux behavior test is skipped by the macOS full gate because it requires `/proc` and `flock`.