### PR TITLE
refactor: extract shared routed-expert FFN helper (byte-identical)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -1221,6 +1221,27 @@ static void softmax(float *x,int n){ float m=-1e30f; for(int i=0;i<n;i++) if(x[i
 static inline float sigmoidf(float x){ return 1.f/(1.f+expf(-x)); }
 static inline float siluf(float x){ return x/(1.f+expf(-x)); }
 
+/* FFN di un expert MoE (routed): gate+up -> silu(gate)*up -> down. Un solo helper per
+ * i ~6 siti inline di moe() e (piu' avanti) il worker distribuito, che la chiama con i
+ * propri buffer e i tensori dell'expert — nessun locale di moe(). xg arriva GIA' ruotata
+ * (Q^T x) dal chiamante via E8_XE (#452: una copia ruotata per chiamata, MAI per expert).
+ * La rotazione dell'input del down e' per-expert e vive qui: `d->fmt==6` la applica
+ * SEMPRE — e' la forma CANONICA, pura funzione del fmt del down-tensor. Perche' resta
+ * byte-identica al vecchio inline: (a) i fallback device-lost Vulkan ricaricano solo
+ * expert che erano in registry (vk_reg_at), e vk_registry_fill ammette solo fmt 2/4/5 —
+ * li' d->fmt!=6 e la rotazione e' un no-op; (b) l'oracolo e ogni modello single-format
+ * (l'output di una conversione normale) non hanno mai un expert fmt=6 accanto a fmt 2/4/5.
+ * Le DUE copie che saltavano la rotazione e potevano davvero vedere fmt=6 — la CPU-share
+ * del blocco Vulkan e il fallback CUDA — ora seguono il canonico: su un container
+ * mixed-format (fmt per-tensor da qt_resolve_fmt, nessuna uniformita' tra expert, vedi il
+ * commento MB_BUILD) e' la correzione di un bug latente, NON un no-op. */
+static void expert_ffn(float *hh, float *gg, float *uu, const float *xg, QT *g, QT *u, QT *d, int nr, int I){
+    expert_gate_up(gg,uu,xg,g,u,nr);
+    for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
+    if(d->fmt==6) e8_rot_rows(gg,nr,I);   /* down input is per-expert — rotate here */
+    matmul_qt(hh, gg, d, nr);
+}
+
 /* RoPE interleaved su un vettore di dimensione qk_rope a posizione pos */
 static void rope_interleave(float *v, int pos, const Cfg *c){
     int half = c->qk_rope/2;
@@ -4698,9 +4719,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                     if(!e->slab) expert_load(m,layer,e->eid,e,1,1);   /* demand=1: moe miss path (FASE A snapshot valid) */
                     for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)crmap[c2*S+r]*D, D*sizeof(float));
                     double te0=now_s();
-                    expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
-                    for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
-                    matmul_qt(hh, gg, &e->d, nr);
+                    expert_ffn(hh,gg,uu,xg,&e->g,&e->u,&e->d,nr,I);
                     for(int r=0;r<nr;r++){ float *os=out+(int64_t)crmap[c2*S+r]*D, wgt=cwmap[c2*S+r], *hr=hh+(int64_t)r*D;
                         for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
                     if(g_prof){ m->t_ecpu+=now_s()-te0;
@@ -4719,9 +4738,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                     ESlot *e=&m->ws[nmiss<63?nmiss:63];
                     if(e->eid!=veid[c2] || !e->slab) expert_load(m,layer,veid[c2],e,1,0);   /* device-lost recovery: DISK-CLASS leaves it unclassified */
                     for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)vrmap[c2*S+r]*D, D*sizeof(float));
-                    expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
-                    for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
-                    matmul_qt(hh, gg, &e->d, nr);
+                    expert_ffn(hh,gg,uu,xg,&e->g,&e->u,&e->d,nr,I);
                     for(int r=0;r<nr;r++){ float *os=out+(int64_t)vrmap[c2*S+r]*D, wgt=vwmap[c2*S+r], *hr=hh+(int64_t)r*D;
                         for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
                 }
@@ -4739,9 +4756,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                     ESlot *e=&m->ws[nmiss<63?nmiss:63];
                     if(e->eid!=veid2[c2] || !e->slab) expert_load(m,layer,veid2[c2],e,1,0);
                     for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D, x+(int64_t)vrmap2[c2*S+r]*D, D*sizeof(float));
-                    expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
-                    for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
-                    matmul_qt(hh, gg, &e->d, nr);
+                    expert_ffn(hh,gg,uu,xg,&e->g,&e->u,&e->d,nr,I);
                     for(int r=0;r<nr;r++){ float *os=out+(int64_t)vrmap2[c2*S+r]*D, wgt=vwmap2[c2*S+r], *hr=hh+(int64_t)r*D;
                         for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
                 }
@@ -4797,10 +4812,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
             }
             if(!e->slab) expert_host_ensure(m,layer,e);
 #endif
