### PR TITLE
fix(doctor,planner): make DeepSeek-V4 checkpoints pass doctor and plan correctly

### DIFF
--- a/c/doctor.py
+++ b/c/doctor.py
@@ -20,11 +20,31 @@ SAFETENSORS_DTYPES = {
     "F32": 4,
     "U8": 1,
     "I8": 1,
+    # Native fp8 checkpoints (DeepSeek-V4, GLM-5.2-FP8 unrepacked) and the I64/U64
+    # routing-table tensors DeepSeek-V4 ships (e.g. layers.N.ffn.gate.tid2eid) --
+    # mirrors the dtype table already fixed on the C engine side (c/st.h), which
+    # doctor.py's own copy was never updated to match. Byte sizes match st.h's
+    # st_dtype_esz(): fp8 variants are 1 byte, I64/U64 are 8 bytes.
+    "F8_E4M3": 1,
+    "F8_E4M3FN": 1,
+    "float8_e4m3fn": 1,
+    "F8_E8M0": 1,
+    "F8_E8M0FNU": 1,
+    "I64": 8,
+    "U64": 8,
 }
+# Each entry is a tuple of known-equivalent names for one conceptual tensor
+# (embedding / final norm / output head) across the families colibri supports.
+# DeepSeek-V4 checkpoints use short top-level names (embed.weight / norm.weight
+# / head.weight) instead of the model.*/lm_head.* convention every other
+# supported family uses; a flat exact-name tuple flagged a valid DeepSeek-V4
+# checkpoint as missing all three core tensors. Alias groups fix this without
+# needing arch detection: any family already passing (name present in its own
+# group) keeps passing, DeepSeek-V4's real names now also satisfy the check.
 REQUIRED_CORE_TENSORS = (
-    "model.embed_tokens.weight",
-    "model.norm.weight",
-    "lm_head.weight",
+    ("model.embed_tokens.weight", "embed.weight"),
+    ("model.norm.weight", "norm.weight"),
+    ("lm_head.weight", "head.weight"),
 )
 
 
@@ -270,7 +290,12 @@ def deep_container_report(model, mirror_dir=None):
         except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
             index = {"status": "fail", "summary": f"model index is invalid: {error}"}
 
