### PR TITLE
perf(deepseek_v4): expert-loader pool default 3 → 9 lanes (measured 1.41× decode)

### DIFF
--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -4515,13 +4515,23 @@ typedef struct {
  * only the pool. */
 enum { DUAL_EXPERT_LOADER_COUNT = COLI_V4_EXPERT_LOADER_COUNT };
 enum { DUAL_EXPERT_LOADER_MAX = 16 };
+/* Default del POOL (non della riserva CPU qui sotto: quella resta sul COMPILE
+ * default — le lane bloccano in pread e non consumano core, vedi il commento
+ * sopra). 9 misurato contro 3 su questa classe di macchina: 8 run interfogliate
+ * a box quieto sul V4-Flash reale, decode 147.3s -> 104.8s medi (1.41x, 1.46x
+ * in mediana), TTFT invariato nel rumore, zero OOM/crash su 8/8 run — coerente
+ * con la misura in-tree 48ms -> 29.6ms per lettura fredda. V4_LOADER_LANES
+ * resta la manopola per dischi che si comportano diversamente.
+ * EN: pool default only; the CPU reservation keeps subtracting the compile
+ * constant. 9 vs 3 measured on the real checkpoint: 1.41x decode, no OOM. */
+enum { DUAL_EXPERT_LOADER_DEFAULT_LANES = 9 };
 
 static int dual_loader_lanes(void) {
     static int lanes;
     if (!lanes) {
         const char *value = getenv("V4_LOADER_LANES");
-        int n = value ? atoi(value) : DUAL_EXPERT_LOADER_COUNT;
-        if (n < 1) n = DUAL_EXPERT_LOADER_COUNT;
+        int n = value ? atoi(value) : DUAL_EXPERT_LOADER_DEFAULT_LANES;
+        if (n < 1) n = DUAL_EXPERT_LOADER_DEFAULT_LANES;
         if (n > DUAL_EXPERT_LOADER_MAX) n = DUAL_EXPERT_LOADER_MAX;
         lanes = n;
     }


### PR DESCRIPTION
## What

`V4_LOADER_LANES` (48db957) made the expert-loader pool depth runtime-tunable but left the default at the compile constant **3**. This flips the **pool default only** to **9** — the CPU reservation deliberately keeps subtracting the compile constant, per the two-consumers note in the source: lanes block in `pread` and do not consume cores.

## Evidence

Quiet-box campaign on the **real V4-Flash checkpoint** (156 GB streamed on a 25 GB box), 8 interleaved runs (3,9)×4, same prompt, 32 tokens:

| | lanes=3 | lanes=9 | ratio |
|---|---|---|---|
| decode, mean of 4 | 147.3 s | **104.8 s** | **1.41×** |
| decode, median | 152.9 s | 104.4 s | 1.46× |
| TTFT | 55.7 s | 62.6 s | noise |
| completions / OOM | 4/4, none | **4/4, none** | — |

An earlier apparent lanes=9 crash reproduced as *host memory pressure* (a stale 18 GB python3 OOM kill in dmesg), not the pool — the quiet campaign shows 8/8 clean. Consistent with the in-tree 48 ms → 29.6 ms cold-read figure and the QD1=86 MB/s → QD8=696 MB/s `dd` measurement on the same shards. A first noisy attempt at this A/B was **discarded as invalid** (concurrent builds polluted it) — this campaign replaced it rather than averaging it in.

## Gates

- tiny oracle full PASS on the flipped default (token-exact, serve protocol, KV prefix reuse)
- `V4_LOADER_LANES` still overrides for disks that behave differently (the knob's docs unchanged)

Roadmap: closes item 4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)