### PR TITLE
fix(docker): package the gateway's DSML module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,11 @@ jobs:
         run: |
           docker run --rm colibri:ci --version
           docker run --rm colibri:ci --help > /dev/null
+          # The gateway has runtime modules that launcher-only commands do not
+          # import. Exercise that boundary so the advertised serve path cannot
+          # ship with a missing Python file.
+          docker run --rm --entrypoint python3 colibri:ci -c \
+            "import openai_server; print('gateway imports')"
       - name: The engine binary is in the image and is executable
         run: docker run --rm --entrypoint /app/colibri colibri:ci --help 2>&1 | head -5 || true
       - name: Lint both Dockerfiles

--- a/docker/Dockerfile.slim
+++ b/docker/Dockerfile.slim
@@ -38,7 +38,7 @@ WORKDIR /app
 # The engine binary plus the launcher and the files it resolves at runtime
 # (version.py, the gateway, resource planner, doctor, tokenizer headers, tools).
 COPY --from=build /src/c/colibri            ./colibri
-COPY c/coli c/version.py c/openai_server.py c/resource_plan.py c/doctor.py c/autotune.py ./
+COPY c/coli c/version.py c/openai_server.py c/v4_dsml.py c/resource_plan.py c/doctor.py c/autotune.py ./
 COPY c/tools/ ./tools/
 
 ENV COLI_MODEL=/model \


### PR DESCRIPTION
## Summary

- copy `v4_dsml.py` into the slim runtime image next to `openai_server.py`
- import the gateway inside the built image in CI

## Why

`openai_server.py` now imports `v4_dsml` unconditionally, but the slim image does not copy that module. As a result, the documented `coli serve` path exits with `ModuleNotFoundError` even though the current container checks pass through launcher-only commands.

The new check crosses the same runtime boundary that failed in the v1.6.2 release archive: it imports the packaged gateway inside the built image, so a missing Python runtime module fails CI.

## Validation

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- `make check` passed all C tests and 471 Python tests with 59 skipped on macOS arm64
- local Docker build not run because the Docker daemon is not running; the PR container job performs the image build and in-container import

## Compatibility

- the default CPU image remains dependency-free beyond Python's standard library
- no model files, generated binaries, or benchmark artifacts are included