-    missing_core = [name for name in REQUIRED_CORE_TENSORS if name not in tensor_sources]
+    # Report the canonical (first) name of an unsatisfied group -- the alias
+    # list is an input-matching detail, not something to leak into the message.
+    missing_core = [
+        aliases[0] for aliases in REQUIRED_CORE_TENSORS
+        if not any(name in tensor_sources for name in aliases)
+    ]
     required = {
         "status": "fail" if missing_core else "pass",
         "summary": (
@@ -485,10 +510,18 @@ def run_doctor(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0, *,
     else:
         checks.append(_check("accelerator.gpu", "skip", "no supported GPU detected; CPU path is available"))
 
+    # linkage was already computed above (drives the accelerator.gpu check) but
+    # never reached the planner: build_plan() got the raw detected-GPU list
+    # regardless, so a CPU-only engine build (no libcudart/libamdhip64 linkage --
+    # true for deepseek_v4 as of this writing, it has no CUDA target at all)
+    # still had its "VRAM hot tier" sized against real GPU memory the engine
+    # can never touch, starving the RAM tier of the pool space that tier was
+    # phantom-reserving. Pass only GPUs the engine can actually use.
+    usable_gpus = detected_gpus if linkage.get("linked") else []
     try:
         plan = build_plan(model, ram_gb, context, gpu_indices, vram_gb,
                           available_memory=available_memory, available_disk=available_disk,
-                          gpus=detected_gpus)
+                          gpus=usable_gpus)
         model_info = plan["model"]
         checks.append(_check("model.shards", "pass", "safetensors headers are valid",
                              shards=model_info["shards"], model_bytes=model_info["model_bytes"]))

--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -12,7 +12,16 @@ from pathlib import Path
 
 
 GB = 1_000_000_000
-EXPERT_RE = re.compile(r"model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.")
+# Two naming conventions, both matched: the original Llama/Mixtral-style
+# model.layers.N.mlp.experts.M. (kept for whatever family already relies on
+# it) and DeepSeek-V4's layers.N.ffn.experts.M. -- no model. prefix, ffn
+# not mlp. Before this fix every DeepSeek-V4 Flash expert tensor (70932 of
+# them, ~150GB) silently fell through to the dense_bytes accumulator below
+# instead of expert_groups, so the planner budgeted the entire model as
+# permanently-resident dense weight instead of disk-streamable experts --
+# doctor reported a 170GB RAM requirement for a model documented elsewhere in
+# this repo as needing ~16-22GB via streaming.
+EXPERT_RE = re.compile(r"(?:model\.)?layers\.(\d+)\.(?:mlp|ffn)\.experts\.(\d+)\.")
 
 
 def _tensor_sizes(path):


### PR DESCRIPTION
## What

A stock `deepseek-ai/DeepSeek-V4-Flash-0731` checkpoint cannot get through `coli doctor --deep` today, and `coli plan` reports it needs ~170GB of RAM — roughly 10x what this repo documents for the model (~16–22GB via expert streaming). This is four independent bugs stacked on top of each other; each one hides the next, so they only surface one at a time.

Found while bringing the model up on a DGX Spark (GB10, 121GB unified, aarch64). Reported values below are from that machine against the full 166.9GB checkpoint.

## The four bugs

**1. `doctor.py` — `SAFETENSORS_DTYPES` is missing `I64`/`U64` and the fp8 types**

Deep validation aborts on the first routing table it encounters:

```
[fail] model.container  model-00002-of-00048.safetensors: tensor 'layers.0.ffn.gate.tid2eid': unsupported dtype: 'I64'
```

`c/st.h` already indexes exactly these types in `st_dtype_code()` — including a comment describing this same DeepSeek-V4 abort ("PRIMA di questi, st_init faceva exit(1) su un checkpoint DeepSeek-V4 al primo tensore I64"). `doctor.py` keeps its own parallel dtype table that was never updated to match. Byte sizes added here follow `st_dtype_esz()`.

**2. `doctor.py` — `REQUIRED_CORE_TENSORS` assumes one naming convention**

It hardcodes `model.embed_tokens.weight` / `model.norm.weight` / `lm_head.weight`. DeepSeek-V4 ships `embed.weight` / `norm.weight` / `head.weight`, so a complete checkpoint reports as missing all three core tensors:

```
[fail] model.required   3 required core tensor(s) are missing
```

Entries become alias groups. Any family that passed before still passes on its own name — no arch detection needed, and the reported name on a genuine miss is unchanged (the existing `test_deep_check_rejects_missing_core_tensor` assertion still holds).

**3. `resource_plan.py` — `EXPERT_RE` doesn't match DeepSeek-V4 expert names — this is the ~170GB one**

The regex only matched `model.layers.N.mlp.experts.M.`; DeepSeek-V4 uses `layers.N.ffn.experts.M.` (no `model.` prefix, `ffn` not `mlp`). All **70932** expert tensors (~150GB) therefore fell through to the `dense_bytes` accumulator instead of `expert_groups`, and the planner budgeted the entire model as permanently-resident dense weight:

```
before:  RAM 170.6 GB budget · 166.9 GB dense · 0.0 GB warm experts · cap 0/layer
         disk 0.0 GB cold experts
after:   RAM  24.3 GB budget ·  19.7 GB dense · 7.7 GB warm experts · cap 13/layer
         disk 139.5 GB cold experts
```

Note the `0.0 GB cold experts` before — the planner saw a 167GB model with no streamable experts at all, which is the tell.

**4. `doctor.py` — `run_doctor()` computes CUDA linkage, then ignores it when planning**

`linkage` is computed and drives the `accelerator.gpu` check, but `build_plan()` is still handed the raw detected-GPU list. On a CPU-only engine build the planner sizes a VRAM hot tier against memory the engine can never address — and on unified-memory hardware that tier is subtracted from the same physical pool as RAM, so the RAM tier gets starved by a phantom reservation:

```
[fail] memory.ram     RAM budget cannot hold one expert slot per sparse layer
[warn] placement.plan RAM budget clamped from 100.0 GB to 24.3 GB because the GPU shares physical memory
                      99.2 GB VRAM hot tier · ~7420 experts   <- engine cannot use any of it
```

`--vram 0` doesn't help, since 0 is the auto sentinel. `deepseek_v4` has no CUDA target at all today (`Makefile.deepseek-v4` has no CUDA references, and `ldd ./deepseek_v4` shows no `libcudart`), which is how this surfaced there first — but it applies to any CPU-only engine build on unified memory.

## Result

`coli doctor --deep --model <deepseek-v4-flash> --ram 32` goes from `result error` to `result warning`, with only the two legitimate warnings left (engine is CPU-only; cold expert misses reach disk). The engine then runs:

```
$ ./deepseek_v4 ~/models/deepseek-v4-flash "What makes Rust different from C++ in terms of memory safety? 2-3 sentences." --max-tokens 100 --memory-gb 32
generated_text=Rust enforces memory safety at compile time through its ownership system, borrow
checker, and strict rules against null pointers, dangling references, and data races—without
needing a garbage collector. [...]
v4_tokens prompt=28 generated=94 expert_requests=26793 hits=18508 misses=8285 hit_rate=69.078
```

## Testing

- `make check` — **431 tests, `OK (skipped=52)`**, clean build.
- Manual: full `coli doctor --deep` and `coli plan` runs against the real 166.9GB checkpoint, plus the generation above.
- Not covered: I have no non-DeepSeek checkpoint locally, so bugs 2 and 4 are argued to be safe-by-construction (alias groups are additive; `usable_gpus` only ever narrows, and only when linkage reports the engine unlinked) rather than empirically regression-tested against GLM/Kimi/Inkling. Worth a maintainer's eye on that specifically.

Happy to split this into separate PRs per bug if you'd prefer them reviewed independently.
