### PR TITLE
security: resolve six loader/serve advisories (GHSA gf38/2qrj/w696/7654/9gjf/8p69)

### DIFF
--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -7242,12 +7242,31 @@ static int final_hidden(float *output, const float *state,
         coli_tensor_load_f32(&norm, index, "norm.weight", error, error_size))
         return -1;
     int d = config->hidden_size, hc = config->hc_mult;
+    /* SEC (GHSA-9gjf): these global tensors are loaded by their declared numel
+     * with no shape reconciliation (unlike the per-layer tensors, which
+     * coli_v4_layer_validate checks against config). final_hidden then indexes
+     * hc_head_fn at [copy*hc*d + i], hc_head_base at [copy], hc_head_scale at
+     * [0], and norm over d — a truncated global tensor turns each into a heap
+     * OOB read whose stale bytes leak into the logits. Require enough elements
+     * before use; `hc` also bounds the pre[16] stack array below. Free-closed on
+     * mismatch (the old hc>16 early-return leaked all four tensors). */
+    if (hc < 1 || hc > 16 ||
+        function.count < (uint64_t)hc * hc * d ||
+        base.count < (uint64_t)hc ||
+        scale.count < 1 ||
+        norm.count < (uint64_t)d) {
+        coli_float_tensor_free(&norm);
+        coli_float_tensor_free(&scale);
+        coli_float_tensor_free(&base);
+        coli_float_tensor_free(&function);
+        if (error && error_size) snprintf(error, error_size, "global tensor shape mismatch");
+        return -1;
+    }
     int flattened = hc * d;
     float square = 0.0f;
     for (int i = 0; i < flattened; i++) square += state[i] * state[i];
     float inverse_rms = 1.0f / sqrtf(square / flattened + config->rms_norm_eps);
     float pre[16];
