### PR TITLE
fix(arm64): probe dotprod by compiling, prefer armv8.2-a base

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -141,10 +141,25 @@ ifeq ($(shell $(CC) -mcpu=native -dM -E - </dev/null 2>/dev/null | grep -c __ARM
 CPUFEAT  := $(shell grep -m1 '^Features' /proc/cpuinfo 2>/dev/null)
 ARCH_EXT := $(if $(filter asimddp,$(CPUFEAT)),+dotprod)$(if $(filter i8mm,$(CPUFEAT)),+i8mm)
 ifneq ($(ARCH_EXT),)
-ifneq ($(shell $(CC) -march=armv8-a$(ARCH_EXT) -dM -E - </dev/null 2>/dev/null | grep -cE '__ARM_FEATURE_DOTPROD|__ARM_FEATURE_MATMUL_INT8'),0)
+# gcc 11 defines __ARM_FEATURE_DOTPROD for -march=armv8-a+dotprod yet cannot
+# emit vdotq_s32 for that base ("target specific option mismatch"): the macro
+# probe alone is not enough. Verify by compiling the intrinsic for real, and
+# prefer the armv8.2-a base where dotprod is a first-class ISA feature
+# (Neoverse-N1 and friends report asimddp but are armv8.2 cores). Fall back to
+# armv8-a only if the compiler accepts the modifiers there too; otherwise the
+# idot kernels compile out and int4 S=1 decode falls back to f32 (#631, #1104).
+PROBE_C := $(shell mktemp /tmp/coli_v4_probe.XXXXXX.c)
+PROBE_OK := $(shell echo '#include <arm_neon.h>' > $(PROBE_C); echo 'int p(const signed char*w,const signed char*x,int n){int32x4_t a=vdupq_n_s32(0);for(;n>=16;n-=16)a=vdotq_s32(a,vld1q_s8(w),vld1q_s8(x));return vaddvq_s32(a);}' >> $(PROBE_C); $(CC) -c $(PROBE_C) -o /dev/null -march=armv8.2-a$(ARCH_EXT) 2>/dev/null && echo yes; rm -f $(PROBE_C))
+ifeq ($(PROBE_OK),yes)
+ARCHFLAG := -march=armv8.2-a$(ARCH_EXT)
+else
+PROBE_C8 := $(shell mktemp /tmp/coli_v4_probe.XXXXXX.c)
+PROBE_OK8 := $(shell echo '#include <arm_neon.h>' > $(PROBE_C8); echo 'int p(const signed char*w,const signed char*x,int n){int32x4_t a=vdupq_n_s32(0);for(;n>=16;n-=16)a=vdotq_s32(a,vld1q_s8(w),vld1q_s8(x));return vaddvq_s32(a);}' >> $(PROBE_C8); $(CC) -c $(PROBE_C8) -o /dev/null -march=armv8-a$(ARCH_EXT) 2>/dev/null && echo yes; rm -f $(PROBE_C8))
+ifeq ($(PROBE_OK8),yes)
 ARCHFLAG := -march=armv8-a$(ARCH_EXT)
 else
 $(warning $(CC) does not accept$(subst +, +,$(ARCH_EXT)): int8/int4 idot kernels compile out (#631))
+endif
 endif
 endif
 endif


### PR DESCRIPTION
Fixes #1104

## Problem

`make check` fails to compile on ARM64 hardware that supports dot products (e.g. Oracle Cloud A1 Flex, **Neoverse-N1**) when the default `ARCH=native` branch kicks in:

```
/usr/lib/gcc/aarch64-linux-gnu/11/include/arm_neon.h:32134:1: error: inlining failed in call to 'always_inline' 'vdotq_s32': target specific option mismatch
tests/../quant.h:651:29: note: called from here
  651 |     for(;i+16<=I;i+=16) acc=vdotq_s32(acc,vld1q_s8(w+i),vld1q_s8(x+i));
```

## Root cause

The aarch64 `ARCH=native` branch of `c/Makefile` probed for dot-product support with a **macro-only** check:

```make
$(CC) -march=armv8-a$(ARCH_EXT) -dM -E - </dev/null | grep -cE '__ARM_FEATURE_DOTPROD|__ARM_FEATURE_MATMUL_INT8'
```

But **GCC 11 defines `__ARM_FEATURE_DOTPROD` for `-march=armv8-a+dotprod` yet cannot actually emit `vdotq_s32` for that base** ("target specific option mismatch"). The macro is defined, so the guard in `quant.h:642` selects the `vdotq_s32` path — and then the compiler rejects the intrinsic. Every test binary that pulls in `colibri.c` → `quant.h` fails to build.

On Neoverse-N1 (`asimddp` present, an ARMv8.2 core), the fix that *works* is `-march=armv8.2-a+dotprod` — dotprod is a first-class ISA feature there.

## Fix

Replace the macro-only probe with a **real compile** of the `vdotq_s32` intrinsic from a temporary file:

1. Try `armv8.2-a$(ARCH_EXT)` first (compiles on GCC 11 + Neoverse-N1).
2. Fall back to `armv8-a$(ARCH_EXT)` if the compiler accepts the modifiers there too.
3. Otherwise degrade to the existing warning (idot kernels compile out, int4 S=1 decode falls back to f32) — unchanged behavior from before, #631.

`make portable` is untouched (still plain `armv8-a`, no modifiers), so `test_makefile_platform`'s portable-flag expectations hold.

## Validation

On Oracle Cloud A1 Flex (Neoverse-N1, gcc 11.4, Ubuntu 22.04), plain `make check` with **no override** now passes:

```
Ran 565 tests in 663.153s
OK (skipped=36)
```

0 failures. Previously the build failed to compile at all on the default `ARCH=native`.

---

Note: this is the ARM64 portable-build issue documented in #1104; it is independent of the planner-geometry work in #1103 (different files, no overlap).