### PR TITLE
fix(stop): make `coli stop` work on Windows — portable pid liveness probe + SIGKILL guard

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -1315,6 +1315,30 @@ def cmd_chat(a):
 
 def serve_pidfile(port): return os.path.join(tempfile.gettempdir(), f"coli-serve-{port}.pid")
 
+def _pid_alive(pid):
+    """True if `pid` is a live process. os.kill(pid, 0) is the POSIX idiom, but on
+    Windows os.kill() has no signal semantics: for a pid this process did not spawn
+    it raises OSError [WinError 87] ("The parameter is incorrect") rather than
+    reporting liveness. cmd_stop's pidfile probe swallowed that as "not running",
+    so a live serve on a listening port reported "nothing running" and was left up.
+    Query the OS directly there instead: OpenProcess + GetExitCodeProcess, which
+    needs only PROCESS_QUERY_LIMITED_INFORMATION."""
+    if os.name == "nt":
+        import ctypes
+        PROCESS_QUERY_LIMITED_INFORMATION, STILL_ACTIVE = 0x1000, 259
+        k32 = ctypes.windll.kernel32
+        h = k32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not h: return False
+        try:
+            code = ctypes.c_ulong()
+            return bool(k32.GetExitCodeProcess(h, ctypes.byref(code))) and code.value == STILL_ACTIVE
+        finally:
+            k32.CloseHandle(h)
+    try:
+        os.kill(pid, 0); return True
+    except OSError:
+        return False
+
 def _serve_cmdline_matches_port(raw, port):
     argv=[part.decode("utf-8","replace") for part in raw.split(b"\0") if part]
     try: coli_i=next(i for i,arg in enumerate(argv) if os.path.basename(arg)=="coli")
@@ -1382,7 +1406,7 @@ def cmd_stop(a):
     pf=serve_pidfile(a.port)
     try:
         with open(pf) as f: pid=int(f.read().split()[0])
-        os.kill(pid,0); targets[pid]=f"coli serve (pidfile, port {a.port})"
+        if _pid_alive(pid): targets[pid]=f"coli serve (pidfile, port {a.port})"
     except (OSError,ValueError,IndexError): pass
     try: proc_entries=os.listdir("/proc")
     except OSError: proc_entries=[]       # native Windows has no /proc; the pidfile still works

--- a/c/coli
+++ b/c/coli
@@ -1431,8 +1431,19 @@ def cmd_stop(a):
         try: os.kill(pid, signal.SIGTERM)
         except OSError: pass
     time.sleep(2.0)
+    # signal.SIGKILL does not exist on Windows, and AttributeError is not OSError:
+    # referencing it here would escape the handler and abort the command after it
+    # had already SIGTERMed its targets. os.kill() maps every signal to
+    # TerminateProcess there, so SIGTERM is the equivalent forced kill.
+    #
+    # The SIGKILL exit-code check earlier in this file also uses getattr but falls
+    # back to -1; that is deliberate and different. There the value is a sentinel
+    # compared against an exit code, where -1 correctly never matches. Here it is
+    # *sent*, and Windows uses the signal number as the terminated process's exit
+    # code -- so -1 would record 0xFFFFFFFF where SIGTERM records 15.
+    _sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
     for pid in targets:
-        try: os.kill(pid, signal.SIGKILL); print(f"  {pid}: forced (SIGKILL)")
+        try: os.kill(pid, _sigkill); print(f"  {pid}: forced ({_sigkill.name})")
         except OSError: pass       # gia' morto: bene
     try: os.unlink(pf)
     except OSError: pass


### PR DESCRIPTION
Follow-up to #1049, which you invited a PR for. Two fixes, both inside `cmd_stop`.

`6707d1a` fixed the `/proc` traceback I originally reported — confirmed gone on `abbb8de`.
Retesting on current `dev` turned up a different reason `coli stop` still doesn't work on
Windows, plus the `SIGKILL` issue you identified, which that first bug was masking.

## 1. `os.kill(pid, 0)` is not a liveness probe on Windows — this is the one that makes the command wrong

With a live serve on a listening port and a valid pidfile:

```
$ python coli serve --model D:/models/olmoe_merged --host 127.0.0.1 --port 8000   # running
$ type %TEMP%\coli-serve-8000.pid
692712 D:/models/olmoe_merged
$ python coli stop --port 8000
  nothing running — no serve on port 8000, no SERVE engines
$ # exit 0, port 8000 still LISTENING, ~5.2 GB of engines still resident
```

`c/coli:1409` uses the POSIX idiom inside a bare handler:

