### PR TITLE
ci: ARM oracle job + integer-kernel bit-exactness gate (closes #1081)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,6 +381,14 @@ jobs:
         run: pip install -r c/tools/oracle-requirements.txt
       - name: Build colibri
         run: make -C c colibri
+      - name: Integer-kernel exactness vs pure-C reference (#1081)
+        # Integer kernels have no rounding excuse: bit-equality on every ISA.
+        # The same binary check runs on the ARM job below — this is the gate
+        # that would have caught the olmoe/qwen36/inkling IDOT class.
+        run: |
+          cd c
+          gcc -O3 -march=native -fopenmp -I. tests/test_int_kernel_exact.c -o /tmp/tike -lm
+          /tmp/tike
       - name: Generate the glm_tiny fixture
         run: cd c && python3 tools/make_glm_oracle.py
       - name: Token-exact oracle (teacher forcing)
@@ -594,3 +602,35 @@ jobs:
             'tests.test_convert_positioned_write'
           )
           python -m unittest -v @suites
+
+  # ARM oracle (#1081): every tiny-oracle job above runs on x86, so NEON
+  # branches were never compiled, let alone executed — which is how the
+  # olmoe (#1044) / qwen36 (#712 review) / inkling (#1080) IDOT class shipped.
+  # This job builds every engine on arm64 (NEON compile coverage), runs the
+  # integer-kernel bit-exactness gate with the NEON branches live, and replays
+  # the glm_tiny teacher-forcing oracle against a fixture generated on THIS
+  # runner (same-machine torch reference, so no cross-ISA float excuses).
+  oracle-arm:
+    name: ARM (engines + NEON kernel exactness + tiny oracle)
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: c/tools/oracle-requirements.txt
+      - name: Install torch (CPU) + transformers
+        run: pip install -r c/tools/oracle-requirements.txt
+      - name: Build every engine (NEON branches must compile)
+        run: make -C c colibri inkling kimi_k3 olmoe
+      - name: Integer-kernel exactness, NEON branches live (#1081)
+        run: |
+          cd c
+          gcc -O3 -mcpu=native -fopenmp -I. tests/test_int_kernel_exact.c -o /tmp/tike -lm
+          /tmp/tike
+      - name: Generate the glm_tiny fixture on this runner
+        run: cd c && python3 tools/make_glm_oracle.py
+      - name: Token-exact oracle on ARM (teacher forcing)
+        run: cd c && SNAP=./glm_tiny TF=1 COLI_TEMP=0 ./colibri 64 16 16

--- a/c/tests/test_int_kernel_exact.c
+++ b/c/tests/test_int_kernel_exact.c
@@ -1,0 +1,93 @@
+/* Integer-kernel exactness gate (#1081).
+ *
+ * The olmoe (#1044) / qwen36 (#712) / inkling (#1080) class of bug was an ISA
+ * branch of an INTEGER kernel that was not equivalent to the reference path —
+ * invisible to every x86-only oracle. Integer kernels have no rounding excuse:
+ * against a pure-C reference on the same inputs they must match BIT FOR BIT,
+ * on every ISA. This test builds that reference and asserts it for:
+ *
+ *   - dot_i4i8            (pair-layout int4 x int8 — AVX2/VNNI/AVX-512/NEON)
+ *   - planarize_i4        (pair -> plane repack must preserve logical weights)
+ *   - dot_i4p_u           (K1 plane-layout unsigned dot, - 8*sum(x) identity)
+ *   - matmul_i4p_idot     (must equal matmul_i4_idot bitwise, same scales)
+ *
+ * Compile with the NATIVE arch so the SIMD branches under test actually run:
+ *   x86: gcc -O3 -march=native -fopenmp -I. tests/test_int_kernel_exact.c
+ *   arm: gcc -O3 -mcpu=native  -fopenmp -I. tests/test_int_kernel_exact.c */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <math.h>
+#include "../quant.h"
+
+static uint64_t rng = 0x2545F4914F6CDD1Dull;
+static uint32_t rnd(void){ rng^=rng<<13; rng^=rng>>7; rng^=rng<<17; return (uint32_t)(rng>>32); }
+/* CONTRATTO ATTIVAZIONI: qrow_i8 clampa a [-127,127] — il -128 non entra mai
+ * nei kernel, e il trucco abs/sign dei rami VNNI non saprebbe rappresentarlo
+ * (-(-128) resta -128 in int8). Il generatore deve rispettare il contratto.
+ * EN: activations are clamped to [-127,127] by qrow_i8; -128 never reaches the
+ * kernels, and the abs/sign VNNI trick could not represent it anyway. */
+static int8_t rnd_x(void){ int v=(int)(rnd()%255)-127; return (int8_t)v; }
+
+/* pure-C reference: signed pair-layout int4 dot (the format's definition) */
+static int64_t ref_dot_pair(const uint8_t *w4, const int8_t *x, int I){
+    int64_t s=0;
+    for(int i=0;i<I;i++){
+        uint8_t byte=w4[i>>1];
+        int v=(int)((i&1)?(byte>>4):(byte&0xF))-8;
+        s+=(int64_t)v*x[i];
+    }
+    return s;
+}
+static int64_t ref_sum(const int8_t *x, int I){
+    int64_t s=0; for(int i=0;i<I;i++) s+=x[i]; return s;
+}
+
+int main(void){
+    int sizes[]={32,33,64,96,100,2048,6100,6144};
+    int fails=0, checks=0;
+    for(size_t t=0;t<sizeof(sizes)/sizeof(*sizes);t++){
+        int I=sizes[t], rb=(I+1)/2;
+        for(int rep=0;rep<8;rep++){
+            uint8_t *wp=malloc(rb); for(int i=0;i<rb;i++) wp[i]=(uint8_t)rnd();
+            int8_t  *x =malloc(I);  for(int i=0;i<I;i++)  x[i]=rnd_x();
+            int64_t ref=ref_dot_pair(wp,x,I);
+
+            /* 1) pair-layout kernel vs reference */
+            checks++;
+            if((int64_t)dot_i4i8(wp,x,I)!=ref){
+                fails++; fprintf(stderr,"FAIL dot_i4i8 I=%d rep=%d\n",I,rep); }
+
+            /* 2) planarize preserves the logical weights; 3) plane dot identity */
+            uint8_t *wl=malloc(rb); memcpy(wl,wp,rb); planarize_i4_row(wl,I);
+            checks++;
+            int64_t got=(int64_t)dot_i4p_u(wl,x,I)-8*ref_sum(x,I);
+            if(got!=ref){
+                fails++; fprintf(stderr,"FAIL dot_i4p_u I=%d rep=%d (got %lld want %lld)\n",
+                                 I,rep,(long long)got,(long long)ref); }
+            free(wp); free(x); free(wl);
+        }
+    }
+    /* 4) matmul-level: planar IDOT must equal pair IDOT bitwise */
+    {
+        int O=512, I=2048, rb=(I+1)/2, S=4;
+        uint8_t *qp=malloc((size_t)O*rb); for(size_t i=0;i<(size_t)O*rb;i++) qp[i]=(uint8_t)rnd();
+        uint8_t *ql=malloc((size_t)O*rb); memcpy(ql,qp,(size_t)O*rb); planarize_i4(ql,O,I);
+        float *sc=malloc(O*sizeof(float)); for(int o=0;o<O;o++) sc[o]=0.001f+(rnd()%997)*1e-6f;
+        int8_t *xq=malloc((size_t)S*I); for(size_t i=0;i<(size_t)S*I;i++) xq[i]=rnd_x();
+        float *sx=malloc(S*sizeof(float)); int32_t *xs=malloc(S*sizeof(int32_t));
+        for(int s=0;s<S;s++){ sx[s]=0.01f+(rnd()%97)*1e-4f;
+            int32_t a=0; for(int i=0;i<I;i++) a+=xq[(size_t)s*I+i]; xs[s]=a; }
+        float *ya=malloc((size_t)S*O*sizeof(float)), *yb=malloc((size_t)S*O*sizeof(float));
+        matmul_i4_idot(ya,xq,sx,qp,sc,S,I,O);
+        matmul_i4p_idot(yb,xq,sx,xs,ql,sc,S,I,O);
+        for(size_t i=0;i<(size_t)S*O;i++){ checks++;
+            if(memcmp(&ya[i],&yb[i],4)){ fails++;
+                fprintf(stderr,"FAIL matmul_i4p_idot @%zu\n",i); if(fails>8) break; } }
+        free(qp);free(ql);free(sc);free(xq);free(sx);free(xs);free(ya);free(yb);
+    }
+    printf("int-kernel exactness: %d checks, %d failures (%s / " IDOT_KERNEL ")\n",
+           checks,fails,fails?"FAIL":"PASS");
+    return fails?1:0;
+}


### PR DESCRIPTION
Closes #1081.

## What

1. **`tests/test_int_kernel_exact.c`** — integer kernels have no rounding excuse: against a pure-C reference on the same inputs they must match **bit for bit, on every ISA**. Covers `dot_i4i8`, the `planarize_i4` round-trip, `dot_i4p_u` (K1 plane layout, the `−8·sum(x)` identity), and `matmul_i4p_idot` vs `matmul_i4_idot` bitwise. 2,176 checks, 0 failures on x86 (avx-vnni branch live).
2. **`oracle-arm` job** (`ubuntu-24.04-arm`, timeout-bounded per #953's direction): builds **every engine** — NEON compile coverage; K1's `dot_i4p_u` NEON branch had never been compiled by anyone — runs the exactness gate with the NEON branches live, and replays the glm_tiny teacher-forcing oracle against a fixture generated **on the same runner** (same-machine torch reference, no cross-ISA float excuses).
3. The x86 efficiency job now runs the same exactness gate, so both ISAs hold the same bar.

## The test found a real contract on day one

The first draft generated full-range int8 activations and produced **30 false failures against the shipped `dot_i4i8`**: `x = −128`. The abs/sign VNNI trick cannot represent `−(−128)`, and `qrow_i8` clamps to `[−127,127]` — so −128 never reaches the kernels in production. The test now encodes that contract explicitly, with a comment: it is the kind of invariant that only exists in people's heads until a test writes it down.

## Deliberately deferred

`deepseek-v4-tiny-check` on ARM — its `ARCH`/`PORTABLE_ARCH` plumbing needs checking for aarch64 first. qwen36's tiny gate joins when #712 lands (its author's review is what surfaced this class — credit @kreuzzelg).

⚠️ Note for review: this PR is also the **first time K1's NEON branch compiles anywhere**. If the ARM job fails on it, that is the job doing its work — the fix lands here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)