### PR TITLE
fix(windows): unblock the MSYS2 build — _WIN32_WINNT floor + MinGW uname detection

### DIFF
--- a/c/Makefile.deepseek-v4
+++ b/c/Makefile.deepseek-v4
@@ -12,6 +12,21 @@ else
 IS_WIN :=
 UNAME_S := $(shell uname -s 2>/dev/null)
 UNAME_M := $(shell uname -m 2>/dev/null)
+# $(OS) is set by cmd.exe, but an MSYS2/MinGW login shell does not always export
+# it -- there uname reports MINGW64_NT-10.0-26200 / MSYS_NT-* / CYGWIN_NT-*,
+# which matched no branch below and tripped the $(error) on the very platform
+# the message lists as supported. Recognise those families as Windows too.
+#
+# Gated on x86_64 deliberately: the Windows arm below hardcodes ARCH ?= x86-64-v3,
+# so an ARM64 MinGW shell must NOT be routed there -- it would fail later with a
+# confusing -march error instead of the clear $(error) it gets today.
+ifneq (,$(filter MINGW% MSYS% CYGWIN%,$(UNAME_S)))
+ifneq (,$(filter x86_64 amd64,$(UNAME_M)))
+IS_WIN := 1
+UNAME_S :=
+UNAME_M :=
+endif
+endif
 endif
 
 COLI_V4_OK :=

--- a/c/backend_loader.c
+++ b/c/backend_loader.c
@@ -20,6 +20,15 @@
  */
 #ifdef _WIN32
 
+/* FILE_ID_INFO / FileIdInfo (coli_win32_loader_probe, below) are gated behind
+ * _WIN32_WINNT >= _WIN32_WINNT_WIN8 in mingw-w64's winbase.h. MSVC exposes
+ * them unconditionally, so this only bites the MinGW build -- and only where
+ * the file-identity block is actually compiled, i.e. under COLI_HIP_DLL or
+ * COLI_LOADER_TEST_API. Set the floor before <windows.h> is pulled in. */
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0602   /* Windows 8 */
+#endif
+
 #include <stdio.h>
 #include <stddef.h>
 #include <stdlib.h>


### PR DESCRIPTION
﻿
On a clean Windows 11 / MSYS2 (MINGW64) checkout of v1.6.0, `make check` cannot pass. Two
independent one-line causes, both Windows-only, both invisible under MSVC and on CI.

### 1. `Makefile.deepseek-v4` rejects MSYS2 â€” in the guard that lists MSYS2 as supported

```
Makefile.deepseek-v4:31: *** Makefile.deepseek-v4 supports x86-64/aarch64 Linux,
                             Windows/MSYS2, and arm64 macOS.  Stop.
make[1]: *** [Makefile:896: tests/test_deepseek_v4.exe] Error 2
```

Windows is detected only via `ifeq ($(OS),Windows_NT)`. `$(OS)` is set by `cmd.exe` but an
MSYS2/MinGW login shell does not always export it; the `else` branch then reads
`uname -s` â†’ `MINGW64_NT-10.0-26200`, which matches neither `Linux` nor `Darwin`, so
`COLI_V4_OK` stays empty and `$(error)` fires.

```
$ echo "OS=[$OS]"        ->  OS=[]
$ uname -s               ->  MINGW64_NT-10.0-26200
$ uname -m               ->  x86_64
```

Fix: recognise the MinGW/MSYS/Cygwin `uname -s` families as Windows, so detection no longer
hinges on one environment variable.

### 2. `backend_loader.c`: `FILE_ID_INFO` needs `_WIN32_WINNT >= 0x0602` under MinGW

```
backend_loader.c:578:5: error: unknown type name 'FILE_ID_INFO'; did you mean 'FILEMUIINFO'?
backend_loader.c:594:40: error: 'FileIdInfo' undeclared (first use in this function)
```

`FILE_ID_INFO` / `FileIdInfo` are gated behind `_WIN32_WINNT >= _WIN32_WINNT_WIN8` in
mingw-w64's `winbase.h:3305`. Nothing in `backend_loader.c` sets `_WIN32_WINNT`, and the file
includes `<windows.h>` directly rather than going through `compat.h`.

