### PR TITLE
perf(colibri): K2 — 1×4 union tile in the planar IDOT matmul (bit-identical)

### DIFF
--- a/c/quant.h
+++ b/c/quant.h
@@ -1093,7 +1093,54 @@ static void matmul_i4p_idot(float *y, const int8_t *xq, const float *sx, const i
     int rb=(I+1)/2;
     #pragma omp parallel for schedule(static)
     for(int o=0;o<O;o++){ const uint8_t *w=q4+(int64_t)o*rb; float sc=scale[o];
-        for(int s=0;s<S;s++){
+        int s=0;
+#if defined(coli_dpbusd256)
+        /* K2: tile 1x4 sulla union — il blocco pesi (load + 2 and + srli) si
+         * paga UNA volta per 4 righe di attivazione invece che per riga. La
+         * union del prefill consegna nr=2..16 righe per expert: e' esattamente
+         * la finestra che il per-riga serviva peggio. Somme intere ->
+         * bit-identico al path per-riga per associativita'.
+         * EN: 1x4 register tile — the weight block's load+mask cost is paid
+         * once per 4 activation rows. Integer sums: bit-identical to the
+         * per-row path by associativity. */
+        const __m256i m4t=_mm256_set1_epi8(0x0F);
+        for(;s+4<=S;s+=4){
+            const int8_t *x0=xq+(int64_t)s*I, *x1=x0+I, *x2=x1+I, *x3=x2+I;
+            __m256i a0=_mm256_setzero_si256(), a1=_mm256_setzero_si256();
+            __m256i a2=_mm256_setzero_si256(), a3=_mm256_setzero_si256();
+            int i=0;
+            for(;i+64<=I;i+=64){
+                __m256i b =_mm256_loadu_si256((const __m256i*)(w+(i>>1)));
+                __m256i lo=_mm256_and_si256(b,m4t);
+                __m256i hi=_mm256_and_si256(_mm256_srli_epi16(b,4),m4t);
+                a0=coli_dpbusd256(a0,lo,_mm256_loadu_si256((const __m256i*)(x0+i)));
+                a0=coli_dpbusd256(a0,hi,_mm256_loadu_si256((const __m256i*)(x0+i+32)));
+                a1=coli_dpbusd256(a1,lo,_mm256_loadu_si256((const __m256i*)(x1+i)));
+                a1=coli_dpbusd256(a1,hi,_mm256_loadu_si256((const __m256i*)(x1+i+32)));
+                a2=coli_dpbusd256(a2,lo,_mm256_loadu_si256((const __m256i*)(x2+i)));
+                a2=coli_dpbusd256(a2,hi,_mm256_loadu_si256((const __m256i*)(x2+i+32)));
+                a3=coli_dpbusd256(a3,lo,_mm256_loadu_si256((const __m256i*)(x3+i)));
+                a3=coli_dpbusd256(a3,hi,_mm256_loadu_si256((const __m256i*)(x3+i+32)));
+            }
+            int32_t d0=hsum256_i32(a0), d1=hsum256_i32(a1);
+            int32_t d2=hsum256_i32(a2), d3=hsum256_i32(a3);
+            /* coda a coppie, unsigned: stessa identita' -8*xsum del per-riga */
+            for(;i<I;i+=2){
+                uint8_t byte=w[i>>1];
+                d0+=(int32_t)(byte&0xF)*x0[i]; d1+=(int32_t)(byte&0xF)*x1[i];
+                d2+=(int32_t)(byte&0xF)*x2[i]; d3+=(int32_t)(byte&0xF)*x3[i];
+                if(i+1<I){
+                    d0+=(int32_t)(byte>>4)*x0[i+1]; d1+=(int32_t)(byte>>4)*x1[i+1];
+                    d2+=(int32_t)(byte>>4)*x2[i+1]; d3+=(int32_t)(byte>>4)*x3[i+1];
+                }
+            }
+            y[(int64_t)(s+0)*O+o]=(float)(d0-8*xsum[s+0])*sc*sx[s+0];
+            y[(int64_t)(s+1)*O+o]=(float)(d1-8*xsum[s+1])*sc*sx[s+1];
+            y[(int64_t)(s+2)*O+o]=(float)(d2-8*xsum[s+2])*sc*sx[s+2];
+            y[(int64_t)(s+3)*O+o]=(float)(d3-8*xsum[s+3])*sc*sx[s+3];
+        }
+#endif
+        for(;s<S;s++){
             int32_t d=dot_i4p_u(w,xq+(int64_t)s*I,I)-8*xsum[s];
             y[(int64_t)s*O+o]=(float)d*sc*sx[s];
         }

--- a/c/tests/test_int_kernel_exact.c
+++ b/c/tests/test_int_kernel_exact.c
@@ -71,7 +71,7 @@ int main(void){
     }
     /* 4) matmul-level: planar IDOT must equal pair IDOT bitwise */
     {
-        int O=512, I=2048, rb=(I+1)/2, S=4;
+        int O=512, I=2048, rb=(I+1)/2, S=6;   /* K2: 4 righe di tile + 2 di resto */
         uint8_t *qp=malloc((size_t)O*rb); for(size_t i=0;i<(size_t)O*rb;i++) qp[i]=(uint8_t)rnd();
         uint8_t *ql=malloc((size_t)O*rb); memcpy(ql,qp,(size_t)O*rb); planarize_i4(ql,O,I);
         float *sc=malloc(O*sizeof(float)); for(int o=0;o<O;o++) sc[o]=0.001f+(rnd()%997)*1e-6f;


### PR DESCRIPTION
## The idea

The prefill union delivers each expert **nr = 2..16 activation rows**, and the per-row kernel re-paid the weight block's load + mask for every one of them — which is why measured GMAC/s was flat in S. K2 pays it **once per 4 rows**: inside `matmul_i4p_idot`, rows go 4 at a time (one accumulator each, the masked lo/hi weight forms shared across the four `vpdpbusd` pairs), with a per-row remainder identical to the old path.

**Dispatch untouched** — every planar IDOT caller gets the tile for free; S<4 falls through to the exact per-row loop. Structurally this is the piece llama.cpp cannot copy: their wave-prefill rows are redundant replays, so a tile over them would only speed up wasted work; the union's rows are genuinely distinct at 1× I/O.

## Measured (harness vs the pair-layout IDOT baseline, i7-1355U AVX-VNNI)

| S | baseline | **K1+K2 planar tile** | ratio |
|---|---|---|---|
| 2 | 76.9–83.3 GMAC/s | 145.6–153.2 | **1.84–1.89×** |
| 4 | 72.3–81.7 | 193.0–253.2 | **2.67–3.10×** |
| 8 | 87.8–89.4 | 229.3–248.5 | **2.57–2.83×** |

0 bit mismatches at every S and shape (integer sums — bit-identical by associativity). Matches the audit prototype's 2.70–2.99× prediction at S=4.

## Verification

- `test_int_kernel_exact` now runs the matmul comparison at **S=6** (4-row tile main + 2-row remainder): 3,968 checks, 0 failures — and the ARM job from #1083 keeps holding the same bar with NEON live (the tile is gated `coli_dpbusd256`, so non-VNNI builds keep the per-row loop verbatim)
- glm_tiny e2e at int4: **tokens byte-identical** vs unpatched dev, `[K1]` activation line confirming the planar path actually ran

Series: 0.1 ✅ · K1 #1079 ✅ · #1086 fixes ✅ · **this PR = K2** · next: K3 fusion on the FUSED3 (#1082) shape, then the perplexity ablation unlocking `g_i4s=1` + fmt=4/gs64 planar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)