### PR TITLE
CUDA: mxfp4 exponent-255 rows returned NaN instead of ±inf — apply the group scale at the reference's point

### DIFF
--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -306,16 +306,51 @@ __global__ static void quant_matmul(float *y, const float *x, const void *weight
             for (int k=0;k<n;k++) sum += xs[off+k]*w[k];
         }
     } else if (fmt == 7) {
-        /* MXFP4: one ue8m0 exponent per 32 columns. Threads stride over columns
-         * and pick up the group exponent as they cross a boundary -- the same
-         * accumulation order as the CPU scalar path, so a mismatch means the
-         * decode is wrong, not the summation. */
+        /* MXFP4: one ue8m0 exponent per 32 columns. The SCALAR CPU reference
+         * (quant.h matmul_mxfp4's scalar loop -- its AVX2 sibling applies the
+         * scale per 8-lane FMA instead and disagrees with it at s=255)
+         * accumulates each 32-group UNSCALED and multiplies the group
+         * subtotal by the scale once. For scales in [0,254] -- every value a
+         * real checkpoint contains -- the scale is a finite power of two,
+         * scaling each element or the subtotal is exact either way, so
+         * threads stride over columns exactly as before and outputs stay
+         * bit-identical with prior builds. s=255 decodes to +inf (the
+         * documented edge), and there the application point is visible:
+         * per-element scaling turns every zero product into 0*inf = NaN,
+         * where the scalar reference's finite-subtotal-times-inf keeps the
+         * group's sign. Rows carrying a 255 scale byte therefore take the
+         * per-group path mirroring that scalar loop; the row's +-inf/NaN
+         * classification does not depend on summation order unless several
+         * large-finite (s~254) group results overflow only in aggregate --
+         * out-of-domain either way -- so the tree reduce below needs no
+         * change. */
         const uint8_t *wrow = static_cast<const uint8_t *>(weights) + row;
         const uint8_t *scl = reinterpret_cast<const uint8_t *>(scales) + (size_t)o * ng;
-        for (int i = threadIdx.x; i < I; i += blockDim.x) {
-            int g = i >> 5;
-            if (g >= ng) g = ng - 1;
-            sum += xs[i] * mx4_weight_at(wrow, i) * mx4_scale_dev(scl[g]);
+        __shared__ int scale_inf;
+        if (!threadIdx.x) scale_inf = 0;
+        __syncthreads();
+        for (int g = threadIdx.x; g < ng; g += blockDim.x)
+            if (scl[g] == 255) scale_inf = 1;
+        __syncthreads();
+        if (!scale_inf) {
+            for (int i = threadIdx.x; i < I; i += blockDim.x) {
+                int g = i >> 5;
+                if (g >= ng) g = ng - 1;
+                sum += xs[i] * mx4_weight_at(wrow, i) * mx4_scale_dev(scl[g]);
+            }
+        } else {
+            for (int g = threadIdx.x; g < ng; g += blockDim.x) {
+                /* same element->group mapping as the clamp above: the last
+                 * group takes every remaining column, a group past the data
+                 * contributes nothing */
+                int base = g << 5, end = base + 32;
+                if (g == ng - 1 || end > I) end = I;
+                if (base >= end) continue;
+                float ga = 0.0f;
+                for (int i = base; i < end; i++)
+                    ga += xs[i] * mx4_weight_at(wrow, i);
+                sum += ga * mx4_scale_dev(scl[g]);
+            }
         }
     } else if (fmt == 4) {
         /* Grouped int4: one f32 scale per gs elements along I (ng groups per row).

--- a/c/tests/test_mxfp4_cuda.cu
+++ b/c/tests/test_mxfp4_cuda.cu
@@ -53,6 +53,38 @@ static uint32_t rnd(void) {
     return (uint32_t)(rng_state >> 32);
 }
 
+/* CPU-vs-GPU compare shared by every case: NaN only agrees with NaN, inf must
+ * agree in sign, finite values to 1e-4 relative. */
+static void compare_case(const char *what, const float *y_cpu, const float *y_gpu,
+                         int S, int I, int O) {
+    double worst = 0.0;
+    int bad = 0;
+    for (int i = 0; i < S * O; i++) {
+        float a = y_cpu[i], b = y_gpu[i];
+        if (std::isnan(a) || std::isnan(b)) { /* NaN only agrees with NaN: without this,
+                                                 NaN against anything falls through the
+                                                 relative compare (NaN > tol is false)
+                                                 and silently counts as a pass */
+            if (std::isnan(a) != std::isnan(b)) bad++;
+            continue;
+        }
+        if (isinf(a) || isinf(b)) {           /* exponent 255: both must agree it is inf */
+            if (isinf(a) != isinf(b) || (isinf(a) && ((a > 0) != (b > 0)))) bad++;
+            continue;
+        }
+        double den = fabs(a) > 1e-6 ? fabs(a) : 1e-6;
+        double rel = fabs((double)a - (double)b) / den;
+        if (rel > worst) worst = rel;
+        if (rel > 1e-4) bad++;
+    }
+    if (bad) {
+        printf("  FAIL %-28s %d/%d elements differ, worst rel %.3e\n", what, bad, S * O, worst);
+        fails++;
+    } else {
+        printf("  ok   %-28s S=%-3d I=%-5d O=%-4d worst rel %.2e\n", what, S, I, O, worst);
+    }
+}
+
 /* One case: random MXFP4 weights, random activations, CPU vs CUDA. */
 static void one_case(const char *what, int S, int I, int O, int fixed_exp) {
     int rb = (I + 1) / 2, ng = (I + 31) / 32;
@@ -78,36 +110,65 @@ static void one_case(const char *what, int S, int I, int O, int fixed_exp) {
         goto done;
     }
 
-    {
-        double worst = 0.0;
-        int bad = 0;
-        for (int i = 0; i < S * O; i++) {
-            float a = y_cpu[i], b = y_gpu[i];
-            if (std::isnan(a) || std::isnan(b)) { /* NaN only agrees with NaN: without this,
-                                                     NaN against anything falls through the
-                                                     relative compare (NaN > tol is false)
-                                                     and silently counts as a pass */
-                if (std::isnan(a) != std::isnan(b)) bad++;
-                continue;
-            }
-            if (isinf(a) || isinf(b)) {           /* exponent 255: both must agree it is inf */
-                if (isinf(a) != isinf(b) || (isinf(a) && ((a > 0) != (b > 0)))) bad++;
-                continue;
-            }
-            double den = fabs(a) > 1e-6 ? fabs(a) : 1e-6;
-            double rel = fabs((double)a - (double)b) / den;
-            if (rel > worst) worst = rel;
-            if (rel > 1e-4) bad++;
-        }
-        if (bad) {
-            printf("  FAIL %-28s %d/%d elements differ, worst rel %.3e\n", what, bad, S * O, worst);
-            fails++;
-        } else {
-            printf("  ok   %-28s S=%-3d I=%-5d O=%-4d worst rel %.2e\n", what, S, I, O, worst);
-        }
-    }
+    compare_case(what, y_cpu, y_gpu, S, I, O);
 done:
     free(q4); free(e8); free(x); free(y_cpu); free(y_gpu);
+}
+
+/* exp-255 on mixed rows and groups, I % 32 != 0 on purpose: quant.h's AVX2
+ * path (which only runs when I % 32 == 0) applies the group scale per 8-lane
+ * FMA and NaNs where the scalar path gives the group-sign inf at s=255, so an
+ * odd width pins the scalar reference on every host. Odd output rows carry
+ * the 255 byte in group 1 -- NOT group 0 -- so a decoder that only classifies
+ * a row by its first group misses it; even rows stay in the normal range and
+ * must be unaffected by their neighbours. */
+static void mixed_rows_255(void) {
+    const int S = 1, I = 97, O = 16, rb = (97 + 1) / 2, ng = (97 + 31) / 32;
+    uint8_t q4[16 * 49], e8[16 * 4];
+    float x[97], y_cpu[16] = {0}, y_gpu[16] = {0};
+    for (int i = 0; i < O * rb; i++) q4[i] = (uint8_t)(rnd() & 0xFF);
+    for (int o = 0; o < O; o++)
+        for (int g = 0; g < ng; g++)
+            e8[o * ng + g] = ((o & 1) && g == 1) ? 255 : (uint8_t)(110 + (rnd() % 30));
+    for (int i = 0; i < S * I; i++) x[i] = ((float)(rnd() % 2001) - 1000.0f) / 1000.0f;
+
+    mxfp4_ref(y_cpu, x, q4, e8, S, I, O);
+    if (!coli_cuda_matmul_mxfp4(y_gpu, x, q4, e8, S, I, O)) {
+        printf("  FAIL exp-255 mixed rows          CUDA path refused the call\n");
+        fails++;
+        return;
+    }
+    compare_case("exp-255 mixed rows/groups", y_cpu, y_gpu, S, I, O);
+}
+
+/* A 254 group and a 255 group in the same row, I % 32 != 0 (scalar reference,
+ * as above). Weights and activations are pinned so the 254 group's subtotal
+ * is +-1.6 * 2^127 -- large but finite, sign alternating by row -- and the
+ * 255 group's is 1.6 * inf = +inf: every row must come out +inf on both
+ * sides. A decoder that applies a group scale twice turns the odd rows' 254
+ * subtotal into -inf and the row into NaN. */
+static void mixed_254_255(void) {
+    const int S = 1, I = 97, O = 8, rb = 49, ng = 4;
+    uint8_t q4[8 * 49], e8[8 * 4];
+    float x[97], y_cpu[8] = {0}, y_gpu[8] = {0};
+    memset(q4, 0x22, sizeof q4);                    /* every weight +1.0 */
+    for (int o = 0; o < O; o++) {
+        if (o & 1)                                  /* group 1 weights -1.0 on odd rows */
+            memset(q4 + o * rb + 16, 0xAA, 16);
+        e8[o * ng + 0] = 127;                       /* cols  0..31: scale 1    */
+        e8[o * ng + 1] = 254;                       /* cols 32..63: scale 2^127 */
+        e8[o * ng + 2] = 255;                       /* cols 64..95: scale +inf  */
+        e8[o * ng + 3] = 127;                       /* col  96 (tail): scale 1  */
+    }
+    for (int i = 0; i < S * I; i++) x[i] = 0.05f;
+
+    mxfp4_ref(y_cpu, x, q4, e8, S, I, O);
+    if (!coli_cuda_matmul_mxfp4(y_gpu, x, q4, e8, S, I, O)) {
+        printf("  FAIL exp-254+255 mixed groups    CUDA path refused the call\n");
+        fails++;
+        return;
+    }
+    compare_case("exp-254+255 mixed groups", y_cpu, y_gpu, S, I, O);
 }
 
 /* Every e2m1 code, decoded in isolation: one column set to code c, x = 1.0,
@@ -157,7 +218,12 @@ int main(void) {
     one_case("non-multiple-of-32 columns", 1,   96,    8, -1);   /* 3 groups exactly */
     one_case("tail group (I%32 != 0)",     1,   80,    8, -1);   /* 2.5 groups */
     one_case("exponent 0 -> +0",           1,   64,   16,  0);
-    one_case("exponent 255 -> inf",        1,   64,   16, 255);
+    /* I % 32 != 0: pins the scalar CPU reference on every host -- quant.h's
+     * AVX2 path disagrees with its scalar path at s=255 (NaN vs group-sign
+     * inf) and only dispatches when I % 32 == 0. */
+    one_case("exponent 255 -> inf",        1,   65,   16, 255);
+    mixed_rows_255();
+    mixed_254_255();
     one_case("exponent 127 -> unit scale", 1,   64,   16, 127);
 
     printf(fails ? "test_mxfp4_cuda: %d failure(s)\n" : "test_mxfp4_cuda: ok\n", fails);

--- a/c/tests/test_mxfp4_cuda.cu
+++ b/c/tests/test_mxfp4_cuda.cu
@@ -83,6 +83,13 @@ static void one_case(const char *what, int S, int I, int O, int fixed_exp) {
         int bad = 0;
         for (int i = 0; i < S * O; i++) {
             float a = y_cpu[i], b = y_gpu[i];
+            if (std::isnan(a) || std::isnan(b)) { /* NaN only agrees with NaN: without this,
+                                                     NaN against anything falls through the
+                                                     relative compare (NaN > tol is false)
+                                                     and silently counts as a pass */
+                if (std::isnan(a) != std::isnan(b)) bad++;
+                continue;
+            }
             if (isinf(a) || isinf(b)) {           /* exponent 255: both must agree it is inf */
                 if (isinf(a) != isinf(b) || (isinf(a) && ((a > 0) != (b > 0)))) bad++;
                 continue;


### PR DESCRIPTION
*Authored by Fable 5 in Claude Code, analysis in partnership with @Monotophic.*

`test_mxfp4_cuda`'s "exponent 255 -> inf" case fails 6/16 on any CUDA device
that actually executes it (we hit it on GB10/sm_121 while validating #1037,
reproduced on pristine `main` and `dev`), and the failure aborts `make
cuda-test` 
so nothing after it runs. Root cause, not a toolchain bug: the CUDA
fmt=7 matmul applies the ue8m0 group scale **per element** while `quant.h`'s
scalar reference applies it **once per 32-group sum**. For every finite scale
the two commute exactly (power-of-two multiply), which is why this was
invisible; at scale byte 255 the scale is +inf and every zero product becomes
`0 × inf = NaN` on the GPU where the reference's group sum gives ±inf.

**The fix** (3 commits, +138/−30, no new flags or formats):
1. `backend_cuda.cu`: rows containing no 255 scale byte execute the pre-fix
   loop **verbatim** — finite-path outputs are bit-identical by construction
   (verified: 264 decode/dense/tail dumps byte-identical, independently
   re-verified by a second blind run on separate inputs, 472 outputs, 0
   mismatches). Rows carrying a 255 byte apply the scale at the reference's
   point (unscaled group sum × scale once); ±inf/NaN classification there is
   order-independent, so summation order doesn't matter. Finite-path cost
   measured on GB10: new ≤ old consistently (−5 to −17% kernel window).
2. Test compare made NaN-aware: NaN only agrees with NaN. Previously a
   NaN-vs-finite pair could pass through the relative-error compare — with
   the old kernel, 10/16 rows of the exp-255 case "passed" that way.
3. Test shapes made host-ISA-robust (see the disclosure below) + two coverage
   cases: 255 in a non-first group of some rows only, and a mixed 254+255
   row. Both bite: mutants that misclassify (group-0-only scan) or
   double-apply the scale fail exactly these cases and nothing else.

**Capstone matrix** — one decisive falsifier per claim:

| claim | decisive evidence |
|---|---|
| defect real, ours to see | pristine `main`/`dev`, GB10: `FAIL exponent 255 -> inf 6/16` verbatim; reverting only the kernel fix reproduces it against the shipped tests |
| finite behavior unchanged | old-vs-new kernel: byte-identical outputs on 264-dump sweep incl. all 255 finite scale bytes, s=254 overflow rows, odd-width tails, mixed launches |
| exp-255 now matches the reference | isnan- and sign-aware compare vs scalar CPU across dense/batched/tail/mixed fixtures: 0/53 mismatches through the matmul path |
| tests would catch regressions | three mutants (classification, double-scale, NaN-injection), each caught by its designated case, bite transcripts in the test run |
| full suite | `make cuda-test CUDA=1` exit 0 end-to-end on GB10 |

**@JustVugg: A semantics inconsistency you should rule on (we made a call; happy to
revisit).** While fixing this we found the exp-255 story is internally
inconsistent five ways:
1. the test expects **inf**;
2. the repo's comments document 255→+inf as an out-of-domain don't-care
   ("real checkpoints never contain either");
3. the OCP MX spec defines E8M0's 255 encoding as **NaN**, with no inf
   representation at all;
4. the pre-fix GPU behavior was neither (NaN via 0×inf on every row);
5. `quant.h`'s own two CPU implementations disagree with each other: the
   scalar loop scales the completed group sum, the AVX2 path 
   (`#ifdef __AVX2__` + `I%32==0`) scales each 8-lane FMA subtotal — at s=255 the
   AVX2 path produces NaN where the scalar path produces ±inf. We confirmed
   this on Zen5 silicon with a bit-exact replica of this test's fixture
   (16/16 rows NaN under AVX2), which also falsifies the header comment
   claiming the two stay bit-identical at s=255. That is why commit 3 moves
   the test shapes to `I%32 != 0` — it pins the scalar reference on every
   host, so this test now demands the same thing everywhere.

The call made in this PR: **mirror the scalar reference and leave the documented
inf convention untouched** — smallest change that makes GPU genuinely agree
with the reference the tests compare against. **Would you rather converge on 
OCP conformance (255 → NaN)?** If so, this PR is structured
so that's a small follow-on (the classification point is now explicit in one
place per backend), and we'd also suggest deciding what the AVX2 CPU path
should do at 255/near-overflow — we can take that follow-on if you want it.
Related disclosure, deliberately untouched here: at s=254 (2^127, finite) the
per-element path can overflow to mixed-sign ±inf where the scalar reference
stays finite-signed — the same application-point divergence reached via
overflow, out-of-domain for real checkpoints, preserved bit-for-bit by this
PR's finite-path guarantee.

An observation for the record: the CUDA CI lane is syntax-only and this test
exits 0 with "skipping" when no device is present — every green run to date
compiled the test but never executed it. Our GB10 appears to be the first
silicon it ever ran on, which is how a 100%-reproducible failure stayed
invisible. (A GPU-runtime CI lane is its own conversation; just naming why
this surfaced only now.)

<details>
<summary>Verification detail (methods + counts)</summary>

- Root-cause instrumentation: per-element decode/accumulation dumps on GB10;
  GPU all-16-rows NaN, CPU ±inf on the 6 sign-agreeing rows, NaN on 10
  (inf−inf across group sums) — the 6/16 "differ" plus 10/16 tolerance
  fall-through. Standalone device probe: `mx4_scale_dev(255)` = exact
  +0x7f800000; per-element-vs-per-group orderings reproduce the divergence in
  isolation; compute_80 PTX JIT byte-identical (rules out arch-conditional
  compilation).
- Fix verification: hybrid classification read-set proven equal to the row's
  readable scale bytes on the only live fmt=7 entry point; row/group mapping
  checked exhaustively over 32,704 (I, ng) configs, 0 violations; no new
  abort surfaces; per-block-uniform branch (no divergent-barrier hazard).
- Independent blind validation: separate harnesses, separate inputs — full
  gate re-run, 5 mutations (all shipped-suite-relevant ones caught; the two
  coverage gaps found were closed by commit 3 and re-verified: the previously
  surviving mutants now fail exactly their designated cases).
- AVX2/scalar reference divergence: registered predictions (AVX2→NaN,
  scalar→±inf, finite-path agreement ~1e-6 rel) all CONFIRMED on Zen5,
  gcc 13.3.0, including on the bit-exact fixture replica.
- Serving/thermal hygiene: all GPU verification ran bracketed alongside live
  serving with health checks before/after every block; no interference.

</details>

*Coordinates: measured 2026-08-15 against dev `e27c37e` (base of this branch);
GB10 sm_121 / CUDA 13.0.88; AVX2 confirmation on Zen5 / gcc 13.3.0. The one
check we could not run: `make cuda-test` end-to-end on an x86-64 AVX2 host
with a CUDA device (no such box on hand) — with commit 3's shapes the result
should be ISA-independent; a run from anyone with that hardware would close
it.*