### PR TITLE
perf(cache): use second-chance expert eviction

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -378,6 +378,7 @@ typedef struct {
  * expert non hanno tutti la stessa taglia (layer MTP int8 = 2x i layer int4). */
 typedef struct { int eid; QT g,u,d; uint8_t *slab; float *fslab;
                  int64_t slab_cap, fslab_cap; uint64_t used;
+                 uint8_t recent; /* second-chance reference bit */
                  unsigned in_flight; /* async GPU readers borrowing this slot */
                  /* pin-arena backing (#419): when set, slab/fslab are interior
                   * slices of a per-layer arena and must never be free()d —
@@ -393,24 +394,38 @@ static void eslot_release(ESlot *s){
 static int eslot_busy(const ESlot *s){ return __atomic_load_n(&s->in_flight,__ATOMIC_ACQUIRE)!=0; }
 static void eslots_acquire(ESlot **slots,int n){ for(int i=0;i<n;i++) eslot_acquire(slots[i]); }
 static void eslots_release(ESlot **slots,int n){ for(int i=0;i<n;i++) eslot_release(slots[i]); }
-/* Victim per una riga piena (#1034): uno slot svuotato da rss_guard (eid=-1,
- * slab=NULL) e' riusabile SOLO finche' gli slab vivi della riga stanno sotto
- * ecap — riusarlo rialloca uno slab, quindi e' crescita, non eviction. Le
- * prenotazioni in volo (eid<-1) contano come vive: stanno per possederne uno.
- * EN: reusing a slab-less slot re-allocates, so it only counts as eviction
- * EN: while the row's live-slab count is under ecap; else pick a slab owner. */
-static int eslot_lru_victim(ESlot *slots,int n,int ecap){
-    int lru=-1, empty=-1, live=0;
+/* Second-chance (clock) victim for a full row, cap-aware (#1034).
+ * Two policies must both hold:
+ *  - clock: skip a slot whose reference bit is set, clearing it (second chance),
+ *    so a hot resident survives one sweep instead of dying on a raw LRU stamp;
+ *  - cap: a slot emptied by rss_guard (eid==-1, slab==NULL) is only reusable while
+ *    the row's live-slab count is under ecap, because reusing it re-allocates a
+ *    slab and that is growth, not eviction. At or over the cap, evict a slab owner.
+ * In-flight reservations (eid<-1) count as live: they are about to own a slab.
+ * The hand persists per layer, so sweeps resume where the last one stopped. */
+static int eslot_clock_victim(ESlot *slots,int n,int *hand,int ecap){
+    if(n<=0) return -1;
+    if(*hand<0 || *hand>=n) *hand=0;
+    int live=0, empty=-1;
     for(int i=0;i<n;i++){
         ESlot *s=&slots[i];
         if(s->slab || s->eid<-1) live++;
-        if(eslot_busy(s) || s->eid<-1) continue;
-        if(!s->slab){ if(s->eid==-1 && empty<0) empty=i; continue; }
-        if(s->eid==-1) return i;              /* slot libero che possiede ancora lo slab */
-        if(lru<0 || s->used<slots[lru].used) lru=i;
+        /* An emptied, idle slot is a candidate only if the cap allows growth. */
+        if(!s->slab && s->eid==-1 && !eslot_busy(s) && empty<0) empty=i;
     }
-    if(empty>=0 && live<ecap) return empty;   /* sotto il tetto: meglio il vuoto che sfrattare */
-    return lru;
+    int owner=-1;
+    /* Two passes: the first may clear reference bits, the second then finds a victim. */
+    for(int pass=0;pass<2 && owner<0;pass++) for(int seen=0;seen<n;seen++){
+        int i=*hand; *hand=(i+1)%n;
+        ESlot *s=&slots[i];
+        if(eslot_busy(s) || s->eid<-1 || !s->slab) continue;  /* busy, reserved, or empty */
+        if(s->eid==-1){ owner=i; break; }        /* free but still owns its slab: best victim */
+        if(!s->recent){ owner=i; break; }        /* reference bit already clear: evict */
+        s->recent=0;                             /* grant the second chance */
+    }
+    if(empty>=0 && live<ecap) return empty;      /* under the cap: growing beats evicting */
+    if(owner>=0) return owner;
+    return live<ecap ? empty : -1;
 }
 
 typedef struct {
@@ -442,7 +457,7 @@ typedef struct {
     uint8_t **Lc8, **Rc8; float **Lsc, **Rsc;    /* alias KV8 (fp8 + scale) della KVState attiva */
     int *kv_start;                               /* prima pos valida nella KV del layer (MTP: parziale) */
     KVState *kv;
-    ESlot **ecache; int *ecn; int ecap;          /* LRU expert per-layer */
+    ESlot **ecache; int *ecn, *ehand; int ecap;      /* second-chance expert cache per layer */
     float **kv_dev_L, **kv_dev_R; int *kv_dev_valid; /* ombra KV su device (decode) */
     float **ln_dev;                              /* in_ln/post_ln cached on device: [layer*2+{0,1}] (Inc.4) */
 #ifdef COLI_VULKAN
@@ -2250,6 +2265,7 @@ static void model_init(Model *m, const char *snap, int cap, int ebits, int dbits
     m->L=calloc(c->n_layers,sizeof(Layer));
     int NR=c->n_layers+1;                        /* +1: riga del layer MTP */
     m->ecap=cap; m->ecache=calloc(NR,sizeof(ESlot*)); m->ecn=calloc(NR,sizeof(int));
+    m->ehand=calloc(NR,sizeof(int));
     m->kv_dev_L=calloc(NR,sizeof(float*)); m->kv_dev_R=calloc(NR,sizeof(float*));
     m->kv_dev_valid=calloc(NR,sizeof(int));
 #ifdef COLI_VULKAN
@@ -5307,7 +5323,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
             ESlot *P=m->pin[layer];
             for(int z=0;z<m->npin[layer];z++) if(P[z].eid==eid){ m->hits++; m->hit_pin++; use[j]=&P[z]; break; }
             if(!use[j]){ ESlot *Sl=m->ecache[layer]; int nn=m->ecn[layer];
-                for(int z=0;z<nn;z++) if(Sl[z].eid==eid){ m->hits++; m->hit_ecache++; Sl[z].used=(uint64_t)__atomic_add_fetch(&m->eclock,1,__ATOMIC_RELAXED); use[j]=&Sl[z]; break; } }
+                for(int z=0;z<nn;z++) if(Sl[z].eid==eid){ m->hits++; m->hit_ecache++; Sl[z].used=(uint64_t)__atomic_add_fetch(&m->eclock,1,__ATOMIC_RELAXED); Sl[z].recent=1; use[j]=&Sl[z]; break; } }
             if(!use[j]){ qof[j]=nmiss; use[j]=&m->ws[nmiss]; missk[nmiss++]=j; m->miss++;
                 if(g_disk_split){ if(m->ld_ctx==1) m->miss_draft++; else if(m->ld_ctx==2) m->miss_absorb++; } }
         }
@@ -5962,12 +5978,13 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
           int promo = nmiss<m->ecap ? nmiss : m->ecap;
           for(int a=0;a<promo;a++){ int q=nmiss-1-a; ESlot *dst;
               if(*nn<m->ecap) dst=&Sl[(*nn)++];
-              else { int lru=eslot_lru_victim(Sl,*nn,m->ecap);
+              /* second chance, then a slab owner; emptied slots only reused under ecap (#1034) */
+              else { int lru=eslot_clock_victim(Sl,*nn,&m->ehand[layer],m->ecap);
                      if(lru<0){ static int warned;
                          if(!warned){ warned=1; fprintf(stderr,"[CUDA] no reusable LRU expert slot (in flight or cap reached); skipping cache promotion\n"); }
                          continue; }
                      dst=&Sl[lru]; }
-              ESlot tmp=*dst; *dst=m->ws[q]; m->ws[q]=tmp; dst->used=(uint64_t)__atomic_add_fetch(&m->eclock,1,__ATOMIC_RELAXED); }
+              ESlot tmp=*dst; *dst=m->ws[q]; m->ws[q]=tmp; dst->used=(uint64_t)__atomic_add_fetch(&m->eclock,1,__ATOMIC_RELAXED); dst->recent=1; }
         }
     }
     /* ---- FASE E: shared expert (PIPE2: gia' sul device; Metal CB: gia' sommata) ---- */
@@ -6156,7 +6173,8 @@ static void pilot_realload(Model *m, int layer, int eid){
     int slot,isnew=0;
     if(nn<m->ecap){ slot=nn; isnew=1; m->ecn[layer]=nn+1; }   /* cresci: pubblica subito lo slot (marcato prenotato) */
     else {
-        slot=eslot_lru_victim(Sl,nn,m->ecap);           /* riusa libero-con-slab, poi LRU; slot svuotati solo sotto ecap (#1034) */
+        /* second chance, then a slab owner; emptied slots only reused under ecap (#1034) */
+        slot=eslot_clock_victim(Sl,nn,&m->ehand[layer],m->ecap);
         if(slot<0){ atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);
                     pthread_mutex_unlock(&g_pilot_mx); return; }   /* tutti in volo, o cap raggiunto */
         /* LFRU eviction guard (#441, narrowed by #497 — folded into the SPMC selection):
@@ -6185,7 +6203,7 @@ static void pilot_realload(Model *m, int layer, int eid){
 
     pthread_mutex_lock(&g_pilot_mx);
     if(rc==0){
-        dst->used=(uint64_t)__atomic_add_fetch(&m->eclock,1,__ATOMIC_RELAXED);  /* eid gia' reale (expert_load); timbra used fresco */
+        dst->used=(uint64_t)__atomic_add_fetch(&m->eclock,1,__ATOMIC_RELAXED); dst->recent=1;  /* eid gia' reale (expert_load); timbra used fresco */
         atomic_fetch_add_explicit(&g_pilot_loads,1,memory_order_relaxed);
     } else {
         /* load fallito: libera la prenotazione. LO SLOT VA ANCHE RIPORTATO A used=0:
@@ -6195,7 +6213,7 @@ static void pilot_realload(Model *m, int layer, int eid){
          * sottraeva ~19MB di cache in modo permanente e silenzioso. used=0 e' la stessa
          * convenzione "slot vergine" di rss_guard: diventa la PRIMA vittima, non l'ultima. */
         dst->eid=-1;
-        dst->used=0;
+        dst->used=0; dst->recent=0;
         atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);
     }
     g_pilot_inflight[layer]--;
@@ -6229,7 +6247,8 @@ static void pilot_uring_batch(Model *m){
         if(found){ pthread_mutex_unlock(&g_pilot_mx); continue; }
         int slot;
         if(nn<m->ecap){ slot=nn; m->ecn[layer]=nn+1; }
-        else slot=eslot_lru_victim(Sl,nn,m->ecap);    /* riusa libero-con-slab, poi LRU; slot svuotati solo sotto ecap (#1034) */
+        /* second chance, then a slab owner; emptied slots only reused under ecap (#1034) */
+        else slot=eslot_clock_victim(Sl,nn,&m->ehand[layer],m->ecap);
         if(slot<0){ atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed); pthread_mutex_unlock(&g_pilot_mx); continue; }
         /* LFRU eviction guard (#441, narrowed by #497): protect only a genuinely WARM
          * resident (>=2 accesses) that is clearly hotter (see pilot_realload) */
@@ -6267,10 +6286,10 @@ static void pilot_uring_batch(Model *m){
         pthread_mutex_lock(&g_pilot_mx);
         if(rc==0){
             d->dst->eid=d->eid;
-            d->dst->used=(uint64_t)__atomic_add_fetch(&m->eclock,1,__ATOMIC_RELAXED);
+            d->dst->used=(uint64_t)__atomic_add_fetch(&m->eclock,1,__ATOMIC_RELAXED); d->dst->recent=1;
             atomic_fetch_add_explicit(&g_pilot_loads,1,memory_order_relaxed);
         }else{
-            d->dst->eid=-1;
+            d->dst->eid=-1; d->dst->recent=0;
             atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);
         }
         g_pilot_inflight[d->layer]--;
@@ -8080,7 +8099,7 @@ static void rss_guard(Model *m){
             s->slab=NULL; s->fslab=NULL; s->slab_cap=s->fslab_cap=0;
             QT *q[3]={&s->g,&s->u,&s->d};
             for(int k=0;k<3;k++){ q[k]->qf=NULL; q[k]->q8=NULL; q[k]->q4=NULL; q[k]->s=NULL; }
-            s->used=0;                                    /* primo candidato al riuso */
+            s->used=0; s->recent=0;                        /* first clock candidate on reuse */
             pthread_mutex_unlock(&g_pilot_mx);
             freed += sb; dropped++;
         }

--- a/c/olmoe.c
+++ b/c/olmoe.c
@@ -70,8 +70,21 @@ typedef struct {
 /* pinned=1 means this slot is strongly preferred to keep (hot expert); it will
  * not be evicted during normal LRU eviction, but may be displaced under extreme
  * cache pressure when all slots are pinned or in-flight. */
-typedef struct { int eid; int pinned; int8_t *g, *u, *d; float *gs, *us, *ds; uint64_t used; } Slot;
-typedef struct { Slot *slots; int n, cap; } LCache;
+typedef struct { int eid; int pinned; int8_t *g, *u, *d; float *gs, *us, *ds; uint64_t used; uint8_t recent; } Slot;
+typedef struct { Slot *slots; int n, cap, hand; } LCache;
+
+static int slot_clock_victim(LCache *lc, int allow_pinned) {
+    if (lc->n <= 0) return -1;
+    if (lc->hand < 0 || lc->hand >= lc->n) lc->hand = 0;
+    for (int pass = 0; pass < 2; pass++) for (int seen = 0; seen < lc->n; seen++) {
+        int i = lc->hand; lc->hand = (i + 1) % lc->n;
+        Slot *s = &lc->slots[i];
+        if (s->eid < 0 || (!allow_pinned && s->pinned)) continue;
+        if (!s->recent) return i;
+        s->recent = 0;
+    }
+    return -1;
+}
 
 typedef struct {
     Cfg c;
@@ -487,7 +500,7 @@ static void expert_get(Model *m, int layer, int eid, Slot **out) {
     LCache *lc = &m->cache[layer];
     pthread_mutex_lock(&g_pilot_mx);
     for (int i = 0; i < lc->n; i++) if (lc->slots[i].eid == eid) {
-        m->hits++; lc->slots[i].used = ++m->clock; *out = &lc->slots[i];
+        m->hits++; lc->slots[i].used = ++m->clock; lc->slots[i].recent = 1; *out = &lc->slots[i];
         if (m->last_access) m->last_access[layer * m->c.n_experts + eid] = m->clock;
         pthread_mutex_unlock(&g_pilot_mx);
         return;
@@ -499,20 +512,9 @@ static void expert_get(Model *m, int layer, int eid, Slot **out) {
         s = &lc->slots[lc->n++];
         slot_ensure_allocated(m, s);
     } else {
-        /* LRU eviction — skip pinned and in-flight (eid==-1) slots */
-        int lru = -1;
-        for (int i = 0; i < lc->n; i++) {
-            if (lc->slots[i].pinned || lc->slots[i].eid < 0) continue;
-            if (lru < 0 || lc->slots[i].used < lc->slots[lru].used) lru = i;
-        }
-        if (lru < 0) {
-            /* All slots are pinned or in-flight; find oldest non-in-flight slot
-             * (may be pinned, but never select one currently being loaded). */
-            for (int i = 0; i < lc->n; i++) {
-                if (lc->slots[i].eid < 0) continue; /* never evict in-flight */
-                if (lru < 0 || lc->slots[i].used < lc->slots[lru].used) lru = i;
-            }
-        }
+        /* Prefer unpinned slots; pinned slots retain the historical last-resort fallback. */
+        int lru = slot_clock_victim(lc, 0);
+        if (lru < 0) lru = slot_clock_victim(lc, 1);
         while (lru < 0) {
             /* EVERY slot is in flight: each buffer is owned by an unlocked pread
              * in the pilot worker (or a demand load) that will publish into it.
@@ -524,15 +526,13 @@ static void expert_get(Model *m, int layer, int eid, Slot **out) {
             pthread_mutex_unlock(&g_pilot_mx);
             sleep_ms(1);
             pthread_mutex_lock(&g_pilot_mx);
-            for (int i = 0; i < lc->n; i++) {
-                if (lc->slots[i].eid < 0) continue;
-                if (lru < 0 || lc->slots[i].used < lc->slots[lru].used) lru = i;
-            }
+            lru = slot_clock_victim(lc, 1);
         }
         s = &lc->slots[lru];
         s->pinned = 0;
     }
     s->eid = -1;
+    s->recent = 0;
     s->used = ++m->clock;
     pthread_mutex_unlock(&g_pilot_mx);
 
@@ -542,6 +542,7 @@ static void expert_get(Model *m, int layer, int eid, Slot **out) {
     s->eid = eid;
     s->pinned = m->is_pinned[layer * c->n_experts + eid];
     s->used = ++m->clock;
+    s->recent = 1;
     if (m->last_access) m->last_access[layer * c->n_experts + eid] = m->clock;
     *out = s;
     pthread_mutex_unlock(&g_pilot_mx);
@@ -831,12 +832,7 @@ static void pilot_realload(Model *m, int layer, int eid) {
         s = &lc->slots[lc->n++];
         slot_ensure_allocated(m, s);
     } else {
-        /* LRU eviction — skip pinned and in-flight (eid==-1) slots */
-        int lru = -1;
-        for (int i = 0; i < lc->n; i++) {
-            if (lc->slots[i].pinned || lc->slots[i].eid < 0) continue;
-            if (lru < 0 || lc->slots[i].used < lc->slots[lru].used) lru = i;
-        }
+        int lru = slot_clock_victim(lc, 0);
         if (lru < 0) {
             m->is_queued[layer * c->n_experts + eid] = 0;
             pthread_mutex_unlock(&g_pilot_mx);
@@ -858,7 +854,7 @@ static void pilot_realload(Model *m, int layer, int eid) {
 
         s = &lc->slots[lru]; s->pinned = 0;
     }
-    s->eid = -1; s->used = ++m->clock;
+    s->eid = -1; s->recent = 0; s->used = ++m->clock;
     pthread_mutex_unlock(&g_pilot_mx);
 
     load_expert_merged(m, layer, eid, s);
@@ -867,6 +863,7 @@ static void pilot_realload(Model *m, int layer, int eid) {
     s->eid = eid;
     s->pinned = m->is_pinned[layer * c->n_experts + eid];
     s->used = ++m->clock;
+    s->recent = 1;
     if (m->last_access) m->last_access[layer * c->n_experts + eid] = m->clock;
     m->is_queued[layer * c->n_experts + eid] = 0;
     pthread_mutex_unlock(&g_pilot_mx);

--- a/c/tests/test_eslot_inflight.c
+++ b/c/tests/test_eslot_inflight.c
@@ -1,8 +1,11 @@
-/* Async CUDA groups may borrow an LRU slot until stream completion.  The
- * oldest slot is therefore not necessarily an eligible eviction victim.
- * And a slot whose slab was freed by rss_guard (#1034) is only reusable
- * while the row's live-slab count stays under ecap: reusing it re-allocates
- * a slab, which is growth, not eviction. */
+/* Async CUDA groups may borrow a slot until stream completion, so the next slot
+ * under the clock hand is not automatically an eligible victim.
+ * Two invariants are covered together:
+ *  - clock: a slot with its reference bit set survives one sweep (second chance),
+ *    borrowed/reserved slots are skipped, and the hand rotates fairly;
+ *  - #1034: a slot whose slab was freed by rss_guard is only reusable while the
+ *    row's live-slab count stays under ecap, since reusing it re-allocates a slab,
+ *    which is growth rather than eviction. */
 #define main coli_glm_main_unused
 #include "../colibri.c"
 #undef main
@@ -11,32 +14,56 @@
 
 int main(void){
     uint8_t dummy[4];
-    ESlot slots[3]={0};
-    for(int i=0;i<3;i++){ slots[i].slab=dummy; slots[i].used=(uint64_t)i+1; }
 
-    if(eslot_lru_victim(slots,3,3)!=0) return 1;
-    eslot_acquire(&slots[0]);
-    if(eslot_lru_victim(slots,3,3)!=1) return 2;
-    eslot_acquire(&slots[1]); eslot_acquire(&slots[2]);
-    if(eslot_lru_victim(slots,3,3)!=-1) return 3;
+    /* ---- clock behaviour (victims must own a slab to be evictable) ---- */
+    ESlot slots[4]={0};
+    int hand=0;
+    for(int i=0;i<4;i++){ slots[i].eid=10+i; slots[i].slab=dummy; slots[i].recent=1; }
 
-    eslot_release(&slots[0]); eslot_release(&slots[1]); eslot_release(&slots[2]);
-    if(eslot_lru_victim(slots,3,3)!=0) return 4;
+    /* Every bit set: the first sweep clears them, the second evicts slot 0. */
+    if(eslot_clock_victim(slots,4,&hand,4)!=0) return 1;
+    if(hand!=1) return 2;
+    for(int i=0;i<4;i++) if(slots[i].recent) return 3;
 
-    /* #1034: slot svuotato da rss_guard (eid=-1, slab=NULL) */
-    slots[1].eid=-1; slots[1].slab=NULL;
-    if(eslot_lru_victim(slots,3,2)!=0) return 5;   /* live=2>=ecap=2: eviction, non crescita */
-    if(eslot_lru_victim(slots,3,3)!=1) return 6;   /* live=2<ecap=3: il vuoto si puo' riusare */
+    /* A re-referenced slot 0 is spared; the hand is already past it anyway. */
+    slots[0].recent=1;
+    if(eslot_clock_victim(slots,4,&hand,4)!=1) return 4;
 
-    /* slot libero che possiede ancora lo slab: riuso a costo zero, sempre preferito */
-    slots[0].eid=-1;
-    if(eslot_lru_victim(slots,3,2)!=0) return 7;
+    /* Borrowed slot is skipped, and slot 0 spends its second chance. */
+    hand=0; slots[0].recent=1; eslot_acquire(&slots[1]);
+    if(eslot_clock_victim(slots,4,&hand,4)!=2) return 5;
+    slots[2].eid=-3; /* another pilot worker's reservation: never a victim */
+    if(eslot_clock_victim(slots,4,&hand,4)!=3) return 6;
 
-    /* prenotazione in volo (eid<-1): mai vittima, e conta come slab vivo */
-    slots[0].eid=0; slots[2].eid=-5;
-    if(eslot_lru_victim(slots,3,2)!=0) return 8;   /* live=2 (slot0 + prenotazione) >= ecap */
-    if(eslot_lru_victim(slots,3,3)!=1) return 9;   /* live=2<ecap=3: di nuovo il vuoto */
+    /* Everything in flight or reserved: no victim at all. */
+    eslot_acquire(&slots[0]); eslot_acquire(&slots[2]); eslot_acquire(&slots[3]);
+    if(eslot_clock_victim(slots,4,&hand,4)!=-1) return 7;
 
+    /* A free slot that still owns its slab is the cheapest victim, bit or no bit. */
+    eslot_release(&slots[0]); eslot_release(&slots[1]);
+    eslot_release(&slots[2]); eslot_release(&slots[3]);
+    hand=0; slots[2].eid=-1;
+    for(int i=0;i<4;i++) slots[i].recent=1;
+    if(eslot_clock_victim(slots,4,&hand,4)!=2) return 8;
+
+    /* ---- #1034: an emptied slot is growth, so the cap gates its reuse ---- */
+    ESlot row[3]={0};
+    int rh=0;
+    for(int i=0;i<3;i++){ row[i].eid=20+i; row[i].slab=dummy; row[i].recent=0; }
+
+    /* rss_guard emptied slot 1 (eid=-1, slab=NULL); live slabs = 2. */
+    row[1].eid=-1; row[1].slab=NULL;
+    rh=0; if(eslot_clock_victim(row,3,&rh,2)!=0) return 9;   /* live=2>=ecap: evict an owner */
+    rh=0; if(eslot_clock_victim(row,3,&rh,3)!=1) return 10;  /* live=2<ecap: reuse the empty */
+
+    /* A free slot that still owns its slab beats the empty one even at the cap. */
+    row[0].eid=-1;
+    rh=0; if(eslot_clock_victim(row,3,&rh,2)!=0) return 11;
+
+    /* An in-flight reservation (eid<-1) is never a victim and counts as live. */
+    row[0].eid=20; row[0].recent=0; row[2].eid=-5;
+    rh=0; if(eslot_clock_victim(row,3,&rh,2)!=0) return 12;  /* live=2 (slot0 + reservation) */
+    rh=0; if(eslot_clock_victim(row,3,&rh,3)!=1) return 13;  /* under the cap: the empty again */
     puts("test_eslot_inflight: ok");
     return 0;
 }

--- a/c/tests/test_olmoe_serve_framing.c
+++ b/c/tests/test_olmoe_serve_framing.c
@@ -175,8 +175,23 @@ static void test_bad_frame_stops_before_the_next_command(void)
     fclose(output);
 }
 
+static void test_clock_eviction_skips_pinned_and_inflight(void)
+{
+    Slot slots[4] = {0};
+    LCache cache = {.slots = slots, .n = 4, .cap = 4};
+    for (int i = 0; i < 4; i++) { slots[i].eid = 10 + i; slots[i].recent = 1; }
+    assert(slot_clock_victim(&cache, 0) == 0);
+    assert(cache.hand == 1);
+    slots[1].pinned = 1;
+    assert(slot_clock_victim(&cache, 0) == 2);
+    slots[0].eid = slots[2].eid = slots[3].eid = -1;
+    assert(slot_clock_victim(&cache, 0) == -1);
+    assert(slot_clock_victim(&cache, 1) == 1);
+}
+
 int main(void)
 {
+    test_clock_eviction_skips_pinned_and_inflight();
     test_submit_moves_exact_payload_into_queue();
     test_cancel_only_matches_active_request();
     test_errors_are_byte_exact_and_frames_are_consumed();


### PR DESCRIPTION
## Summary

Replace full oldest-timestamp scans in the OLMoE and GLM expert caches with a per-layer clock/second-chance hand.

The change keeps the existing safety rules:

- OLMoE prefers unpinned slots and only considers pinned slots as the existing last-resort fallback.
- In-flight loads are never selected.
- GLM skips async GPU borrows and pilot reservations.
- Failed or RSS-guard-cleared slots become immediate reuse candidates.

Hits and successful publications set a one-bit recent marker. Victim selection clears recent markers while advancing the hand, avoiding a full minimum-timestamp comparison on every full-cache miss.

This does not claim that eviction scanning caused the throughput curve reported in the issue. That causal explanation was withdrawn in the issue thread. The change is scoped to the independently valid hot-path scalability and critical-section cleanup.

## Validation

- [ ] `make -C c check`
- [x] Focused GLM clock test: `make -B tests/test_eslot_inflight && ./tests/test_eslot_inflight`
- [x] Focused OLMoE clock and framing test: `make -B tests/test_olmoe_serve_framing && ./tests/test_olmoe_serve_framing`
- [x] OLMoE math regression: `./tests/test_olmoe_matmul_q`
- [x] Default CPU builds: `make colibri olmoe`
- [x] `git diff --check`

A model-free microbenchmark calling the production GLM selector showed the old minimum scan growing from 2.87 ns/call at one slot to 873.85 ns/call at 256 slots. With second chance and the real replacement pattern, the same sizes measured 14.06, 21.68, 17.88, and 17.24 ns/call respectively. These numbers only validate selector scaling, not end-to-end token throughput.

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included
- [x] No CUDA behavior is added or required

Refs #1050