```python
with open(pf) as f: pid=int(f.read().split()[0])
os.kill(pid,0); targets[pid]=f"coli serve (pidfile, port {a.port})"
except (OSError,ValueError,IndexError): pass
```

On Windows `os.kill()` has no signal semantics, and for a pid the calling process did not spawn
it raises `OSError [WinError 87] ("The parameter is incorrect")` instead of reporting liveness.
That is swallowed, `targets` stays empty, and the command returns at its "nothing running"
branch having stopped nothing. So the adjacent comment — *"native Windows has no /proc; the
pidfile still works"* — does not hold in practice.

`_pid_alive()` queries the OS directly on Windows (`OpenProcess` with
`PROCESS_QUERY_LIMITED_INFORMATION` + `GetExitCodeProcess`) and keeps `os.kill(pid, 0)`
everywhere else. **POSIX behaviour is unchanged.**

> **Testing note, because it cost me an hour:** `os.kill(pid, 0)` *does* succeed against a child
> the same interpreter spawned via `subprocess.Popen` — that handle already carries the access
> rights `OpenProcess` would have to request for a foreign pid. A smoke test written that way
> passes and hides the bug completely.

## 2. `signal.SIGKILL` — only reachable once the probe is fixed

```python
try: os.kill(pid, signal.SIGKILL); print(f"  {pid}: forced (SIGKILL)")
except OSError: pass
```

`signal.SIGKILL` does not exist on win32 and `AttributeError` is not `OSError`, so this escapes
the handler and aborts the command *after* it has already SIGTERMed its targets.

**This line is dead on Windows before the first commit** — `targets` was always empty, so
`cmd_stop` returned before escalating. Fixing the probe is what exposes it. Worth stating
explicitly: reading the second commit alone doesn't show why it matters.

The fallback is `signal.SIGTERM`, not the `-1` used by the `SIGKILL` exit-code check earlier in
this file. That difference is deliberate and commented: there the value is a sentinel compared
against an exit code, where `-1` correctly never matches; here it is *sent*, and Windows records
the signal number as the terminated process's exit code — `-1` would record `0xFFFFFFFF` where
`SIGTERM` records 15. The status line now prints the signal actually used rather than a
hardcoded `SIGKILL`.

**Escalation path checked**, since these fixes make it reachable for the first time on Windows:
`SIGTERM` at `:1400` then the escalation call at `:1411` means two `SIGTERM`s there. Against an
already-dead pid the second raises `OSError [WinError 5]`, and against a never-existed pid
`OSError [WinError 87]` — both caught by the existing handler. No new traceback.

## Result

```
before:  nothing running — no serve on port 8000, no SERVE engines
         port 8000 still LISTENING, pidfile left behind, ~5.2 GB resident

after:   stopping 361356: coli serve (pidfile, port 8000)
         ✓ stopped — RAM released
         port 8000 free, pidfile removed
```

A stale pidfile naming a dead pid is still correctly ignored (`_pid_alive` returns False), so a
recycled pid is not killed by mistake.

## Test evidence

`c/tests/test_stop_scope.py` — your own coverage of this code — passes: **8 tests, `OK (skipped=1)`**.

On `make check`, honestly: **this branch alone cannot go green on Windows/MSYS2**, because
`make check` currently dies before any test runs, at
`Makefile.deepseek-v4:31 → Error 2 at tests/test_deepseek_v4.exe`. That is unrelated to this PR
and is what #1047 fixes.

With #1047's two commits applied on top of this branch:

```
Ran 574 tests in 166.913s
OK (skipped=39)
```

So these changes introduce no regression; the branch is red on its own only because of that
separately-filed blocker. Taking #1047 first would make this one verifiable in CI on Windows.

## Not included: an orphaned engine holding ~2.6 GB

Documented with measurements in #1049. Even with `cmd_stop` fixed, the OMP re-exec'd engine
survives a successful stop — its parent has already exited, so neither the pidfile
(written at `c/coli:1355`, before `openai_server.serve()` spawns the engine at
`openai_server.py:1700`) nor parent-child discovery reaches it. Fixing it means changing the
pidfile contract across a second file, or reading another process's environment block on
Windows to mirror the Linux `/proc/PID/environ` path. Both are larger than this PR should be and
are your design call — happy to implement whichever you prefer.

## Environment

Windows 11 Enterprise 26200, native (no WSL) · MSYS2 20260611 (MINGW64) · mingw-w64 gcc 16.2.0 ·
Python 3.12.10 · OLMoE int8 engine. Base: `origin/dev` @ `abbb8de`.
