### PR TITLE
[deepseek_v4] performance: use coli_v4_route_bf16 in moe_token

### DIFF
--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -3140,6 +3140,13 @@ static int normalized_hc_pre(float *reduced, float *post, float *comb,
     return result;
 }
 
+#ifndef COLI_V4_DISABLE_BF16_ROUTE
+int coli_v4_route_bf16(float *weights, int *indices, const float *hidden,
+                       const uint16_t *gate, const float *bias,
+                       const int *forced_indices, int experts, int dimension,
+                       int topk, float route_scale);
+#endif
+
 static int moe_token(float *output,
                      const ColiDeepSeekV4LayerWeights *weights,
                      const ColiDeepSeekV4Config *config,
@@ -3147,18 +3154,24 @@ static int moe_token(float *output,
     int d = config->hidden_size;
     int n = config->n_routed_experts;
     int topk = config->num_experts_per_tok;
+#ifndef COLI_V4_DISABLE_BF16_ROUTE
+    float *gate = NULL;
+    const uint16_t *raw_gate = value(weights, "ffn.gate.weight", NULL);
+    int missing_gate = !raw_gate;
+#else
     size_t gate_count = (size_t)n * d;
     float *gate = malloc(gate_count * sizeof(*gate));
+    int missing_gate = !gate;
+#endif
     float *route_weights = malloc((size_t)topk * sizeof(*route_weights));
     int *indices = malloc((size_t)topk * sizeof(*indices));
     float *expert_output = malloc((size_t)d * sizeof(*expert_output));
     float *shared_output = malloc((size_t)d * sizeof(*shared_output));
-    if (!gate || !route_weights || !indices || !expert_output || !shared_output) {
+    if (missing_gate || !route_weights || !indices || !expert_output || !shared_output) {
         free(shared_output); free(expert_output); free(indices);
         free(route_weights); free(gate);
         return -1;
     }
-    decode_bf16(gate, value(weights, "ffn.gate.weight", NULL), gate_count);
     const int64_t *table = value(weights, "ffn.gate.tid2eid", NULL);
     const float *bias = value(weights, "ffn.gate.bias", NULL);
     int result = token < 0 || token >= config->vocab_size;
@@ -3169,10 +3182,20 @@ static int moe_token(float *output,
         for (int i = 0; i < topk; i++)
             indices[i] = (int)table[(size_t)token * topk + i];
     }
-    if (!result) result = coli_v4_route(
-        route_weights, indices, input, gate, bias,
+#ifndef COLI_V4_DISABLE_BF16_ROUTE
+    if (!result) result = coli_v4_route_bf16(
+        route_weights, indices, input, raw_gate, bias,
         weights->plan.uses_hash_router ? indices : NULL,
         n, d, topk, config->routed_scaling_factor);
+#else
+    if (!result) {
+        decode_bf16(gate, value(weights, "ffn.gate.weight", NULL), gate_count);
+        result = coli_v4_route(
+            route_weights, indices, input, gate, bias,
+            weights->plan.uses_hash_router ? indices : NULL,
+            n, d, topk, config->routed_scaling_factor);
+    }
+#endif
 
     ColiTensorView w1, w2, w3;
     if (!result && (fp8_view(&w1, weights, "ffn.shared_experts.w1") ||


### PR DESCRIPTION
## Summary

I have let deepseek_v4-flash optimize its own engine. And it found something:

> The single-token decode path moe_token was decoding the entire n×d gate matrix (n_routed_experts × hidden_size, e.g. 256×7168 ≈ 1.8M bf16 values) into a freshly-malloc'd float buffer on every token, every layer, then calling the float-gate router coli_v4_route.
> 
> Meanwhile the prefill/batch path already used the bf16-gate router coli_v4_route_bf16, which reads the raw bf16 gate directly and avoids both the decode pass and the large allocation.
> 
> I changed moe_token to use coli_v4_route_bf16 with the raw bf16 gate, mirroring the batch path. This eliminates the O(n·d) gate-decode pass and the ~7 MB per-call allocation from the decode hot loop.

I have tested the performance with multiple runs:

```shell
rm -f ds4flash-0731/.coli_usage && time ./deepseek_v4 ds4flash-0731 "Hi" --thinking --max-tokens 1 --memory-gb 40 --no-dspark
```

Without the optimization it takes ~13 seconds and with the optimization ~11 seconds (AMD Ryzen 9 3900X 12-Core Processor, 64GB DDR4).
I have deleted the coli_usage before every run and made sure that the experts are in OS cache (single token + enough free memory).

I also tested the generation of longer texts and compared them (with/without the optimization) and they had the same output. I do not cite them because they contained much more time generating (and i think the optimization is only for prefill?).

## Validation

- [x] `make -C c check`
- [ ] CUDA changes were tested with `make -C c cuda-test` (if applicable)
- [x] Performance claims include hardware, commands, and repeatable measurements

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included

## Disclaimer

deepseek_v4-flash has done the work and i'm unsure if my validations are correct. So please check them yourself too.