### PR TITLE
fix(inkling): IDOT opt-in — the fast path is x86-only and not token-equivalent

### DIFF
--- a/c/inkling.c
+++ b/c/inkling.c
@@ -321,7 +321,11 @@ static inline __m256i i8dot_block(__m256i acc, __m256i a, __m256i b) {
 static void matmul_q(float *y, const float *x, const int8_t *q, const float *scale, int I, int O) {
 #if defined(__AVX2__)
     static int idot = -1;
-    if (idot < 0) { const char *e = getenv("IDOT"); idot = !(e && *e == '0'); }
+    /* Opt-in (IDOT=1), not default: the fast path only exists under __AVX2__
+     * and quantizes ACTIVATIONS per 32-block — the same model produced
+     * different tokens on x86 vs ARM with the old on-by-default. Same class
+     * and same fix as olmoe (#1044) and qwen36 (#712 review). */
+    if (idot < 0) { const char *e = getenv("IDOT"); idot = (e && atoi(e)); }
     if (idot && I % 32 == 0 && I <= 8192) {
         int nb = I / 32;
         int8_t xi[8192]; float xs[256];
@@ -366,7 +370,11 @@ static void matmul_q(float *y, const float *x, const int8_t *q, const float *sca
 static void matmul_q4(float *y, const float *x, const uint8_t *p, const float *scale, int I, int O) {
 #if defined(__AVX2__)
     static int idot = -1;
-    if (idot < 0) { const char *e = getenv("IDOT"); idot = !(e && *e == '0'); }
+    /* Opt-in (IDOT=1), not default: the fast path only exists under __AVX2__
+     * and quantizes ACTIVATIONS per 32-block — the same model produced
+     * different tokens on x86 vs ARM with the old on-by-default. Same class
+     * and same fix as olmoe (#1044) and qwen36 (#712 review). */
+    if (idot < 0) { const char *e = getenv("IDOT"); idot = (e && atoi(e)); }
     if (idot && I % 32 == 0 && I <= 8192) {
         int nb = I / 32;
         int8_t xi[8192]; float xs[256];


### PR DESCRIPTION
Follow-through on [#712's review finding](https://github.com/JustVugg/colibri/pull/712#issuecomment-5329152053) (credit @kreuzzelg): inkling's IDOT fast path exists only under `__AVX2__` and quantizes **activations** per 32-block, while the scalar route is byte-exact — so with the old on-by-default, the same model with the same settings produced **different tokens on x86 vs ARM**, and no measurement ever blessed that default.

Same class and same one-line fix as olmoe (#1044) and qwen36: `IDOT=1` restores the fast path explicitly; the default is now the byte-exact route on every ISA.

Both call sites flipped (`matmul_q`, the dual variant). Build clean. Note this intentionally changes default behavior on x86 (exact-but-slower); users who had measured and accepted the int8 numerics opt back in with one env var.

A companion issue will track the structural gap this exposed: our tiny-oracle gates run on x86 only, so ARM-divergent paths are invisible to CI — `ubuntu-24.04-arm` runners can close that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)