-            expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
-            for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
-            if(e->d.fmt==6) e8_rot_rows(gg,nr,I);   /* down input is per-expert — rotate here */
-            matmul_qt(hh, gg, &e->d, nr);
+            expert_ffn(hh,gg,uu,xg,&e->g,&e->u,&e->d,nr,I);
             for(int r=0;r<nr;r++){ float *os=out+(int64_t)rows[r]*D, wgt=rw[r], *hr=hh+(int64_t)r*D;
                 for(int d=0;d<D;d++) os[d]+=wgt*hr[d]; }
             double dt=now_s()-t0;m->t_emm+=dt;if(g_prof){m->t_ecpu+=dt;
@@ -4828,9 +4840,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                         ESlot *e=eg_e[gi];
                         for(int r=0;r<nr;r++) memcpy(xg+(int64_t)r*D,x+(int64_t)eg_row[gi][r]*D,D*sizeof(float));
                         expert_host_ensure(m,layer,e);
-                        expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
-                        for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
-                        matmul_qt(hh,gg,&e->d,nr);
+                        expert_ffn(hh,gg,uu,xg,&e->g,&e->u,&e->d,nr,I);
                         for(int r=0;r<nr;r++){ float *os=out+(int64_t)eg_row[gi][r]*D; float wgt=eg_w[gi][r];
                             for(int d=0;d<D;d++) os[d]+=wgt*hh[(int64_t)r*D+d]; }
                     }
@@ -4941,10 +4951,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                     double tc=g_prof?now_s():0;
                     if(!coli_cuda_expert_mlp(e->g.cuda,e->u.cuda,e->d.cuda,hh,xg,nr)){
                         expert_host_ensure(m,layer,e);
-                        expert_gate_up(gg,uu,xg,&e->g,&e->u,nr);
-                        for(int64_t z=0;z<(int64_t)nr*I;z++) gg[z]=siluf(gg[z])*uu[z];
-                        if(e->d.fmt==6) e8_rot_rows(gg,nr,I);   /* down input, as on the main CPU path */
-                        matmul_qt(hh,gg,&e->d,nr);
+                        expert_ffn(hh,gg,uu,xg,&e->g,&e->u,&e->d,nr,I);
                         if(g_prof){m->cpu_expert_bytes+=qt_bytes(&e->g)+qt_bytes(&e->u)+qt_bytes(&e->d);
                             m->cpu_expert_rows+=(uint64_t)nr;}
                     }


### PR DESCRIPTION
## Summary

`moe()` inlines the four-step routed-expert FFN (`expert_gate_up → silu(gate)*up → [fmt=6 down-input rotation] → down matmul`) six separate times, and those six copies were written inconsistently: four omit the fmt=6 down-input rotation, two apply it. This extracts the sequence into one `expert_ffn` helper and routes all six call sites through it.

The helper takes the expert's own tensors plus buffers and a row count — no `moe()` locals — so a downstream distributed worker can call the same helper instead of carrying a parallel copy. Input arrives already rotated by the caller via `E8_XE` (the per-call cache is preserved, #452); the fmt=6 down-input rotation lives inside the helper and is applied whenever `d->fmt==6`.

## Validation

- `make` → 0 warnings.
- `make check` → green (C suite `ALL PASS (0 failures)`, Python `Ran 473 tests OK`).
- `gcc -fsyntax-only -DCOLI_CUDA -DCOLI_VULKAN -DCOLI_METAL -Wall -Wextra c/colibri.c` → 0 warnings (the `#ifdef`-gated call sites still compile).

## Compatibility

No new knobs, no behaviour change on any single-format model (the oracle `SNAP=./glm_tiny TF=1 ./colibri 64 16 16` is byte-identical before and after). The helper applies the fmt=6 down-input rotation unconditionally — it is a pure function of the down tensor's format. Of the four copies that previously skipped it, the two Vulkan device-lost fallbacks provably cannot see fmt=6 (the Vulkan tier loads only fmt 2/4/5), and the other two (Vulkan CPU-share, CUDA early-issued-take fallback) can reach fmt=6 only in a mixed-format container, where this now matches the canonical path. Single-machine path unchanged.
