### PR TITLE
feat(planner): OLMoE PlannerGeometry adapter (#1066)

### DIFF
--- a/c/family_registry.py
+++ b/c/family_registry.py
@@ -149,6 +149,25 @@ def _qwen36_geometry(config, context, _model_dir):
     return PlannerGeometry(kv, fixed, 0, _required_int(config, "num_experts", "qwen36"))
 
 
+def _olmoe_geometry(config, context, _model_dir):
+    """Conventional full multi-head attention: every layer holds a K and a V
+    cache in fp32, and olmoe.c sizes both at num_attention_heads * head_dim, not
+    num_key_value_heads (`c/olmoe.c:1019-1020`, with head_dim = hidden_size //
+    num_attention_heads at `:327`). There is no recurrent or convolutional state,
+    and the KV cache is the only buffer that grows with context, so fixed and
+    workspace are zero -- the bounded per-forward scratch (attention scores,
+    logits, expert temporaries) is already covered by the base runtime reserve."""
+    layers = _required_int(config, "num_hidden_layers", "olmoe")
+    hidden = _required_int(config, "hidden_size", "olmoe")
+    heads = _required_int(config, "num_attention_heads", "olmoe")
+    head_dim = hidden // heads
+    if head_dim < 1:
+        raise ValueError("olmoe: hidden_size is smaller than num_attention_heads")
+    experts = _required_int(config, "num_experts", "olmoe")
+    state = layers * context * heads * head_dim * 2 * 4
+    return PlannerGeometry(state, 0, 0, experts)
+
+
 _GLM_EXPERT = re.compile(
     r"(?:^|\.)model\.layers\.(\d+)\.mlp\.experts\.(\d+)\."
 )
@@ -276,8 +295,8 @@ FAMILIES = (
         cli_adapter="olmoe",
         gateway_adapter="olmoe",
         planner_id="olmoe_gqa",
-        planner_geometry=None,
-        planner_unsupported_reason="OLMoE planning awaits a measured runtime/workspace reserve",
+        planner_geometry=_olmoe_geometry,
+        planner_unsupported_reason="",
         expert_inventory=_individual_expert_inventory(_GLM_EXPERT),
         config_section="root",
         limits=FamilyLimits(4096, 4096, 1024, 1024, 1, 8, "CTX"),

--- a/c/tests/test_family_registry.py
+++ b/c/tests/test_family_registry.py
@@ -177,8 +177,36 @@ class FamilyRegistryTest(unittest.TestCase):
         self.assertEqual(geometry.configured_experts, 4)
         self.assertEqual(geometry.context_state_bytes, 13_312)
 
+    def test_olmoe_fixture_models_conventional_fp32_kv_cache(self):
+        # OLMoE keeps a full K and V cache per layer, sized at num_attention_heads
+        # * head_dim in fp32 (olmoe.c:1019-1020), no recurrent/fixed state, and no
+        # model-specific workspace beyond the base runtime reserve.
+        config = {
+            "model_type": "olmoe",
+            "num_hidden_layers": 4,
+            "hidden_size": 32,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 4,
+            "num_experts": 8,
+            "num_experts_per_tok": 2,
+            "intermediate_size": 16,
+            "vocab_size": 100,
+        }
+        by_id, by_type = _build_registry(FAMILIES)
+        family = by_type["olmoe"]
+        self.assertEqual(family, by_id["olmoe"])
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        geometry = planner_geometry(resolved, 32)
+        self.assertEqual(geometry.configured_experts, 8)
+        # layers=4, context=32, heads=4, head_dim=32//4=8, K and V, fp32:
+        # 4 * 32 * 4 * 8 * 2 * 4 = 32768
+        self.assertEqual(geometry.context_state_bytes, 4 * 32 * 4 * 8 * 2 * 4)
+        self.assertEqual(geometry.fixed_state_bytes, 0)
+        self.assertEqual(geometry.workspace_bytes, 0)
+
     def test_unproven_production_planners_refuse_instead_of_inventing_zero(self):
-        for model_type in ("inkling", "kimi_k3", "olmoe", "deepseek_v4"):
+        for model_type in ("inkling", "kimi_k3", "deepseek_v4"):
             family = family_for_config({"model_type": model_type})
             resolved = type("R", (), {"descriptor": family, "family_config": {},
                                        "model_dir": "."})()

--- a/c/tests/test_resource_plan.py
+++ b/c/tests/test_resource_plan.py
@@ -217,6 +217,37 @@ class ResourcePlanTest(unittest.TestCase):
                     one["tiers"]["ram"]["fixed_state_bytes"])
         self.assertEqual(delta, 3 * per_slot)
 
+    def test_olmoe_plans_instead_of_refusing(self):
+        # #1066: OLMoE used to refuse in `coli plan`/`doctor` because its
+        # planner_geometry was None (which under-reserved as zero-byte KV). With
+        # the adapter it plans, charging an fp32 K and V cache per layer sized at
+        # num_attention_heads * head_dim (mirrors olmoe.c:1019-1020), no fixed
+        # recurrent state.
+        with tempfile.TemporaryDirectory() as tmp:
+            model = Path(tmp)
+            (model / "config.json").write_text(json.dumps({
+                "model_type": "olmoe",
+                "num_hidden_layers": 2,
+                "hidden_size": 32,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 4,
+                "num_experts": 2,
+                "num_experts_per_tok": 2,
+                "intermediate_size": 16,
+                "vocab_size": 100,
+            }))
+            write_shard(model / "model.safetensors", [
+                ("model.embed_tokens.weight", 100),
+                ("model.layers.0.mlp.experts.0.gate_proj.weight", 30),
+                ("model.layers.0.mlp.experts.1.gate_proj.weight", 30),
+            ])
+            plan = build_plan(model, context=32, kv_slots=1,
+                              available_memory=32 * GB, available_disk=1, gpus=[])
+            ram = plan["tiers"]["ram"]
+            # layers=2, ctx=32, heads=4, head_dim=32//4=8, K and V, fp32:
+            self.assertEqual(ram["sequence_state_bytes"], 2 * 32 * 4 * 8 * 2 * 4)
+            self.assertEqual(ram["fixed_state_bytes"], 0)
+
     def test_glm_dsa_state_is_charged_only_when_every_indexer_weight_exists(self):
         config = json.loads((self.model / "config.json").read_text())
         config.update({"index_head_dim": 16,


### PR DESCRIPTION
Implements the OLMoE per-family planner adapter from #1066 (the simplest of the
four families listed there). OLMoE had planner_geometry=None, so `coli plan` and
`coli doctor` refused instead of reporting a real budget.

The geometry is derived from the engine, not borrowed from GLM: olmoe.c keeps a
full K and V cache per layer in fp32, sized at num_attention_heads * head_dim
(c/olmoe.c:1019-1020; head_dim = hidden_size // num_attention_heads at :327),
allocated at n_heads rather than n_key_value_heads. There is no recurrent or
convolutional state and the KV cache is the only context-scaling buffer, so
fixed_state_bytes and workspace_bytes are both zero; the bounded per-forward
scratch is already covered by the base runtime reserve.

Tests: a geometry fixture in test_family_registry.py, an end-to-end build_plan
test in test_resource_plan.py proving OLMoE no longer refuses, and the existing
"unproven planners refuse" test updated to drop olmoe. Full planner suite passes.

Scope: OLMoE only. Kimi K3 (KDA recurrent + MXFP4), Inkling (hybrid GQA/sconv +
audio) and DeepSeek V4 still need their own measured geometry and stay refusing.