### PR TITLE
fix(convert): publish OLMoE shards atomically

### DIFF
--- a/c/tests/test_olmoe_atomic_output.py
+++ b/c/tests/test_olmoe_atomic_output.py
@@ -1,0 +1,107 @@
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+CONVERTER = Path(__file__).resolve().parent.parent / "tools" / "convert_olmoe_merged.py"
+
+
+def load_converter():
+    torch = types.ModuleType("torch")
+    safetensors = types.ModuleType("safetensors")
+    safetensors.safe_open = mock.Mock()
+    safetensors_torch = types.ModuleType("safetensors.torch")
+    safetensors_torch.save_file = mock.Mock()
+    spec = importlib.util.spec_from_file_location("olmoe_atomic_output_test", CONVERTER)
+    module = importlib.util.module_from_spec(spec)
+    with mock.patch.dict(sys.modules, {
+        "torch": torch,
+        "safetensors": safetensors,
+        "safetensors.torch": safetensors_torch,
+    }):
+        spec.loader.exec_module(module)
+    return module
+
+
+converter = load_converter()
+
+
+class FakeTensor:
+    def __init__(self, payload=b"tensor"):
+        self.payload = payload
+
+    def contiguous(self):
+        return self
+
+
+class AtomicOlmoeOutputTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.out_dir = Path(self.directory.name)
+        self.destination = self.out_dir / "model-00000.safetensors"
+        self.temporary = Path(str(self.destination) + ".tmp")
+
+    def test_success_publishes_complete_shard(self):
+        writer = converter.OutputWriter(self.out_dir)
+        writer.add("weight", FakeTensor(b"complete"))
+
+        def save_file(tensors, path):
+            Path(path).write_bytes(tensors["weight"].payload)
+
+        with mock.patch.object(converter, "save_file", side_effect=save_file):
+            writer.flush()
+
+        self.assertEqual(self.destination.read_bytes(), b"complete")
+        self.assertFalse(self.temporary.exists())
+        self.assertEqual(writer.buf, {})
+        self.assertEqual(writer.shard_idx, 1)
+
+    def test_failed_save_cleans_temp_and_preserves_retry_state(self):
+        writer = converter.OutputWriter(self.out_dir)
+        tensor = FakeTensor()
+        writer.add("weight", tensor)
+        self.temporary.write_bytes(b"stale")
+
+        def fail_save(tensors, path):
+            self.assertFalse(Path(path).exists())
+            Path(path).write_bytes(b"partial")
+            raise OSError("disk full")
+
+        with mock.patch.object(converter, "save_file", side_effect=fail_save):
+            with self.assertRaisesRegex(OSError, "disk full"):
+                writer.flush()
+
+        self.assertFalse(self.destination.exists())
+        self.assertFalse(self.temporary.exists())
+        self.assertIs(writer.buf["weight"], tensor)
+        self.assertEqual(writer.shard_idx, 0)
+
+    def test_grouped_add_keeps_expert_companions_in_same_shard(self):
+        writer = converter.OutputWriter(self.out_dir, flush_every=3)
+        published = []
+
+        def save_file(tensors, path):
+            published.append(set(tensors))
+            Path(path).write_bytes(b"complete")
+
+        with mock.patch.object(converter, "save_file", side_effect=save_file):
+            writer.add("dense.a", FakeTensor())
+            writer.add("dense.b", FakeTensor())
+            writer.add_many((
+                ("expert.merged_weight", FakeTensor()),
+                ("expert.qs", FakeTensor()),
+            ))
+
+        self.assertEqual(len(published), 1)
+        self.assertIn("expert.merged_weight", published[0])
+        self.assertIn("expert.qs", published[0])
+        self.assertEqual(writer.buf, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tools/convert_olmoe_merged.py
+++ b/c/tools/convert_olmoe_merged.py
@@ -19,6 +19,7 @@ Usage:
 """
 
 import argparse
+import os
 import re
 import shutil
 import sys
@@ -78,7 +79,17 @@ class OutputWriter:
         self.shard_idx = len(list(out_dir.glob("model-*.safetensors")))
 
     def add(self, name: str, tensor: "torch.Tensor"):
-        self.buf[name] = tensor.contiguous()
+        self.add_many(((name, tensor),))
+
+    def add_many(self, tensors):
+        """Add a group of tensors before deciding whether to flush.
+
+        Companion tensors such as an expert's merged weights and row scales
+        must be published together so a resumed conversion never mistakes a
+        half-written expert for a completed one.
+        """
+        for name, tensor in tensors:
+            self.buf[name] = tensor.contiguous()
         if len(self.buf) >= self.flush_every:
             self.flush()
 
@@ -86,7 +97,13 @@ class OutputWriter:
         if not self.buf:
             return
         fn = self.out_dir / f"model-{self.shard_idx:05d}.safetensors"
-        save_file(self.buf, str(fn))
+        tmp = Path(str(fn) + ".tmp")
+        tmp.unlink(missing_ok=True)
+        try:
+            save_file(self.buf, str(tmp))
+            os.replace(tmp, fn)
+        finally:
+            tmp.unlink(missing_ok=True)
         print(f"  wrote {fn.name} ({len(self.buf)} tensors)", flush=True)
         self.buf = {}
         self.shard_idx += 1
@@ -164,8 +181,10 @@ def convert_local(src_dir: Path, out_dir: Path, flush_every: int):
             sys.exit(f"Missing projection for layer {layer} expert {expert}: have {list(projs)}")
         gate, up, down = get(projs["gate_proj"]), get(projs["up_proj"]), get(projs["down_proj"])
         merged_q, merged_s = convert_expert(gate, up, down)
-        writer.add(mw, merged_q)
-        writer.add(f"model.layers.{layer}.mlp.experts.{expert}.qs", merged_s)
+        writer.add_many((
+            (mw, merged_q),
+            (f"model.layers.{layer}.mlp.experts.{expert}.qs", merged_s),
+        ))
         n_done += 1
         if n_done % 100 == 0 or n_done == n_total:
             print(f"  {n_done}/{n_total} experts converted...", flush=True)
@@ -224,8 +243,10 @@ def convert_streaming(repo: str, out_dir: Path, flush_every: int, min_free_gb: f
                 slot[proj] = f.get_tensor(name)
                 if all(k in slot for k in ("gate_proj", "up_proj", "down_proj")):
                     merged_q, merged_s = convert_expert(slot["gate_proj"], slot["up_proj"], slot["down_proj"])
-                    writer.add(mw, merged_q)
-                    writer.add(f"model.layers.{layer}.mlp.experts.{expert}.qs", merged_s)
+                    writer.add_many((
+                        (mw, merged_q),
+                        (f"model.layers.{layer}.mlp.experts.{expert}.qs", merged_s),
+                    ))
                     del pending_experts[key]
 
         Path(local_path).unlink(missing_ok=True)  # delete the source shard now -- disk-safe


### PR DESCRIPTION
## Problem

The OLMoE converter wrote each output shard directly to its final name. An interrupted save could therefore leave a partial file that the resume scan treated as valid. There was also a second resume hazard: when the buffer was near its flush limit, `merged_weight` could be flushed before the expert's `.qs` scale tensor. A rerun sees `merged_weight` and treats that expert as complete, leaving the scale tensor missing.

## Change

- Save to a sibling `.tmp` file and publish with an atomic replace.
- Clean stale and failed temporary output.
- Keep the writer buffer and shard index unchanged when publication fails, so the same writer can retry.
- Add expert weights and scales as a group before checking the flush threshold in both local and streaming conversion.

The regression coverage reproduces a failed partial save and the flush-boundary case with a buffer one tensor below its limit.

## Verification

- `python3 -m unittest c.tests.test_olmoe_atomic_output`: 3 passed
- `python3 -m py_compile c/tools/convert_olmoe_merged.py c/tests/test_olmoe_atomic_output.py`
- `make check`: all C tests passed; 474 Python tests passed, 59 skipped
- `git diff --check`
