### PR TITLE
docs(api): map tool calling support by engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,9 @@ python ./coli chat --model /path/to/DeepSeek-V4-Flash --ram 22
 # also: coli run / coli serve / coli web
 ```
 
-Greedy decode, one KV slot; tools and grammar are not wired up yet.
+Greedy decode and one KV slot. Tool calling is wired through the HTTP gateway
+with V4's native prompt and DSML call blocks; grammar is not supported. See the
+[per-engine API matrix](docs/api.md#tool-calling-support).
 
 **Give it RAM.** 43 × 256 routed experts are ~137 GiB on disk and a token
 touches 301 of them, so the expert cache hit rate is what sets tok/s — `--ram`

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -108,7 +108,7 @@ Run directly (or via `coli serve`). OpenAI-compatible `/v1/chat/completions`.
 | `--queue-timeout` | `$COLI_QUEUE_TIMEOUT` or `300` | Request queue timeout (s). |
 | `--kv-slots` | `$COLI_KV_SLOTS` or `1` | KV conversation slots. |
 
-Tool calling (`tools` in the request) is supported; the opt-in `COLI_TOOL_SALVAGE=1` env var recovers malformed int4 tool calls. Server-relevant env vars: `COLI_METAL`, `PIPE`, `DIRECT`, `COLI_NO_OMP_TUNE`, `RAM_GB`, `CTX`, `KVSAVE` (all from [ENVIRONMENT.md](ENVIRONMENT.md)) apply because the server launches the same `glm` engine.
+Tool calling is supported by GLM and DeepSeek V4; Inkling, Kimi K3, and OLMoE reject active tool declarations and choices explicitly. See the [per-engine API matrix](api.md#tool-calling-support). The opt-in `COLI_TOOL_SALVAGE=1` env var recovers malformed GLM int4 tool calls; V4 uses its native DSML parser. Engine-specific runtime variables are listed in [ENVIRONMENT.md](ENVIRONMENT.md); the server passes the environment through to the selected engine.
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -39,14 +39,31 @@ sequences. The extension
 `enable_thinking: true` enables GLM-5.2's reasoning block; the standard
 `reasoning_effort` field also enables it unless set to `none`.
 
-The server is deliberately text-only and serves one generation at a time: the
-744B model stays in one persistent process, so concurrent HTTP requests queue
-instead of loading duplicate model copies. Tool-calling **is** supported on this
-path — pass OpenAI `tools` and (optionally) `tool_choice`, mirroring the
-Anthropic endpoint below. Image/audio input, log probabilities, and token
-penalties return an explicit error rather than being silently ignored. The
-default bind address is localhost; set `COLI_API_KEY` before exposing the
-server beyond the machine.
+The server serves one generation at a time: the model stays in one persistent
+process, so concurrent HTTP requests queue instead of loading duplicate model
+copies. Tool calling depends on the active engine; see the support matrix below.
+Images, log probabilities, and token penalties return an explicit error rather
+than being silently ignored. Audio is accepted only by Inkling checkpoints with
+audio support. The default bind address is localhost; set `COLI_API_KEY` before
+exposing the server beyond the machine.
+
+### Tool-calling support
+
+| Engine | OpenAI `tools` | Anthropic `tool_use` | Native format |
+|---|---|---|---|
+| GLM-5.2 (`colibri`) | yes | yes | `<tool_call>` blocks |
+| DeepSeek V4 | yes | yes | native DSML tool-call blocks |
+| Inkling | no | no | active tool declarations/choices return HTTP 400 |
+| Kimi K3 | no | no | active tool declarations/choices return HTTP 400 |
+| OLMoE | no | no | active tool declarations/choices return HTTP 400 |
+
+On supported engines, pass OpenAI `tools` and optionally `tool_choice` to
+`/v1/chat/completions`. The Anthropic endpoint translates `tools`,
+`tool_use`/`tool_result`, and the `auto`, `any`, `none`, and forced-tool choice
+modes into the active engine's native prompt and back into protocol responses.
+Protocol support does not guarantee that every quantized model emits valid
+tool syntax; `COLI_TOOL_SALVAGE=1` is an opt-in recovery path for malformed GLM
+int4 tool calls. DeepSeek V4 uses its strict native DSML parser instead.
 
 When a reverse proxy or MagicDNS hostname preserves a public `Host` header,
 trust that exact hostname with repeatable `--allowed-host` options. The
@@ -104,15 +121,14 @@ sequence (`message_start` → `content_block_*` → `message_delta` → `message
 plus protocol `ping` keepalives during long prefills), `stop_reason`, Anthropic
 `usage` field names, and `x-api-key` authentication (`Authorization: Bearer`
 also works). The gateway renders each request with the active engine's native