-    if (hc > 16) return -1;
     for (int copy = 0; copy < hc; copy++) {
         float mix = 0.0f;
         for (int i = 0; i < flattened; i++)
@@ -10633,6 +10652,21 @@ int coli_v4_config_parse(ColiDeepSeekV4Config *config, const char *json,
         json_free(root);
         free(arena);
         return set_error(error, error_size, "inconsistent DeepSeek-V4 config dimensions");
+    }
+    /* SEC (GHSA-7654): rope vs head/index-head cross relationship. The per-field
+     * checks above never compared qk_rope_head_dim against index_head_dim; when
+     * qk_rope_head_dim > index_head_dim the indexer/compressor computed the RoPE
+     * sub-vector pointer as `output + index_head_dim - qk_rope_head_dim` — a
+     * negative offset — and rotated/rounded bf16 to the left of the heap block.
+     * No weight tensor carries the rope dim, so a benign snapshot + a tampered
+     * config.json alone reaches this. */
+    if (config->head_dim < 1 || config->index_head_dim < 1 ||
+        config->qk_rope_head_dim < 2 || (config->qk_rope_head_dim % 2) != 0 ||
+        config->qk_rope_head_dim > config->head_dim ||
+        config->qk_rope_head_dim > config->index_head_dim) {
+        json_free(root);
+        free(arena);
+        return set_error(error, error_size, "inconsistent DeepSeek-V4 rope/index head dims");
     }
     json_free(root);
     free(arena);

--- a/c/deepseek_v4_dspark.inc
+++ b/c/deepseek_v4_dspark.inc
@@ -188,12 +188,24 @@ static int v4_ds_load_fp8_suffix(const ColiSafetensorsIndex *index, int stage,
     return v4_ds_load_fp8(index, wn, sn, weight, scale);
 }
 
+/* SEC (GHSA-9gjf): every F32 sidecar loaded here is later indexed linearly by
+ * config-derived dimensions, but coli_tensor_load_f32 does no shape accounting —
+ * an undersized snapshot tensor became a heap OOB read. `expected` is the numel
+ * the consumer will index; require at least that many (-1 = skip). `<` (not `!=`)
+ * so a legitimately padded checkpoint is never false-rejected. */
 static int v4_ds_load_f32_suffix(ColiFloatTensor *output,
                                  const ColiSafetensorsIndex *index, int stage,
-                                 const char *suffix) {
+                                 const char *suffix, int64_t expected) {
     char name[160], error[256];
     if (v4_ds_name(name, sizeof(name), stage, suffix)) return -1;
-    return coli_tensor_load_f32(output, index, name, error, sizeof(error));
+    if (coli_tensor_load_f32(output, index, name, error, sizeof(error))) return -1;
+    if (expected >= 0 && (int64_t)output->count < expected) {
+        fprintf(stderr, "[MTP] shape mismatch: %s (numel %llu, need >= %lld)\n",
+                name, (unsigned long long)output->count, (long long)expected);
+        coli_float_tensor_free(output);
+        return -1;
+    }
+    return 0;
 }
 
 static void v4_ds_fp8_view(ColiTensorView *view,
@@ -256,17 +268,20 @@ static int v4_ds_core_load(const ColiSafetensorsIndex *index,
                        &g_v4ds_core.main_proj_w,
                        &g_v4ds_core.main_proj_s) ||
         v4_ds_load_f32_suffix(&g_v4ds_core.main_norm, index, 0,
-                              "main_norm.weight") ||
+                              "main_norm.weight", config->hidden_size) ||
         v4_ds_load_f32_suffix(&g_v4ds_core.head_fn, index, 2,
-                              "hc_head_fn") ||
+                              "hc_head_fn",
+                              (int64_t)config->hc_mult * config->hc_mult *
+                              config->hidden_size) ||
         v4_ds_load_f32_suffix(&g_v4ds_core.head_base, index, 2,
-                              "hc_head_base") ||
+                              "hc_head_base", config->hc_mult) ||
         v4_ds_load_f32_suffix(&g_v4ds_core.head_scale, index, 2,
-                              "hc_head_scale") ||
+                              "hc_head_scale", 1) ||
         v4_ds_load_f32_suffix(&g_v4ds_core.norm, index, 2,
-                              "norm.weight") ||
+                              "norm.weight", config->hidden_size) ||
         v4_ds_load_f32_suffix(&g_v4ds_core.confidence_proj, index, 2,
-                              "confidence_head.proj.weight") ||
+                              "confidence_head.proj.weight",
+                              (int64_t)config->hidden_size + V4_DSPARK_RANK) ||
         v4_ds_read_raw(index, "mtp.2.markov_head.markov_w1.weight",
                        COLI_ST_BF16, (void **)&g_v4ds_core.markov_w1,
                        &g_v4ds_core.markov_w1_bytes) ||
