### PR TITLE
perf(colibri): K1 — plane-nibble int4 layout + unsigned-VNNI dot (bit-identical)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -231,6 +231,7 @@ typedef struct {
  * two renumbers demonstrate. */
 typedef struct {
     int fmt; float *qf; int8_t *q8; uint8_t *q4; float *s; int O, I, gs;  /* gs=group size (0=per-row, 128=grouped) */
+    int planar;  /* K1: fmt=2 con nibble a PIANI (vedi quant.h) — i kernel *_i4p; 0 = coppie classiche */
 #ifdef COLI_CUDA
     ColiCudaTensor *cuda;
 #endif
@@ -506,7 +507,7 @@ static void matmul_i4_grouped_pair(float *yg, float *yu, const float *x,
                                     int S, int I, int O, int gs);
 
 static void expert_gate_up(float *g,float *u,const float *x,QT *wg,QT *wu,int S){
-    if(!g_no_fused_pair&&!spec_pinned()&&S==1&&wg->fmt==2&&wu->fmt==2&&wg->I==wu->I&&wg->O==wu->O)
+    if(!g_no_fused_pair&&!spec_pinned()&&S==1&&wg->fmt==2&&!wg->planar&&!wu->planar&&wu->fmt==2&&wg->I==wu->I&&wg->O==wu->O)
         matmul_i4_pair(g,u,x,wg->q4,wg->s,wu->q4,wu->s,wg->I,wg->O);
     else if(!g_no_fused_pair&&S==1&&wg->fmt==4&&wu->fmt==4&&wg->I==wu->I&&wg->O==wu->O&&wg->gs==wu->gs)
         matmul_i4_grouped_pair(g,u,x,wg->q4,wg->s,wu->q4,wu->s,S,wg->I,wg->O,wg->gs);
@@ -922,6 +923,37 @@ static void matmul_i4_grouped_pair(float *yg, float *yu, const float *x,
     }
 }
 
+/* ---- K1: layout int4 a piani, gate e repack (vedi quant.h) -----------------
+ * Planarizziamo SOLO i tensori MoE (slab expert + trio MLP denso + shared):
+ * i loro consumatori sono esattamente matmul_qt/expert_gate_up, tutti
+ * planar-aware. kv_b (letto raw dal path DSA fuso), embedding (dequant
+ * per-token) e attenzione restano a coppie PER COSTRUZIONE. Off su build GPU
+ * (i backend leggono q4 a coppie), sotto XEXP (dot_i4i8 sulle slab) e su
+ * build AVX-512F (il ramo f32 a 512 bit accumula in altro ordine).
+ * EN: K1 planar gate. MoE tensors only; GPU builds, XEXP and AVX-512F builds
+ * keep the classic pair layout. PLANAR=0 is the kill switch. */
+static int g_planar=-1;
+static int planar_on(void){
+    if(g_planar<0){
+#if defined(COLI_CUDA)||defined(COLI_METAL)||defined(COLI_VULKAN)
+        g_planar=0;
+#elif defined(__AVX512F__)&&defined(__AVX512BW__)
+        g_planar=0;
+#else
+        const char *e=getenv("PLANAR"); g_planar=!(e&&*e=='0');
+        const char *xe=getenv("XEXP"); if(xe&&*xe=='1') g_planar=0;
+#endif
+    }
+    return g_planar;
+}
+static _Atomic long g_planar_n;   /* tensori planarizzati (telemetria una-tantum) */
+static void qt_planarize(QT *t){
+    if(!planar_on()||t->fmt!=2||t->planar||!t->q4) return;
+    planarize_i4(t->q4,t->O,t->I); t->planar=1;
+    if(atomic_fetch_add_explicit(&g_planar_n,1,memory_order_relaxed)==0)
+        fprintf(stderr,"[K1] planar int4 layout active (PLANAR=0 disables)\n");
+}
+
 /* ---- quantizzazione attivazioni sollevata a livello layer ---------------------------
  * moe() quantizza x UNA volta per layer e raccoglie le righe int8 accanto al gather
  * f32; il ramo IDOT di matmul_qt_ex le riusa quando (x,S,I) coincidono ESATTAMENTE
@@ -935,7 +967,7 @@ static void matmul_i4_grouped_pair(float *yg, float *yu, const float *x,
  * gathers int8 rows next to the f32 gather; the IDOT branch reuses them on an
  * exact (x,S,I) pointer/shape match. Bit-identical (qrow_i8 is a pure function
  * of the row bytes). Every other path ignores the context and is unchanged. */
-static struct { const float *x; int S, I; const int8_t *xq; const float *sx; } g_pq;
+static struct { const float *x; int S, I; const int8_t *xq; const float *sx; const int32_t *xsum; } g_pq;
 static void pq_build(const float *x, int S, int D, int8_t *xq, float *sx){
     /* righe indipendenti -> parallelizzare sulle righe e' bit-identico; il loop
      * DENTRO qrow_i8 resta scalare (stesso ordine di lrintf di sempre).
@@ -943,6 +975,13 @@ static void pq_build(const float *x, int S, int D, int8_t *xq, float *sx){
      * the per-row loop inside qrow_i8 stays scalar (same lrintf order). */
     #pragma omp parallel for schedule(static) if(S>=8)
     for(int s=0;s<S;s++) sx[s]=qrow_i8(x+(int64_t)s*D, xq+(int64_t)s*D, D);
+}
+/* somma int32 per riga degli int8 gia' quantizzati: il termine -8*sum(x) del
+ * dot planare unsigned (K1). EN: per-row int32 sums of the quantized rows. */
+static void pq_build_xsum(const int8_t *xq, int S, int D, int32_t *xsum){
+    #pragma omp parallel for schedule(static) if(S>=8)
+    for(int s=0;s<S;s++){ int32_t t=0; const int8_t *r=xq+(int64_t)s*D;
+        for(int i=0;i<D;i++) t+=r[i]; xsum[s]=t; }
 }
 /* Il gate/up di questo expert passerebbe dall'IDOT di matmul_qt_ex? Specchia
  * l'ordine di dispatch di expert_gate_up: a S==1 la fused pair f32 (fmt=2)
@@ -1014,6 +1053,22 @@ static void matmul_qt_ex(float *y, const float *x, QT *w, int S, int allow_idot)
             for(int s=0;s<S;s++) sx[s]=qrow_i8(x+(int64_t)s*I, xq+(int64_t)s*I, I);
         }
         if(w->fmt==1) matmul_q_idot(y,xq,sx,w->q8,w->s,S,I,w->O);
+        else if(w->planar){
+            /* K1: kernel planare unsigned; il termine -8*sum(x) arriva dal
+             * contesto (g_pq, gia' raccolto per riga) o si calcola qui.
+             * EN: planar unsigned kernel; -8*sum(x) from g_pq or computed. */
+            const int32_t *xs32 = (g_pq.x==x && g_pq.S==S && g_pq.I==I) ? g_pq.xsum : NULL;
+            static _Thread_local int32_t *xsb; static _Thread_local size_t xsb_cap;
+            if(!xs32){
+                if((size_t)S>xsb_cap){ free(xsb); xsb=malloc((size_t)S*sizeof(int32_t));
+                    xsb_cap=xsb?(size_t)S:0;
+                    if(!xsb){ fprintf(stderr,"OOM planar xsum\n"); exit(1); } }
+                for(int s2=0;s2<S;s2++){ int32_t t2=0; const int8_t *r2=xq+(int64_t)s2*I;
+                    for(int i2=0;i2<I;i2++) t2+=r2[i2]; xsb[s2]=t2; }
+                xs32=xsb;
+            }
+            matmul_i4p_idot(y,xq,sx,xs32,w->q4,w->s,S,I,w->O);
+        }
         else matmul_i4_idot(y,xq,sx,w->q4,w->s,S,I,w->O);
         return;
     }