-chat template; GLM, Inkling, Kimi K3, and DeepSeek V4 prompts are not
-interchangeable. Extended thinking is enabled with
-`{"thinking": {"type": "enabled"}}` and is translated to that architecture's
-reasoning protocol.
+chat template; GLM, Inkling, Kimi K3, OLMoE, and DeepSeek V4 prompts are not
+interchangeable. Where the engine exposes a reasoning mode, extended thinking
+is enabled with `{"thinking": {"type": "enabled"}}` and translated to that
+architecture's reasoning protocol; OLMoE disables it explicitly.
 
-Tool use (`tool_use` / `tool_result`, `input_schema`, and every `tool_choice`
-mode) is currently GLM-only. Inkling, Kimi K3, and DeepSeek V4 reject tool
-requests explicitly instead of feeding GLM tool markers to an incompatible
-tokenizer.
+Tool use follows the per-engine matrix above. Unsupported engines reject active
+tool declarations and choices explicitly instead of feeding another
+architecture's markers to an incompatible tokenizer.
 
 Not supported, and refused explicitly rather than ignored: `stop_sequences`,
 `top_k`, and non-text content blocks (images, documents). Errors use Anthropic's

--- a/docs/deepseek-v4.md
+++ b/docs/deepseek-v4.md
@@ -76,9 +76,13 @@ If the ceiling exceeds what the context window can hold, the engine clamps it
 and says so on stderr; raise `CTX` for genuinely longer answers.
 
 V4 chat uses native model markers. Native serving currently supports greedy
-generation and one active KV slot; tools and grammar are rejected. Requests
-re-prefill their context, while the process, weights, dense tensors, head, and
-expert cache stay warm.
+generation and one active KV slot. The HTTP gateway renders OpenAI and
+Anthropic tools into V4's native prompt contract, then parses DSML call blocks
+back into each protocol; grammar remains unsupported. See the
+[per-engine API matrix](api.md#tool-calling-support). Requests reuse a strict
+prompt prefix and prefill only its new suffix; divergent prompts prefill from
+the start. The process, weights, dense tensors, head, and expert cache stay
+warm.
 
 ## Validation
 

--- a/docs/deepseek-v4.zh-CN.md
+++ b/docs/deepseek-v4.zh-CN.md
@@ -65,8 +65,11 @@ python ./coli serve --model /path/to/DeepSeek-V4-Flash --ram 32
 python ./coli web --model /path/to/DeepSeek-V4-Flash --ram 32
 ```
 
-V4 chat 使用模型原生标记。原生服务当前只支持 greedy 和一个活动 KV slot，
-tools 与 grammar 会被拒绝。请求会重新 prefill，但进程、权重、dense、
+V4 chat 使用模型原生标记。原生服务当前支持 greedy 和一个活动 KV slot。
+HTTP gateway 会把 OpenAI 与 Anthropic 的工具转换为 V4 原生 prompt 协议，
+再把 DSML 调用块解析回相应协议；grammar 仍不支持。参见
+[各引擎 API 支持表](api.md#tool-calling-support)。请求会复用严格匹配的 prompt
+前缀，只 prefill 新增后缀；prompt 分叉时则从头 prefill。进程、权重、dense、
 head 与专家缓存会保持热状态。
 
 ## 验证


### PR DESCRIPTION
## Summary

- add one canonical OpenAI/Anthropic tool-calling support matrix for every served engine
- document GLM and DeepSeek V4 as supported, with their distinct native prompt/call formats
- document the explicit unsupported-engine behavior for Inkling, Kimi K3, and OLMoE
- remove stale claims that DeepSeek V4 rejects tools, while preserving its grammar and single-KV-slot limitations
- clarify GLM-only salvage, V4 prefix reuse, Inkling audio, and OLMoE reasoning behavior encountered in the same API sections

## Why

The gateway has supported DeepSeek V4 tool calling through its native prompt contract and DSML call blocks since #948, but the README and V4/API docs still said that tools were rejected. Users therefore had to discover the actual per-engine boundary by trial, as reported in #1029.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_openai_server tests.test_anthropic_messages tests.test_openai_tools_e2e tests.test_v4_cli` (186 tests passed)
- `git diff --check`

Closes #1029