### PR TITLE
fix(web): auto-connect in useEffect, atlas from engine origin, drop inert ternary

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -168,10 +168,16 @@ export default function App() {
     }
   }
 
-  if (servedByEngine && !autoConnected.current && !connected) {
-    autoConnected.current = true
-    setTimeout(() => connect(), 0)
-  }
+  // Auto-connect once when the UI is served by the engine itself. In an
+  // effect, not in the render body: a side effect during render breaks under
+  // StrictMode double-rendering and concurrent re-renders.
+  useEffect(() => {
+    if (servedByEngine && !autoConnected.current && !connected) {
+      autoConnected.current = true
+      connect()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [servedByEngine, connected])
 
   const canSend = useMemo(() => draft.trim() && model && !loading, [draft, loading, model])
 
@@ -209,7 +215,7 @@ export default function App() {
           if (firstToken) { setTtft(performance.now() - t0); setStreamStart(performance.now()); firstToken = false }
           count++
           setTokenCount(count)
-          const elapsed = (performance.now() - (firstToken ? t0 : t0)) / 1000
+          const elapsed = (performance.now() - t0) / 1000
           if (elapsed > 0.3) setTokPerSec(count / ((performance.now() - t0) / 1000))
           updateMessages((current) => current.map((item) =>
             item.id === assistant.id ? { ...item, content: item.content + delta } : item,

--- a/web/src/Brain.tsx
+++ b/web/src/Brain.tsx
@@ -35,10 +35,16 @@ export function Brain({ baseUrl, apiKey, connected }: { baseUrl: string; apiKey:
 
   // load the expert atlas if published (measured topic affinity, #175)
   useEffect(() => {
-    fetch("/experts.json").then(r => r.ok ? r.json() : null).then(d => {
-      if (d?.experts) setAtlas(d.experts)
-    }).catch(() => {})
-  }, [])
+    // The atlas lives next to the engine's /experts endpoint, not on the page
+    // origin: when the UI is hosted elsewhere (dev server, static hosting) a
+    // root-relative fetch pointed at the wrong server and the atlas never
+    // loaded. Same base + auth as the live expert map above.
+    const base = baseUrl.replace(/\/v1\/?$/, "")
+    fetch(endpoint(base, "/experts.json"), { headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {} })
+      .then(r => r.ok ? r.json() : null).then(d => {
+        if (d?.experts) setAtlas(d.experts)
+      }).catch(() => {})
+  }, [baseUrl, apiKey])
 
   // track container size for responsive cell sizing
   useEffect(() => {


### PR DESCRIPTION
Three user-reported findings, all verified on dev before fixing:

1. **Auto-connect ran during render** (`App.tsx` component body) — side effect in render, breaks under StrictMode double-rendering. Now a `useEffect` keyed on `(servedByEngine, connected)`; the `autoConnected` ref still guarantees once-only.
2. **The expert atlas never loaded on split origins**: `Brain.tsx` fetched `/experts.json` root-relative on the *page* origin, while the live `/experts` map right beside it already used the engine `baseUrl`. The atlas now uses the same base + auth header, with `[baseUrl, apiKey]` deps.
3. **Inert ternary** `(firstToken ? t0 : t0)` in the streaming tok/s path — both branches identical; replaced with `t0`, behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)