@@ -1021,6 +1076,7 @@ static void matmul_qt_ex(float *y, const float *x, QT *w, int S, int allow_idot)
     else if(w->fmt==3) matmul_i2(y,x,w->q4,w->s,S,w->I,w->O);
     else if(w->fmt==5) matmul_i3(y,x,w->q4,w->s,S,w->I,w->O);
     else if(w->fmt==8) matmul_fp8(y,x,(const uint8_t*)w->q8,w->s,S,w->I,w->O);
+    else if(w->planar) matmul_i4p(y,x,w->q4,w->s,S,w->I,w->O);
     else matmul_i4(y,x,w->q4,w->s,S,w->I,w->O);
 }
 
@@ -1251,7 +1307,7 @@ static _Atomic long g_pilot_loads=0;     /* load cross-layer VERI completati (ba
 static _Atomic long g_pilot_drops=0;     /* predizioni scartate perche' il main possiede gia' il layer */
 /* format from `bits`: >=16 f32, 5..8 int8, 4 int4-packed, 3 int3-g64 (group scales), <=2 int2 */
 static void qt_alloc(QT *t, int O, int I, int bits){
-    t->O=O; t->I=I; t->gs=0; t->qf=NULL; t->q8=NULL; t->q4=NULL; t->s=NULL;
+    t->O=O; t->I=I; t->gs=0; t->qf=NULL; t->q8=NULL; t->q4=NULL; t->s=NULL; t->planar=0;
     if(bits>=16){ t->fmt=0; t->qf=falloc((int64_t)O*I); }
     else if(bits>=5 || g_nopack){ t->fmt=1; t->q8=qalloc((int64_t)O*I); t->s=qsalloc(O); }
     else if(bits>=4){ t->fmt=2; t->q4=qalloc((int64_t)O*((I+1)/2)); t->s=qsalloc(O); }
@@ -1792,6 +1848,7 @@ static void qt_verify_fmt_stamp(const char *name, const char *stamped, int fmt){
  *  - altrimenti: tensore pieno (f32/bf16) -> quantizzato a runtime a `bits` (oracolo tiny / pesi pieni)
  * drop=1 -> fadvise DONTNEED (streaming expert). */
 static void qt_from_disk(Model *m, const char *name, int O, int I, int bits, int drop, QT *t){
+    t->planar=0;   /* K1: il flag non sopravvive mai a un refill */
     char sn[300]; snprintf(sn,sizeof(sn),"%s.qs",name);
     if(st_has(&m->S,sn)){
         int64_t nb=st_nbytes(&m->S,name);
@@ -2051,6 +2108,7 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
             l->gate_proj = qt_load(m,P("mlp.gate_proj.weight"), c->dense_inter, D, dbits);
             l->up_proj   = qt_load(m,P("mlp.up_proj.weight"),   c->dense_inter, D, dbits);
             l->down_proj = qt_load(m,P("mlp.down_proj.weight"), D, c->dense_inter, dbits);
+            qt_planarize(&l->gate_proj); qt_planarize(&l->up_proj); qt_planarize(&l->down_proj);   /* K1 */
         } else {
             l->router=ld(m,P("mlp.gate.weight"));
             l->router_bias=ld(m,P("mlp.gate.e_score_correction_bias"));
@@ -2058,6 +2116,7 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
             l->sh_gate = qt_load(m,P("mlp.shared_experts.gate_proj.weight"), sI, D, dbits);
             l->sh_up   = qt_load(m,P("mlp.shared_experts.up_proj.weight"),   sI, D, dbits);
             l->sh_down = qt_load(m,P("mlp.shared_experts.down_proj.weight"), D, sI, dbits);
+            qt_planarize(&l->sh_gate); qt_planarize(&l->sh_up); qt_planarize(&l->sh_down);   /* K1 */
 #ifdef COLI_CUDA
             qt_cuda_colocate(&l->sh_gate,&l->kv_b);  /* PIPE2: shared chain on the layer home device */
             qt_cuda_colocate(&l->sh_up,&l->sh_gate);
@@ -2438,6 +2497,7 @@ static int expert_load_impl(Model *m, int layer, int eid, ESlot *s, int fatal, i
         qt_from_disk(m,nm[0],I,D,b,g_drop,&s->g);
         qt_from_disk(m,nm[1],I,D,b,g_drop,&s->u);
         qt_from_disk(m,nm[2],D,I,b,g_drop,&s->d);
+        qt_planarize(&s->g); qt_planarize(&s->u); qt_planarize(&s->d);   /* K1 */
         atomic_fetch_add_explicit(&g_prof_io,
             st_nbytes(&m->S,nm[0])+st_nbytes(&m->S,nm[1])+st_nbytes(&m->S,nm[2]),memory_order_relaxed);
         s->eid=eid; return 0;
@@ -2473,7 +2533,7 @@ static int expert_load_impl(Model *m, int layer, int eid, ESlot *s, int fatal, i
                 int64_t nb=tw[k]->nbytes;
                 int gs=0;
                 int fmt=qt_resolve_fmt(tw[k]->name,OO[k],II[k],nb,tq[k]->nbytes,&gs,NULL);   /* routed expert: never stamped */
-                qt[k]->fmt=fmt; qt[k]->O=OO[k]; qt[k]->I=II[k]; qt[k]->gs=gs; qt[k]->qf=NULL;
+                qt[k]->fmt=fmt; qt[k]->O=OO[k]; qt[k]->I=II[k]; qt[k]->gs=gs; qt[k]->qf=NULL; qt[k]->planar=0;   /* K1: byte nella MAPPA (read-only/shared): MAI planarizzare */
                 qt[k]->q8=(int8_t*)((char*)bw[k]+tw[k]->off); qt[k]->q4=(uint8_t*)((char*)bw[k]+tw[k]->off);
                 qt[k]->s=(float*)((char*)bq[k]+tq[k]->off);
             }
@@ -2673,6 +2733,11 @@ static int expert_load_impl(Model *m, int layer, int eid, ESlot *s, int fatal, i
         int fmt=qt_resolve_fmt(tw[k]->name,OO[k],II[k],nb,tq[k]->nbytes,&gs,NULL);   /* routed expert: never stamped */
         qt[k]->fmt=fmt; qt[k]->O=OO[k]; qt[k]->I=II[k]; qt[k]->gs=gs; qt[k]->qf=NULL;
         qt[k]->q8=(int8_t*)(s->slab+pos[k]); qt[k]->q4=s->slab+pos[k]; qt[k]->s=fp[k];
+        /* K1: slab di proprieta' (pread, riscritta a ogni fill) -> planarizza.
+         * Il reset dentro qt_planarize non basta: il flag del fill PRECEDENTE
+         * va azzerato PRIMA, perche' i byte appena letti sono a coppie.
+         * EN: slab-owned bytes -> planarize; clear the stale flag first. */
+        qt[k]->planar=0; qt_planarize(qt[k]);
     }
     s->eid=eid; return 0;
 }
@@ -4684,6 +4749,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
      * EN: hoisted activation quantization, materialized on the FIRST IDOT-eligible
      * expert; zero cost when no expert would take the IDOT branch. */
     int8_t *xq_all=NULL, *xqg=NULL; float *sx_all=NULL, *sxg=NULL; int pq_ready=0;
+    int32_t *xsum_all=NULL, *xsumg=NULL;   /* K1: termine -8*sum(x) per il dot planare */
     g_pq.x=NULL;      /* mai fidarsi di un contesto di un moe() precedente / never trust a stale context */
     float *xe=NULL;   /* fmt=6: x under the rotation Q^T, built once per call — all routed
                        * experts of the layer share it (the placement rule in quant.h) */
@@ -5225,11 +5291,13 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
                     if(!xq_all){
                         xq_all=xalloc((size_t)S*D,"moe xq"); sx_all=xalloc((size_t)S*sizeof(float),"moe sx");
                         xqg   =xalloc((size_t)S*D,"moe xqg"); sxg  =xalloc((size_t)S*sizeof(float),"moe sxg");
+                        xsum_all=xalloc((size_t)S*sizeof(int32_t),"moe xsum");
+                        xsumg   =xalloc((size_t)S*sizeof(int32_t),"moe xsumg");
                     }
-                    pq_build(x,S,D,xq_all,sx_all); pq_ready=1;
+                    pq_build(x,S,D,xq_all,sx_all); pq_build_xsum(xq_all,S,D,xsum_all); pq_ready=1;
                 }
-                for(int r=0;r<nr;r++){ memcpy(xqg+(int64_t)r*D, xq_all+(int64_t)rows[r]*D,(size_t)D); sxg[r]=sx_all[rows[r]]; }
-                g_pq.x=xg; g_pq.S=nr; g_pq.I=D; g_pq.xq=xqg; g_pq.sx=sxg;
+                for(int r=0;r<nr;r++){ memcpy(xqg+(int64_t)r*D, xq_all+(int64_t)rows[r]*D,(size_t)D); sxg[r]=sx_all[rows[r]]; xsumg[r]=xsum_all[rows[r]]; }
+                g_pq.x=xg; g_pq.S=nr; g_pq.I=D; g_pq.xq=xqg; g_pq.sx=sxg; g_pq.xsum=xsumg;
             }
             expert_ffn(hh,gg,uu,xg,&e->g,&e->u,&e->d,nr,I);
             for(int r=0;r<nr;r++){ float *os=out+(int64_t)rows[r]*D, wgt=rw[r], *hr=hh+(int64_t)r*D;
@@ -5467,7 +5535,7 @@ shared_done:
     free(logits_all); free(choice); free(idxs); free(ws); free(keff); free(uniq);
     g_pq.x=NULL;   /* xg sta per essere liberato: nessun contesto deve sopravvivergli
                     * EN: xg is about to be freed — no context may outlive it */
-    free(xq_all); free(sx_all); free(xqg); free(sxg);
+    free(xq_all); free(sx_all); free(xqg); free(sxg); free(xsum_all); free(xsumg);
     free(xg); free(gg); free(uu); free(hh); free(rows); free(rw); free(xe);
     #undef E8_XE
 #ifdef COLI_CUDA

--- a/c/quant.h
+++ b/c/quant.h
@@ -939,6 +939,263 @@ static void matmul_i4_idot(float *y, const int8_t *xq, const float *sx, const ui
         for(int s=0;s<S;s++) y[(int64_t)s*O+o]=(float)dot_i4i8(w,xq+(int64_t)s*I,I)*sc*sx[s]; }
 }
 
+
+/* ================= K1: layout int4 A PIANI (fmt 2/4, opzionale) ==============
+ * Layout classico ("a coppie"): byte k = elementi (2k, 2k+1). Ogni kernel paga
+ * unpacklo/unpackhi per riordinare i nibble, e l'IDOT paga sub+abs+sign per
+ * forzare l'operando con segno dentro vpdpbusd (che e' nativamente u8 x s8).
+ *
+ * Layout A PIANI, per blocco di 64 elementi consecutivi (32 byte):
+ *   byte k del blocco = (elem k + 8) | ((elem k+32 + 8) << 4)      k = 0..31
+ * `and 0x0F` produce gli elementi 0..31 GIA' in ordine; `srli 4 + and` produce
+ * 32..63 in ordine: l'unpack sparisce. La coda (I mod 64) resta a coppie.
+ *
+ * L'algebra dell'IDOT: i nibble memorizzati sono u = v+8 (unsigned 0..15), e
+ *   dot(v, x) = dot(u, x) - 8 * sum(x)
+ * dove sum(x) e' UN int32 per riga di attivazione, condiviso da ogni riga di
+ * output. vpdpbusd consuma (u8, s8) direttamente: via sub+abs+sign (3 op
+ * vettoriali per dpbusd). Misurato su questa famiglia: 1.87x L3-resident,
+ * 25.3 GB/s DRAM (al tetto), 0 differenze di bit.
+ * NB: allargare a 256 bit SENZA cambiare layout e' stato misurato 0.79-0.81x
+ * (il fixup di lane costa piu' della larghezza): il layout e' la precondizione
+ * della larghezza, non un'ottimizzazione indipendente.
+ *
+ * I kernel f32 planari preservano ESATTAMENTE l'ordine di accumulazione dei
+ * gemelli a coppie (stesse lane, stessa sequenza 0..63): bit-identici anche
+ * loro. EN: plane-nibble int4 layout. Low nibble of block byte k = element k,
+ * high = element k+32; the unpack disappears, and the stored-unsigned nibbles
+ * feed vpdpbusd natively via dot(v,x) = dot(u,x) - 8*sum(x). The f32 planar
+ * kernels keep the pair kernels' exact accumulation order: bit-identical. */
+
+/* riordina in place una riga (o un tensore [O,rb] riga per riga) da coppie a
+ * piani; la coda I%64 resta a coppie. EN: in-place pair->planar repack. */
+static void planarize_i4_row(uint8_t *row, int I){
+    uint8_t tmp[32];
+    int nb=I/64;
+    for(int b=0;b<nb;b++){
+        uint8_t *blk=row+b*32;
+        for(int k=0;k<32;k++){
+            int e_lo=2*k, e_hi=2*k+1;   /* elementi del byte k a coppie */
+            (void)e_lo; (void)e_hi;
+        }
+        /* pair: byte j ha (elem 2j, elem 2j+1). planar: byte k = (elem k, elem k+32) */
+        for(int k=0;k<32;k++){
+            int src_lo=k, src_hi=k+32;                       /* elementi voluti */
+            uint8_t nib_lo=(blk[src_lo>>1]>>((src_lo&1)*4))&0xF;
+            uint8_t nib_hi=(blk[src_hi>>1]>>((src_hi&1)*4))&0xF;
+            tmp[k]=(uint8_t)(nib_lo|(nib_hi<<4));
+        }
+        memcpy(blk,tmp,32);
+    }
+}
+static void planarize_i4(uint8_t *q4, int O, int I){
+    int rb=(I+1)/2;
+    #pragma omp parallel for schedule(static)
+    for(int o=0;o<O;o++) planarize_i4_row(q4+(int64_t)o*rb, I);
+}
+
+/* dot unsigned-nibble planare * int8: ritorna dot(u, x) SENZA la correzione
+ * -8*sum(x) (la applica il chiamante, una volta per riga di output).
+ * Coda I%64: nibble a coppie letti come unsigned, stessa identita'. */
+#if defined(__AVXVNNI__) || (defined(__AVX512VNNI__) && defined(__AVX512VL__))
+#if defined(__AVXVNNI__) && !defined(__AVX512VNNI__)
+#define coli_dpbusd256 _mm256_dpbusd_avx_epi32
+#else
+#define coli_dpbusd256 _mm256_dpbusd_epi32
+#endif
+#endif
+static inline int32_t dot_i4p_u(const uint8_t *w4, const int8_t *x, int I){
+    int32_t sum=0; int i=0;
+#if defined(coli_dpbusd256)
+    const __m256i m4=_mm256_set1_epi8(0x0F);
+    __m256i a0=_mm256_setzero_si256(),a1=_mm256_setzero_si256();
+    __m256i a2=_mm256_setzero_si256(),a3=_mm256_setzero_si256();
+    for(;i+128<=I;i+=128){
+        __m256i b0=_mm256_loadu_si256((const __m256i*)(w4+(i>>1)));
+        __m256i b1=_mm256_loadu_si256((const __m256i*)(w4+(i>>1)+32));
+        a0=coli_dpbusd256(a0,_mm256_and_si256(b0,m4),
+                          _mm256_loadu_si256((const __m256i*)(x+i)));
+        a1=coli_dpbusd256(a1,_mm256_and_si256(_mm256_srli_epi16(b0,4),m4),
+                          _mm256_loadu_si256((const __m256i*)(x+i+32)));
+        a2=coli_dpbusd256(a2,_mm256_and_si256(b1,m4),
+                          _mm256_loadu_si256((const __m256i*)(x+i+64)));
+        a3=coli_dpbusd256(a3,_mm256_and_si256(_mm256_srli_epi16(b1,4),m4),
+                          _mm256_loadu_si256((const __m256i*)(x+i+96)));
+    }
+    __m256i acc=_mm256_add_epi32(_mm256_add_epi32(a0,a1),_mm256_add_epi32(a2,a3));
+    for(;i+64<=I;i+=64){
+        __m256i b0=_mm256_loadu_si256((const __m256i*)(w4+(i>>1)));
+        acc=coli_dpbusd256(acc,_mm256_and_si256(b0,m4),
+                           _mm256_loadu_si256((const __m256i*)(x+i)));
+        acc=coli_dpbusd256(acc,_mm256_and_si256(_mm256_srli_epi16(b0,4),m4),
+                           _mm256_loadu_si256((const __m256i*)(x+i+32)));
+    }
+    sum=hsum256_i32(acc);
+#elif defined(__AVX2__)
+    const __m256i m4=_mm256_set1_epi8(0x0F);
+    const __m256i ones=_mm256_set1_epi16(1);
+    __m256i acc=_mm256_setzero_si256();
+    for(;i+64<=I;i+=64){
+        __m256i b0=_mm256_loadu_si256((const __m256i*)(w4+(i>>1)));
+        /* maddubs(u8, s8): u<=15, |x|<=127 -> coppia <= 3810, int16 sicuro */
+        __m256i p0=_mm256_maddubs_epi16(_mm256_and_si256(b0,m4),
+                                        _mm256_loadu_si256((const __m256i*)(x+i)));
+        __m256i p1=_mm256_maddubs_epi16(_mm256_and_si256(_mm256_srli_epi16(b0,4),m4),
+                                        _mm256_loadu_si256((const __m256i*)(x+i+32)));
+        acc=_mm256_add_epi32(acc,_mm256_madd_epi16(p0,ones));
+        acc=_mm256_add_epi32(acc,_mm256_madd_epi16(p1,ones));
+    }
+    sum=hsum256_i32(acc);
+#elif defined(__ARM_NEON)
+    int32x4_t acc=vdupq_n_s32(0);
+    for(;i+64<=I;i+=64){
+        uint8x16_t b0=vld1q_u8(w4+(i>>1)), b1=vld1q_u8(w4+(i>>1)+16);
+        int8x16_t lo0=vreinterpretq_s8_u8(vandq_u8(b0,vdupq_n_u8(0x0F)));
+        int8x16_t lo1=vreinterpretq_s8_u8(vandq_u8(b1,vdupq_n_u8(0x0F)));
+        int8x16_t hi0=vreinterpretq_s8_u8(vshrq_n_u8(b0,4));
+        int8x16_t hi1=vreinterpretq_s8_u8(vshrq_n_u8(b1,4));
+#if defined(__ARM_FEATURE_DOTPROD)
+        acc=vdotq_s32(acc,lo0,vld1q_s8(x+i));
+        acc=vdotq_s32(acc,lo1,vld1q_s8(x+i+16));
+        acc=vdotq_s32(acc,hi0,vld1q_s8(x+i+32));
+        acc=vdotq_s32(acc,hi1,vld1q_s8(x+i+48));
+#else
+        int8x16_t xs0=vld1q_s8(x+i), xs1=vld1q_s8(x+i+16);
+        int8x16_t xs2=vld1q_s8(x+i+32), xs3=vld1q_s8(x+i+48);
+        int16x8_t m;
+        m=vmull_s8(vget_low_s8(lo0),vget_low_s8(xs0));  acc=vpadalq_s16(acc,m);
+        m=vmull_s8(vget_high_s8(lo0),vget_high_s8(xs0)); acc=vpadalq_s16(acc,m);
+        m=vmull_s8(vget_low_s8(lo1),vget_low_s8(xs1));  acc=vpadalq_s16(acc,m);
+        m=vmull_s8(vget_high_s8(lo1),vget_high_s8(xs1)); acc=vpadalq_s16(acc,m);
+        m=vmull_s8(vget_low_s8(hi0),vget_low_s8(xs2));  acc=vpadalq_s16(acc,m);
+        m=vmull_s8(vget_high_s8(hi0),vget_high_s8(xs2)); acc=vpadalq_s16(acc,m);
+        m=vmull_s8(vget_low_s8(hi1),vget_low_s8(xs3));  acc=vpadalq_s16(acc,m);
+        m=vmull_s8(vget_high_s8(hi1),vget_high_s8(xs3)); acc=vpadalq_s16(acc,m);
+#endif
+    }
+    sum=vaddvq_s32(acc);
+#endif
+    for(;i+64<=I;i+=64){          /* fallback scalare sui blocchi planari */
+        const uint8_t *blk=w4+(i>>1);
+        for(int k=0;k<32;k++){
+            sum+=(int32_t)(blk[k]&0xF)*x[i+k];
+            sum+=(int32_t)(blk[k]>>4)*x[i+k+32];
+        }
+    }
+    for(;i<I;i+=2){               /* coda a coppie, unsigned (u=v+8 memorizzato) */
+        uint8_t byte=w4[i>>1];
+        sum+=(int32_t)(byte&0xF)*x[i];
+        if(i+1<I) sum+=(int32_t)(byte>>4)*x[i+1];
+    }
+    return sum;
+}
+
+/* matmul IDOT planare (fmt=2): y = (dot_u - 8*xsum[s]) * scale[o] * sx[s].
+ * Bit-identico a matmul_i4_idot: somme intere, identita' esatta. */
+static void matmul_i4p_idot(float *y, const int8_t *xq, const float *sx, const int32_t *xsum,
+                            const uint8_t *q4, const float *scale, int S, int I, int O){
+    int rb=(I+1)/2;
+    #pragma omp parallel for schedule(static)
+    for(int o=0;o<O;o++){ const uint8_t *w=q4+(int64_t)o*rb; float sc=scale[o];
+        for(int s=0;s<S;s++){
+            int32_t d=dot_i4p_u(w,xq+(int64_t)s*I,I)-8*xsum[s];
+            y[(int64_t)s*O+o]=(float)d*sc*sx[s];
+        }
+    }
+}
+
+/* f32 planare (fmt=2): stesso ordine di accumulazione di matmul_i4 (sequenza
+ * 0..63 in blocchi di 8 lane, stessa lane per elemento) -> bit-identico. */
+static void matmul_i4p(float *y, const float *x, const uint8_t *q4, const float *scale,
+                       int S, int I, int O){
+#ifdef __AVX2__
+    int rb=(I+1)/2;
+    #pragma omp parallel for schedule(static)
+    for(int o=0;o<O;o++){
+        const uint8_t *w=q4+(int64_t)o*rb; float sc=scale[o];
+        for(int s=0;s<S;s++){
+            const float *xs=x+(int64_t)s*I;
+            const __m256i m4=_mm256_set1_epi32(0xF), b8=_mm256_set1_epi32(8);
+            __m256 acc=_mm256_setzero_ps();
+            int i=0;
+            for(;i+64<=I;i+=64){
+                __m128i lo0=_mm_loadu_si128((const __m128i*)(w+(i>>1)));      /* byte 0..15 */
+                __m128i lo1=_mm_loadu_si128((const __m128i*)(w+(i>>1)+16));   /* byte 16..31 */
+                /* elementi 0..31: nibble bassi in ordine */
+                __m256i e0=_mm256_and_si256(_mm256_cvtepu8_epi32(lo0),m4);
+                __m256i e1=_mm256_and_si256(_mm256_cvtepu8_epi32(_mm_srli_si128(lo0,8)),m4);
+                __m256i e2=_mm256_and_si256(_mm256_cvtepu8_epi32(lo1),m4);
+                __m256i e3=_mm256_and_si256(_mm256_cvtepu8_epi32(_mm_srli_si128(lo1,8)),m4);
+                acc=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i),
+                                    _mm256_cvtepi32_ps(_mm256_sub_epi32(e0,b8)),acc);
+                acc=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i+8),
+                                    _mm256_cvtepi32_ps(_mm256_sub_epi32(e1,b8)),acc);
+                acc=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i+16),
+                                    _mm256_cvtepi32_ps(_mm256_sub_epi32(e2,b8)),acc);
+                acc=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i+24),
+                                    _mm256_cvtepi32_ps(_mm256_sub_epi32(e3,b8)),acc);
+                /* elementi 32..63: nibble alti in ordine */
+                __m256i h0=_mm256_srli_epi32(_mm256_cvtepu8_epi32(lo0),4);
+                __m256i h1=_mm256_srli_epi32(_mm256_cvtepu8_epi32(_mm_srli_si128(lo0,8)),4);
+                __m256i h2=_mm256_srli_epi32(_mm256_cvtepu8_epi32(lo1),4);
+                __m256i h3=_mm256_srli_epi32(_mm256_cvtepu8_epi32(_mm_srli_si128(lo1,8)),4);
+                acc=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i+32),
+                                    _mm256_cvtepi32_ps(_mm256_sub_epi32(_mm256_and_si256(h0,m4),b8)),acc);
+                acc=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i+40),
+                                    _mm256_cvtepi32_ps(_mm256_sub_epi32(_mm256_and_si256(h1,m4),b8)),acc);
+                acc=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i+48),
+                                    _mm256_cvtepi32_ps(_mm256_sub_epi32(_mm256_and_si256(h2,m4),b8)),acc);
+                acc=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i+56),
+                                    _mm256_cvtepi32_ps(_mm256_sub_epi32(_mm256_and_si256(h3,m4),b8)),acc);
+            }
+            /* coda: PRIMA il loop vettoriale a 16 del gemello (stesso acc,
+             * stessa sequenza per-lane {8m+L}: nessuna cucitura), POI la coda
+             * scalare identica. EN: tail = the pair kernel's 16-wide loop into
+             * the same acc (seamless per-lane order), then its scalar tail. */
+            {
+                const __m128i m4p=_mm_set1_epi8(0x0F); const __m256i b8p=_mm256_set1_epi32(8);
+                for(;i+16<=I;i+=16){ __m128i by=_mm_loadl_epi64((const __m128i*)(w+(i>>1)));
+                    __m128i lo=_mm_and_si128(by,m4p), hi=_mm_and_si128(_mm_srli_epi16(by,4),m4p);
+                    __m128i nib=_mm_unpacklo_epi8(lo,hi);
+                    __m256 w0=_mm256_cvtepi32_ps(_mm256_sub_epi32(_mm256_cvtepu8_epi32(nib),b8p));
+                    __m256 w1=_mm256_cvtepi32_ps(_mm256_sub_epi32(_mm256_cvtepu8_epi32(_mm_srli_si128(nib,8)),b8p));
+                    acc=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i),   w0, acc);
+                    acc=_mm256_fmadd_ps(_mm256_loadu_ps(xs+i+8), w1, acc); }
+            }
+            float a=hsum256(acc);
+            for(;i+1<I;i+=2){ uint8_t byte=w[i>>1]; int lo=(int)(byte&0xF)-8, hi=(int)(byte>>4)-8;
+                a += xs[i]*(float)lo + xs[i+1]*(float)hi; }
+            if(i<I){ uint8_t byte=w[i>>1]; int lo=(int)(byte&0xF)-8; a += xs[i]*(float)lo; }
+            y[(int64_t)s*O+o]=a*sc;
+        }
+    }
+#else
+    /* scalare: blocchi planari + coda a coppie */
+    int rb=(I+1)/2;
+    #pragma omp parallel for schedule(static)
+    for(int o=0;o<O;o++){
+        const uint8_t *w=q4+(int64_t)o*rb; float sc=scale[o];
+        for(int s=0;s<S;s++){
+            const float *xs=x+(int64_t)s*I; float a=0; int i=0;
+            for(;i+64<=I;i+=64){
+                const uint8_t *blk=w+(i>>1);
+                for(int k=0;k<32;k++){
+                    a+=xs[i+k]*(float)((int)(blk[k]&0xF)-8);
+                    a+=xs[i+k+32]*(float)((int)(blk[k]>>4)-8);
+                }
+            }
+            for(;i<I;i+=2){
+                uint8_t byte=w[i>>1];
+                a+=xs[i]*(float)((int)(byte&0xF)-8);
+                if(i+1<I) a+=xs[i+1]*(float)((int)(byte>>4)-8);
+            }
+            y[(int64_t)s*O+o]=a*sc;
+        }
+    }
+#endif
+}
+/* ============================ fine blocco K1 ============================== */
+
 /* ---- per-thread quantization scratch -------------------------------------- */
 typedef struct { int8_t *xq; size_t xq_cap; float *sx; size_t sx_cap; } QScratch;
 static _Thread_local QScratch g_qscratch;


