### PR TITLE
fix(test): stub numpy in the OLMoE converter import mock (dev CI is red)

### DIFF
--- a/c/tests/test_olmoe_atomic_output.py
+++ b/c/tests/test_olmoe_atomic_output.py
@@ -19,6 +19,11 @@ def load_converter():
     spec = importlib.util.spec_from_file_location("olmoe_atomic_output_test", CONVERTER)
     module = importlib.util.module_from_spec(spec)
     with mock.patch.dict(sys.modules, {
+        # numpy joins the converter's dependency guard in #1048 (safetensors.torch
+        # imports it internally). This test imports the converter with its real
+        # dependencies absent, so every name in that guard has to be stubbed here
+        # or the guard sys.exit()s during exec_module and the module never loads.
+        "numpy": mock.Mock(),
         "torch": torch,
         "safetensors": safetensors,
         "safetensors.torch": safetensors_torch,


### PR DESCRIPTION
`dev` has been red since #1048 merged. This is one line plus the comment explaining it.

## Cause

#1048 added `import numpy` to `convert_olmoe_merged.py`'s dependency guard — which is **correct**: `safetensors.torch` imports numpy internally, so without it users got a confusing error instead of the install hint.

But `c/tests/test_olmoe_atomic_output.py` imports that converter *with its real dependencies absent*, stubbing `torch`, `safetensors` and `safetensors.torch` in `sys.modules`. `numpy` was not stubbed, so on a runner that doesn't have it the guard exits during `exec_module` and the test module never loads:

```
File "c/tools/convert_olmoe_merged.py", line 34, in <module>
SystemExit: Missing dependencies: No module named 'numpy'
```

## Why the PR was green and `dev` is not

The test only fails where numpy is genuinely absent, which is the case on the runner that executes the push job. Anything added to that guard has to be stubbed by this test — now stated in a comment, so the next addition doesn't repeat it.

## Verified by reproducing it, not by assuming

Blocking numpy with a `meta_path` finder:

- **`dev` as it stands** → dies with the exact CI error;
- **this branch** → 3 tests pass;
- with numpy installed normally → still passes.

For the record: this is my fault rather than @sami7969's. Their change was right and their PR was green; I merged it without noticing that the only test importing that converter stubs its dependency list by hand.
