### PR TITLE
fix(test): the f32 planar assertion must mirror planar_on() exactly

### DIFF
--- a/c/tests/test_int_kernel_exact.c
+++ b/c/tests/test_int_kernel_exact.c
@@ -87,10 +87,16 @@ int main(void){
                 fprintf(stderr,"FAIL matmul_i4p_idot @%zu\n",i); if(fails>8) break; } }
         free(qp);free(ql);free(sc);free(xq);free(sx);free(xs);free(ya);free(yb);
     }
-#if defined(__AVX2__)
-    /* f32 planare vs f32 a coppie: bit-uguali DOVE il gate accende il planare
-     * (build AVX2 — su ARM matmul_i4p non ha ramo NEON e il gate resta spento;
-     * il test asserisce il claim esattamente dove il claim e' fatto). */
+#if defined(__AVX2__) && !(defined(__AVX512F__) && defined(__AVX512BW__))
+    /* f32 planare vs f32 a coppie: bit-uguali DOVE il gate accende il planare.
+     * Il gate del motore (planar_on) esclude ARM (niente ramo NEON in
+     * matmul_i4p) E i build AVX-512F (matmul_i4 li' puo' prendere il ramo
+     * dot_i4f_avx512, ordine di accumulo diverso) — il test DEVE rispecchiare
+     * il gate alla lettera, o asserisce un claim che il motore non fa.
+     * Trovato dal runner-lottery: la PR e' passata su un runner AVX2, il push
+     * su dev e' finito su un runner AVX-512-VNNI ed e' fallito qui (#1081).
+     * EN: the test must mirror planar_on() exactly; an AVX-512 runner runs
+     * matmul_i4's 512-bit arm while the engine keeps planar OFF there. */
     {
         int O=256, I=6100, rb=(I+1)/2, S=3;   /* coda I%64!=0 inclusa */
         uint8_t *qp=malloc((size_t)O*rb); for(size_t i=0;i<(size_t)O*rb;i++) qp[i]=(uint8_t)rnd();


### PR DESCRIPTION
Fixes the red dev push CI (Efficiency suite, 53s).

`FAIL matmul_i4p f32 ... (avx512-vnni)`: the push run landed on an **AVX-512-VNNI runner**, where `matmul_i4` takes the `dot_i4f_avx512` arm (different accumulation order) — while the engine's planar gate deliberately keeps planar **off** on AVX-512F builds (#1086). The test asserted the f32 equality under plain `__AVX2__`, i.e. a claim the engine never makes on that hardware. The PR run had passed because it drew an AVX2-only runner: **runner lottery, not a code change, flipped the result.**

The comparison is now gated `__AVX2__ && !(__AVX512F__ && __AVX512BW__)` — `planar_on()` to the letter — with a comment telling the story so the next gate change updates both places. 2,944 checks, 0 failures locally.

Merge order note: this goes in **before** #1088 (K2), which is green by the same lottery and would stay exposed otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)