### PR TITLE
Release v1.6.2 — security: six loader/serve advisories fixed

### DIFF
--- a/c/.gitignore
+++ b/c/.gitignore
@@ -3,6 +3,8 @@ glm_tiny/
 olmoe_hf/
 olmoe_i4/
 .build-config
+build/
+COLI_V4_UNIT_*.o
 tests/test_st_mirror
 tests/test_st_pread
 tools/libiq3.so

--- a/c/Makefile
+++ b/c/Makefile
@@ -941,6 +941,9 @@ tests/test_cap_precedence$(EXE): tests/test_cap_precedence.c colibri.c st.h urin
 tests/test_cap_mixed_width$(EXE): tests/test_cap_mixed_width.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h route_trace.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
+tests/test_eslot_inflight$(EXE): tests/test_eslot_inflight.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h route_trace.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
 tests/test_ssd_probe$(EXE): tests/test_ssd_probe.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 

--- a/c/Makefile
+++ b/c/Makefile
@@ -218,6 +218,14 @@ ifneq ($(IS_WIN),)
 NVCCFLAGS ?= -O3 -std=c++17 $(CUDA_GENCODE) -Xcompiler=-W3
 else
 NVCCFLAGS ?= -O3 -std=c++17 $(CUDA_GENCODE) -Xcompiler=-Wall,-Wextra
+# glibc >= 2.41 declares the C23 math additions (rsqrt/rsqrtf, sinpi/cospi, ...)
+# with __THROW -> noexcept(true), clashing with CUDA's crt/math_functions.h
+# under C++17 (noexcept is part of the function type since C++17). Force-include
+# a compat header that strips __THROW from the host pass; see
+# glibc_c23_math_compat.h. MSVC never sees glibc headers, so Linux-only.
+ifneq ($(LINUX),)
+NVCCFLAGS += -Xcompiler=-include,$(CURDIR)/glibc_c23_math_compat.h
+endif
 endif
 # HIP=1 builds the SAME backend for AMD GPUs via ROCm: backend_cuda.cu is
 # compiled unchanged through backend_gpu_compat.h (one source, two vendors,

--- a/c/Makefile
+++ b/c/Makefile
@@ -325,6 +325,9 @@ endif
 GPUCC      = $(NVCC)
 GPUFLAGS   = $(NVCCFLAGS)
 GPUCC_NAME = nvcc (set CUDA_HOME or NVCC)
+# tests/mxfp4_ref.c is compiled by $(CC) with OpenMP. Its object therefore
+# needs the host OpenMP runtime when the GPU compiler performs the final link.
+GPU_OMP_LINK = -Xcompiler=-fopenmp
 # PYTHON is a HOST tool (clean/test-c/test-python run it on the build machine),
 # so key it off the host, NOT $(IS_WIN) — which is derived from the *target*
 # triple ($(CC) -dumpmachine). Otherwise a cross build (make CC=x86_64-w64-
@@ -435,6 +438,7 @@ CUDA_OBJ   = backend_cuda.o
 GPUCC      = $(HIPCC)
 GPUFLAGS   = $(HIPCCFLAGS)
 GPUCC_NAME = hipcc (set ROCM_HOME or HIPCC)
+GPU_OMP_LINK = -fopenmp
 # rocWMMA needs matrix cores (MFMA gfx908+ / WMMA gfx11xx); on these archs its
 # headers static_assert (ROCm/TheRock#1944). Compile the WMMA paths out and
 # let backend_gpu_compat.h fall back via COLI_GPU_HAS_WMMA=0. The flag must
@@ -681,7 +685,7 @@ cuda-test: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/test_backen
 	# as C on purpose: quant.h uses _Thread_local, which nvcc's C++ front end
 	# rejects, and re-implementing it for the test would defeat the comparison.
 	$(CC) $(CFLAGS) -c tests/mxfp4_ref.c -o tests/mxfp4_ref.o
-	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/test_mxfp4_cuda.cu tests/mxfp4_ref.o -o mxfp4_cuda_test$(EXE)
+	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/test_mxfp4_cuda.cu tests/mxfp4_ref.o -o mxfp4_cuda_test$(EXE) $(GPU_OMP_LINK)
 	./mxfp4_cuda_test$(EXE)
 
 # convenience alias: kernel correctness on AMD (same test, hipcc toolchain)

--- a/c/Makefile
+++ b/c/Makefile
@@ -954,6 +954,12 @@ tests/bench_dsa_select$(EXE): tests/bench_dsa_select.c colibri.c st.h uring.h js
 tests/bench_idot$(EXE): tests/bench_idot.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h route_trace.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
+# bench_gemv_stream: microbenchmark (decode-regime GEMV bandwidth vs the read ceiling;
+# frozen-baseline + deinterleaved-x candidate A/B), NOT a test gate.
+# Build on demand: make tests/bench_gemv_stream ARCH=native
+tests/bench_gemv_stream$(EXE): tests/bench_gemv_stream.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h route_trace.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
 # bench_mla_simd: microbenchmark (scalar vs AVX2/NEON MLA-absorb reductions, #442),
 # NOT a test gate. Build on demand: make tests/bench_mla_simd
 tests/bench_mla_simd$(EXE): tests/bench_mla_simd.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h route_trace.h

--- a/c/coli
+++ b/c/coli
@@ -941,7 +941,7 @@ def cmd_run(a):
         prompt_path=None
         try:
             cmd=[engine,os.path.abspath(a.model)]
-            if sys.platform=="win32":
+            if sys.platform in ("win32", "msys", "cygwin"):
                 with tempfile.NamedTemporaryFile(
                         mode="w",encoding="utf-8",newline="",delete=False,
                         prefix="coli-v4-prompt-",suffix=".txt") as stream:

--- a/c/coli
+++ b/c/coli
@@ -1321,6 +1321,7 @@ def cmd_serve(a):
                             "olmoe-colibri" if arch=="olmoe" else
                             "glm-5.2-colibri")
     try:
+        if a.temp is not None: os.environ["COLI_TEMP"] = str(a.temp)
         openai_server.serve(a.model,a.host,a.port,model_id,a.api_key,
               a.cap,ngen_for(a,interactive=True),engine,env_for_engine(a,arch),a.cors_origin,
               a.max_queue,a.queue_timeout,a.kv_slots,allowed_hosts=a.allowed_host)

--- a/c/coli
+++ b/c/coli
@@ -1302,6 +1302,34 @@ def cmd_chat(a):
 
 def serve_pidfile(port): return os.path.join(tempfile.gettempdir(), f"coli-serve-{port}.pid")
 
+def _serve_cmdline_matches_port(raw, port):
+    argv=[part.decode("utf-8","replace") for part in raw.split(b"\0") if part]
+    try: coli_i=next(i for i,arg in enumerate(argv) if os.path.basename(arg)=="coli")
+    except StopIteration: return False
+    if coli_i+1>=len(argv) or argv[coli_i+1]!="serve":
+        return False
+    configured=8000
+    for i,arg in enumerate(argv[coli_i+2:], start=coli_i+2):
+        if arg=="--port" and i+1<len(argv):
+            try: configured=int(argv[i+1])
+            except ValueError: return False
+        elif arg.startswith("--port="):
+            try: configured=int(arg.split("=",1)[1])
+            except ValueError: return False
+    return configured==port
+
+def _serve_environ_matches_port(raw, port):
+    env={}
+    for entry in raw.split(b"\0"):
+        if b"=" in entry:
+            key,value=entry.split(b"=",1); env[key]=value
+    return env.get(b"SERVE")==b"1" and env.get(b"COLI_SERVE_PORT")==str(port).encode()
+
+def _serve_engine_env(a, arch):
+    env=env_for_engine(a,arch)
+    env["COLI_SERVE_PORT"]=str(a.port)
+    return env
+
 def cmd_serve(a):
     arch=model_arch(a.model)
     engine=engine_for(a.model)
@@ -1322,7 +1350,7 @@ def cmd_serve(a):
                             "glm-5.2-colibri")
     try:
         openai_server.serve(a.model,a.host,a.port,model_id,a.api_key,
-              a.cap,ngen_for(a,interactive=True),engine,env_for_engine(a,arch),a.cors_origin,
+              a.cap,ngen_for(a,interactive=True),engine,_serve_engine_env(a,arch),a.cors_origin,
               a.max_queue,a.queue_timeout,a.kv_slots,allowed_hosts=a.allowed_host)
     finally:
         try: os.unlink(serve_pidfile(a.port))
@@ -1334,36 +1362,38 @@ def cmd_stop(a):
     not `glm`: every `pkill -x glm` in history silently killed nothing (that is
     how two 17+5 GB ghost engines OOM'd this box on 2026-07-16). This finds the
     real processes: the pidfile first, then /proc by cmdline/environ — only
-    processes that are demonstrably ours (SERVE=1 + our SNAP, or `coli serve`
-    in the command line)."""
+    the requested port's tagged engine and matching `coli serve` wrapper."""
     banner("stop")
-    targets=[]  # (pid, descrizione)
+    targets={}  # pid -> descrizione
     pf=serve_pidfile(a.port)
     try:
-        pid=int(open(pf).read().split()[0])
-        os.kill(pid,0); targets.append((pid,f"coli serve (pidfile, port {a.port})"))
+        with open(pf) as f: pid=int(f.read().split()[0])
+        os.kill(pid,0); targets[pid]=f"coli serve (pidfile, port {a.port})"
     except (OSError,ValueError,IndexError): pass
-    for pd in os.listdir("/proc"):
+    try: proc_entries=os.listdir("/proc")
+    except OSError: proc_entries=[]       # native Windows has no /proc; the pidfile still works
+    for pd in proc_entries:
         if not pd.isdigit(): continue
         pid=int(pd)
         try:
-            cmd=open(f"/proc/{pd}/cmdline","rb").read().replace(b"\0",b" ").decode("utf-8","replace")
-            if "coli" in cmd and " serve" in cmd and pid!=os.getpid():
-                if not any(p==pid for p,_ in targets): targets.append((pid,"coli serve (cmdline)"))
-            comm=open(f"/proc/{pd}/comm").read().strip()
+            with open(f"/proc/{pd}/cmdline","rb") as f: cmd=f.read()
+            if pid!=os.getpid() and _serve_cmdline_matches_port(cmd,a.port):
+                targets.setdefault(pid,f"coli serve (cmdline, port {a.port})")
+            with open(f"/proc/{pd}/comm") as f: comm=f.read().strip()
             if comm in ("colibri","glm","exe","olmoe","inkling","kimi_k3","deepseek_v4"):
-                env=open(f"/proc/{pd}/environ","rb").read().replace(b"\0",b"\n").decode("utf-8","replace")
-                if "SERVE=1" in env: targets.append((pid,f"engine `{comm}` (SERVE=1)"))
+                with open(f"/proc/{pd}/environ","rb") as f: env=f.read()
+                if _serve_environ_matches_port(env,a.port):
+                    targets.setdefault(pid,f"engine `{comm}` (port {a.port})")
         except (OSError,PermissionError): continue
     if not targets:
         print(f"  nothing running — no serve on port {a.port}, no SERVE engines"); return
-    for pid,desc in targets: print(f"  {'would stop' if a.dry_run else 'stopping'} {pid}: {desc}")
+    for pid,desc in targets.items(): print(f"  {'would stop' if a.dry_run else 'stopping'} {pid}: {desc}")
     if a.dry_run: return
-    for pid,_ in targets:
+    for pid in targets:
         try: os.kill(pid, signal.SIGTERM)
         except OSError: pass
     time.sleep(2.0)
-    for pid,_ in targets:
+    for pid in targets:
         try: os.kill(pid, signal.SIGKILL); print(f"  {pid}: forced (SIGKILL)")
         except OSError: pass       # gia' morto: bene
     try: os.unlink(pf)

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -360,11 +360,26 @@ typedef struct {
  * expert non hanno tutti la stessa taglia (layer MTP int8 = 2x i layer int4). */
 typedef struct { int eid; QT g,u,d; uint8_t *slab; float *fslab;
                  int64_t slab_cap, fslab_cap; uint64_t used;
+                 unsigned in_flight; /* async GPU readers borrowing this slot */
                  /* pin-arena backing (#419): when set, slab/fslab are interior
                   * slices of a per-layer arena and must never be free()d —
                   * expert_host_release detaches them, expert_host_ensure
                   * re-attaches. NULL for every individually-allocated slot. */
                  uint8_t *aslab; float *afslab; } ESlot;
+
+static void eslot_acquire(ESlot *s){ __atomic_add_fetch(&s->in_flight,1,__ATOMIC_ACQ_REL); }
+static void eslot_release(ESlot *s){
+    unsigned old=__atomic_fetch_sub(&s->in_flight,1,__ATOMIC_ACQ_REL);
+    if(!old){ fprintf(stderr,"[CUDA] ESlot reference underflow\n"); abort(); }
+}
+static int eslot_busy(const ESlot *s){ return __atomic_load_n(&s->in_flight,__ATOMIC_ACQUIRE)!=0; }
+static void eslots_acquire(ESlot **slots,int n){ for(int i=0;i<n;i++) eslot_acquire(slots[i]); }
+static void eslots_release(ESlot **slots,int n){ for(int i=0;i<n;i++) eslot_release(slots[i]); }
+static int eslot_lru_victim(ESlot *slots,int n){
+    int lru=-1;
+    for(int i=0;i<n;i++) if(!eslot_busy(&slots[i])&&(lru<0||slots[i].used<slots[lru].used)) lru=i;
+    return lru;
+}
 
 typedef struct {
     float **Lc, **Rc, **Ic;
@@ -3058,6 +3073,8 @@ static int g_pres_home=-1;                /* home device, -1 = path off        *
 static const float *g_pres_xsrc;          /* nrm_d on the home device          */
 static float *g_pres_slots;               /* [ndev][D] partial slots on home   */
 static int g_pres_used[COLI_CUDA_MAX_DEVICES], g_pres_nused;
+static ESlot *g_pres_refs[COLI_CUDA_MAX_DEVICES*64];
+static int g_pres_nrefs;
 #endif   /* ABSORB: -1 auto (decode S<=4), 0 mai, 1 sempre (test) */
 static int g_dsa_force=0; /* DSA_FORCE=1: selezione sempre attiva (test: top-min(k,T)=denso) */
 static int cmp_fdesc(const void *a,const void *b){
@@ -4503,9 +4520,13 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                     }
                     double tg0=now_s();
                     int all=1, issued[COLI_CUDA_MAX_DEVICES]={0};
-                    for(int di=0;di<g_cuda_ndev && all;di++) if(pd_nc[di])
+                    for(int di=0;di<g_cuda_ndev && all;di++) if(pd_nc[di]){
+                        ESlot *refs[64]; for(int q=0;q<pd_nc[di];q++) refs[q]=pg_e[pd_which[di][q]];
+                        eslots_acquire(refs,pd_nc[di]);
                         all=issued[di]=coli_cuda_expert_group_issue(pd_g[di],pd_u[di],pd_d[di],
                                 pd_rows[di],pd_nc[di],group_x+(int64_t)pd_off[di]*D);
+                        if(!issued[di]) eslots_release(refs,pd_nc[di]);
+                    }
                     g_ovl_issue+=now_s()-tg0;
                     if(all){
                         static int announced2;
@@ -4523,8 +4544,10 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                             m->gpu_expert_calls++;
                         }
                     } else {
-                        for(int di=0;di<g_cuda_ndev;di++)
-                            if(issued[di]) coli_cuda_expert_group_take(g_cuda_devices[di]);
+                        for(int di=0;di<g_cuda_ndev;di++) if(issued[di]){
+                            coli_cuda_expert_group_take(g_cuda_devices[di]);
+                            for(int q=0;q<pd_nc[di];q++) eslot_release(pg_e[pd_which[di][q]]);
+                        }
                     }
                 }
             }
@@ -4793,6 +4816,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
             g_ovl_cpu+=tg1-g_ovl_mark;               /* CPU-row window between issue and take */
             for(int di=0;di<g_cuda_ndev;di++) if(dev_nc0[di]){
                 const float *hy=coli_cuda_expert_group_take(g_cuda_devices[di]);
+                for(int q=0;q<dev_nc0[di];q++) eslot_release(eg_e[dev_which0[di][q]]);
                 int cur=0;
                 for(int q=0;q<dev_nc0[di];q++){
                     int gi=dev_which0[di][q], nr=eg_n[gi];
@@ -4848,22 +4872,29 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
         if(g_group_async<0) g_group_async=getenv("COLI_GROUP_ASYNC")?atoi(getenv("COLI_GROUP_ASYNC")):0;
         if(g_group_async && S<=4 && g_cuda_ndev>0){
             int issued[COLI_CUDA_MAX_DEVICES]={0}, all=1;
-            for(int di=0;di<g_cuda_ndev && all;di++) if(dev_nc[di])
+            for(int di=0;di<g_cuda_ndev && all;di++) if(dev_nc[di]){
+                ESlot *refs[64]; for(int q=0;q<dev_nc[di];q++) refs[q]=group_e[dev_which[di][q]];
+                eslots_acquire(refs,dev_nc[di]);
                 all=issued[di]=coli_cuda_expert_group_issue(dev_g[di],dev_u[di],dev_d[di],
                         dev_rows[di],dev_nc[di],group_x+(int64_t)dev_off[di]*D);
+                if(!issued[di]) eslots_release(refs,dev_nc[di]);
+            }
             if(all){
                 static int announced;
                 if(!announced){ announced=1; fprintf(stderr,"[CUDA] expert group async path active\n"); }
                 async_done=1;
                 for(int di=0;di<g_cuda_ndev;di++) if(dev_nc[di]){
                     const float *hy=coli_cuda_expert_group_take(g_cuda_devices[di]);
+                    for(int q=0;q<dev_nc[di];q++) eslot_release(group_e[dev_which[di][q]]);
                     if(hy){ dev_ok[di]=1;
                         memcpy(group_y+(int64_t)dev_off[di]*D,hy,(size_t)dev_total[di]*D*sizeof(float)); }
                     else dev_ok[di]=0;      /* per-device sync failure: CPU fallback below */
                 }
                 if(g_prof) m->t_egpu+=now_s()-tg;
-            } else for(int di=0;di<g_cuda_ndev;di++)
-                if(issued[di]) coli_cuda_expert_group_take(g_cuda_devices[di]);
+            } else for(int di=0;di<g_cuda_ndev;di++) if(issued[di]){
+                coli_cuda_expert_group_take(g_cuda_devices[di]);
+                for(int q=0;q<dev_nc[di];q++) eslot_release(group_e[dev_which[di][q]]);
+            }
         }
         if(!async_done){
             /* resident path (#431 PR-C0): issue the group on its device with the input
@@ -4875,11 +4906,14 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                 for(int di=0;di<g_cuda_ndev;di++) if(dev_nc[di]){
                     float wbuf[64];
                     for(int q=0;q<dev_nc[di];q++) wbuf[q]=group_weight[(int64_t)dev_which[di][q]*S];
+                    ESlot *refs[64]; for(int q=0;q<dev_nc[di];q++) refs[q]=group_e[dev_which[di][q]];
+                    eslots_acquire(refs,dev_nc[di]);
                     if(coli_cuda_expert_group_resident_issue(dev_g[di],dev_u[di],dev_d[di],wbuf,dev_nc[di],
                             g_pres_home,g_pres_xsrc,g_pres_slots+(int64_t)g_pres_nused*D)){
                         g_pres_used[g_pres_nused++]=g_cuda_devices[di];
+                        for(int q=0;q<dev_nc[di];q++) g_pres_refs[g_pres_nrefs++]=refs[q];
                         dev_ok[di]=2;                       /* handled on device: skip host collection */
-                    }
+                    } else eslots_release(refs,dev_nc[di]);
                 }
             }
         }
