### PR TITLE
feat(engine): per-token logprob channel, echo prefill read-out, and token-ID prompt intake

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -6865,8 +6865,13 @@ static void intr_install(void){}
  * a mux spec turn is running and are reset at each turn boundary, so every other
  * spec_decode caller (chat, run, oracle) sees them permanently 0. */
 static volatile sig_atomic_t g_mux_stop=0, g_mux_cancel=0;
+/* emit callback contract (U7a): `lo` is the vocab-sized logit row the token
+ * was picked or verified from -- live only for the duration of the call.
+ * Accepted DRAFT tokens get their verification row, so the per-token numeric
+ * channel has no gap on the speculative path (they bypass every pick_tok
+ * call site in the mux loop). Callers that don't need it ignore it. */
 static int spec_decode(Model *m, int *all, int kv, int n_new, int eos, float *logit,
-                       void (*emit)(int,void*), void *ud, int *kv_out, float **logit_out){
+                       void (*emit)(int,const float*,void*), void *ud, int *kv_out, float **logit_out){
     Cfg *c=&m->c; int V=c->vocab; int emitted=0, done=0;
     int draft[64]; if(g_draft>63) g_draft=63;
     int carry_ban=-1;                    /* token rifiutato dalla verifica: escluso dal resample */
@@ -6889,9 +6894,9 @@ static int spec_decode(Model *m, int *all, int kv, int n_new, int eos, float *lo
     uint64_t cp_prop0=g_corp_prop, cp_acc0=g_corp_acc; int cp_pause=0;
     while(emitted<n_new && !done && !g_intr && !g_mux_stop && !g_mux_cancel){
         /* g_intr / g_mux_*: stessa uscita del tetto n_new (#678) */
-        int next=pick_tok(logit,V,carry_ban); carry_ban=-1; free(logit); logit=NULL;
-        if((eos>=0 && next==eos) || is_stop(next)) break;
-        emit(next,ud); all[kv]=next; emitted++; m->n_emit++;
+        int next=pick_tok(logit,V,carry_ban); carry_ban=-1;
+        if((eos>=0 && next==eos) || is_stop(next)){ free(logit); logit=NULL; break; }
+        emit(next,logit,ud); free(logit); logit=NULL; all[kv]=next; emitted++; m->n_emit++;
         gr_feed(&g_grd,next);                           /* il walker segue l'output emesso */
         /* One-shot generation does not need logits or KV for the last token.
          * Stateful callers do: their kv_out becomes chat history, feeds MORE,
@@ -6965,7 +6970,7 @@ static int spec_decode(Model *m, int *all, int kv, int n_new, int eos, float *lo
                    accept = (rndu() < g_pbuf[draft[k]]); }
             if(!accept){ if(g_temp>0) carry_ban=draft[k]; break; }
             if((eos>=0 && draft[k]==eos) || is_stop(draft[k])){ done=1; break; }
-            emit(draft[k],ud); all[kv+1+k]=draft[k]; emitted++; m->n_emit++;
+            emit(draft[k],lo+(int64_t)k*V,ud); all[kv+1+k]=draft[k]; emitted++; m->n_emit++;
             gr_feed(&g_grd,draft[k]); k++;
         }
         if(gsrc==1) g_grd.acc+=(uint64_t)k;
@@ -6991,10 +6996,11 @@ static int spec_decode(Model *m, int *all, int kv, int n_new, int eos, float *lo
 
 /* emit callback: accumula in un array (validazione) */
 typedef struct { int *dst; int n; } EmitStore;
-static void emit_store(int t, void *ud){ EmitStore *e=(EmitStore*)ud; e->dst[e->n++]=t; }
+static void emit_store(int t, const float *lo, void *ud){ (void)lo; EmitStore *e=(EmitStore*)ud; e->dst[e->n++]=t; }
 /* emit callback: detokenizza e stampa in streaming (chat/run), con heartbeat */
 typedef struct { Tok *T; Model *m; double t0; int count; int quiet; } EmitStream;
-static void emit_stream(int t, void *ud){
+static void emit_stream(int t, const float *lo, void *ud){
+    (void)lo;
     EmitStream *e=(EmitStream*)ud; char dec[64];
     int dn=tok_decode(e->T,&t,1,dec,63); dec[dn]=0; fputs(dec,stdout); fflush(stdout);
     if(!e->quiet && ++e->count%16==0){ double tt=e->m->hits+e->m->miss;
@@ -7781,6 +7787,8 @@ typedef struct {
     float *spec_logit;                   /* continuation logits between chunks; NULL = the last
                                             emitted token sits at hist[len], not yet forwarded */
     unsigned long long id;
+    int logprobs;                        /* per-token numeric channel (U7a): requested
+                                            top-k count from SUBMIT logprobs=k; 0 = off */
     float temp, top_p;
     double started;
     uint64_t hits0, miss0;
@@ -7788,10 +7796,97 @@ typedef struct {
                                             feeds the PROF protocol line and the PROF=1 report */
 } ServeReq;
 
-static void mux_data(Tok *T, unsigned long long id, int token){
+/* Numeric tail shared by opted-in DATA and ECHO frames (U7a): writes
+ * " <lp> <k> [<tid> <tlp>]*k" into dst. lp = log-softmax of `token` over the
+ * logit row; the top-k table selects by logit (identical order to selecting
+ * by log-probability) and is UNSORTED, same as run_ablate_score's tk output.
+ * The token's own entry, when it appears in the table, is the SAME double as
+ * lp printed through the same format -- the bit-identity the harness's
+ * is_greedy check depends on. lo==NULL (an echo's position 0: nothing to
+ * condition on) writes " nan 0"; the server maps that to OpenAI's null.
+ * k is capped by COLI_SUBMIT_TOPK_MAX (=32, run_ablate_score's ceiling). */
+static int logprob_tail(char *dst, size_t cap, const float *lo, int V, int token, int topk){
+    int tk_id[COLI_SUBMIT_TOPK_MAX]; float tk_val[COLI_SUBMIT_TOPK_MAX];
+    int w;
+    if(!lo || token<0 || token>=V) return snprintf(dst,cap," nan 0");
+    if(topk>COLI_SUBMIT_TOPK_MAX) topk=COLI_SUBMIT_TOPK_MAX;
+    if(topk>V) topk=V;
+    float mx=lo[0]; for(int i=1;i<V;i++) if(lo[i]>mx) mx=lo[i];
+    double se=0; for(int i=0;i<V;i++) se+=exp((double)lo[i]-mx);
+    double logZ=(double)mx+log(se);
+    for(int k=0;k<topk;k++){ tk_id[k]=-1; tk_val[k]=-1e30f; }
+    for(int i=0;i<V;i++){ float v=lo[i];
+        int mn=0; for(int k=1;k<topk;k++) if(tk_val[k]<tk_val[mn]) mn=k;
+        if(v>tk_val[mn]){ tk_val[mn]=v; tk_id[mn]=i; } }
+    w=snprintf(dst,cap," %.6f %d",(double)lo[token]-logZ,topk);
+    for(int k=0;k<topk && w>0 && (size_t)w<cap;k++)
+        w+=snprintf(dst+w,cap-(size_t)w," %d %.6f",tk_id[k],(double)tk_val[k]-logZ);
+    return w;
+}
+
+/* One generated token -> one DATA frame. Opted-in requests (SUBMIT logprobs=k)
+ * carry the numeric channel in the header: "DATA <id> <n> <lp> <k> [tid tlp]*k";
+ * opt-out requests keep the exact legacy 3-field frame, byte for byte -- an old
+ * server (whose dispatcher hard-fails on unknown framing) can only ever be
+ * paired with requests that never opt in, so it never sees the extended form. */
+static void mux_data(Tok *T, unsigned long long id, int token,
+                     const float *lo, int V, int topk){
     char out[256]; int n=tok_decode(T,&token,1,out,sizeof(out));
-    printf("DATA %llu %d\n",id,n); if(n>0) fwrite(out,1,(size_t)n,stdout); putchar('\n');
+    if(topk>0 && lo){
+        char tail[1024]; logprob_tail(tail,sizeof(tail),lo,V,token,topk);
+        printf("DATA %llu %d%s\n",id,n,tail);
+    } else
+        printf("DATA %llu %d\n",id,n);
+    if(n>0) fwrite(out,1,(size_t)n,stdout); putchar('\n');
     fflush(stdout);
+}
+
+/* Echoed-prompt read-out frame (U7a, opt-in only): "ECHO <id> <n> <pos> <lp>
+ * <k> [tid tlp]*k" + payload framed exactly like DATA (n bytes + '\n').
+ * One frame per prompt position, in position order, BEFORE any DATA frame;
+ * position 0 carries " nan 0" (nothing to condition on). Never emitted unless
+ * the request set SUBMIT logprobs=k, so an old server can never receive one. */
+static void mux_echo(Tok *T, unsigned long long id, int pos, int token,
+                     const float *lo, int V, int topk){
+    char out[256]; int n=tok_decode(T,&token,1,out,sizeof(out));
+    char tail[1024]; logprob_tail(tail,sizeof(tail),lo,V,token,topk);
+    printf("ECHO %llu %d %d%s\n",id,n,pos,tail);
+    if(n>0) fwrite(out,1,(size_t)n,stdout); putchar('\n');
+    fflush(stdout);
+}
+
+/* Opt-in prefill read-out (U7a, SUBMIT logprobs=k): one full-prompt forward
+ * whose per-position hidden states are read out through lm_head -- one ECHO
+ * frame per prompt position. Structurally run_score's loop, but live inside
+ * the serve path and gated per request instead of a launch-env-gated
+ * exit-early mode. Cost: one vocab-sized lm_head matmul per prompt position
+ * (P x vocab, P = prompt length), paid ONLY by requests that opted in; the
+ * opt-out path keeps step()'s single last-position lm_head untouched.
+ * Returns the last position's logits (step()'s contract) as the generation
+ * continuation. The caller resets the slot to len 0 first: the read-out
+ * needs logits at EVERY position, so this path takes no cached-prefix skip
+ * and no cross-slot KV adoption (KV rows [0,nt) are rewritten in full). */
+static float *mux_prefill_echo(Model *m, Tok *T, unsigned long long id,
+                               const int *ids, int nt, int topk){
+    Cfg *c=&m->c; int D=c->hidden, V=c->vocab;
+    float *x=falloc((int64_t)nt*D);
+    for(int s=0;s<nt;s++) embed_row(m, ids[s], x+(int64_t)s*D);
+    layers_forward(m,x,nt,0);
+    if(m->hlast) memcpy(m->hlast, x+(int64_t)(nt-1)*D, D*sizeof(float));
+    if(m->has_mtp && nt>=2 && g_draft>0) mtp_absorb(m, ids+1, x, nt-1, 0);  /* same as step() */
+    float *lo=falloc(V), *row=falloc(D);
+    mux_echo(T,id,0,ids[0],NULL,V,0);
+    double th0=now_s();
+    for(int pos=1; pos<nt; pos++){
+        rmsnorm(row, x+(int64_t)(pos-1)*D, m->final_norm, D, c->eps);
+        matmul_qt(lo, row, &m->lm_head, 1);
+        mux_echo(T,id,pos,ids[pos],lo,V,topk);
+    }
+    rmsnorm(row, x+(int64_t)(nt-1)*D, m->final_norm, D, c->eps);
+    matmul_qt(lo, row, &m->lm_head, 1);
+    m->t_head += now_s()-th0;
+    free(x); free(row);
+    return lo;                           /* last position: the generation continuation */
 }
 
 /* #678: non-blocking stdin poll while a single-slot spec turn is running. Consumes
@@ -7844,10 +7939,13 @@ static void mux_ctl_poll(unsigned long long id){
     }
 }
 
-/* emit callback for the single-slot speculative path: stream straight to the mux protocol */
-typedef struct { Tok *T; unsigned long long id; } MuxEmit;
-static void mux_spec_emit(int t, void *ud){
-    MuxEmit *e=(MuxEmit*)ud; mux_data(e->T,e->id,t);
+/* emit callback for the single-slot speculative path: stream straight to the mux
+ * protocol. `lo` is the row the token was picked/verified from (spec_decode's
+ * emit contract) -- accepted draft tokens included, so opted-in requests get a
+ * numeric value on EVERY generated token, with no speculative-path gap. */
+typedef struct { Tok *T; unsigned long long id; int V, logprobs; } MuxEmit;
+static void mux_spec_emit(int t, const float *lo, void *ud){
+    MuxEmit *e=(MuxEmit*)ud; mux_data(e->T,e->id,t,lo,e->V,e->logprobs);
     mux_ctl_poll(e->id);                 /* #678: honor STOP/CANCEL within ~1 token */
 }
 
@@ -7973,7 +8071,20 @@ static int mux_submit(Model *m, Tok *T, ServeCtx *ctx, ServeReq *req, GrDraft *g
      * mid-markup and emitted a bare "<". Retries were identical because the surviving *head*
      * never changes when a client appends to the end (hence "prefill 0" on every retry).
      * Refuse loudly instead; the gateway turns this into a 400 context_length_exceeded. */
-    int nt=tok_encode(T,raw,(int)sub.bytes,tmp,maxctx-1);
+    int nt;
+    if(sub.tok_ids){
+        /* Pre-tokenized intake (SUBMIT ids=1, U7a): the payload is ASCII token
+         * ids fed straight into the same tmp[] buffer the text path fills --
+         * identical embedding/position machinery downstream, no tok_encode, no
+         * detokenize/re-encode round trip. Same one-token headroom contract as
+         * the text arm above (coli_ids_parse reports the cap on overflow). */
+        nt=coli_ids_parse(raw,(size_t)sub.bytes,tmp,maxctx-1,m->c.vocab);
+        if(nt<0){
+            free(tmp); free(raw); free(line);
+            printf("ERROR %llu BAD_REQUEST\n",sub.id); fflush(stdout); return 0;
+        }
+    } else
+        nt=tok_encode(T,raw,(int)sub.bytes,tmp,maxctx-1);
     free(raw); free(line);
     if(nt<1){ free(tmp); printf("ERROR %llu EMPTY_PROMPT\n",sub.id); fflush(stdout); return 0; }
     if(nt>maxctx-2){
@@ -7989,7 +8100,12 @@ static int mux_submit(Model *m, Tok *T, ServeCtx *ctx, ServeReq *req, GrDraft *g
      * first with an ERROR, so a request yields exactly one of ACCEPT or an early ERROR -- which
      * lets a CONTEXT_EXCEEDED become a clean HTTP 400 instead of a broken already-200 stream. */
     printf("ACCEPT %llu %d\n",sub.id,nt); fflush(stdout);
-    int prefix=0; while(prefix<sc->len && prefix<nt && sc->hist[prefix]==tmp[prefix]) prefix++;
+    /* Echo read-out (U7a): needs logits at EVERY prompt position, so the whole
+     * prompt re-prefills from position 0 -- no cached-prefix skip and no
+     * cross-slot adoption below (either would leave positions with no logits). */
+    int echo = sub.logprobs>0;
+    int prefix=0;
+    if(!echo) while(prefix<sc->len && prefix<nt && sc->hist[prefix]==tmp[prefix]) prefix++;
     if(prefix<sc->len){ sc->len=prefix; if(m->has_mtp) m->kv_start[m->c.n_layers]=-1;
         kv_disk_truncate(m,sc->len); }
     /* Cross-slot prefix adoption (COLI_KV_SHARE=1) — RadixAttention's benefit
@@ -8004,7 +8120,7 @@ static int mux_submit(Model *m, Tok *T, ServeCtx *ctx, ServeReq *req, GrDraft *g
      * generated tokens identical to the full-prefill run. */
     static int kvshare=-1;
     if(kvshare<0) kvshare=getenv("COLI_KV_SHARE")?atoi(getenv("COLI_KV_SHARE")):0;
-    if(kvshare && nctx>1 && prefix>=sc->len){
+    if(kvshare && !echo && nctx>1 && prefix>=sc->len){
         int best=-1, blen=sc->len;
         for(int i=0;i<nctx;i++){
             if(i==sub.slot) continue;
@@ -8041,11 +8157,13 @@ static int mux_submit(Model *m, Tok *T, ServeCtx *ctx, ServeReq *req, GrDraft *g
     if(add>0) memcpy(sc->hist+sc->len,tmp+sc->len,(size_t)add*sizeof(int));
     fprintf(stderr,"[API] KV slot %d prefix %d/%d token, prefill %d\n",sub.slot,sc->len,nt,add);
     free(tmp);
-    float *logit = add>0 ? step(m,sc->hist+sc->len,add,sc->len)
-                         : step(m,sc->hist+sc->len-1,1,sc->len-1);
+    float *logit = echo ? mux_prefill_echo(m,T,sub.id,sc->hist,nt,sub.logprobs)
+                        : add>0 ? step(m,sc->hist+sc->len,add,sc->len)
+                                : step(m,sc->hist+sc->len-1,1,sc->len-1);
     sc->len+=add; sc->first=0;
     ServeReq *r=&req[sub.slot]; memset(r,0,sizeof(*r));
     r->id=sub.id; r->maximum=sub.max_tokens; r->temp=sub.temperature; r->top_p=sub.top_p;
+    r->logprobs=sub.logprobs;
     r->prompt_tokens=nt; r->started=now_s(); r->hits0=m->hits; r->miss0=m->miss;
     prof_base(m,&r->pb);                 /* a few loads: cheap enough to always track */
     /* Clamp to the KV room WITHOUT flagging: length_limited must mean "the
@@ -8067,12 +8185,13 @@ static int mux_submit(Model *m, Tok *T, ServeCtx *ctx, ServeReq *req, GrDraft *g
         r->spec=1; r->spec_logit=logit; r->active=1;
         return 1;
     }
-    int next=pick_tok(logit,m->c.vocab,-1); free(logit);
-    if(r->maximum<=0){ r->length_limited=1; mux_done(m,sc,r); return 1; }   /* no room at all */
-    if(next==eos || is_stop(next)){ mux_done(m,sc,r); return 1; }
+    int next=pick_tok(logit,m->c.vocab,-1);
+    if(r->maximum<=0){ free(logit); r->length_limited=1; mux_done(m,sc,r); return 1; }   /* no room at all */
+    if(next==eos || is_stop(next)){ free(logit); mux_done(m,sc,r); return 1; }
     r->pending=next; r->emitted=1; r->active=1; sc->hist[sc->len]=next; m->n_emit++;
     if(grd[sub.slot].on){ grammar_reset(&grd[sub.slot]); gr_feed(&grd[sub.slot],next); }
-    mux_data(T,r->id,next);
+    mux_data(T,r->id,next,logit,m->c.vocab,r->logprobs);
+    free(logit);
     if(r->emitted>=r->maximum){ r->length_limited=1; mux_done(m,sc,r); }
     return 1;
 }
@@ -8168,7 +8287,7 @@ static void run_serve_mux(Model *m, const char *snap){
                 kv_bind(m,&sc->kv);
                 g_temp=r->temp; g_nuc=r->top_p;
                 float *lg=r->spec_logit; r->spec_logit=NULL;   /* spec_decode takes ownership */
-                MuxEmit ud={&T,r->id};
+                MuxEmit ud={&T,r->id,m->c.vocab,r->logprobs};
                 g_mux_stop=0; g_mux_cancel=0;                  /* fresh per turn (#678) */
                 int prod=spec_decode(m,sc->hist,sc->len,r->maximum-r->emitted,eos,lg,
                                      mux_spec_emit,&ud,&sc->len,NULL);
@@ -8209,7 +8328,7 @@ static void run_serve_mux(Model *m, const char *snap){
                     if(next==eos || is_stop(next)){ mux_done(m,sc,r); done=1; break; }
                     r->pending=next; sc->hist[sc->len]=next; r->emitted++; m->n_emit++;
                     if(gd->on) gr_feed(gd,next);
-                    mux_data(&T,r->id,next);
+                    mux_data(&T,r->id,next,lo+(int64_t)j*m->c.vocab,m->c.vocab,r->logprobs);
                     if(r->emitted>=r->maximum){ r->length_limited=1; mux_done(m,sc,r); done=1; break; }
                     if(j<k){
                         if(next!=draft[j]) break;    /* rejected: seq[j+1..] stale, overwritten next forward */
@@ -8233,7 +8352,7 @@ static void run_serve_mux(Model *m, const char *snap){
             if(next==eos || is_stop(next)){mux_done(m,sc,r);continue;}
             r->pending=next; sc->hist[sc->len]=next; r->emitted++; m->n_emit++;
             if(grd[i].on) gr_feed(&grd[i],next);   /* walker stays in sync when not drafting */
-            mux_data(&T,r->id,next);
+            mux_data(&T,r->id,next,lo+(int64_t)s*m->c.vocab,m->c.vocab,r->logprobs);
             if(r->emitted>=r->maximum){ r->length_limited=1; mux_done(m,sc,r); }
         }
         free(lo);

--- a/c/decode_batch.h
+++ b/c/decode_batch.h
@@ -29,33 +29,51 @@ typedef struct {
  * full 7-field header, e.g. "SUBMIT 1 0 12 16 0 1 0 logprobs=5 ids=1".
  * A namespace instead of more positional fields: the next per-request knob
  * (a future seed, say) claims a key here rather than forcing another
- * field-count migration of this scarce wire budget. Unknown keys reject the
- * whole frame -- framing stays as unambiguous as the legacy arms'
- * trailing-field guard. An OLD engine rejects ANY extended header cleanly:
- * both legacy sscanf arms fail on the extra field (their trailing %c matches
- * the separating space) and the engine answers ERROR 0 BAD_REQUEST. */
+ * field-count migration of this scarce wire budget. Unknown keys, duplicate
+ * keys, glued tokens and out-of-range values all reject the whole frame --
+ * framing stays as unambiguous as the legacy arms' trailing-field guard.
+ * An OLD engine rejects ANY extended header: both legacy sscanf arms fail on
+ * the extra field (their trailing %c matches the separating space) and the
+ * engine answers ERROR 0 BAD_REQUEST. The rejection itself is safe, but the
+ * reject path does not drain the rejected request's payload bytes, so an old
+ * engine re-reads them as protocol lines -- the pre-existing behavior of
+ * every malformed-SUBMIT reject, not exposure added by this namespace.
+ *
+ * The value is accumulated by hand into a bounded int (digit loop stops once
+ * the running value exceeds the largest legal value of any key, then a
+ * pending-digit check rejects): sscanf %llu on an overflowing field is
+ * undefined behavior (C11 7.21.6.2), so no sscanf ever touches the value. */
 static inline int coli_submit_ext(const char *p, ColiSubmit *s)
 {
-    int seen = 0;
+    int seen = 0, seen_logprobs = 0, seen_ids = 0;
     while (*p == ' ' || *p == '\t') p++;
     while (*p) {
         char key[16];
-        unsigned long long val;
-        int n = 0;
-        if (sscanf(p, "%15[a-z_]=%llu%n", key, &val, &n) != 2 || n <= 0)
-            return 0;
-        if (p[n] && p[n] != ' ' && p[n] != '\t') return 0;
+        int kn = 0, val = 0;
+        const char *d;
+        while (kn < 15 && ((*p >= 'a' && *p <= 'z') || *p == '_'))
+            key[kn++] = *p++;
+        key[kn] = 0;
+        if (kn == 0 || *p != '=') return 0;
+        p++;
+        d = p;
+        while (*p >= '0' && *p <= '9' && val <= COLI_SUBMIT_TOPK_MAX)
+            val = val * 10 + (*p++ - '0');
+        if (p == d) return 0;                        /* no digits after '=' */
+        if (*p >= '0' && *p <= '9') return 0;        /* out of range: digits left */
+        if (*p && *p != ' ' && *p != '\t') return 0; /* glued garbage after value */
         if (!strcmp(key, "logprobs")) {          /* per-token top-k emission */
-            if (val > COLI_SUBMIT_TOPK_MAX) return 0;
-            s->logprobs = (int)val;
+            if (seen_logprobs || val > COLI_SUBMIT_TOPK_MAX) return 0;
+            seen_logprobs = 1;
+            s->logprobs = val;
         } else if (!strcmp(key, "ids")) {        /* pre-tokenized prompt intake */
-            if (val > 1) return 0;
-            s->tok_ids = (int)val;
+            if (seen_ids || val > 1) return 0;
+            seen_ids = 1;
+            s->tok_ids = val;
         } else {
-            return 0;
+            return 0;                            /* unknown key */
         }
         seen = 1;
-        p += n;
         while (*p == ' ' || *p == '\t') p++;
     }
     return seen;
@@ -87,9 +105,14 @@ static inline int coli_submit_parse(const char *line, ColiSubmit *s)
     }
     if (!ok) {
         s->gbytes = 0;
+        /* Extended arm: the numeric gbytes field and the first key=value token
+         * MUST be whitespace-separated ("512logprobs=5" is one malformed field,
+         * not a 512 followed by an opt-in -- %llu would otherwise stop at the
+         * first letter and silently split it). */
         if (sscanf(line, "SUBMIT %llu %d %llu %d %f %f %llu%n", &s->id,
                    &s->slot, &s->bytes, &s->max_tokens, &s->temperature,
                    &s->top_p, &s->gbytes, &base) == 7 && base > 0 &&
+            (line[base] == ' ' || line[base] == '\t') &&
             coli_submit_ext(line + base, s)) ok = 1;
     }
     if (!ok) return 0;

--- a/c/decode_batch.h
+++ b/c/decode_batch.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include <stdio.h>
+#include <string.h>
 #include <math.h>
 
 /* `base` belongs to one sequence's KV state.  Keeping this arithmetic in a
@@ -12,36 +13,121 @@ static inline float *coli_kv_row(float *base, int position, int width)
     return base + (size_t)position * (size_t)width;
 }
 
+/* Per-token top-k emission cap: run_ablate_score's existing top-32 read-out
+ * ceiling, adopted as the wire cap too (no named consumer asks for more). */
+#define COLI_SUBMIT_TOPK_MAX 32
+
 typedef struct {
     unsigned long long id, bytes, gbytes;
     int slot, max_tokens;
     float temperature, top_p;
+    int logprobs;   /* requested per-token top-k count; 0 = channel off (opt-in) */
+    int tok_ids;    /* 1 = payload is ASCII token ids, not raw prompt text */
 } ColiSubmit;
+
+/* Extension fields, 8th whitespace field onward: "key=value" tokens after the
+ * full 7-field header, e.g. "SUBMIT 1 0 12 16 0 1 0 logprobs=5 ids=1".
+ * A namespace instead of more positional fields: the next per-request knob
+ * (a future seed, say) claims a key here rather than forcing another
+ * field-count migration of this scarce wire budget. Unknown keys reject the
+ * whole frame -- framing stays as unambiguous as the legacy arms'
+ * trailing-field guard. An OLD engine rejects ANY extended header cleanly:
+ * both legacy sscanf arms fail on the extra field (their trailing %c matches
+ * the separating space) and the engine answers ERROR 0 BAD_REQUEST. */
+static inline int coli_submit_ext(const char *p, ColiSubmit *s)
+{
+    int seen = 0;
+    while (*p == ' ' || *p == '\t') p++;
+    while (*p) {
+        char key[16];
+        unsigned long long val;
+        int n = 0;
+        if (sscanf(p, "%15[a-z_]=%llu%n", key, &val, &n) != 2 || n <= 0)
+            return 0;
+        if (p[n] && p[n] != ' ' && p[n] != '\t') return 0;
+        if (!strcmp(key, "logprobs")) {          /* per-token top-k emission */
+            if (val > COLI_SUBMIT_TOPK_MAX) return 0;
+            s->logprobs = (int)val;
+        } else if (!strcmp(key, "ids")) {        /* pre-tokenized prompt intake */
+            if (val > 1) return 0;
+            s->tok_ids = (int)val;
+        } else {
+            return 0;
+        }
+        seen = 1;
+        p += n;
+        while (*p == ' ' || *p == '\t') p++;
+    }
+    return seen;
+}
 
 /* Parse the textual header. The payload is read separately using `bytes`, so
  * it may contain newlines. Reject trailing fields to keep framing unambiguous.
  * Optional 7th field `gbytes`: length of a per-request grammar (raw GBNF, or a
  * JSON-Schema compiled engine-side) appended to the payload AFTER the prompt
- * bytes. 6-field headers remain valid (gbytes = 0). */
+ * bytes. 6-field headers remain valid (gbytes = 0). Fields past the 7th are
+ * key=value extension tokens (coli_submit_ext above), only ever sent by a
+ * server that knows this engine understands them. */
 static inline int coli_submit_parse(const char *line, ColiSubmit *s)
 {
     char tail;
+    int ok = 0, base = 0;
     if (!line || !s) return 0;
     s->gbytes = 0;
+    s->logprobs = 0;
+    s->tok_ids = 0;
     if (sscanf(line, "SUBMIT %llu %d %llu %d %f %f %llu %c", &s->id, &s->slot,
                &s->bytes, &s->max_tokens, &s->temperature, &s->top_p,
-               &s->gbytes, &tail) != 7) {
+               &s->gbytes, &tail) == 7) ok = 1;
+    if (!ok) {
         s->gbytes = 0;
         if (sscanf(line, "SUBMIT %llu %d %llu %d %f %f %c", &s->id, &s->slot,
                    &s->bytes, &s->max_tokens, &s->temperature, &s->top_p,
-                   &tail) != 6)
-            return 0;
+                   &tail) == 6) ok = 1;
     }
+    if (!ok) {
+        s->gbytes = 0;
+        if (sscanf(line, "SUBMIT %llu %d %llu %d %f %f %llu%n", &s->id,
+                   &s->slot, &s->bytes, &s->max_tokens, &s->temperature,
+                   &s->top_p, &s->gbytes, &base) == 7 && base > 0 &&
+            coli_submit_ext(line + base, s)) ok = 1;
+    }
+    if (!ok) return 0;
     return s->id > 0 && s->bytes <= (16u << 20) && s->gbytes <= (1u << 20) &&
            s->slot >= 0 && s->max_tokens >= 1 &&
            isfinite(s->temperature) && isfinite(s->top_p) &&
            s->temperature >= 0 && s->temperature <= 2 &&
            s->top_p > 0 && s->top_p <= 1;
+}
+
+/* SUBMIT ids=1 payload: ASCII decimal token ids separated by whitespace,
+ * parsed straight into the prompt buffer -- the pre-tokenized intake path
+ * that bypasses tok_encode entirely (no detokenize/re-encode round trip, so
+ * the ids the caller sent are exactly the ids the engine scores). Returns
+ * the id count, or -1 on any malformed or out-of-range id. More than `cap`
+ * ids reports `cap`: the caller parses with one spare slot and treats a full
+ * buffer as overflow, mirroring tok_encode's stop-at-cap contract (#401). */
+static inline int coli_ids_parse(const char *buf, size_t len, int *out,
+                                 int cap, int vocab)
+{
+    size_t i = 0;
+    int n = 0;
+    if (!buf || !out || cap < 1 || vocab < 1) return -1;
+    while (i < len) {
+        while (i < len && (unsigned char)buf[i] <= ' ') i++;
+        if (i >= len) break;
+        if (n >= cap) return cap;            /* overflow: caller refuses loudly */
+        {
+            long v = 0;
+            size_t d = i;
+            while (i < len && buf[i] >= '0' && buf[i] <= '9' && v < vocab)
+                v = v * 10 + (buf[i++] - '0');
+            if (i == d || v >= vocab || (i < len && (unsigned char)buf[i] > ' '))
+                return -1;
+            out[n++] = (int)v;
+        }
+    }
+    return n;
 }
 
 #endif

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -1889,7 +1889,14 @@ class Engine:
                 if not fields:
                     continue
                 kind = fields[0]
-                if kind == "DATA" and len(fields) == 3:
+                if kind == "DATA" and len(fields) >= 3:
+                    # 3 fields: the legacy frame. More: the U7a per-token
+                    # numeric channel ("DATA <id> <n> <lp> <k> [tid tlp]*k"),
+                    # emitted only for requests that opted in via the SUBMIT
+                    # logprobs field. The payload framing is identical; the
+                    # numeric fields are consumed by the server feature half
+                    # (U7b) -- accepted here so the frame never kills the
+                    # dispatcher (and with it every in-flight request).
                     request_id = fields[1]
                     size = int(fields[2])
                     if not 0 <= size <= 65536:
@@ -1901,6 +1908,19 @@ class Engine:
                         events = self.pending.get(request_id)
                     if events is not None:
                         events.put(("data", data))
+                elif kind == "ECHO" and len(fields) >= 6:
+                    # U7a prefill read-out: "ECHO <id> <n> <pos> <lp> <k>
+                    # [tid tlp]*k" plus a DATA-framed payload (n bytes + LF).
+                    # Emitted only for opted-in requests; no current request
+                    # path opts in, so the frame is read (to keep the stream
+                    # in sync) and dropped -- U7b delivers it to the response
+                    # assembly when it wires the opt-in.
+                    size = int(fields[2])
+                    if not 0 <= size <= 65536:
+                        raise RuntimeError("invalid engine DATA size")
+                    self._read_exact(size)
+                    if self._read_exact(1) != b"\n":
+                        raise RuntimeError("invalid engine DATA terminator")
                 elif kind == "ACCEPT" and len(fields) >= 3:
                     # #597: the engine validated the submission (fits context) before prefill.
                     # Keep it pending — DATA/DONE still follow — and let generate() commit the

--- a/c/tests/check_data_logprob_gaps.py
+++ b/c/tests/check_data_logprob_gaps.py
@@ -32,8 +32,13 @@ Then:
     python3 tests/check_data_logprob_gaps.py engine_stdout.raw --id 7 --topk 5
 
 Checks performed:
-  - every DATA frame for --id has exactly 5 + 2k header fields, a finite
-    float lp, and k == --topk (k may be < topk only if vocab < topk);
+  - every DATA frame for --id has exactly 5 + 2k header fields, a parseable
+    float lp, and k == --topk (k may be < topk only if vocab < topk).
+    A non-finite lp ("nan"/"inf": degenerate logits, e.g. an all -inf row
+    after grammar masking) counts as PRESENT -- the channel carried a value,
+    which is exactly what this audit is for -- and is FLAGGED in the output
+    without failing the check (whether the engine should serialize such rows
+    differently is a U7b server-side register question, not a gap);
   - ECHO frames (if the request also echoed) cover contiguous positions
     0..P-1, position 0 carrying "nan 0";
   - payload framing (n bytes + newline) stays byte-exact throughout, so a
@@ -82,6 +87,7 @@ def parse_frames(blob):
 def check(frames, request_id, topk):
     rid = str(request_id).encode()
     problems = []
+    flags = []
     data_frames = 0
     echo_positions = []
     for fields, payload in frames:
@@ -101,7 +107,11 @@ def check(frames, request_id, topk):
                 problems.append(f"malformed DATA numeric fields: {fields!r}")
                 continue
             if not math.isfinite(lp):
-                problems.append(f"non-finite lp in DATA frame: {fields!r}")
+                # PRESENT, not a gap: the channel carried a value; degenerate
+                # logits (an all -inf row, say) legitimately produce nan/inf.
+                # Flagged so a reviewer sees it; never fails the audit.
+                flags.append(f"non-finite lp in DATA frame #{data_frames}"
+                             f" (present, flagged): {fields!r}")
             if k != topk:
                 problems.append(f"DATA top-k {k} != requested {topk}: {fields!r}")
             if len(fields) != 5 + 2 * k:
@@ -119,7 +129,7 @@ def check(frames, request_id, topk):
                 problems.append(f"short ECHO frame: {fields!r}")
     if echo_positions and echo_positions != list(range(len(echo_positions))):
         problems.append(f"ECHO positions not contiguous from 0: {echo_positions}")
-    return data_frames, len(echo_positions), problems
+    return data_frames, len(echo_positions), problems, flags
 
 
 def main():
@@ -131,12 +141,14 @@ def main():
     args = parser.parse_args()
     blob = open(args.transcript, "rb").read()
     frames = parse_frames(blob)
-    data_frames, echo_frames, problems = check(frames, args.id, args.topk)
+    data_frames, echo_frames, problems, flags = check(frames, args.id, args.topk)
     print(f"[gapcheck] id={args.id}: {data_frames} DATA frames, "
-          f"{echo_frames} ECHO frames")
+          f"{echo_frames} ECHO frames, {len(flags)} flagged non-finite")
     if data_frames == 0:
         problems.append("no DATA frames found for this id -- wrong id, or the "
                         "run produced nothing (check ERROR frames)")
+    for flag in flags:
+        print(f"[gapcheck] FLAG: {flag}")
     for problem in problems:
         print(f"[gapcheck] {problem}")
     verdict = ("FAIL" if problems

--- a/c/tests/check_data_logprob_gaps.py
+++ b/c/tests/check_data_logprob_gaps.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Speculative-decoding gap check (U7a acceptance test 4).
+
+Asserts, over a captured raw engine-stdout transcript, that EVERY generated
+DATA frame of an opted-in request carries the per-token numeric channel
+("DATA <id> <n> <lp> <k> [tid tlp]*k") -- accepted draft tokens included.
+Speculatively-accepted draft tokens bypass the pick_tok call sites in the mux
+loop (packet Fork 5's implementation risk), so a gap would show up as a
+legacy 3-field DATA frame in the middle of an opted-in generation.
+
+Run recipe (orchestrator; needs a real model -- CPU or CUDA build):
+
+    # single KV slot + model drafts live = the speculative serve regime
+    cd c && make glm
+    SERVE=1 SERVE_BATCH=1 KV_SLOTS=1 DRAFT=2 CTX=4096 \
+        ./colibri <snapshot-dir> < submit.txt | tee engine_stdout.raw
+
+  where submit.txt contains one opted-in generation request, e.g. (prompt
+  "Hello" = 5 payload bytes, 64 new tokens, greedy, logprobs top-5):
+
+    SUBMIT 7 0 5 64 0 1 0 logprobs=5
+    Hello
+
+  (payload line follows the header; the trailing newline after the payload is
+  part of the framing). A speculative run needs an MTP-bearing container or
+  the n-gram fallback to actually accept drafts -- confirm acceptance in the
+  stderr log ("[MTP] ..." / spec acceptance lines) so the run genuinely
+  exercised the draft-accept emit path rather than trivially passing.
+
+Then:
+
+    python3 tests/check_data_logprob_gaps.py engine_stdout.raw --id 7 --topk 5
+
+Checks performed:
+  - every DATA frame for --id has exactly 5 + 2k header fields, a finite
+    float lp, and k == --topk (k may be < topk only if vocab < topk);
+  - ECHO frames (if the request also echoed) cover contiguous positions
+    0..P-1, position 0 carrying "nan 0";
+  - payload framing (n bytes + newline) stays byte-exact throughout, so a
+    single malformed frame cannot hide by desynchronizing the parse.
+Exit 0 = no gaps; non-zero = at least one gap/malformed frame (listed).
+"""
+import argparse
+import math
+import sys
+
+
+def parse_frames(blob):
+    """Parse the serve-mux stdout byte stream into (header_fields, payload)."""
+    frames = []
+    i = 0
+    n = len(blob)
+    while i < n:
+        j = blob.find(b"\n", i)
+        if j < 0:
+            break
+        line = blob[i:j]
+        i = j + 1
+        fields = line.split()
+        if not fields:
+            continue
+        kind = fields[0]
+        if kind in (b"DATA", b"ECHO") and len(fields) >= 3:
+            try:
+                size = int(fields[2])
+            except ValueError:
+                frames.append((fields, None))
+                continue
+            payload = blob[i:i + size]
+            i += size
+            if i < n and blob[i:i + 1] == b"\n":
+                i += 1
+            else:
+                frames.append((fields, b"<BAD TERMINATOR>"))
+                continue
+            frames.append((fields, payload))
+        else:
+            frames.append((fields, None))
+    return frames
+
+
+def check(frames, request_id, topk):
+    rid = str(request_id).encode()
+    problems = []
+    data_frames = 0
+    echo_positions = []
+    for fields, payload in frames:
+        if len(fields) < 2 or fields[1] != rid:
+            continue
+        kind = fields[0]
+        if kind == b"DATA":
+            data_frames += 1
+            if len(fields) == 3:
+                problems.append(f"GAP: legacy 3-field DATA frame #{data_frames}"
+                                f" (payload {payload!r}) has no logprob")
+                continue
+            try:
+                lp = float(fields[3])
+                k = int(fields[4])
+            except (ValueError, IndexError):
+                problems.append(f"malformed DATA numeric fields: {fields!r}")
+                continue
+            if not math.isfinite(lp):
+                problems.append(f"non-finite lp in DATA frame: {fields!r}")
+            if k != topk:
+                problems.append(f"DATA top-k {k} != requested {topk}: {fields!r}")
+            if len(fields) != 5 + 2 * k:
+                problems.append(f"DATA field count {len(fields)} != 5+2k: {fields!r}")
+        elif kind == b"ECHO":
+            try:
+                pos = int(fields[3])
+            except (ValueError, IndexError):
+                problems.append(f"malformed ECHO frame: {fields!r}")
+                continue
+            echo_positions.append(pos)
+            if pos == 0 and (fields[4] != b"nan" or fields[5] != b"0"):
+                problems.append(f"ECHO position 0 should carry 'nan 0': {fields!r}")
+            if pos > 0 and len(fields) < 6:
+                problems.append(f"short ECHO frame: {fields!r}")
+    if echo_positions and echo_positions != list(range(len(echo_positions))):
+        problems.append(f"ECHO positions not contiguous from 0: {echo_positions}")
+    return data_frames, len(echo_positions), problems
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("transcript", help="raw engine stdout capture")
+    parser.add_argument("--id", required=True, help="request id to audit")
+    parser.add_argument("--topk", type=int, required=True,
+                        help="the SUBMIT logprobs=k value the request used")
+    args = parser.parse_args()
+    blob = open(args.transcript, "rb").read()
+    frames = parse_frames(blob)
+    data_frames, echo_frames, problems = check(frames, args.id, args.topk)
+    print(f"[gapcheck] id={args.id}: {data_frames} DATA frames, "
+          f"{echo_frames} ECHO frames")
+    if data_frames == 0:
+        problems.append("no DATA frames found for this id -- wrong id, or the "
+                        "run produced nothing (check ERROR frames)")
+    for problem in problems:
+        print(f"[gapcheck] {problem}")
+    verdict = ("FAIL" if problems
+               else "PASS: every generated token carries a logprob value")
+    print(f"[gapcheck] {verdict}")
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/c/tests/golden_fixture_capture.py
+++ b/c/tests/golden_fixture_capture.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Golden-fixture invariant harness (U7a acceptance test 1 / packet test-plan I1).
+
+Captures full HTTP responses for a battery of NON-logprobs requests against a
+RUNNING colibri server, normalizes the volatile fields (ids, timestamps), and
+byte-diffs two capture directories. The engine-channel change (U7a) is opt-in
+and no server request path opts in, so a pre-U7a capture and a post-U7a capture
+of the same battery on the same box/backend/model must be byte-identical --
+this script is the mechanism proving that, not reviewer inspection.
+
+Usage:
+    # 1. start the server on the CURRENT (pre-change) build, then:
+    python3 tests/golden_fixture_capture.py capture \
+        --base-url http://127.0.0.1:8000 --model <model-id> --out fixtures_pre
+
+    # 2. rebuild/restart on the post-change build (same box, same backend,
+    #    same container, same CTX/KV_SLOTS env), then:
+    python3 tests/golden_fixture_capture.py capture \
+        --base-url http://127.0.0.1:8000 --model <model-id> --out fixtures_post
+
+    # 3. compare (exit 0 = byte-identical modulo normalized fields):
+    python3 tests/golden_fixture_capture.py diff fixtures_pre fixtures_post
+
+Battery: chat, chat+tools, chat streaming, completions without logprobs, and
+the error cases whose behavior must not move (seed 400, array-prompt 400,
+logprobs 400, out-of-range temperature 400) plus /v1/models.
+
+Normalization: every "id"/"created" field (recursively, and per SSE event) is
+replaced with a constant; nothing else is touched. Generation-bearing requests
+run at temperature 0. If a token-level diff still appears pre-vs-post on the
+SAME backend, triage it against the open engine-determinism finding
+(CUDA_VS_CPU_ARM_B_2026-08-17) before treating it as a U7a regression.
+"""
+import argparse
+import json
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+
+NORMALIZED_KEYS = ("id", "created")
+
+
+def battery(model):
+    chat_messages = [
+        {"role": "system", "content": "You are a terse assistant."},
+        {"role": "user", "content": "Say the word 'fixture' and stop."},
+    ]
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }]
+    return [
+        ("chat_basic", "POST", "/v1/chat/completions",
+         {"model": model, "messages": chat_messages,
+          "max_tokens": 16, "temperature": 0}),
+        ("chat_tools", "POST", "/v1/chat/completions",
+         {"model": model, "messages": [
+             {"role": "user", "content": "What is the weather in Rome?"}],
+          "tools": tools, "tool_choice": "auto",
+          "max_tokens": 48, "temperature": 0}),
+        ("chat_stream", "POST", "/v1/chat/completions",
+         {"model": model, "messages": chat_messages,
+          "max_tokens": 16, "temperature": 0, "stream": True}),
+        ("completions_plain", "POST", "/v1/completions",
+         {"model": model, "prompt": "The capital of France is",
+          "max_tokens": 8, "temperature": 0}),
+        ("completions_stop", "POST", "/v1/completions",
+         {"model": model, "prompt": "Count: one, two,",
+          "max_tokens": 16, "temperature": 0, "stop": ["five"]}),
+        ("err_seed", "POST", "/v1/completions",
+         {"model": model, "prompt": "hello", "max_tokens": 1, "seed": 1234}),
+        ("err_array_prompt", "POST", "/v1/completions",
+         {"model": model, "prompt": [1, 2, 3], "max_tokens": 1}),
+        ("err_logprobs", "POST", "/v1/completions",
+         {"model": model, "prompt": "hello", "max_tokens": 1, "logprobs": 1}),
+        ("err_bad_temperature", "POST", "/v1/chat/completions",
+         {"model": model, "messages": chat_messages,
+          "max_tokens": 1, "temperature": 9}),
+        ("models", "GET", "/v1/models", None),
+    ]
+
+
+def normalize(obj):
+    if isinstance(obj, dict):
+        return {k: ("<normalized>" if k in NORMALIZED_KEYS else normalize(v))
+                for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [normalize(v) for v in obj]
+    return obj
+
+
+def normalize_body(raw, content_type):
+    text = raw.decode("utf-8", "replace")
+    if "text/event-stream" in (content_type or ""):
+        events = []
+        for line in text.splitlines():
+            if not line.strip():
+                continue
+            if line.startswith("data:"):
+                payload = line[5:].strip()
+                if payload == "[DONE]":
+                    events.append("[DONE]")
+                else:
+                    try:
+                        events.append(normalize(json.loads(payload)))
+                    except ValueError:
+                        events.append({"unparsed": payload})
+            else:
+                events.append({"raw_line": line})
+        return {"sse_events": events}
+    try:
+        return normalize(json.loads(text))
+    except ValueError:
+        return {"raw_text": text}
+
+
+def run_case(base_url, name, method, path, body):
+    data = None if body is None else json.dumps(body).encode()
+    request = urllib.request.Request(
+        base_url.rstrip("/") + path, data=data, method=method,
+        headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=600) as response:
+            status = response.status
+            content_type = response.headers.get("Content-Type", "")
+            raw = response.read()
+    except urllib.error.HTTPError as error:
+        status = error.code
+        content_type = error.headers.get("Content-Type", "")
+        raw = error.read()
+    return {"case": name, "request": {"method": method, "path": path,
+                                      "body": body},
+            "status": status,
+            "body": normalize_body(raw, content_type)}
+
+
+def capture(args):
+    out = pathlib.Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    for name, method, path, body in battery(args.model):
+        record = run_case(args.base_url, name, method, path, body)
+        target = out / (name + ".json")
+        target.write_text(json.dumps(record, indent=2, sort_keys=True,
+                                     ensure_ascii=False) + "\n")
+        print(f"[capture] {name}: HTTP {record['status']} -> {target}")
+    print(f"[capture] done: {out}")
+    return 0
+
+
+def diff(args):
+    a, b = pathlib.Path(args.dir_a), pathlib.Path(args.dir_b)
+    names = sorted({p.name for p in a.glob("*.json")} |
+                   {p.name for p in b.glob("*.json")})
+    failures = 0
+    for name in names:
+        fa, fb = a / name, b / name
+        if not fa.exists() or not fb.exists():
+            print(f"[diff] {name}: MISSING on one side")
+            failures += 1
+            continue
+        if fa.read_bytes() != fb.read_bytes():
+            print(f"[diff] {name}: DIFFERS")
+            failures += 1
+        else:
+            print(f"[diff] {name}: identical")
+    if failures:
+        print(f"[diff] FAIL: {failures}/{len(names)} cases differ")
+        return 1
+    print(f"[diff] PASS: {len(names)} cases byte-identical "
+          "(modulo normalized ids/timestamps)")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    p_capture = sub.add_parser("capture")
+    p_capture.add_argument("--base-url", default="http://127.0.0.1:8000")
+    p_capture.add_argument("--model", required=True)
+    p_capture.add_argument("--out", required=True)
+    p_capture.set_defaults(func=capture)
+    p_diff = sub.add_parser("diff")
+    p_diff.add_argument("dir_a")
+    p_diff.add_argument("dir_b")
+    p_diff.set_defaults(func=diff)
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/c/tests/test_decode_batch.c
+++ b/c/tests/test_decode_batch.c
@@ -82,6 +82,24 @@ static void test_submit_extension_fields(void)
     assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 logprobs=5x", &sub));
     assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 logprobs=5 junk", &sub));
     assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 logprobs", &sub));
+    /* glued numeric field + key: one malformed field, NOT "512" + an opt-in
+     * (%llu would otherwise stop at the first letter and silently split it) */
+    assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 512logprobs=5", &sub));
+    assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0logprobs=5", &sub));
+    assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0ids=1", &sub));
+    /* duplicate keys: rejected outright, never silently last-wins */
+    assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 logprobs=3 logprobs=5", &sub));
+    assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 ids=1 ids=1", &sub));
+    assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 ids=0 ids=0", &sub));
+    /* overflowing values: rejected by the bounded digit loop, no sscanf %llu
+     * ever sees the value (overflow there is UB; a wrapping libc would fold
+     * 2^64+5 back to an in-range 5) */
+    assert(!coli_submit_parse(
+        "SUBMIT 42 3 17 64 0.7 0.95 0 logprobs=18446744073709551621", &sub));
+    assert(!coli_submit_parse(
+        "SUBMIT 42 3 17 64 0.7 0.95 0 ids=18446744073709551617", &sub));
+    assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 logprobs=329", &sub));
+    assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 logprobs=1000", &sub));
     /* an extended header still validates the base fields */
     assert(!coli_submit_parse("SUBMIT 0 3 17 64 0.7 0.95 0 logprobs=5", &sub));
     assert(!coli_submit_parse("SUBMIT 42 3 17 0 0.7 0.95 0 logprobs=5", &sub));

--- a/c/tests/test_decode_batch.c
+++ b/c/tests/test_decode_batch.c
@@ -52,11 +52,86 @@ static void test_submit_header(void)
     assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 512 extra", &sub));
 }
 
+/* U7a extension fields: key=value tokens from the 8th field onward. The two
+ * legacy arms stay byte-identical in behavior (asserted above); the third arm
+ * accepts only known keys with in-range values, so an unknown or malformed
+ * extension rejects the whole frame exactly like a trailing garbage field. */
+static void test_submit_extension_fields(void)
+{
+    ColiSubmit sub;
+    /* legacy headers leave the new capabilities off */
+    assert(coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95", &sub));
+    assert(sub.logprobs == 0 && sub.tok_ids == 0);
+    assert(coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 512", &sub));
+    assert(sub.logprobs == 0 && sub.tok_ids == 0);
+    /* the 8-field opt-in forms */
+    assert(coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 logprobs=5", &sub));
+    assert(sub.logprobs == 5 && sub.tok_ids == 0 && sub.gbytes == 0);
+    assert(coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 ids=1", &sub));
+    assert(sub.tok_ids == 1 && sub.logprobs == 0);
+    assert(coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 512 logprobs=32 ids=1", &sub));
+    assert(sub.logprobs == 32 && sub.tok_ids == 1 && sub.gbytes == 512);
+    assert(coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 logprobs=0 ids=0", &sub));
+    assert(sub.logprobs == 0 && sub.tok_ids == 0);
+    /* rejects: over-cap, out-of-range, unknown key, malformed token */
+    assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 logprobs=33", &sub));
+    assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 ids=2", &sub));
+    assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 seed=7", &sub));
+    assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 logprobs=", &sub));
+    assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 =5", &sub));
+    assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 logprobs=5x", &sub));
+    assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 logprobs=5 junk", &sub));
+    assert(!coli_submit_parse("SUBMIT 42 3 17 64 0.7 0.95 0 logprobs", &sub));
+    /* an extended header still validates the base fields */
+    assert(!coli_submit_parse("SUBMIT 0 3 17 64 0.7 0.95 0 logprobs=5", &sub));
+    assert(!coli_submit_parse("SUBMIT 42 3 17 0 0.7 0.95 0 logprobs=5", &sub));
+}
+
+/* U7a token-ID intake: the ids the caller formatted are exactly the ids that
+ * come back out (the zero-round-trip property) -- and malformed input never
+ * parses partially. */
+static void test_ids_parse_round_trip(void)
+{
+    /* fixed known-good example: format then parse must reproduce the array */
+    const int ids[6] = {0, 154822, 154824, 12, 7, 99999};
+    char buf[128];
+    int out[8], n, k;
+    n = snprintf(buf, sizeof(buf), "%d %d %d %d %d %d",
+                 ids[0], ids[1], ids[2], ids[3], ids[4], ids[5]);
+    assert(n > 0);
+    k = coli_ids_parse(buf, (size_t)n, out, 8, 160000);
+    assert(k == 6);
+    for (int i = 0; i < 6; i++) assert(out[i] == ids[i]);
+
+    /* whitespace forms: leading/trailing/newlines are all separators */
+    k = coli_ids_parse("  5\n7\t9  ", 9, out, 8, 100);
+    assert(k == 3 && out[0] == 5 && out[1] == 7 && out[2] == 9);
+
+    /* rejects: sign, non-digit, vocab bound (exact and above), garbage tail */
+    assert(coli_ids_parse("-1", 2, out, 8, 100) == -1);
+    assert(coli_ids_parse("5x", 2, out, 8, 100) == -1);
+    assert(coli_ids_parse("1 two 3", 7, out, 8, 100) == -1);
+    assert(coli_ids_parse("100", 3, out, 8, 100) == -1);   /* id == vocab */
+    assert(coli_ids_parse("99", 2, out, 8, 100) == 1 && out[0] == 99);
+    assert(coli_ids_parse("101", 3, out, 8, 100) == -1);
+    assert(coli_ids_parse("123456789012345", 15, out, 8, 100) == -1);
+
+    /* empty payload parses to zero ids (the caller's EMPTY_PROMPT arm) */
+    assert(coli_ids_parse("   ", 3, out, 8, 100) == 0);
+
+    /* overflow reports the cap so the caller's context check refuses loudly,
+     * mirroring tok_encode's stop-at-cap contract (#401) */
+    assert(coli_ids_parse("1 2 3 4 5", 9, out, 4, 100) == 4);
+    assert(coli_ids_parse("1 2 3 4", 7, out, 4, 100) == 4);
+}
+
 int main(void)
 {
     test_rows_use_their_own_sequence_storage();
     test_const_reader_selects_the_same_row();
     test_submit_header();
+    test_submit_extension_fields();
+    test_ids_parse_round_trip();
     puts("decode batch helper tests: ok");
     return 0;
 }

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -660,6 +660,57 @@ class DispatcherTest(unittest.TestCase):
             "attention_s": 0.6, "lm_head_s": 0.2, "forwards": 15,
         }])
 
+    def test_accepts_u7a_echo_and_extended_data_frames(self):
+        # U7a forward-compat: the engine's opt-in per-token numeric channel --
+        # ECHO frames for echoed prompt positions and DATA frames extended
+        # with "<lp> <k> [tid tlp]*k" -- must NOT trip the dispatcher's
+        # catch-all (which kills every in-flight request). Text delivery and
+        # the DONE stats stay exactly as for legacy frames; the numeric
+        # fields are consumed by the server feature half (U7b).
+        def respond(process, frame):
+            request_id = frame.split()[1]
+            process.stdout.feed(b"ACCEPT " + request_id + b" 3\n")
+            process.stdout.feed(b"ECHO " + request_id + b" 2 0 nan 0\nHi\n")
+            process.stdout.feed(
+                b"ECHO " + request_id +
+                b" 6 1 -0.105361 2 7 -0.105361 9 -2.302585\n world\n")
+            process.stdout.feed(
+                b"ECHO " + request_id +
+                b" 1 2 -1.203973 2 4 -0.803973 6 -1.203973\n!\n")
+            process.stdout.feed(
+                b"DATA " + request_id +
+                b" 2 -0.223144 2 3 -0.223144 8 -1.723144\nok\n")
+            process.stdout.feed(
+                b"DONE " + request_id + b" STAT 1 2.5 0 1.0 3 0\n")
+
+        process = FakeProcess(respond)
+        with patch("openai_server.subprocess.Popen", return_value=process):
+            engine = Engine("glm", "model")
+        chunks = []
+        stats = engine.generate("Hi world!", 4, 0.0, 1.0, chunks.append)
+        self.assertEqual(chunks, ["ok"])
+        self.assertEqual(stats["completion_tokens"], 1)
+        self.assertEqual(stats["prompt_tokens"], 3)
+        self.assertIsNone(engine.dispatcher_error)
+        engine.close()
+
+    def test_unknown_frame_still_stops_dispatcher(self):
+        # The catch-all that makes an unrecognized frame a hard failure is
+        # load-bearing for the U7a compatibility asymmetry (a new engine's
+        # frame reaching an OLD server kills the dispatcher -- the reason the
+        # engine half ships first and stays opt-in). Accepting ECHO/extended
+        # DATA must not have widened acceptance beyond those frames.
+        def respond(process, frame):
+            request_id = frame.split()[1]
+            process.stdout.feed(b"LOGPROB " + request_id + b" 0.5\n")
+
+        process = FakeProcess(respond)
+        with patch("openai_server.subprocess.Popen", return_value=process):
+            engine = Engine("glm", "model")
+        with self.assertRaisesRegex(RuntimeError, "invalid engine response: LOGPROB"):
+            engine.generate("hello", 4, 0.7, 0.9, lambda _: None)
+        engine.close()
+
     def test_cancels_generation_after_consumer_disconnects(self):
         request_id = None
 

--- a/c/tests/test_spec_decode_state.c
+++ b/c/tests/test_spec_decode_state.c
@@ -162,6 +162,40 @@ static int test_persisted_tail(void) {
     return 0;
 }
 
+/* U7a: spec_decode's emit callback receives the logit row its token was
+ * picked/verified from -- including ACCEPTED DRAFT tokens, which bypass every
+ * pick_tok call site in the mux loop (the speculative-gap hazard the packet's
+ * Fork 5 flags). Greedy contract: no row may be NULL, and every row's argmax
+ * must be the emitted token -- proving the row really is that token's scoring
+ * distribution, not a stale or shifted one. */
+typedef struct { int n, null_rows, mismatches; } EmitProbe;
+static void emit_probe(int t, const float *lo, void *ud) {
+    EmitProbe *e = (EmitProbe *)ud;
+    e->n++;
+    if (!lo) { e->null_rows++; return; }
+    if (argmax_v(lo, V) != t) e->mismatches++;
+}
+
+static int test_emit_carries_scoring_logits_for_accepted_drafts(void) {
+    const int next[V] = {0, 2, 3, 1, 4, 5, 6, 7};
+    Toy t;
+    toy_init(&t, next);
+    reset_decode_globals(2);
+
+    /* Same shape as test_accepted_speculative_tokens: the repeated [1,2]
+     * bigram proposes [3,1]; one picked token + two accepted drafts. */
+    int all[12] = {1, 2, 3, 1};
+    EmitProbe probe = {0, 0, 0};
+    int kv = -1;
+    CHECK(spec_decode(&t.m, all, 4, 3, -1, choose(2), emit_probe, &probe, &kv, NULL) == 3);
+    CHECK(probe.n == 3);          /* 1 pick_tok token + 2 accepted draft tokens */
+    CHECK(probe.null_rows == 0);  /* the draft-accept arm has no numeric gap */
+    CHECK(probe.mismatches == 0); /* each row scores exactly its own token */
+
+    toy_free(&t);
+    return 0;
+}
+
 static int test_accepted_speculative_tokens(void) {
     const int next[V] = {0, 2, 3, 1, 4, 5, 6, 7};
     Toy t;
@@ -217,6 +251,7 @@ int main(void) {
     CHECK(test_ngen_zero_and_one_shot() == 0);
     CHECK(test_stateful_ngen_and_more() == 0);
     CHECK(test_persisted_tail() == 0);
+    CHECK(test_emit_carries_scoring_logits_for_accepted_drafts() == 0);
     CHECK(test_accepted_speculative_tokens() == 0);
     CHECK(test_eos_and_non_limit_stop() == 0);
     puts("spec_decode state tests: ok");


### PR DESCRIPTION
Authored by Fable 5 in Claude Code, analysis in partnership with @Monotophic

Engine half of OpenAI-compatible logprobs/echo support (server half
follows separately; this lands first because the compatibility asymmetry
only fails safe in this direction). Opt-in per request; fully inert
otherwise — proven by a captured golden-fixture battery (chat, tools,
streaming, completions, error cases) byte-identical against the pre-change
server.

What it adds, all gated on new SUBMIT extension fields (key=value form —
the 8th positional field is already claimed by the deepseek_v4
prefix-hint dialect): per-token log-probability + top-k table on generated
DATA frames; an ECHO frame family carrying prompt-position logprobs
(prefill read-out, one V-sized buffer, no P×vocab allocation); token-ID
array prompt intake that bypasses tok_encode (zero re-tokenization risk
for harness clients); dispatcher acceptance of the new frame type.
Strict extension parsing: glued, duplicated, or out-of-range fields
reject via the named BAD_REQUEST path.

**Behavioral contract**
- Requests that do not opt in are byte-identical to pre-change behavior
  and pay zero additional lm_head cost.
- Opted-in generation emits a logprob for EVERY token — including
  speculatively accepted draft tokens (no gaps).
- An old engine receiving the new SUBMIT form rejects with the named
  error (does not crash); note: the rejected request's payload bytes are
  not drained by the pre-existing protocol (unchanged here) — pairing an
  old server with a new engine is prevented by posting order.

**Capstone matrix**
| claim | decisive evidence |
|---|---|
| inert when not opted in | golden-fixture battery: 10/10 cases byte-identical baseline vs U7a (diff exit 0), rerun control identical |
| no speculative gaps | live MTP draft=2 run (69% acceptance, ~18 accepted-draft tokens): 64/64 DATA frames carry logprob tails, gapcheck exit 0 |
| old-direction fails safe | 8-field SUBMIT vs old parse arms → named BAD_REQUEST (test); synthetic new frame vs old dispatcher → named RuntimeError (test) |
| strict parse | pre-fix probes showed 2 wrong ACCEPTs (glued/overflow); 12 rejection cases now pass, hand-parsed bounded ints (no %llu UB) |
| suite green | make test-c + server suite (143) + full 558-test sweep exit 0; bites confirmed on every new test vs ad79236 |

<details><summary>Fuller matrix and review record</summary>
Two-reviewer roster + fix round + model-gate runner. Auditor-verified: no
dialect ambiguity with deepseek_v4's positional extension (separate
parser); no cross-slot frame interleave under KV_SLOTS>1; top-k clamped
at the run_ablate_score ceiling (32); token-ID intake bounds-checked
(negative/≥vocab/huge). Non-finite logits emit honest "nan"/"inf" wire
values; JSON serialization policy is deliberately deferred to the server
PR (register item). Remaining UNVERIFIED, disclosed: CUDA-backend
speculative variant not separately run (CPU-path speculation was
exercised live); embedding-identity for token-ID intake verified
structurally, not on a live model.
</details>

**Shared-namespace scan (at push, 2026-08-18 ~11 PM Eastern):** no
competing claim on the new SUBMIT keys or frame type in dev HEAD or any
open PR. #1096 (DeepSeek-V4 serve-codec refactor) shares only
`tests/test_openai_server.py`, additively on both sides — the V4 framing
dialect is intentionally disjoint from this PR's extension (that
dialect's existing claim on the 8th positional field is why this
extension is key=value).

**Durable vs current-state:** wire form and gating are durable;
acceptance-rate and test-count figures are current-state (2026-08-18,
base ad79236).
