### PR TITLE
docs(hotfix): refresh the expired Discord invite on main

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://discord.gg/fpQxKnRb"><b>Discord</b></a> ·
+  <a href="https://discord.gg/MAaKtQRc"><b>Discord</b></a> ·
   <a href="README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.zh-TW.md">繁體中文</a> · Italiano
 </p>
 
@@ -348,7 +348,7 @@ Se ti è utile:
 - ⭐ metti una stella al repository e condividilo;
 - 🐛 apri issue con i numeri di benchmark del tuo hardware — i datapoint
   fanno avanzare questo progetto più di qualsiasi altra cosa;
-- 💬 entra nella [comunità Discord](https://discord.gg/fpQxKnRb) per discutere
+- 💬 entra nella [comunità Discord](https://discord.gg/MAaKtQRc) per discutere
   esperimenti, risultati hardware e direzioni di ricerca;
 - 💬 contattaci via GitHub issues per sponsorizzare lo sviluppo o donare hardware.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <p align="center">
   <a href="https://justvugg.github.io/colibri"><b>Website</b></a> ·
-  <a href="https://discord.gg/fpQxKnRb"><b>Discord</b></a> ·
+  <a href="https://discord.gg/MAaKtQRc"><b>Discord</b></a> ·
   English · <a href="README.zh-CN.md">简体中文</a> · <a href="README.zh-TW.md">繁體中文</a> · <a href="README.it.md">Italiano</a>
 </p>
 
@@ -513,7 +513,7 @@ today its numbers come from a community of real machines. If it's useful to you:
 - ⭐ star the repo and share it;
 - 🐛 open issues with benchmark numbers from your hardware — datapoints move
   this project more than anything else;
-- 💬 join the [Discord community](https://discord.gg/fpQxKnRb) to discuss
+- 💬 join the [Discord community](https://discord.gg/MAaKtQRc) to discuss
   experiments, hardware results, and research directions;
 - 💬 reach out via GitHub issues to sponsor development or donate hardware.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://discord.gg/fpQxKnRb"><b>Discord</b></a> ·
+  <a href="https://discord.gg/MAaKtQRc"><b>Discord</b></a> ·
   <a href="README.md">English</a> · 简体中文 · <a href="README.zh-TW.md">繁體中文</a> · <a href="README.it.md">Italiano</a>
 </p>
 
@@ -318,7 +318,7 @@ colibrì 最初由一人使用 12 核心、25 GB RAM 的笔记本开发；
 
 - ⭐ 为仓库加星并分享；
 - 🐛 以 issue 提交你的硬件 benchmark 数据——实测数据比任何其他事都更能推动项目；
-- 💬 加入 [Discord 社区](https://discord.gg/fpQxKnRb)，讨论实验、硬件数据与研究方向；
+- 💬 加入 [Discord 社区](https://discord.gg/MAaKtQRc)，讨论实验、硬件数据与研究方向；
 - 💬 若想赞助开发或捐赠硬件，请通过 GitHub issues 联系。
 
 ## 仓库结构

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://discord.gg/fpQxKnRb"><b>Discord</b></a> ·
+  <a href="https://discord.gg/MAaKtQRc"><b>Discord</b></a> ·
   <a href="README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · 繁體中文 · <a href="README.it.md">Italiano</a>
 </p>
 
@@ -300,7 +300,7 @@ colibrì 最初是由一人使用 12 核心、25 GB RAM 的筆電開發；
 
 - ⭐ 為儲存庫加星並分享；
 - 🐛 以 issue 提交你的硬體 benchmark 數據——實測資料比任何其他事都更能推動專案；
-- 💬 加入 [Discord 社群](https://discord.gg/fpQxKnRb)，討論實驗、硬體數據與研究方向；
+- 💬 加入 [Discord 社群](https://discord.gg/MAaKtQRc)，討論實驗、硬體數據與研究方向；
 - 💬 若想贊助開發或捐贈硬體，請透過 GitHub issues 聯絡。
 
 ## 儲存庫結構


### PR DESCRIPTION
**Docs-only hotfix, targeted at `main` deliberately.**

`main` is the repository's default branch, so the expired invite (`discord.gg/fpQxKnRb`) is what every visitor sees on the landing page right now. Reported in #1046 with a screenshot of Discord rejecting it.

Changes four READMEs (`README.md`, `README.it.md`, `README.zh-CN.md`, `README.zh-TW.md`), two occurrences each — the header badge and the community line. No code, no build, no behaviour.

The same change already landed on `dev` via #1051; this exists so the fix is visible immediately instead of waiting for the next release cut. Normal PRs target `dev` — this is the exception for a user-facing broken link on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)