### PR TITLE
fix(cuda): add the __syncwarp() grouped_s4_wmma's siblings carry

### DIFF
--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -683,6 +683,9 @@ __global__ static void grouped_s4_wmma(float *y,const uint8_t *x,const float *xs
         wmma::mma_sync(acc,af,bf,acc);
     }
     __shared__ int out[8][64]; wmma::store_matrix_sync(out[warp],acc,8,wmma::mem_row_major);
+    __syncwarp();   /* i due fratelli sopra la portano; stessa lettura cross-lane di out[warp]
+                     * subito sotto -> stesso requisito di visibilita' (racecheck: 3 hazard qui).
+                     * EN: the two sibling kernels carry this; same cross-lane read follows. */
     for(int i=lane;i<64;i+=32){int s=i/8,o=tile*8+i%8;
         if(s<d.rows&&o<O)y[(size_t)(d.offset+s)*O+o]=(float)out[warp][i]*xscale[d.offset+s]*ws[o];}
 #endif


### PR DESCRIPTION
Closes #1099 (report by @monotophic, analysis credited to Opus 5 in their issue — verified against source and taken as-is).

`grouped_s4_wmma` stores its WMMA accumulator to `out[warp]` and reads it back **across lanes** with no warp barrier; its two siblings (`backend_cuda.cu:617`, `:646`) carry `__syncwarp()` after the identical store-then-cross-lane-read pattern. The reporter's `compute-sanitizer --tool=racecheck` run shows **3 hazards at exactly this store**.

One line, mirroring the siblings, with a comment naming the requirement. CUDA syntax-check CI gates the compile; no behavioural change on correct executions — this closes the window where an incorrect one was possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)