### PR TITLE
fix(k1): planar off on non-AVX2 builds; drop WIP loop; f32 planar in the exactness gate

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -939,6 +939,13 @@ static int planar_on(void){
         g_planar=0;
 #elif defined(__AVX512F__)&&defined(__AVX512BW__)
         g_planar=0;
+#elif !defined(__AVX2__)
+        g_planar=0;   /* matmul_i4p non ha (ancora) un ramo NEON: su ARM il path
+                       * f32 planare degraderebbe a scalare E cambierebbe l'ordine
+                       * di accumulo rispetto al gemello NEON a coppie — il claim
+                       * bit-identico vale solo dove i gemelli esistono entrambi.
+                       * EN: no NEON arm in matmul_i4p yet — planar stays off on
+                       * non-AVX2 builds until one lands with matching order. */
 #else
         const char *e=getenv("PLANAR"); g_planar=!(e&&*e=='0');
         const char *xe=getenv("XEXP"); if(xe&&*xe=='1') g_planar=0;

--- a/c/quant.h
+++ b/c/quant.h
@@ -974,10 +974,6 @@ static void planarize_i4_row(uint8_t *row, int I){
     int nb=I/64;
     for(int b=0;b<nb;b++){
         uint8_t *blk=row+b*32;
-        for(int k=0;k<32;k++){
-            int e_lo=2*k, e_hi=2*k+1;   /* elementi del byte k a coppie */
-            (void)e_lo; (void)e_hi;
-        }
         /* pair: byte j ha (elem 2j, elem 2j+1). planar: byte k = (elem k, elem k+32) */
         for(int k=0;k<32;k++){
             int src_lo=k, src_hi=k+32;                       /* elementi voluti */

--- a/c/tests/test_int_kernel_exact.c
+++ b/c/tests/test_int_kernel_exact.c
@@ -87,6 +87,26 @@ int main(void){
                 fprintf(stderr,"FAIL matmul_i4p_idot @%zu\n",i); if(fails>8) break; } }
         free(qp);free(ql);free(sc);free(xq);free(sx);free(xs);free(ya);free(yb);
     }
+#if defined(__AVX2__)
+    /* f32 planare vs f32 a coppie: bit-uguali DOVE il gate accende il planare
+     * (build AVX2 — su ARM matmul_i4p non ha ramo NEON e il gate resta spento;
+     * il test asserisce il claim esattamente dove il claim e' fatto). */
+    {
+        int O=256, I=6100, rb=(I+1)/2, S=3;   /* coda I%64!=0 inclusa */
+        uint8_t *qp=malloc((size_t)O*rb); for(size_t i=0;i<(size_t)O*rb;i++) qp[i]=(uint8_t)rnd();
+        uint8_t *ql=malloc((size_t)O*rb); memcpy(ql,qp,(size_t)O*rb); planarize_i4(ql,O,I);
+        float *sc=malloc(O*sizeof(float)); for(int o=0;o<O;o++) sc[o]=0.001f+(rnd()%997)*1e-6f;
+        float *x=malloc((size_t)S*I*sizeof(float));
+        for(size_t i=0;i<(size_t)S*I;i++) x[i]=((int32_t)(rnd()&0xFFFF)-0x8000)/8192.0f;
+        float *ya=malloc((size_t)S*O*sizeof(float)), *yb=malloc((size_t)S*O*sizeof(float));
+        matmul_i4(ya,x,qp,sc,S,I,O);
+        matmul_i4p(yb,x,ql,sc,S,I,O);
+        for(size_t i=0;i<(size_t)S*O;i++){ checks++;
+            if(memcmp(&ya[i],&yb[i],4)){ fails++;
+                fprintf(stderr,"FAIL matmul_i4p f32 @%zu\n",i); if(fails>8) break; } }
+        free(qp);free(ql);free(sc);free(x);free(ya);free(yb);
+    }
+#endif
     printf("int-kernel exactness: %d checks, %d failures (%s / " IDOT_KERNEL ")\n",
            checks,fails,fails?"FAIL":"PASS");
     return fails?1:0;


### PR DESCRIPTION
Three user-reported findings against #1079 — all verified real, all fixed:

1. **`planar_on()` did not exclude ARM**, but `matmul_i4p` has no NEON arm: on a CPU-only ARM box (Graviton, RPi, macOS without Metal) a planar tensor's f32 dispatch degraded to scalar **and** changed the FP accumulation order vs the pair kernel's NEON arm — so the bit-identical claim only held on AVX2. Planar now requires an AVX2 build, with a comment stating the re-enable condition: a NEON `matmul_i4p` with matching per-lane order.
2. **Dead WIP loop in `planarize_i4_row`** (two computed-then-voided indices) — removed.
3. **The f32 planar kernel had no in-tree coverage**: the exactness gate now also asserts `matmul_i4p == matmul_i4` **bitwise** (S=3, I=6100 so the pair-layout tail is exercised), gated `__AVX2__` — the test asserts the claim exactly where the gate makes it. 2,944 checks, 0 failures locally; the ARM job from #1083 keeps holding the integer-kernel bar with NEON live.

Credit to the reporter — finding 1 in particular is precisely the class the new ARM job exists for, and the ARM re-enable now has a written condition instead of a silent gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)