This does **not** affect the default CUDA host build, because the file-identity block is
compiled conditionally (`backend_loader.c:418`):

```c
#if defined(COLI_HIP_DLL) || defined(COLI_LOADER_TEST_API)
```

whose own comment notes "The whole block is compiled only where something consumes it, so a
CUDA host carries none of it." So it bites exactly two places: the **AMD/HIP Windows build**,
and â€” because `tests/test_backend_loader.py` builds its harness with `-DCOLI_HIP_DLL`
unconditionally â€” **`make check` on any Windows machine, regardless of GPU vendor.**

Isolated:
```sh
gcc -DCOLI_CUDA                -I. -c backend_loader.c   # OK
gcc -DCOLI_HIP_DLL -DCOLI_CUDA -I. -c backend_loader.c   # FAILS
gcc -DCOLI_HIP_DLL -DCOLI_CUDA -D_WIN32_WINNT=0x0602 -I. -c backend_loader.c   # OK
```
Through the Makefile:
```sh
make backend_loader.o CUDA_DLL=1   # -DCOLI_CUDA          -> OK, 26,996 B
make backend_loader.o HIP_DLL=1    # adds -DCOLI_HIP_DLL  -> FILE_ID_INFO undeclared
```

Possibly a regression from #788 (`feat(windows): enable native HIP with deterministic runtime
binding`), which introduced the Windows HIP arm.

### Result

Measured on this branch's base (`origin/dev`, `e27c37e`), Windows 11 / MSYS2,
mingw-w64 gcc 16.2.0:

**Before â€” the build dies before any test runs:**
```
Makefile.deepseek-v4:31: *** Makefile.deepseek-v4 supports x86-64/aarch64 Linux,
                             Windows/MSYS2, and arm64 macOS.  Stop.
make[1]: *** [Makefile:908: tests/test_deepseek_v4.exe] Error 2
make: *** [Makefile:1079: check] Error 2
```
No test suite executes at all â€” `make check` is unusable on Windows/MSYS2 as of `dev`.

**After:**
```
Ran 543 tests in 155.403s
OK (skipped=39)
```

| | before (`origin/dev`) | after |
|---|---|---|
| build | **fails at `test_deepseek_v4.exe`** | succeeds |
| tests run | **0** | **543** |
| verdict | `Error 2` | **`OK (skipped=39)`** |

No workarounds needed now â€” previously this required `OS=Windows_NT` to be exported by hand,
and even then the `_WIN32_WINNT` issue took out the nine `test_backend_loader` classes in
`setUpClass`.

For reference, on the **v1.6.0 tag** (where `$(OS)` was supplied manually so the build could
proceed) the second bug alone produced:
```
Ran 433 tests in 753.284s
FAILED (failures=1, errors=9, skipped=35)      ->  Ran 503 tests, OK (skipped=34) with the fix
```
The ~70-test rise there is the nine `test_backend_loader` classes finally executing rather
than erroring in `setUpClass`.

### Note on `UNAME_M`, and why the uname branch is gated on x86_64

The new branch clears `UNAME_M` alongside `UNAME_S`, mirroring exactly what the existing
`ifeq ($(OS),Windows_NT)` branch already does at line 10. That is safe: `UNAME_M` is read only
inside the `Linux` and `Darwin` arms (lines 21 and 25), and the `IS_WIN` path never consults it.

It is nonetheless gated on `x86_64`/`amd64` **deliberately**. The Windows arm hardcodes
`ARCH ?= x86-64-v3` and passes `-march=$(ARCH)`, so routing an ARM64 MinGW shell into it would
trade today's clear `$(error)` for a confusing `-march` failure further along. Windows-on-ARM
is not supported by this Makefile either way; the gate just preserves the better diagnostic
rather than degrading it. Happy to drop the gate if you'd rather keep the branch simple.

### Environment

Windows 11 Enterprise 26200 (25H2), native (no WSL) Â· MSYS2 20260611 (MINGW64) Â·
mingw-w64 gcc 16.2.0 Â· GNU Make 4.4.1 Â· Python 3.12.10 Â· RTX 5090 Laptop (sm_120), CUDA
driver 596.11. Both changes are inside `#ifdef _WIN32` / the non-`$(OS)` branch, so Linux and
macOS builds are untouched.

