### PR TITLE
fix(server): account admitted client cancellations

### DIFF
--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -175,13 +175,20 @@ class GenerationScheduler:
             self.active += 1
             self.admitted += 1
             wait_seconds = time.monotonic() - queued_at
+        cancelled_after_admission = False
         try:
             yield wait_seconds, available
+        except ClientCancelled:
+            cancelled_after_admission = True
+            raise
         finally:
             with self.condition:
                 self.active -= 1
                 self.free_slots.add(available)
-                self.completed += 1
+                if cancelled_after_admission:
+                    self.cancelled += 1
+                else:
+                    self.completed += 1
                 self.condition.notify_all()
 
     def snapshot(self):

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -334,6 +334,21 @@ class SchedulerTest(unittest.TestCase):
         self.assertEqual(stats["timed_out"], 1)
         self.assertEqual(stats["cancelled"], 1)
 
+    def test_counts_admitted_client_cancellation_without_completion(self):
+        scheduler = GenerationScheduler(max_queue=0, queue_timeout=1)
+        with self.assertRaises(ClientCancelled):
+            with scheduler.admit():
+                raise ClientCancelled()
+        stats = scheduler.snapshot()
+        self.assertEqual(stats["active"], 0)
+        self.assertEqual(stats["admitted"], 1)
+        self.assertEqual(stats["completed"], 0)
+        self.assertEqual(stats["cancelled"], 1)
+
+        with scheduler.admit():
+            pass
+        self.assertEqual(scheduler.snapshot()["completed"], 1)
+
     def test_admits_waiters_in_fifo_order(self):
         scheduler = GenerationScheduler(max_queue=2, queue_timeout=1)
         entered = threading.Event()


### PR DESCRIPTION
## Summary

- Count `ClientCancelled` after admission as cancelled rather than completed.
- Continue releasing the scheduler slot and notifying waiters normally.
- Add regression coverage for cancellation followed by successful reuse.

## Why

The slot cleanup was correct, but every admitted request incremented `completed`, including requests that terminated through `ClientCancelled`. This inflated successful-completion metrics.

## Validation

- `make -C c check` — 535 tests passed, 36 skipped
- Focused `SchedulerTest` suite
- `git diff --check`
