### PR TITLE
perf(colibri): K1b — grouped planar IDOT for gs64 containers, opt-in (IDOT_GS=1)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -509,7 +509,7 @@ static void matmul_i4_grouped_pair(float *yg, float *yu, const float *x,
 static void expert_gate_up(float *g,float *u,const float *x,QT *wg,QT *wu,int S){
     if(!g_no_fused_pair&&!spec_pinned()&&S==1&&wg->fmt==2&&!wg->planar&&!wu->planar&&wu->fmt==2&&wg->I==wu->I&&wg->O==wu->O)
         matmul_i4_pair(g,u,x,wg->q4,wg->s,wu->q4,wu->s,wg->I,wg->O);
-    else if(!g_no_fused_pair&&S==1&&wg->fmt==4&&wu->fmt==4&&wg->I==wu->I&&wg->O==wu->O&&wg->gs==wu->gs)
+    else if(!g_no_fused_pair&&S==1&&wg->fmt==4&&!wg->planar&&!wu->planar&&wu->fmt==4&&wg->I==wu->I&&wg->O==wu->O&&wg->gs==wu->gs)
         matmul_i4_grouped_pair(g,u,x,wg->q4,wg->s,wu->q4,wu->s,S,wg->I,wg->O,wg->gs);
     else { matmul_qt(g,x,wg,S); matmul_qt(u,x,wu,S); }
 }
@@ -954,8 +954,23 @@ static int planar_on(void){
     return g_planar;
 }
 static _Atomic long g_planar_n;   /* tensori planarizzati (telemetria una-tantum) */
+/* K1b: IDOT a gruppi per fmt=4 (gs%64==0) — OPT-IN, cambia le numeriche
+ * (attivazioni int8): resta 0 finche' l'ablazione non benedice un default.
+ * EN: opt-in grouped IDOT for fmt=4; int8 activations, awaiting ablation. */
+static int g_idot_gs=-1;
+static int idot_gs_on(void){
+    if(g_idot_gs<0){ const char *e=getenv("IDOT_GS"); g_idot_gs=(e&&atoi(e))?1:0;
+        if(g_idot_gs&&!planar_on()) g_idot_gs=0;   /* richiede la famiglia planare */
+        if(g_idot_gs) fprintf(stderr,"[K1b] grouped planar IDOT active for gs64 tensors (opt-in)\n"); }
+    return g_idot_gs;
+}
 static void qt_planarize(QT *t){
-    if(!planar_on()||t->fmt!=2||t->planar||!t->q4) return;
+    if(!planar_on()||t->planar||!t->q4) return;
+    if(t->fmt==4){
+        if(!idot_gs_on()||t->gs<64||t->gs%64) return;   /* K1b: solo su opt-in */
+        planarize_i4(t->q4,t->O,t->I); t->planar=1; return;
+    }
+    if(t->fmt!=2) return;
     planarize_i4(t->q4,t->O,t->I); t->planar=1;
     if(atomic_fetch_add_explicit(&g_planar_n,1,memory_order_relaxed)==0)
         fprintf(stderr,"[K1] planar int4 layout active (PLANAR=0 disables)\n");
@@ -1000,8 +1015,8 @@ static inline int pq_want(const QT *g,const QT *u,int nr){
     if(!g_idot) return 0;
     if(nr==1 && !g_no_fused_pair && !spec_pinned() &&
        g->fmt==2 && u->fmt==2 && g->I==u->I && g->O==u->O) return 0;
-    int a = g->fmt==1 || (g->fmt==2 && (spec_pinned() ? g_i4s<=1 : nr>=g_i4s));
-    int b = u->fmt==1 || (u->fmt==2 && (spec_pinned() ? g_i4s<=1 : nr>=g_i4s));
+    int a = g->fmt==1 || (g->fmt==2 && (spec_pinned() ? g_i4s<=1 : nr>=g_i4s)) || (g->fmt==4 && g->planar);
+    int b = u->fmt==1 || (u->fmt==2 && (spec_pinned() ? g_i4s<=1 : nr>=g_i4s)) || (u->fmt==4 && u->planar);
     return a || b;
 }
 
@@ -1046,7 +1061,32 @@ static void matmul_qt_ex(float *y, const float *x, QT *w, int S, int allow_idot)
     }
 #endif
     if(w->fmt==0){ matmul(y,x,w->qf,S,w->I,w->O); return; }
-    if(w->fmt==4){ matmul_i4_grouped(y,x,w->q4,w->s,S,w->I,w->O,w->gs); return; }
+    if(w->fmt==4){
+        if(w->planar){
+            /* K1b: quantizza le attivazioni (o riusa il contesto g_pq) e calcola le
+             * somme per (riga, gruppo) — il termine -8*sum del dot unsigned.
+             * EN: grouped planar IDOT — int8 activations + per-(row,group) sums. */
+            int I=w->I, ng=(I+w->gs-1)/w->gs; int8_t *xq; float *sx;
+            if(S<0 || I<0 || (size_t)S>SIZE_MAX/(size_t)(I?I:1)){ fprintf(stderr,"matmul_qt: shape overflow\n"); exit(1); }
+            if(g_pq.x==x && g_pq.S==S && g_pq.I==I){ xq=(int8_t*)g_pq.xq; sx=(float*)g_pq.sx; }
+            else {
+                quant_scratch((size_t)S*I,(size_t)S,&xq,&sx);
+                for(int s=0;s<S;s++) sx[s]=qrow_i8(x+(int64_t)s*I, xq+(int64_t)s*I, I);
+            }
+            static _Thread_local int32_t *xsg; static _Thread_local size_t xsg_cap;
+            if((size_t)S*ng>xsg_cap){ free(xsg); xsg=malloc((size_t)S*ng*sizeof(int32_t));
+                xsg_cap=xsg?(size_t)S*ng:0; if(!xsg){ fprintf(stderr,"OOM xsg\n"); exit(1); } }
+            for(int s=0;s<S;s++) for(int g=0;g<ng;g++){
+                int base=g*w->gs, end=base+w->gs; if(end>I) end=I;
+                int32_t t2=0; const int8_t *r2=xq+(int64_t)s*I;
+                for(int i=base;i<end;i++) t2+=r2[i];
+                xsg[(int64_t)s*ng+g]=t2;
+            }
+            matmul_i4p_grouped_idot(y,xq,sx,xsg,w->q4,w->s,S,I,w->O,w->gs);
+            return;
+        }
+        matmul_i4_grouped(y,x,w->q4,w->s,S,w->I,w->O,w->gs); return;
+    }
     if(w->fmt==6){ matmul_e8(y,x,w->q4,NULL,S,w->I,w->O); return; }   /* scales live in-block */
     if(allow_idot && g_idot && (w->fmt==1 || (w->fmt==2 && (spec_pinned() ? g_i4s<=1 : S>=g_i4s)))){
         int I=w->I; int8_t *xq; float *sx;
@@ -1383,7 +1423,7 @@ static void expert_ffn(float *hh, float *gg, float *uu, const float *xg, QT *g, 
      * branch, quantize h here (rows in parallel, same qrow_i8 -> identical
      * bytes) and publish the g_pq context matmul_qt_ex already consumes;
      * cleared right after so no stale match can outlive this call. */
-    if(g_idot && (d->fmt==1 || (d->fmt==2 && (spec_pinned() ? g_i4s<=1 : nr>=g_i4s)))){
+    if(g_idot && (d->fmt==1 || (d->fmt==2 && (spec_pinned() ? g_i4s<=1 : nr>=g_i4s)) || (d->fmt==4 && d->planar))){
         static _Thread_local int8_t *hq; static _Thread_local size_t hq_cap;
         static _Thread_local float *hsx; static _Thread_local int32_t *hxs;
         static _Thread_local size_t hrow_cap;

--- a/c/quant.h
+++ b/c/quant.h
@@ -1086,6 +1086,77 @@ static inline int32_t dot_i4p_u(const uint8_t *w4, const int8_t *x, int I){
     return sum;
 }
 
+/* ---- K1b (OPT-IN, IDOT_GS=1): IDOT planare A GRUPPI (fmt=4, gs%64==0) -----
+ * Con gs=64 il gruppo di scala COINCIDE col blocco-piano da 64 elementi: il
+ * dot unsigned del blocco (2 dpbusd) -> int32 di gruppo, meno 8*somma(x) del
+ * gruppo, per la scala f32 del gruppo. Attivazioni int8 (stessa famiglia
+ * qrow_i8 del resto dell'IDOT): NON bit-identico al kernel f32 a gruppi --
+ * per questo e' dietro flag, in attesa dell'ablazione. xsg = somme int32
+ * per (riga, gruppo), calcolate dal chiamante in una passata esatta.
+ * EN: grouped planar IDOT, opt-in. With gs=64 the scale group IS the plane
+ * block; per-group unsigned dot minus 8*group-sum, times the group scale.
+ * int8 activations: not bit-identical to the f32 grouped kernel, hence the
+ * flag until the ablation blesses a default. */
+static void matmul_i4p_grouped_idot(float *y, const int8_t *xq, const float *sx,
+                                    const int32_t *xsg, const uint8_t *q4,
+                                    const float *scale, int S, int I, int O, int gs){
+    int rb=(I+1)/2, ng=(I+gs-1)/gs, bpg=gs/64;   /* blocchi-piano per gruppo */
+    #pragma omp parallel for schedule(static)
+    for(int o=0;o<O;o++){
+        const uint8_t *w=q4+(int64_t)o*rb;
+        const float *scl=scale+(int64_t)o*ng;
+        for(int s=0;s<S;s++){
+            const int8_t *xr=xq+(int64_t)s*I;
+            const int32_t *xg=xsg+(int64_t)s*ng;
+            float a=0; int g=0;
+            for(; (g+1)*gs<=I; g++){                     /* gruppi interi */
+                int32_t d=0;
+                for(int b=0;b<bpg;b++){
+                    int base=g*gs+b*64;
+                    const uint8_t *blk=w+(base>>1);
+                    const int8_t *xb=xr+base;
+#if defined(coli_dpbusd256)
+                    const __m256i m4=_mm256_set1_epi8(0x0F);
+                    __m256i bb=_mm256_loadu_si256((const __m256i*)blk);
+                    __m256i acc=_mm256_setzero_si256();
+                    acc=coli_dpbusd256(acc,_mm256_and_si256(bb,m4),
+                                       _mm256_loadu_si256((const __m256i*)xb));
+                    acc=coli_dpbusd256(acc,_mm256_and_si256(_mm256_srli_epi16(bb,4),m4),
+                                       _mm256_loadu_si256((const __m256i*)(xb+32)));
+                    d+=hsum256_i32(acc);
+#elif defined(__AVX2__)
+                    const __m256i m4=_mm256_set1_epi8(0x0F);
+                    const __m256i ones=_mm256_set1_epi16(1);
+                    __m256i bb=_mm256_loadu_si256((const __m256i*)blk);
+                    __m256i p0=_mm256_maddubs_epi16(_mm256_and_si256(bb,m4),
+                                                    _mm256_loadu_si256((const __m256i*)xb));
+                    __m256i p1=_mm256_maddubs_epi16(_mm256_and_si256(_mm256_srli_epi16(bb,4),m4),
+                                                    _mm256_loadu_si256((const __m256i*)(xb+32)));
+                    __m256i acc=_mm256_add_epi32(_mm256_madd_epi16(p0,ones),
+                                                 _mm256_madd_epi16(p1,ones));
+                    d+=hsum256_i32(acc);
+#else
+                    for(int k=0;k<32;k++){
+                        d+=(int32_t)(blk[k]&0xF)*xb[k];
+                        d+=(int32_t)(blk[k]>>4)*xb[k+32];
+                    }
+#endif
+                }
+                a=fmaf((float)(d-8*xg[g]),scl[g],a);
+            }
+            if(g*gs<I){                                  /* coda: gruppo parziale, nibble a coppie */
+                int32_t d=0;
+                for(int i=g*gs;i<I;i++){
+                    uint8_t byte=w[i>>1];
+                    d+=(int32_t)((i&1)?(byte>>4):(byte&0xF))*xr[i];
+                }
+                a=fmaf((float)(d-8*xg[g]),scl[g],a);
+            }
+            y[(int64_t)s*O+o]=a*sx[s];
+        }
+    }
+}
+
 /* matmul IDOT planare (fmt=2): y = (dot_u - 8*xsum[s]) * scale[o] * sx[s].
  * Bit-identico a matmul_i4_idot: somme intere, identita' esatta. */
 static void matmul_i4p_idot(float *y, const int8_t *xq, const float *sx, const int32_t *xsum,

--- a/c/tests/test_int_kernel_exact.c
+++ b/c/tests/test_int_kernel_exact.c
@@ -113,6 +113,48 @@ int main(void){
         free(qp);free(ql);free(sc);free(x);free(ya);free(yb);
     }
 #endif
+    /* K1b: matmul_i4p_grouped_idot vs riferimento C puro con lo STESSO ordine
+     * float (per-gruppo: int esatto -> fmaf con la scala; poi * sx). Il kernel
+     * e' opt-in e non-bit-identico al f32 a gruppi; contro il SUO riferimento
+     * deve invece essere esatto al bit su ogni ISA. Copre gs=64 e gs=128
+     * (bpg=2) e una coda I%gs!=0. */
+    {
+        int cases[][2]={{64,2048},{128,2048},{64,2000}};
+        for(int t=0;t<3;t++){
+            int gs=cases[t][0], I=cases[t][1], O=128, S=3;
+            int rb=(I+1)/2, ng=(I+gs-1)/gs;
+            uint8_t *qp=malloc((size_t)O*rb); for(size_t i=0;i<(size_t)O*rb;i++) qp[i]=(uint8_t)rnd();
+            uint8_t *ql=malloc((size_t)O*rb); memcpy(ql,qp,(size_t)O*rb); planarize_i4(ql,O,I);
+            float *sc=malloc((size_t)O*ng*sizeof(float));
+            for(size_t i=0;i<(size_t)O*ng;i++) sc[i]=0.0005f+(rnd()%911)*1e-6f;
+            int8_t *xq=malloc((size_t)S*I); for(size_t i=0;i<(size_t)S*I;i++) xq[i]=rnd_x();
+            float *sx=malloc(S*sizeof(float)); for(int s=0;s<S;s++) sx[s]=0.01f+(rnd()%89)*1e-4f;
+            int32_t *xsg=malloc((size_t)S*ng*sizeof(int32_t));
+            for(int s=0;s<S;s++) for(int g=0;g<ng;g++){
+                int base=g*gs,end=base+gs; if(end>I) end=I;
+                int32_t a=0; for(int i=base;i<end;i++) a+=xq[(size_t)s*I+i]; xsg[(size_t)s*ng+g]=a; }
+            float *ya=malloc((size_t)S*O*sizeof(float)), *yb=malloc((size_t)S*O*sizeof(float));
+            /* riferimento: dot int per gruppo sul layout A COPPIE (pesi logici) */
+            for(int o=0;o<O;o++) for(int s=0;s<S;s++){
+                float a=0;
+                for(int g=0;g<ng;g++){
+                    int base=g*gs,end=base+gs; if(end>I) end=I;
+                    int64_t d=0;
+                    for(int i=base;i<end;i++){
+                        uint8_t byte=qp[(size_t)o*rb+(i>>1)];
+                        d+=(int64_t)((i&1)?(byte>>4):(byte&0xF))*xq[(size_t)s*I+i];
+                    }
+                    a=fmaf((float)((int32_t)d-8*xsg[(size_t)s*ng+g]),sc[(size_t)o*ng+g],a);
+                }
+                ya[(size_t)s*O+o]=a*sx[s];
+            }
+            matmul_i4p_grouped_idot(yb,xq,sx,xsg,ql,sc,S,I,O,gs);
+            for(size_t i=0;i<(size_t)S*O;i++){ checks++;
+                if(memcmp(&ya[i],&yb[i],4)){ fails++;
+                    fprintf(stderr,"FAIL grouped_idot gs=%d I=%d @%zu\n",gs,I,i); if(fails>8) break; } }
+            free(qp);free(ql);free(sc);free(xq);free(sx);free(xsg);free(ya);free(yb);
+        }
+    }
     printf("int-kernel exactness: %d checks, %d failures (%s / " IDOT_KERNEL ")\n",
            checks,fails,fails?"FAIL":"PASS");
     return fails?1:0;

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -109,7 +109,8 @@ Format: `VAR` — default — effect.
 | `PROF` | `0` (off) | Performance profile: a startup header (machine + effective config), then per run — or per turn in serve mode, on stderr — forward-latency percentiles (p50/p90/p99/max), expert-I/O totals and cache-tier fill, phase shares of wall time, and a verdict naming the knob most likely to help on this machine. Output is additive; `PROF` unset changes nothing. |
 | `COLI_NO_FUSED_PAIR` | `0` (off) | `=1` disables the fused-pair matmul kernel. |
 | `DISK_SPLIT` | `0` (off) | `=1` splits the reported disk-load time across the draft/absorb/forward phases in stats. |
-| `I4S` | unset | Engage the int4 `IDOT` kernel only for batch `S>=<n>` (testing). |
+| `I4S` | per-ISA (`1` on AVX-512-VNNI / NEON-dotprod, `2` elsewhere) | Engage the int4 `IDOT` kernel for batch `S>=<n>`. `I4S=1` turns IDOT on at decode too: int8-quantized activations on expert matmuls — **not bit-identical** to the f32 decode path (measured 0.39% of scale on the gate output; the same numerics prefill already uses at `S>=2`, and the shipped default on AVX-512-VNNI, measured +5.5% end-to-end there). Attention projections always stay exact regardless. A default flip on AVX-VNNI awaits the quality ablation. |
+| `IDOT_GS` | `0` (off) | **Opt-in** grouped planar IDOT for `fmt=4` (gs64/gs128) tensors: int8 activations with the K1 plane layout, one integer dot per scale group. Same numerics family as `I4S=1` — not bit-identical to the f32 grouped kernel, hence off until the ablation. Requires the planar family (AVX2 build, no GPU backend, no `XEXP`). Activation prints `[K1b]` once. |
 | `SPEC_PIN` | `1` (on) | Speculation gate mode. `0` reverts to the legacy S-dependent speculation gates (#163). |
 | `COLI_RAM_OVERCOMMIT` | off | `=1` overrides the "projected peak > MemAvailable → exit(2)" guard so a run that risks kernel OOM-kill is allowed to proceed. |
 


### PR DESCRIPTION
## What

The **recommended container format could never reach the integer kernels**: `fmt=4` (grouped int4, gs64) returned to the f32 kernel at every S. With gs=64 the scale group *coincides* with the K1 plane block, so the fast path falls out naturally: per group, one unsigned dot (two `vpdpbusd`) − `8·sum(x)` of the group, × the group's f32 scale.

**Opt-in (`IDOT_GS=1`), honestly labeled:** int8 activations are the same numerics family as `I4S=1` and **not bit-identical** to the f32 grouped kernel — the default stays off until the quality ablation blesses it. Off = byte-for-byte unchanged (verified: glm_tiny e2e token-identical at int8 and int4 vs unpatched dev).

## Gates

| gate | result |
|---|---|
| kernel vs pure-C reference with the **identical float order** (gs=64, gs=128 two-blocks-per-group, `I%gs` tail) | bit-exact — 5,120 checks, 0 failures |
| e2e flag-off vs unpatched dev | token-identical (int8 + int4) |
| ARM job (#1083) | holds the same reference bar with NEON live |
| builds | colibri, olmoe, kimi_k3 clean |

## Wiring

`qt_planarize` covers fmt=4 under the flag (same MoE-only sites, same slab-refill reset discipline from K1); the dispatch consumes the `g_pq` context and computes per-(row,group) sums; the S==1 fused f32 pair skips planar tensors; `pq_want` and the K3-lite h-hoist extend to planar fmt=4 so gate/up **and** down ride the same context. `[K1b]` stderr line reports activation.

`docs/ENVIRONMENT.md` now documents `I4S` honestly (per-ISA default, what it changes, the shipped +5.5% AVX-512 A/B) and `IDOT_GS`.

## What decides the default

The light ablation (logit KL vs the exact anchor on a real GLM container) gates both `I4S=1`-on-AVX-VNNI and `IDOT_GS=1` defaults in one campaign — kit ready, waiting on the model disk. Until then both are documented opt-ins, same policy we applied to olmoe (#1044), inkling (#1080) and qwen36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)