### PR TITLE
fix(release): package v4_dsml.py so the archived openai_server imports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,7 @@ jobs:
           cp c/coli dist/
           cp c/version.py dist/
           cp c/openai_server.py dist/
+          cp c/v4_dsml.py dist/        # openai_server imports v4_dsml (vendored DeepSeek V4 DSML primitives); without it the packaged server won't import
           cp c/resource_plan.py dist/
           cp c/doctor.py dist/
           cp c/autotune.py dist/


### PR DESCRIPTION
The **v1.6.2** tag build failed the *verify the packaged archive actually runs* step with `ModuleNotFoundError: No module named 'v4_dsml'`.

`c/openai_server.py` imports `v4_dsml` (vendored DeepSeek V4 DSML primitives from #1003/#948) but `release.yml` never copied `c/v4_dsml.py` into the archive — so the packaged server can't import. One-line fix: copy it next to `openai_server.py`.

Unrelated to the security fixes in v1.6.2; this is a pre-existing packaging gap that the first release since the DSML refactor exposed. After merge → dev → main, the `v1.6.2` tag is re-pointed so release.yml re-runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)