@@ -320,27 +335,39 @@ static int v4_ds_stage_load(const ColiSafetensorsIndex *index,
     V4_DS_LOAD_FP8(sh3,  "ffn.shared_experts.w3");
 #undef V4_DS_LOAD_FP8
 
-#define V4_DS_LOAD_F32(field, suffix) \
-    do { if (v4_ds_load_f32_suffix(&stage->field, index, stage_id, suffix)) \
+#define V4_DS_LOAD_F32(field, suffix, expected) \
+    do { if (v4_ds_load_f32_suffix(&stage->field, index, stage_id, suffix, \
+                                   expected)) \
              return 0; } while (0)
-    V4_DS_LOAD_F32(q_norm,       "attn.q_norm.weight");
-    V4_DS_LOAD_F32(kv_norm,      "attn.kv_norm.weight");
-    V4_DS_LOAD_F32(attn_norm,    "attn_norm.weight");
-    V4_DS_LOAD_F32(ffn_norm,     "ffn_norm.weight");
-    V4_DS_LOAD_F32(attn_sink,    "attn.attn_sink");
-    V4_DS_LOAD_F32(hc_attn_fn,   "hc_attn_fn");
-    V4_DS_LOAD_F32(hc_attn_base, "hc_attn_base");
-    V4_DS_LOAD_F32(hc_attn_scale,"hc_attn_scale");
-    V4_DS_LOAD_F32(hc_ffn_fn,    "hc_ffn_fn");
-    V4_DS_LOAD_F32(hc_ffn_base,  "hc_ffn_base");
-    V4_DS_LOAD_F32(hc_ffn_scale, "hc_ffn_scale");
-    V4_DS_LOAD_F32(gate_w,       "ffn.gate.weight");
-    V4_DS_LOAD_F32(gate_b,       "ffn.gate.bias");
+    {   int64_t mixes = (int64_t)(2 + config->hc_mult) * config->hc_mult;
+        int64_t flat = (int64_t)config->hc_mult * config->hidden_size;
+        V4_DS_LOAD_F32(q_norm,       "attn.q_norm.weight", config->q_lora_rank);
+        V4_DS_LOAD_F32(kv_norm,      "attn.kv_norm.weight", config->head_dim);
+        V4_DS_LOAD_F32(attn_norm,    "attn_norm.weight", config->hidden_size);
+        V4_DS_LOAD_F32(ffn_norm,     "ffn_norm.weight", config->hidden_size);
+        V4_DS_LOAD_F32(attn_sink,    "attn.attn_sink", config->num_attention_heads);
+        V4_DS_LOAD_F32(hc_attn_fn,   "hc_attn_fn", mixes * flat);
+        V4_DS_LOAD_F32(hc_attn_base, "hc_attn_base", mixes);
+        V4_DS_LOAD_F32(hc_attn_scale,"hc_attn_scale", 3);
+        V4_DS_LOAD_F32(hc_ffn_fn,    "hc_ffn_fn", mixes * flat);
+        V4_DS_LOAD_F32(hc_ffn_base,  "hc_ffn_base", mixes);
+        V4_DS_LOAD_F32(hc_ffn_scale, "hc_ffn_scale", 3);
+        V4_DS_LOAD_F32(gate_w,       "ffn.gate.weight",
+                       (int64_t)config->n_routed_experts * config->hidden_size);
+        V4_DS_LOAD_F32(gate_b,       "ffn.gate.bias", config->n_routed_experts);
+    }
 #undef V4_DS_LOAD_F32
 
     static const char *matrices[3] = {"w1", "w2", "w3"};
+    /* SEC (GHSA-8p69): slab_bytes must cover the LARGEST expert, not expert 0.
+     * Each slot later copies whichever expert is routed to it, using that
+     * expert's own declared nbytes — so sizing from expert 0 alone let a crafted
+     * checkpoint (expert 0 tiny, another expert large) overflow the slab with
+     * file-controlled bytes (heap OOB write). Real MTP checkpoints have uniform
+     * expert shapes, so max == expert 0 and behaviour is unchanged. */
     stage->slab_bytes = 0;
     for (int expert = 0; expert < config->n_routed_experts; expert++) {
+        int64_t expert_bytes = 0;
         for (int matrix = 0; matrix < 3; matrix++) {
             char name[192];
             snprintf(name, sizeof(name), "mtp.%d.ffn.experts.%d.%s.weight",
@@ -351,11 +378,12 @@ static int v4_ds_stage_load(const ColiSafetensorsIndex *index,
             stage->es[expert][matrix] = coli_st_find(index, name);
             if (!stage->ew[expert][matrix] || !stage->es[expert][matrix])
                 return 0;
-            if (!expert)
-                stage->slab_bytes += stage->ew[expert][matrix]->nbytes +
-                                     stage->es[expert][matrix]->nbytes;
+            expert_bytes += stage->ew[expert][matrix]->nbytes +
+                            stage->es[expert][matrix]->nbytes;
         }
+        if (expert_bytes > stage->slab_bytes) stage->slab_bytes = expert_bytes;
     }
+    if (stage->slab_bytes < 1) return 0;
 
     /* V4_MTP_GB is intentionally total, not per stage. */
     double total_gb = coli_v4_dspark_cache_gb();
@@ -413,12 +441,21 @@ static int v4_ds_expert(const ColiSafetensorsIndex *index,
         }
         stage->slots[slot].id = -1;
         uint8_t *cursor = stage->slots[slot].slab;
+        uint8_t *slab_end = cursor + stage->slab_bytes;
         for (int matrix = 0; matrix < 3; matrix++) {
             const ColiSafetensorsTensor *scale = stage->es[expert][matrix];
             const ColiSafetensorsTensor *weight = stage->ew[expert][matrix];
+            /* SEC (GHSA-8p69): defence in depth — never write past the slab even
+             * if the max-sizing above is ever defeated (shape drift within a
+             * stage). Fail closed rather than overflow. */
+            if (scale->nbytes < 0 || weight->nbytes < 0 ||
+                (size_t)(slab_end - cursor) < (size_t)scale->nbytes)
+                return 0;
             if (coli_st_read_tensor(index, scale, cursor))
                 return 0;
             cursor += scale->nbytes;
+            if ((size_t)(slab_end - cursor) < (size_t)weight->nbytes)
+                return 0;
             int shard = coli_st_tensor_shard(index, weight);
             if (shard < 0 || weight->off < 0 ||
                 coli_st_read_at_streaming(

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -802,6 +802,21 @@ static void model_init(Model *m, const char *snap, int cap, int bits) {
      * sidecar dropped in the snapshot dir (st_init indexes every *.safetensors).
      * Absent tensors = text-only engine, exactly as before. */
     if (st_has(&m->S, "model.audio.encoder.weight")) {
+        /* SEC (GHSA-w696): mel_bins/mel_vocab come straight from config.json with
+         * no bounds. audio_embed_row indexes the table at (b*mel_vocab+v)*D with
+         * b<mel_bins, v<mel_vocab — so the table must have exactly
+         * mel_bins*mel_vocab rows or that index runs off the heap (bidirectional
+         * OOB read, config-controlled). Reconcile the real element count against
+         * the geometry before using it. */
+        st_tensor *aet = st_find(&m->S, "model.audio.encoder.weight");
+        if (c->mel_bins < 1 || c->mel_vocab < 1 || D < 1 ||
+            (int64_t)c->mel_bins * c->mel_vocab > INT64_MAX / D ||
+            !aet || aet->numel != (int64_t)c->mel_bins * c->mel_vocab * D) {
+            fprintf(stderr, "[audio] rejected: encoder table has %lld elements, "
+                    "config geometry is %d bins x %d levels x D=%d\n",
+                    aet ? (long long)aet->numel : -1, c->mel_bins, c->mel_vocab, D);
+            exit(1);
+        }
         m->audio_enc  = load_w(m, "model.audio.encoder.weight", 0);
         m->audio_norm = load_t(m, "model.audio.final_norm.weight");
         fprintf(stderr, "[audio] DMel encoder loaded (%d bins x %d levels -> D=%d)\n",

--- a/c/json.h
+++ b/c/json.h
@@ -53,7 +53,11 @@ static jval *j_new(jtype t) {
 static jval *j_parse_val(jparser *p);
 
 static char *j_parse_str_raw(jparser *p) {
-    /* assume *p->s == '"' */
+    /* SEC (GHSA-2qrj): fail closed if not actually at a quote. The old comment
+     * "assume *p->s == '\"'" was violated on the object-key path, and the
+     * unconditional p->s++ would step past the buffer's NUL terminator and scan
+     * adjacent heap (OOB read leaking into tensor names). */
+    if (*p->s != '"') return j_dup(p, "", 0);
     p->s++;
     /* buffer su heap che CRESCE: niente troncamento silenzioso a 64KB (le stringhe
      * lunghe di tokenizer.json/config venivano tagliate) e niente 64KB di stack. */
@@ -108,6 +112,7 @@ static jval *j_parse_val(jparser *p) {
         if (*p->s == '}') { p->s++; p->depth--; return v; }
         for (;;) {
             j_ws(p);
+            if (*p->s != '"') break;   /* SEC (GHSA-2qrj): object key must be a quoted string; stop on malformed input */
             char *key = j_parse_str_raw(p);
             j_ws(p); if (*p->s == ':') p->s++;
             jval *val = j_parse_val(p);

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -1786,7 +1786,11 @@ static int serve_read_req(ServeReq *q, const char *active){
     if(strcmp(cmd,"SUBMIT")) return 0;
     int slot, plen, max_tok; float temp, top_p;
     if(sscanf(line,"%*s %*s %d %d %d %f %f",&slot,&plen,&max_tok,&temp,&top_p)!=5||
-       plen<0||plen>(1<<24)||max_tok<1){
+       plen<0||plen>(1<<24)||max_tok<1||max_tok>(1<<20)){
+        /* SEC (GHSA-gf38): max_tok needs an upper bound too. INT_MAX wrapped the
+         * signed np+max_tok context check below and made the kv_alloc size
+         * negative, so kv_alloc's early-return kept the previous request's small
+         * KV buffers and the generation loop wrote past them (heap OOB write). */
         printf("ERROR %s bad submit header\n",id); fflush(stdout); return 0;
     }
     (void)slot;
@@ -1830,7 +1834,7 @@ static void serve_one(Model *m, Tok *T, ServeReq *q){
         np+=tok_encode(T,q->payload,q->plen,ids+np,cap-np);
     }
     int max_ctx=getenv("K3_MAXT")?atoi(getenv("K3_MAXT")):8192;
-    if(np<1||np+q->max_tok>max_ctx){
+    if(np<1||(int64_t)np+q->max_tok>max_ctx){ /* SEC (GHSA-gf38): int64 so np+max_tok can't wrap negative */
         printf("ERROR %s CONTEXT_EXCEEDED prompt_tokens=%d requested=%d capacity=%d\n",
                q->id,np,q->max_tok,max_ctx);
         fflush(stdout); free(ids); return;


### PR DESCRIPTION
Single consolidated fix for the six privately-reported memory-safety advisories, targeting **dev** (per our flow: PR → CI green → merge; the advisory temp-fork PRs #1011–#1016 default to `main`, this replaces them with one reviewed change on dev).

All six are reachable from attacker-controlled input — a malicious model file / `config.json`, or the kimi_k3 SERVE stdin. Each fix validates at the trust boundary; **no behavioural change on well-formed models or requests**.

| Advisory | File | Fix |
|---|---|---|
| GHSA-gf38 | `kimi_k3.c` | bound `max_tok` (≤1<<20) + int64 context check — was signed-overflow → heap OOB write |
| GHSA-2qrj | `json.h` | object key must open with `"` — was OOB read past NUL into tensor names |
| GHSA-w696 | `inkling.c` | reconcile audio table numel vs `bins·vocab·D` — was config-controlled OOB read |
| GHSA-7654 | `deepseek_v4.c` | cross-check `qk_rope ≤ index/head` — was negative RoPE offset OOB R/W from config.json |
| GHSA-9gjf | `deepseek_v4.c` + `deepseek_v4_dspark.inc` | require enough elements on global/sidecar tensors — was OOB read into logits (also fixes a leak) |
| GHSA-8p69 | `deepseek_v4_dspark.inc` | size the MTP slab from the largest expert + per-copy guard — was file-controlled heap overflow |

Tensor-shape checks use `>= expected` (not exact `!=`) so a legitimately padded official checkpoint is never false-rejected.

**Verification:** kimi_k3 / inkling / deepseek_v4 build clean; `test_json`, `test_kimi_request_state`, `test_deepseek_v4` and the DSpark source test pass; ASAN confirms the json OOB read is gone and well-formed JSON still parses.

Supersedes advisory PRs #1011 #1012 #1013 #1014 #1015 #1016 — close those in favour of this once merged, then publish the six advisories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)