### PR TITLE
Release v1.6.2 (repackage) — add v4_dsml.py to the archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,7 @@ jobs:
           cp c/coli dist/
           cp c/version.py dist/
           cp c/openai_server.py dist/
+          cp c/v4_dsml.py dist/        # openai_server imports v4_dsml (vendored DeepSeek V4 DSML primitives); without it the packaged server won't import
           cp c/resource_plan.py dist/
           cp c/doctor.py dist/
           cp c/autotune.py dist/


### PR DESCRIPTION
Follow-up to the v1.6.2 tag build, which failed the *verify the packaged archive* step with `ModuleNotFoundError: No module named 'v4_dsml'`.

Brings the packaging fix (#1021) to `main`: `release.yml` now copies `c/v4_dsml.py` next to `openai_server.py`. No engine/source changes — the six security fixes from v1.6.2 are unchanged.

After merge, the `v1.6.2` tag is re-pointed to this commit so release.yml re-runs and publishes the artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)