### PR DESCRIPTION
## The idea

Two changes that only pay **together** (widening AVX-VNNI to 256-bit *without* the layout measured **0.79–0.81× — actively harmful**; the layout is the precondition):

1. **Plane layout.** Per 64-element block (32 bytes): low nibble of byte *k* = element *k*, high nibble = element *k+32*. `and 0x0F` yields elements 0..31 already in order, `srli+and` yields 32..63 — the `unpacklo/unpackhi` (and the 256-bit lane fixup) disappear. Tail `I%64` stays pair-packed.
2. **Unsigned algebra.** Stored nibbles are already `u = v+8`, and `vpdpbusd` is natively u8×s8: `dot(v,x) = dot(u,x) − 8·sum(x)`, where `sum(x)` is **one int32 per activation row** — produced by the #1071 layer pass (`g_pq` now carries it). This deletes the `sub+abs+sign` triple paid per `vpdpbusd` today. **8 uops per 64 MACs instead of 32.** Zero cost in bytes: it is a permutation inside the row.

## Measured (harness on this header, logically identical weights packed both ways)

| S | `matmul_i4_idot` (pair) | **`matmul_i4p_idot` (planar)** | ratio | mismatches |
|---|---|---|---|---|
| 1 | 87.7 GMAC/s | **137.8** | 1.57× | 0 |
| 2 | 83.5 | 123.9 | 1.48× | 0 |
| 4 | 60.2 | **159.8** | **2.65×** | 0 |
| 8 | 95.3 | **179.0** | 1.88× | 0 |

