### PR TITLE
fix(doctor): accept engine-supported I64/F8 dtypes in --deep validator

### DIFF
--- a/c/doctor.py
+++ b/c/doctor.py
@@ -20,6 +20,15 @@ SAFETENSORS_DTYPES = {
     "F32": 4,
     "U8": 1,
     "I8": 1,
+    # dtypes st.h's st_dtype_code accepts beyond the classic set (DeepSeek V4 /
+    # Kimi-style checkpoints); sizes mirror st_dtype_esz exactly.
+    "I64": 8,
+    "U64": 8,
+    "F8_E4M3": 1,
+    "F8_E4M3FN": 1,
+    "float8_e4m3fn": 1,
+    "F8_E8M0": 1,
+    "F8_E8M0FNU": 1,
 }
 REQUIRED_CORE_TENSORS = (
     "model.embed_tokens.weight",

--- a/c/tests/test_doctor.py
+++ b/c/tests/test_doctor.py
@@ -8,7 +8,13 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from doctor import cuda_linkage, exit_code, format_doctor, run_doctor
+from doctor import (
+    _tensor_layout,
+    cuda_linkage,
+    exit_code,
+    format_doctor,
+    run_doctor,
+)
 from resource_plan import GB
 
 
@@ -310,6 +316,27 @@ class DoctorTest(unittest.TestCase):
         self.assertEqual(checks["model.required"]["status"], "pass")
         self.assertEqual(checks["model.index"]["status"], "skip")
         self.assertEqual(checks["storage.mirror"]["status"], "skip")
+
+    def test_tensor_layout_accepts_engine_supported_dtypes(self):
+        # I64 (Hash-MoE tid2eid) and F8 dtypes are read by the engine (st.h
+        # st_dtype_code) but were absent from the validator's table; --deep must
+        # accept them at the byte sizes st_dtype_esz reports (I64/U64 -> 8, F8 -> 1).
+        cases = {
+            "I64": (8, 4),
+            "U64": (8, 4),
+            "F8_E4M3": (1, 4),
+            "F8_E4M3FN": (1, 4),
+            "float8_e4m3fn": (1, 4),
+            "F8_E8M0": (1, 4),
+            "F8_E8M0FNU": (1, 4),
+        }
+        for dtype, (size, elements) in cases.items():
+            span = size * elements
+            meta = {"dtype": dtype, "shape": [elements], "data_offsets": [0, span]}
+            self.assertEqual(_tensor_layout(meta, span), (0, span))
+            bad = {"dtype": dtype, "shape": [elements], "data_offsets": [0, span - 1]}
+            with self.assertRaises(ValueError):
+                _tensor_layout(bad, span)
 
     def test_deep_check_rejects_overlapping_tensor_ranges(self):
         header = {


### PR DESCRIPTION
## Summary

Fixes #1062.

`coli doctor --deep --model <DeepSeek-V4-Flash>` fails with `unsupported dtype: 'I64'` on `layers.0.ffn.gate.tid2eid` (and would also reject `F8_E4M3` / `F8_E8M0`). This is a false negative: `coli run`/`serve` load and run the same checkpoint correctly.

`c/doctor.py` `_tensor_layout()` rejects any dtype absent from `SAFETENSORS_DTYPES`, which listed only `BF16/F16/F32/U8/I8`. The engine already accepts more — `c/st.h` `st_dtype_code` maps `I64`/`U64`, `F8_E4M3`/`F8_E4M3FN`/`float8_e4m3fn` and `F8_E8M0`/`F8_E8M0FNU`, and `c/deepseek_v4.c` reads `ffn.gate.tid2eid` as `int64_t*`. Only the `--deep` validator's table was out of sync.

The smallest fix: extend `SAFETENSORS_DTYPES` to mirror `st_dtype_code` name-for-name, with byte sizes taken from `st_dtype_esz` (`I64`/`U64` → 8, F8 variants → 1). The element-size cross-check (`end - start == elements * size`) stays correct — only `U8`/`I8` remain exempt, matching st.h's dtype-code-3 exemption at load (`st.h` `st_init`). `--deep`-only; standard `coli doctor` is unaffected.

st.h → doctor byte-size parity (source of truth = `st_dtype_esz`):

| dtype name(s) | st_dtype_code | st_dtype_esz | doctor |
| --- | --- | --- | --- |
| `I64` / `U64` | 6 | 8 | 8 |
| `F8_E4M3` / `F8_E4M3FN` / `float8_e4m3fn` | 4 | 1 | 1 |
| `F8_E8M0` / `F8_E8M0FNU` | 5 | 1 | 1 |

Added a regression test (`test_tensor_layout_accepts_engine_supported_dtypes`) that accepts each new dtype at its correct size and still rejects a mismatched byte span. I don't have the 284B V4 checkpoint; the fix is validated against `st.h` and the existing test suite.

## Validation

- [x] `make -C c check` — Python suite (`test-python`) 514 passed; C suite passes except `tests/test_ssd_probe`, an environment-dependent probe test that passes standalone and is unrelated to this Python-only change (no C files touched).
- [ ] CUDA changes were tested with `make -C c cuda-test` (if applicable) — n/a, no CUDA change
- [ ] Performance claims include hardware, commands, and repeatable measurements — n/a, no performance claims

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included