@@ -4933,7 +4967,11 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
           int promo = nmiss<m->ecap ? nmiss : m->ecap;
           for(int a=0;a<promo;a++){ int q=nmiss-1-a; ESlot *dst;
               if(*nn<m->ecap) dst=&Sl[(*nn)++];
-              else { int lru=0; for(int z=1;z<*nn;z++) if(Sl[z].used<Sl[lru].used) lru=z; dst=&Sl[lru]; }
+              else { int lru=eslot_lru_victim(Sl,*nn);
+                     if(lru<0){ static int warned;
+                         if(!warned){ warned=1; fprintf(stderr,"[CUDA] all LRU expert slots are in flight; skipping cache promotion\n"); }
+                         continue; }
+                     dst=&Sl[lru]; }
               ESlot tmp=*dst; *dst=m->ws[q]; m->ws[q]=tmp; dst->used=(uint64_t)__atomic_add_fetch(&m->eclock,1,__ATOMIC_RELAXED); }
         }
     }
@@ -5122,6 +5160,7 @@ static void pilot_realload(Model *m, int layer, int eid){
     else {
         slot=-1;
         for(int z=0;z<nn;z++){
+            if(eslot_busy(&Sl[z])) continue;             /* borrowed by an async GPU read */
             if(Sl[z].eid==-1){ slot=z; break; }         /* riusa uno slot libero/fallito */
             if(Sl[z].eid< -1) continue;                 /* prenotazione di un ALTRO worker: mai vittima */
             if(slot<0 || Sl[z].used<Sl[slot].used) slot=z;
@@ -5201,6 +5240,7 @@ static void pilot_uring_batch(Model *m){
         else{
             slot=-1;
             for(int z=0;z<nn;z++){
+                if(eslot_busy(&Sl[z])) continue;      /* borrowed by an async GPU read */
                 if(Sl[z].eid==-1){ slot=z; break; }
                 if(Sl[z].eid< -1) continue;          /* URING reservation in flight */
                 if(slot<0 || Sl[z].used<Sl[slot].used) slot=z;
@@ -5575,7 +5615,7 @@ static int pipe_layer_sparse(Model *m, Layer *l, int li, float *x_dev, int S, in
     if(g_cuda_resid && S==1){
         g_pres_slots=coli_cuda_pipe_scratch(dev,25,(size_t)g_cuda_ndev*D*sizeof(float));
         res_acc     =coli_cuda_pipe_scratch(dev,26,(size_t)D*sizeof(float));
-        if(g_pres_slots && res_acc){ g_pres_home=dev; g_pres_xsrc=nrm_d; g_pres_nused=0; }
+        if(g_pres_slots && res_acc){ g_pres_home=dev; g_pres_xsrc=nrm_d; g_pres_nused=0; g_pres_nrefs=0; }
         else { g_pres_slots=NULL; res_acc=NULL; }
     }
     moe(m,l,li,nrm_host,S,out_host,0);                            /* self-times its own t_emm */
@@ -5587,8 +5627,9 @@ static int pipe_layer_sparse(Model *m, Layer *l, int li, float *x_dev, int S, in
              * stream behind every issue event and reduces in issue order. A
              * failure here would silently drop routed experts — that is a wrong
              * answer, not a slow one, so it is fatal by design. */
-            if(!coli_cuda_expert_group_resident_take(dev,g_pres_used,nused,g_pres_slots,res_acc,D)||
-               !coli_cuda_pipe_add(dev,x_dev,res_acc,(size_t)D)){
+            int take_ok=coli_cuda_expert_group_resident_take(dev,g_pres_used,nused,g_pres_slots,res_acc,D);
+            eslots_release(g_pres_refs,g_pres_nrefs); g_pres_nrefs=0;
+            if(!take_ok || !coli_cuda_pipe_add(dev,x_dev,res_acc,(size_t)D)){
                 fprintf(stderr,"[CUDA] resident expert take failed — refusing to drop routed experts\n");
                 exit(1);
             }
@@ -6997,7 +7038,7 @@ static void rss_guard(Model *m){
             int nn=m->ecn[l], lru=-1;
             for(int z=0;z<nn;z++){                        /* solo slot pubblicati e con slab */
                 ESlot *cand=&m->ecache[l][z];
-                if(cand->eid<0 || !cand->slab) continue;
+                if(cand->eid<0 || !cand->slab || eslot_busy(cand)) continue;
                 if(lru<0 || cand->used<m->ecache[l][lru].used) lru=z;
             }
             if(lru<0){ pthread_mutex_unlock(&g_pilot_mx); continue; }

--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -3607,6 +3607,18 @@ double coli_v4_block_profile_now(void);
 void coli_v4_block_profile_add(int kind, double seconds);
 #endif
 
+/* #890: expert-forward compute accounting — defined in the expert-store unit,
+ * called here around the matmul, read per-turn in the serve loop. Always on
+ * (unlike the block profiler above), because the dashboard always needs it. */
+void coli_v4_expert_store_add_matmul(ColiExpertStore *store, double sec);
+double coli_v4_expert_store_matmul_sec(ColiExpertStore *store);
+
+static double v4_now_mono(void) {   /* #890 phase timing, same clock as disk_sec */
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+}
+
 static int profiled_expert_load_start(ExpertLoadHandle *handle,
                                       ExpertLoadJob *job) {
 #ifdef COLI_V4_EXPERIMENTAL_BLOCK_OTHER_PROFILE
@@ -3783,9 +3795,13 @@ static int moe_token_pipeline(float *output,
             else
                 loader_active[slot] = 1;
         }
-        if (!result) result = coli_v4_expert_forward_ref(
-            expert_output, &expert, input, expert_weights[current],
-            config->swiglu_limit);
+        if (!result) {
+            double mm0 = v4_now_mono();
+            result = coli_v4_expert_forward_ref(
+                expert_output, &expert, input, expert_weights[current],
+                config->swiglu_limit);
+            coli_v4_expert_store_add_matmul(store, v4_now_mono() - mm0);
+        }
         coli_expert_release(store, &expert);
         if (!result)
             for (int i = 0; i < d; i++) output[i] += expert_output[i];
@@ -3816,9 +3832,13 @@ static int moe_token_pipeline(float *output,
             else
                 loader_active = 1;
         }
-        if (!result) result = coli_v4_expert_forward_ref(
-            expert_output, &expert, input, expert_weights[current],
-            config->swiglu_limit);
+        if (!result) {
+            double mm0 = v4_now_mono();
+            result = coli_v4_expert_forward_ref(
+                expert_output, &expert, input, expert_weights[current],
+                config->swiglu_limit);
+            coli_v4_expert_store_add_matmul(store, v4_now_mono() - mm0);
+        }
         coli_expert_release(store, &expert);
         if (!result)
             for (int i = 0; i < d; i++) output[i] += expert_output[i];
@@ -5359,6 +5379,9 @@ typedef struct {
     ColiExpertStoreStats stats;
     pthread_mutex_t mutex;
     double disk_sec;   /* cumulative wall time spent reading expert bytes from disk */
+    double matmul_sec; /* cumulative expert-forward compute time (#890): the phase the
+                        * dashboard needs alongside disk_sec so it stops folding
+                        * everything into "other". One shared instance per store. */
     uint8_t *ehit;     /* layers*experts_per_layer: experts routed in the current turn */
     uint8_t *eheat;    /* layers*experts_per_layer: cumulative routing selections, capped 63 */
 } V4ExpertStoreState;
@@ -6485,6 +6508,27 @@ double coli_v4_expert_store_disk_sec(ColiExpertStore *store) {
     double value;
     pthread_mutex_lock(&state->mutex);
     value = state->disk_sec;
+    pthread_mutex_unlock(&state->mutex);
+    return value;
+}
+
+/* #890: the compute phase, accumulated by the MoE and read by the serve loop —
+ * the disk_sec twin. add is called from the block units around expert forward;
+ * the getter is read per-turn in v4_serve_one, same as disk_sec. */
+void coli_v4_expert_store_add_matmul(ColiExpertStore *store, double sec) {
+    if (!store || !store->state || sec <= 0.0) return;
+    V4ExpertStoreState *state = store->state;
+    pthread_mutex_lock(&state->mutex);
+    state->matmul_sec += sec;
+    pthread_mutex_unlock(&state->mutex);
+}
+double coli_v4_expert_store_matmul_sec(ColiExpertStore *store) {
+    V4ExpertStoreState *state;
+    if (!store || !store->state) return 0.0;
+    state = store->state;
+    double value;
+    pthread_mutex_lock(&state->mutex);
+    value = state->matmul_sec;
     pthread_mutex_unlock(&state->mutex);
     return value;
 }
@@ -8795,6 +8839,7 @@ extern void coli_v4_expert_store_emit_tiers(ColiExpertStore *store);
 extern void coli_v4_expert_store_emit_emap(ColiExpertStore *store);
 extern void coli_v4_expert_store_emit_hits(ColiExpertStore *store);
 extern double coli_v4_expert_store_disk_sec(ColiExpertStore *store);
+extern double coli_v4_expert_store_matmul_sec(ColiExpertStore *store);   /* #890 */
 
 static void v4_hwinfo_emit(void) {
     char cpu[256] = "";
@@ -8836,13 +8881,15 @@ static void v4_hwinfo_emit(void) {
 }
 
 /* PROF wall_s prompt_tokens completion_tokens expert_disk_s expert_wait_s
- * expert_matmul_s attention_s lm_head_s forwards — the V4 runtime has no
- * per-phase instrumentation beyond disk-read time, so the phase fields other
- * than expert_disk_s stay zero and the frontend folds them into "other". */
+ * expert_matmul_s attention_s lm_head_s forwards — disk (I/O) and matmul
+ * (expert-forward compute) are the two phases the runtime tracks per turn
+ * (#890); the frontend folds the remainder — attention, head, framing — into
+ * "other". Before this the matmul field was hardcoded 0 and every turn read as
+ * 100% other whenever the model sat warm in page cache. */
 static void v4_prof_emit(double wall_s, int prompt_tokens, int completion,
-                         double expert_disk_s) {
-    printf("PROF %.3f %d %d %.3f 0.000 0.000 0.000 0.000 0\n",
-           wall_s, prompt_tokens, completion, expert_disk_s);
+                         double expert_disk_s, double expert_matmul_s) {
+    printf("PROF %.3f %d %d %.3f 0.000 %.3f 0.000 0.000 0\n",
+           wall_s, prompt_tokens, completion, expert_disk_s, expert_matmul_s);
     fflush(stdout);
 }
 
@@ -8995,6 +9042,8 @@ static void v4_serve_one(ColiV4Engine *engine, ColiV4Session *session,
         engine->experts->ops->stats(engine->experts, &before);
     double disk_before =
         engine->experts ? coli_v4_expert_store_disk_sec(engine->experts) : 0.0;
+    double matmul_before =
+        engine->experts ? coli_v4_expert_store_matmul_sec(engine->experts) : 0.0;
     V4ServeStream stream = {session, request->id, 0};
     ColiV4SessionGenerateStats stats = {0};
     char error[512] = {0};
@@ -9035,7 +9084,11 @@ static void v4_serve_one(ColiV4Engine *engine, ColiV4Session *session,
     double expert_disk_s = engine->experts
         ? coli_v4_expert_store_disk_sec(engine->experts) - disk_before
         : 0.0;
-    v4_prof_emit(elapsed, stats.prompt_tokens, completion, expert_disk_s);
+    double expert_matmul_s = engine->experts
+        ? coli_v4_expert_store_matmul_sec(engine->experts) - matmul_before
+        : 0.0;
+    v4_prof_emit(elapsed, stats.prompt_tokens, completion,
+                 expert_disk_s, expert_matmul_s);
     coli_v4_expert_store_emit_hits(engine->experts);
     coli_v4_expert_store_emit_emap(engine->experts);
     coli_v4_expert_store_emit_tiers(engine->experts);
@@ -9773,6 +9826,9 @@ typedef struct {
     ColiExpertStoreStats stats;
     pthread_mutex_t mutex;
     double disk_sec;   /* cumulative wall time spent reading expert bytes from disk */
+    double matmul_sec; /* cumulative expert-forward compute time (#890): the phase the
+                        * dashboard needs alongside disk_sec so it stops folding
+                        * everything into "other". One shared instance per store. */
     uint8_t *ehit;     /* layers*experts_per_layer: experts routed in the current turn */
     uint8_t *eheat;    /* layers*experts_per_layer: cumulative routing selections, capped 63 */
 } V4ExpertStoreState;

--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -7242,12 +7242,31 @@ static int final_hidden(float *output, const float *state,
         coli_tensor_load_f32(&norm, index, "norm.weight", error, error_size))
         return -1;
     int d = config->hidden_size, hc = config->hc_mult;
+    /* SEC (GHSA-9gjf): these global tensors are loaded by their declared numel
+     * with no shape reconciliation (unlike the per-layer tensors, which
+     * coli_v4_layer_validate checks against config). final_hidden then indexes
+     * hc_head_fn at [copy*hc*d + i], hc_head_base at [copy], hc_head_scale at
+     * [0], and norm over d — a truncated global tensor turns each into a heap
+     * OOB read whose stale bytes leak into the logits. Require enough elements
+     * before use; `hc` also bounds the pre[16] stack array below. Free-closed on
+     * mismatch (the old hc>16 early-return leaked all four tensors). */
+    if (hc < 1 || hc > 16 ||
+        function.count < (uint64_t)hc * hc * d ||
+        base.count < (uint64_t)hc ||
+        scale.count < 1 ||
+        norm.count < (uint64_t)d) {
+        coli_float_tensor_free(&norm);
+        coli_float_tensor_free(&scale);
+        coli_float_tensor_free(&base);
+        coli_float_tensor_free(&function);
+        if (error && error_size) snprintf(error, error_size, "global tensor shape mismatch");
+        return -1;
+    }
     int flattened = hc * d;
     float square = 0.0f;
     for (int i = 0; i < flattened; i++) square += state[i] * state[i];
     float inverse_rms = 1.0f / sqrtf(square / flattened + config->rms_norm_eps);
     float pre[16];
-    if (hc > 16) return -1;
     for (int copy = 0; copy < hc; copy++) {
         float mix = 0.0f;
         for (int i = 0; i < flattened; i++)
@@ -10633,6 +10652,21 @@ int coli_v4_config_parse(ColiDeepSeekV4Config *config, const char *json,
         json_free(root);
         free(arena);
         return set_error(error, error_size, "inconsistent DeepSeek-V4 config dimensions");
+    }
+    /* SEC (GHSA-7654): rope vs head/index-head cross relationship. The per-field
+     * checks above never compared qk_rope_head_dim against index_head_dim; when
+     * qk_rope_head_dim > index_head_dim the indexer/compressor computed the RoPE
+     * sub-vector pointer as `output + index_head_dim - qk_rope_head_dim` — a
+     * negative offset — and rotated/rounded bf16 to the left of the heap block.
+     * No weight tensor carries the rope dim, so a benign snapshot + a tampered
+     * config.json alone reaches this. */
+    if (config->head_dim < 1 || config->index_head_dim < 1 ||
+        config->qk_rope_head_dim < 2 || (config->qk_rope_head_dim % 2) != 0 ||
+        config->qk_rope_head_dim > config->head_dim ||
+        config->qk_rope_head_dim > config->index_head_dim) {
+        json_free(root);
+        free(arena);
+        return set_error(error, error_size, "inconsistent DeepSeek-V4 rope/index head dims");
     }
     json_free(root);
     free(arena);

--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -5358,6 +5358,9 @@ typedef struct {
     unsigned active_leases;
     ColiExpertStoreStats stats;
     pthread_mutex_t mutex;
+    double disk_sec;   /* cumulative wall time spent reading expert bytes from disk */
+    uint8_t *ehit;     /* layers*experts_per_layer: experts routed in the current turn */
+    uint8_t *eheat;    /* layers*experts_per_layer: cumulative routing selections, capped 63 */
 } V4ExpertStoreState;
 
 static int set_error(char *error, size_t size, const char *format, ...) {
@@ -5509,6 +5512,8 @@ static int lookup(ColiExpertStore *store, ColiExpertKey key,
         }
         /* A short read must never expose a partially overwritten old slot. */
         slot->expert = -1;
+        struct timespec disk_t0;
+        clock_gettime(CLOCK_MONOTONIC, &disk_t0);
         if (coli_st_read_at_streaming(
                 state->index, record->shard, record->scale_offset,
                 (size_t)record->scale_bytes, slot->slab) != 0 ||
@@ -5516,9 +5521,21 @@ static int lookup(ColiExpertStore *store, ColiExpertKey key,
                 state->index, record->shard, record->weight_offset,
                 (size_t)record->weight_bytes,
                 slot->slab + record->scale_bytes) != 0) {
+            struct timespec disk_t1;
+            clock_gettime(CLOCK_MONOTONIC, &disk_t1);
+            state->disk_sec +=
+                (double)(disk_t1.tv_sec - disk_t0.tv_sec) +
+                (disk_t1.tv_nsec - disk_t0.tv_nsec) * 1e-9;
             pthread_mutex_unlock(&state->mutex);
             memset(view, 0, sizeof(*view));
             return -1;
+        }
+        {
+            struct timespec disk_t1;
+            clock_gettime(CLOCK_MONOTONIC, &disk_t1);
+            state->disk_sec +=
+                (double)(disk_t1.tv_sec - disk_t0.tv_sec) +
+                (disk_t1.tv_nsec - disk_t0.tv_nsec) * 1e-9;
         }
         slot->expert = key.expert;
         state->stats.misses++;
@@ -5527,6 +5544,13 @@ static int lookup(ColiExpertStore *store, ColiExpertKey key,
     slot->references++;
     state->active_leases++;
     slot->used = ++state->clock;
+    if (state->ehit) {
+        size_t expert_index =
+            (size_t)key.layer * state->experts_per_layer + key.expert;
+        state->ehit[expert_index] = 1;
+        if (state->eheat && state->eheat[expert_index] < 63)
+            state->eheat[expert_index]++;
+    }
     memset(view, 0, sizeof(*view));
     view->key = key;
     fill_tensor_view(&view->gate, record, slot, V4_W1);
@@ -5630,6 +5654,8 @@ static void destroy(ColiExpertStore *store) {
         coli_st_index_close(state->index);
         free(state->records);
         free(state->slots);
+        free(state->ehit);
+        free(state->eheat);
         free(state);
     }
     free(store);
@@ -5699,6 +5725,14 @@ int coli_deepseek_v4_expert_store_open(
     }
     for (int i = 0; i < state->layers * state->slots_per_layer; i++)
         state->slots[i].expert = -1;
+    size_t telemetry_cells =
+        (size_t)state->layers * state->experts_per_layer;
+    state->ehit = calloc(telemetry_cells, sizeof(*state->ehit));
+    state->eheat = calloc(telemetry_cells, sizeof(*state->eheat));
+    if (!state->ehit || !state->eheat) {
+        set_error(error, error_size, "out of memory creating expert telemetry");
+        goto fail;
+    }
     state->stats.capacity_bytes = (uint64_t)state->layers *
                                   state->slots_per_layer * state->record_bytes;
     store->ops = &operations;
@@ -5709,6 +5743,8 @@ int coli_deepseek_v4_expert_store_open(
 fail:
     if (state->slots) free(state->slots);
     free(state->records);
+    free(state->ehit);
+    free(state->eheat);
     coli_st_index_close(state->index);
     pthread_mutex_destroy(&state->mutex);
     free(state);
@@ -6100,6 +6136,13 @@ static int lookup_hot(ColiExpertStore *store, ColiExpertKey key,
     pthread_mutex_lock(&state->mutex);
     state->stats.requests++;
     policy->usage[(size_t)key.layer * state->experts_per_layer + key.expert]++;
+    if (state->ehit) {
+        size_t expert_index =
+            (size_t)key.layer * state->experts_per_layer + key.expert;
+        state->ehit[expert_index] = 1;
+        if (state->eheat && state->eheat[expert_index] < 63)
+            state->eheat[expert_index]++;
+    }
     uint64_t layer_requests = ++policy->layer_requests[key.layer];
     if (policy->repin_interval &&
         layer_requests % policy->repin_interval == 0)
@@ -6154,8 +6197,15 @@ static int lookup_hot(ColiExpertStore *store, ColiExpertKey key,
     state->active_leases++;
     slot->used = ++state->clock;
     pthread_mutex_unlock(&state->mutex);
+    struct timespec disk_t0;
+    clock_gettime(CLOCK_MONOTONIC, &disk_t0);
     int read_result = v4_read_expert_record(state, record, slot);
+    struct timespec disk_t1;
+    clock_gettime(CLOCK_MONOTONIC, &disk_t1);
     pthread_mutex_lock(&state->mutex);
+    state->disk_sec +=
+        (double)(disk_t1.tv_sec - disk_t0.tv_sec) +
+        (disk_t1.tv_nsec - disk_t0.tv_nsec) * 1e-9;
     if (read_result) {
         slot->references = 0; slot->expert = -1;
         if (state->active_leases) state->active_leases--;
@@ -6332,6 +6382,111 @@ int COLI_V4_ROWS16_STORE_OPEN(
         hot_prewarm_history(policy, state))
         fprintf(stderr, "v4_autopin warning=partial-warmup; continuing\n");
     return 0;
+}
+
+/* -------------------------------------------------------------------------
+ * Dashboard telemetry (TIERS/EMAP/HITS) — emitted to stdout in the same
+ * wire format openai_server.py parses for the GLM engine (telemetry.h):
+ *
+ *   TIERS vram ram disk vram_gb ram_gb
+ *   EMAP  rows cols hex        (per expert: 2 hex digits, tier<<6 | heat)
+ *   HITS  rows cols hex        (per-turn routed-expert bitmap, then cleared)
+ *
+ * The serve unit (COLI_V4_UNIT_GENERATE_STATS) calls these at turn
+ * boundaries; the per-expert state lives here, so the store emits them.
+ * V4 is CPU-only, so the VRAM tier is always 0 and "ram" means "resident in
+ * the expert-store cache slots". Heat is the cumulative routing-selection
+ * count (capped at 63, matching the GLM map's low-6-bit field).
+ * ---------------------------------------------------------------------- */
+
+void coli_v4_expert_store_emit_tiers(ColiExpertStore *store) {
+    V4ExpertStoreState *state;
+    if (!store || !store->state) return;
+    state = store->state;
+    int resident = 0;
+    pthread_mutex_lock(&state->mutex);
+    for (int i = 0; i < state->layers * state->slots_per_layer; i++)
+        if (state->slots[i].slab && state->slots[i].expert >= 0) resident++;
+    pthread_mutex_unlock(&state->mutex);
+    int total = state->layers * state->experts_per_layer;
+    int ram = resident, disk = total - ram;
+    if (ram < 0) ram = 0;
+    if (disk < 0) disk = 0;
+    printf("TIERS 0 %d %d 0.00 %.2f\n", ram, disk,
+           (double)resident * state->record_bytes / 1e9);
+    fflush(stdout);
+}
+
+void coli_v4_expert_store_emit_emap(ColiExpertStore *store) {
+    V4ExpertStoreState *state;
+    if (!store || !store->state) return;
+    state = store->state;
+    int rows = state->layers, cols = state->experts_per_layer;
+    size_t cells = (size_t)rows * cols;
+    char *hex = malloc(cells * 2 + 1);
+    if (!hex) return;
+    pthread_mutex_lock(&state->mutex);
+    for (size_t i = 0; i < cells; i++) {
+        int tier = 0;
+        int layer = (int)(i / (size_t)cols), expert = (int)(i % (size_t)cols);
+        V4ExpertSlot *slots = state->slots +
+            (size_t)layer * state->slots_per_layer;
+        for (int z = 0; z < state->slots_per_layer; z++)
+            if (slots[z].slab && slots[z].expert == expert) { tier = 1; break; }
+        int heat = state->eheat ? state->eheat[i] : 0;
+        if (heat > 63) heat = 63;
+        int b = (tier << 6) | heat;
+        hex[i * 2] = "0123456789abcdef"[b >> 4];
+        hex[i * 2 + 1] = "0123456789abcdef"[b & 15];
+    }
+    pthread_mutex_unlock(&state->mutex);
+    hex[cells * 2] = 0;
+    printf("EMAP %d %d %s\n", rows, cols, hex);
+    fflush(stdout);
+    free(hex);
+}
+
+void coli_v4_expert_store_emit_hits(ColiExpertStore *store) {
+    V4ExpertStoreState *state;
+    if (!store || !store->state) return;
+    state = store->state;
+    int rows = state->layers, cols = state->experts_per_layer;
+    size_t cells = (size_t)rows * cols;
+    size_t nbytes = (cells + 7) / 8;
+    char *hex = malloc(nbytes * 2 + 1);
+    if (!hex) return;
+    uint8_t *bitmap = calloc(nbytes, 1);
+    if (!bitmap) {
+        free(hex);
+        return;
+    }
+    pthread_mutex_lock(&state->mutex);
+    if (state->ehit) {
+        for (size_t i = 0; i < cells; i++)
+            if (state->ehit[i]) bitmap[i >> 3] |= (uint8_t)(1u << (i & 7));
+        memset(state->ehit, 0, cells);
+    }
+    pthread_mutex_unlock(&state->mutex);
+    for (size_t b = 0; b < nbytes; b++) {
+        hex[b * 2] = "0123456789abcdef"[bitmap[b] >> 4];
+        hex[b * 2 + 1] = "0123456789abcdef"[bitmap[b] & 15];
+    }
+    hex[nbytes * 2] = 0;
+    printf("HITS %d %d %s\n", rows, cols, hex);
+    fflush(stdout);
+    free(bitmap);
+    free(hex);
+}
+
+double coli_v4_expert_store_disk_sec(ColiExpertStore *store) {
+    V4ExpertStoreState *state;
+    if (!store || !store->state) return 0.0;
+    state = store->state;
+    double value;
+    pthread_mutex_lock(&state->mutex);
+    value = state->disk_sec;
+    pthread_mutex_unlock(&state->mutex);
+    return value;
 }
 #endif /* COLI_V4_UNIT_EXPERT_STORE_HOT_ROWS16 */
 
@@ -8633,6 +8788,64 @@ static double v4_serve_rss_gb(void) {
 #endif
 }
 
+/* Dashboard telemetry: the per-expert state lives in the expert-store unit
+ * (COLI_V4_UNIT_EXPERT_STORE_HOT_ROWS16), so the emitters are exported from
+ * there and called at turn boundaries from this unit. */
+extern void coli_v4_expert_store_emit_tiers(ColiExpertStore *store);
+extern void coli_v4_expert_store_emit_emap(ColiExpertStore *store);
+extern void coli_v4_expert_store_emit_hits(ColiExpertStore *store);
+extern double coli_v4_expert_store_disk_sec(ColiExpertStore *store);
+
+static void v4_hwinfo_emit(void) {
+    char cpu[256] = "";
+    int cores = 0;
+    double ram_total = 0.0, ram_avail = 0.0;
+#ifdef _SC_NPROCESSORS_ONLN
+    cores = (int)sysconf(_SC_NPROCESSORS_ONLN);
+#endif
+    FILE *ci = fopen("/proc/cpuinfo", "r");
+    if (ci) {
+        char line[256];
+        while (fgets(line, sizeof(line), ci))
+            if (!strncmp(line, "model name", 10)) {
+                char *p = strchr(line, ':');
+                if (p) {
+                    p++;
+                    while (*p == ' ') p++;
+                    int n = (int)strlen(p);
+                    if (n > 0 && p[n - 1] == '\n') p[--n] = 0;
+                    snprintf(cpu, sizeof(cpu), "%s", p);
+                }
+                break;
+            }
+        fclose(ci);
+    }
+    FILE *mi = fopen("/proc/meminfo", "r");
+    if (mi) {
+        char line[256];
+        double mt = 0.0, ma = 0.0;
+        while (fgets(line, sizeof(line), mi)) {
+            if (sscanf(line, "MemTotal: %lf", &mt) == 1) ram_total = mt / 1e6;
+            if (sscanf(line, "MemAvailable: %lf", &ma) == 1) ram_avail = ma / 1e6;
+        }
+        fclose(mi);
+    }
+    printf("HWINFO %d %.1f %.1f 0 0.0 %s|v4-cpu\n", cores, ram_total,
+           ram_avail, cpu[0] ? cpu : "unknown");
+    fflush(stdout);
+}
+
+/* PROF wall_s prompt_tokens completion_tokens expert_disk_s expert_wait_s
+ * expert_matmul_s attention_s lm_head_s forwards — the V4 runtime has no
+ * per-phase instrumentation beyond disk-read time, so the phase fields other
+ * than expert_disk_s stay zero and the frontend folds them into "other". */
+static void v4_prof_emit(double wall_s, int prompt_tokens, int completion,
+                         double expert_disk_s) {
+    printf("PROF %.3f %d %d %.3f 0.000 0.000 0.000 0.000 0\n",
+           wall_s, prompt_tokens, completion, expert_disk_s);
+    fflush(stdout);
+}
+
 static int v4_serve_read_request(V4ServeRequest *request,
                                  const char *active_id) {
     char line[512], command[16], id[64];
@@ -8756,6 +8969,8 @@ static void v4_serve_one(ColiV4Engine *engine, ColiV4Session *session,
     ColiExpertStoreStats before = {0}, after = {0};
     if (engine->experts && engine->experts->ops && engine->experts->ops->stats)
         engine->experts->ops->stats(engine->experts, &before);
+    double disk_before =
+        engine->experts ? coli_v4_expert_store_disk_sec(engine->experts) : 0.0;
     V4ServeStream stream = {session, request->id, 0};
     ColiV4SessionGenerateStats stats = {0};
     char error[512] = {0};
@@ -8793,6 +9008,13 @@ static void v4_serve_one(ColiV4Engine *engine, ColiV4Session *session,
            hit_rate, v4_serve_rss_gb(), stats.prompt_tokens, length_limited,
            session->prefix_reused);
     fflush(stdout);
+    double expert_disk_s = engine->experts
+        ? coli_v4_expert_store_disk_sec(engine->experts) - disk_before
+        : 0.0;
+    v4_prof_emit(elapsed, stats.prompt_tokens, completion, expert_disk_s);
+    coli_v4_expert_store_emit_hits(engine->experts);
+    coli_v4_expert_store_emit_emap(engine->experts);
+    coli_v4_expert_store_emit_tiers(engine->experts);
 }
 
 static int v4_serve_main(void) {
@@ -8840,6 +9062,9 @@ static int v4_serve_main(void) {
     fputs("\x01\x01READY\x01\x01\n", stdout);
     printf("STAT 0 0.0 0.0 %.2f 0 0\n", v4_serve_rss_gb());
     fflush(stdout);
+    v4_hwinfo_emit();
+    coli_v4_expert_store_emit_tiers(engine->experts);
+    coli_v4_expert_store_emit_emap(engine->experts);
     for (;;) {
         V4ServeRequest request = {0};
         int result;
@@ -9520,6 +9745,9 @@ typedef struct {
     unsigned active_leases;
     ColiExpertStoreStats stats;
     pthread_mutex_t mutex;
+    double disk_sec;   /* cumulative wall time spent reading expert bytes from disk */
+    uint8_t *ehit;     /* layers*experts_per_layer: experts routed in the current turn */
+    uint8_t *eheat;    /* layers*experts_per_layer: cumulative routing selections, capped 63 */
 } V4ExpertStoreState;
 
 static int set_error(char *error, size_t size, const char *format, ...) {
@@ -9671,6 +9899,8 @@ static int lookup(ColiExpertStore *store, ColiExpertKey key,
         }
         /* A short read must never expose a partially overwritten old slot. */
         slot->expert = -1;
+        struct timespec disk_t0;
+        clock_gettime(CLOCK_MONOTONIC, &disk_t0);
         if (coli_st_read_at_streaming(
                 state->index, record->shard, record->scale_offset,
                 (size_t)record->scale_bytes, slot->slab) != 0 ||
@@ -9678,9 +9908,21 @@ static int lookup(ColiExpertStore *store, ColiExpertKey key,
                 state->index, record->shard, record->weight_offset,
                 (size_t)record->weight_bytes,
                 slot->slab + record->scale_bytes) != 0) {
+            struct timespec disk_t1;
+            clock_gettime(CLOCK_MONOTONIC, &disk_t1);
+            state->disk_sec +=
+                (double)(disk_t1.tv_sec - disk_t0.tv_sec) +
+                (disk_t1.tv_nsec - disk_t0.tv_nsec) * 1e-9;
             pthread_mutex_unlock(&state->mutex);
             memset(view, 0, sizeof(*view));
             return -1;
+        }
+        {
+            struct timespec disk_t1;
+            clock_gettime(CLOCK_MONOTONIC, &disk_t1);
+            state->disk_sec +=
+                (double)(disk_t1.tv_sec - disk_t0.tv_sec) +
+                (disk_t1.tv_nsec - disk_t0.tv_nsec) * 1e-9;
         }
         slot->expert = key.expert;
         state->stats.misses++;
@@ -9689,6 +9931,13 @@ static int lookup(ColiExpertStore *store, ColiExpertKey key,
     slot->references++;
     state->active_leases++;
     slot->used = ++state->clock;
+    if (state->ehit) {
+        size_t expert_index =
+            (size_t)key.layer * state->experts_per_layer + key.expert;
+        state->ehit[expert_index] = 1;
+        if (state->eheat && state->eheat[expert_index] < 63)
+            state->eheat[expert_index]++;
+    }
     memset(view, 0, sizeof(*view));
     view->key = key;
     fill_tensor_view(&view->gate, record, slot, V4_W1);
@@ -9790,6 +10039,8 @@ static void destroy(ColiExpertStore *store) {
         coli_st_index_close(state->index);
         free(state->records);
         free(state->slots);
+        free(state->ehit);
+        free(state->eheat);
         free(state);
     }
     free(store);
@@ -9859,6 +10110,14 @@ int coli_deepseek_v4_expert_store_open(
     }
     for (int i = 0; i < state->layers * state->slots_per_layer; i++)
         state->slots[i].expert = -1;
+    size_t telemetry_cells =
+        (size_t)state->layers * state->experts_per_layer;
+    state->ehit = calloc(telemetry_cells, sizeof(*state->ehit));
+    state->eheat = calloc(telemetry_cells, sizeof(*state->eheat));
+    if (!state->ehit || !state->eheat) {
+        set_error(error, error_size, "out of memory creating expert telemetry");
+        goto fail;
+    }
     state->stats.capacity_bytes = (uint64_t)state->layers *
                                   state->slots_per_layer * state->record_bytes;
     store->ops = &operations;
@@ -9869,6 +10128,8 @@ int coli_deepseek_v4_expert_store_open(
 fail:
     if (state->slots) free(state->slots);
     free(state->records);
+    free(state->ehit);
+    free(state->eheat);
     coli_st_index_close(state->index);
     pthread_mutex_destroy(&state->mutex);
     free(state);

--- a/c/deepseek_v4_dspark.inc
+++ b/c/deepseek_v4_dspark.inc
@@ -188,12 +188,24 @@ static int v4_ds_load_fp8_suffix(const ColiSafetensorsIndex *index, int stage,
     return v4_ds_load_fp8(index, wn, sn, weight, scale);
 }
 
+/* SEC (GHSA-9gjf): every F32 sidecar loaded here is later indexed linearly by
+ * config-derived dimensions, but coli_tensor_load_f32 does no shape accounting —
+ * an undersized snapshot tensor became a heap OOB read. `expected` is the numel
+ * the consumer will index; require at least that many (-1 = skip). `<` (not `!=`)
+ * so a legitimately padded checkpoint is never false-rejected. */
 static int v4_ds_load_f32_suffix(ColiFloatTensor *output,
                                  const ColiSafetensorsIndex *index, int stage,
-                                 const char *suffix) {
+                                 const char *suffix, int64_t expected) {
     char name[160], error[256];
     if (v4_ds_name(name, sizeof(name), stage, suffix)) return -1;
-    return coli_tensor_load_f32(output, index, name, error, sizeof(error));
+    if (coli_tensor_load_f32(output, index, name, error, sizeof(error))) return -1;
+    if (expected >= 0 && (int64_t)output->count < expected) {
+        fprintf(stderr, "[MTP] shape mismatch: %s (numel %llu, need >= %lld)\n",
+                name, (unsigned long long)output->count, (long long)expected);
+        coli_float_tensor_free(output);
+        return -1;
+    }
+    return 0;
 }
 
 static void v4_ds_fp8_view(ColiTensorView *view,
@@ -256,17 +268,20 @@ static int v4_ds_core_load(const ColiSafetensorsIndex *index,
                        &g_v4ds_core.main_proj_w,
                        &g_v4ds_core.main_proj_s) ||
         v4_ds_load_f32_suffix(&g_v4ds_core.main_norm, index, 0,
-                              "main_norm.weight") ||
+                              "main_norm.weight", config->hidden_size) ||
         v4_ds_load_f32_suffix(&g_v4ds_core.head_fn, index, 2,
-                              "hc_head_fn") ||
+                              "hc_head_fn",
+                              (int64_t)config->hc_mult * config->hc_mult *
+                              config->hidden_size) ||
         v4_ds_load_f32_suffix(&g_v4ds_core.head_base, index, 2,
-                              "hc_head_base") ||
+                              "hc_head_base", config->hc_mult) ||
         v4_ds_load_f32_suffix(&g_v4ds_core.head_scale, index, 2,
-                              "hc_head_scale") ||
+                              "hc_head_scale", 1) ||
         v4_ds_load_f32_suffix(&g_v4ds_core.norm, index, 2,
-                              "norm.weight") ||
+                              "norm.weight", config->hidden_size) ||
         v4_ds_load_f32_suffix(&g_v4ds_core.confidence_proj, index, 2,
-                              "confidence_head.proj.weight") ||
+                              "confidence_head.proj.weight",
+                              (int64_t)config->hidden_size + V4_DSPARK_RANK) ||
         v4_ds_read_raw(index, "mtp.2.markov_head.markov_w1.weight",
                        COLI_ST_BF16, (void **)&g_v4ds_core.markov_w1,
                        &g_v4ds_core.markov_w1_bytes) ||
@@ -320,27 +335,39 @@ static int v4_ds_stage_load(const ColiSafetensorsIndex *index,
     V4_DS_LOAD_FP8(sh3,  "ffn.shared_experts.w3");
 #undef V4_DS_LOAD_FP8
 
-#define V4_DS_LOAD_F32(field, suffix) \
-    do { if (v4_ds_load_f32_suffix(&stage->field, index, stage_id, suffix)) \
+#define V4_DS_LOAD_F32(field, suffix, expected) \
+    do { if (v4_ds_load_f32_suffix(&stage->field, index, stage_id, suffix, \
+                                   expected)) \
              return 0; } while (0)
-    V4_DS_LOAD_F32(q_norm,       "attn.q_norm.weight");
-    V4_DS_LOAD_F32(kv_norm,      "attn.kv_norm.weight");
-    V4_DS_LOAD_F32(attn_norm,    "attn_norm.weight");
-    V4_DS_LOAD_F32(ffn_norm,     "ffn_norm.weight");
-    V4_DS_LOAD_F32(attn_sink,    "attn.attn_sink");
-    V4_DS_LOAD_F32(hc_attn_fn,   "hc_attn_fn");
-    V4_DS_LOAD_F32(hc_attn_base, "hc_attn_base");
-    V4_DS_LOAD_F32(hc_attn_scale,"hc_attn_scale");
-    V4_DS_LOAD_F32(hc_ffn_fn,    "hc_ffn_fn");
-    V4_DS_LOAD_F32(hc_ffn_base,  "hc_ffn_base");
-    V4_DS_LOAD_F32(hc_ffn_scale, "hc_ffn_scale");
-    V4_DS_LOAD_F32(gate_w,       "ffn.gate.weight");
-    V4_DS_LOAD_F32(gate_b,       "ffn.gate.bias");
+    {   int64_t mixes = (int64_t)(2 + config->hc_mult) * config->hc_mult;
+        int64_t flat = (int64_t)config->hc_mult * config->hidden_size;
+        V4_DS_LOAD_F32(q_norm,       "attn.q_norm.weight", config->q_lora_rank);
+        V4_DS_LOAD_F32(kv_norm,      "attn.kv_norm.weight", config->head_dim);
+        V4_DS_LOAD_F32(attn_norm,    "attn_norm.weight", config->hidden_size);
+        V4_DS_LOAD_F32(ffn_norm,     "ffn_norm.weight", config->hidden_size);
+        V4_DS_LOAD_F32(attn_sink,    "attn.attn_sink", config->num_attention_heads);
+        V4_DS_LOAD_F32(hc_attn_fn,   "hc_attn_fn", mixes * flat);
+        V4_DS_LOAD_F32(hc_attn_base, "hc_attn_base", mixes);
+        V4_DS_LOAD_F32(hc_attn_scale,"hc_attn_scale", 3);
+        V4_DS_LOAD_F32(hc_ffn_fn,    "hc_ffn_fn", mixes * flat);
+        V4_DS_LOAD_F32(hc_ffn_base,  "hc_ffn_base", mixes);
+        V4_DS_LOAD_F32(hc_ffn_scale, "hc_ffn_scale", 3);
+        V4_DS_LOAD_F32(gate_w,       "ffn.gate.weight",
+                       (int64_t)config->n_routed_experts * config->hidden_size);
+        V4_DS_LOAD_F32(gate_b,       "ffn.gate.bias", config->n_routed_experts);
+    }
 #undef V4_DS_LOAD_F32
 
     static const char *matrices[3] = {"w1", "w2", "w3"};
+    /* SEC (GHSA-8p69): slab_bytes must cover the LARGEST expert, not expert 0.
+     * Each slot later copies whichever expert is routed to it, using that
+     * expert's own declared nbytes — so sizing from expert 0 alone let a crafted
+     * checkpoint (expert 0 tiny, another expert large) overflow the slab with
+     * file-controlled bytes (heap OOB write). Real MTP checkpoints have uniform
+     * expert shapes, so max == expert 0 and behaviour is unchanged. */
     stage->slab_bytes = 0;
     for (int expert = 0; expert < config->n_routed_experts; expert++) {
+        int64_t expert_bytes = 0;
         for (int matrix = 0; matrix < 3; matrix++) {
             char name[192];
             snprintf(name, sizeof(name), "mtp.%d.ffn.experts.%d.%s.weight",
@@ -351,11 +378,12 @@ static int v4_ds_stage_load(const ColiSafetensorsIndex *index,
             stage->es[expert][matrix] = coli_st_find(index, name);
             if (!stage->ew[expert][matrix] || !stage->es[expert][matrix])
                 return 0;
-            if (!expert)
-                stage->slab_bytes += stage->ew[expert][matrix]->nbytes +
-                                     stage->es[expert][matrix]->nbytes;
+            expert_bytes += stage->ew[expert][matrix]->nbytes +
+                            stage->es[expert][matrix]->nbytes;
         }
+        if (expert_bytes > stage->slab_bytes) stage->slab_bytes = expert_bytes;
     }
+    if (stage->slab_bytes < 1) return 0;
 
     /* V4_MTP_GB is intentionally total, not per stage. */
     double total_gb = coli_v4_dspark_cache_gb();
@@ -413,12 +441,21 @@ static int v4_ds_expert(const ColiSafetensorsIndex *index,
         }
         stage->slots[slot].id = -1;
         uint8_t *cursor = stage->slots[slot].slab;
+        uint8_t *slab_end = cursor + stage->slab_bytes;
         for (int matrix = 0; matrix < 3; matrix++) {
             const ColiSafetensorsTensor *scale = stage->es[expert][matrix];
             const ColiSafetensorsTensor *weight = stage->ew[expert][matrix];
+            /* SEC (GHSA-8p69): defence in depth — never write past the slab even
+             * if the max-sizing above is ever defeated (shape drift within a
+             * stage). Fail closed rather than overflow. */
+            if (scale->nbytes < 0 || weight->nbytes < 0 ||
+                (size_t)(slab_end - cursor) < (size_t)scale->nbytes)
+                return 0;
             if (coli_st_read_tensor(index, scale, cursor))
                 return 0;
             cursor += scale->nbytes;
+            if ((size_t)(slab_end - cursor) < (size_t)weight->nbytes)
+                return 0;
             int shard = coli_st_tensor_shard(index, weight);
             if (shard < 0 || weight->off < 0 ||
                 coli_st_read_at_streaming(

--- a/c/download_fp8.py
+++ b/c/download_fp8.py
@@ -4,7 +4,7 @@ Usage: python download_fp8.py
        python download_fp8.py --parallel 4
        python download_fp8.py --source hf  (force HuggingFace)
 """
-import os, sys, time, threading, argparse, subprocess
+import os, time, threading, argparse, subprocess
 
 REPO_MS = "ZhipuAI/GLM-5.2-FP8"        # ModelScope
 REPO_HF = "zai-org/GLM-5.2-FP8"        # HuggingFace
@@ -78,6 +78,10 @@ def download_file_curl(fn, base_url, expected_size):
         return True
     return False
 
+def shard_complete(path, expected_size):
+    return (os.path.exists(path)
+            and (expected_size <= 0 or os.path.getsize(path) == expected_size))
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--parallel", type=int, default=3)
@@ -100,12 +104,20 @@ def main():
         except Exception as e:
             print(f"{C.yel}failed ({e}){C.r}")
             if args.source == "ms":
-                print("ModelScope failed and --source ms was set. Exiting."); return
+                print("ModelScope failed and --source ms was set. Exiting."); return 1
+
+    if not shards and args.source == "ms":
+        print(f"{C.yel}No checkpoint shards found on ModelScope. Exiting.{C.r}")
+        return 1
 
     if not shards:
+        use_ms = False
         print(f"{C.dim}Using HuggingFace...{C.r}", end=" ", flush=True)
         shards, sizes = get_shard_list_hf()
         print(f"{C.grn}✓{C.r} {len(shards)} shards found")
+    if not shards:
+        print(f"{C.yel}No checkpoint shards found. Exiting.{C.r}")
+        return 1
 
     total = len(shards)
     total_bytes = sum(sizes.values())
@@ -121,13 +133,15 @@ def main():
                 if use_ms: download_file_ms(fn)
                 else: download_file_hf(fn)
             except Exception: pass
+    missing_meta = [fn for fn in meta_files
+                    if not os.path.isfile(os.path.join(DEST, fn))]
 
     # Build work queue
     todo = []
     done_set = set()
     for fn in shards:
         outpath = os.path.join(DEST, fn)
-        if os.path.exists(outpath) and os.path.getsize(outpath) == sizes.get(fn, 0):
+        if shard_complete(outpath, sizes.get(fn, 0)):
             done_set.add(fn)
         else:
             todo.append(fn)
@@ -142,7 +156,10 @@ def main():
     print()
 
     if not todo:
-        print(f"{C.grn}✓ All shards already downloaded!{C.r}\n"); return
+        if missing_meta:
+            print(f"{C.yel}Missing metadata: {', '.join(missing_meta)}{C.r}")
+            return 1
+        print(f"{C.grn}✓ All shards already downloaded!{C.r}\n"); return 0
 
     lock = threading.Lock()
     completed = list(done_set)
@@ -215,17 +232,21 @@ def main():
     for t in threads: t.join()
 
     print()
-    final = sum(1 for fn in shards
-                if os.path.exists(os.path.join(DEST, fn))
-                and os.path.getsize(os.path.join(DEST, fn)) == sizes.get(fn, 0))
-    if final == total:
+    final = sum(1 for fn in shards if shard_complete(
+        os.path.join(DEST, fn), sizes.get(fn, 0)))
+    if final == total and not missing_meta:
         print(f"{C.grn}{'='*50}")
         print(f"  ✓ All {total} shards downloaded!{C.r}\n")
+        return 0
     else:
         print(f"{C.yel}  {final}/{total} complete, {total-final} remaining{C.r}")
-        print(f"  Re-run to resume.\n")
+        if missing_meta:
+            print(f"  Missing metadata: {', '.join(missing_meta)}")
+        print("  Re-run to resume.\n")
+        return 1
 
 if __name__ == "__main__":
-    try: main()
+    try: raise SystemExit(main())
     except KeyboardInterrupt:
         print(f"\n\n{C.yel}Interrupted. Re-run to resume — no data lost.{C.r}\n")
+        raise SystemExit(130)

--- a/c/glibc_c23_math_compat.h
+++ b/c/glibc_c23_math_compat.h
@@ -22,8 +22,8 @@
 #define COLI_GLIBC_C23_MATH_COMPAT_H
 
 #if defined(__cplusplus) && defined(__linux__)
-#include <sys/cdefs.h> /* glibc's own guards; forces __THROW into existence */
-#if defined(__THROW)
+#include <features.h> /* defines __GLIBC__ on glibc; musl ships one too */
+#if defined(__GLIBC__) && defined(__THROW)
 #undef __THROW
 #define __THROW
 #endif

--- a/c/glibc_c23_math_compat.h
+++ b/c/glibc_c23_math_compat.h
@@ -1,0 +1,32 @@
+// glibc_c23_math_compat.h — glibc >= 2.41 C++17 noexcept clash for CUDA host passes.
+//
+// glibc >= 2.41 (Debian trixie, Ubuntu 26.04, ...) declares the C23 math
+// additions (rsqrt/rsqrtf, sinpi/cospi, ...) via __THROW, which expands to
+// noexcept(true) in C++. CUDA's crt/math_functions.h declares the same
+// functions WITHOUT an exception specification, and since C++17 noexcept is
+// part of the function type, nvcc's host pass fails with:
+//
+//   mathcalls.h: error: exception specification is incompatible with that of
+//   previous function "rsqrt" (declared at ... crt/math_functions.h)
+//
+// This header is force-included into the HOST pass (NVCCFLAGS
+// -Xcompiler=-include, ... on Linux). It strips glibc's __THROW so the C
+// declarations carry no exception specification, matching CUDA's. The device
+// pass is unaffected: -Xcompiler flags never reach nvcc's device frontend,
+// and it includes CUDA's math_functions.h directly.
+//
+// Deliberately Linux-only: Windows builds use MSVC cl.exe, which never sees
+// glibc headers.
+
+#ifndef COLI_GLIBC_C23_MATH_COMPAT_H
+#define COLI_GLIBC_C23_MATH_COMPAT_H
+
+#if defined(__cplusplus) && defined(__linux__)
+#include <sys/cdefs.h> /* glibc's own guards; forces __THROW into existence */
+#if defined(__THROW)
+#undef __THROW
+#define __THROW
+#endif
+#endif /* __cplusplus && __linux__ */
+
+#endif /* COLI_GLIBC_C23_MATH_COMPAT_H */

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -802,6 +802,21 @@ static void model_init(Model *m, const char *snap, int cap, int bits) {
      * sidecar dropped in the snapshot dir (st_init indexes every *.safetensors).
      * Absent tensors = text-only engine, exactly as before. */
     if (st_has(&m->S, "model.audio.encoder.weight")) {
+        /* SEC (GHSA-w696): mel_bins/mel_vocab come straight from config.json with
+         * no bounds. audio_embed_row indexes the table at (b*mel_vocab+v)*D with
+         * b<mel_bins, v<mel_vocab — so the table must have exactly
+         * mel_bins*mel_vocab rows or that index runs off the heap (bidirectional
+         * OOB read, config-controlled). Reconcile the real element count against
+         * the geometry before using it. */
+        st_tensor *aet = st_find(&m->S, "model.audio.encoder.weight");
+        if (c->mel_bins < 1 || c->mel_vocab < 1 || D < 1 ||
+            (int64_t)c->mel_bins * c->mel_vocab > INT64_MAX / D ||
+            !aet || aet->numel != (int64_t)c->mel_bins * c->mel_vocab * D) {
+            fprintf(stderr, "[audio] rejected: encoder table has %lld elements, "
+                    "config geometry is %d bins x %d levels x D=%d\n",
+                    aet ? (long long)aet->numel : -1, c->mel_bins, c->mel_vocab, D);
+            exit(1);
+        }
         m->audio_enc  = load_w(m, "model.audio.encoder.weight", 0);
         m->audio_norm = load_t(m, "model.audio.final_norm.weight");
         fprintf(stderr, "[audio] DMel encoder loaded (%d bins x %d levels -> D=%d)\n",

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -33,6 +33,10 @@
 #endif
 #include "st.h"
 #include "tok.h"
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+#include "omp_tune.h"
 #include "route_trace.h"
 #include "kv_prefix.h"                          /* KV prefix reuse (shared) */                          /* shared routing telemetry (#700) */
 #ifdef COLI_CUDA
@@ -2058,6 +2062,7 @@ int main(int argc, char **argv) {
 #endif
     }
 #endif  /* !COLI_CUDA && !__APPLE__ */
+    coli_omp_tune_threads("inkling");
     const char *snap = getenv("SNAP");
     if (!snap) { fprintf(stderr, "set SNAP=<snapshot directory>\n"); return 1; }
     g_topp = getenv("TOPP") ? (float)atof(getenv("TOPP")) : 0.f;

--- a/c/json.h
+++ b/c/json.h
@@ -53,7 +53,11 @@ static jval *j_new(jtype t) {
 static jval *j_parse_val(jparser *p);
 
 static char *j_parse_str_raw(jparser *p) {
-    /* assume *p->s == '"' */
+    /* SEC (GHSA-2qrj): fail closed if not actually at a quote. The old comment
+     * "assume *p->s == '\"'" was violated on the object-key path, and the
+     * unconditional p->s++ would step past the buffer's NUL terminator and scan
+     * adjacent heap (OOB read leaking into tensor names). */
+    if (*p->s != '"') return j_dup(p, "", 0);
     p->s++;
     /* buffer su heap che CRESCE: niente troncamento silenzioso a 64KB (le stringhe
      * lunghe di tokenizer.json/config venivano tagliate) e niente 64KB di stack. */
@@ -108,6 +112,7 @@ static jval *j_parse_val(jparser *p) {
         if (*p->s == '}') { p->s++; p->depth--; return v; }
         for (;;) {
             j_ws(p);
+            if (*p->s != '"') break;   /* SEC (GHSA-2qrj): object key must be a quoted string; stop on malformed input */
             char *key = j_parse_str_raw(p);
             j_ws(p); if (*p->s == ':') p->s++;
             jval *val = j_parse_val(p);

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -252,9 +252,9 @@ static void rmsnorm_(float *out, const float *x, const float *w, int D, float ep
  *    experts enter from freshly-read RAM slots (K3_VK_UP per step) until the
  *    VRAM budget (K3_VK_GB) is reached; resident experts then skip BOTH the
  *    disk read and the CPU matmuls at decode (C==1). */
-static int g_k3_vk=0;                     /* backend live (K3_VK=0 disables) */
 #ifdef COLI_VULKAN
 #include "backend_vulkan.h"
+static int g_k3_vk=0;                     /* backend live (K3_VK=0 disables) */
 typedef struct { void *w1, *w2, *w3; } VkExp;   /* ColiVkTensor* triple */
 static VkExp *g_vkexp; static int64_t g_vkexp_n;
 static int g_vk_upcap=8, g_vk_up_left=0, g_vk_full=0;

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -1786,7 +1786,11 @@ static int serve_read_req(ServeReq *q, const char *active){
     if(strcmp(cmd,"SUBMIT")) return 0;
     int slot, plen, max_tok; float temp, top_p;
     if(sscanf(line,"%*s %*s %d %d %d %f %f",&slot,&plen,&max_tok,&temp,&top_p)!=5||
-       plen<0||plen>(1<<24)||max_tok<1){
+       plen<0||plen>(1<<24)||max_tok<1||max_tok>(1<<20)){
+        /* SEC (GHSA-gf38): max_tok needs an upper bound too. INT_MAX wrapped the
+         * signed np+max_tok context check below and made the kv_alloc size
+         * negative, so kv_alloc's early-return kept the previous request's small
+         * KV buffers and the generation loop wrote past them (heap OOB write). */
         printf("ERROR %s bad submit header\n",id); fflush(stdout); return 0;
     }
     (void)slot;
@@ -1830,7 +1834,7 @@ static void serve_one(Model *m, Tok *T, ServeReq *q){
         np+=tok_encode(T,q->payload,q->plen,ids+np,cap-np);
     }
     int max_ctx=getenv("K3_MAXT")?atoi(getenv("K3_MAXT")):8192;
-    if(np<1||np+q->max_tok>max_ctx){
+    if(np<1||(int64_t)np+q->max_tok>max_ctx){ /* SEC (GHSA-gf38): int64 so np+max_tok can't wrap negative */
         printf("ERROR %s CONTEXT_EXCEEDED prompt_tokens=%d requested=%d capacity=%d\n",
                q->id,np,q->max_tok,max_ctx);
         fflush(stdout); free(ids); return;

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -1622,7 +1622,16 @@ def generation_options(body, limit):
         maximum = limit
     temperature = body.get("temperature")
     top_p = body.get("top_p")
-    temperature = 0.7 if temperature is None else temperature
+    if temperature is None:
+        # The launcher publishes --temp through COLI_TEMP (#509, #968). The
+        # gateway must use that value as its request default or the SERVE frame
+        # replaces it with 0.7 before any engine can honor the setting.
+        try:
+            temperature = float(os.environ.get("COLI_TEMP", "0.7"))
+            if not math.isfinite(temperature) or not 0 <= temperature <= 2:
+                temperature = 0.7
+        except ValueError:
+            temperature = 0.7
     top_p = 0.9 if top_p is None else top_p
     if isinstance(maximum, bool) or not isinstance(maximum, int) or maximum < 1:
         raise APIError(400, f"`{maximum_param}` must be a positive integer.", maximum_param)

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -19,6 +19,8 @@ import sys
 import threading
 import time
 import uuid
+
+import v4_dsml                      # vendored DeepSeek V4 DSML reference primitives
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from urllib.parse import unquote, urlsplit
@@ -380,42 +382,8 @@ def parse_tool_calls(reply, tools=None):
 #   <｜DSML｜parameter name="k" string="true">v</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>
 # preceded by "\n\n". There is no standalone "tool" role: results are <tool_result>{content}
 # </tool_result> blocks merged into the following user turn. DSML = U+FF5C (｜) + ASCII.
-DSV4_DSML = "｜DSML｜"
-DSV4_EOS = "<\uff5cend\u2581of\u2581sentence\uff5c>"
-_DSV4_BLOCK_RE = re.compile(
-    r"<" + DSV4_DSML + r"tool_calls>(.*?)</" + DSV4_DSML + r"tool_calls>", re.DOTALL)
-_DSV4_INVOKE_RE = re.compile(
-    r"<" + DSV4_DSML + r"invoke name=\"(.*?)\">(.*?)</" + DSV4_DSML + r"invoke>", re.DOTALL)
-_DSV4_PARAM_RE = re.compile(
-    r"<" + DSV4_DSML + r"parameter name=\"(.*?)\" string=\"(true|false)\">(.*?)</" +
-    DSV4_DSML + r"parameter>", re.DOTALL)
-
-DSV4_TOOLS_TEMPLATE = """## Tools
-
-You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{dsml}tool_calls>" block like the following:
-
-<{dsml}tool_calls>
-<{dsml}invoke name="$TOOL_NAME">
-<{dsml}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml}parameter>
-...
-</{dsml}invoke>
-<{dsml}invoke name="$TOOL_NAME2">
-...
-</{dsml}invoke>
-</{dsml}tool_calls>
-
-String parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.
-
-If thinking_mode is enabled (triggered by {think_open}), you MUST output your complete reasoning inside {think_open}...{think_close} BEFORE any tool calls or final response.
-
-Otherwise, output directly after {think_close} with tool calls or final response.
-
-### Available Tool Schemas
-
-{tool_schemas}
-
-You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
-"""
+DSV4_DSML = v4_dsml.dsml_token
+DSV4_EOS = v4_dsml.eos_token
 
 # OpenAI-style reasoning_effort levels -> the V4 vocabulary (encoding_dsv4.py has only
 # low/high/max; `low` adds nothing). In thinking mode the level's prompt is prepended at the
@@ -438,75 +406,41 @@ DSV4_REASONING_EFFORT_PROMPTS = {
 
 
 def _dsv4_tools_block(tools):
-    """V4 tool-declaration block (byte-matches encoding_dsv4.py's TOOLS_TEMPLATE)."""
+    """V4 tool-declaration block, rendered by the vendored reference template."""
     schemas = []
     for tool in (tools or []):
         fn = tool.get("function", tool) if isinstance(tool, dict) else {}
-        clean = {k: v for k, v in fn.items() if k not in ("defer_loading", "strict")}
-        schemas.append(json.dumps(clean, ensure_ascii=False))
-    return DSV4_TOOLS_TEMPLATE.format(dsml=DSV4_DSML, think_open=THINK_OPEN,
-                                      think_close=THINK_CLOSE, tool_schemas="\n".join(schemas))
+        # Gateway-side scrub: OpenAI clients attach routing hints the model
+        # schema must not carry.
+        schemas.append({k: v for k, v in fn.items() if k not in ("defer_loading", "strict")})
+    return v4_dsml.render_tools(schemas)
 
 
 def _dsv4_tool_calls(tool_calls):
-    """Render OpenAI-format tool_calls into a V4 DSML block (incl. the leading \\n\\n)."""
-    calls = []
-    for tc in tool_calls:
-        fn = tc.get("function", tc) if isinstance(tc, dict) else {}
-        name = fn.get("name") or ""
-        args = fn.get("arguments")
-        try:
-            arguments = json.loads(args) if isinstance(args, str) else (args or {})
-        except (json.JSONDecodeError, TypeError, ValueError):
-            arguments = {}
-        params = []
-        for key, value in (arguments or {}).items():
-            is_str = "true" if isinstance(value, str) else "false"
-            text = value if isinstance(value, str) else json.dumps(value, ensure_ascii=False)
-            params.append('<%sparameter name="%s" string="%s">%s</%sparameter>'
-                          % (DSV4_DSML, key, is_str, text, DSV4_DSML))
-        calls.append('<%sinvoke name="%s">\n%s\n</%sinvoke>'
-                     % (DSV4_DSML, name, "\n".join(params), DSV4_DSML))
-    return '\n\n<%stool_calls>\n%s\n</%stool_calls>' % (DSV4_DSML, "\n".join(calls), DSV4_DSML)
+    """Render OpenAI-format tool_calls into a V4 DSML block (incl. the leading 
+
+)."""
+    return v4_dsml.render_tool_calls(tool_calls)
 
 
 def parse_dsv4_tool_calls(reply):
     """Parse DeepSeek V4 DSML tool calls out of one assistant reply.
 
-    Returns (content, tool_calls): the visible answer text with the DSML block (and any
-    thinking/eos markers) removed, plus OpenAI-format tool_calls. Tolerant of truncated
-    output: an incomplete block yields no calls rather than an error.
+    The block itself is decoded by the vendored reference parser (strict, so a
+    malformed block degrades to no calls instead of half-parsed arguments).
+    Gateway hardening on top: an incomplete block (e.g. length-truncated
+    output) is cut from the visible content so raw DSML syntax never leaks,
+    and any thinking/eos markers around the block are scrubbed.
     """
-    content, calls = reply, []
-    block = _DSV4_BLOCK_RE.search(reply)
-    if block:
-        content = reply[:block.start()].rstrip("\n")
-        for m in _DSV4_INVOKE_RE.finditer(block.group(1)):
-            name = m.group(1).strip()
-            if not name:
-                continue
-            arguments = {}
-            for p in _DSV4_PARAM_RE.finditer(m.group(2)):
-                key, is_str, value = p.group(1), p.group(2), p.group(3)
-                if is_str != "true":
-                    try:
-                        value = json.loads(value)
-                    except (json.JSONDecodeError, TypeError, ValueError):
-                        pass
-                arguments[key] = value
-            calls.append({"id": "call_" + uuid.uuid4().hex[:24], "type": "function",
-                          "function": {"name": name,
-                                       "arguments": json.dumps(arguments, ensure_ascii=False)}})
-    else:
-        # No complete block (e.g. length-truncated output): drop everything from the first
-        # V4 tool marker so raw DSML syntax never leaks into the visible content.
-        cut = len(reply)
+    content, calls = v4_dsml.parse_completion_text(reply)
+    if not calls:
+        cut = len(content)
         for marker in ("<" + DSV4_DSML + "tool_calls", "<" + DSV4_DSML + "invoke"):
-            pos = reply.find(marker)
-            if pos >= 0 and pos < cut:
+            pos = content.find(marker)
+            if 0 <= pos < cut:
                 cut = pos
-        if cut < len(reply):
-            content = reply[:cut]
+        if cut < len(content):
+            content = content[:cut]
     for marker in (DSV4_EOS, THINK_OPEN, THINK_CLOSE):
         content = content.replace(marker, "")
     return content.strip(), calls

--- a/c/scripts/supervisor.sh
+++ b/c/scripts/supervisor.sh
@@ -18,18 +18,50 @@ flock -n 9 || { echo "a supervisor is already running; exiting"; exit 1; }
 log(){ echo "[$(date +%H:%M:%S)] $*"; }
 
 start_conv(){
-    cd "$CODE"
+    cd "$CODE" || { log "cannot enter $CODE"; return 1; }
     nohup python3 tools/convert_fp8_to_int4.py --repo zai-org/GLM-5.2-FP8 \
         --outdir "$DIR" --ebits 4 --io-bits 8 >> "$CONVLOG" 2>&1 &
+    conv_pid=$!
     log "converter started (PID $!)"
+}
+
+# Match only a converter that owns this supervisor's output directory. A global
+# pgrep/pkill also sees conversions for other models and can stop all of them
+# when this one finishes or stalls.
+find_conv_pid(){
+    local cmdline pid arg i saw_script saw_outdir
+    local -a argv
+    for cmdline in /proc/[0-9]*/cmdline; do
+        pid=${cmdline#/proc/}; pid=${pid%/cmdline}
+        [ "$pid" = "$$" ] && continue
+        [ -r "$cmdline" ] || continue
+        argv=()
+        while IFS= read -r -d '' arg; do argv+=("$arg"); done < "$cmdline"
+        saw_script=0; saw_outdir=0
+        for ((i=0; i<${#argv[@]}; i++)); do
+            case "${argv[i]}" in */convert_fp8_to_int4.py|convert_fp8_to_int4.py) saw_script=1;; esac
+            if [ "${argv[i]}" = "--outdir" ] && [ "${argv[i+1]:-}" = "$DIR" ]; then
+                saw_outdir=1
+            fi
+        done
+        if [ "$saw_script" -eq 1 ] && [ "$saw_outdir" -eq 1 ]; then
+            echo "$pid"
+            return
+        fi
+    done
 }
 
 last_size=-1; stall=0
 while :; do
     done_n=$(ls "$DIR"/out-*.safetensors 2>/dev/null | wc -l)
-    if [ "$done_n" -ge "$TOTAL" ]; then log "DONE: $done_n/$TOTAL shards. Exiting."; pkill -f convert_fp8 2>/dev/null; exit 0; fi
+    conv_pid=$(find_conv_pid)
+    if [ "$done_n" -ge "$TOTAL" ]; then
+        log "DONE: $done_n/$TOTAL shards. Exiting."
+        [ -z "$conv_pid" ] || kill "$conv_pid" 2>/dev/null
+        exit 0
+    fi
 
-    if ! pgrep -f convert_fp8 >/dev/null; then
+    if [ -z "$conv_pid" ]; then
         log "converter is not running ($done_n/$TOTAL): starting it"
         start_conv; last_size=-1; stall=0; sleep 20; continue
     fi
@@ -41,7 +73,7 @@ while :; do
             stall=$((stall+30))
             if [ "$stall" -ge "$STALL_S" ]; then
                 log "download stalled for ${stall}s at $((size/1000000)) MB ($done_n/$TOTAL): restarting the converter"
-                pkill -f convert_fp8; sleep 5
+                kill "$conv_pid" 2>/dev/null; sleep 5
                 start_conv; last_size=-1; stall=0
             fi
         else

--- a/c/setup.sh
+++ b/c/setup.sh
@@ -7,6 +7,9 @@ cd "$(dirname "$0")"
 echo "🐦 colibrì — setup"
 
 UNAME_S=$(uname -s)
+OMP_PROBE=".colibri-omp-probe-$$"
+cleanup_omp_probe() { rm -f "$OMP_PROBE" "$OMP_PROBE.exe"; }
+trap cleanup_omp_probe EXIT
 
 # 1) dipendenze
 command -v make >/dev/null || { echo "make is missing"; exit 1; }
@@ -21,14 +24,16 @@ Darwin)
 MINGW*|MSYS*)
     command -v gcc  >/dev/null || { echo "gcc is missing (MinGW-w64). Install: pacman -S mingw-w64-x86_64-gcc make"; exit 1; }
     echo "  gcc: $(gcc -dumpversion) · MinGW-w64"
-    echo -n "  OpenMP: "; echo 'int main(){return 0;}' | gcc -fopenmp -xc - -o /tmp/_omp 2>/dev/null && echo ok || { echo "libgomp is missing (pacman -S mingw-w64-x86_64-gcc)"; exit 1; }
+    echo -n "  OpenMP: "; echo 'int main(){return 0;}' | gcc -fopenmp -xc - -o "$OMP_PROBE" 2>/dev/null && echo ok || { echo "libgomp is missing (pacman -S mingw-w64-x86_64-gcc)"; exit 1; }
     ;;
 *)
     command -v gcc  >/dev/null || { echo "gcc is missing (for example: sudo apt install build-essential)"; exit 1; }
     echo "  gcc: $(gcc -dumpversion) · $(nproc) core"
-    echo -n "  OpenMP: "; echo 'int main(){return 0;}' | gcc -fopenmp -xc - -o /tmp/_omp 2>/dev/null && echo ok || { echo "libgomp is missing"; exit 1; }
+    echo -n "  OpenMP: "; echo 'int main(){return 0;}' | gcc -fopenmp -xc - -o "$OMP_PROBE" 2>/dev/null && echo ok || { echo "libgomp is missing"; exit 1; }
     ;;
 esac
+cleanup_omp_probe
+trap - EXIT
 
 # 2) build: nativa (veloce, per QUESTA macchina). Per un binario da distribuire: make portable
 echo "  building (ARCH=${ARCH:-native})…"

--- a/c/tests/bench_gemv_stream.c
+++ b/c/tests/bench_gemv_stream.c
@@ -1,0 +1,360 @@
+/* Microbenchmark: decode-regime GEMV bandwidth vs the machine's read ceiling.
+ *
+ * bench_idot measures the kernels' warm-cache compute ceiling. Decode lives in the
+ * opposite regime: expert weights do NOT fit in cache, every token streams them from
+ * RAM, and arithmetic intensity is ~1 MAC/byte. This measures the REAL quant.h row
+ * loops (matmul_q int8, matmul_i4 int4, their own internal OMP) over a working set
+ * far larger than the LLC, cycling experts so no call sees a warm weight — then a
+ * read baseline in the same process, same pass, so the ratio cancels host noise.
+ *
+ * The int8-vs-int4 GB/s comparison is the sharp edge: equal GB/s means the decode
+ * GEMV is bandwidth-bound (int4 = free 2x tokens/byte); int4 well below int8 means
+ * the unpack is compute-bound on this ISA and kernel work has headroom.
+ *
+ * Arms: f32-act int8/int4 (IDOT=0 paths), idot int8/int4 (production decode), a FROZEN
+ * baseline copy of today's plain-AVX2 dot_i4i8 (any future kernel change A/Bs against
+ * it), a DEINTERLEAVED-x candidate kernel (no unpacks; bit-exact, gated inline), a warm
+ * single-expert arm (ALU ceiling vs streaming), and a parallel-read ceiling.
+ *
+ * Run:  make tests/bench_gemv_stream ARCH=native && OMP_NUM_THREADS=N ./tests/bench_gemv_stream
+ * (not in TEST_BINS -- a measurement, not a gate. On shared vCPUs the read ceiling
+ * scales with N and never shows the physical RAM roof, so absolute GB/s there is
+ * indicative only; the within-pass ratios are the signal. Physical AVX2-only silicon
+ * is what decides whether the deinterleaved candidate is worth landing.) */
+#define main coli_glm_main_unused
+#include "../colibri.c"
+#undef main
+#include <stdint.h>
+#include <string.h>
+
+/* FROZEN baseline: verbatim copy of dev's plain-AVX2 dot_i4i8 as of 2026-08-09,
+ * bench_idot's old-vs-new pattern. While quant.h is unchanged the ratio prints 1.00x;
+ * any future kernel change A/Bs against this copy in one process over identical frozen
+ * inputs, so host noise cancels in the ratio. */
+#ifdef __AVX2__
+static inline int32_t dot_i4i8_old(const uint8_t *w4, const int8_t *x, int I) {
+    int32_t sum = 0; int i = 0;
+    const __m128i m4 = _mm_set1_epi8(0x0F); const __m256i b8 = _mm256_set1_epi8(8);
+    const __m256i ones = _mm256_set1_epi16(1);
+    __m256i acc = _mm256_setzero_si256();
+    for (; i + 32 <= I; i += 32) {
+        __m128i by = _mm_loadu_si128((const __m128i*)(w4 + (i >> 1)));
+        __m128i lo = _mm_and_si128(by, m4), hi = _mm_and_si128(_mm_srli_epi16(by, 4), m4);
+        __m128i n0 = _mm_unpacklo_epi8(lo, hi), n1 = _mm_unpackhi_epi8(lo, hi);
+        __m256i wv = _mm256_sub_epi8(_mm256_set_m128i(n1, n0), b8);
+        __m256i xv = _mm256_loadu_si256((const __m256i*)(x + i));
+        __m256i p = _mm256_maddubs_epi16(_mm256_sign_epi8(wv, wv), _mm256_sign_epi8(xv, wv));
+        acc = _mm256_add_epi32(acc, _mm256_madd_epi16(p, ones));
+    }
+    sum = hsum256_i32(acc);
+    for (; i < I; i++) { int8_t w = (int8_t)((i & 1) ? (w4[i >> 1] >> 4) : (w4[i >> 1] & 0x0F)) - 8; sum += w * x[i]; }
+    return sum;
+}
+static void matmul_i4_idot_old(float *y, const int8_t *xq, const float *sx, const uint8_t *q4,
+                               const float *scale, int S, int I, int O) {
+    int rb = (I + 1) / 2;
+    #pragma omp parallel for schedule(static)
+    for (int o = 0; o < O; o++) { const uint8_t *w = q4 + (int64_t)o * rb; float sc = scale[o];
+        for (int s = 0; s < S; s++) y[(int64_t)s * O + o] = (float)dot_i4i8_old(w, xq + (int64_t)s * I, I) * sc * sx[s]; }
+}
+#endif
+
+/* CANDIDATE dot_i4i8_de: x pre-deinterleaved (even/odd elements) so lo/hi nibbles are
+ * used straight after and/srli — no unpacks, no lane insert. The deinterleave runs once
+ * per activation vector and amortises over every row of the projection. Products are
+ * identical and integer adds are associative, so the result must stay bit-identical. */
+#ifdef __AVX2__
+static inline int32_t dot_i4i8_de(const uint8_t *w4, const int8_t *xe, const int8_t *xo, int I) {
+    int32_t sum = 0; int i = 0;
+    const __m256i m4 = _mm256_set1_epi8(0x0F); const __m256i b8 = _mm256_set1_epi8(8);
+    const __m256i ones = _mm256_set1_epi16(1);
+    __m256i a0 = _mm256_setzero_si256(), a1 = _mm256_setzero_si256();
+    for (; i + 64 <= I; i += 64) {
+        __m256i by = _mm256_loadu_si256((const __m256i*)(w4 + (i >> 1)));   /* 32 B = 64 elems */
+        __m256i we = _mm256_sub_epi8(_mm256_and_si256(by, m4), b8);
+        __m256i wo = _mm256_sub_epi8(_mm256_and_si256(_mm256_srli_epi16(by, 4), m4), b8);
+        __m256i xev = _mm256_loadu_si256((const __m256i*)(xe + (i >> 1)));
+        __m256i xov = _mm256_loadu_si256((const __m256i*)(xo + (i >> 1)));
+        a0 = _mm256_add_epi32(a0, _mm256_madd_epi16(_mm256_maddubs_epi16(_mm256_sign_epi8(we, we), _mm256_sign_epi8(xev, we)), ones));
+        a1 = _mm256_add_epi32(a1, _mm256_madd_epi16(_mm256_maddubs_epi16(_mm256_sign_epi8(wo, wo), _mm256_sign_epi8(xov, wo)), ones));
+    }
+    sum = hsum256_i32(_mm256_add_epi32(a0, a1));
+    for (; i < I; i++) { int8_t w = (int8_t)((i & 1) ? (w4[i >> 1] >> 4) : (w4[i >> 1] & 0x0F)) - 8;
+                         sum += w * ((i & 1) ? xo[i >> 1] : xe[i >> 1]); }
+    return sum;
+}
+static void i4_deinterleave(const int8_t *x, int I, int8_t *xe, int8_t *xo) {
+    int j = 0;
+    for (; j + 2 <= I; j += 2) { xe[j >> 1] = x[j]; xo[j >> 1] = x[j + 1]; }
+    if (I & 1) xe[I >> 1] = x[I - 1];
+}
+static void matmul_i4_idot_de(float *y, const int8_t *xq, const float *sx, const uint8_t *q4,
+                              const float *scale, int I, int O, int8_t *xe, int8_t *xo) {
+    int rb = (I + 1) / 2;                                        /* S=1 decode shape */
+    i4_deinterleave(xq, I, xe, xo);
+    #pragma omp parallel for schedule(static)
+    for (int o = 0; o < O; o++)
+        y[o] = (float)dot_i4i8_de(q4 + (int64_t)o * rb, xe, xo, I) * scale[o] * sx[0];
+}
+#endif
+
+static uint32_t rs = 0x2545F491u;
+static uint32_t xr(void) { rs ^= rs << 13; rs ^= rs >> 17; rs ^= rs << 5; return rs; }
+static double tnow(void) { struct timespec t; clock_gettime(CLOCK_MONOTONIC, &t); return t.tv_sec + t.tv_nsec * 1e-9; }
+static int cmpd(const void *a, const void *b) { double x = *(const double*)a, y = *(const double*)b; return x < y ? -1 : x > y; }
+static double median5(double *v) { qsort(v, 5, sizeof(double), cmpd); return v[2]; }
+
+/* GLM-like expert: gate/up [INTER,HID], down [HID,INTER]; top-K experts per token */
+enum { HID = 5120, INTER = 1536, NEXP = 32, TOPK = 8, TOKENS = 24, REPS = 5 };
+
+int main(void) {
+    const int64_t w8_per = (int64_t)INTER * HID * 2 + (int64_t)HID * INTER;   /* int8 bytes/expert */
+    const int64_t w4_per = w8_per / 2;
+    printf("bench_gemv_stream: %d experts x %.1f MB int8 (working set %.2f GB), top-%d, S=1\n",
+           NEXP, w8_per / 1e6, NEXP * w8_per / 1e9, TOPK);
+
+    /* one contiguous slab per format, cut into per-expert views */
+    int8_t  *w8 = malloc((size_t)NEXP * w8_per);
+    uint8_t *w4 = malloc((size_t)NEXP * w4_per);
+    float   *sc = malloc((size_t)NEXP * (INTER * 2 + HID) * sizeof(float));
+    float   *x  = malloc((size_t)HID * sizeof(float));
+    float   *g  = malloc((size_t)INTER * sizeof(float));
+    float   *u  = malloc((size_t)INTER * sizeof(float));
+    float   *d  = malloc((size_t)HID * sizeof(float));
+    int8_t  *xq = malloc((size_t)HID);                            /* idot activations */
+    int8_t  *gq = malloc((size_t)INTER);
+    float   *rd = malloc((size_t)1 << 30);                        /* 1 GiB read baseline */
+    if (!w8 || !w4 || !sc || !x || !g || !u || !d || !xq || !gq || !rd) { fprintf(stderr, "OOM\n"); return 1; }
+    for (int i = 0; i < HID; i++)   xq[i] = (int8_t)(xr() % 15) - 7;
+    for (int i = 0; i < INTER; i++) gq[i] = (int8_t)(xr() % 15) - 7;
+    float sx1 = 0.031f;                                           /* one activation scale, S=1 */
+    for (int64_t i = 0; i < (int64_t)NEXP * w8_per; i++) w8[i] = (int8_t)(xr() & 0xff);
+    for (int64_t i = 0; i < (int64_t)NEXP * w4_per; i++) w4[i] = (uint8_t)(xr() & 0xff);
+    for (int64_t i = 0; i < (int64_t)NEXP * (INTER * 2 + HID); i++) sc[i] = 1.0f + (float)(xr() & 7) * 0.01f;
+    for (int i = 0; i < HID; i++) x[i] = (float)(int)(xr() % 17) - 8.0f;
+    for (int64_t i = 0; i < ((int64_t)1 << 30) / 4; i++) rd[i] = (float)(xr() & 0xff);
+
+    double sink = 0;                                              /* defeats DCE across arms */
+
+    /* --- arm A: int8 GEMV, cold experts (round-robin so no reuse across calls) --- */
+    double a5[5];
+    for (int r = 0; r < 5; r++) {
+        int e = 0; double t0 = tnow();
+        for (int t = 0; t < TOKENS; t++)
+            for (int k = 0; k < TOPK; k++, e = (e + 1) % NEXP) {
+                const int8_t *base = w8 + (int64_t)e * w8_per;
+                const float  *s    = sc + (int64_t)e * (INTER * 2 + HID);
+                matmul_q(g, x, base,                              s,             1, HID, INTER);
+                matmul_q(u, x, base + (int64_t)INTER * HID,       s + INTER,     1, HID, INTER);
+                for (int i = 0; i < INTER; i++) g[i] *= u[i];     /* keep g live like the FFN does */
+                matmul_q(d, g, base + (int64_t)INTER * HID * 2,   s + INTER * 2, 1, INTER, HID);
+                sink += d[0] + d[HID - 1];
+            }
+        a5[r] = (double)TOKENS * TOPK * w8_per / (tnow() - t0);
+    }
+    double gbs8 = median5(a5) / 1e9;
+
+    /* --- arm B: same shape, int4 packed --- */
+    double b5[5];
+    for (int r = 0; r < 5; r++) {
+        int e = 0; double t0 = tnow();
+        for (int t = 0; t < TOKENS; t++)
+            for (int k = 0; k < TOPK; k++, e = (e + 1) % NEXP) {
+                const uint8_t *base = w4 + (int64_t)e * w4_per;
+                const float   *s    = sc + (int64_t)e * (INTER * 2 + HID);
+                matmul_i4(g, x, base,                                  s,             1, HID, INTER);
+                matmul_i4(u, x, base + (int64_t)INTER * HID / 2,       s + INTER,     1, HID, INTER);
+                for (int i = 0; i < INTER; i++) g[i] *= u[i];
+                matmul_i4(d, g, base + (int64_t)INTER * HID,           s + INTER * 2, 1, INTER, HID);
+                sink += d[0] + d[HID - 1];
+            }
+        b5[r] = (double)TOKENS * TOPK * w4_per / (tnow() - t0);
+    }
+    double gbs4 = median5(b5) / 1e9;
+
+    /* --- arm E: the PRODUCTION decode path — idot int8×int8 (dot_i8i8) --- */
+    double e5[5];
+    for (int r = 0; r < 5; r++) {
+        int e = 0; double t0 = tnow();
+        for (int t = 0; t < TOKENS; t++)
+            for (int k = 0; k < TOPK; k++, e = (e + 1) % NEXP) {
+                const int8_t *base = w8 + (int64_t)e * w8_per;
+                const float  *s    = sc + (int64_t)e * (INTER * 2 + HID);
+                matmul_q_idot(g, xq, &sx1, base,                            s,             1, HID, INTER);
+                matmul_q_idot(u, xq, &sx1, base + (int64_t)INTER * HID,     s + INTER,     1, HID, INTER);
+                matmul_q_idot(d, gq, &sx1, base + (int64_t)INTER * HID * 2, s + INTER * 2, 1, INTER, HID);
+                sink += d[0] + d[HID - 1];
+            }
+        e5[r] = (double)TOKENS * TOPK * w8_per / (tnow() - t0);
+    }
+    double gbs8i = median5(e5) / 1e9;
+
+    /* --- arm F: idot int4 (dot_i4i8) — the GLM fmt-4 decode kernel --- */
+    double f5[5];
+    for (int r = 0; r < 5; r++) {
+        int e = 0; double t0 = tnow();
+        for (int t = 0; t < TOKENS; t++)
+            for (int k = 0; k < TOPK; k++, e = (e + 1) % NEXP) {
+                const uint8_t *base = w4 + (int64_t)e * w4_per;
+                const float   *s    = sc + (int64_t)e * (INTER * 2 + HID);
+                matmul_i4_idot(g, xq, &sx1, base,                            s,             1, HID, INTER);
+                matmul_i4_idot(u, xq, &sx1, base + (int64_t)INTER * HID / 2, s + INTER,     1, HID, INTER);
+                matmul_i4_idot(d, gq, &sx1, base + (int64_t)INTER * HID,     s + INTER * 2, 1, INTER, HID);
+                sink += d[0] + d[HID - 1];
+            }
+        f5[r] = (double)TOKENS * TOPK * w4_per / (tnow() - t0);
+    }
+    double gbs4i = median5(f5) / 1e9;
+
+    /* --- arm G: the OLD single-accumulator idot int4, same inputs — the A/B --- */
+    double g5[5]; double gbs4o = 0;
+#ifdef __AVX2__
+    for (int r = 0; r < 5; r++) {
+        int e = 0; double t0 = tnow();
+        for (int t = 0; t < TOKENS; t++)
+            for (int k = 0; k < TOPK; k++, e = (e + 1) % NEXP) {
+                const uint8_t *base = w4 + (int64_t)e * w4_per;
+                const float   *s    = sc + (int64_t)e * (INTER * 2 + HID);
+                matmul_i4_idot_old(g, xq, &sx1, base,                            s,             1, HID, INTER);
+                matmul_i4_idot_old(u, xq, &sx1, base + (int64_t)INTER * HID / 2, s + INTER,     1, HID, INTER);
+                matmul_i4_idot_old(d, gq, &sx1, base + (int64_t)INTER * HID,     s + INTER * 2, 1, INTER, HID);
+                sink += d[0] + d[HID - 1];
+            }
+        g5[r] = (double)TOKENS * TOPK * w4_per / (tnow() - t0);
+    }
+    gbs4o = median5(g5) / 1e9;
+
+    /* bit-exactness spot check across the whole working set, old vs current */
+    {
+        int64_t rows_checked = 0;
+        for (int e = 0; e < NEXP; e++) {
+            const uint8_t *base = w4 + (int64_t)e * w4_per;
+            for (int o = 0; o < INTER; o += 97) {                 /* stride: cover all experts cheaply */
+                int32_t a = dot_i4i8(base + (int64_t)o * (HID / 2), xq, HID);
+                int32_t b = dot_i4i8_old(base + (int64_t)o * (HID / 2), xq, HID);
+                if (a != b) { printf("EXACTNESS FAIL expert %d row %d: %d != %d\n", e, o, a, b); return 1; }
+                rows_checked++;
+            }
+        }
+        printf("  old-vs-new bit-exact on %lld sampled rows\n", (long long)rows_checked);
+    }
+#endif
+
+    /* --- arm H: the deinterleaved-x candidate, same inputs --- */
+    double h5[5]; double gbs4d = 0;
+#ifdef __AVX2__
+    {
+        int8_t *xeb = malloc((size_t)(HID + 1) / 2), *xob = malloc((size_t)(HID + 1) / 2);
+        int8_t *geb = malloc((size_t)(INTER + 1) / 2), *gob = malloc((size_t)(INTER + 1) / 2);
+        if (!xeb || !xob || !geb || !gob) { fprintf(stderr, "OOM de\n"); return 1; }
+        for (int r = 0; r < 5; r++) {
+            int e = 0; double t0 = tnow();
+            for (int t = 0; t < TOKENS; t++)
+                for (int k = 0; k < TOPK; k++, e = (e + 1) % NEXP) {
+                    const uint8_t *base = w4 + (int64_t)e * w4_per;
+                    const float   *s    = sc + (int64_t)e * (INTER * 2 + HID);
+                    matmul_i4_idot_de(g, xq, &sx1, base,                            s,             HID, INTER, xeb, xob);
+                    matmul_i4_idot_de(u, xq, &sx1, base + (int64_t)INTER * HID / 2, s + INTER,     HID, INTER, xeb, xob);
+                    matmul_i4_idot_de(d, gq, &sx1, base + (int64_t)INTER * HID,     s + INTER * 2, INTER, HID, geb, gob);
+                    sink += d[0] + d[HID - 1];
+                }
+            h5[r] = (double)TOKENS * TOPK * w4_per / (tnow() - t0);
+        }
+        gbs4d = median5(h5) / 1e9;
+
+        /* exactness: candidate vs current, whole sampled set + ragged tails */
+        i4_deinterleave(xq, HID, xeb, xob);
+        int64_t rows = 0;
+        for (int e = 0; e < NEXP; e++) {
+            const uint8_t *base = w4 + (int64_t)e * w4_per;
+            for (int o = 0; o < INTER; o += 97) {
+                int32_t a = dot_i4i8(base + (int64_t)o * (HID / 2), xq, HID);
+                int32_t b = dot_i4i8_de(base + (int64_t)o * (HID / 2), xeb, xob, HID);
+                if (a != b) { printf("DE EXACTNESS FAIL e%d o%d: %d != %d\n", e, o, a, b); return 1; }
+                rows++;
+            }
+        }
+        for (int I2 = 1; I2 <= 200; I2++) {                       /* ragged sizes, both parities */
+            i4_deinterleave(xq, I2, xeb, xob);
+            int32_t a = dot_i4i8(w4, xq, I2), b = dot_i4i8_de(w4, xeb, xob, I2);
+            if (a != b) { printf("DE TAIL FAIL I=%d: %d != %d\n", I2, a, b); return 1; }
+        }
+        printf("  candidate bit-exact on %lld sampled rows + I=1..200 tails\n", (long long)rows);
+        free(xeb); free(xob); free(geb); free(gob);
+    }
+#endif
+
+    /* --- arm C: warm sanity — one expert, must beat arm A by a wide margin or the
+     *     "cold" arms were never actually streaming RAM --- */
+    double c5[5];
+    for (int r = 0; r < 5; r++) {
+        double t0 = tnow();
+        for (int t = 0; t < TOKENS * TOPK; t++) {
+            matmul_q(g, x, w8, sc, 1, HID, INTER);
+            sink += g[0];
+        }
+        c5[r] = (double)TOKENS * TOPK * INTER * HID / (tnow() - t0);
+    }
+    double gbsw = median5(c5) / 1e9;
+
+    /* --- arm W: warm idot4, current vs deinterleaved — one gate matrix in cache.
+     *     Separates the ALU ceiling from the streaming cost: if DE wins big here but
+     *     only 9% cold, the cold arms are memory-limited and kernel µops are moot. --- */
+#ifdef __AVX2__
+    {
+        int8_t *xeb = malloc((size_t)(HID + 1) / 2), *xob = malloc((size_t)(HID + 1) / 2);
+        double wc5[5], wd5[5];
+        for (int r = 0; r < 5; r++) {
+            double t0 = tnow();
+            for (int t = 0; t < TOKENS * TOPK; t++) {
+                matmul_i4_idot(g, xq, &sx1, w4, sc, 1, HID, INTER);
+                sink += g[0];
+            }
+            wc5[r] = (double)TOKENS * TOPK * ((int64_t)INTER * HID / 2) / (tnow() - t0);
+        }
+        for (int r = 0; r < 5; r++) {
+            double t0 = tnow();
+            for (int t = 0; t < TOKENS * TOPK; t++) {
+                matmul_i4_idot_de(g, xq, &sx1, w4, sc, HID, INTER, xeb, xob);
+                sink += g[0];
+            }
+            wd5[r] = (double)TOKENS * TOPK * ((int64_t)INTER * HID / 2) / (tnow() - t0);
+        }
+        printf("  warm idot4 cur   : %6.2f GB/s   warm idot4 DEINT: %6.2f GB/s   (DE/cur warm: %.2fx)\n",
+               median5(wc5) / 1e9, median5(wd5) / 1e9, median5(wd5) / median5(wc5));
+        free(xeb); free(xob);
+    }
+#endif
+
+    /* --- arm D: read ceiling — every thread streams the 1 GiB buffer --- */
+    double d5[5];
+    for (int r = 0; r < 5; r++) {
+        double t0 = tnow(); double acc = 0;
+        #pragma omp parallel for reduction(+:acc) schedule(static)
+        for (int64_t i = 0; i < ((int64_t)1 << 30) / 4; i += 8) acc += rd[i];
+        d5[r] = (double)(1 << 30) / (tnow() - t0);
+        sink += acc;
+    }
+    double gbsr = median5(d5) / 1e9;
+
+    printf("  f32-act int8 cold: %6.2f GB/s of weights  (IDOT=0 path)\n", gbs8);
+    printf("  f32-act int4 cold: %6.2f GB/s of weights\n", gbs4);
+    printf("  idot int8 cold   : %6.2f GB/s of weights  (production decode, dot_i8i8)\n", gbs8i);
+    printf("  idot int4 cold   : %6.2f GB/s of weights  (production decode, dot_i4i8)\n", gbs4i);
+    if (gbs4o > 0)
+        printf("  idot int4 BASE   : %6.2f GB/s of weights  (frozen baseline copy; 1.00x while quant.h is unchanged)\n",
+               gbs4o);
+    if (gbs4d > 0)
+        printf("  idot int4 DEINT  : %6.2f GB/s of weights  (deinterleaved x)  vs current: %.2fx  tokens vs idot8: %.2fx\n",
+               gbs4d, gbs4d / gbs4i, 2.0 * gbs4d / gbs8i);
+    printf("  int8 GEMV warm   : %6.2f GB/s  (kernel ceiling, weights in cache)\n", gbsw);
+    printf("  read ceiling     : %6.2f GB/s  (parallel strided sum, 1 GiB)\n", gbsr);
+    printf("  efficiency vs read: f32i8 %.0f%%  f32i4 %.0f%%  idot8 %.0f%%  idot4 %.0f%%\n",
+           100.0 * gbs8 / gbsr, 100.0 * gbs4 / gbsr, 100.0 * gbs8i / gbsr, 100.0 * gbs4i / gbsr);
+    printf("  tokens/s, idot4 vs idot8 (same weights, half the bytes): %.2fx\n", 2.0 * gbs4i / gbs8i);
+    printf("  (sink %.3g)\n", sink);
+    if (gbsw < gbs8 * 0.95) { printf("SANITY FAIL: warm below cold — measurement broken\n"); return 1; }
+    printf("  regime of the f32-act path: %s (warm ceiling at %.0f%% of read ceiling)\n",
+           gbsw < 0.7 * gbsr ? "COMPUTE-bound" : "bandwidth-bound", 100.0 * gbsw / gbsr);
+    return 0;
+}

--- a/c/tests/test_cuda_test_makefile.py
+++ b/c/tests/test_cuda_test_makefile.py
@@ -1,0 +1,46 @@
+"""Build-contract checks for the real-GPU MXFP4 correctness test."""
+import subprocess
+import unittest
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent.parent
+
+
+def cuda_test_recipe(*variables):
+    result = subprocess.run(
+        ["make", "-Bn", "cuda-test",
+         "TRIPLET=x86_64-unknown-linux-gnu", *variables],
+        cwd=HERE, text=True, capture_output=True, check=False, timeout=120)
+    return result.stdout + result.stderr
+
+
+def mxfp4_link_line(recipe):
+    return next(
+        (line for line in recipe.splitlines()
+         if "tests/test_mxfp4_cuda.cu" in line and " -o " in line),
+        "")
+
+
+class CudaTestMakefileTest(unittest.TestCase):
+    def test_nvcc_links_the_cpu_oracle_openmp_runtime(self):
+        line = mxfp4_link_line(cuda_test_recipe("CUDA=1", "NVCC=nvcc"))
+        self.assertTrue(line, "no MXFP4 CUDA link command in dry-run recipe")
+        self.assertIn("-Xcompiler=-fopenmp", line)
+
+    def test_hipcc_links_the_cpu_oracle_openmp_runtime(self):
+        line = mxfp4_link_line(cuda_test_recipe(
+            "HIP=1", "HIP_ARCH=gfx1100", "HIPCC=hipcc"))
+        self.assertTrue(line, "no MXFP4 HIP link command in dry-run recipe")
+        self.assertIn("-fopenmp", line)
+        self.assertNotIn("-Xcompiler=-fopenmp", line)
+
+    def test_setup_openmp_probe_does_not_require_tmp(self):
+        setup = (HERE / "setup.sh").read_text(encoding="utf-8")
+        self.assertNotIn("/tmp/_omp", setup)
+        self.assertIn('OMP_PROBE=".colibri-omp-probe-$$"', setup)
+        self.assertIn('rm -f "$OMP_PROBE" "$OMP_PROBE.exe"', setup)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tests/test_download_fp8.py
+++ b/c/tests/test_download_fp8.py
@@ -1,0 +1,94 @@
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+import download_fp8
+
+
+class DownloadExitStatusTests(unittest.TestCase):
+    META_FILES = ("config.json", "tokenizer.json", "tokenizer_config.json",
+                  "generation_config.json", "model.safetensors.index.json")
+
+    def run_main(self, dest, *args):
+        with mock.patch.object(download_fp8, "DEST", dest), \
+             mock.patch.object(sys, "argv", ["download_fp8.py", *args]):
+            return download_fp8.main()
+
+    def test_failed_shard_returns_nonzero(self):
+        manifest = (["model-00001.safetensors"],
+                    {"model-00001.safetensors": 4})
+        with tempfile.TemporaryDirectory() as dest, \
+             mock.patch.object(download_fp8, "get_shard_list_hf",
+                               return_value=manifest), \
+             mock.patch.object(download_fp8, "download_file_hf",
+                               side_effect=RuntimeError("offline")), \
+             mock.patch.object(download_fp8.time, "sleep"):
+            self.assertEqual(self.run_main(dest, "--source", "hf"), 1)
+
+    def test_explicit_modelscope_failure_returns_nonzero(self):
+        with tempfile.TemporaryDirectory() as dest, \
+             mock.patch.object(download_fp8, "get_shard_list_ms",
+                               side_effect=RuntimeError("offline")):
+            self.assertEqual(self.run_main(dest, "--source", "ms"), 1)
+
+    def test_explicit_modelscope_empty_manifest_does_not_fall_back(self):
+        with tempfile.TemporaryDirectory() as dest, \
+             mock.patch.object(download_fp8, "get_shard_list_ms",
+                               return_value=([], {})), \
+             mock.patch.object(download_fp8, "get_shard_list_hf") as hf:
+            self.assertEqual(self.run_main(dest, "--source", "ms"), 1)
+            hf.assert_not_called()
+
+    def test_auto_empty_modelscope_manifest_uses_huggingface(self):
+        name = "model-00001.safetensors"
+        manifest = ([name], {name: 4})
+        with tempfile.TemporaryDirectory() as dest, \
+             mock.patch.object(download_fp8, "get_shard_list_ms",
+                               return_value=([], {})), \
+             mock.patch.object(download_fp8, "get_shard_list_hf",
+                               return_value=manifest), \
+             mock.patch.object(download_fp8, "download_file_ms") as ms:
+            def download(fn):
+                with open(os.path.join(dest, fn), "wb") as out:
+                    out.write(b"data" if fn == name else b"")
+            with mock.patch.object(download_fp8, "download_file_hf",
+                                   side_effect=download):
+                self.assertEqual(self.run_main(dest), 0)
+            ms.assert_not_called()
+
+    def test_complete_manifest_returns_zero(self):
+        name = "model-00001.safetensors"
+        manifest = ([name], {name: 4})
+        with tempfile.TemporaryDirectory() as dest, \
+             open(os.path.join(dest, name), "wb") as shard:
+            shard.write(b"data")
+            shard.flush()
+            for metadata in self.META_FILES:
+                open(os.path.join(dest, metadata), "wb").close()
+            with mock.patch.object(download_fp8, "get_shard_list_hf",
+                                   return_value=manifest), \
+                 mock.patch.object(download_fp8, "download_file_hf"):
+                self.assertEqual(self.run_main(dest, "--source", "hf"), 0)
+
+    def test_missing_metadata_returns_nonzero(self):
+        name = "model-00001.safetensors"
+        with tempfile.TemporaryDirectory() as dest:
+            with open(os.path.join(dest, name), "wb") as shard:
+                shard.write(b"data")
+            manifest = ([name], {name: 4})
+            with mock.patch.object(download_fp8, "get_shard_list_hf",
+                                   return_value=manifest), \
+                 mock.patch.object(download_fp8, "download_file_hf"):
+                self.assertEqual(self.run_main(dest, "--source", "hf"), 1)
+
+    def test_empty_manifest_returns_nonzero(self):
+        with tempfile.TemporaryDirectory() as dest, \
+             mock.patch.object(download_fp8, "get_shard_list_hf",
+                               return_value=([], {})):
+            self.assertEqual(self.run_main(dest, "--source", "hf"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tests/test_eslot_inflight.c
+++ b/c/tests/test_eslot_inflight.c
@@ -1,0 +1,23 @@
+/* Async CUDA groups may borrow an LRU slot until stream completion.  The
+ * oldest slot is therefore not necessarily an eligible eviction victim. */
+#define main coli_glm_main_unused
+#include "../colibri.c"
+#undef main
+
+#include <stdio.h>
+
+int main(void){
+    ESlot slots[3]={0};
+    slots[0].used=1; slots[1].used=2; slots[2].used=3;
+
+    if(eslot_lru_victim(slots,3)!=0) return 1;
+    eslot_acquire(&slots[0]);
+    if(eslot_lru_victim(slots,3)!=1) return 2;
+    eslot_acquire(&slots[1]); eslot_acquire(&slots[2]);
+    if(eslot_lru_victim(slots,3)!=-1) return 3;
+
+    eslot_release(&slots[0]); eslot_release(&slots[1]); eslot_release(&slots[2]);
+    if(eslot_lru_victim(slots,3)!=0) return 4;
+    puts("test_eslot_inflight: ok");
+    return 0;
+}

--- a/c/tests/test_inkling_omp_source.py
+++ b/c/tests/test_inkling_omp_source.py
@@ -1,0 +1,18 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class InklingOpenMPWiringTest(unittest.TestCase):
+    def test_direct_engine_uses_shared_physical_core_sizing(self):
+        source = (ROOT / "inkling.c").read_text(encoding="utf-8")
+        self.assertTrue('#include "omp_tune.h"' in source,
+                        "inkling.c does not include the shared OpenMP sizing helper")
+        self.assertTrue('coli_omp_tune_threads("inkling")' in source,
+                        "Inkling direct execution does not size its OpenMP team")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -187,6 +187,15 @@ class TemplateTest(unittest.TestCase):
         opts = generation_options({"response_format": {"type": "gbnf", "grammar": "not a grammar ::="}}, 8)
         self.assertEqual(opts[3], "not a grammar ::=")
 
+    def test_coli_temp_is_the_default_for_requests_that_omit_temperature(self):
+        with patch.dict("openai_server.os.environ", {"COLI_TEMP": "0.25"}):
+            self.assertEqual(generation_options({}, 8)[1], 0.25)
+            self.assertEqual(generation_options({"temperature": 0}, 8)[1], 0.0)
+        for invalid in ("malformed", "5", "-1", "nan", "1e999"):
+            with self.subTest(invalid=invalid):
+                with patch.dict("openai_server.os.environ", {"COLI_TEMP": invalid}):
+                    self.assertEqual(generation_options({}, 8)[1], 0.7)
+
     def test_validates_stop_sequences(self):
         self.assertEqual(generation_options({"stop": "END"}, 8)[4], ("END",))
         self.assertEqual(generation_options({"stop": ["ONE", "TWO"]}, 8)[4],

--- a/c/tests/test_stop_scope.py
+++ b/c/tests/test_stop_scope.py
@@ -1,0 +1,101 @@
+import contextlib
+import importlib.machinery
+import importlib.util
+import io
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+C_DIR = Path(__file__).resolve().parents[1]
+loader = importlib.machinery.SourceFileLoader("coli_stop_scope", str(C_DIR / "coli"))
+spec = importlib.util.spec_from_loader(loader.name, loader)
+coli = importlib.util.module_from_spec(spec)
+loader.exec_module(coli)
+
+
+class StopScopeTests(unittest.TestCase):
+    def cmdline(self, *args):
+        return b"\0".join(arg.encode() for arg in args) + b"\0"
+
+    def test_explicit_port_does_not_match_another_server(self):
+        raw = self.cmdline("python3", "/opt/colibri/coli", "serve",
+                           "--model", "/models/a", "--port", "9000")
+        self.assertTrue(coli._serve_cmdline_matches_port(raw, 9000))
+        self.assertFalse(coli._serve_cmdline_matches_port(raw, 8000))
+
+    def test_equals_port_syntax(self):
+        raw = self.cmdline("/opt/colibri/coli", "serve", "--port=9000")
+        self.assertTrue(coli._serve_cmdline_matches_port(raw, 9000))
+
+    def test_serve_as_an_argument_is_not_a_server(self):
+        raw = self.cmdline("python3", "/opt/colibri/coli", "chat",
+                           "--prompt", "serve", "--port", "9000")
+        self.assertFalse(coli._serve_cmdline_matches_port(raw, 9000))
+
+    def test_default_port_matches_only_8000(self):
+        raw = self.cmdline("python3", "/opt/colibri/coli", "serve",
+                           "--model", "/models/a")
+        self.assertTrue(coli._serve_cmdline_matches_port(raw, 8000))
+        self.assertFalse(coli._serve_cmdline_matches_port(raw, 9000))
+
+    def test_engine_tag_is_port_specific(self):
+        raw = b"SNAP=/models/a\0SERVE=1\0COLI_SERVE_PORT=9000\0"
+        self.assertTrue(coli._serve_environ_matches_port(raw, 9000))
+        self.assertFalse(coli._serve_environ_matches_port(raw, 8000))
+
+    def test_serve_tags_the_engine_environment(self):
+        args = types.SimpleNamespace(port=9123)
+        with mock.patch.object(coli, "env_for_engine", return_value={"X": "1"}):
+            env = coli._serve_engine_env(args, "glm")
+        self.assertEqual(env, {"X": "1", "COLI_SERVE_PORT": "9123"})
+
+    def test_stop_handles_platform_without_proc(self):
+        args = types.SimpleNamespace(port=9123, dry_run=True)
+        with mock.patch.object(coli, "banner"), \
+             mock.patch.object(coli, "serve_pidfile", return_value="/not/a/pidfile"), \
+             mock.patch.object(coli.os, "listdir", side_effect=OSError):
+            coli.cmd_stop(args)
+
+    @unittest.skipUnless(sys.platform.startswith("linux") and Path("/proc").is_dir(),
+                         "process discovery uses Linux /proc")
+    def test_stop_kills_only_the_requested_server(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = Path(tmp) / "coli"
+            script.write_text("import time\ntime.sleep(60)\n", encoding="utf-8")
+            own = subprocess.Popen([sys.executable, str(script), "serve",
+                                    "--port", "9123"])
+            other = subprocess.Popen([sys.executable, str(script), "serve",
+                                      "--port", "9124"])
+            try:
+                for _ in range(50):
+                    try:
+                        if b"serve" in Path(f"/proc/{own.pid}/cmdline").read_bytes():
+                            break
+                    except OSError:
+                        pass
+                    time.sleep(0.02)
+                args = types.SimpleNamespace(port=9123, dry_run=False)
+                with mock.patch.object(coli, "banner"), \
+                     mock.patch.object(coli, "serve_pidfile",
+                                       return_value=os.path.join(tmp, "missing.pid")), \
+                     mock.patch.object(coli.time, "sleep"), \
+                     contextlib.redirect_stdout(io.StringIO()):
+                    coli.cmd_stop(args)
+                own.wait(timeout=5)
+                self.assertIsNone(other.poll(), "stop killed a server on another port")
+            finally:
+                for process in (own, other):
+                    if process.poll() is None:
+                        process.terminate()
+                    process.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tests/test_supervisor_scope.py
+++ b/c/tests/test_supervisor_scope.py
@@ -1,0 +1,61 @@
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+C_DIR = Path(__file__).resolve().parents[1]
+SUPERVISOR = C_DIR / "scripts" / "supervisor.sh"
+
+
+@unittest.skipUnless(
+    sys.platform.startswith("linux") and shutil.which("flock") and Path("/proc").is_dir(),
+    "the conversion supervisor targets Linux/WSL",
+)
+class SupervisorScopeTests(unittest.TestCase):
+    def test_completion_stops_only_its_own_converter(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            script = root / "convert_fp8_to_int4.py"
+            script.write_text("import time\ntime.sleep(60)\n", encoding="utf-8")
+            own_dir = root / "own model"
+            other_dir = root / "other model"
+            own_dir.mkdir()
+            other_dir.mkdir()
+
+            own = subprocess.Popen([
+                sys.executable, str(script), "--repo", "repo", "--outdir", str(own_dir)
+            ])
+            other = subprocess.Popen([
+                sys.executable, str(script), "--repo", "repo", "--outdir", str(other_dir)
+            ])
+            try:
+                for _ in range(50):
+                    cmdline = Path(f"/proc/{own.pid}/cmdline")
+                    if cmdline.exists() and b"convert_fp8_to_int4.py" in cmdline.read_bytes():
+                        break
+                    time.sleep(0.02)
+                env = os.environ.copy()
+                env.update({"COLI_MODEL": str(own_dir), "TOTAL_SHARDS": "0"})
+                result = subprocess.run(
+                    ["bash", str(SUPERVISOR)], cwd=C_DIR, env=env,
+                    text=True, capture_output=True, timeout=10, check=False,
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                own.wait(timeout=5)
+                self.assertIsNone(other.poll(),
+                                  "the supervisor stopped another model's converter")
+            finally:
+                for process in (own, other):
+                    if process.poll() is None:
+                        process.terminate()
+                    process.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tools/datapoint.py
+++ b/c/tools/datapoint.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""datapoint.py - run the standard colibri machine datapoint.
+
+Measures what docs/benchmarks.md asks for - engine load, capped greedy
+decode tok/s, and iobench disk figures - and prints a ready-to-paste
+markdown datapoint block.
+
+The decode number is exact: generation is capped at --max-new tokens,
+so the token count is known without re-tokenizing the output.
+
+Cold vs warm: before measuring, the page cache is evicted (macOS: `purge`
+if permitted, otherwise by writing a temp file larger than RAM, which
+forces resident pages out). The first decode run is then a true cold
+run; the second is warm. iobench cold runs right after eviction, before
+the decode runs can re-warm the container. Use --no-evict to skip the
+eviction (e.g. when cache warmth is irrelevant or eviction is unwanted).
+
+Usage:
+  python tools/datapoint.py --snap models/olmoe_merged [--engine ./olmoe]
+                            [--shard models/olmoe_merged/model-00000.safetensors]
+                            [--max-new 128] [--warm-runs 1]
+"""
+
+import argparse
+import os
+import platform
+import re
+import subprocess
+import sys
+import tempfile
+import time
+
+LOAD_RE = re.compile(r"resident weights loaded in ([\d.]+)s \| RSS after load: ([\d.]+) GB")
+IOBENCH_RE = re.compile(r"-> ([\d.]+) GB/s")
+
+
+def machine_info():
+    info = {}
+    if sys.platform == "darwin":
+        info["cpu"] = subprocess.run(["sysctl", "-n", "machdep.cpu.brand_string"],
+                                     capture_output=True, text=True).stdout.strip()
+        mem = subprocess.run(["sysctl", "-n", "hw.memsize"],
+                             capture_output=True, text=True).stdout.strip()
+        info["ram"] = f"{int(mem) / 1073741824:.0f} GB"
+        info["ram_gb"] = int(mem) / 1073741824
+        info["os"] = platform.mac_ver()[0]
+    elif sys.platform.startswith("linux"):
+        info["cpu"] = platform.processor() or "?"
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemTotal:"):
+                    info["ram_gb"] = int(line.split()[1]) / 1048576
+                    info["ram"] = f"{info['ram_gb']:.0f} GB"
+                    break
+        info["os"] = platform.platform()
+    else:
+        info["cpu"] = platform.processor() or "?"
+        info["ram"] = "?"
+        info["ram_gb"] = 8.0
+        info["os"] = platform.platform()
+    info["cores"] = os.cpu_count()
+    return info
+
+
+def evict_cache(ram_gb):
+    """Evict resident page cache pages without privileges.
+
+    macOS `purge` needs root; the portable fallback writes a temp file
+    larger than RAM, which forces the older resident pages out of cache.
+    Returns True if an eviction was actually attempted.
+    """
+    if sys.platform == "darwin":
+        r = subprocess.run(["purge"], capture_output=True)
+        if r.returncode == 0:
+            return True
+    size_mb = int(ram_gb) * 1024 + 1024
+    try:
+        with tempfile.NamedTemporaryFile(delete=True, suffix=".evict") as f:
+            chunk = b"\0" * (1 << 20)
+            written = 0
+            while written < size_mb:
+                f.write(chunk)
+                written += 1
+            f.flush()
+        return True
+    except OSError as e:
+        print(f"[datapoint] cache eviction skipped: {e}", file=sys.stderr)
+        return False
+
+
+def run_engine(engine, snap, prompt, max_new, runs, cap, bits):
+    results = []
+    for i in range(runs):
+        env = dict(os.environ, CHAT="1", TEMP="0", MAX_NEW=str(max_new), SNAP=snap)
+        t0 = time.monotonic()
+        proc = subprocess.run([engine, str(cap), str(bits)], input=prompt + "\n",
+                              capture_output=True, text=True, env=env)
+        wall = time.monotonic() - t0
+        m = LOAD_RE.search(proc.stdout) or LOAD_RE.search(proc.stderr)
+        if not m:
+            sys.exit(f"could not parse engine load line from stdout/stderr:\n{proc.stdout[-300:]}{proc.stderr[-300:]}")
+        load_s, rss = float(m.group(1)), float(m.group(2))
+        gen_s = wall - load_s
+        results.append({"tokens": max_new, "wall_s": wall, "gen_s": gen_s,
+                        "tok_s": max_new / gen_s, "rss": rss, "load_s": load_s})
+    return results
+
+
+def run_iobench(iobench, shard, mode):
+    proc = subprocess.run([iobench, shard, "19", "64", "8", str(mode)],
+                          capture_output=True, text=True)
+    m = IOBENCH_RE.search(proc.stdout)
+    return float(m.group(1)) if m else None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--engine", default="./olmoe", help="engine binary (default ./olmoe)")
+    ap.add_argument("--snap", required=True, help="model snapshot directory")
+    ap.add_argument("--iobench", default="./iobench", help="iobench binary")
+    ap.add_argument("--shard", default=None, help="shard file for iobench")
+    ap.add_argument("--prompt", default="Continue this story: The lighthouse keeper climbed the stairs and saw something impossible in the fog. ",
+                    help="prompt used for the decode runs")
+    ap.add_argument("--max-new", type=int, default=128, help="decode cap per run")
+    ap.add_argument("--warm-runs", type=int, default=1, help="warm decode runs after the cold run")
+    ap.add_argument("--cap", type=int, default=16, help="per-layer expert cache cap passed to the engine")
+    ap.add_argument("--bits", type=int, default=8, help="quant bits passed to the engine")
+    ap.add_argument("--no-evict", action="store_true", help="skip page-cache eviction")
+    args = ap.parse_args()
+
+    info = machine_info()
+    evicted = False if args.no_evict else evict_cache(info.get("ram_gb", 8.0))
+    cold_label = "cold (cache evicted)" if evicted else "cold (cache not evicted)"
+
+    disk = {}
+    if args.shard and evicted:
+        # true cold disk figure first, before decode re-warms the container
+        disk["cold"] = run_iobench(args.iobench, args.shard, 1)
+
+    cold = run_engine(args.engine, args.snap, args.prompt, args.max_new, 1, args.cap, args.bits)
+    warm = run_engine(args.engine, args.snap, args.prompt, args.max_new, max(1, args.warm_runs), args.cap, args.bits)
+
+    if args.shard:
+        if "cold" not in disk:
+            disk["cold"] = run_iobench(args.iobench, args.shard, 1)
+        disk["buffered"] = run_iobench(args.iobench, args.shard, 0)
+
+    out = ["**Datapoint (automated runner)**", "", "| component | detail |",
+           "|---|---|", f"| machine | {info['cpu']} |",
+           f"| RAM | {info['ram']} |", f"| cores | {info['cores']} |",
+           f"| OS | {info['os']} |", f"| engine | {os.path.basename(args.engine)}, snapshot {args.snap}, cap={args.cap}, bits={args.bits} |",
+           "", f"**Decode (TEMP=0, capped at {args.max_new} tokens, exact count):**", "",
+           "| phase | tokens | gen s | tok/s | RSS after load |", "|---|---|---|---|---|"]
+    for r in cold:
+        out.append(f"| {cold_label} | {r['tokens']} | {r['gen_s']:.2f} | {r['tok_s']:.2f} | {r['rss']:.2f} GB |")
+    for r in warm:
+        out.append(f"| warm | {r['tokens']} | {r['gen_s']:.2f} | {r['tok_s']:.2f} | {r['rss']:.2f} GB |")
+    out.append(f"| load | - | {cold[0]['load_s']:.2f} | - | - |")
+
+    if args.shard:
+        out += ["", "**Disk (iobench, 19 MB x 64, 8 threads):**", "",
+                "| mode | GB/s |", "|---|---|"]
+        for name, val in disk.items():
+            out.append(f"| {name} | {val:.2f} |" if val is not None else f"| {name} | n/a |")
+        if sys.platform == "darwin":
+            out += ["", "Note: macOS has no O_DIRECT; iobench uses F_NOCACHE, which stops new caching",
+                    "but cannot evict pages already resident (doc caveat #86). The cold figure above was",
+                    "taken right after cache eviction, before decode re-warmed the container."]
+
+    print("\n".join(out))
+
+
+if __name__ == "__main__":
+    main()

--- a/c/v4_dsml.py
+++ b/c/v4_dsml.py
@@ -1,0 +1,249 @@
+"""DeepSeek V4 DSML primitives, vendored from the checkpoint reference.
+
+Byte-exact excerpts of ``encoding/encoding_dsv4.py`` (inside
+``deepseek-ai/DeepSeek-V4-Flash-0731``) covering the DSML surfaces the gateway
+speaks: the tool-declaration template, the ``<｜DSML｜tool_calls>`` block
+encoding, and the strict block parser. Keeping these as verbatim reference
+code (instead of a re-implementation) makes a checkpoint encoding revision a
+mechanical re-vendor + diff.
+
+What is deliberately NOT vendored:
+
+- ``encode_messages`` / ``render_message`` — the gateway's turn structure
+  (``render_chat_v4``) is authoritative: it always terminates the prompt with
+  an assistant generation cue (the reference leaves a trailing assistant
+  ``tool_calls`` turn uncued), renders ``reasoning_content`` for every turn
+  that carries one, and merges ``tool`` messages itself.
+- ``REASONING_EFFORT_PROMPTS`` — the gateway ships tuned effort prompts with
+  an explicit token budget; the reference's unbounded "no shortcuts
+  permitted" variants routinely consumed the whole completion budget with
+  reasoning.
+
+Gateway adaptations, each marked ADAPTED below:
+
+- ``tool_calls_from_openai_format`` accepts ``arguments`` as a JSON string OR
+  a dict (messages arrive from arbitrary OpenAI clients).
+- ``parse_completion_text`` wraps the strict reference parser so malformed or
+  truncated DSML degrades to plain content instead of raising, and re-shapes
+  calls to the gateway contract ({"id", "type", "function": {...}}).
+"""
+
+import json
+import re
+import sys
+import uuid
+
+# ============================================================
+# Special tokens and templates (byte-exact with the reference)
+# ============================================================
+
+bos_token: str = "<｜begin▁of▁sentence｜>"
+eos_token: str = "<｜end▁of▁sentence｜>"
+thinking_start_token: str = "<think>"
+thinking_end_token: str = "</think>"
+dsml_token: str = "｜DSML｜"
+
+tool_call_template: str = (
+    "<{dsml_token}invoke name=\"{name}\">\n{arguments}\n</{dsml_token}invoke>"
+)
+tool_calls_template = (
+    "<{dsml_token}{tc_block_name}>\n{tool_calls}\n</{dsml_token}{tc_block_name}>"
+)
+tool_calls_block_name: str = "tool_calls"
+
+tool_output_template: str = "<tool_result>{content}</tool_result>"
+
+# Marker that opens a tool_calls block in model output (used by the gateway's
+# streaming suppression as well as the parser).
+TOOL_CALLS_OPEN = f"<{dsml_token}{tool_calls_block_name}>"    # full opener (streaming suppression)
+TOOL_CALLS_PREFIX = f"<{dsml_token}{tool_calls_block_name}"   # reference parse anchor (no '>')
+TOOL_CALLS_BLOCK_START = "\n\n" + TOOL_CALLS_PREFIX           # as emitted in model output
+
+TOOLS_TEMPLATE = """## Tools
+
+You have access to a set of tools to help answer the user's question. You can invoke tools by writing a "<{dsml_token}tool_calls>" block like the following:
+
+<{dsml_token}tool_calls>
+<{dsml_token}invoke name="$TOOL_NAME">
+<{dsml_token}parameter name="$PARAMETER_NAME" string="true|false">$PARAMETER_VALUE</{dsml_token}parameter>
+...
+</{dsml_token}invoke>
+<{dsml_token}invoke name="$TOOL_NAME2">
+...
+</{dsml_token}invoke>
+</{dsml_token}tool_calls>
+
+String parameters should be specified as is and set `string="true"`. For all other types (numbers, booleans, arrays, objects), pass the value in JSON format and set `string="false"`.
+
+If thinking_mode is enabled (triggered by {thinking_start_token}), you MUST output your complete reasoning inside {thinking_start_token}...{thinking_end_token} BEFORE any tool calls or final response.
+
+Otherwise, output directly after {thinking_end_token} with tool calls or final response.
+
+### Available Tool Schemas
+
+{tool_schemas}
+
+You MUST strictly follow the above defined tool name and parameter schemas to invoke tool calls.
+"""
+
+# ============================================================
+# Encoding helpers (byte-exact unless marked ADAPTED)
+# ============================================================
+
+def to_json(value):
+    try:
+        return json.dumps(value, ensure_ascii=False)
+    except Exception:
+        return json.dumps(value, ensure_ascii=True)
+
+
+def tools_from_openai_format(tools):
+    return [tool.get("function", tool) for tool in tools]
+
+
+def tool_calls_from_openai_format(tool_calls):
+    """ADAPTED: tolerate "arguments" given as a dict, not only a JSON string."""
+    out = []
+    for tool_call in tool_calls:
+        fn = tool_call.get("function", tool_call) if isinstance(tool_call, dict) else {}
+        args = fn.get("arguments", "{}")
+        if not isinstance(args, str):
+            args = to_json(args)
+        out.append({"name": fn.get("name"), "arguments": args})
+    return out
+
+
+def encode_arguments_to_dsml(tool_call):
+    p_dsml_template = '<{dsml_token}parameter name="{key}" string="{is_str}">{value}</{dsml_token}parameter>'
+    p_dsml_strs = []
+    try:
+        arguments = json.loads(tool_call["arguments"])
+    except Exception:
+        arguments = {"arguments": tool_call["arguments"]}
+    if not isinstance(arguments, dict):
+        arguments = {"arguments": arguments}
+    for k, v in arguments.items():
+        p_dsml_strs.append(p_dsml_template.format(
+            dsml_token=dsml_token, key=k,
+            is_str="true" if isinstance(v, str) else "false",
+            value=v if isinstance(v, str) else to_json(v)))
+    return "\n".join(p_dsml_strs)
+
+
+def decode_dsml_to_arguments(tool_name, tool_args):
+    def _decode_value(key, value, string):
+        if string == "true":
+            value = to_json(value)
+        return f"{to_json(key)}: {value}"
+    tool_args_json = ("{" + ", ".join(
+        [_decode_value(k, v, string=is_str) for k, (v, is_str) in tool_args.items()]) + "}")
+    return dict(name=tool_name, arguments=tool_args_json)
+
+
+def render_tools(tools):
+    tools_json = [to_json(t) for t in tools]
+    return TOOLS_TEMPLATE.format(
+        tool_schemas="\n".join(tools_json),
+        dsml_token=dsml_token,
+        thinking_start_token=thinking_start_token,
+        thinking_end_token=thinking_end_token,
+    )
+
+
+def render_tool_calls(tool_calls):
+    """OpenAI-format tool_calls -> the DSML block a V4 assistant turn carries,
+    including the reference's leading blank line."""
+    calls = tool_calls_from_openai_format(tool_calls)
+    rendered = [
+        tool_call_template.format(dsml_token=dsml_token,
+                                  name=tc.get("name") or "",
+                                  arguments=encode_arguments_to_dsml(tc))
+        for tc in calls
+    ]
+    return "\n\n" + tool_calls_template.format(
+        dsml_token=dsml_token, tool_calls="\n".join(rendered),
+        tc_block_name=tool_calls_block_name)
+
+
+# ============================================================
+# Parsing — strict reference core + tolerant gateway wrapper
+# ============================================================
+
+def _read_until_stop(index, text, stop):
+    min_pos = len(text)
+    matched_stop = None
+    for s in stop:
+        pos = text.find(s, index)
+        if pos != -1 and pos < min_pos:
+            min_pos = pos
+            matched_stop = s
+    if matched_stop:
+        return min_pos + len(matched_stop), text[index:min_pos], matched_stop
+    return len(text), text[index:], None
+
+
+def _parse_tool_calls_strict(index, text):
+    """Reference parse of a <dsml>tool_calls block. Raises ValueError on malformed."""
+    tool_calls = []
+    tool_calls_end_token = f"</{dsml_token}{tool_calls_block_name}>"
+    while index < len(text):
+        index, sep, stop_token = _read_until_stop(
+            index, text, [f"<{dsml_token}invoke", tool_calls_end_token])
+        if sep != ">\n":
+            raise ValueError(f"Tool call format error: expected '>\\n' but got '{sep}'")
+        if stop_token == tool_calls_end_token:
+            break
+        if stop_token is None:
+            raise ValueError("Missing special token in tool calls")
+        index, tool_name_content, stop_token = _read_until_stop(
+            index, text, [f"<{dsml_token}parameter", f"</{dsml_token}invoke"])
+        p_tool_name = re.findall(r'^\s*name="(.*?)">\n$', tool_name_content, flags=re.DOTALL)
+        if len(p_tool_name) != 1:
+            raise ValueError(f"Tool name format error: '{tool_name_content}'")
+        tool_name = p_tool_name[0]
+        tool_args = {}
+        while stop_token == f"<{dsml_token}parameter":
+            index, param_content, stop_token = _read_until_stop(
+                index, text, [f"/{dsml_token}parameter"])
+            param_kv = re.findall(r'^ name="(.*?)" string="(true|false)">(.*?)<$',
+                                  param_content, flags=re.DOTALL)
+            if len(param_kv) != 1:
+                raise ValueError(f"Parameter format error: '{param_content}'")
+            param_name, string, param_value = param_kv[0]
+            if param_name in tool_args:
+                raise ValueError(f"Duplicate parameter name: '{param_name}'")
+            tool_args[param_name] = (param_value, string)
+            index, content, stop_token = _read_until_stop(
+                index, text, [f"<{dsml_token}parameter", f"</{dsml_token}invoke"])
+            if content != ">\n":
+                raise ValueError(f"Parameter format error: expected '>\\n' but got '{content}'")
+        tool_calls.append(decode_dsml_to_arguments(tool_name=tool_name, tool_args=tool_args))
+    return index, stop_token, tool_calls
+
+
+def parse_completion_text(text):
+    """ADAPTED: split `content [+ blank line + DSML tool_calls block]` from a
+    finished assistant turn. Never raises.
+
+    Returns (content, tool_calls) where tool_calls use the gateway shape
+    [{"id": "call_...", "type": "function", "function": {"name", "arguments"}}].
+    Malformed or truncated DSML degrades to plain content (logged to stderr);
+    the caller decides whether raw markers may stay visible.
+    """
+    cut = text.find(TOOL_CALLS_BLOCK_START)
+    parse_at = cut + len(TOOL_CALLS_BLOCK_START) if cut >= 0 else -1
+    if cut < 0 and text.startswith(TOOL_CALLS_PREFIX):
+        cut, parse_at = 0, len(TOOL_CALLS_PREFIX)   # reply opening directly with the block
+    if cut < 0:
+        return text, []
+    try:
+        _index, _stop, calls = _parse_tool_calls_strict(parse_at, text)
+    except ValueError as exc:
+        sys.stderr.write(f"[api] deepseek_v4: DSML tool_calls parse failed ({exc}) "
+                         "-- treating as plain content\n")
+        sys.stderr.flush()
+        return text, []
+    shaped = [{"id": "call_" + uuid.uuid4().hex[:24], "type": "function",
+               "function": {"name": c["name"], "arguments": c["arguments"]}}
+              for c in calls]
+    return text[:cut], shaped

--- a/c/version.py
+++ b/c/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the colibri version number."""
 
-__version__ = "1.6.1"
+__version__ = "1.6.2"

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -52,11 +52,16 @@ gcc -O2 -fopenmp iobench.c -o iobench
 # 2) chat; watch the per-turn stats line (tok/s, expert hit-rate, RSS):
 COLI_MODEL=/path/to/glm52_i4 ./coli chat
 
-# 3) record expert usage, then pin the hottest experts in your spare RAM:
+# 3) full automated datapoint — machine info + cold/warm decode + disk, one command:
+python tools/datapoint.py --snap /path/to/model --shard /path/to/container/model-00000.safetensors
+# (stdlib-only; evicts the page cache before the cold run, caps decode at --max-new
+#  tokens so tok/s is exact, and prints a ready-to-paste datapoint block)
+
+# 4) record expert usage, then pin the hottest experts in your spare RAM:
 STATS=stats.txt ./coli chat
 PIN=stats.txt PIN_GB=20 ./coli chat        # scale PIN_GB to your free RAM
 
-# 4) quality benchmarks (MMLU/HellaSwag/ARC):
+# 5) quality benchmarks (MMLU/HellaSwag/ARC):
 ./coli bench
 ```
 

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -1,0 +1,127 @@
+const de: Record<string, string> = {
+  // navigation
+  "nav.chat": "Chat",
+  "nav.brain": "Expertenkarte",
+  "nav.profiling": "Profiling",
+
+  // Marke
+  "brand.tagline": "lokaler Riese, kleiner Fußabdruck",
+
+  // Seitenleiste – Verbindung
+  "sidebar.connection": "Verbindung",
+  "sidebar.endpoint": "API-Endpunkt",
+  "sidebar.apiKey": "API-Schlüssel",
+  "sidebar.apiKeyPlaceholder": "optional",
+  "sidebar.apiKeyHelp": "Nur im Speicher · wird an diesen Endpunkt gesendet",
+  "sidebar.probe": "Server prüfen",
+  "status.connected": "Engine erreichbar",
+  "status.notConnected": "Nicht verbunden",
+  "status.runtimeUnavailable": "Laufzeitmetriken nicht verfügbar",
+  "status.serverError": "Server konnte nicht erreicht werden.",
+  "status.generationFailed": "Generierung fehlgeschlagen.",
+
+  // Seitenleiste – Laufzeit
+  "sidebar.runtime": "Laufzeit",
+  "sidebar.runtimeProbe": "Server prüfen, um den Laufzeitstatus zu sehen.",
+  "sidebar.schedulerOnline": "Scheduler online",
+  "dashboard.active": "Aktiv",
+  "dashboard.queued": "Wartend",
+  "dashboard.completed": "Abgeschlossen",
+  "dashboard.failures": "Fehler",
+  "dashboard.session": "Sitzung:",
+  "dashboard.prompt": "Prompt",
+  "dashboard.completion": "Antwort",
+
+  // Seitenleiste – Tiers
+  "tier.vram": "VRAM",
+  "tier.ram": "RAM",
+  "tier.disk": "Datenträger",
+  "tier.ariaLabel": "Experten: {{vram}} VRAM, {{ram}} RAM, {{disk}} Datenträger",
+
+  // Seitenleiste – Inferenz
+  "sidebar.inference": "Inferenz",
+  "sidebar.model": "Modell",
+  "sidebar.kvSession": "KV-Sitzung",
+  "sidebar.kvSessionHelp": "Isolierter Kontext · Unterhaltung folgt dem gewählten Slot",
+  "sidebar.sessionLabel": "Sitzung {{slot}}",
+  "sidebar.temperature": "Temperatur",
+  "sidebar.maxTokens": "Maximale Ausgabetokens",
+  "sidebar.reasoning": "Reasoning",
+  "sidebar.transport": "OpenAI-kompatibler Transport",
+
+  // Kopfzeile
+  "topbar.activeModel": "AKTIVES MODELL",
+  "topbar.tokens": "{{n}} Tokens",
+  "topbar.tokPerSec": "{{n}} Tok/s",
+  "topbar.slot": "Slot {{n}}",
+  "topbar.truncated": "Abgeschnitten",
+  "topbar.truncatedHelp": "Die Antwort erreichte die maximale Tokenanzahl und wurde abgeschnitten. Erhöhe \"Maximale Ausgabetokens\", um die vollständige Antwort zu sehen.",
+  "topbar.clear": "Leeren",
+
+  // Startansicht
+  "hero.title": "COLIBRÌ ENGINE",
+  "hero.subtitle": "Frag den Riesen.",
+  "hero.tagline": "Deine Hardware bleibt deine.",
+  "hero.description": "Mit einem lokalen Colibrì-Server verbinden und Antworten direkt von deiner Hardware streamen. Nichts verlässt den gewählten Endpunkt.",
+  "prompts.routing": "Erkläre, wie Experten-Routing funktioniert",
+  "prompts.benchmark": "Schreibe einen kleinen C-Benchmark",
+  "prompts.caching": "Vergleiche RAM- und VRAM-Caching",
+
+  // Chat
+  "chat.you": "Du",
+  "chat.colibri": "colibrì",
+  "chat.placeholder": "Nachricht an colibrì…",
+  "chat.inputHint": "Eingabetaste zum Senden · Umschalt+Eingabetaste für Zeilenumbruch",
+  "chat.stop": "Generierung stoppen",
+  "chat.send": "Nachricht senden",
+
+  // Expertenkarte
+  "brain.title": "Expertenkortex",
+  "brain.waiting": "warte auf Engine",
+  "brain.layers": "{{rows}} Schichten × {{cols}} Experten",
+  "brain.brightnessHint": "Helligkeit = Routing-Aktivität",
+  "brain.flashHint": "⚡ weißes Blinken = in diesem Zug geroutet",
+  "brain.connectHint": "Verbinde dich mit der Engine, um den Kortex zu sehen.",
+  "brain.neverRouted": "nie geroutet",
+  "brain.selections": "~2^{{heat}} Auswahlen",
+  "brain.specialist": "⭐ Spezialist: {{top}}",
+  "brain.generalist": "Generalist",
+  "brain.mtp": "MTP-Head – entwirft das nächste Token für spekulative Dekodierung",
+  "brain.early": "frühe Schichten – Oberflächenmerkmale: Tokens, Schreibweise, lokale Syntax",
+  "brain.lowerMiddle": "untere mittlere Schichten – Phrasenstruktur, Wortbeziehungen, einfache Fakten",
+  "brain.upperMiddle": "obere mittlere Schichten – Semantik, langer Kontext, Reasoning-Schritte",
+  "brain.late": "späte Schichten – Antwortplanung, Stil, Kohärenz",
+  "brain.final": "letzte Schichten – Ausgabeformung: wählt die tatsächliche nächste-Token-Verteilung",
+
+  // Profiling
+  "profile.title": "Profiling – wo die Engine Zeit pro Zug verbringt",
+  "profile.ioWait": "I/O-Wartezeit",
+  "profile.expertMatmul": "Experten-Matmul",
+  "profile.attention": "Attention",
+  "profile.lmHead": "LM-Head",
+  "profile.other": "Sonstiges",
+  "profile.empty": "Noch keine profilierten Züge – sende eine Chat-Nachricht, dann erscheint die Aufschlüsselung.",
+  "profile.connectHint": "Verbinde dich mit der Engine, um Zeiten pro Zug zu erfassen.",
+  "profile.lastTurn": "Letzter Zug",
+  "profile.wallTime": "Gesamtzeit",
+  "profile.batching": "Batching",
+  "profile.tokensPerForward": "Tokens / Forward",
+  "profile.diskService": "Datenträgerdienst",
+  "profile.overlapped": "mit Berechnung überlappt",
+  "profile.window": "Fenster · letzte {{n}} Züge",
+  "profile.throughputTitle": "Durchsatz pro Zug (Tok/s)",
+  "profile.phaseTitle": "Gesamtzeit pro Zug nach Phase (s)",
+  "profile.turnCol": "Zug",
+  "profile.tokensCol": "Tokens",
+  "profile.wallCol": "Gesamt",
+  "profile.turnsLabel": "{{n}} Züge · ältester → neuester",
+  "profile.oneTurn": "1 Zug",
+  "profile.diskNote": "Datenträgerdienst ist die Zeit zum Lesen von Experten in I/O-Threads; sie überlappt mit der Berechnung. Nur die I/O-Wartezeit des Rechenthreads fließt in die Gesamtzeit ein. Bei mehreren KV-Sitzungen beschreiben die Anteile die ganze Engine im Zeitfenster des Zuges.",
+
+  // Fehlergrenze
+  "error.title": "Die colibrì-Oberfläche hat einen Fehler festgestellt",
+  "error.hint": "Die Engine ist nicht betroffen. Versuche, die Seite neu zu laden.",
+  "error.retry": "Erneut versuchen",
+}
+
+export default de

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -4,12 +4,14 @@ import en from "./en"
 import zhCN from "./zh-CN"
 import zhTW from "./zh-TW"
 import it from "./it"
+import de from "./de"
 
 const LOCALES = [
   { code: "en", label: "English" },
   { code: "zh-CN", label: "简体中文" },
   { code: "zh-TW", label: "繁體中文" },
   { code: "it", label: "Italiano" },
+  { code: "de", label: "Deutsch" },
 ] as const
 
 const DICTS: Record<string, Record<string, string>> = {
@@ -17,6 +19,7 @@ const DICTS: Record<string, Record<string, string>> = {
   "zh-CN": zhCN,
   "zh-TW": zhTW,
   "it": it,
+  "de": de,
 }
 
 const STORAGE_KEY = "colibri-locale"


### PR DESCRIPTION
## v1.6.2 — security release

Headline: **six privately-reported memory-safety advisories fixed** (#1018), all reachable from attacker-controlled input (a malicious model file / `config.json`, or the kimi_k3 SERVE stdin). Each fix validates at the trust boundary with no behavioural change on well-formed models or requests.

| Advisory | File | Class |
|---|---|---|
| GHSA-gf38 | `kimi_k3.c` | signed overflow → heap OOB write |
| GHSA-2qrj | `json.h` | OOB read past NUL |
| GHSA-w696 | `inkling.c` | config-controlled OOB read |
| GHSA-7654 | `deepseek_v4.c` | negative RoPE offset OOB R/W |
| GHSA-9gjf | `deepseek_v4.c` + `deepseek_v4_dspark.inc` | OOB read into logits |
| GHSA-8p69 | `deepseek_v4_dspark.inc` | file-controlled heap overflow write |

Tensor-shape checks use `>= expected` so a legitimately padded official checkpoint is never false-rejected.

Also carries everything merged to `dev` since v1.6.1 (V4 serve-telemetry #1005/#890, and assorted small fixes).

**Verification:** #1018 landed on dev with 19/19 checks green; engines build clean; `test_json`, `test_kimi_request_state`, `test_deepseek_v4` and the DSpark source test pass; ASAN confirms the json OOB read is gone.

Merge to `main`, then tag `v1.6.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)