### PR TITLE
fix(quant): pin the grouped-int4 group accumulate as an fma

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -888,7 +888,9 @@ static void matmul_i4_grouped_pair(float *yg, float *yu, const float *x,
                     accu=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i),   w0u, accu);
                     accu=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i+8), w1u, accu);
                 }
-                ag+=hsum256(accg)*scg; au+=hsum256(accu)*scu;
+                /* Same pinning as matmul_i4_grouped in quant.h: contraction
+                 * here is the compiler's choice, so the result was too. */
+                ag=fmaf(hsum256(accg),scg,ag); au=fmaf(hsum256(accu),scu,au);
 #endif
                 for(; i+1<base+glen; i+=2){
                     uint8_t bg=wg[i>>1], bu=wu2[i>>1];

--- a/c/quant.h
+++ b/c/quant.h
@@ -188,7 +188,14 @@ static void matmul_i4_grouped(float *y, const float *x, const uint8_t *q4, const
                     __m256 w1=_mm256_cvtepi32_ps(_mm256_sub_epi32(_mm256_cvtepu8_epi32(_mm_srli_si128(nib,8)),b8));
                     acc=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i),   w0, acc);
                     acc=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i+8), w1, acc); }
-                a+=hsum256(acc)*sc;
+                /* Pinned as an fma in the SOURCE. With the default
+                 * -ffp-contract=fast the compiler may fuse this multiply-add
+                 * (one rounding) or not (two), so the same source produced
+                 * different bits depending on the flag -- see the PR for a
+                 * reproduction. That made every bit-exactness gate, including
+                 * the glm_tiny token oracle, depend on build flags rather than
+                 * on the code. */
+                a=fmaf(hsum256(acc),sc,a);
 #endif
                 for(; i<base+glen; i+=2){
                     if(i+1<base+glen){ uint8_t byte=w[i>>1];


### PR DESCRIPTION
## The problem

Both grouped-int4 kernels — `matmul_i4_grouped` (`c/quant.h`) and
`matmul_i4_grouped_pair` (`c/colibri.c`) — end each group with:

```c
a += hsum256(acc) * sc;
```

GCC defaults to `-ffp-contract=fast` for C, so that line is free to become a
single fused multiply-add (one rounding) *or* a separate multiply and add (two).
It is the compiler's choice, and it is observable: building the identical source
with `-ffp-contract=off` changes the result in the last ULP.

So the engine's numerical output for fmt=4 depends on a build flag rather than on
the code.

## Why it matters

The `glm_tiny` token-exactness oracle is used as a correctness gate for kernel
work — #482 is someone stopping a SIMD refactor because the gate read 30/32
instead of the documented 32/32, precisely because you cannot refactor a kernel
against a reference you do not trust. A gate whose reference moves when someone
passes a different flag cannot serve that purpose.

It also means two builds of the same commit can disagree, which makes numerical
bug reports harder to reproduce than they need to be.

## Reproduction

Self-contained — copies `matmul_i4_grouped` verbatim, prints raw float bits:

```c
// repro.c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <stdint.h>
#include <immintrin.h>

static inline float hsum256(__m256 v){
    __m128 lo=_mm256_castps256_ps128(v), hi=_mm256_extractf128_ps(v,1);
    lo=_mm_add_ps(lo,hi); __m128 sh=_mm_movehl_ps(lo,lo); lo=_mm_add_ps(lo,sh);
    sh=_mm_shuffle_ps(lo,lo,1); lo=_mm_add_ss(lo,sh); return _mm_cvtss_f32(lo);
}
/* verbatim from quant.h, omp pragma dropped (each o is independent) */
static void matmul_i4_grouped(float *y, const float *x, const uint8_t *q4, const float *scale,
                              int S, int I, int O, int gs){
    int rb=(I+1)/2; int ng=(I+gs-1)/gs;
    for(int o=0;o<O;o++){
        const uint8_t *w=q4+(int64_t)o*rb;
        const float *scl=scale+(int64_t)o*ng;
        for(int s=0;s<S;s++){
            const float *xs=x+(int64_t)s*I; float a=0;
            for(int g=0; g*gs<I; g++){
                int base=g*gs; int glen=gs; if(base+glen>I) glen=I-base;
                float sc=scl[g]; int i=base;
                const __m128i m4=_mm_set1_epi8(0x0F); const __m256i b8=_mm256_set1_epi32(8);
                __m256 acc=_mm256_setzero_ps();
                for(; i+16<=base+glen; i+=16){ __m128i by=_mm_loadl_epi64((const __m128i*)(w+(i>>1)));
                    __m128i lo=_mm_and_si128(by,m4),hi=_mm_and_si128(_mm_srli_epi16(by,4),m4);
                    __m128i nib=_mm_unpacklo_epi8(lo,hi);
                    __m256 w0=_mm256_cvtepi32_ps(_mm256_sub_epi32(_mm256_cvtepu8_epi32(nib),b8));
                    __m256 w1=_mm256_cvtepi32_ps(_mm256_sub_epi32(_mm256_cvtepu8_epi32(_mm_srli_si128(nib,8)),b8));
                    acc=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i),   w0, acc);
                    acc=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i+8), w1, acc); }
                a+=hsum256(acc)*sc;              /* <-- the line */
                for(; i<base+glen; i+=2){
                    if(i+1<base+glen){ uint8_t byte=w[i>>1];
                        a+=(xs[i]*(float)((int)(byte&0xF)-8)+xs[i+1]*(float)((int)(byte>>4)-8))*sc; }
                    else { uint8_t byte=w[i>>1]; a+=xs[i]*(float)((int)(byte&0xF)-8)*sc; } }
            }
            y[(int64_t)s*O+o]=a;
        }
    }
}
int main(void){
    const int I=6144, gs=64, O=32, S=2;
    int rb=(I+1)/2, ng=(I+gs-1)/gs;
    uint8_t *q4=malloc((size_t)O*rb); float *scale=malloc((size_t)O*ng*sizeof(float));
    float *x=malloc((size_t)S*I*sizeof(float)), *y=malloc((size_t)S*O*sizeof(float));
    uint64_t r=0x9E3779B97F4A7C15ULL;
    #define NEXT (r^=r<<13, r^=r>>7, r^=r<<17, r)
    for(int i=0;i<O*rb;i++) q4[i]=(uint8_t)(NEXT>>32);
    for(int i=0;i<O*ng;i++) scale[i]=(float)((int)(NEXT>>40)%2000-1000)/13337.0f;
    for(int i=0;i<S*I;i++) x[i]=(float)((int)(NEXT>>40)%2000-1000)/977.0f;
    matmul_i4_grouped(y,x,q4,scale,S,I,O,gs);
    for(int i=0;i<S*O;i++){ uint32_t b; memcpy(&b,&y[i],4); printf("%08x\n", b); }
    return 0;
}
```

```sh
gcc -O3 -march=x86-64-v3 -ffp-contract=fast -o a repro.c
gcc -O3 -march=x86-64-v3 -ffp-contract=off  -o b repro.c
./a > fast.txt; ./b > off.txt; diff fast.txt off.txt
```

```
2,4c2,4
< c10176e0
< c0685b3e
< 4145e8d8
---
> c10176df
> c0685b48
> 4145e8d9
```

Replacing the marked line with `a=fmaf(hsum256(acc),sc,a);` makes the two builds
identical.

## The fix

Write the intended operation explicitly:

```c
a = fmaf(hsum256(acc), sc, a);
```

`fmaf()` is chosen deliberately over splitting into two roundings, because it is
what the default build already does — so **a stock build's output does not
change**. Verified bit-identical against the pre-patch default build across
layers 3 / 40 / 77 and experts 0 / 137 at 4 rows on a GLM-5.2 int4-gs64
checkpoint. What changes is that `-ffp-contract=off` now agrees with it.

The same one-line change applies to `matmul_i4_grouped_pair`, which has the same
pattern for the fused gate/up path.

## Scope

- The scalar tails in both functions are left alone. They are unreachable
  whenever the group size is a multiple of 16 — the AVX2 block consumes the
  whole group — so pinning them would mean guessing at a contraction for code
  that does not run. Worth doing if a checkpoint ever ships a group size that
  reaches them.
- Other kernels (fmt=1, fmt=2, fmt=6, fmt=8) have their own accumulate patterns
  and are not touched here. If this approach seems right I am happy to do a pass
  over them in a follow-up.
- `#include <math.h>` was already present in both files.