Three shapes including `I%64≠0` — **0 bit mismatches everywhere**. The f32 planar kernel is at parity (~1.0×) by design: it preserves the pair kernel's exact per-lane accumulation order (its tail runs the pair kernel's own 16-wide loop into the same accumulator — the harness caught the original seam at 22/2048 mismatches before the fix).

## Where it applies — and deliberately where it does not

Planarized (every consumer is planar-aware): **expert slabs** (pread path; the slab `planar` flag is reset on every refill since slabs are reused across experts), the **dense MLP trio**, the **shared-expert trio**.

By construction NOT planar:
- `kv_b` — raw-read by the fused DSA path
- the embedding — per-token raw dequant
- attention projections — `allow_idot=0` f32, planar wins nothing there
- **mmap-backed tensors** — bytes live in the shared file mapping
- fmt=4 (grouped) — its planar kernel ships with the `g_i4s` ablation work (K1b)

Gate: off on CUDA/Metal/Vulkan builds (backends read pair bytes), off under `XEXP`, off on AVX-512F builds (the 512-bit f32 arm accumulates in a different order). `PLANAR=0` is the kill switch; a one-time `[K1] planar int4 layout active` stderr note reports activation.

## E2E verification

glm_tiny, `COLI_TEMP=0`, int4 and int8, short+long prompts:

| comparison | result |
|---|---|
| planar vs unpatched dev base | token-identical (4 cases) |
| `PLANAR=0` vs base (kill-switch control) | token-identical |
| activation | `[K1]` line confirms the planar path actually ran |
| tiny tok/s at int4 (3 runs) | planar ≥ base in all runs (tiny-model variance too high to headline; the kernel table above is the citable number) |

`colibri`, `olmoe`, `kimi_k3` build clean against the shared header.

## What this unlocks

This is the precondition for the rest of the kernel series: the union register tile (measured 2.8–3.2× at prefill `nr`=2–16 on planar operands), the fused expert pass, and the `g_i4s=1` decode flip on AVX-VNNI (8.0 → 25.3 GB/s, behind a perplexity ablation) all build on this layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)