### PR TITLE
chore: version 1.6.2

### DIFF
--- a/c/version.py
+++ b/c/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the colibri version number."""
 
-__version__ = "1.6.1"
+__version__ = "1.6.2"


### PR DESCRIPTION
Bumps the single-source-of-truth version to **1.6.2** for the security release (six loader/serve advisories, #1018). Lands on `dev` so the release PR #1019 (dev → main) carries it before tagging `v1.6.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)