### PR TITLE
fix(convert): declare numpy in the OLMoE guard, and correct the OLMoE size in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ the model's `config.json`):
 >
 > | Model | Disk for the weights | RAM | GPU |
 > |---|---|---|---|
-> | **OLMoE** | ~4 GB | 8 GB | not needed |
+> | **OLMoE** | ~7 GB (int8 container) | 8 GB | not needed |
 > | **GLM-5.2** | ~372 GB | 16 GB min, 24 GB comfortable | not needed |
 > | **Inkling** | ~469 GB | 25 GB with the int4 dense container, ~120 GB without | not needed |
 > | **Kimi K3** | ~1.6 TB | 32 GB+ | not needed |
@@ -386,7 +386,7 @@ the model's `config.json`):
 | **Inkling** (Thinking Machines) | 975B / 41B | [`nbeerbower/Inkling-colibri-int4`](https://huggingface.co/nbeerbower/Inkling-colibri-int4) (469 GB) | `make -C c inkling` | [inkling.md](docs/inkling.md) |
 | **Kimi K3** (Moonshot) | 2.8T / 104B | [`moonshotai/Kimi-K3`](https://huggingface.co/moonshotai/Kimi-K3) — original checkpoint, routed experts stay **native MXFP4** | `make -C c kimi_k3` | [kimi_k3.md](docs/kimi_k3.md) |
 | **DeepSeek V4 Flash** | 284B / 13B | official sharded checkpoint — routed experts stay **native fp4**, dense stays fp8-e4m3 | `make -C c deepseek-v4` | [deepseek-v4.md](docs/deepseek-v4.md) |
-| **OLMoE** (AI2) | 7B / 1B | converted with `c/tools/convert_olmoe_merged.py` | `make -C c olmoe` | — |
+| **OLMoE** (AI2) | 7B / 1B | converted with `c/tools/convert_olmoe_merged.py` — **int8** container, ~7 GB | `make -C c olmoe` | — |
 
 Kimi K3 needs no conversion: its QAT-trained MXFP4 experts are streamed straight from
 the original Hugging Face shards, and the bf16 dense set is quantized at load time.

--- a/c/tools/convert_olmoe_merged.py
+++ b/c/tools/convert_olmoe_merged.py
@@ -25,11 +25,13 @@ import sys
 from pathlib import Path
 
 try:
+    import numpy  # noqa: F401  -- safetensors.torch.save_file imports it internally
     import torch
     from safetensors import safe_open
     from safetensors.torch import save_file
 except ImportError as exc:
-    sys.exit(f"Missing dependencies: {exc}. Install: pip install torch safetensors huggingface_hub")
+    sys.exit(f"Missing dependencies: {exc}. "
+             f"Install: pip install numpy torch safetensors huggingface_hub")
 
 EXPERT_KEY_RE = re.compile(
     r"model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.(gate_proj|up_proj|down_proj)\.weight"


### PR DESCRIPTION
﻿
Two small OLMoE onboarding fixes found while bringing up v1.6.0 on Windows. Neither is
platform-specific.

### 1. `numpy` is required but not declared â€” the run dies *after* a 5 GB download

`tools/convert_olmoe_merged.py` guards its imports up front, but `safetensors.torch.save_file`
imports **numpy** internally. Without numpy the script starts fine, downloads a ~5 GB source
shard, converts it, and only then dies at the first flush â€” several minutes and several GB in,
at exactly the point the work would start paying off.

The install hint in the failure message is itself the insufficient set:

```python
sys.exit(f"Missing dependencies: {exc}. Install: pip install torch safetensors huggingface_hub")
```

Reproduced with precisely that install line:

```
[1/3] downloading model-00001-of-00003.safetensors (1054 GB free)...
Traceback (most recent call last):
  File "tools/convert_olmoe_merged.py", line 227, in convert_streaming
    writer.add(mw, merged_q)
  File "tools/convert_olmoe_merged.py", line 89, in flush
    save_file(self.buf, str(fn))
  File "safetensors/torch.py", line 483, in _to_ndarray
    import numpy as np
ModuleNotFoundError: No module named 'numpy'
```

Fix: add numpy to the guard and to the hint, so it fails in the first second instead of after
the download.

### 2. README lists OLMoE at ~4 GB; the converted container is 7.0 GB

The model table gives **~4 GB**. The repo's own converter produces **7.0 GB on disk**, and the
engine banner and `coli doctor` both report **7.4 GB**:

```
$ du -sh /d/models/olmoe_merged
7.0G

model-00000.safetensors 1.83 GB   model-00003.safetensors 1.83 GB
model-00001.safetensors 1.65 GB   model-00004.safetensors 0.47 GB
model-00002.safetensors 1.63 GB
```
```
OLMoE Â· 7B Â· 7.4 GB on disk
model  5 shards Â· 7.4 GB
```

The likely origin is an int4/int8 mix-up: the converter's own docstring says *"Convert OLMoE
HuggingFace checkpoint to colibri merged **int8** format"* and it quantises row-wise to
`torch.int8`. At int8, ~6.4B expert params â‰ˆ 6.4 GB, which matches. ~4 GB would be about right
for an int4 container, which this tool does not produce.

Since every other row in that table is int4/fp4/MXFP4, OLMoE being int8 is easy to miss, so
the patch names the format in the row as well as correcting the number.

(Source repo `allenai/OLMoE-1B-7B-0125-Instruct` is 13.84 GB of bf16, for reference. Worth
noting the converter's disk behaviour is good and under-advertised: it streams shard-by-shard
and deletes each source shard after extraction, so peak *extra* disk is one shard, not the
whole checkpoint.)

### Environment

Windows 11 Enterprise 26200, native Â· Python 3.12.10 Â· torch 2.13.0+cpu Â· safetensors 0.8.0 Â·
huggingface-hub 1.27.0 Â· colibri v1.6.0 (`72cd9f7`).
n
## Not included, but adjacent

`docs/windows.md` recommends `pip install -U "huggingface_hub[hf_transfer]"`. On
huggingface-hub 1.27.0 that extra no longer exists:

```
warning: The package `huggingface-hub==1.27.0` does not have an extra named `hf-transfer`
```

`hf_transfer` is a standalone package now. Left out of this PR to keep it focused â€” happy to
add it here or send it separately, whichever you prefer.

