### PR TITLE
planner: add OLMoE + Kimi K3 + Inkling + DeepSeek V4 geometry adapters (closes #1066)

### DIFF
--- a/c/family_registry.py
+++ b/c/family_registry.py
@@ -168,6 +168,64 @@ def _olmoe_geometry(config, context, _model_dir):
     return PlannerGeometry(state, 0, 0, experts)
 
 
+
+def _kimi_geometry(config, context, _model_dir):
+    """Kimi K3: hybrid -- 69 KDA (recurrent) + 24 gated MLA layers.
+
+    The engine marks KDA layers via linear_attn_config.kda_layers (1-based
+    indices, kimi_k3.c:552-555); every other layer is a gated MLA layer.
+    Only the MLA layers keep a positional Lc/Rc cache (kimi_k3.c:1704-1706),
+    so only they scale with context:
+
+        MLA cache = n_mla * context * (kv_lora + qk_rope) * 4
+
+    The KDA layers carry a per-head recurrent state that does NOT depend on
+    context (kimi_k3.c:691): kda_heads * kda_hd * kda_hd floats per layer.
+    That belongs in fixed_state_bytes, exactly like GLM's indexer state.
+
+    Workspace mirrors the prefill temporary set (C == context):
+      KDA (kimi_k3.c:896-898): q,k,v,gp,on,graw = 6*C*P, t1 = C*kda_hd,
+                               braw = C*hidden, P = kda_heads*kda_hd
+      MLA (kimi_k3.c:992-994): qa = C*q_lora, qv = C*H*qh, ckv = C*(kvl+qr),
+                               gv = C*H*vh, ctx = C*H*vh
+    The planner reserves the larger of the two (a single forward pass only
+    touches one layer type at a time).
+    """
+    layers = _required_int(config, "num_hidden_layers", "kimi_k3")
+    experts = _required_int(config, "num_experts", "kimi_k3")
+    hidden = _required_int(config, "hidden_size", "kimi_k3")
+    heads = _required_int(config, "num_attention_heads", "kimi_k3")
+    q_lora = _required_int(config, "q_lora_rank", "kimi_k3")
+    kv_lora = _required_int(config, "kv_lora_rank", "kimi_k3")
+    qk_nope = _required_int(config, "qk_nope_head_dim", "kimi_k3")
+    qk_rope = _required_int(config, "qk_rope_head_dim", "kimi_k3")
+    v_head = _required_int(config, "v_head_dim", "kimi_k3")
+
+    la = config.get("linear_attn_config")
+    if not isinstance(la, dict):
+        raise ValueError("kimi_k3: missing or invalid planning key 'linear_attn_config'")
+    kda_heads = _required_int(la, "num_heads", "kimi_k3")
+    kda_hd = _required_int(la, "head_dim", "kimi_k3")
+    kda_list = la.get("kda_layers")
+    if not isinstance(kda_list, list):
+        raise ValueError("kimi_k3: missing or invalid planning key 'linear_attn_config.kda_layers'")
+    n_kda = sum(1 for v in kda_list if isinstance(v, int) and 1 <= v <= layers)
+    n_mla = layers - n_kda
+    if n_mla < 0:
+        n_mla = 0
+
+    state = n_mla * context * (kv_lora + qk_rope) * 4
+    fixed = n_kda * kda_heads * kda_hd * kda_hd * 4
+
+    kda_proj = kda_heads * kda_hd
+    ws_kda = context * (6 * kda_proj + kda_hd + hidden) * 4
+    qh = qk_nope + qk_rope
+    ws_mla = context * (q_lora + heads * qh + kv_lora + qk_rope +
+                        2 * heads * v_head) * 4
+    workspace = max(ws_kda, ws_mla)
+    return PlannerGeometry(state, fixed, workspace, experts)
+
+
 _GLM_EXPERT = re.compile(
     r"(?:^|\.)model\.layers\.(\d+)\.mlp\.experts\.(\d+)\."
 )
@@ -271,8 +329,8 @@ FAMILIES = (
         cli_adapter="kimi",
         gateway_adapter="kimi",
         planner_id="kimi_hybrid",
-        planner_geometry=None,
-        planner_unsupported_reason="Kimi planning awaits measured KDA recurrent-state and native MXFP4 reserves",
+        planner_geometry=_kimi_geometry,
+        planner_unsupported_reason="",
         expert_inventory=_individual_expert_inventory(_KIMI_EXPERT),
         config_section="text_config",
         limits=FamilyLimits(8192, 1048576, 1024, 1024, 1, 8, "K3_MAXT"),

--- a/c/family_registry.py
+++ b/c/family_registry.py
@@ -226,6 +226,104 @@ def _kimi_geometry(config, context, _model_dir):
     return PlannerGeometry(state, fixed, workspace, experts)
 
 
+
+def _inkling_local_layers(config, layers):
+    """Which Inkling layers are sliding-window (1-based rule from inkling.c:557-568).
+
+    Precedence, mirroring the engine:
+      1. explicit ``layer_types`` array ("hybrid_sliding" marks local layers)
+      2. ``local_layer_ids`` array of 0-based layer indices
+      3. the default ``(i + 1) % 6 != 0`` rule (5 of every 6 layers sliding)
+    """
+    lt = config.get("layer_types")
+    if isinstance(lt, list):
+        if len(lt) != layers:
+            raise ValueError("inkling: layer_types length must match num_hidden_layers")
+        return [t == "hybrid_sliding" for t in lt]
+    ll = config.get("local_layer_ids")
+    if isinstance(ll, list):
+        local = [False] * layers
+        for v in ll:
+            if isinstance(v, int) and 0 <= v < layers:
+                local[v] = True
+        return local
+    return [(i + 1) % 6 != 0 for i in range(layers)]
+
+
+def _inkling_geometry(config, context, _model_dir):
+    """Inkling: hybrid GQA -- sliding-window layers (window ring) + global layers
+    + short convolutions (sconv) on K/V/attn/mlp + optional DMel audio tower.
+
+    Mirrors the engine's allocation in inkling.c:
+
+    KV cache (kv_alloc, inkling.c:1687-1699): every layer keeps its own
+    K/V pair sized from the layer's kv heads and head dim (L_KV/L_HD,
+    inkling.c:80-82). Sliding layers are a ring of ``window`` rows
+    (kv_ring_rows, inkling.c:1124-1125) -- at context > window that is a
+    ~64x cut on 5-of-6 layers; global layers keep the full context.
+
+        state[layer] = 2 * kv * rows * hd * 4,  rows = window | context
+
+    Conv states (inkling.c:888-890, 1646): four depthwise short-conv states
+    per layer -- cs[0]/cs[1] are kv-wide (kvdim), cs[2]/cs[3] are hidden-wide
+    -- each holding ``conv_k - 1`` history rows. These do not scale with
+    context, so they are fixed_state_bytes.
+
+        fixed[layer] = (2 * kvdim + 2 * hidden) * (conv_k - 1) * 4
+
+    Workspace (attention temporaries, inkling.c:1141-1147): q, k, vv, rr
+    and ctx are per-batch S buffers; with S == context at prefill the peak
+    is the maximum across layer types (global vs sliding differ).
+
+        ws = S * (2 * qdim + 2 * kvdim + H * d_rel) * 4
+
+    Audio tower (inkling.c:808-832): a DMel encoder embedding table
+    [mel_bins * mel_vocab, hidden] plus one RMSNorm weight. It is a fixed
+    resident allocation when ``audio_config`` is present, so it joins
+    fixed_state_bytes.
+    """
+    layers = _required_int(config, "num_hidden_layers", "inkling")
+    experts = _required_int(config, "n_routed_experts", "inkling")
+    hidden = _required_int(config, "hidden_size", "inkling")
+    heads = _required_int(config, "num_attention_heads", "inkling")
+    n_kv = _required_int(config, "num_key_value_heads", "inkling")
+    head_dim = _required_int(config, "head_dim", "inkling")
+    swa_heads = _optional_int(config, "swa_num_attention_heads", heads, 1)
+    swa_kv = _optional_int(config, "swa_num_key_value_heads", n_kv, 1)
+    swa_hd = _optional_int(config, "swa_head_dim", head_dim, 1)
+    window = _optional_int(config, "sliding_window_size", 512, 1)
+    d_rel = _optional_int(config, "d_rel", 16, 1)
+    conv_k = _optional_int(config, "sconv_kernel_size",
+                           _optional_int(config, "conv_kernel_size", 4, 1), 1)
+
+    local = _inkling_local_layers(config, layers)
+    if len(local) != layers:
+        raise ValueError("inkling: layer_types length must match num_hidden_layers")
+
+    state = 0
+    fixed = 0
+    workspace = 0
+    for i in range(layers):
+        kv = swa_kv if local[i] else n_kv
+        hd = swa_hd if local[i] else head_dim
+        h = swa_heads if local[i] else heads
+        rows = window if (local[i] and window > 0 and window < context) else context
+        state += 2 * kv * rows * hd * 4
+        kvdim = kv * hd
+        fixed += (2 * kvdim + 2 * hidden) * (conv_k - 1) * 4
+        qdim = h * hd
+        ws = context * (2 * qdim + 2 * kvdim + h * d_rel) * 4
+        workspace = max(workspace, ws)
+
+    ac = config.get("audio_config")
+    if isinstance(ac, dict):
+        mel_bins = _optional_int(ac, "n_mel_bins", 80, 1)
+        mel_vocab = _optional_int(ac, "mel_vocab_size", 16, 1)
+        fixed += (mel_bins * mel_vocab * hidden + hidden) * 4
+
+    return PlannerGeometry(state, fixed, workspace, experts)
+
+
 _GLM_EXPERT = re.compile(
     r"(?:^|\.)model\.layers\.(\d+)\.mlp\.experts\.(\d+)\."
 )
@@ -305,8 +403,8 @@ FAMILIES = (
         cli_adapter="inkling",
         gateway_adapter="inkling",
         planner_id="inkling_hybrid",
-        planner_geometry=None,
-        planner_unsupported_reason="Inkling planning awaits a measured hybrid GQA/sconv runtime adapter",
+        planner_geometry=_inkling_geometry,
+        planner_unsupported_reason="",
         expert_inventory=_inkling_expert_inventory,
         config_section="text_config",
         limits=FamilyLimits(8192, 1048576, 1024, 1024, 1, 8, "CTX_MAX"),

--- a/c/family_registry.py
+++ b/c/family_registry.py
@@ -324,6 +324,75 @@ def _inkling_geometry(config, context, _model_dir):
     return PlannerGeometry(state, fixed, workspace, experts)
 
 
+
+def _dsv4_geometry(config, context, _model_dir):
+    """DeepSeek V4: sliding-window ring + per-layer compressor/indexer states.
+
+    Mirrors the engine's own ``context_bytes()`` (deepseek_v4.c:1271-1284)
+    exactly -- this is the resident cache the C runtime sizes at load:
+
+        base       = num_hidden_layers * sliding_window * head_dim * 4
+        per layer: ratio = compress_ratios[layer]
+                   compressed = ceil(context / ratio)
+                   total += compressed * head_dim * 4
+                   if ratio == 4:
+                       total += compressed * index_head_dim * 4
+
+    The window ring (``base``) does not depend on the context: it is a fixed
+    circular buffer, so it belongs in fixed_state_bytes. The compressor and
+    indexer states scale with ``context / ratio`` and belong in
+    context_state_bytes.
+
+    Workspace mirrors the batched-attention scratch set
+    (deepseek_v4.c:2741-2750): qa (q_rank), q (q_width), kv (head_dim),
+    attended (q_width), oa (oa_width), norm (max(q_rank, head_dim)) -- with
+    q_width = heads * head_dim and oa_width = o_groups * o_lora_rank. With
+    batch == context at prefill the peak is the sum of the batch-wide float
+    buffers plus the single norm buffer.
+
+    Experts: configured_experts = n_routed_experts.
+    """
+    layers = _required_int(config, "num_hidden_layers", "deepseek_v4")
+    experts = _required_int(config, "n_routed_experts", "deepseek_v4")
+    hidden = _required_int(config, "hidden_size", "deepseek_v4")
+    heads = _required_int(config, "num_attention_heads", "deepseek_v4")
+    head_dim = _required_int(config, "head_dim", "deepseek_v4")
+    q_rank = _required_int(config, "q_lora_rank", "deepseek_v4")
+    o_groups = _required_int(config, "o_groups", "deepseek_v4")
+    o_rank = _required_int(config, "o_lora_rank", "deepseek_v4")
+    window = _required_int(config, "sliding_window", "deepseek_v4")
+    index_hd = _required_int(config, "index_head_dim", "deepseek_v4")
+
+    ratios = config.get("compress_ratios")
+    if not isinstance(ratios, list) or len(ratios) != layers:
+        raise ValueError(
+            "deepseek_v4: compress_ratios must be a list matching "
+            "num_hidden_layers")
+
+    # Fixed window ring: n_layers * window * head_dim fp32.
+    fixed = layers * window * head_dim * 4
+
+    # Compressor + indexer states, scaling with context / ratio.
+    state = 0
+    for ratio in ratios:
+        if not isinstance(ratio, bool) and isinstance(ratio, int) and ratio > 0:
+            compressed = (context + ratio - 1) // ratio
+            state += compressed * head_dim * 4
+            if ratio == 4:
+                state += compressed * index_hd * 4
+        elif ratio != 0:
+            raise ValueError("deepseek_v4: compress_ratios entries must be "
+                             "non-negative integers")
+
+    # Batched-attention scratch (prefill, batch == context).
+    q_width = heads * head_dim
+    oa_width = o_groups * o_rank
+    workspace = (context * (q_rank + 2 * q_width + head_dim + oa_width) +
+                 max(q_rank, head_dim)) * 4
+
+    return PlannerGeometry(state, fixed, workspace, experts)
+
+
 _GLM_EXPERT = re.compile(
     r"(?:^|\.)model\.layers\.(\d+)\.mlp\.experts\.(\d+)\."
 )
@@ -507,8 +576,8 @@ FAMILIES = (
         cli_adapter="deepseek_v4",
         gateway_adapter="deepseek_v4",
         planner_id="deepseek_v4",
-        planner_geometry=None,
-        planner_unsupported_reason="DeepSeek V4 uses its C resident-tier planner; Python parity is not yet proven",
+        planner_geometry=_dsv4_geometry,
+        planner_unsupported_reason="",
         expert_inventory=_individual_expert_inventory(_V4_EXPERT),
         config_section="root",
         limits=FamilyLimits(4096, 1048576, 1024, 16384, 1, 8, "CTX"),

--- a/c/tests/test_family_registry.py
+++ b/c/tests/test_family_registry.py
@@ -206,7 +206,7 @@ class FamilyRegistryTest(unittest.TestCase):
         self.assertEqual(geometry.workspace_bytes, 0)
 
     def test_unproven_production_planners_refuse_instead_of_inventing_zero(self):
-        for model_type in ("deepseek_v4",):
+        for model_type in ():
             family = family_for_config({"model_type": model_type})
             resolved = type("R", (), {"descriptor": family, "family_config": {},
                                        "model_dir": "."})()
@@ -597,6 +597,145 @@ class FamilyRegistryTest(unittest.TestCase):
                                    "model_dir": "."})()
         with self.assertRaises(ValueError):
             planner_geometry(resolved, 32)
+
+    def test_dsv4_geometry_matches_engine_context_bytes(self):
+        # 4 layers: ratios [0, 2, 4, 4] -> no-compress, compressor, indexer, indexer
+        config = {
+            "model_type": "deepseek_v4",
+            "hidden_size": 2048,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 16,
+            "head_dim": 32,
+            "q_lora_rank": 16,
+            "o_groups": 4,
+            "o_lora_rank": 64,
+            "sliding_window": 8,
+            "index_head_dim": 24,
+            "n_routed_experts": 32,
+            "compress_ratios": [0, 2, 4, 4],
+        }
+        by_id, by_type = _build_registry(FAMILIES)
+        family = by_type[config["model_type"]]
+        self.assertEqual(family, by_id["deepseek_v4"])
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        geometry = planner_geometry(resolved, 32)
+        # Fixed window ring: 4 layers * window 8 * head_dim 32 * 4
+        self.assertEqual(geometry.fixed_state_bytes, 4 * 8 * 32 * 4)
+        # Compressor states: ceil(32/2)=16 * hd * 4  +  ceil(32/4)=8 * hd * 4 * 2
+        state = 16 * 32 * 4 + 8 * 32 * 4 + 8 * 32 * 4
+        # Indexer states (ratio==4): ceil(32/4)=8 * index_hd 24 * 4, for 2 layers
+        state += 8 * 24 * 4 + 8 * 24 * 4
+        self.assertEqual(geometry.context_state_bytes, state)
+        self.assertEqual(geometry.configured_experts, 32)
+
+    def test_dsv4_geometry_fixed_ring_does_not_scale_with_context(self):
+        config = {
+            "model_type": "deepseek_v4",
+            "hidden_size": 2048,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 16,
+            "head_dim": 32,
+            "q_lora_rank": 16,
+            "o_groups": 4,
+            "o_lora_rank": 64,
+            "sliding_window": 8,
+            "index_head_dim": 24,
+            "n_routed_experts": 32,
+            "compress_ratios": [0, 2, 4, 4],
+        }
+        by_id, _ = _build_registry(FAMILIES)
+        family = by_id["deepseek_v4"]
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        small = planner_geometry(resolved, 16)
+        large = planner_geometry(resolved, 64)
+        # Window ring is context-independent
+        self.assertEqual(small.fixed_state_bytes, large.fixed_state_bytes)
+        # Compressed states scale ~linearly with context (ceil divisions)
+        ratio = large.context_state_bytes / small.context_state_bytes
+        self.assertAlmostEqual(ratio, 4, delta=0.5)
+
+    def test_dsv4_geometry_workspace_matches_attention_scratch(self):
+        config = {
+            "model_type": "deepseek_v4",
+            "hidden_size": 2048,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 16,
+            "head_dim": 32,
+            "q_lora_rank": 16,
+            "o_groups": 4,
+            "o_lora_rank": 64,
+            "sliding_window": 8,
+            "index_head_dim": 24,
+            "n_routed_experts": 32,
+            "compress_ratios": [0, 2, 4, 4],
+        }
+        by_id, _ = _build_registry(FAMILIES)
+        family = by_id["deepseek_v4"]
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        geometry = planner_geometry(resolved, 32)
+        ctx = 32
+        q_width = 16 * 32       # heads * head_dim
+        oa_width = 4 * 64       # o_groups * o_lora_rank
+        expected = (ctx * (16 + 2 * q_width + 32 + oa_width) +
+                    max(16, 32)) * 4
+        self.assertEqual(geometry.workspace_bytes, expected)
+
+    def test_dsv4_geometry_rejects_bad_compress_ratios(self):
+        config = {
+            "model_type": "deepseek_v4",
+            "hidden_size": 2048,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 16,
+            "head_dim": 32,
+            "q_lora_rank": 16,
+            "o_groups": 4,
+            "o_lora_rank": 64,
+            "sliding_window": 8,
+            "index_head_dim": 24,
+            "n_routed_experts": 32,
+            "compress_ratios": [0, 2],  # wrong length
+        }
+        by_id, _ = _build_registry(FAMILIES)
+        family = by_id["deepseek_v4"]
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        with self.assertRaises(ValueError):
+            planner_geometry(resolved, 32)
+
+    def test_dsv4_geometry_rejects_missing_keys(self):
+        by_id, _ = _build_registry(FAMILIES)
+        family = by_id["deepseek_v4"]
+        resolved = type("R", (), {"descriptor": family, "family_config": {},
+                                   "model_dir": "."})()
+        with self.assertRaises(ValueError):
+            planner_geometry(resolved, 32)
+
+    def test_dsv4_geometry_all_uncompressed_layers_have_only_ring(self):
+        config = {
+            "model_type": "deepseek_v4",
+            "hidden_size": 2048,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 16,
+            "head_dim": 32,
+            "q_lora_rank": 16,
+            "o_groups": 4,
+            "o_lora_rank": 64,
+            "sliding_window": 8,
+            "index_head_dim": 24,
+            "n_routed_experts": 32,
+            "compress_ratios": [0, 0, 0, 0],
+        }
+        by_id, _ = _build_registry(FAMILIES)
+        family = by_id["deepseek_v4"]
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        geometry = planner_geometry(resolved, 64)
+        # No compressors: context state is zero, only the ring is resident
+        self.assertEqual(geometry.context_state_bytes, 0)
+        self.assertEqual(geometry.fixed_state_bytes, 4 * 8 * 32 * 4)
 
     def test_cli_and_gateway_dispatch_follow_the_registry(self):
         import openai_server

--- a/c/tests/test_family_registry.py
+++ b/c/tests/test_family_registry.py
@@ -205,14 +205,73 @@ class FamilyRegistryTest(unittest.TestCase):
         self.assertEqual(geometry.fixed_state_bytes, 0)
         self.assertEqual(geometry.workspace_bytes, 0)
 
-    def test_unproven_production_planners_refuse_instead_of_inventing_zero(self):
-        for model_type in ():
+    def test_production_planners_report_real_geometry(self):
+        # #1066 is closed: every production planner now returns a real
+        # PlannerGeometry instead of refusing with PlannerUnsupportedError.
+        # The plan must never be a silently-invented zero-byte budget --
+        # every family here has a resident KV/state cache, so at least one
+        # of context_state_bytes or fixed_state_bytes must be non-zero.
+        cases = {
+            "olmoe": {
+                "model_type": "olmoe",
+                "hidden_size": 2048,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 16,
+                "num_key_value_heads": 16,
+                "num_experts": 8,
+            },
+            "kimi_k3": {
+                "model_type": "kimi_k3",
+                "hidden_size": 2048,
+                "num_hidden_layers": 8,
+                "num_attention_heads": 16,
+                "q_lora_rank": 64,
+                "kv_lora_rank": 128,
+                "qk_nope_head_dim": 64,
+                "qk_rope_head_dim": 32,
+                "v_head_dim": 128,
+                "num_experts": 32,
+                "linear_attn_config": {
+                    "num_heads": 8,
+                    "head_dim": 64,
+                    "kda_layers": [1, 2, 3, 4, 5],
+                },
+            },
+            "inkling": {
+                "model_type": "inkling",
+                "hidden_size": 2048,
+                "num_hidden_layers": 6,
+                "num_attention_heads": 16,
+                "num_key_value_heads": 4,
+                "head_dim": 32,
+                "n_routed_experts": 8,
+            },
+            "deepseek_v4": {
+                "model_type": "deepseek_v4",
+                "hidden_size": 2048,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 16,
+                "head_dim": 32,
+                "q_lora_rank": 16,
+                "o_groups": 4,
+                "o_lora_rank": 64,
+                "sliding_window": 8,
+                "index_head_dim": 24,
+                "n_routed_experts": 32,
+                "compress_ratios": [0, 2, 4, 4],
+            },
+        }
+        for model_type, config in cases.items():
             family = family_for_config({"model_type": model_type})
-            resolved = type("R", (), {"descriptor": family, "family_config": {},
-                                       "model_dir": "."})()
-            with self.subTest(model_type=model_type), \
-                 self.assertRaises(PlannerUnsupportedError):
-                planner_geometry(resolved, 32)
+            resolved = type("R", (), {"descriptor": family,
+                                      "family_config": config,
+                                      "model_dir": "."})()
+            with self.subTest(model_type=model_type):
+                geometry = planner_geometry(resolved, 32)
+                self.assertIsInstance(geometry, PlannerGeometry)
+                self.assertGreater(
+                    geometry.context_state_bytes + geometry.fixed_state_bytes,
+                    0)
 
 
     def test_olmoe_geometry_matches_engine_kv_allocation(self):

--- a/c/tests/test_family_registry.py
+++ b/c/tests/test_family_registry.py
@@ -214,6 +214,93 @@ class FamilyRegistryTest(unittest.TestCase):
                  self.assertRaises(PlannerUnsupportedError):
                 planner_geometry(resolved, 32)
 
+
+    def test_olmoe_geometry_matches_engine_kv_allocation(self):
+        # OLMoE config shaped like the real 1B-7B model (AI2), but small.
+        config = {
+            "model_type": "olmoe",
+            "hidden_size": 2048,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 16,
+            "num_experts": 8,
+            "num_experts_per_tok": 2,
+            "intermediate_size": 512,
+            "vocab_size": 50304,
+        }
+        by_id, by_type = _build_registry(FAMILIES)
+        family = by_type[config["model_type"]]
+        self.assertEqual(family, by_id["olmoe"])
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        geometry = planner_geometry(resolved, 32)
+        # Engine allocates K+V with n_heads (not n_kv_heads), fp32:
+        #   head_dim = hidden // n_heads = 2048 // 16 = 128
+        #   state   = layers * context * heads * head_dim * 2 * 4
+        self.assertEqual(geometry.configured_experts, 8)
+        self.assertEqual(geometry.context_state_bytes,
+                         2 * 32 * 16 * 128 * 2 * 4)
+        self.assertEqual(geometry.fixed_state_bytes, 0)
+        # Workspace: the bounded per-forward scratch (attention scores,
+        # logits, expert temporaries) is covered by the base runtime reserve,
+        # so the planner reports no context-scaling workspace (dev #1095).
+        self.assertEqual(geometry.workspace_bytes, 0)
+
+    def test_olmoe_geometry_scales_with_context(self):
+        config = {
+            "model_type": "olmoe",
+            "hidden_size": 2048,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 16,
+            "num_experts": 8,
+            "num_experts_per_tok": 2,
+            "intermediate_size": 512,
+            "vocab_size": 50304,
+        }
+        by_id, by_type = _build_registry(FAMILIES)
+        family = by_type[config["model_type"]]
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        small = planner_geometry(resolved, 16)
+        large = planner_geometry(resolved, 64)
+        ratio = large.context_state_bytes / small.context_state_bytes
+        self.assertEqual(ratio, 4)  # linear in context
+        # Workspace stays at zero at every context (per dev #1095): only the
+        # KV state scales with context, so the ratio above is the full story.
+        self.assertEqual(small.workspace_bytes, 0)
+        self.assertEqual(large.workspace_bytes, 0)
+
+    def test_olmoe_geometry_rejects_missing_keys(self):
+        by_id, _ = _build_registry(FAMILIES)
+        family = by_id["olmoe"]
+        resolved = type("R", (), {"descriptor": family, "family_config": {},
+                                   "model_dir": "."})()
+        with self.assertRaises(ValueError):
+            planner_geometry(resolved, 32)
+
+    def test_olmoe_geometry_uses_n_heads_not_n_kv_heads(self):
+        # GQA where kv < q heads: the engine still allocates K/V per q head,
+        # so the plan must follow num_attention_heads (olmoe.c:1019-1020).
+        config = {
+            "model_type": "olmoe",
+            "hidden_size": 2048,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 4,   # GQA ratio 4
+            "num_experts": 8,
+            "num_experts_per_tok": 2,
+            "intermediate_size": 512,
+            "vocab_size": 50304,
+        }
+        by_id, _ = _build_registry(FAMILIES)
+        family = by_id["olmoe"]
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        geometry = planner_geometry(resolved, 32)
+        self.assertEqual(geometry.context_state_bytes,
+                         2 * 32 * 16 * 128 * 2 * 4)  # 16 heads, not 4
+
     def test_cli_and_gateway_dispatch_follow_the_registry(self):
         import openai_server
         from importlib.machinery import SourceFileLoader

--- a/c/tests/test_family_registry.py
+++ b/c/tests/test_family_registry.py
@@ -206,7 +206,7 @@ class FamilyRegistryTest(unittest.TestCase):
         self.assertEqual(geometry.workspace_bytes, 0)
 
     def test_unproven_production_planners_refuse_instead_of_inventing_zero(self):
-        for model_type in ("inkling", "deepseek_v4"):
+        for model_type in ("deepseek_v4",):
             family = family_for_config({"model_type": model_type})
             resolved = type("R", (), {"descriptor": family, "family_config": {},
                                        "model_dir": "."})()
@@ -446,6 +446,157 @@ class FamilyRegistryTest(unittest.TestCase):
         ws_mla = (ctx * 64 + ctx * 16 * qh + ctx * (128 + 32) +
                   2 * ctx * 16 * 128) * 4
         self.assertEqual(geometry.workspace_bytes, max(ws_kda, ws_mla))
+
+    def test_inkling_geometry_matches_engine_hybrid_allocation(self):
+        # 6 layers: default rule (i+1)%6 -> 5 sliding + 1 global (last).
+        config = {
+            "model_type": "inkling",
+            "hidden_size": 2048,
+            "num_hidden_layers": 6,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 4,
+            "head_dim": 32,
+            "swa_num_attention_heads": 16,
+            "swa_num_key_value_heads": 2,
+            "swa_head_dim": 32,
+            "sliding_window_size": 8,
+            "d_rel": 4,
+            "sconv_kernel_size": 3,
+            "n_routed_experts": 8,
+        }
+        by_id, by_type = _build_registry(FAMILIES)
+        family = by_type[config["model_type"]]
+        self.assertEqual(family, by_id["inkling"])
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        geometry = planner_geometry(resolved, 32)
+        # 5 sliding layers: kv=2, hd=32, rows=window=8 -> 2*2*8*32*4 each
+        sliding = 5 * (2 * 2 * 8 * 32 * 4)
+        # 1 global layer: kv=4, hd=32, rows=context=32 -> 2*4*32*32*4
+        global_ = 1 * (2 * 4 * 32 * 32 * 4)
+        self.assertEqual(geometry.context_state_bytes, sliding + global_)
+        # Conv states per layer: (2*kvdim + 2*hidden) * (conv_k-1) * 4
+        kvdim_s = 2 * 32   # sliding kv*hd
+        kvdim_g = 4 * 32   # global kv*hd
+        fixed = 5 * (2 * kvdim_s + 2 * 2048) * 2 * 4
+        fixed += 1 * (2 * kvdim_g + 2 * 2048) * 2 * 4
+        self.assertEqual(geometry.fixed_state_bytes, fixed)
+        self.assertEqual(geometry.configured_experts, 8)
+
+    def test_inkling_geometry_sliding_ring_does_not_scale_past_window(self):
+        config = {
+            "model_type": "inkling",
+            "hidden_size": 2048,
+            "num_hidden_layers": 6,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 4,
+            "head_dim": 32,
+            "swa_num_attention_heads": 16,
+            "swa_num_key_value_heads": 2,
+            "swa_head_dim": 32,
+            "sliding_window_size": 8,
+            "d_rel": 4,
+            "sconv_kernel_size": 3,
+            "n_routed_experts": 8,
+        }
+        by_id, _ = _build_registry(FAMILIES)
+        family = by_id["inkling"]
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        small = planner_geometry(resolved, 8)    # context == window
+        large = planner_geometry(resolved, 64)   # context > window
+        # Sliding ring rows are capped at window, so beyond window the
+        # sliding contribution is flat; only the 1 global layer grows.
+        delta = large.context_state_bytes - small.context_state_bytes
+        self.assertEqual(delta, 1 * (2 * 4 * (64 - 8) * 32 * 4))
+        # Fixed (conv) state is context-independent
+        self.assertEqual(small.fixed_state_bytes, large.fixed_state_bytes)
+
+    def test_inkling_geometry_local_layer_ids_override_default(self):
+        config = {
+            "model_type": "inkling",
+            "hidden_size": 2048,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 4,
+            "head_dim": 32,
+            "swa_num_attention_heads": 16,
+            "swa_num_key_value_heads": 2,
+            "swa_head_dim": 32,
+            "sliding_window_size": 8,
+            "d_rel": 4,
+            "sconv_kernel_size": 3,
+            "n_routed_experts": 8,
+            "local_layer_ids": [0, 2],   # only layers 0 and 2 are sliding
+        }
+        by_id, _ = _build_registry(FAMILIES)
+        family = by_id["inkling"]
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        geometry = planner_geometry(resolved, 32)
+        # 2 sliding (kv=2, rows=8) + 2 global (kv=4, rows=32)
+        expected = 2 * (2 * 2 * 8 * 32 * 4) + 2 * (2 * 4 * 32 * 32 * 4)
+        self.assertEqual(geometry.context_state_bytes, expected)
+
+    def test_inkling_geometry_audio_tower_adds_fixed_reserve(self):
+        base = {
+            "model_type": "inkling",
+            "hidden_size": 2048,
+            "num_hidden_layers": 6,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 4,
+            "head_dim": 32,
+            "swa_num_attention_heads": 16,
+            "swa_num_key_value_heads": 2,
+            "swa_head_dim": 32,
+            "sliding_window_size": 8,
+            "d_rel": 4,
+            "sconv_kernel_size": 3,
+            "n_routed_experts": 8,
+        }
+        by_id, _ = _build_registry(FAMILIES)
+        family = by_id["inkling"]
+        resolved = type("R", (), {"descriptor": family, "family_config": base,
+                                   "model_dir": "."})()
+        no_audio = planner_geometry(resolved, 32)
+
+        with_audio_cfg = dict(base)
+        with_audio_cfg["audio_config"] = {"n_mel_bins": 80, "mel_vocab_size": 16}
+        resolved2 = type("R", (), {"descriptor": family,
+                                   "family_config": with_audio_cfg,
+                                   "model_dir": "."})()
+        audio = planner_geometry(resolved2, 32)
+        # audio_enc table [80*16, 2048] + norm [2048], fp32
+        expected_audio = (80 * 16 * 2048 + 2048) * 4
+        self.assertEqual(audio.fixed_state_bytes - no_audio.fixed_state_bytes,
+                         expected_audio)
+        self.assertEqual(audio.context_state_bytes, no_audio.context_state_bytes)
+
+    def test_inkling_geometry_rejects_missing_keys(self):
+        by_id, _ = _build_registry(FAMILIES)
+        family = by_id["inkling"]
+        resolved = type("R", (), {"descriptor": family, "family_config": {},
+                                   "model_dir": "."})()
+        with self.assertRaises(ValueError):
+            planner_geometry(resolved, 32)
+
+    def test_inkling_geometry_rejects_bad_layer_types_length(self):
+        config = {
+            "model_type": "inkling",
+            "hidden_size": 2048,
+            "num_hidden_layers": 6,
+            "num_attention_heads": 16,
+            "num_key_value_heads": 4,
+            "head_dim": 32,
+            "n_routed_experts": 8,
+            "layer_types": ["hybrid_sliding"],  # wrong length
+        }
+        by_id, _ = _build_registry(FAMILIES)
+        family = by_id["inkling"]
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        with self.assertRaises(ValueError):
+            planner_geometry(resolved, 32)
 
     def test_cli_and_gateway_dispatch_follow_the_registry(self):
         import openai_server

--- a/c/tests/test_family_registry.py
+++ b/c/tests/test_family_registry.py
@@ -206,7 +206,7 @@ class FamilyRegistryTest(unittest.TestCase):
         self.assertEqual(geometry.workspace_bytes, 0)
 
     def test_unproven_production_planners_refuse_instead_of_inventing_zero(self):
-        for model_type in ("inkling", "kimi_k3", "deepseek_v4"):
+        for model_type in ("inkling", "deepseek_v4"):
             family = family_for_config({"model_type": model_type})
             resolved = type("R", (), {"descriptor": family, "family_config": {},
                                        "model_dir": "."})()
@@ -300,6 +300,152 @@ class FamilyRegistryTest(unittest.TestCase):
         geometry = planner_geometry(resolved, 32)
         self.assertEqual(geometry.context_state_bytes,
                          2 * 32 * 16 * 128 * 2 * 4)  # 16 heads, not 4
+
+    def test_kimi_geometry_matches_engine_hybrid_allocation(self):
+        # Kimi K3-shaped config: 8 layers, 5 KDA + 3 MLA (small synthetic).
+        config = {
+            "model_type": "kimi_k3",
+            "hidden_size": 2048,
+            "num_hidden_layers": 8,
+            "num_attention_heads": 16,
+            "q_lora_rank": 64,
+            "kv_lora_rank": 128,
+            "qk_nope_head_dim": 64,
+            "qk_rope_head_dim": 32,
+            "v_head_dim": 128,
+            "num_experts": 32,
+            "linear_attn_config": {
+                "num_heads": 8,
+                "head_dim": 64,
+                "short_conv_kernel_size": 3,
+                "kda_layers": [1, 2, 3, 4, 5],
+            },
+        }
+        by_id, by_type = _build_registry(FAMILIES)
+        family = by_type[config["model_type"]]
+        self.assertEqual(family, by_id["kimi"])
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        geometry = planner_geometry(resolved, 32)
+        # MLA cache: 3 MLA layers x context x (kv_lora + qk_rope) x 4
+        self.assertEqual(geometry.context_state_bytes,
+                         3 * 32 * (128 + 32) * 4)
+        # KDA fixed recurrent state: 5 KDA layers x heads x hd x hd x 4
+        self.assertEqual(geometry.fixed_state_bytes,
+                         5 * 8 * 64 * 64 * 4)
+        self.assertEqual(geometry.configured_experts, 32)
+
+    def test_kimi_geometry_kda_state_does_not_scale_with_context(self):
+        config = {
+            "model_type": "kimi_k3",
+            "hidden_size": 2048,
+            "num_hidden_layers": 8,
+            "num_attention_heads": 16,
+            "q_lora_rank": 64,
+            "kv_lora_rank": 128,
+            "qk_nope_head_dim": 64,
+            "qk_rope_head_dim": 32,
+            "v_head_dim": 128,
+            "num_experts": 32,
+            "linear_attn_config": {
+                "num_heads": 8,
+                "head_dim": 64,
+                "short_conv_kernel_size": 3,
+                "kda_layers": [1, 2, 3, 4, 5],
+            },
+        }
+        by_id, _ = _build_registry(FAMILIES)
+        family = by_id["kimi"]
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        small = planner_geometry(resolved, 16)
+        large = planner_geometry(resolved, 64)
+        # KDA recurrent state is context-independent
+        self.assertEqual(small.fixed_state_bytes, large.fixed_state_bytes)
+        # MLA cache scales linearly with context
+        self.assertEqual(large.context_state_bytes / small.context_state_bytes, 4)
+
+    def test_kimi_geometry_rejects_missing_linear_attn_config(self):
+        by_id, _ = _build_registry(FAMILIES)
+        family = by_id["kimi"]
+        config = {
+            "model_type": "kimi_k3",
+            "hidden_size": 2048,
+            "num_hidden_layers": 8,
+            "num_attention_heads": 16,
+            "q_lora_rank": 64,
+            "kv_lora_rank": 128,
+            "qk_nope_head_dim": 64,
+            "qk_rope_head_dim": 32,
+            "v_head_dim": 128,
+            "num_experts": 32,
+        }
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        with self.assertRaises(ValueError):
+            planner_geometry(resolved, 32)
+
+    def test_kimi_geometry_rejects_missing_kda_layers(self):
+        by_id, _ = _build_registry(FAMILIES)
+        family = by_id["kimi"]
+        config = {
+            "model_type": "kimi_k3",
+            "hidden_size": 2048,
+            "num_hidden_layers": 8,
+            "num_attention_heads": 16,
+            "q_lora_rank": 64,
+            "kv_lora_rank": 128,
+            "qk_nope_head_dim": 64,
+            "qk_rope_head_dim": 32,
+            "v_head_dim": 128,
+            "num_experts": 32,
+            "linear_attn_config": {"num_heads": 8, "head_dim": 64},
+        }
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        with self.assertRaises(ValueError):
+            planner_geometry(resolved, 32)
+
+    def test_kimi_geometry_rejects_missing_keys(self):
+        by_id, _ = _build_registry(FAMILIES)
+        family = by_id["kimi"]
+        resolved = type("R", (), {"descriptor": family, "family_config": {},
+                                   "model_dir": "."})()
+        with self.assertRaises(ValueError):
+            planner_geometry(resolved, 32)
+
+    def test_kimi_geometry_workspace_is_max_of_kda_and_mla(self):
+        config = {
+            "model_type": "kimi_k3",
+            "hidden_size": 2048,
+            "num_hidden_layers": 8,
+            "num_attention_heads": 16,
+            "q_lora_rank": 64,
+            "kv_lora_rank": 128,
+            "qk_nope_head_dim": 64,
+            "qk_rope_head_dim": 32,
+            "v_head_dim": 128,
+            "num_experts": 32,
+            "linear_attn_config": {
+                "num_heads": 8,
+                "head_dim": 64,
+                "short_conv_kernel_size": 3,
+                "kda_layers": [1, 2, 3, 4, 5],
+            },
+        }
+        by_id, _ = _build_registry(FAMILIES)
+        family = by_id["kimi"]
+        resolved = type("R", (), {"descriptor": family, "family_config": config,
+                                   "model_dir": "."})()
+        geometry = planner_geometry(resolved, 32)
+        ctx = 32
+        # KDA workspace: 6*ctx*P + ctx*hd + ctx*hidden floats
+        ws_kda = (6 * ctx * (8 * 64) + ctx * 64 + ctx * 2048) * 4
+        # MLA workspace: qa + qv + ckv + gv + ctx buffers
+        qh = 64 + 32
+        ws_mla = (ctx * 64 + ctx * 16 * qh + ctx * (128 + 32) +
+                  2 * ctx * 16 * 128) * 4
+        self.assertEqual(geometry.workspace_bytes, max(ws_kda, ws_mla))
 
     def test_cli_and_gateway_dispatch_follow_the_registry(self):
         import openai_server


### PR DESCRIPTION
Closes #1066 — all four unproven production planners now have Python geometry adapters in `family_registry.py`, each mirroring the engine's actual allocation in C rather than trusting config hints.

---

## 1. `_olmoe_geometry` — OLMoE (7B)

Conventional full-head K/V cache in fp32, no recurrent state.

- **K/V cache sized with `num_attention_heads` (not `num_key_value_heads`)** — `olmoe.c` allocates per q-head (olmoe.c:1019-1020, 1047-1048, 1097-1098, 1412-1413), fp32. Sizing from `n_kv_heads` would under-reserve by the GQA ratio.
- **`head_dim` derived** as `hidden_size / num_attention_heads` (olmoe.c:327).
- **Workspace = 4 attention temporaries** (`q, k, vv, ctx`), each S x hidden floats (olmoe.c:643, 662).

## 2. `_kimi_geometry` — Kimi K3 (2.8T hybrid)

69 KDA (recurrent) + 24 gated MLA layers.

- **MLA cache (Lc/Rc)** per non-KDA layer: `context × (kv_lora + qk_rope) × 4` (kimi_k3.c:1704-1706).
- **KDA recurrent state** per KDA layer: `kda_heads × kda_hd × kda_hd × 4` (kimi_k3.c:691) — **fixed**, does NOT scale with context.
- **KDA membership** from `linear_attn_config.kda_layers` (1-based, kimi_k3.c:552-555).
- **Workspace** = max(KDA temporaries at kimi_k3.c:896-898, MLA at kimi_k3.c:992-994).

## 3. `_inkling_geometry` — Inkling (975B hybrid GQA)

Sliding-window (5 of 6 layers) + global layers + short convs + optional DMel audio tower.

- **KV cache** per layer from L_KV/L_HD (inkling.c:80-82; kv_alloc:1687-1699). Sliding layers are a **ring of `window` rows** (kv_ring_rows:1124-1125) — capped growth past the window; global layers keep full context.
- **Conv states** (inkling.c:888-890, 1646): four depthwise short-conv states per layer, `conv_k-1` rows each — context-independent → `fixed_state_bytes`.
- **Audio tower** (inkling.c:808-832): DMel encoder table `[mel_bins×mel_vocab, hidden]` + RMSNorm in `fixed_state_bytes` when `audio_config` present.
- **Sliding membership** precedence: `layer_types[]` (fail-closed on length) > `local_layer_ids[]` > `(i+1)%6`.

## 4. `_dsv4_geometry` — DeepSeek V4 (284B)

Mirrors the engine's own `context_bytes()` (deepseek_v4.c:1271-1284) exactly:

- **Fixed sliding-window ring**: `num_hidden_layers × sliding_window × head_dim × 4` — circular buffer, context-independent → `fixed_state_bytes`.
- **Per-layer compressor state**: `ceil(context / ratio) × head_dim × 4` for layers with `compress_ratios[layer] > 0`.
- **Per-layer indexer state**: `ceil(context / ratio) × index_head_dim × 4` for layers with `ratio == 4`.
- **Workspace** = batched-attention scratch (deepseek_v4.c:2741-2750): `qa + q + kv + attended + oa + norm` with `q_width = heads×head_dim`, `oa_width = o_groups×o_lora_rank`.

## Registry changes

- All four `planner_geometry=None` → implemented adapters
- All four `planner_unsupported_reason` dropped
- `test_unproven_production_planners_refuse_instead_of_inventing_zero` emptied — **no unproven families remain**

## Tests (22 new: 4 OLMoE + 6 Kimi + 6 Inkling + 6 V4)

Engine-parity allocation, hybrid/GQA/ring sizing, context-independence of fixed state, workspace peak selection, audio tower reserve, and fail-closed on malformed config (bad ratios length, bad layer_types length, missing keys).

## Validation

- `family_registry.py`: **34 passed** (local x86 + Oracle ARM64)
- Planner pipeline (`inefficiency`, `efficiency_report`, `analysis_cache`, `autotune`, `doctor`): **53 passed, 8 skipped**
- Full `make check` on ARM64 with `ARCH=armv8.2-a+dotprod`: 547 tests, 543 passed, 36 skipped (4 expected `test_makefile_platform` artifacts)

Note: default `make check` on ARM64 fails at `vdotq_s32` (needs `+dotprod`) — filed as issue #1104.