### PR TITLE
Metal (Apple GPU) backend for Kimi K3 — rebase of #790 by @RDouglasSharp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,9 @@ c/coli_cuda_dsv4*.dll
 c/coli_cuda_dsv4*.lib
 c/coli_cuda_dsv4*.exp
 c/*.obj
+# macOS
+.DS_Store
+**/.DS_Store
+
+# compiled objects
+*.o

--- a/c/Makefile
+++ b/c/Makefile
@@ -956,8 +956,8 @@ NOCUDA_CFLAGS  = $(filter-out -DCOLI_CUDA -DCOLI_ANS,$(CFLAGS))
 NOCUDA_LDFLAGS = $(filter-out -lcudart -lstdc++ -lcuda -L$(CUDA_HOME)/lib64 \
                    -Wl$(comma)-rpath$(comma)$(CUDA_HOME)/lib64,$(LDFLAGS))
 
-kimi_k3$(EXE): kimi_k3.c st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h omp_tune.h route_trace.h kv_prefix.h serve_codec.h backend_cuda.h $(CUDA_OBJ) $(VK_OBJ) $(VK_SPV)
-	$(CC) $(CFLAGS) kimi_k3.c $(CUDA_OBJ) $(VK_OBJ) -o kimi_k3$(EXE) $(LDFLAGS)
+kimi_k3$(EXE): kimi_k3.c st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h omp_tune.h route_trace.h kv_prefix.h serve_codec.h backend_cuda.h $(CUDA_OBJ) $(VK_OBJ) $(VK_SPV) $(METAL_OBJ)
+	$(CC) $(CFLAGS) kimi_k3.c $(CUDA_OBJ) $(VK_OBJ) $(METAL_OBJ) -o kimi_k3$(EXE) $(LDFLAGS)
 
 # Use a baseline that matches the compiler target. macOS already targets a
 # portable baseline when ARCH is empty; forcing the x86 value there breaks

--- a/c/backend_metal.h
+++ b/c/backend_metal.h
@@ -26,6 +26,27 @@ int  coli_metal_available(void);
 void coli_metal_stats(size_t *tensor_count, size_t *tensor_bytes);
 int  coli_metal_mem_info(size_t *used_bytes, size_t *total_bytes);
 
+/* ---- Standalone elementwise / normalization ops ---------------------------------- */
+/*
+ * RMSNorm: out[nrows*D] = rmsnorm(x[nrows*D], w[D], eps).
+ * Each of nrows independent rows of width D. w is shared (1 copy, [D]).
+ * Returns 1 on success, 0 if Metal unavailable.
+ */
+int coli_metal_rmsnorm(float *x, const float *w, int nrows, int D, float eps);
+
+/*
+ * Residual add: y[i] += a[i] for i in [0, n).
+ * Returns 1 on success, 0 if Metal unavailable.
+ */
+int coli_metal_add(float *y, const float *a, size_t n);
+
+/*
+ * SiLU gate-multiply: g[i] = silu(g[i]) * u[i] for i in [0, n).
+ * Destroy-u variant: u is consumed (gate * up fusion for SwiGLU).
+ * Returns 1 on success, 0 if Metal unavailable.
+ */
+int coli_metal_silu_mul(float *g, const float *u, size_t n);
+
 /*
  * y[S,O] = (x[S,I] @ W[O,I]^T) * scale[o]. fmt=4 (grouped int4) instead folds a
  * PER-GROUP scale into the accumulation -- see the shader comment in backend_metal.mm.
@@ -120,6 +141,19 @@ int coli_metal_attn_decode(const float *x,
     const void *o_w, const float *o_s, int o_fmt, int o_gs,
     float *Lc, float *Rc, int S, int pos_base, int st0, float eps, float theta, float ascale, float *out);
 
+/*
+ * Write S KV-cache rows on GPU. out = Lc + pos_base*kv_lora gets rmsnorm(raw L, kv_a_ln, eps)
+ * and Rc + pos_base*qk_rope gets rope_interleave(raw R, pos_base+s, theta). Mirrors the
+ * CPU cache write: rmsnorm(Lc[pos], Lc[pos], kv_a_ln, kv_lora, eps) + rope_interleave(Rc[pos], pos, cfg).
+ * L_raw/R_raw are [S, kv_lora] / [S, qk_rope]. Returns 1 on success, 0 if Metal unavailable. */
+int coli_metal_kv_write(float *Lc, float *Rc, const float *L_raw, const float *R_raw,
+    const float *kv_a_ln, int S, int pos_base, int kv_lora, int qk_rope, float eps, float theta);
+
+/*
+ * Zero cache rows Lc[from*kv_lora .. (to-1)*kv_lora] and Rc[from*qk_rope .. (to-1)*qk_rope]
+ * on GPU. Covered by dedicated kernel. Returns 1 on success, 0 if Metal unavailable. */
+int coli_metal_kv_clear(float *Lc, float *Rc, int from, int to, int kv_lora, int qk_rope);
+
 /* Diagnostics: GPU blocks executed, CPU-fallback blocks, experts run on GPU. */
 void coli_metal_moe_counts(uint64_t *ok, uint64_t *fb, uint64_t *experts);
 void coli_metal_moe_times(double *setup, double *gpu, double *scatter);
@@ -167,6 +201,70 @@ ColiMetalMoeHandle* coli_metal_moe_block_begin(int nb, int D, int Iinter, int fm
                          const float *xg, const int *xoff, const int *nr,
                          const int *rows, const float *rw);
 int coli_metal_moe_block_end(ColiMetalMoeHandle *h, float *out);
+
+/*
+ * KDA state recurrence for one token (decode: C=1). Replaces the serial per-head
+ * sweep in kda_forward(): decay state by alpha, accumulate kS, expand by kn*vt,
+ * merge output with qn. Each thread handles one element of [H * hd] output space;
+ * alpha/kn/qn/alpha are precomputed per-head arrays.
+ *   S          — in-place state `[H * hd * hd]` (row-major: [h][kk][vv])
+ *   qn         — L2-normalized, gated Q        `[H * hd]`
+ *   kn         — L2-normalized K               `[H * hd]`
+ *   vh         — gated V                        `[H * hd]`
+ *   alpha      — decay factors                  `[H * hd]`
+ *   beta       — mixing factor                  `[H]`
+ *   oh         — output accumulator             `[H * hd]` (initialized to 0 by kernel)
+ *   H, hd     — number of heads, head dimension
+ * Returns 1 on success, 0 if Metal unavailable.
+ */
+int coli_metal_kda_state(float *S, const float *qn, const float *kn, const float *vh,
+                           const float *alpha, const float *beta, float *oh,
+                           int H, int hd);
+
+/*
+ * KDA Conv1d + SiLU gate for one projection (q, k, or v). Replaces the OMP-parallel
+ * depthwise conv loop in kda_forward(). The conv window is stateful across tokens:
+ *   conv_win[d*K]   — [P, K] shift register, oldest first, newest at K-1
+ *   vec[d]          — [P] raw projected value (saved to window[K-1], overwritten with gated result)
+ *   taps[d*K]       — [P, K] depthwise convolution taps (constant weights)
+ * One kernel dispatch per projection. Threadgroup of 256 threads, one thread per dimension.
+ * Returns 1 on success, 0 if Metal unavailable.
+ */
+int coli_metal_kda_conv_silu(float *conv_win, float *vec, const float *taps, int P, int K);
+
+/*
+ * KDA L2 normalization: in-place normalization of Q and K per head.
+ *   q[h*hd:(h+1)*hd] *= 1/sqrt(sum(q^2) + eps) * qscale
+ *   k[h*hd:(h+1)*hd] *= 1/sqrt(sum(k^2) + eps)
+ *   eps = 1e-6, qscale = 1/sqrt(hd).
+ * One kernel dispatch for all H heads. Returns 1 on success, 0 if Metal unavailable.
+ */
+int coli_metal_kda_l2_norm(float *q, float *k, int H, int hd, float qscale);
+
+/*
+ * Fused KDA token step: conv_silu(q,k,v) + l2_norm(q,k) + state recurrence,
+ * all encoded into a single MTLCommandBuffer. This eliminates per-kernel
+ * command-buffer creation/commit/wait overhead (~5 × 150us → one 150us).
+ *   win_q, win_k, win_v  — [P*K] conv windows (stateful across tokens)
+ *   qt, kt                — [P] = [H*hd] raw projected (become L2-normalized q/k in-place)
+ *   tv                    — [P] = [H*hd] raw projected (becomes SiLU-gated V in-place)
+ *   taps_q, taps_k, taps_v — [P*K] depthwise taps (constant)
+ *   S                     — [H*hd*hd] in-place attention state
+ *   alpha                 — [H*hd] precomputed decay factors (CPU from rgt+dt+A)
+ *   beta                  — [H] precomputed mixing factors (CPU from braw)
+ *   oh                    — [H*hd] output accumulator (written by kernel, read by CPU)
+ *   P, K, H, hd           — projection dim, kernel width, heads, head dim
+ * Returns 1 on success, 0 if Metal unavailable. Caller must zero oh[] before call.
+ */
+int coli_metal_kda_fused_token(
+    float *win_q, float *qt,
+    float *win_k, float *kt,
+    float *win_v, float *tv,
+    const float *taps_q, const float *taps_k, const float *taps_v,
+    float *S,
+    const float *alpha, const float *beta,
+    float *oh,
+    int P, int K, int H, int hd);
 
 #ifdef __cplusplus
 }

--- a/c/backend_metal.mm
+++ b/c/backend_metal.mm
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <vector>
 #include <mutex>
+#include <unordered_map>
 
 // ---- shader: general quantized GEMV, one threadgroup per output element (o,si) ----
 // y[si,o] = (sum_i dequant(W[o,i]) * x[si,i]) * scale[o]. fmt: 0=f32 1=i8 2=i4 3=i2.
@@ -445,6 +446,138 @@ kernel void r_top8_par(device const float* sig [[buffer(0)]], device const float
   if(normk){ float sm=0; for(int kk=0;kk<Ke;kk++) sm+=ww[kk]; sm+=1e-20f; for(int kk=0;kk<Ke;kk++) ww[kk]/=sm; }
   for(int kk=0;kk<Ke;kk++) ww[kk]*=rscale;
 }
+
+// ===== KV cache kernels =====
+// per-row rope_interleave on a single qk_rope vector (no heads). grid = S*(qk_rope/2).
+kernel void kv_rope(device float* R [[buffer(0)]], constant int& pos_base [[buffer(1)]],
+                    constant int& qk_rope [[buffer(2)]], constant float& theta [[buffer(3)]],
+                    uint gid [[thread_position_in_grid]]) {
+  int S=gid/(qk_rope/2); int j=gid%(qk_rope/2); int s=S; int hl=qk_rope/2;
+  int pos=pos_base+s;
+  device float* rv=R+(long)s*qk_rope;
+  float inv=pow(theta, -2.0f*j/(float)qk_rope); float ang=pos*inv, cs=cos(ang), sn=sin(ang);
+  // Read original pair BEFORE any write (threadgroup-local copy to avoid hazard)
+  thread float a=rv[2*j], b=rv[2*j+1];
+  // Write to both halves — may read from positions we'll also write, but we already have a/b
+  rv[j]     = a*cs - b*sn;
+  rv[hl+j]  = b*cs + a*sn;
+}
+// clear range: zero rows [from, to) [from,to) of Lc/Rc. grid = 2*nrows*maxD.
+kernel void kv_clear(device float* Lc [[buffer(0)]], device float* Rc [[buffer(1)]],
+                     constant int& from [[buffer(2)]], constant int& to [[buffer(3)]],
+                     constant int& kv_lora [[buffer(4)]], constant int& qk_rope [[buffer(5)]],
+                     uint gid [[thread_position_in_grid]]) {
+  int nr=to-from; int sel=gid%(2*nr), row=gid/(2*nr);
+   int s= row; if(s>=nr) return;
+   if(sel < nr){ Lc[(long)(from+s)*kv_lora+gid%(kv_lora)]=0.f; }
+   else        { Rc[(long)(from+s)*qk_rope+gid%(qk_rope)]=0.f; }
+}
+
+// ===== KDA Conv1d + SiLU kernel =====
+// Each thread (0..P-1) handles one dimension of one projection (q, k, or v).
+//  conv_win[d*K]   — stateful shift register [P*K], oldest first, newest at K-1
+//  vec[d]          — raw projected value (saved to window[K-1], overwritten with SiLU result)
+//  taps[d*K]       — constant convolution taps [P*K]
+kernel void kda_conv_silu(
+    device float* conv_win  [[buffer(0)]],
+    device float* vec       [[buffer(1)]],
+    device const float* taps [[buffer(2)]],
+    constant int& P         [[buffer(3)]],
+    constant int& K         [[buffer(4)]],
+    uint gid [[thread_position_in_grid]]) {
+  int d = (int)gid;
+  if (d >= P) return;
+  long base = (long)d * K;
+
+  // Shift window left by 1 and store new value at position K-1
+  for (int j = 0; j < K - 1; j++) {
+    conv_win[base + j] = conv_win[base + j + 1];
+  }
+  conv_win[base + K - 1] = vec[d];
+
+  // Compute dot product of taps and window
+  float acc = 0.f;
+  for (int j = 0; j < K; j++) {
+    acc += taps[base + j] * conv_win[base + j];
+  }
+
+  // Apply SiLU: x / (1 + exp(-x))
+  vec[d] = acc / (1.f + exp(-acc));
+}
+
+// ===== KDA L2 normalization kernel =====
+// Each thread (0..H-1) normalizes one head of Q and K in-place.
+//  q[h*hd:(h+1)*hd] *= 1/sqrt(sum(q^2) + eps) * qscale
+//  k[h*hd:(h+1)*hd] *= 1/sqrt(sum(k^2) + eps)
+kernel void kda_l2_norm(
+    device float* q       [[buffer(0)]],
+    device float* k       [[buffer(1)]],
+    constant int& H       [[buffer(2)]],
+    constant int& hd      [[buffer(3)]],
+    constant float& qscale [[buffer(4)]],
+    uint gid [[thread_position_in_grid]]) {
+  int h = (int)gid;
+  if (h >= H) return;
+
+  long base = (long)h * hd;
+  float sq = 0.f, sk = 0.f;
+  for (int i = 0; i < hd; i++) {
+    sq += q[base + i] * q[base + i];
+    sk += k[base + i] * k[base + i];
+  }
+  sq = 1.f / sqrt(sq + 1e-6f);
+  sk = 1.f / sqrt(sk + 1e-6f);
+  float qs = sq * qscale;
+  for (int i = 0; i < hd; i++) {
+    q[base + i] *= qs;
+    k[base + i] *= sk;
+  }
+}
+
+// ===== KDA state recurrence kernel =====
+// Each thread handles one (h, i) element of output space [H, hd].
+// Two-pass sweep: (1) decay S by alpha, accumulate kS = S^T * kn,
+//   then vt = (vh - kS) * beta; (2) expand S += kn[kk]*vt[vv],
+//   merge oh[i] += qn[kk] * S[kk][i].
+kernel void kda_state(
+    device float* S      [[buffer(0)]],     // [H, hd, hd] in-place state
+    device const float* qn     [[buffer(1)]],   // [H, hd] L2-normalized, gated Q
+    device const float* kn     [[buffer(2)]],   // [H, hd] L2-normalized K
+    device const float* vh     [[buffer(3)]],   // [H, hd] gated V
+    device const float* alpha  [[buffer(4)]],   // [H, hd] per-head decay factors
+    device const float* beta   [[buffer(5)]],   // [H] mixing factor
+    device float* oh     [[buffer(6)]],     // [H, hd] output accumulator
+    constant int& H      [[buffer(7)]],
+    constant int& hd     [[buffer(8)]],
+    uint gid [[thread_position_in_grid]]) {
+  int th = gid / hd;
+  int i = gid % hd;
+  if (th >= H) return;
+  long hS = (long)th * hd * hd;
+  long hq = (long)th * hd;
+  const device float* qn_h = qn + hq;
+  const device float* kn_h = kn + hq;
+  const device float* vh_h = vh + hq;
+  const device float* alpha_h = alpha + hq;
+  // Pass 1: decay + kS accumulate for this output column
+  float kiS = 0.f;
+  for (int kk = 0; kk < hd; kk++) {
+    long row = hS + (long)kk * hd;
+    float al = alpha_h[kk];
+    S[row + i] *= al;
+    kiS += kn_h[kk] * S[row + i];
+  }
+  float vi = (vh_h[i] - kiS) * beta[th];
+  // Pass 2: expand + merge
+  float oi = 0.f;
+  for (int kk = 0; kk < hd; kk++) {
+    long row = hS + (long)kk * hd;
+    float kv = kn_h[kk];
+    S[row + i] += kv * vi;
+    oi += qn_h[kk] * S[row + i];
+  }
+  oh[hq + i] = oi;
+}
 )METAL";
 
 struct ColiMetalTensor {
@@ -481,6 +614,9 @@ static id<MTLBuffer> fwht_signs(int n) {
 }
 static id<MTLComputePipelineState> g_a_rms, g_a_rope, g_a_copy, g_a_qabs, g_a_score, g_a_smax, g_a_clat, g_a_ctx;
 static id<MTLComputePipelineState> g_a_add, g_r_router, g_r_top8, g_r_top8p;
+static id<MTLComputePipelineState> g_kv_rope, g_kv_clear;
+static id<MTLComputePipelineState> g_kda_state;
+static id<MTLComputePipelineState> g_kda_conv_silu, g_kda_l2_norm;
 static int g_rtop8_par = 1;      // COLI_RTOP8 (default ON); COLI_RTOP8=0 opts out to the
                                   // serial kernel — see coli_metal_init.
 static int g_rtop8_width_ok = 1; // hardware fact, independent of the policy gate above:
@@ -629,8 +765,9 @@ static size_t fmt_bytes(int fmt, int I, int O) {
 // tensor in that encoding could ever reach this Metal-side sizing helper.
 static size_t fmt_scale_bytes(int fmt, int I, int O, int gs) {
   if (fmt == 4) return (size_t)O * ((I + gs - 1) / gs) * sizeof(float);
-  if (fmt == 8) return (size_t)((O + 127) / 128) * (size_t)((I + 127) / 128) * sizeof(float);
-  return (size_t)O * sizeof(float);
+  if (fmt == 6) return (size_t)O * ((I + gs - 1) / gs) * 2; // e8: 2-byte group scales
+  if (fmt == 8) return (size_t)((O + 127) / 128) * (size_t)((I + 127) / 128) * sizeof(float); // fp8 block scales
+  return (size_t)O * sizeof(float); // per-row scale, fmt 0/1/2/3 (dev catch-all; #790 rebase must keep this)
 }
 
 // Wrap host memory zero-copy if page-aligned, else copy into a shared buffer.
@@ -639,6 +776,22 @@ static id<MTLBuffer> wrap(const void *p, size_t n) {
   if (((uintptr_t)p % pg) == 0 && (n % pg) == 0)
     return [g_dev newBufferWithBytesNoCopy:(void*)p length:n options:MTLResourceStorageModeShared deallocator:nil];
   return [g_dev newBufferWithBytes:p length:n options:MTLResourceStorageModeShared];
+}
+
+// Wrap-once cache for host buffers that live for the whole model (KDA state, conv windows,
+// conv taps). These are re-used every token, so wrapping them on each call churns thousands
+// of MTLBuffer objects. Keyed by host pointer, which is safe ONLY because these allocations
+// are never freed or resized during inference. Do NOT use for per-forward transient buffers
+// (qt/kt/tv/alpha/beta/oh) — their pointers get freed and reused.
+static std::unordered_map<const void*, id<MTLBuffer>> g_wrap_cache;
+static std::mutex g_wrap_cache_mu;
+static id<MTLBuffer> wrap_persistent(const void *p, size_t n) {
+  std::lock_guard<std::mutex> lk(g_wrap_cache_mu);
+  auto it = g_wrap_cache.find(p);
+  if (it != g_wrap_cache.end()) return it->second;
+  id<MTLBuffer> b = wrap(p, n);
+  if (b) g_wrap_cache[p] = b;
+  return b;
 }
 
 extern "C" int coli_metal_init(void) {
@@ -664,7 +817,10 @@ extern "C" int coli_metal_init(void) {
     g_a_rms=P("a_rmsnorm"); g_a_rope=P("a_rope"); g_a_copy=P("a_copy");
     g_a_qabs=P("a_qabs"); g_a_score=P("a_score"); g_a_smax=P("a_smax"); g_a_clat=P("a_clat"); g_a_ctx=P("a_ctx");
     g_a_add=P("a_add"); g_r_router=P("r_router"); g_r_top8=P("r_top8"); g_r_top8p=P("r_top8_par");
-    if(!g_a_add||!g_r_router||!g_r_top8||!g_r_top8p){ fprintf(stderr,"[metal] tail pipelines failed\n"); g_dev=nil; return 0; }
+    g_kv_rope=P("kv_rope"); g_kv_clear=P("kv_clear");
+    g_kda_state=P("kda_state");
+    g_kda_conv_silu=P("kda_conv_silu"); g_kda_l2_norm=P("kda_l2_norm");
+    if(!g_a_add||!g_r_router||!g_r_top8||!g_r_top8p||!g_kv_rope||!g_kv_clear||!g_kda_state||!g_kda_conv_silu||!g_kda_l2_norm){ fprintf(stderr,"[metal] tail pipelines failed\n"); g_dev=nil; return 0; }
     // r_top8_par's reduction hardcodes SIMD width 32 (shuffle-down offsets 16..1, one
     // 32-thread threadgroup per row). True on all Apple Silicon shipped to date, but a
     // non-32-width device would reduce wrongly AND race multiple lane-0 writers, so this
@@ -801,13 +957,14 @@ extern "C" int coli_metal_matmul(ColiMetalTensor **tp, float *y, const float *x,
   /* fmt==8 (fp8 passthrough) is an explicit allow-list entry, not folded into the 0..4
    * contiguous range check below: it is not adjacent to it. */
   if (!g_dev || fmt < 0 || (fmt > 4 && fmt != 8)) return 0;
+  if(!weights||!x||!y) return 0;
   @autoreleasepool {
     ColiMetalTensor *t = *tp;
     if (!t) {
       t = new ColiMetalTensor();
       t->fmt = fmt; t->I = I; t->O = O; t->wbytes = fmt_bytes(fmt, I, O);
       t->w = wrap(weights, t->wbytes);
-      t->s = wrap(scales, fmt_scale_bytes(fmt, I, O, gs));
+      { size_t sb=fmt_scale_bytes(fmt, I, O, gs); t->s=sb?wrap(scales,sb):0; }
       *tp = t;
       g_tensor_count++; g_tensor_bytes += t->wbytes;
     }
@@ -1395,4 +1552,414 @@ extern "C" int coli_metal_moe_block_end(ColiMetalMoeHandle *h, float *out) {
   @autoreleasepool { ok = moe_finish(h->cb,h->hh,h->nb,h->R,h->D,h->rows.data(),h->rwv.data(),out); }
   h->cb=nil; h->hh=nil; delete h;
   return ok;
+}
+
+/* ---- Standalone elementwise / normalization ops --------------------------------
+
+ These are thin wrappers around the already-compiled g_a_rms / g_a_add / g_moe_silu
+ pipelines.  Each helper allocates a Managed (私密) buffer so the initial CPU-side
+ floating-point data survives for GPU reads, then uses `blitSynchronizeResource` +
+ `blitFromResource:toBuffer` to push back the GPU result into caller's ptr.  */
+
+// Push initial bytes from a CPU pointer into a Managed buffer and return the buffer.
+static id<MTLBuffer> cpubuf(id<MTLDevice> dev, const void *cpu, size_t len) {
+  id<MTLBuffer> b = [dev newBufferWithLength:len options:MTLResourceStorageModeManaged];
+  if (!b) return nil;
+  memcpy(b.contents, cpu, len);
+  [b didModifyRange:NSMakeRange(0, (NSUInteger)len)];
+  return b;
+}
+
+extern "C" int coli_metal_rmsnorm(float *x, const float *w, int nrows, int D, float eps) {
+  if (!g_dev) return 0;
+  @autoreleasepool {
+    id<MTLCommandBuffer> cb = [g_queue commandBuffer];
+    id<MTLBuffer> xb = cpubuf(g_dev, x, (size_t)nrows*D*4);
+    id<MTLBuffer> wb = cpubuf(g_dev, w, (size_t)D*4);
+    if (!xb || !wb) return 0;
+    id<MTLComputeCommandEncoder> e = [cb computeCommandEncoder];
+    int tgsz = 256;
+    [e setComputePipelineState:g_a_rms];
+    [e setBuffer:xb offset:0 atIndex:0]; [e setBuffer:wb offset:0 atIndex:1];
+    [e setBytes:&D length:4 atIndex:2]; [e setBytes:&eps length:4 atIndex:3];
+    [e dispatchThreadgroups:MTLSizeMake(nrows,1,1) threadsPerThreadgroup:MTLSizeMake(tgsz,1,1)];
+    [e endEncoding];
+    { id<MTLBlitCommandEncoder> bl = [cb blitCommandEncoder]; [bl synchronizeResource:xb]; [bl endEncoding]; }
+    [cb commit]; [cb waitUntilCompleted];
+    memcpy(x, xb.contents, (size_t)nrows * D * 4);
+    return cb.status != MTLCommandBufferStatusError;
+  }
+}
+
+extern "C" int coli_metal_add(float *y, const float *a, size_t n) {
+  if (!g_dev || n == 0) return n == 0 ? 1 : 0;
+  @autoreleasepool {
+    id<MTLCommandBuffer> cb = [g_queue commandBuffer];
+    id<MTLBuffer> yb = cpubuf(g_dev, y, n*4);
+    id<MTLBuffer> ab = cpubuf(g_dev, a, n*4);
+    if (!yb || !ab) return 0;
+    id<MTLComputeCommandEncoder> e = [cb computeCommandEncoder];
+    int tgsz = 256;
+    [e setComputePipelineState:g_a_add];
+    [e setBuffer:yb offset:0 atIndex:0]; [e setBuffer:ab offset:0 atIndex:1];
+    [e dispatchThreads:MTLSizeMake((uint32_t)n,1,1) threadsPerThreadgroup:MTLSizeMake(tgsz,1,1)];
+    [e endEncoding];
+    { id<MTLBlitCommandEncoder> bl = [cb blitCommandEncoder]; [bl synchronizeResource:yb]; [bl endEncoding]; }
+    [cb commit]; [cb waitUntilCompleted];
+    memcpy(y, yb.contents, n*4);
+    return cb.status != MTLCommandBufferStatusError;
+  }
+}
+
+extern "C" int coli_metal_silu_mul(float *g, const float *u, size_t n) {
+  if (!g_dev || n == 0) return n == 0 ? 1 : 0;
+  @autoreleasepool {
+    id<MTLCommandBuffer> cb = [g_queue commandBuffer];
+    id<MTLBuffer> gb = cpubuf(g_dev, g, n*4);
+    id<MTLBuffer> ub = cpubuf(g_dev, u, n*4);
+    if (!gb || !ub) return 0;
+    id<MTLComputeCommandEncoder> e = [cb computeCommandEncoder];
+    int tgsz = 256;
+    [e setComputePipelineState:g_moe_silu];
+    [e setBuffer:gb offset:0 atIndex:0]; [e setBuffer:ub offset:0 atIndex:1];
+    [e dispatchThreads:MTLSizeMake((uint32_t)n,1,1) threadsPerThreadgroup:MTLSizeMake(tgsz,1,1)];
+    [e endEncoding];
+    { id<MTLBlitCommandEncoder> bl = [cb blitCommandEncoder]; [bl synchronizeResource:gb]; [bl endEncoding]; }
+    [cb commit]; [cb waitUntilCompleted];
+    memcpy(g, gb.contents, n*4);
+    return cb.status != MTLCommandBufferStatusError;
+  }
+}
+
+// — KV cache row write & clear —
+
+static int cpy(id<MTLCommandBuffer> cb, id<MTLBuffer> dst, ptrdiff_t doff,
+               id<MTLBuffer> src, ptrdiff_t soff, uint32_t n) {
+  id<MTLComputeCommandEncoder> e = [cb computeCommandEncoder];
+  [e setComputePipelineState:g_a_copy];
+  [e setBuffer:dst offset:0 atIndex:0]; [e setBuffer:src offset:0 atIndex:1];
+  [e setBytes:&doff length:4 atIndex:2]; [e setBytes:&soff length:4 atIndex:3];
+  uint32_t tg=128, nt=((uint32_t)n+tg-1)/tg;
+  [e dispatchThreads:MTLSizeMake(nt*tg,1,1) threadsPerThreadgroup:MTLSizeMake(tg,1,1)];
+  [e endEncoding];
+  return cb.status != MTLCommandBufferStatusError;
+}
+
+extern "C" int coli_metal_kv_write(float *Lc, float *Rc, const float *L_raw, const float *R_raw,
+    const float *kv_a_ln, int S, int pos_base, int kv_lora, int qk_rope, float eps, float theta) {
+  if (!g_dev || S <= 0) return S <= 0 ? 1 : 0;
+  @autoreleasepool {
+    id<MTLCommandBuffer> cb = [g_queue commandBuffer];
+
+    id<MTLBuffer> bLc = wrap(Lc,  (size_t)S * kv_lora * 4);
+    id<MTLBuffer> bRc = wrap(Rc,  (size_t)S * qk_rope * 4);
+    id<MTLBuffer> bLu = wrap(L_raw, (size_t)S * kv_lora * 4);
+    id<MTLBuffer> bRu = wrap(R_raw, (size_t)S * qk_rope * 4);
+    id<MTLBuffer> bWa = wrap(kv_a_ln, kv_lora * 4);
+
+    if (!bLc || !bRc || !bLu || !bRu || !bWa) return 0;
+
+    // 1) Copy raw L → Lc rows
+    int rL = cpy(cb, bLc, 0, bLu, 0, (uint32_t)(S * kv_lora));
+    // 2) Copy raw R → Rc rows
+    int rR = cpy(cb, bRc, 0, bRu, 0, (uint32_t)(S * qk_rope));
+    if (!rL || !rR) return 0; // will still commit below — a_copy sets both buffers
+
+    auto rms = [&](id<MTLCommandBuffer> x, id<MTLBuffer> b, size_t off, id<MTLBuffer> Qw, int n) {
+      int QV = n; uint32_t tg = 128, nt = ((uint32_t)QV + tg - 1) / tg;
+      id<MTLComputeCommandEncoder> e = [x computeCommandEncoder];
+      [e setComputePipelineState:g_a_rms];
+      [e setBuffer:b  offset:off atIndex:0]; [e setBuffer:Qw offset:0 atIndex:1];
+      float ep[2] = {eps, 0}; [e setBytes:ep length:8 atIndex:2];
+      [e dispatchThreads:MTLSizeMake(nt*tg,1,1) threadsPerThreadgroup:MTLSizeMake(tg,1,1)];
+      [e endEncoding];
+    };
+
+    auto rope = [&](id<MTLCommandBuffer> x, id<MTLBuffer> b, size_t off,
+                    int base, int rs, int hs, int nh, float theta) {
+      uint32_t ttgq = 256; uint32_t threads = (uint32_t)nh * (uint32_t)(rs / 2);
+      uint32_t ntg = (threads + ttgq - 1) / ttgq;
+      id<MTLComputeCommandEncoder> e = [x computeCommandEncoder];
+      [e setComputePipelineState:g_a_rope];
+      [e setBuffer:b    offset:off atIndex:0];
+      [e setBytes:&pos_base length:4 atIndex:1];
+      int v0[4] = {base, rs, hs, 0};
+      [e setBytes:v0 length:16 atIndex:2];
+      float th[2] = {theta, 0}; [e setBytes:th length:8 atIndex:3];
+      [e dispatchThreads:MTLSizeMake(ntg*ttgq,1,1) threadsPerThreadgroup:MTLSizeMake(ttgq,1,1)];
+      [e endEncoding];
+    };
+
+    // 3) rmsnorm on L rows
+    for (int i = 0; i < S; i++)
+      rms(cb, bLc, (size_t)i * kv_lora * 4, bWa, kv_lora);
+
+    // 4) rope_interleave on R rows
+    rope(cb, bRc, 0, 0, qk_rope, 0, S, theta);
+
+    [cb commit]; [cb waitUntilCompleted];
+    return cb.status != MTLCommandBufferStatusError;
+  }
+}
+
+extern "C" int coli_metal_kv_clear(float *Lc, float *Rc, int from, int to, int kv_lora, int qk_rope) {
+  if (!g_dev) return 0;
+  int nr = to - from;
+  if (nr <= 0) return 1;
+  @autoreleasepool {
+    id<MTLCommandBuffer> cb = [g_queue commandBuffer];
+    id<MTLBuffer> bLc = wrap(Lc, (size_t)nr * kv_lora * 4);
+    id<MTLBuffer> bRc = wrap(Rc, (size_t)nr * qk_rope * 4);
+    if (!bLc || !bRc) return 0;
+
+    uint32_t maxD = (uint32_t)(kv_lora > qk_rope ? kv_lora : qk_rope);
+    uint32_t total = 2 * (uint32_t)nr * maxD;
+    uint32_t tg = 256, ntg = (total + tg - 1) / tg;
+
+    id<MTLComputeCommandEncoder> e = [cb computeCommandEncoder];
+    [e setComputePipelineState:g_kv_clear];
+    [e setBuffer:bLc offset:(size_t)from * kv_lora * 4 atIndex:0];
+    [e setBuffer:bRc offset:(size_t)from * qk_rope * 4 atIndex:1];
+    int v[4] = {from, to, kv_lora, qk_rope};
+    [e setBytes:v length:16 atIndex:2];
+    [e dispatchThreads:MTLSizeMake(ntg * tg, 1, 1) threadsPerThreadgroup:MTLSizeMake(tg, 1, 1)];
+    [e endEncoding];
+
+    [cb commit]; [cb waitUntilCompleted];
+    return cb.status != MTLCommandBufferStatusError;
+  }
+}
+
+// — KDA state recurrence —
+
+extern "C" int coli_metal_kda_state(float *S, const float *qn, const float *kn, const float *vh,
+                                     const float *alpha, const float *beta, float *oh,
+                                     int H, int hd) {
+  if (!g_dev || H <= 0) return H <= 0 ? 1 : 0;
+  @autoreleasepool {
+    id<MTLCommandBuffer> cb = [g_queue commandBuffer];
+    id<MTLBuffer> bS = wrap(S,        (size_t)H * hd * hd * sizeof(float));
+    id<MTLBuffer> bqn = wrap(qn,      (size_t)H * hd * sizeof(float));
+    id<MTLBuffer> bkn = wrap(kn,      (size_t)H * hd * sizeof(float));
+    id<MTLBuffer> bvh = wrap(vh,      (size_t)H * hd * sizeof(float));
+    id<MTLBuffer> balph = wrap(alpha, (size_t)H * hd * sizeof(float));
+    id<MTLBuffer> bbet = wrap(beta,   (size_t)H * sizeof(float));
+    id<MTLBuffer> boh = wrap(oh,      (size_t)H * hd * sizeof(float));
+    if (!bS || !bqn || !bkn || !bvh || !balph || !bbet || !boh) return 0;
+    uint32_t total = (uint32_t)H * (uint32_t)hd;
+    uint32_t tg = 256, ntg = (total + tg - 1) / tg;
+    id<MTLComputeCommandEncoder> e = [cb computeCommandEncoder];
+    [e setComputePipelineState:g_kda_state];
+    [e setBuffer:bS    offset:0 atIndex:0];
+    [e setBuffer:bqn   offset:0 atIndex:1];
+    [e setBuffer:bkn   offset:0 atIndex:2];
+    [e setBuffer:bvh   offset:0 atIndex:3];
+    [e setBuffer:balph offset:0 atIndex:4];
+    [e setBuffer:bbet  offset:0 atIndex:5];
+    [e setBuffer:boh   offset:0 atIndex:6];
+    [e setBytes:&H length:4 atIndex:7];
+    [e setBytes:&hd length:4 atIndex:8];
+    [e dispatchThreads:MTLSizeMake(ntg * tg, 1, 1) threadsPerThreadgroup:MTLSizeMake(tg, 1, 1)];
+    [e endEncoding];
+    [cb commit]; [cb waitUntilCompleted];
+    { memcpy(oh, [boh contents], (size_t)H * hd * sizeof(float)); }
+    return cb.status != MTLCommandBufferStatusError;
+  }
+}
+
+// — KDA Conv1d + SiLU (one projection) —
+
+extern "C" int coli_metal_kda_conv_silu(float *conv_win, float *vec, const float *taps, int P, int K) {
+  if (!g_dev || P <= 0) return P <= 0 ? 1 : 0;
+  @autoreleasepool {
+    id<MTLCommandBuffer> cb = [g_queue commandBuffer];
+    id<MTLBuffer> bwin = wrap(conv_win, (size_t)P * K * sizeof(float));
+    id<MTLBuffer> bvec = wrap(vec,      (size_t)P * sizeof(float));
+    id<MTLBuffer> btap = wrap(taps,     (size_t)P * K * sizeof(float));
+    if (!bwin || !bvec || !btap) return 0;
+
+    id<MTLComputeCommandEncoder> e = [cb computeCommandEncoder];
+    [e setComputePipelineState:g_kda_conv_silu];
+    [e setBuffer:bwin offset:0 atIndex:0];
+    [e setBuffer:bvec offset:0 atIndex:1];
+    [e setBuffer:btap offset:0 atIndex:2];
+
+    int Pv = P; int Kv = K;
+    [e setBytes:&Pv length:4 atIndex:3];
+    [e setBytes:&Kv length:4 atIndex:4];
+
+    uint32_t tg = 256, ntg = (P + tg - 1) / tg;
+    [e dispatchThreads:MTLSizeMake(ntg * tg, 1, 1) threadsPerThreadgroup:MTLSizeMake(tg, 1, 1)];
+    [e endEncoding];
+    [cb commit]; [cb waitUntilCompleted];
+    return cb.status != MTLCommandBufferStatusError;
+  }
+}
+
+// — KDA L2 normalization (q and k, in-place) —
+
+extern "C" int coli_metal_kda_l2_norm(float *q, float *k, int H, int hd, float qscale) {
+  if (!g_dev || H <= 0) return H <= 0 ? 1 : 0;
+  @autoreleasepool {
+    id<MTLCommandBuffer> cb = [g_queue commandBuffer];
+    id<MTLBuffer> bq = wrap(q, (size_t)H * hd * sizeof(float));
+    id<MTLBuffer> bk = wrap(k, (size_t)H * hd * sizeof(float));
+    if (!bq || !bk) return 0;
+
+    id<MTLComputeCommandEncoder> e = [cb computeCommandEncoder];
+    [e setComputePipelineState:g_kda_l2_norm];
+    [e setBuffer:bq offset:0 atIndex:0];
+    [e setBuffer:bk offset:0 atIndex:1];
+
+    int Hv = H; int hdv = hd;
+    [e setBytes:&Hv length:4 atIndex:2];
+    [e setBytes:&hdv length:4 atIndex:3];
+    [e setBytes:&qscale length:sizeof(float) atIndex:4];
+
+    uint32_t tg = 256, ntg = (H + tg - 1) / tg;
+    [e dispatchThreads:MTLSizeMake(ntg * tg, 1, 1) threadsPerThreadgroup:MTLSizeMake(tg, 1, 1)];
+    [e endEncoding];
+    [cb commit]; [cb waitUntilCompleted];
+    return cb.status != MTLCommandBufferStatusError;
+  }
+}
+
+/* ---------- KDA fused token step ----------
+ * Single command buffer: conv_silu(q,k,v) → l2_norm(q,k) → state recurrence.
+ * Alpha and beta are precomputed on CPU (graw+dt → alpha, braw → beta).
+ * oh[] is written by state kernel; caller must zero before call.
+ * After return, CPU performs per-head RMSNorm + sigmoid gate from oh → on. */
+extern "C" int coli_metal_kda_fused_token(
+    float *win_q, float *qt,
+    float *win_k, float *kt,
+    float *win_v, float *tv,
+    const float *taps_q, const float *taps_k, const float *taps_v,
+    float *S,
+    const float *alpha, const float *beta,
+    float *oh,
+    int P, int K, int H, int hd) {
+  if (!g_dev || P <= 0 || H <= 0) return 0;
+  @autoreleasepool {
+    id<MTLCommandBuffer> cb = [g_queue commandBuffer];
+
+    // Pre-wrap all buffers
+    size_t P_K_sz = (size_t)P * K * sizeof(float);
+    size_t P_sz   = (size_t)P * sizeof(float);
+    size_t S_sz   = (size_t)H * hd * hd * sizeof(float);
+    size_t a_sz   = (size_t)H * hd * sizeof(float);
+    size_t b_sz   = (size_t)H * sizeof(float);
+
+    // Persistent (model-lifetime) buffers: wrap once and reuse. win_* and S are 16 KB-aligned
+    // (afcalloc) so these are zero-copy — GPU writes to conv windows and state land directly
+    // in host memory and persist to the next token. taps are read-only constants.
+    id<MTLBuffer> bwin_q = wrap_persistent(win_q, P_K_sz);
+    id<MTLBuffer> bwin_k = wrap_persistent(win_k, P_K_sz);
+    id<MTLBuffer> bwin_v = wrap_persistent(win_v, P_K_sz);
+    id<MTLBuffer> btap_q = wrap_persistent(taps_q, P_K_sz);
+    id<MTLBuffer> btap_k = wrap_persistent(taps_k, P_K_sz);
+    id<MTLBuffer> btap_v = wrap_persistent(taps_v, P_K_sz);
+    id<MTLBuffer> bS     = wrap_persistent(S, S_sz);
+    // Transient (per-forward) buffers: pointers change each call, so wrap fresh every time.
+    id<MTLBuffer> bqt    = wrap(qt, P_sz);
+    id<MTLBuffer> bkt    = wrap(kt, P_sz);
+    id<MTLBuffer> btv    = wrap(tv, P_sz);
+    id<MTLBuffer> balph  = wrap(alpha, a_sz);
+    id<MTLBuffer> bbet   = wrap(beta, b_sz);
+    id<MTLBuffer> boh    = wrap(oh, a_sz);
+
+    #define _BT(b) ((b)?(void*)1:(void*)0)
+    if(!bwin_q||!bwin_k||!bwin_v||!bqt||!bkt||!btv||
+       !btap_q||!btap_k||!btap_v||!bS||!balph||!bbet||!boh){
+      fprintf(stderr,"[FUSED] wrap nil: q=%p k=%p v=%p qt=%p kt=%p tv=%p tq=%p tk=%p tv2=%p S=%p a=%p b=%p oh=%p\n",
+              _BT(bwin_q),_BT(bwin_k),_BT(bwin_v),_BT(bqt),_BT(bkt),_BT(btv),
+              _BT(btap_q),_BT(btap_k),_BT(btap_v),_BT(bS),_BT(balph),_BT(bbet),_BT(boh));
+      return 0;
+    }
+    #undef _BT
+
+    /* -- Dispatch 1-3: conv_silu for q, k, v -- */
+    { // conv q
+      id<MTLComputeCommandEncoder> e = [cb computeCommandEncoder];
+      [e setComputePipelineState:g_kda_conv_silu];
+      [e setBuffer:bwin_q offset:0 atIndex:0];
+      [e setBuffer:bqt    offset:0 atIndex:1];
+      [e setBuffer:btap_q offset:0 atIndex:2];
+      int Pv=P, Kv=K;
+      [e setBytes:&Pv length:4 atIndex:3];
+      [e setBytes:&Kv length:4 atIndex:4];
+      uint32_t tg=256, ntg=(P+tg-1)/tg;
+      [e dispatchThreads:MTLSizeMake(ntg*tg,1,1) threadsPerThreadgroup:MTLSizeMake(tg,1,1)];
+      [e endEncoding];
+    }
+    { // conv k
+      id<MTLComputeCommandEncoder> e = [cb computeCommandEncoder];
+      [e setComputePipelineState:g_kda_conv_silu];
+      [e setBuffer:bwin_k offset:0 atIndex:0];
+      [e setBuffer:bkt    offset:0 atIndex:1];
+      [e setBuffer:btap_k offset:0 atIndex:2];
+      int Pv=P, Kv=K;
+      [e setBytes:&Pv length:4 atIndex:3];
+      [e setBytes:&Kv length:4 atIndex:4];
+      uint32_t tg=256, ntg=(P+tg-1)/tg;
+      [e dispatchThreads:MTLSizeMake(ntg*tg,1,1) threadsPerThreadgroup:MTLSizeMake(tg,1,1)];
+      [e endEncoding];
+    }
+    { // conv v
+      id<MTLComputeCommandEncoder> e = [cb computeCommandEncoder];
+      [e setComputePipelineState:g_kda_conv_silu];
+      [e setBuffer:bwin_v offset:0 atIndex:0];
+      [e setBuffer:btv    offset:0 atIndex:1];
+      [e setBuffer:btap_v offset:0 atIndex:2];
+      int Pv=P, Kv=K;
+      [e setBytes:&Pv length:4 atIndex:3];
+      [e setBytes:&Kv length:4 atIndex:4];
+      uint32_t tg=256, ntg=(P+tg-1)/tg;
+      [e dispatchThreads:MTLSizeMake(ntg*tg,1,1) threadsPerThreadgroup:MTLSizeMake(tg,1,1)];
+      [e endEncoding];
+    }
+
+    /* -- Dispatch 4: l2_norm on q, k -- */
+    {
+      id<MTLComputeCommandEncoder> e = [cb computeCommandEncoder];
+      [e setComputePipelineState:g_kda_l2_norm];
+      [e setBuffer:bqt offset:0 atIndex:0];
+      [e setBuffer:bkt offset:0 atIndex:1];
+      int Hv=H, hdv=hd;
+      float qs = 1.f / sqrtf((float)hd);
+      [e setBytes:&Hv length:4 atIndex:2];
+      [e setBytes:&hdv length:4 atIndex:3];
+      [e setBytes:&qs length:sizeof(float) atIndex:4];
+      uint32_t tg=256, ntg=(H+tg-1)/tg;
+      [e dispatchThreads:MTLSizeMake(ntg*tg,1,1) threadsPerThreadgroup:MTLSizeMake(tg,1,1)];
+      [e endEncoding];
+    }
+
+    /* -- Dispatch 5: state recurrence -- */
+    {
+      id<MTLComputeCommandEncoder> e = [cb computeCommandEncoder];
+      [e setComputePipelineState:g_kda_state];
+      [e setBuffer:bS    offset:0 atIndex:0];
+      [e setBuffer:bqt   offset:0 atIndex:1];
+      [e setBuffer:bkt   offset:0 atIndex:2];
+      [e setBuffer:btv   offset:0 atIndex:3];
+      [e setBuffer:balph offset:0 atIndex:4];
+      [e setBuffer:bbet  offset:0 atIndex:5];
+      [e setBuffer:boh   offset:0 atIndex:6];
+      [e setBytes:&H length:4 atIndex:7];
+      [e setBytes:&hd length:4 atIndex:8];
+      uint32_t total=(uint32_t)H*(uint32_t)hd;
+      uint32_t tg=256, ntg=(total+tg-1)/tg;
+      [e dispatchThreads:MTLSizeMake(ntg*tg,1,1) threadsPerThreadgroup:MTLSizeMake(tg,1,1)];
+      [e endEncoding];
+    }
+
+    [cb commit];
+    [cb waitUntilCompleted];
+    memcpy(oh, [boh contents], (size_t)H * hd * sizeof(float));
+    memcpy(S, [bS contents], S_sz);
+    memcpy(win_q, [bwin_q contents], P_K_sz);
+    memcpy(win_k, [bwin_k contents], P_K_sz);
+    memcpy(win_v, [bwin_v contents], P_K_sz);
+    return cb.status != MTLCommandBufferStatusError;
+  }
 }

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -49,6 +49,9 @@
  *                        everywhere; output identical.
  *   K3_VK_GB=N           VRAM cap for the tier (default: driver budget)
  *   K3_VK_UP=N           routed-expert uploads per step (default 8)
+ *   K3_METAL=0|1         Metal tier (build with `make METAL=1 kimi_k3`; Phase 4:
+ *                        scaffolding only — dispatch hooks present, forward NOT
+ *                        IMPLEMENTED; all ops fall through to CPU).
  *   K3_DIRECT=0|1        O_DIRECT expert reads (default 1; buffered fallback)
  *   K3_IDOT=0|1          int8-activation expert matmuls (default 1; 0 = float)
  *   K3_PIPE=0|1          overlap expert loads with compute (default 1)
@@ -99,7 +102,7 @@ typedef struct {
     int hidden, n_layers, vocab, first_dense, dense_inter;
     /* MLA */
     int n_heads, q_lora, kv_lora, qk_nope, qk_rope, qk_head, v_head;
-    float attn_scale;
+    float attn_scale, theta;
     /* KDA */
     int kda_heads, kda_hd, kda_proj, conv_k;
     float gate_lb;
@@ -110,12 +113,15 @@ typedef struct {
     int res_bs;
     float eps;
     int8_t is_kda[128];
+    int8_t idx_type[128];                     /* DSA: 1=full (own Ic + top-K), 0=shared (reuse) */
+    int index_hd, index_nh, index_topk;       /* DSA indexer dimensions */
     int bos, eos[8], n_eos;
 } Cfg;
 
 /* ---------- RAM-resident or read-only mapped weight ---------- */
 typedef struct { int fmt; float *f; int8_t *q8; uint8_t *q4; float *s; int O, I, gs;
-                 void *vk; /* ColiVkTensor* once uploaded (K3_VK); NULL = CPU only */
+                 void *vk;    /* ColiVkTensor* once uploaded (K3_VK); NULL = CPU only */
+                 void *metal; /* ColiMetalTensor* once registered (K3_METAL); NULL = CPU only */
                  st_mapped_raw data_map, scale_map;
                  int mapped; } W;
 
@@ -125,11 +131,16 @@ typedef struct {                          /* KDA layer */
     float *fa, *fb;                       /* decay low-rank, f32 [hd,hidden] [proj,hd] */
     float *bp;                            /* beta proj f32 [heads,hidden] */
     float *dt, *A, *onw;                  /* dt_bias[proj], exp(A_log)[heads], o_norm[hd] */
+    void   *metal_fa, *metal_fb, *metal_bp; /* Metal tensor wrappers for f32 weights */
 } Kda;
 
 typedef struct {                          /* gated MLA layer */
     W qa, qb, kva, kvb, o, g;
     float *qa_ln, *kva_ln;
+    /* DSA indexer (full layers only, optional) */
+    W      wk, wq, wp;                    /* [index_hd x {hidden, q_lora, index_hd}] */
+    float  *knw, *knb;                    /* key layernorm [index_hd] */
+    float  *Ic;                           /* indexer cache [max_t * index_hd] */
 } Mla;
 
 typedef struct {                          /* LatentMoE */
@@ -178,6 +189,8 @@ typedef struct {
      * and only the 24 MLA layers keep Lc/Rc — so an explicit record of the
      * tokens fed is the only description of it that cannot drift. */
     kv_prefix kvp;
+    /* DSA selection: per-slot k_idx arrays (shared across layers) */
+    int    *dsa_nsel, *dsa_sel; int64_t dsa_scap; /* k_idx selection: [S] counts + [S*topk] indices */
     /* experts */
     ERef *eref;                           /* [n_layers][n_experts] (dense rows zeroed) */
     LCache *ecache;
@@ -238,6 +251,20 @@ static double rss_gb(void){ struct rusage r; getrusage(RUSAGE_SELF,&r);
 }
 static float *falloc(int64_t n){ float *p=malloc((size_t)n*sizeof(float)); if(!p){fprintf(stderr,"OOM %lld floats\n",(long long)n);exit(1);} return p; }
 static float *fcalloc(int64_t n){ float *p=calloc((size_t)n,sizeof(float)); if(!p){fprintf(stderr,"OOM %lld floats\n",(long long)n);exit(1);} return p; }
+/* Aligned + zeroed alloc. Metal's wrap() only takes the zero-copy (newBufferWithBytesNoCopy)
+ * path when the pointer AND size are 16384-aligned; otherwise it makes a private GPU copy
+ * that is never synced back. Buffers the GPU WRITES and must persist across tokens (KDA
+ * state, conv windows) therefore have to be 16 KB-aligned so GPU updates land in host memory.
+ * Freed with plain free(); posix_memalign memory is free()-compatible on macOS. */
+static float *afcalloc(int64_t n){
+#ifdef COLI_METAL
+    size_t sz=(size_t)n*sizeof(float); void *p=NULL;
+    if(posix_memalign(&p,16384,sz)){ fprintf(stderr,"OOM %lld floats\n",(long long)n); exit(1); }
+    memset(p,0,sz); return (float*)p;
+#else
+    return fcalloc(n);
+#endif
+}
 static inline float sigmoidf_(float x){ return 1.f/(1.f+expf(-x)); }
 static inline float siluf_(float x){ return x/(1.f+expf(-x)); }
 static void softmax_(float *x, int n){ float m=x[0]; for(int i=1;i<n;i++) if(x[i]>m)m=x[i];
@@ -246,6 +273,51 @@ static void rmsnorm_(float *out, const float *x, const float *w, int D, float ep
     double ms=0; for(int i=0;i<D;i++) ms+=(double)x[i]*x[i];
     float r=1.f/sqrtf((float)(ms/D)+eps);
     for(int i=0;i<D;i++) out[i]=x[i]*r*w[i];
+}
+
+/* ---------- DSA (Dictionary Sparse Attention) CPU helpers ---------- */
+static void dsa_rope(float *v, int pos, int qk_rope, float base_theta){
+    int half = qk_rope/2;
+    if(qk_rope > 256){ fprintf(stderr,"qk_rope=%d exceeds rope buffer (256)\n",qk_rope); exit(1); }
+    float in[256]; memcpy(in,v,qk_rope*sizeof(float));
+    for(int j=0;j<half;j++){
+        float inv=powf(base_theta,-2.0f*j/qk_rope), ang=pos*inv;
+        float cs=cosf(ang), sn=sinf(ang);
+        float a=in[2*j], b=in[2*j+1];
+        v[j]      = a*cs - b*sn;
+        v[half+j] = b*cs + a*sn;
+    }
+}
+
+typedef struct { float sc; int idx; } DsaEntry;
+static int dsa_entry_cmp_desc(const void *a,const void *b){
+    float d=((const DsaEntry*)b)->sc-((const DsaEntry*)a)->sc;
+    return d>0?1:d<0?-1:0;
+}
+
+/* dsa_score: multi-head cosine distance + ReLU + weight + top-K select.
+ * qi: [nh * index_hd] — per-head indexer query (post-RoPE, post-projection)
+ * Ic: [nk * index_hd] — indexer cache rows
+ * w32: [nh] — weight scalars from P projection
+ * nk: number of cache rows in context
+ * sel: output buffer of maxsel ints (sorted desc by score)
+ * Returns actual count of selected indices. Caller supplies token-local DsaEntry array. */
+static int dsa_score_single(int *sel, int maxsel, const float *qi, const float *Ic, int index_hd,
+                            const float *w32, int nh, int nk, DsaEntry *entries){
+    if(nk <= 0 || maxsel <= 0) return 0;
+    for(int t=0;t<nk;t++){
+        float s = 0;
+        for(int h=0;h<nh;h++){
+            float d=0;
+            for(int i=0;i<index_hd;i++) d += qi[(int64_t)h*index_hd+i] * Ic[(int64_t)t*index_hd+i];
+            s += w32[h]*(d>0?d:0); /* ReLU per-head */
+        }
+        entries[t]=(DsaEntry){s/sqrtf((float)nh), t};
+    }
+    int K = nk < maxsel ? nk : maxsel;
+    qsort(entries, nk, sizeof(DsaEntry), dsa_entry_cmp_desc);
+    for(int k=0;k<K;k++) sel[k]=entries[k].idx;
+    return K;
 }
 
 /* ---------- W: load-time quantization + matvec ---------- */
@@ -299,7 +371,46 @@ static int w_vk_upload(W *w){
         fmt==1?(const void*)w->q8:(const void*)w->q4,w->s,fmt,w->I,w->O,w->gs);
 }
 #endif
+/* ---------- Metal tier (K3_METAL, build with `make METAL=1 kimi_k3`) ----------
+ * Phase 4: scaffolding — init, dispatch hooks, feature flags.
+ * Not implemented; w_matmul intentionally falls through to CPU. */
+static int g_k3_metal=0;  /* backend live (K3_METAL env) */
+/* Phase 9: layer-level validation — capture intermediates for one layer */
+static int   g_k3_val_layer = -1;  /* K3_VALIDATE_LAYER=N (0-indexed, -1=off) */
+static int   g_k3_val_token = 0;   /* K3_VALIDATE_TOKEN (always use 0) */
+static FILE *g_k3_val_fp    = NULL; /* output file for intermediate dumps */
+/* Phase 10: full model validation — per-step logits (stays open across prefill+decode) */
+static FILE *g_k3_val_lfp   = NULL; /* K3_VAL_LOGITS: per-step logit dump */
+
+static void val_dump(const char *name, const float *v, int n);  /* forward-declare */
+static FILE *g_k3_dfp = NULL;  /* K3_DEBUG_OUT: Metal/CPU side-by-side per-dim comparison */
+#ifdef COLI_METAL
+#include "backend_metal.h"
+
+/* Metal forward entry point — Phase 4: NOT IMPLEMENTED */
+static int kimima_forward_metal(Model *m, Layer *l, int li, const float *x, int C, float *out){
+    (void)m; (void)l; (void)li; (void)x; (void)C; (void)out;
+    return 0; /* 0 = NOT IMPLEMENTED — fall through to CPU */
+}
+#endif
 static void w_matmul(float *y, const float *x, const W *w, int S){
+#ifdef COLI_METAL
+    if(g_k3_metal && coli_metal_available()){
+        if(w->fmt==0){
+            /* fmt=0 is raw f32, no scales needed — Metal shader handles it */
+            coli_metal_matmul((ColiMetalTensor**)&((W*)w)->metal, y, x, w->f, NULL, 0, S, w->I, w->O, 0);
+            return;
+        }
+        if(w->fmt==1){
+            coli_metal_matmul((ColiMetalTensor**)&((W*)w)->metal, y, x, w->q8, w->s, 1, S, w->I, w->O, 0);
+            return;
+        }
+        if(w->fmt==4){
+            coli_metal_matmul((ColiMetalTensor**)&((W*)w)->metal, y, x, w->q4, w->s, 4, S, w->I, w->O, w->gs);
+            return;
+        }
+    }
+#endif
 #ifdef COLI_VULKAN
     if(g_k3_vk&&S==1&&w->vk&&
        coli_vk_matmul((ColiVkTensor**)&((W*)w)->vk,y,x,NULL,NULL,w->fmt,1,w->I,w->O,w->gs))
@@ -309,6 +420,16 @@ static void w_matmul(float *y, const float *x, const W *w, int S){
     else if(w->fmt==1) matmul_q(y,x,w->q8,w->s,S,w->I,w->O);
     else if(w->fmt==4) matmul_i4_grouped(y,x,w->q4,w->s,S,w->I,w->O,w->gs);
     else { fprintf(stderr,"w_matmul: bad fmt %d\n",w->fmt); exit(1); }
+}
+/* f32 GEMM with Metal dispatch: y[S,O] = x[S,I] @ W[O,I]^T */
+static void k3_matmul_f32(void *tens, float *y, const float *x, const float *W, int S, int I, int O){
+#ifdef COLI_METAL
+    if(g_k3_metal && coli_metal_available()){
+        coli_metal_matmul((ColiMetalTensor**)tens, y, x, W, NULL, 0, S, I, O, 0);
+        return;
+    }
+#endif
+    matmul(y,x,W,S,I,O);
 }
 /* acc[0..I) += coef * row r (MLA absorb builds q_abs from kv_b rows) */
 static void w_addrow(const W *w, int r, float coef, float *acc){
@@ -534,6 +655,9 @@ static void load_cfg(Cfg *c, const char *snap){
     c->situ_b1     =(float)req_num(tc,"activation_situ_beta");
     c->situ_b2     =(float)req_num(tc,"activation_situ_linear_beta");
     jval *ep=json_get(tc,"rms_norm_eps"); c->eps=ep?(float)ep->num:1e-5f;
+    jval *rp=json_get(tc,"rope_parameters");
+    if(rp&&rp->t==J_OBJ){ jval *th=json_get(rp,"rope_theta"); c->theta=th?(float)th->num:10000.f; }
+    else c->theta=10000.f;
     c->qk_head=c->qk_nope+c->qk_rope;
     c->attn_scale=1.f/sqrtf((float)c->qk_head);
     jval *la=json_get(tc,"linear_attn_config");
@@ -553,6 +677,21 @@ static void load_cfg(Cfg *c, const char *snap){
     if(!kl||kl->t!=J_ARR){ fprintf(stderr,"config.json: missing kda_layers\n"); exit(1); }
     for(int i=0;i<kl->len;i++){ int v=(int)kl->kids[i]->num;      /* 1-indexed */
         if(v>=1&&v<=c->n_layers) c->is_kda[v-1]=1; }
+    /* DSA indexer (optional — if absent in config, DSA is disabled) */
+    { jval *jn=json_get(tc,"index_hd");   c->index_hd   = jn&&jn->t==J_NUM ? (int)jn->num : 0; }
+    { jval *jn=json_get(tc,"index_nh");   c->index_nh   = jn&&jn->t==J_NUM ? (int)jn->num : 0; }
+    { jval *jn=json_get(tc,"index_topk"); c->index_topk = jn&&jn->t==J_NUM ? (int)jn->num : 0; }
+    if(c->index_hd > 0){
+        /* Default: all MLA layers are "full" DSA layers (compute own Ic + top-K) */
+        for(int i=0;i<c->n_layers;i++) if(!c->is_kda[i]) c->idx_type[i]=1;
+        jval *il=json_get(tc,"index_layers");
+        if(il && il->t==J_ARR){
+            /* Override: explicit list of 1-indexed full DSA layers */
+            memset(c->idx_type, 0, sizeof(c->idx_type));
+            for(int i=0;i<il->len;i++){ int v=(int)il->kids[i]->num;
+                if(v>=1&&v<=c->n_layers) c->idx_type[v-1]=1; }
+        }
+    }
     jval *b=json_get(root,"bos_token_id"); if(!b) b=json_get(tc,"bos_token_id");
     c->bos = b&&b->t==J_NUM ? (int)b->num : -1;
     jval *e=json_get(root,"eos_token_id"); if(!e) e=json_get(tc,"eos_token_id");
@@ -688,10 +827,12 @@ static void model_init(Model *m, const char *snap, int n_layers_env){
               a->A=falloc(c->kda_heads);
               for(int h=0;h<c->kda_heads;h++) a->A[h]=expf(al[h]);
               free(al); }
-            m->kstate[i]=fcalloc((int64_t)c->kda_heads*c->kda_hd*c->kda_hd);
-            m->cwq[i]=fcalloc((int64_t)P*c->conv_k);
-            m->cwk[i]=fcalloc((int64_t)P*c->conv_k);
-            m->cwv[i]=fcalloc((int64_t)P*c->conv_k);
+            /* afcalloc: 16 KB-aligned so Metal wraps these zero-copy and GPU state/window
+             * updates persist across tokens (see afcalloc note). CPU path is unaffected. */
+            m->kstate[i]=afcalloc((int64_t)c->kda_heads*c->kda_hd*c->kda_hd);
+            m->cwq[i]=afcalloc((int64_t)P*c->conv_k);
+            m->cwk[i]=afcalloc((int64_t)P*c->conv_k);
+            m->cwv[i]=afcalloc((int64_t)P*c->conv_k);
         } else {
             Mla *a=&l->m;
             w_load(m,&a->qa,NM("model.layers.%d.self_attn.q_a_proj.weight",i),c->q_lora,c->hidden,mbits);
@@ -702,6 +843,14 @@ static void model_init(Model *m, const char *snap, int n_layers_env){
             w_load(m,&a->g,NM("model.layers.%d.self_attn.g_proj.weight",i),c->n_heads*c->v_head,c->hidden,mbits);
             a->qa_ln =f32_load(m,NM("model.layers.%d.self_attn.q_a_layernorm.weight",i),c->q_lora);
             a->kva_ln=f32_load(m,NM("model.layers.%d.self_attn.kv_a_layernorm.weight",i),c->kv_lora);
+            /* DSA indexer weights – only for "full" layers (idx_type=1) */
+            if(c->index_hd > 0 && c->idx_type[i]){
+                w_load(m,&a->wk,NM("model.layers.%d.self_attn.w_k.weight",i),(int64_t)c->index_hd,c->hidden,mbits);
+                w_load(m,&a->wq,NM("model.layers.%d.self_attn.w_q.weight",i),(int64_t)c->index_hd,c->q_lora,mbits);
+                w_load(m,&a->wp,NM("model.layers.%d.self_attn.w_p.weight",i),(int64_t)c->index_hd,c->hidden,mbits);
+                a->knw=f32_load(m,NM("model.layers.%d.self_attn.kn_w",i),(int64_t)c->index_hd);
+                a->knb=f32_load(m,NM("model.layers.%d.self_attn.kn_b",i),(int64_t)c->index_hd);
+            }
         }
         if(l->sparse){
             Moe *o=&l->moe;
@@ -761,6 +910,17 @@ static void model_init(Model *m, const char *snap, int n_layers_env){
         fprintf(stderr,"[K3-VK] resident: %d shared-expert mats (%.1f/%.1f GB); routed MXFP4 tier fills at decode (K3_VK_UP=%d/step, cap %s)\n",
                 nsh,used,budget,g_vk_upcap,g_vk_gb>0?"K3_VK_GB":"driver budget");
       }
+    }
+#endif
+#ifdef COLI_METAL
+    { const char *ev=getenv("K3_METAL");
+      if(ev&&atoi(ev)){
+        fprintf(stderr,"[K3-METAL] attempting init (K3_METAL=%s)\n", ev);
+        g_k3_metal=coli_metal_init();
+        if(!g_k3_metal) fprintf(stderr,"[K3-METAL] FAILED — CPU only\n");
+      }
+      if(g_k3_metal)
+        fprintf(stderr,"[K3-METAL] init OK (fused KDA token GPU: conv_silu×3+l2_norm+kda_state; attn state CPU)\n");
     }
 #endif
     expert_table_init(m);
@@ -870,6 +1030,45 @@ static void model_init(Model *m, const char *snap, int n_layers_env){
     }
     fprintf(stderr,"[K3] init done in %.1fs | %d layers | expert cache %d/layer (%.1f MB/slot) | RSS %.1f GB\n",
             now_s()-t0,c->n_layers,cap,m->e_slot/1e6,rss_gb());
+    /* Phase 9: layer validation init */
+    { const char *vl=getenv("K3_VALIDATE_LAYER");
+      const char *vt=getenv("K3_VALIDATE_TOKEN");
+      if(vl){
+        g_k3_val_layer=atoi(vl);
+        g_k3_val_token=vt?atoi(vt):0;
+        if(g_k3_val_token<0) g_k3_val_token=0;
+        if(g_k3_val_layer<0||g_k3_val_layer>=c->n_layers){
+          fprintf(stderr,"[K3-VAL] layer %d out of range (0..%d) — disabled\n",g_k3_val_layer,c->n_layers-1);
+          g_k3_val_layer=-1;
+        } else {
+          const char *ofn=getenv("K3_VALIDATE_OUT");
+          if(!ofn) ofn="/tmp/k3_val";
+          g_k3_val_fp=fopen(ofn,"w");
+          if(!g_k3_val_fp){
+            fprintf(stderr,"[K3-VAL] cannot open %s (%s) — disabled\n",ofn,strerror(errno));
+            g_k3_val_layer=-1;
+          } else {
+            fprintf(stderr,"[K3-VAL] active: layer %d, token %d, output %s (%d dims)\n",
+                    g_k3_val_layer,g_k3_val_token,ofn,c->hidden);
+          }
+        }
+      }
+    }
+    /* K3_DEBUG_OUT: Metal/CPU side-by-side dim comparison */
+    { const char *dbg=getenv("K3_DEBUG_OUT");
+      if(dbg){ g_k3_dfp=fopen(dbg,"w"); if(g_k3_dfp) fprintf(stderr,"[K3-DBG] active: output %s\n",dbg); }
+    }
+    /* Phase 10: full model logits capture */
+    { const char *vl=getenv("K3_VAL_LOGITS");
+      if(vl){
+        g_k3_val_lfp=fopen(vl,"wb");
+        if(!g_k3_val_lfp){
+          fprintf(stderr,"[K3-VAL-LOGITS] cannot open %s (%s) — disabled\n",vl,strerror(errno));
+        } else {
+          fprintf(stderr,"[K3-VAL-LOGITS] active: output %s (%d dims)\n",vl,c->vocab);
+        }
+      }
+    }
     #undef NM
 }
 
@@ -888,47 +1087,126 @@ static void res_mix(float *out, const float *prefix, const float *bres, int nb, 
     for(int d=0;d<D;d++){ float a=0; for(int e=0;e<=nb;e++) a+=sc[e]*v[e][d]; out[d]=a; }
 }
 
+/* Phase 9: dump ONE token's vector to output file (.ascii lines: dim0 val0\n dim1 val1\n ...) */
+static void val_dump(const char *name, const float *v, int n){
+    if(!g_k3_val_fp) return;
+    fprintf(g_k3_val_fp, "%s %d\n",name,n);
+    for(int i=0;i<n;i++) fprintf(g_k3_val_fp,"  %d %.16g\n",i,v[i]);
+}
+
 /* ---------- KDA layer (chunk of C tokens; projections batched, recurrence
  * sequential per token, AVX2 on the state sweeps) ---------- */
 static void kda_forward(Model *m, Layer *l, int li, const float *x, int C, float *out){
     Cfg *c=&m->c; Kda *a=&l->a;
     int P=c->kda_proj, H=c->kda_heads, hd=c->kda_hd, K=c->conv_k;
+    { static int once=0; if(li==0 && !once){ once=1;
+        fprintf(stderr,"[KDA] L%d metal=%d P=%d H=%d hd=%d K=%d\n", li, g_k3_metal, P, H, hd, K); } }
     float *q=falloc((int64_t)C*P), *k=falloc((int64_t)C*P), *v=falloc((int64_t)C*P);
     float *gp=falloc((int64_t)C*P), *on=falloc((int64_t)C*P);
     float *t1=falloc((int64_t)C*c->kda_hd), *graw=falloc((int64_t)C*P), *braw=falloc((int64_t)C*H);
+#ifdef COLI_METAL
+    float *meta_oh = NULL, *meta_alpha = NULL, *meta_beta = NULL;
+    if(g_k3_metal){
+        meta_oh   = falloc((int64_t)C*P);
+        meta_alpha = falloc((int64_t)C*P);
+        meta_beta  = falloc((int64_t)C*H);
+    }
+#endif
+    { static int once=0; if(li==0 && !once){ once=1;
+        fprintf(stderr,"[K3-FMT] L%d KDA: q.fmt=%d gs=%d k.fmt=%d gs=%d v.fmt=%d gs=%d g.fmt=%d gs=%d\n",
+                li, a->q.fmt, a->q.gs, a->k.fmt, a->k.gs, a->v.fmt, a->v.gs, a->g.fmt, a->g.gs);
+        fflush(stderr); } }
     w_matmul(q,x,&a->q,C); w_matmul(k,x,&a->k,C); w_matmul(v,x,&a->v,C);
     w_matmul(gp,x,&a->g,C);
-    matmul(t1,x,a->fa,C,c->hidden,c->kda_hd);
-    matmul(graw,t1,a->fb,C,c->kda_hd,P);
-    matmul(braw,x,a->bp,C,c->hidden,H);
+    k3_matmul_f32((void*)&a->metal_fa, t1, x, a->fa, C, c->hidden, c->kda_hd);
+    k3_matmul_f32((void*)&a->metal_fb, graw, t1, a->fb, C, c->kda_hd, P);
+    k3_matmul_f32((void*)&a->metal_bp, braw, x, a->bp, C, c->hidden, H);
     float qscale=1.f/sqrtf((float)hd);
     for(int t=0;t<C;t++){
         float *qt=q+(int64_t)t*P, *kt=k+(int64_t)t*P, *tv=v+(int64_t)t*P;
         float *gpt=gp+(int64_t)t*P, *ont=on+(int64_t)t*P;
         const float *rgt=graw+(int64_t)t*P, *bt=braw+(int64_t)t*H;
-        /* depthwise causal conv (window: oldest..newest) + SiLU, rolls forward */
-        float *wins[3]={m->cwq[li],m->cwk[li],m->cwv[li]};
-        float *vecs[3]={qt,kt,tv}; float *taps[3]={a->conv_q,a->conv_k,a->conv_v};
-        for(int w2=0;w2<3;w2++){
-            float *win=wins[w2], *vec=vecs[w2]; const float *cw=taps[w2];
-            #pragma omp parallel for schedule(static)
-            for(int d=0;d<P;d++){
-                float *wd=win+(int64_t)d*K;
-                for(int j=0;j<K-1;j++) wd[j]=wd[j+1];
-                wd[K-1]=vec[d];
-                float acc=0; const float *cd=cw+(int64_t)d*K;
-                for(int j=0;j<K;j++) acc+=cd[j]*wd[j];
-                vec[d]=siluf_(acc);
+#ifdef COLI_METAL
+        if(g_k3_metal){
+            float *mo = meta_oh + (int64_t)t*P;
+            float *ma = meta_alpha + (int64_t)t*P;
+            float *mb = meta_beta + (int64_t)t*H;
+            for(int h=0;h<H;h++){
+                const float *rgt_h=rgt+(int64_t)h*hd; float *ma_h=ma+(int64_t)h*hd;
+                for(int i=0;i<hd;i++){
+                    float z=rgt_h[i]+a->dt[(int64_t)h*hd+i];
+                    ma_h[i]=expf(c->gate_lb*sigmoidf_(a->A[h]*z));
+                }
+                mb[h]=sigmoidf_(bt[h]);
+            }
+            memset(mo, 0, (size_t)P * sizeof(float));
+            if(!coli_metal_kda_fused_token(m->cwq[li], qt, m->cwk[li], kt, m->cwv[li], tv,
+                    a->conv_q, a->conv_k, a->conv_v, m->kstate[li], ma, mb, mo, P, K, H, hd)){
+                g_k3_metal = 0;
+                fprintf(stderr, "[K3-METAL] kda_fused_token L%d t%d failed — falling back to CPU\n", li, t);
+            } else {
+      if(g_k3_dfp && li==0 && t==0){
+          fprintf(stderr,"[META_ENTER] li=%d t=%d g_k3_metal=%d\n",li,t,g_k3_metal);
+          fprintf(g_k3_dfp,"[META_DIMS] P=%d H=%d hd=%d K=%d kda_proj=%d kda_hd=%d kda_heads=%d\n",
+              P, H, hd, K, c->kda_proj, c->kda_hd, c->kda_heads);
+          fprintf(g_k3_dfp,"[META_Q] h0 d0-%d:\n",hd-1);
+                  for(int i=0;i<hd;i++) fprintf(g_k3_dfp,"  %d %.12g\n",i,qt[i]);
+                  fprintf(g_k3_dfp,"[META_K] h0 d0-%d:\n",hd-1);
+                  for(int i=0;i<hd;i++) fprintf(g_k3_dfp,"  %d %.12g\n",i,kt[i]);
+                  fprintf(g_k3_dfp,"[META_V] h0 d0-%d:\n",hd-1);
+                  for(int i=0;i<hd;i++) fprintf(g_k3_dfp,"  %d %.12g\n",i,tv[i]);
+                  fprintf(g_k3_dfp,"[META_OH] h0 d0-%d:\n",hd-1);
+                  for(int i=0;i<hd;i++) fprintf(g_k3_dfp,"  %d %.12g\n",i,mo[i]);
+                  fprintf(g_k3_dfp,"[META_ALPHA] h0 d0-%d:\n",hd-1);
+                  for(int i=0;i<hd;i++) fprintf(g_k3_dfp,"  %d %.12g\n",i,ma[i]);
+                  fprintf(g_k3_dfp,"[META_BETA] h0 %.12g\n",mb[0]);
+                  // Compute ratio oh[i]/(tv[i]*mb[0]) for all dims
+                  fprintf(g_k3_dfp,"\n[META_DOT_RATIO] oh[i] / (tv[i] * beta):\n");
+                  for(int i=0;i<hd;i++){
+                    float r = mo[i] / (tv[i] * mb[0]);
+                    fprintf(g_k3_dfp,"  %d %.12g\n",i,r);
+                  }
+                  fflush(g_k3_dfp);
+                }
+                for(int h=0;h<H;h++){
+                    const float *oh_h=mo+(int64_t)h*hd;
+                    double ms=0;
+                    for(int i=0;i<hd;i++) ms+=(double)oh_h[i]*oh_h[i];
+                    float r=1.f/sqrtf((float)(ms/hd)+c->eps);
+                    float *dst=ont+(int64_t)h*hd;
+                    for(int i=0;i<hd;i++)
+                        dst[i]=oh_h[i]*r*a->onw[i]*sigmoidf_(gpt[(int64_t)h*hd+i]);
+                }
+                continue;
+            }
+        }
+#endif
+        {
+            float *wins_cpu[3]={m->cwq[li],m->cwk[li],m->cwv[li]};
+            float *vecs_cpu[3]={qt,kt,tv}; float *taps_cpu[3]={a->conv_q,a->conv_k,a->conv_v};
+            for(int w2=0;w2<3;w2++){
+                float *win=wins_cpu[w2], *vec=vecs_cpu[w2]; const float *cw=taps_cpu[w2];
+                #pragma omp parallel for schedule(static)
+                for(int d=0;d<P;d++){
+                    float *wd=win+(int64_t)d*K;
+                    for(int j=0;j<K-1;j++) wd[j]=wd[j+1];
+                    wd[K-1]=vec[d];
+                    float acc=0; const float *cd=cw+(int64_t)d*K;
+                    for(int j=0;j<K;j++) acc+=cd[j]*wd[j];
+                    vec[d]=siluf_(acc);
+                }
             }
         }
         #pragma omp parallel for schedule(static)
         for(int h=0;h<H;h++){
             const float *qh=qt+(int64_t)h*hd, *kh=kt+(int64_t)h*hd, *vh=tv+(int64_t)h*hd;
             float qn[512], kn[512], alpha[512], kS[512], vt[512], oh[512];
+            {
             float sq=0,sk=0;
             for(int i=0;i<hd;i++){ sq+=qh[i]*qh[i]; sk+=kh[i]*kh[i]; }
             sq=1.f/sqrtf(sq+1e-6f); sk=1.f/sqrtf(sk+1e-6f);
             for(int i=0;i<hd;i++){ qn[i]=qh[i]*sq*qscale; kn[i]=kh[i]*sk; }
+            }
             for(int i=0;i<hd;i++){
                 float z=rgt[(int64_t)h*hd+i]+a->dt[(int64_t)h*hd+i];
                 alpha[i]=expf(c->gate_lb*sigmoidf_(a->A[h]*z));
@@ -973,6 +1251,26 @@ static void kda_forward(Model *m, Layer *l, int li, const float *x, int C, float
 #ifdef __AVX2__
             }
 #endif
+            if(g_k3_dfp && li==0 && t==0 && h==0){
+              fprintf(g_k3_dfp,"[CPU_DIMS] P=%d H=%d hd=%d K=%d\n",P,H,hd,K);
+              fprintf(g_k3_dfp,"[CPU_QTRAW] h0 d0-%d (conv_silu out):\n",hd-1);
+              for(int i=0;i<hd;i++) fprintf(g_k3_dfp,"  %d %.12g\n",i,qh[i]);
+              fprintf(g_k3_dfp,"[CPU_VTRAW] h0 d0-%d (conv_silu out):\n",hd-1);
+              for(int i=0;i<hd;i++) fprintf(g_k3_dfp,"  %d %.12g\n",i,vh[i]);
+              fprintf(g_k3_dfp,"[CPU_QN] h0 d0-%d (l2_norm q):\n",hd-1);
+              for(int i=0;i<hd;i++) fprintf(g_k3_dfp,"  %d %.12g\n",i,qn[i]);
+              fprintf(g_k3_dfp,"[CPU_KN] h0 d0-%d (l2_norm k):\n",hd-1);
+              for(int i=0;i<hd;i++) fprintf(g_k3_dfp,"  %d %.12g\n",i,kn[i]);
+              fprintf(g_k3_dfp,"[CPU_OH] h0 d0-%d (state out):\n",hd-1);
+              for(int i=0;i<hd;i++) fprintf(g_k3_dfp,"  %d %.12g\n",i,oh[i]);
+              // Compute ratio oh[i]/(vh[i]*beta)
+              fprintf(g_k3_dfp,"\n[CPU_DOT_RATIO] oh[i] / (vh[i] * beta):\n");
+              for(int i=0;i<hd;i++){
+                float r = oh[i] / (vh[i] * beta);
+                fprintf(g_k3_dfp,"  %d %.12g\n",i,r);
+              }
+              fflush(g_k3_dfp);
+            }
             /* per-head RMSNorm * sigmoid(full-rank gate) */
             double ms=0; for(int vv=0;vv<hd;vv++) ms+=(double)oh[vv]*oh[vv];
             float r=1.f/sqrtf((float)(ms/hd)+c->eps);
@@ -982,28 +1280,53 @@ static void kda_forward(Model *m, Layer *l, int li, const float *x, int C, float
     }
     w_matmul(out,on,&a->o,C);
     free(q);free(k);free(v);free(gp);free(on);free(t1);free(graw);free(braw);
+#ifdef COLI_METAL
+    if(g_k3_metal || meta_oh){
+        free(meta_oh); free(meta_alpha); free(meta_beta);
+    }
+#endif
 }
 
 /* ---------- gated MLA layer (chunk of C tokens, NoPE, absorb; projections
  * batched, per-token causal attention — token t attends to 0..pos0+t) ------ */
-static void mla_forward(Model *m, Layer *l, int li, const float *x, int pos0, int C, float *out){
+    static void mla_forward(Model *m, Layer *l, int li, const float *x, int pos0, int C, float *out){
     Cfg *c=&m->c; Mla *a=&l->m;
     int H=c->n_heads, qh=c->qk_head, vh=c->v_head, kvl=c->kv_lora, qr=c->qk_rope;
     float *qa=falloc((int64_t)C*c->q_lora), *qv=falloc((int64_t)C*H*qh);
     float *ckv=falloc((int64_t)C*(kvl+qr));
     float *gv=falloc((int64_t)C*H*vh), *ctx=falloc((int64_t)C*H*vh);
+    { static int once=0; if(!once){ once=1;
+        fprintf(stderr,"[K3-FMT] L%d MLA: qa.fmt=%d gs=%d qb.fmt=%d gs=%d kva.fmt=%d gs=%d\n",
+                li, a->qa.fmt, a->qa.gs, a->qb.fmt, a->qb.gs, a->kva.fmt, a->kva.gs);
+        fflush(stderr); } }
     w_matmul(qa,x,&a->qa,C);
     for(int t=0;t<C;t++)
         rmsnorm_(qa+(int64_t)t*c->q_lora,qa+(int64_t)t*c->q_lora,a->qa_ln,c->q_lora,c->eps);
     w_matmul(qv,qa,&a->qb,C);
     w_matmul(ckv,x,&a->kva,C);
-    for(int t=0;t<C;t++){                            /* append the whole chunk to the
-                                                      * cache first: token t's scores
-                                                      * only read rows 0..pos0+t */
-        float *Lrow=m->Lc[li]+(int64_t)(pos0+t)*kvl, *Rrow=m->Rc[li]+(int64_t)(pos0+t)*qr;
-        const float *cv=ckv+(int64_t)t*(kvl+qr);
-        rmsnorm_(Lrow,cv,a->kva_ln,kvl,c->eps);
-        memcpy(Rrow,cv+kvl,qr*sizeof(float));        /* NoPE: cached raw, no rotation */
+    /* KV cache write stays on CPU even under Metal. The MLA attention loop below reads the
+     * cache directly from host memory (m->Lc[li]/m->Rc[li]), so the write must land there.
+     * coli_metal_kv_write() wrote into an unaligned wrap() copy that was never synced back,
+     * and at row 0 instead of row pos_base — so on Metal the host cache was never populated
+     * and attention read garbage, collapsing decode after a few tokens. This write is a
+     * trivial rmsnorm+copy per row (negligible vs MoE), so CPU is the correct home for it. */
+    for (int t = 0; t < C; t++) {
+        float *Lrow = m->Lc[li] + (int64_t)(pos0 + t) * kvl,
+              *Rrow = m->Rc[li] + (int64_t)(pos0 + t) * qr;
+        const float *cv = ckv + (int64_t)t * (kvl + qr);
+        rmsnorm_(Lrow, cv, a->kva_ln, kvl, c->eps);
+        memcpy(Rrow, cv + kvl, qr * sizeof(float));
+    }
+    /* DSA indexer: prefill — write K portion for full layers */
+    if(c->index_hd > 0 && c->idx_type[li]){
+        for(int t=0;t<C;t++){
+            float *ikd = a->Ic + (int64_t)(pos0+t) * c->index_hd;
+            const float *xt = x + (int64_t)t * c->hidden;
+            w_matmul(ikd, xt, &a->wk, 1);                        /* [index_hd] from [hidden] */
+            rmsnorm_(ikd, ikd, a->knw, c->index_hd, c->eps);
+            if(c->qk_rope > 0)
+                dsa_rope(ikd, pos0+t, c->qk_rope, c->theta);   /* in-place on first qk_rope dims */
+        }
     }
     w_matmul(gv,x,&a->g,C);
     for(int tt=0;tt<C;tt++){
@@ -1607,6 +1930,7 @@ static float *step_chunk_ex(Model *m, const int *ids, int pos0, int C,
             st_read_slice_f32(&m->S,nm,(int64_t)ids[t]*D,D,hidden+(int64_t)t*D,0);
         }
     }
+    if(pos0==0&&C<=1) fprintf(stderr,"[DBG] step_chunk pos=%d C=%d metal=%d\n", pos0, C, g_k3_metal);
     for(int i=0;i<c->n_layers;i++){
         Layer *l=&m->L[i];
         int snap=(i%c->res_bs==0);                    /* block boundary: same for all t */
@@ -1615,30 +1939,45 @@ static float *step_chunk_ex(Model *m, const int *ids, int pos0, int C,
             memcpy(p,h,D*sizeof(float));              /* prefix_sum at entry */
             if(nb>0) res_mix(h,p,bres+(int64_t)t*nbmax*D,nb,D,l->attn_sw,c->eps);
             if(snap) memcpy(bres+(int64_t)t*nbmax*D+(int64_t)nb*D,p,D*sizeof(float));
-            rmsnorm_(nrm+(int64_t)t*D,h,l->in_ln,D,c->eps);
+             rmsnorm_(nrm+(int64_t)t*D,h,l->in_ln,D,c->eps);
+            /* Phase 9: capture attn-input nrm for target token */
+            if(g_k3_val_layer==i && t==g_k3_val_token){
+              val_dump("nrm_attn",nrm+(int64_t)t*D,D); }
         }
         int have_prefix=!snap;
         if(snap) nb++;
         double t0=now_s();
         if(l->kda) kda_forward(m,l,i,nrm,C,att);
         else       mla_forward(m,l,i,nrm,pos0,C,att);
-        m->t_attn+=now_s()-t0;
+        { static int once=0; if(i==0 && !once){ once=1;
+            fprintf(stderr,"[K3-PATH] L0 attn=%s metal=%d\n", l->kda?"KDA":"MLA", g_k3_metal); fflush(stderr); } }
+         m->t_attn+=now_s()-t0;
+         /* Phase 9: capture attn output (att) for target token */
+         if(g_k3_val_layer==i && g_k3_val_token<C) val_dump("att",att+(int64_t)g_k3_val_token*D,D);
         for(int t=0;t<C;t++){
             float *p=prefix+(int64_t)t*D, *a=att+(int64_t)t*D;
-            if(have_prefix){ for(int d=0;d<D;d++) p[d]+=a[d]; }
-            else           { memcpy(p,a,D*sizeof(float)); }
-            res_mix(mix,p,bres+(int64_t)t*nbmax*D,nb,D,l->mlp_sw,c->eps);
-            rmsnorm_(nrm+(int64_t)t*D,mix,l->post_ln,D,c->eps);
+             if(have_prefix){ for(int d=0;d<D;d++) p[d]+=a[d]; }
+             else           { memcpy(p,a,D*sizeof(float)); }
+             res_mix(mix,p,bres+(int64_t)t*nbmax*D,nb,D,l->mlp_sw,c->eps);
+             rmsnorm_(nrm+(int64_t)t*D,mix,l->post_ln,D,c->eps);
+            /* Phase 9: capture MLP-input (post-attention nrm) */
+            if(g_k3_val_layer==i && t==g_k3_val_token){
+              val_dump("nrm_mlp",nrm+(int64_t)t*D,D); }
         }
         t0=now_s();
         if(l->sparse) moe_forward(m,l,i,nrm,C,mlp);
         else          dense_forward(m,l,nrm,C,mlp);
-        m->t_moe+=now_s()-t0;
+         m->t_moe+=now_s()-t0;
+         /* Phase 9: capture mlp output for target token */
+         if(g_k3_val_layer==i && g_k3_val_token<C) val_dump("mlp",mlp+(int64_t)g_k3_val_token*D,D);
         for(int t=0;t<C;t++){
             float *p=prefix+(int64_t)t*D;
             for(int d=0;d<D;d++) p[d]+=mlp[(int64_t)t*D+d];
             memcpy(hidden+(int64_t)t*D,p,D*sizeof(float));
             if(m->trace) fwrite(hidden+(int64_t)t*D,sizeof(float),D,m->trace);
+            /* Phase 9: capture layer output (hidden) for target token */
+            if(g_k3_val_layer==i && t==g_k3_val_token){
+              val_dump("hidden",hidden+(int64_t)t*D,D); }
         }
         /* Prefill does not emit tokens, and a full chunk can take minutes on
          * CPU. Poll after each layer so the gateway can cancel before the
@@ -1653,14 +1992,16 @@ static float *step_chunk_ex(Model *m, const int *ids, int pos0, int C,
         double t0=now_s();
         for(int t=0;t<C;t++){
             /* head only where needed: the chunk's last token (feeds sampling)
-             * and every position when K3_LOGITS dumps teacher-forced logits */
-            if(!g_lfp && t<C-1) continue;
+             * and every position when K3_LOGITS dumps teacher-forced logits;
+             * also all positions during Phase 10 validation */
+            if(!g_lfp && !g_k3_val_lfp && t<C-1) continue;
             res_mix(mix,hidden+(int64_t)t*D,bres+(int64_t)t*nbmax*D,nb,D,m->out_sw,c->eps);
             rmsnorm_(mix,mix,m->final_norm,D,c->eps);
             if(m->trace) fwrite(mix,sizeof(float),D,m->trace);
             float *lo=falloc(c->vocab);
             w_matmul(lo,mix,&m->lm_head,1);
             if(g_lfp) fwrite(lo,sizeof(float),(size_t)c->vocab,g_lfp);
+            if(g_k3_val_lfp) fwrite(lo,sizeof(float),(size_t)c->vocab,g_k3_val_lfp);
             if(t==C-1) logits=lo; else free(lo);
         }
         m->t_head+=now_s()-t0;
@@ -1714,6 +2055,13 @@ static void kv_alloc(Model *m, int max_t){
 
     /* the record describes those same positions, so it survives with them */
     if(!kv_prefix_grow(&m->kvp,max_t,keep)) kv_prefix_clear(&m->kvp);
+    /* DSA indexer cache — only for full layers (idx_type=1) */
+    for(int i=0;i<c->n_layers;i++){
+        Mla *a=&m->L[i].m;
+        if(c->index_hd > 0 && c->idx_type[i]){
+            a->Ic = falloc((int64_t)max_t * c->index_hd);
+        }
+    }
 }
 
 typedef struct { float p; int id; } SampleProb;
@@ -1889,11 +2237,34 @@ static void model_state_reset(Model *m){
             memset(m->cwk[i],0,(size_t)c->kda_proj*c->conv_k*sizeof(float));
             memset(m->cwv[i],0,(size_t)c->kda_proj*c->conv_k*sizeof(float));
         }
-        if(m->Lc&&m->Lc[i]) free(m->Lc[i]);
-        if(m->Rc&&m->Rc[i]) free(m->Rc[i]);
     }
-    free(m->Lc); free(m->Rc);
-    m->Lc=NULL; m->Rc=NULL; m->max_t=0;
+#ifdef COLI_METAL
+    if(m->Lc && m->max_t>0 && g_k3_metal){
+        /* KV cache is CPU-managed (host memory) even under Metal — clear in place and keep the
+         * buffers for reuse. coli_metal_kv_clear() wrote to an unsynced GPU copy, so the host
+         * cache stayed stale across turns; memset zeroes the memory attention actually reads. */
+        for(int i=0;i<c->n_layers;i++) if(!m->L[i].kda){
+            if(m->Lc[i]) memset(m->Lc[i],0,(size_t)m->max_t*c->kv_lora*sizeof(float));
+            if(m->Rc[i]) memset(m->Rc[i],0,(size_t)m->max_t*c->qk_rope*sizeof(float));
+        }
+        for(int i=0;i<c->n_layers;i++){
+            Mla *a=&m->L[i].m;
+            if(c->index_hd > 0 && c->idx_type[i] && a->Ic)
+                memset(a->Ic,0,(size_t)m->max_t*c->index_hd*sizeof(float));
+        }
+    } else
+#endif
+    {
+        for(int i=0;i<c->n_layers;i++){
+            if(m->Lc && m->Lc[i]) free(m->Lc[i]);
+            if(m->Rc && m->Rc[i]) free(m->Rc[i]);
+            Mla *a=&m->L[i].m;
+            if(c->index_hd > 0 && c->idx_type[i] && a->Ic) free(a->Ic);
+        }
+        if(m->Lc) free(m->Lc);
+        if(m->Rc) free(m->Rc);
+        m->Lc=NULL; m->Rc=NULL; m->max_t=0;
+    }
 }
 
 /* Decide reuse before changing the state it describes. A miss discards the
@@ -2219,7 +2590,12 @@ int main(int argc, char **argv){
           fprintf(stderr,"[K3] tokenizer.json loaded (family=%s)\n",T.kimi?"kimi":(T.o200k?"o200k":"cl100k")); } }
     if(serving){
         if(!has_tok){ fprintf(stderr,"serve mode needs tokenizer.json\n"); return 1; }
-        serve_loop(&m,&T);
+         serve_loop(&m,&T);
+        if(g_k3_val_fp){ fflush(g_k3_val_fp); fclose(g_k3_val_fp); g_k3_val_fp=NULL; }
+        if(g_k3_val_lfp){ fflush(g_k3_val_lfp); fclose(g_k3_val_lfp); g_k3_val_lfp=NULL; }
+#ifdef COLI_METAL
+        if(g_k3_metal) coli_metal_shutdown();
+#endif
         return 0;
     }
     int sp[4]={-1,-1,-1,-1};
@@ -2269,7 +2645,12 @@ int main(int argc, char **argv){
     fprintf(stderr,"\n[K3] prefill done in %.1fs (%.2f tok/s)\n",now_s()-t0,np/(now_s()-t0));
     if(!m.has_head||!lo){
         fprintf(stderr,"[K3] no head — trace written, stopping after prefill\n");
-        if(m.trace) fclose(m.trace);
+    if(m.trace) fclose(m.trace);
+    if(g_k3_val_fp){ fflush(g_k3_val_fp); fclose(g_k3_val_fp); g_k3_val_fp=NULL; }
+        if(g_k3_val_lfp){ fflush(g_k3_val_lfp); fclose(g_k3_val_lfp); g_k3_val_lfp=NULL; }
+#ifdef COLI_METAL
+        if(g_k3_metal) coli_metal_shutdown();
+#endif
         return 0;
     }
     double tg=now_s(); int ntok=0;
@@ -2306,8 +2687,13 @@ int main(int argc, char **argv){
         if(np+ntok>=max_t){ fprintf(stderr,"\n[K3] context full\n"); break; }
         lo=step_chunk(&m,&t,np+ntok-1,1);
         double el=now_s()-tg;
-        fprintf(stderr,"  [tok %d: %.1fs/tok, hit %.0f%%, %.1f GB read]\n",
-                ntok,el/ntok,100.0*m.hits/(m.hits+m.miss+1e-9),m.ebytes/1e9);
+        /* Per-token stats every K3_STAT_EVERY tokens (default 32) to keep the token stream
+         * readable. The final summary below always prints. K3_STAT_EVERY=1 restores per-token. */
+        static int stat_every=-1;
+        if(stat_every<0){ const char *e=getenv("K3_STAT_EVERY"); stat_every=e?atoi(e):32; if(stat_every<1) stat_every=1; }
+        if(ntok % stat_every == 0)
+            fprintf(stderr,"  [tok %d: %.1fs/tok, hit %.0f%%, %.1f GB read]\n",
+                    ntok,el/ntok,100.0*m.hits/(m.hits+m.miss+1e-9),m.ebytes/1e9);
     }
     if(lo) free(lo);
     double dt=now_s()-tg;
@@ -2329,5 +2715,10 @@ int main(int argc, char **argv){
     { const char *sv=getenv("USAGE_SAVE");
       if(!(sv && atoi(sv)==0) && g_k3_usage[0])
           rt_save(g_k3_usage,0); }                   /* same bytes as every other engine */
+    if(g_k3_val_fp){ fflush(g_k3_val_fp); fclose(g_k3_val_fp); g_k3_val_fp=NULL; }
+    if(g_k3_val_lfp){ fflush(g_k3_val_lfp); fclose(g_k3_val_lfp); g_k3_val_lfp=NULL; }
+#ifdef COLI_METAL
+    if(g_k3_metal) coli_metal_shutdown();
+#endif
     return 0;
 }

--- a/c/tests/test_backend_metal.mm
+++ b/c/tests/test_backend_metal.mm
@@ -649,6 +649,87 @@ static int run_attn_grouped(int S, int pos_base, int gs, const char* name){
   return pass?0:1;
 }
 
+// ---- Shared error-reporting helper ------------------------------------------------
+// Computes maxAbsErr and meanAbsErr between GPU and CPU arrays, prints standardized
+// report line. `tol` is the max-abs-error tolerance (absolute, not normalized).
+// Returns 0 on pass, 1 on failure.
+static int report_err(const float *cpu, const float *gpu, size_t n, const char *name, double tol) {
+  double maxabs=0, sumabs=0, ymax=0;
+  for (size_t i=0; i<n; i++) {
+    double d = fabs((double)cpu[i] - (double)gpu[i]);
+    double v = fabs((double)cpu[i]);
+    maxabs = fmax(maxabs, d);
+    sumabs += d;
+    ymax = fmax(ymax, v);
+  }
+  double mae = sumabs / (double)n;
+  double nerr = maxabs / (ymax + 1e-9);
+  int ok = maxabs < tol;
+  printf("  %-30s maxAbs=%.2e mae=%.2e nerr=%.2e  %s\n", name, maxabs, mae, nerr, ok ? "ok" : "*** MISMATCH");
+  return ok ? 0 : 1;
+}
+
+// ---- RMSNorm CPU reference -------------------------------------------------------
+static void cpu_rmsnorm(float *out, const float *x, const float *w, int D, float eps) {
+  double ms = 0; for (int i=0; i<D; i++) ms += (double)x[i] * (double)x[i];
+  float r = 1.f / sqrtf((float)(ms / D) + eps);
+  for (int i=0; i<D; i++) out[i] = x[i] * r * w[i];
+}
+
+static int run_rmsnorm(int nrows, int D, const char *name) {
+  std::vector<float> x((size_t)nrows * D), w(D), ref((size_t)nrows * D), gpu((size_t)nrows * D);
+  srand(5050 + D + nrows);
+  for (auto &v : x) v = ((rand() % 2000) - 1000) / 1000.f;
+  for (auto &v : w) v = 0.5f + (rand() % 1000) / 1000.f;
+  float eps = 1e-5f;
+  for (int r = 0; r < nrows; r++) {
+    cpu_rmsnorm(&ref[(size_t)r * D], &x[(size_t)r * D], w.data(), D, eps);
+  }
+  memcpy(gpu.data(), x.data(), (size_t)nrows * D * 4);
+  if (!coli_metal_rmsnorm(gpu.data(), w.data(), nrows, D, eps)) {
+    printf("  %-30s FAIL (rmsnorm returned 0)\n", name); return 1;
+  }
+  return report_err(ref.data(), gpu.data(), (size_t)nrows * D, name, 1e-4);
+}
+
+// ---- Residual add CPU reference --------------------------------------------------
+static void cpu_add(float *y, const float *a, size_t n) {
+  for (size_t i = 0; i < n; i++) y[i] += a[i];
+}
+
+static int run_add(size_t n, const char *name) {
+  std::vector<float> y_cpu(n), y_gpu(n), a(n);
+  srand(6060 + (int)(n % 10000));
+  for (auto &v : y_cpu) v = ((rand() % 2000) - 1000) / 1000.f;
+  for (auto &v : a)     v = ((rand() % 2000) - 1000) / 1000.f;
+  memcpy(y_gpu.data(), y_cpu.data(), n * 4);
+  cpu_add(y_cpu.data(), a.data(), n);
+  if (!coli_metal_add(y_gpu.data(), a.data(), n)) {
+    printf("  %-30s FAIL (add returned 0)\n", name); return 1;
+  }
+  return report_err(y_cpu.data(), y_gpu.data(), n, name, 1e-6);
+}
+
+// ---- SiLU-multiply CPU reference -------------------------------------------------
+static float cpu_siluf(float x) { return x / (1.f + expf(-x)); }
+
+static void cpu_silu_mul(float *g, const float *u, size_t n) {
+  for (size_t i = 0; i < n; i++) g[i] = cpu_siluf(g[i]) * u[i];
+}
+
+static int run_silu_mul(size_t n, const char *name) {
+  std::vector<float> g_cpu(n), g_gpu(n), u(n);
+  srand(7070 + (int)(n % 10000));
+  for (auto &v : g_cpu) v = ((rand() % 4000) - 2000) / 1000.f;     // wider range to exercise sigmoid saturation
+  for (auto &v : u)     v = ((rand() % 2000) - 1000) / 1000.f;
+  memcpy(g_gpu.data(), g_cpu.data(), n * 4);
+  cpu_silu_mul(g_cpu.data(), u.data(), n);
+  if (!coli_metal_silu_mul(g_gpu.data(), u.data(), n)) {
+    printf("  %-30s FAIL (silu_mul returned 0)\n", name); return 1;
+  }
+  return report_err(g_cpu.data(), g_gpu.data(), n, name, 1e-4);
+}
+
 int main(void) {
   if (!coli_metal_init()) { printf("Metal unavailable (skipping)\n"); return 0; }
   /* GitHub Actions Apple Silicon runners expose Metal through the Apple
@@ -662,8 +743,67 @@ int main(void) {
            [[dev name] UTF8String]);
     return 0;
   }
-  printf("Metal backend kernel tests:\n");
+  printf("Metal standalone op tests (MAE / maxAbs error vs CPU reference):\n");
   int fail=0;
+  // RMSNorm: single-row and multi-row, real model dims, small D
+  fail |= run_rmsnorm(1, 6144, "rmsnorm S=1 D=6144");
+  fail |= run_rmsnorm(1, 256,  "rmsnorm S=1 D=256");
+  fail |= run_rmsnorm(1, 4096, "rmsnorm S=1 D=4096");
+  fail |= run_rmsnorm(1, 73,   "rmsnorm S=1 D=73 (odd)");
+  fail |= run_rmsnorm(4, 2048, "rmsnorm S=4 D=2048");
+  fail |= run_rmsnorm(8, 4096, "rmsnorm S=8 D=4096");
+  // Residual add: small, mid, large
+  fail |= run_add(256,    "add n=256");
+  fail |= run_add(6144,   "add n=6144");
+  fail |= run_add(32768,  "add n=32768");
+  fail |= run_add(1,      "add n=1 (degenerate)");
+  // SiLU-multiply: small, mid, large
+  fail |= run_silu_mul(256,    "silu_mul n=256");
+  fail |= run_silu_mul(2048,   "silu_mul n=2048");
+  fail |= run_silu_mul(32768,  "silu_mul n=32768");
+  fail |= run_silu_mul(13,     "silu_mul n=13 (odd)");
+  fail |= run_silu_mul(1,      "silu_mul n=1 (degenerate)");
+  // ---- Phase 5: expanded standalone op battery (edge cases + real model shapes) ----
+  printf("  Phase 5: expanded standalone op battery:\n");
+  // RMSNorm: simd boundary, extreme D, large batch, pathological inputs
+  fail |= run_rmsnorm(1, 1,      "rmsnorm S=1 D=1 (degenerate)");
+  fail |= run_rmsnorm(1, 2,      "rmsnorm S=1 D=2 (minimum)");
+  fail |= run_rmsnorm(1, 16,     "rmsnorm S=1 D=16 (sub-simd)");
+  fail |= run_rmsnorm(1, 32,     "rmsnorm S=1 D=32 (simd_width)");
+  fail |= run_rmsnorm(1, 128,    "rmsnorm S=1 D=128");
+  fail |= run_rmsnorm(1, 16384,  "rmsnorm S=1 D=16384 (larger)");
+  fail |= run_rmsnorm(16, 6144,  "rmsnorm S=16 D=6144 (batch)");
+  fail |= run_rmsnorm(32, 2048,  "rmsnorm S=32 D=2048 (wide batch)");
+  // Residual add: simd boundary, very large, non-power-of-2
+  fail |= run_add(16,       "add n=16 (sub-simd)");
+  fail |= run_add(32,       "add n=32 (simd_width)");
+  fail |= run_add(131072,   "add n=131072 (large)");
+  fail |= run_add(262145,   "add n=262145 (large odd)");
+  fail |= run_add(65537,    "add n=65537 (prime-ish)");
+  // SiLU-multiply: simd boundary, large, odd
+  fail |= run_silu_mul(32,     "silu_mul n=32 (simd_width)");
+  fail |= run_silu_mul(128,    "silu_mul n=128");
+  fail |= run_silu_mul(65536,  "silu_mul n=65536 (large)");
+  fail |= run_silu_mul(131073, "silu_mul n=131073 (large odd)");
+  fail |= run_silu_mul(7,      "silu_mul n=7 (small odd)");
+  fail |= run_silu_mul(2,      "silu_mul n=2 (minimum)");
+  fail |= run_silu_mul(16,     "silu_mul n=16 (sub-simd)");
+  /* TODO: KV-cache tests — run_kv_* not implemented yet
+  printf("Metal KV cache tests (MAE / maxAbs error vs CPU reference):\n");
+  fail |= run_kv_write(1, 0,   "kv_write S=1 pos=0");
+  fail |= run_kv_write(4, 12,  "kv_write S=4 pos=12");
+  fail |= run_kv_write(1, 100, "kv_write S=1 pos=100");
+  fail |= run_kv_write(8, 0,   "kv_write S=8 pos=0");
+  fail |= run_kv_clear(1, 10,  "kv_clear [0,10)");
+  fail |= run_kv_clear(5, 20,  "kv_clear [5,20)");
+  fail |= run_kv_clear(0, 0,   "kv_clear empty range");
+  fail |= run_kv_prefill(10,   "kv_prefill 10 tokens");
+  fail |= run_kv_decode(15,    "kv_decode pos=15");
+  fail |= run_kv_long_decode(100, "kv_long_decode pos=100");
+  fail |= run_kv_reset(12,     "kv_reset write-clear-reuse");
+  fail |= run_kv_multiseq(3, 8, "kv_multiseq 3 seqs len=8");
+  */
+  printf("Metal quantized GEMV tests:\n");
   fail |= run(I8, 2048,6144,1, "int8 gate/up S=1");
   fail |= run(I4, 2048,6144,1, "int4 gate/up S=1");
   fail |= run(I4, 6144,2048,1, "int4 down S=1");

--- a/docs/METAL.txt
+++ b/docs/METAL.txt
@@ -1,0 +1,323 @@
+If you're coming from CUDA or Vulkan compute, Metal is generally pleasant to write, but there are a number of architectural differences that can cause subtle correctness or performance problems. For a project like Colibri, the biggest issues are less about the shader language itself and more about adapting to Apple's GPU architecture.
+
+Here are the ones I'd pay attention to.
+
+1. Apple GPUs are tile-based and unified-memory architectures
+
+This is the biggest conceptual difference.
+
+Unlike discrete NVIDIA GPUs:
+
+CPU and GPU normally share physical memory.
+Explicit host/device copies are often unnecessary.
+Memory bandwidth is excellent, but unnecessary synchronization can be expensive.
+
+A common mistake is writing code that mimics CUDA's upload/download pattern.
+
+Instead, prefer:
+
+persistent buffers
+in-place computation
+minimal CPU synchronization
+2. Threadgroup size matters much more than you expect
+
+Metal lets you launch arbitrary threadgroup sizes, but Apple GPUs have preferred sizes.
+
+For compute kernels, common values are:
+
+32
+64
+128
+256
+
+Many CUDA kernels use:
+
+1024 threads/block
+
+which is almost never appropriate on Apple GPUs.
+
+Always check
+
+pipeline.maxTotalThreadsPerThreadgroup
+
+and tune accordingly.
+
+3. SIMD groups are not CUDA warps
+
+CUDA:
+
+warp = 32
+
+Metal:
+
+simdgroup
+
+The width depends on hardware.
+
+Never assume
+
+32
+
+Use Metal intrinsics instead.
+
+Examples:
+
+simd_sum()
+simd_broadcast()
+simd_prefix_exclusive_sum()
+
+rather than rolling your own warp logic.
+
+4. Threadgroup memory is limited
+
+Metal equivalent:
+
+threadgroup float cache[...];
+
+This is similar to CUDA shared memory.
+
+However,
+
+available size varies
+exceeding limits may silently reduce occupancy
+
+Large attention kernels often need redesign rather than direct translation.
+
+5. Buffer alignment rules
+
+Metal is stricter than CUDA.
+
+Structures shared between Swift/C++ and Metal need proper alignment.
+
+For example
+
+struct Params
+{
+    uint32_t n;
+    float scale;
+};
+
+may require padding.
+
+Using
+
+alignas(16)
+
+is often necessary.
+
+Incorrect alignment leads to mysterious incorrect values rather than crashes.
+
+6. No pointer arithmetic between address spaces
+
+Metal has address spaces:
+
+device
+
+constant
+
+thread
+
+threadgroup
+
+Pointers cannot be mixed freely.
+
+For example
+
+device float*
+
+cannot simply become
+
+threadgroup float*
+
+CUDA code often assumes generic pointers.
+
+Metal does not.
+
+7. Constant buffers are special
+
+If data never changes during dispatch:
+
+constant Params&
+
+is preferable to
+
+device Params*
+
+The compiler can generate significantly better code.
+
+8. Synchronization is different
+
+Within a threadgroup:
+
+threadgroup_barrier(...)
+
+works similarly to CUDA.
+
+Across threadgroups:
+
+there is no global barrier.
+
+If Vulkan code relies on multiple compute passes with pipeline barriers, you'll typically express that as multiple Metal compute dispatches encoded in sequence on the same command buffer.
+
+9. Resource binding is explicit
+
+Metal kernels declare resources like
+
+kernel void foo(
+    device float *a [[buffer(0)]],
+    device float *b [[buffer(1)]]
+)
+
+Binding indices must match exactly.
+
+A surprisingly common bug is
+
+shader:
+buffer(3)
+
+CPU:
+setBuffer(..., index:2)
+
+Everything compiles.
+
+Results are garbage.
+
+10. Pipeline creation is expensive
+
+Never rebuild pipelines repeatedly.
+
+Compile once.
+
+Reuse forever.
+
+Colibri should cache every
+
+MTLComputePipelineState
+
+object.
+
+11. Don't recreate command queues
+
+Typically
+
+1 device
+
+1 command queue
+
+for the lifetime of the application.
+
+Recreating them every inference hurts performance.
+
+12. Minimize command buffers
+
+Apple drivers are very efficient, but dispatch overhead exists.
+
+Prefer
+
+one command buffer
+
+many kernels
+
+rather than
+
+hundreds of tiny command buffers
+13. Storage modes matter
+
+Metal offers:
+
+Shared
+
+Private
+
+Managed (macOS)
+
+Memoryless
+
+For inference:
+
+Shared is simple and leverages unified memory, making it suitable for many workloads.
+
+Private can improve GPU-only performance for buffers the CPU never touches, but requires explicit transfer strategies.
+
+Choosing the wrong storage mode can negate performance gains.
+
+14. Metal compiler is aggressive
+
+The compiler performs extensive optimization.
+
+Occasionally it removes code you expected to execute.
+
+When debugging numerical issues,
+
+disable fast math:
+
+-fast-math
+
+or use precise math attributes where appropriate.
+
+15. Float16 behaviour
+
+Apple hardware is extremely good at FP16.
+
+But beware:
+
+half
+
+float
+
+mixing.
+
+Implicit promotions can increase register pressure.
+
+Conversely, forcing everything to half can accumulate numerical error in reductions or attention score calculations. A common pattern is FP16 storage with FP32 accumulation.
+
+16. Memory access patterns matter
+
+Apple GPUs strongly prefer contiguous accesses.
+
+Good:
+
+0
+1
+2
+3
+4
+
+Bad:
+
+0
+4096
+8192
+12288
+
+When porting Vulkan kernels, examine tensor layouts to preserve coalesced access.
+
+17. Profiling is essential
+
+Use Xcode's Metal tools rather than guessing. They can show:
+
+GPU occupancy
+threadgroup utilization
+memory bandwidth
+cache behavior
+pipeline execution timeline
+shader hotspots
+
+These tools often reveal bottlenecks that aren't obvious from code inspection alone.
+
+For Colibri specifically
+
+Because Colibri already has:
+
+a CPU implementation of Kimi K3 (correctness reference),
+a Vulkan implementation (GPU algorithm reference), and
+a Metal backend for other models (backend framework),
+
+the highest-risk areas are likely to be:
+
+Delta Attention kernels, where threadgroup sizing, memory access, and synchronization patterns may need to be adapted rather than translated directly.
+MoE expert execution, particularly batching expert GEMMs efficiently without excessive command encoding overhead.
+KV-cache layout and updates, ensuring the memory layout remains GPU-friendly and matches the CPU/Vulkan semantics.
+Numerical parity, especially if the Vulkan backend relies on fused operations or different precision choices.
+
+The most reliable development pattern is to keep the CPU implementation as the oracle, compare Vulkan and Metal outputs after each kernel port, and optimize only after establishing numerical equivalence.

--- a/docs/kimi_k3_metal_tuning.md
+++ b/docs/kimi_k3_metal_tuning.md
@@ -1,0 +1,88 @@
+# Kimi K3 — Metal tuning & performance (Apple Silicon)
+
+Measured on an **M5 Max, 128 GB** (unified memory), model split across two
+drives via `K3_DIRS`. Kimi K3 is the most disk-bound engine in the project, so
+these results separate **compute** (where the GPU wins) from **decode
+wall-clock** (which is governed by routed-expert streaming, not the backend).
+
+## Recommended settings (M5 Max, 128 GB)
+
+Metal:
+
+```
+K3_METAL=1 K3_PIPE=1 K3_DIRECT=1 K3_EXPERT_GB=44 K3_LOAD_THREADS=6 OMP_NUM_THREADS=18 \
+  ./kimi_k3 <model_dir> "<prompt>" --ngen N
+```
+
+CPU (Metal off), for reference / correctness oracle:
+
+```
+K3_METAL=0 K3_PIPE=1 K3_DIRECT=1 K3_EXPERT_GB=48 K3_LOAD_THREADS=6 OMP_NUM_THREADS=18 \
+  ./kimi_k3 <model_dir> "<prompt>" --ngen N
+```
+
+Build with `make -C c kimi_k3 METAL=1`.
+
+## Speed improvement (Metal vs CPU, matched expert hit rate)
+
+The clean, apples-to-apples win is on the compute-bound phases:
+
+| Phase | CPU (`K3_METAL=0`) | Metal (`K3_METAL=1`) | Speedup |
+|---|---|---|---|
+| Prefill (13-token prompt) | 45.4 s | 27.2 s | **1.7×** |
+| Attention (`time: attn`) | 34.5 s | 14.4 s | **2.4×** |
+
+Decode wall-clock is I/O-bound (routed experts stream from disk at these cache
+sizes), so it is set by the expert cache and storage, not by the compute
+backend — Metal and CPU decode land close once the cache is matched. The
+`time: attn / moe / eload` breakdown is printed per run so the split is
+checkable.
+
+## Tuning findings
+
+### `OMP_NUM_THREADS` — 18 (all logical cores)
+
+Swept 6→18. **18 gave the best decode throughput (0.28 tok/s).** The built-in
+auto-sizer (`omp_tune.h`) caps the OpenMP team at `perflevel0` cores (6 on this
+chip), which is correct for P+E layouts but wrong here: the M5 Max's second tier
+runs ~0.70× per core — well above the `N_fast/(N_fast+N_slow)=0.33` break-even
+for equal-split scheduling — so including all 18 helps rather than drags.
+`OMP_NUM_THREADS` overrides the auto-sizer (it yields if the env var is set).
+
+### `K3_EXPERT_GB` — ~40–44
+
+Swept 8→96. The **cache-driven metrics are monotonic**: hit rate 4→53%, bytes
+streamed and `eload` fall as the budget grows. But `eload` hits its floor
+(~10 s) and hit-rate gains flatten around **44 GB** — beyond that you buy <1% hit
+for more memory. On the CPU path the equivalent knee is ~48 GB; Metal sits a
+touch lower because GPU-wired buffers trim the headroom.
+
+**Memory-pressure ceiling:** at very large budgets (≈96 GB) the machine tips
+into the macOS memory compressor and *everything* slows 3–5×, including
+pure-compute phases (`attn`, `head`) that never touch the cache — the tell that
+it's system pressure, not a cache effect. `attn` is the canary: it stays flat
+until pressure begins. Keep total footprint (≈35 GB weights + cache + KV + OS
+headroom) comfortably under ~100 GB on a 128 GB box.
+
+### `K3_LOAD_THREADS` — 6
+
+Storage-concurrency for the `K3_PIPE` prefetcher; 6 balanced well against an
+18-thread compute team on the CPU path. On the Metal path (compute offloaded)
+this can likely go higher — re-check if tuning specifically for GPU decode.
+
+## Caveats on measurement
+
+- Single short (16-token) runs are noisy; thermal state and background load can
+  swing the compute timings several-fold across a back-to-back sweep. For
+  trustworthy numbers, run each point 2–3× and take the **min**, add a cooldown,
+  and use a longer `--ngen` (32–64) so warmup/overhead don't dominate.
+- Judge cache size by the monotonic signals (`hit`, `streamed`, `eload`), not by
+  a single decode time.
+
+## What transfers CPU → GPU
+
+- **Transfers:** the `K3_EXPERT_GB` hit-rate curve (routing/caching are CPU and
+  identical), and `K3_LOAD_THREADS` (storage-bound).
+- **Re-discover on GPU:** the `K3_EXPERT_GB` pressure ceiling (GPU wiring lowers
+  it) and `OMP_NUM_THREADS` (most compute moves to the GPU, so the CPU team
+  optimum shifts — generally lower).

--- a/docs/kimi_metal_gap_analysis.md
+++ b/docs/kimi_metal_gap_analysis.md
@@ -1,0 +1,301 @@
+# Kimi K3 Metal Gap Analysis
+
+Every Kimi K3 operation with CPU, Vulkan, and Metal implementation status.
+All operations originate in `c/kimi_k3.c` unless noted otherwise.
+
+Legend: = implemented, = CPU only, = no GPU backend
+
+---
+
+## 1. Forward Pass (`step_chunk` / `kimima_forward`)
+
+| Op | Description | CPU | Vulkan | Metal |
+|---|---|---|---|---|
+| Embedding lookup | `st_read_slice_f32` reads `model.embed_tokens.weight` by token id | | | |
+| res_mix (AttnRes) | Softmax mix over block snapshots + prefix_sum | | | |
+| rmsnorm_ | Per-row RMSNorm with gamma weights | | | |
+| kda_forward | KDA attention: conv, recurrence, O projection | | | |
+| mla_forward | MLA attention: Q/KV/G projections, cache, absorption, softmax, decode, gate | | | |
+| moe_forward | Stable LatentMoE: router, top-K, latent, experts, shared | | partial | partial |
+| dense_forward | Dense FFN: gate, up, SiTU-GLU, down | | | |
+| Residual add | `prefix_sum = mlp` | | | |
+| Head forward | res_mix, RMSNorm, lm_head projection | | | |
+| Sampling | softmax, top-p, temperature, random weighted pick | | | |
+
+---
+
+## 2. KDA Attention (`kda_forward`)
+
+| Op | Description | CPU | Vulkan | Metal |
+|---|---|---|---|---|
+| Conv4 + SiLU | Causal convolve q/k/v withconv state management | | | |
+| L2 normalize q/k | Per-head L2 normalization | | | |
+| Decay compute | `gk = -5*(exp(A_log)*(W_fb W_fa x + dt_bias))` — per-channel gate | | | |
+| Recurrence | `S = (I - kkT)*Diag(e^gk)*S + kvT` — per-head 128x128 state | | | |
+| O projection | `W_o[sig(W_g x) * RMSNorm_head(St*q)] — 3 matmuls + gate | | | |
+
+---
+
+## 3. MLA Attention (`mla_forward`)
+
+| Op | Description | CPU | Vulkan | Metal |
+|---|---|---|---|---|
+| Q projection | Q projection matmul | | | |
+| Q decode | Q decode matmul | | | |
+| KV projection + NoPE | KV projection matmul + NoPE (rotary-style, not true RoPE) | | | |
+| Cache write | Write L (latent) and R (context) rows to KV cache | | | |
+| G projection + abs gate | G projection matmul, then sigmoid gate on O projection | | | |
+| Absorption | `qr[t,h] = (x[t].q * v_b)` — row dot product, int4 dequant | | | |
+| Scoring | `soc[t,h,u] = x[t].q * L[u] + qr[t,h] * R[u]` | | | |
+| Softmax (causal) | Standard softmax over valid attention mask | | | |
+| Context decode (latent) | `hd_v[t] = ctx[t,h] * v_b` — per-head int4 dequant + reduce | | | |
+| Context decode (full) | `ctx[t,vb] = ctx[t,h] * V[vb*vb:h*vb+h]` — per-head int4 dequant | | | |
+| O projection | gated output projection matmul | | | |
+
+---
+
+## 4. MoE (`moe_forward`)
+
+| Op | Description | CPU | Vulkan | Metal |
+|---|---|---|---|---|
+| Router matmul | `sig[t,e] += bias[e]` — full sigmoid on scores + score-correction bias | | | |
+| Top-K select | `rtop8(sig, E, K, Ksel, topp, 1)` — top-16 on biased scores, renormalized | | | |
+| Shared expert gate | `W * x` — Latent up projection for latent space Ops | | | |
+| Latent up projection | `W * x` — per-token 3584 | | | |
+
+---
+
+## 5. Expert Apply (`expert_apply` / `experts_apply_union`)
+
+| Op | Description | CPU | Vulkan | Metal |
+|---|---|---|---|---|
+| W1 (gate, MXFP4+int8 | `W1 * x` — MXFP4 quantized layer (QAT) | | | |
+| W2 (down) matmul | `W2 * situf_(g*u)` — MXFP4 quantized layer (QAT) | | | |
+| W3 (shared-expert branch) matmul | `W3 * situf_(((W1 * x) - W3))` — MXFP4 quantized layer (QAT) | | | |
+| SiTU-GLU activation | `4*tanh(g/4)*σ(g) * 25*tanh(u/25)` elementwise activation | | | |
+
+---
+
+## 6. Shared Experts (in `moe_forward`)
+
+| Op | Description | CPU | Vulkan | Metal |
+|---|---|---|---|---|
+| sh_gate matmul | `W_sh_gate * x` — full-width shared gate | | | |
+| sh_up matmul | `W_sh_up * x` — full-width shared up | | | |
+| SiTU-GLU (shared) | Elementwise on gate + up | | | |
+| sh_down matmul | `W_sh_down * activation` — full-width shared down | | | |
+| Residual add (shared) | `out += sd` — add shared expert output to MoE output | | | |
+
+---
+
+## 7. Misc / Infrastructure
+
+| Op | Description | CPU | Vulkan | Metal |
+|---|---|---|---|---|
+| Token saving | `st_write_slice_f32` — write embedding row to slot for mixed input | | | |
+| KV cache alloc | `kv_alloc` — allocate L and R cache arrays per non-KDA layer | | | |
+
+---
+
+## Metal Detail: Current Capabilities
+
+### `backend_metal.h` API
+
+| Function | Status | Notes |
+|---|---|---|
+| `coli_metal_init()` | | Init device, queue, residency set |
+| `coli_metal_reload()` | | Re-compile shaders after source change |
+| `coli_metal_register()` / `unregister()` | | Pin/unpin host pointer for zero-copy |
+| `coli_metal_matmul()` | | fmt=1 (int8), fmt=2 (int4-g64), fmt=3 (int2), fmt=4 (grouped int4) |
+| `coli_metal_gemm()` | | Large row-batch GEMM (prefill), fmt=1/2/4, chunked dispatch |
+| `coli_metal_layer_decode()` | | Full MLA decode layer: RMSNorm, attention, shared exp, router, top-8, down |
+| `coli_metal_moe_block()` | | Batched routed expert SwiGLU, fmt=1/2 |
+| `coli_metal_moe_block_begin()` / `_end()` | | Async two-phase: submit without wait, then scatter |
+| `coli_metal_rtop8()` | | Standalone top-8 select (serial + parallel variants) |
+| `coli_metal_stats()` | | Reset counters |
+| `coli_metal_mem_info()` | | Residency, usage, slab info |
+| `coli_metal_shutdown()` | | Teardown |
+
+### Inline Shader Kernels (SIL)
+
+| Kernel | Purpose | Formats |
+|---|---|---|
+| `mm_gemv` | Quantized GEMV, one threadgroup per 4 output elements | fmt 0..4 |
+| `moe_gemv` | Batched routed GEMV (indirect via erow[] address arrays) | fmt 0..4 |
+| `r_router` | Router GEMV: `logit[s][e] = x[s].w_e` | f32 weights |
+| `r_top8` / `r_top8_par` | Top-K: sigmoid+bias, top-p truncation, renormalize, routed scale | f32 |
+
+### Shader Pipeline States
+
+| Pipeline | Purpose |
+|---|---|
+| `g_gemv` | Quantized GEMV (`mm_gemv`) |
+| `g_moe_gemv` | Batched routed GEMV (`moe_gemv`) |
+| `g_r_router` | Router logits (`r_router`) |
+| `g_r_top8` | Serial top-8 select (`r_top8`) |
+| `g_r_top8p` | Parallel top-8 select (`r_top8_par`) |
+| `g_a_rms` | RMSNorm (attention path) |
+| `g_a_copy` | Row copy helper (extract single row from S×AH buffer) |
+| `g_a_add` | Residual add (`axr_ += aout_`) |
+| `g_moe_silu` | Dual silu activation (gate, up) |
+
+### Metal `layer_decode` Attention Kernels
+
+The fused decode layer (`coli_metal_layer_decode`) encodes attention inline via
+`encode_attention()` which dispatches per-halbkhead loops. These are not separate
+pipelines — they are encoded into the same command buffer as a loop over the 96
+half-heads (each half-head is 64 dims for KDA / the MLA equivalent). The kernels
+used are compiled at runtime via `MTLLibrary` source strings embedded in the
+function body. These handle:
+
+- RMSNorm of Q and KV inputs
+- RoPE / NoPE via `generate_rope_phase()`
+- Q × decoded-KV (absorption)
+- Causal softmax
+- Context decode (latent + full)
+- O projection with sigmoid gate
+
+---
+
+## Vulkan Detail: Current Capabilities
+
+### `backend_vulkan.h` API
+
+| Function | Status | Notes |
+|---|---|---|
+| `coli_vk_init()` | | Init device, queue, pipeline |
+| `coli_vk_matmul()` | | fmt=1 (int8), fmt=2 (int4-g64), fmt=7 (MXFP4 integrated) |
+| `coli_vk_expert_upload()` | | Upload expert tier to VRAM |
+| `coli_vk_expert_apply()` | | Single expert apply (W1, W2, W3) |
+| `coli_vk_matmul_pair()` | | Paired W1/W3 matmul for GLU |
+| `coli_vk_set_budget()` | | Set VRAM pressure budget |
+| `coli_vk_mem_info()` | | Memory and tier stats |
+| `coli_vk_shutdown()` | | Teardown |
+
+### Key Gap: fmt=7 MXFP4
+
+Vulkan supports MXFP4+int8 via `fmt=7` in `coli_vk_matmul` and `coli_vk_pair`.
+Metal does **not** support `fmt=7` today — only fmt=1/2/3/4. This means the
+expert W1/W2/W3 MXFP4 weights cannot run on Metal and fall back to CPU.
+
+---
+
+## Summary of Gaps
+
+### Critical (blocks full Metal inference)
+
+1. **KDA attention** — No Metal kernel for any of KDA's 96 conv4, recurrence, decay, or
+   O projection. All 69 KDA layers run on CPU.
+2. **MLA attention (non-fused)** — `coli_metal_layer_decode` covers only S1 (decode,
+   single token). Prefill (S>1, batched MLA) and the per-halbkhead inline kernels
+   have not been extracted to a standalone `coli_metal_mla_forward()` API.
+3. **MXFP4 matmul** — Metal `mm_gemv` does not include `fmt=7`. Vulkan has it.
+4. **rmsnorm_, SiTU-`g` — No Metal kernel for standalone RMSNorm on arbitrary tensors.
+   The `g_a_rms` pipeline exists but is only callable inside `layer_decode`.
+5. **res_mix (AttnRes)** — No Metal kernel for the block-snapshot softmax mix.
+6. **Sampling** — No GPU softmax + top-p + temperature over 262k vocab. Trivial matmul, but not implemented.
+
+### Important (performance blockers)
+
+7. **Stand-alone matmul wrapper** — `coli_metal_matmul()` exists and works, but
+   `kimi_k3.c` has no `#ifdef COLI_METAL` dispatch to call it from `w_matmul()`.
+   The GLM engine (`colibri.c`) has this dispatch; K3 does not.
+8. **Dense forward** — 24 MLA layers use `dense_forward` (3 matmuls + SiTU-GLU).
+   No Metal wrapper exists.
+9. **Head forward** — Final res_mix + RMSNorm + lm_head. No Metal path.
+10. **Conv4 + SiLU** — KDA conv state update. No GPU kernel.
+
+### Lower priority
+
+11. **Embedding lookup** — Random-access row read from safetensors. Trivial to GPU
+    but I/O-bound anyway.
+12. **KV cache alloc/write** — CPU-side allocation. Could be moved to unified memory.
+13. **L2 normalize** — Used in KDA for q/k. Small kernel, but gated by KDA support.
+
+### What would make Metal 24/93 layers on GPU today?
+
+| Required | Count | Impact |
+|---|---|---|
+| Standalone RMSNorm kernel | 1 | Enables dense, head, and any arbitrary tensor |
+| `w_matmul` → `coli_metal_matmul` dispatch in `kimi_k3.c` | 1 | Enables dense_forward and head forward |
+| SiTU-GLU kernel | 1 | Needed for dense + shared experts on GPU |
+| Embedding on GPU | 1 | Avoids CPU-GPU boundary for first layer |
+| Head forward Metal path | 1 | End-to-end for the 24 MLA layers |
+| **Subtotal** | **5** | **24/93 layers (MLA-only models or MLA-only passages)** |
+
+### What would make Metal 93/93 layers on GPU?
+
+The above 5, plus:
+
+| Required | Count | Impact |
+|---|---|---|
+| KDA full kernel (conv + recurrence + decay + O) | 1 | The single largest gap — 69 layers |
+| MXFP4 matmul (`fmt=7`) | 1 | Expert W1/W2/W3 |
+| res_mix kernel | 1 | AttnRes every layer, every forward |
+| MLA full forward (S>1) | 1 | Prefill for MLA layers |
+| **Subtotal** | **11** | **93/93 layers, decode + prefill, everything on GPU** |
+
+---
+
+## Phase 2: Reusable Metal Kernels — Vulkan vs Metal
+
+Cross-references every Vulkan shader / API call against Metal's existing kernels and
+API surface. Identifies what can be reused immediately, what needs extraction from a
+larger Metal function, and what must be implemented from scratch.
+
+| Operation | Vulkan | Metal | Reusable? | Action |
+|---|---|---|---|---|
+| Quantized GEMV | `qmatmul.comp` → `coli_vk_matmul()` (fmt 1,2,4,5,7) | `mm_gemv` → `coli_metal_matmul()` (fmt 1,2,3,4) | **Yes** — same algorithm, more fmt coverage | REUSE Metal. Add `#ifdef COLI_METAL` dispatch in `kimi_k3.c:w_matmul()` to call `coli_metal_matmul()` for fmt 1,2,3,4 |
+| RMSNorm | `rmsnorm.comp` → `coli_vk_attn_qprep()` chain | `g_a_rms` pipeline → inside `layer_decode` only | **Partial** — pipeline exists, no standalone API | EXTEND: extract `g_a_rms` to `coli_metal_rmsnorm(src, dst, w, n, d)` standalone call |
+| Fused gate+up+silu | `qmatmul_gate_up.comp` → `coli_vk_gate_up()` (fmt 3,6,5,7) | `moe_gemv` + `g_moe_silu` inside `moe_block()` | **Partial** — kernels exist inside MoE path | EXTEND: extract `coli_metal_gate_up(x, wgate, wup, out, fmt, n, d)` standalone API |
+| Batched expert (MoE) | `coli_vk_expert_group()` → `_issue()` / `_take()` | `moe_block()` / `moe_block_begin()` / `_end()` | **Yes** — Metal has both sync + async variants | REUSE Metal. Wire `moe_block_begin/end` into `kimi_k3.c:expert_apply_union()` |
+| Router GEMV | General `qmatmul` path | `r_router` → `coli_metal_rtop8()`, serial/parallel | **Yes** | REUSE Metal (already supports top-K with sigmoid+bias+renorm) |
+| Top-K select | No dedicated kernel | `r_top8` / `r_top8_par` pipelines | **Yes** (Metal-only) | REUSE Metal already covers this |
+| KV cache management | `VkKvLayer` → `kv_ensure()` / `kv_row()` / `kv_reset()` | Encoded inside `layer_decode()` inline | **Partial** — cache logic exists but not standalone | EXTEND: extract `coli_metal_kv_ensure(layer, ntoks, nheadd, ldim, rdim)`, `kv_row()`, `kv_reset()` |
+| MLA attention absorb | `attention_absorb.comp` → `coli_vk_attention_absorb()` + `_project()` | Inline in `layer_decode` (per-halbkhead loop) | **Partial** — logic exists, embedded | EXTEND: extract to `coli_metal_attn_absorb(q, v_b, L, R, ctx, out)` standalone API |
+| MoE silu activation | Fused inside `qmatmul_gate_up.comp` | `g_moe_silu` pipeline | **Yes** | REUSE Metal's `g_moe_silu` covers the elementwise SiLU dual activation |
+| MXFP4 matmul | `qmatmul.comp` fmt=7 → `coli_vk_matmul()` | **Not supported** (fmt 0..4 only) | **No** — Vulkan-only | IMPLEMENT: add `fmt=7` block to `mm_gemv` and `moe_gemv` shaders + grow `coli_metal_matmul` switch. Critical for Kimi K3 expert weights (W1/W2/W3) |
+| Dual-GEMV pair | `coli_vk_matmul_pair()` — two resident matmuls on one input | **No equivalent** | **No** — Vulkan-only | IMPLEMENT: `coli_metal_matmul_pair(src, w1, w3, out, fmt, n, d1, d3)`. Needed for KDA conv+recurrence projections and GLU gate+up fusion |
+| Second device (dual GPU) | `coli_vk_init_dev2()` — expert tier on second GPU | Metal only supports one device | **No** | N/A — Apple Silicon has single GPU; not applicable |
+| VRAM pressure-proofing | `mem_budget()` + `alloc_priority()` | **No equivalent** | **No** — Vulkan-only | N/A — Metal uses residency sets with automatic eviction; not a gap |
+| Large-batch GEMM | `qmatmul` with 2D block dispatch | `coli_metal_gemm()` (full chunked 2D dispatch) | **Yes** — Metal has it, Vulkan doesn't | REUSE Metal. Wire into `kimi_k3.c:w_matmul()` for prefill S>1 |
+| SiLU activation | Fused inside `gate_up` | `g_moe_silu` inside `moe_block` | **Partial** — exists but not standalone | EXTEND: extract to `coli_metal_silu(src, dst, n)` for dense + shared expert paths |
+
+### Summary by Action Category
+
+| Action | Count | Impact |
+|---|---|---|
+| **REUSE immediately** (dispatch from `kimi_k3.c`) | 6 | quantized matmul, MoE block, router, top-K, GEMM, silu |
+| **EXTEND** (extract from larger Metal function) | 5 | RMSNorm, gate_up, KV cache, attn_absorb, silu standalone |
+| **IMPLEMENT** (new kernel + API) | 2 | MXFP4 matmul (fmt=7), dual-GEMV pair |
+| **N/A** (not applicable to Metal) | 2 | second device, VRAM pressure |
+| **TOTAL** | **15** | **Cross-references every Vulkan op against Metal** |
+
+### Critical Path to 93/93
+
+The single most impactful implementation is **MXFP4 matmul (`fmt=7`)** in Metal.
+Every Kimi K3 expert layer uses MXFP4 weights for W1/W2/W3. Without it, expert
+computation falls back to CPU. Once `fmt=7` is added, the existing `mm_gemv`,
+`moe_gemv`, and `moe_block` pipelines can cover all expert matmuls with minimal
+additional code — the formatting logic is already there, just needs a new
+dequantization pattern.
+
+---
+
+## Build Status
+
+| Configuration | Result |
+|---|---|
+| `make kimi_k3` | Compiles, runs CPU-only |
+| `make METAL=1 kimi_k3` | Compiles, Metal scaffolding wired |
+| `K3_METAL=1 make METAL=1 kimi_k3` | Metal init/shutdown active; forward NOT IMPLEMENTED, falls through to CPU |
+
+### Phase 4 Changes (scaffolding only)
+
+- `W` struct: added `void *metal` alongside `void *vk`
+- `kimima_forward_metal()`: entry point exists, returns 0 (NOT IMPLEMENTED)
+- `w_matmul()`: `#ifdef COLI_METAL` dispatch hook present, falls through to CPU
+- `model_init()`: reads `K3_METAL` env, calls `coli_metal_init()`, logs status
+- `main()`: three exit paths all call `coli_metal_shutdown()` on cleanup
+- `Makefile`: `$(METAL_OBJ)` added to kimi_k3 link line
+- `K3_METAL` env flag documented in header comment

--- a/docs/metal_implementation.md
+++ b/docs/metal_implementation.md
@@ -1,0 +1,871 @@
+# Metal Implementation — Kimi K3
+
+Metal GPU backend for Kimi K3 (93-layer, 2.8T total / 104B active). Target: 93/93 layers fully on GPU via Metal.
+
+Reference docs:
+- [Gap analysis](kimi_metal_gap_analysis.md) — every operation, CPU/Vulkan/Metal status, ranked gaps
+- [METAL.txt](METAL.txt) — Apple Silicon constraints for kernel authors
+
+## Roadmap
+
+---
+| Phase | Description | Status |
+|---|---|---|
+| 1 | Backend gap analysis (documentation only) | ✅ DONE |
+| 2 | Identify reusable Metal kernels | ✅ DONE |
+| 3 | Metal authoring constraints and approach | ✅ DONE |
+| 4 | Scaffolding: backend selection, dispatch hooks, feature flags | ✅ DONE |
+| 5 | Port dense operations | ✅ DONE |
+| 6 | Port MoE expert execution | ✅ DONE |
+| 7a | Port KV cache (Lc/Rc) | ✅ DONE |
+| 7b | Port DSA indexer (Ic + k_idx) | ✅ DONE |
+| 8.1 | KDA Q/K/V preparation (projections Metal dispatch) | ✅ DONE |
+| 8.2 | KDA attention state recurrence | ✅ DONE |
+| 8.3 | KDA Conv1d + SiLU + L2 normalization | ✅ DONE |
+| 8.4 | Fused KDA token step (one MTLCommandBuffer per token) | ✅ DONE |
+| 8.5 | End-to-end full model (A/B Metal vs CPU) | ✅ DONE |
+| 9 | End-to-end layer validation | ✅ DONE |
+| 10 | Full model validation | ✅ DONE |
+| 11 | Regression testing | TODO |
+| 12 | Performance benchmarking | TODO |
+| 13 | Optimization | TODO |
+
+---
+## Progress
+
+### Phase 1 — Backend gap analysis (documentation only) [2026-07-31] ✅ DONE
+
+The agent should produce a document listing every Kimi operation executed by the Vulkan backend.
+For every operation record
+
+- CPU implementation
+- 
+- Metal implementation status
+
+Output:
+
+- docs/kimi_metal_gap_analysis.md
+
+Created docs/kimi_metal_gap_analysis.md
+
+### Phase 2 — Backend gap analysis (documentation only) [2026-07-31] ✅ DONE
+
+Identify reusable Metal kernels
+Now compare backend_vulkan/ against backend_metal/
+
+Create a table:
+
+Operation	Vulkan	Metal	Action
+RMSNorm	yes	yes	reuse
+GEMM	yes	yes	reuse
+Expert FFN	yes	partial	extend
+KDA attention	yes	no	implement
+KV cache	yes	partial	extend
+
+Goal:
+- Avoid writing new Metal code wherever existing kernels already exist.
+- Add this analysis as a section in /Users/doug/code/colibri-dev/docs/kimi_metal_gap_analysis.md
+
+Identified reusable Metal kernels
+
+### Phase 3 — Metal authoring constraints and approach  [2026-07-31] ✅ DONE
+
+Key Metal constraints to apply when writing kernels:
+
+- Unified memory, zero-copy — no host/device uploads, persistent buffers, in-place compute
+- Threadgroup sizes: 32/64/128/256 (never 1024) — always check maxTotalThreadsPerThreadgroup
+- SIMD groups ≠ warps — use simdgroup, simd_sum(), simd_broadcast(), simd_prefix_exclusive_sum(), never assume width 32
+- Threadgroup memory is limited — large attention kernels need redesign, not direct translation
+- **Buffer alignment: alignas(16) on param structs — misalignment gives wrong values, not crashes
+- Address spaces are strict — device, constant, thread, threadgroup can't be mixed; no pointer arithmetic across spaces
+- constant for read-only params — compiler generates much better code
+- No global barriers — use sequential dispatches on same command buffer instead
+- Buffer indices must match exactly — [[buffer(N)]] ↔ setBuffer(..., index: N), garbage otherwise
+- Pipelines: compile once, reuse forever
+- One device, one command queue for lifetime
+- One command buffer, many kernels — minimize CB count
+- Storage modes: Shared (simple, unified), Private (faster GPU-only, needs explicit transfers)
+- Compiler is aggressive — disable -fast-math for numerical correctness
+- FP16 storage, FP32 accumulation — mix carefully to avoid register pressure and numerical drift
+- Contiguous access = fast, strided = slow — preserve coalesced tensor layouts from Vulkan
+- Profile in Instruments, don't guess
+
+### Phase 4 — Scaffolding: backend selection, dispatch hooks, feature flags [2026-07-31] ✅ DONE
+
+Only infrastructure.
+
+
+Implement:
+
+- backend selection
+- dispatch hooks
+- feature flags
+
+Example
+
+if (backend == METAL)
+    kimi_forward_metal(...)
+
+The implementation should intentionally return:
+
+  NOT IMPLEMENTED
+
+Success:
+
+  Backend selection compiles.
+
+No inference yet.
+
+### Phase 5 — Port dense operations [2026-07-31] ✅ DONE
+
+Ported all operations already implemented in the shared backend (backend_metal). The Kimi K3 `w_matmul()` is Metal-dispatched (quantized fmt=0/1/4); `kimima_forward_metal()` remains a monolithic stub for future use; granular Metal dispatch embedded in `kda_forward()`/`mla_forward()` handles current GPU path.
+
+**Wired in `colibri.c` (shared backend path):**
+- `coli_metal_gemm()` — GEMM for all quantization formats (colibri.c:689)
+- `coli_metal_attn_decode()` — MLA decode attention (colibri.c:2614)
+- `coli_metal_layer_decode()` — Full layer decode (colibri.c:4824)
+- `coli_metal_moe_block{_begin,_end}()` — MoE expert routing + block dispatch (colibri.c:3584)
+- `coli_metal_rtop8()` — Serial/parallel top-8 selection (backend_metal.h:125)
+- `coli_metal_register/unregister()` — Buffer registration on metal-everywhere paths (colibri.c:1495+)
+
+**API available in `backend_metal.h`:**
+| Function | Purpose |
+|---|---|
+| `coli_metal_rmsnorm()` | RMS normalization |
+| `coli_metal_add()` | Element-wise residual add |
+| `coli_metal_silu_mul()` | SwiGLU activation |
+| `coli_metal_matmul()` | GEMM via tensor handle API |
+| `coli_metal_gemm()` | Direct GEMM (F32, Q8, I4 grouped) |
+| `coli_metal_rtop8()` | Router top-k selection |
+| `coli_metal_attn_decode()` | Multi-latent attention (decode) |
+| `coli_metal_layer_decode()` | Full decoder layer |
+| `coli_metal_moe_block*()` | MoE expert block (begin/block/end) |
+| `coli_metal_register()` | Map host memory for GPU access |
+
+**Kimi K3 independent path (Phase 4 ≠ Phase 8):**
+- `kimima_forward_metal()` — returns 0 (`NOT IMPLEMENTED`, stub for future monolithic Metal path)
+- `w_matmul()` — Metal dispatch via `coli_metal_matmul()` for fmt=0/1/4 (implemented Phase 5.2)
+- `k3_matmul_f32()` — Metal dispatch via `coli_metal_matmul(fmt=0)` for f32 weights (Phase 8.1)
+- CPU fallbacks preserved in both paths when Metal unavailable
+
+**Standalone op battery test (Phase 5 expanded coverage):**
+All ops verified against CPU reference — 33 standalone op tests, all pass (maxAbs <= 4.77e-7, MAE <= 5.87e-8 across all RMSNorm cases; exact match on all add cases; maxAbs <= 3.58e-7, MAE <= 1.35e-8 on silu_mul).
+
+| Op | Shapes tested | MaxAbs | MAE |
+|---|---|---|---|
+| rmsnorm | D=1,2,16,32,128,73,256,2048,4096,6144,16384; S=1..32 | 4.77e-7 | 5.87e-8 |
+| add | n=1,16,32,256,6144,32768,65537,131072,262145 | 0.00e+00 | 0.00e+00 |
+| silu_mul | n=1,2,7,13,16,32,128,256,2048,32768,65536,131073 | 3.58e-7 | 1.37e-8 |
+
+**Numerical correctness policy:**
+- Two modes: `fast` (default) and `exact`
+- Fast mode: leverage Metal capabilities fully, preserve token-level output
+- Track max abs error and mean abs error per operation
+- CPU output is always the truth set
+- Exact mode: mirror CPU order of operations to minimize numerical drift
+
+---
+
+### Phase 6 — Port MoE expert execution ✅ DONE
+
+Since routing, expert selection, and scheduling already exist on CPU/Vulkan, Phase 6 reuses the existing dispatcher and only ports the compute-heavy portions to Metal.
+
+**Already exists (reuse):**
+- Expert routing (`rtop8` selection)
+- Expert scheduling and batch assignment
+- Token-to-expert scatter/gather logic
+
+**Ported to Metal:**
+- Expert matrix multiplication (per-expert GEMM) — `coli_metal_moe_block()` (backend_metal.mm)
+- Expert activation (SwiGLU per-expert) — fused inside moe_block command buffer
+- Output accumulation (weighted scatter-add back to token-space) — fused in same submit
+
+**Wired in `colibri.c`:**
+- `coli_metal_moe_block_begin()` at colibri.c:3584 — async two-phase encode+commit
+- `coli_metal_moe_block()` at colibri.c:3646 — synchronous fallback path
+- `coli_metal_moe_block_end()` at colibri.c:3650 — wait, fault-check, scatter-add
+
+**Tests:**
+- Diagnostics via `coli_metal_moe_counts()`, `coli_metal_moe_times()`, `coli_metal_moe_kernel_time()` (backend_metal.h)
+- Counters printed at colibri.c:5651-5657 during inference
+
+---
+
+### Phase 7a — Port KV cache (Lc/Rc)
+
+**Implemented primitives:**
+| Function | Location | Purpose |
+|---|---|---|
+| `coli_metal_kv_write()` | backend_metal.mm:1249 | Write S KV-cache rows: rmsnorm(L) + rope_interleave(R) |
+| `coli_metal_kv_clear()` | backend_metal.mm:1306 | Zero cache rows [from, to) on GPU |
+
+**Fused path (shared backend, GLM models):**
+- `coli_metal_attn_decode()` at colibri.c:2614 — single command buffer: q_a -> rmsnorm -> q_b -> RoPE, kv_a -> latent rmsnorm@pos + krot RoPE@pos (cache write), MLA absorption, o_proj
+- `coli_metal_layer_decode()` at colibri.c:4824 — full layer: in_ln -> attention -> residual -> post_ln -> shared expert -> router+top-K
+
+**Buffer management:**
+- KV cache allocation with page-aligned `falloc()` at colibri.c:4996-5007
+- Metal registration/unregistration of `Lc`/`Rc` buffers at colibri.c:4985, colibri.c:5007
+- All KV rows accessible zero-copy from Metal shaders
+
+**Test coverage (`test_backend_metal.mm`):**
+| Test | Description |
+|---|---|
+| `kv_write S=1..8` | Standalone KV write, various batch sizes and positions |
+| `kv_clear [0,10), [5,20), empty` | Cache clearing, range and edge cases |
+| `kv_prefill 10 tokens` | Sequential cache build during prefill |
+| `kv_decode pos=15` | Single decode-step cache append |
+| `kv_long_decode pos=100` | Late-position decode with large context |
+| `kv_reset write-clear-reuse` | Full cache reset lifecycle |
+| `kv_multiseq 3 seqs len=8` | Multi-sequence independent KV state |
+
+**Kimi K3 independent path (COMPLETED):**
+- `coli_metal_kv_write()` wired into `mla_forward()` (kimi_k3.c) — batched GPU write of L+rmsnorm + R for each prefill chunk; CPU fallback when Metal unavailable
+- `coli_metal_kv_clear()` wired into `model_state_reset()` (kimi_k3.c) — GPU zero of Lc/Rc range [0, max_t) on cache reset, preserving buffers for reuse
+- `kv_alloc()` Metal-aware: reuses existing buffers when `max_t` hasn't grown; frees+reallocs only when growing beyond capacity
+
+---
+
+### Phase 7b — Port DSA indexer (Ic + k_idx) [2026-07-31] ✅ DONE
+
+DSA (Dictionary Sparse Attention) selects a top-K subset of cache rows per decode step,
+so that only the most relevant context positions participate in the attention scoring of
+Phase 8. It operates on a separate "indexer" cache of dimension `index_hd` (typically 64–256),
+which is much cheaper than full K/V.
+
+**Dependency on Phase 8:** Phase 8's attention scoring consumes `k_idx` (the DSA-selected
+positions). Without DSA, attention runs on the full context — correct but slower.
+Without k_idx, Phase 8 still works in a bypass mode (full context).
+
+**New Cfg fields:**
+| Field | JSON key | Type | Purpose |
+|---|---|---|---|
+| `index_hd` | `index_hd` | int | Indexer hidden dim (per-position cache width) |
+| `index_nh` | `index_nh` | int | Number of indexer query heads |
+| `index_topk` | `index_topk` | int | Max positions to select per decode row |
+| `theta` | `rope_parameters.rope_theta` | float | RoPE base theta (default 10000) |
+| `idx_type[128]` | `index_layers` (array of 1-indexed layer ids) | int8_t | Per-layer DSA mode: 1=full, 0=shared |
+
+`idx_type` defaults to "full" (1) for all MLA layers if `index_hd > 0` — explicit `index_layers` overrides.
+
+**New Layer (Mla union) fields — only allocated for full layers:**
+| Field | Type | Purpose |
+|---|---|---|
+| `wk` | `W` | Key projection `[index_hd x hidden]` — shard `self_attn.w_k.weight` |
+| `wq` | `W` | Query projection `[index_hd x q_lora]` — shard `self_attn.w_q.weight` |
+| `wp` | `W` | Weight projection `[index_hd x hidden]` — shard `self_attn.w_p.weight` |
+| `knw` | `float*` | Key layernorm weights `[index_hd]` — shard `self_attn.kn_w` |
+| `knb` | `float*` | Key layernorm biases `[index_hd]` — shard `self_attn.kn_b` |
+| `Ic` | `float*` | Indexer cache `[max_t * index_hd]` — allocated in `kv_alloc()` |
+
+**New Model fields:**
+| Field | Type | Purpose |
+|---|---|---|
+| `dsa_nsel` | `int*` | Per-slot k_idx selection counts `[S]` |
+| `dsa_sel` | `int*` | Per-slot k_idx selected indices `[S * index_topk]` |
+| `dsa_scap` | `int64_t` | Allocated capacity for `dsa_sel` |
+
+**Prefill path (CPU, wired in `mla_forward()`):**
+1. For each token `t` in `[pos0, pos0+C)`, project `x[t]` through `a->wk` via `w_matmul()` → `ikd [index_hd]`
+2. `rmsnorm_(ikd, ikd, a->knw, index_hd, eps)` — in-place RMSNorm on indexer K
+3. `dsa_rope(ikd, pos0+t, qk_rope, theta)` — rope_interleave on first `qk_rope` dims
+4. Write into `a->Ic + (pos0+t)*index_hd`
+
+**Decode path (CPU, helper `dsa_score_single()` ready — wiring pending):**
+1. Project `QR[s]` through `ix_wq[layer]` to produce `qi [nh*index_hd]` (via `w_matmul`)
+2. RoPE on `qi` heads (per-head interleaved RoPE at decode position)
+3. Project `x[s]` through `ix_wp[layer]` to produce weight scalars `w32 [nh]`
+4. `dsa_score_single()` — multi-head cosine distance: for each cache row `t`,
+   compute `Σ_h w32[h] * ReLU(qi·Ic[t] / √hd)`, scaled by `1/√nh`
+5. Top-K selection: `qsort` on `DsaEntry[]` (score+index), extract top-K indices
+6. Output: `k_idx[]` — array of selected positions
+
+**Wiring into kimik3 (COMPLETED):**
+- `load_cfg()`: DSA fields loaded from JSON (`index_hd`, `index_nh`, `index_topk`, optional `index_layers`, `rope_theta`)
+- `model_init()`: DSA weights loaded from shards for full layers only (`wk`, `wq`, `wp`, `knw`, `knb`)
+- `kv_alloc()`: `Ic` buffer allocated per full layer at `[max_t * index_hd]`
+- `model_state_reset()`: `Ic` cleared — Metal path: `coli_metal_kv_clear(Ic)`, CPU path: `free(Ic)`
+- `mla_forward()` prefill: Ic write wired after L/R KV cache write; guarded by `index_hd > 0 && idx_type[li]`
+- CPU helper `dsa_rope()`: rope_interleave on first `qk_rope` dimensions, inline cache, in-place on `[index_hd]`
+- CPU helper `DsaEntry` + `dsa_entry_cmp_desc()`: score+index struct used for `qsort` top-K selection
+- CPU helper `dsa_score_single()`: multi-head cosine distance kernel — for each cache row `t`,
+  computes `Σ_h w32[h] * ReLU(qi·Ic[t] / √hd)`, scaled by `1/√nh`, collects into top-K sort via `qsort`
+- `dsa_nsel`, `dsa_sel`, `dsa_scap` on `Model`: per-slot k_idx selection buffers allocated in `kv_alloc()`
+
+**Wiring pending (Phase 7b remaining):**
+- Decode step in `mla_forward()`: call `dsa_score_single()` + top-K selection before absorption loop,
+  materialize `k_idx[]` from `dsa_sel[d]`
+- Absorption loop: when `k_idx` is non-NULL, iterate `k_idx` instead of full `[0, nk)`;
+  passes `dsel/dnsel` to signal filtered subset (mirrors colibri.c:2826 pattern)
+- Sheet-beam DSA scoring Metal kernel (future: parallelize `dsa_score_single` over cache positions)
+
+**CPU helpers:**
+| Function | Purpose |
+|---|---|
+| `dsa_rope()` | rope_interleave on `[qk_rope]` — inline cache, in-place |
+| `DsaEntry` + `dsa_entry_cmp_desc()` | score+index struct for `qsort` top-K |
+| `dsa_score_single()` | multi-head cosine `[nk]` from `qi[nh*index_hd]` × `Ic[nk*index_hd]` + `w32[nh]` + top-K sort |
+
+**Metal kernels (PLANNED — not yet implemented):**
+| Kernel | Purpose |
+|---|---|
+| `dsa_kv_write` | fused layernorm + rope_interleave on `[S][index_hd]` → `Ic[pos:]` |
+| `dsa_score` | multi-head cosine `[nk]` from `qi[nh*index_hd]` × `Ic[nk*index_hd]` + `w32[nh]` |
+
+**Test strategy:**
+- Verify Ic values match CPU reference for one layer, S prefill tokens
+- Verify k_idx matches CPU top-K selection for one decode step
+- Full-context bypass (no DSA): bit-identical output when `index_hd == 0` (always true for K3)
+
+## Phase 8 — Port KDA attention
+
+This is likely the largest remaining task. Break into independent sub-phases, each comparing Metal output against CPU.
+
+KDA (Kimi Delta Attention) is a state-space model attention variant used in 69 of Kimi K3's 93 layers.
+Each KDA layer has: quantized projections (q, k, v, g, o), f32 low-rank decay projections (fa, fb, bp),
+conv1d depthwise taps (conv_q, conv_k, conv_v), per-head L2 normalization, and a sequential per-token
+state recurrence loop (decay, update, merge for [heads × hd × hd] state).
+
+**Config fields (from `Cfg`):**
+| Field | Value for Kimi K3 | Purpose |
+|---|---|---|
+| `kda_proj` | 2048 | Projection dim per q/k/v |
+| `kda_heads` | 96 | Number of KDA heads |
+| `kda_hd` | 128 | Head dim (2048 / 96 * 6.4 / 128? No — hd = proj / heads * factor) |
+| `conv_k` | 4 | Conv1d kernel width |
+| `gate_lb` | 0.068 | Gate base lower bound |
+
+**Struct `Kda` (per-layer):**
+| Field | Type | Purpose |
+|---|---|---|
+| `q`, `k`, `v`, `g`, `o` | `W` | Quantized projections (fmt=0/1/4) |
+| `fa`, `fb` | `float*` | Decay low-rank f32: `[kda_hd × hidden]`, `[kda_proj × kda_hd]` |
+| `bp` | `float*` | Beta projection f32: `[kda_heads × hidden]` |
+| `dt`, `A`, `onw` | `float*` | dt_bias `[kda_heads × kda_hd]`, exp(A_log) `[kda_heads]`, o_norm `[kda_hd]` |
+| `conv_q`, `conv_k`, `conv_v` | `float*` | Depthwise taps `[kda_proj × conv_k]` |
+| `metal_fa`, `metal_fb`, `metal_bp` | `void*` | Metal tensor wrappers for f32 GEMM (Phase 8.1) |
+
+**Execution order within `kda_forward()`:**
+1. **Batch projections** (C tokens): `w_matmul` for q, k, v, g; `k3_matmul_f32` for fa, fb, bp — Scoped at t=0
+2. **Per-token loop** (t=0..C-1; sequential due to state recurrence):
+   a. Conv1d depthwise + SiLU gate (q, k, v each: shift `[K]` window, dot taps, SiLU multiply)
+   b. Per-head L2 normalize (q, k each: compute norm over `[hd]`, divide; q adds `qscale = 1/√hd`)
+   c. Per-head state sweep (96 heads in parallel via OMP, each does `[hd × hd]` matrix-vector op):
+      - Apply gate via SiLU: `qg[i] = qn[i] * silu(rgt[h*hd + i])`
+      - Compute alpha: `alpha[i] = exp(gate_lb * sigmoid(A[h] * (graw[h*hd+i] + dt[h*hd+i])))`
+      - Decay state: `s[h][i][j] *= alpha[i]` for each `[hd × hd]` row
+      - Accumulate k: `kS[j] += kn[i] * s[h][i][j]`
+      - Compute vt: `vt[i] = (vh[i] - kS[i]) * beta[h]`
+      - Expand state: `s[h][i][j] += kn[i] * vt[j]`
+      - Merge output: `oh[j] += qn[i] * s[h][i][j]`
+   d. Per-head RMSNorm + sigmoid gate on output: `on[h*hd+i] = oh[i] * rmsnorm_factor * onw[i] * sigmoid(gp)`
+3. **Batch output**: `w_matmul(out, on, &a->o, C)`
+
+**Metal dispatch target analysis:**
+- **Projections (q, k, v, g, o)**: Already Metal-dispatched via `w_matmul` (Phase 5). 5 quantized matmuls, O(S × hidden × proj).
+- **Low-rank (fa, fb, bp)**: Metal-dispatched via `k3_matmul_f32` (Phase 8.1). 3 f32 matmuls, O(S × hidden × hd).
+- **Conv1d+SiLU**: Metal-dispatched via `kda_conv_silu` (Phase 8.3). O(C × P × K), 3 dispatches/token.
+- **L2 normalize**: CPU only. O(C × H × hd). Per-token, per-head. Could batch across C but not across H without restructuring.
+- **State sweep**: CPU only. O(C × H × hd²). THE kernel bottleneck. Sequential across tokens, parallel across heads.
+- **RMSNorm + gate**: CPU only. O(C × H × hd). Lightweight, fused within state loop.
+
+### 8.1 — Q/K/V preparation ✅ DONE
+
+**Metal wires completed:**
+- Quantized projections (q, k, v, g) dispatch through `w_matmul()` → `coli_metal_matmul(fmt)` (Phase 5, reused)
+- f32 low-rank projections (fa, fb, bp) dispatch through `k3_matmul_f32()` → `coli_metal_matmul(fmt=0)` (Phase 8.1 new)
+- Output projection (o) dispatches through `w_matmul()` (Phase 5, reused)
+
+**New infrastructure in `kimi_k3.c`:**
+| Additions | Purpose |
+|---|---|
+| `k3_matmul_f32(ColiMetalTensor**, ...)` | Metal-dispatching wrapper for f32 GEMM — calls `coli_metal_matmul()` when Metal available, falls back to `matmul()` |
+| `Kda.metal_fa`, `metal_fb`, `metal_bp` | Metal tensor wrappers for three f32 weight matrices |
+
+**Changes to `kda_forward()`:**
+- `matmul(t1, x, a->fa, ...)` → `k3_matmul_f32(&a->metal_fa, t1, x, a->fa, ...)`
+- `matmul(graw, t1, a->fb, ...)` → `k3_matmul_f32(&a->metal_fb, graw, t1, a->fb, ...)`
+- `matmul(braw, x, a->bp, ...)` → `k3_matmul_f32(&a->metal_bp, braw, x, a->bp, ...)`
+
+**Verification:**
+- Clean compile with `METAL=1` confirmed 2026-07-31.
+- Projections batch C tokens through Metal; conv, L2, state recurrence now Metal-dispatched via Phase 8.2.
+- For decode (C=1), Metal dispatches single-row GEMMs. Performance benefit is latency hiding, not throughput.
+
+### 8.2 — Attention state recurrence ✅ DONE
+
+For Kimi K3 KDA, the "attention score" is the per-head state recurrence: decay, update, merge on
+the `[hd × hd]` state per head. Unlike MLA where attention is softmax over (Q·K) scores, KDA's
+"scoring" is the state-space transition: `s_new = alpha * s_old + kn ⊗ vt`.
+
+**CPU implementation (replaced):** The per-head state sweep (lines ~817-864 of `kda_forward()`),
+runs 96 parallel heads over `[hd × hd]` state. For hd=128, that's 96 × 128² = 1.57M multiply-adds
+per token. With 69 KDA layers × 1 token/decode, that's ~108M ops in state sweeps alone.
+
+**Metal kernel design (IMPLEMENTED):**
+The state recurrence `s[h][hd][hd]` is sequential across tokens but fully parallel across heads and
+state dimensions. The kernel dispatches `[H, hd]` threadgroups — one threadgroup per head, `hd` threads
+per threadgroup. Each thread handles one `(i, j)` element of the output `[hd × hd]`.
+
+Kernel signature (`k3_kda_state` in `backend_metal.mm` SHADER string):
+```
+kernel void k3_kda_state(
+    device float4 *S,          // 0: [H*hd*hd], float4-strided state (mutable)
+    device const float4 *qn,  // 1: [H*hd], float4-strided normalized Q
+    device const float4 *kn,  // 2: [H*hd], float4-strided normalized K
+    device const float4 *vh,  // 3: [H*hd], float4-strided gated V (vh - kS) * beta
+    device const float4 *alpha, // 4: [H*hd], float4-strided decay factors
+    device const float *beta, // 5: [H], per-head gate
+    constant const int2 &dims // 6: {H, hd}
+)
+```
+
+**Math decomposition (two-pass, no threadgroup memory):**
+The state recurrence has inherent dependencies: Pass 2 (expand + accumulate output) cannot begin until
+Pass 1 completes the full set of row decays and kS accumulation. The kernel serializes two passes within
+each thread:
+
+- **Pass 1** (row decay + kS accumulate): Each thread `(i,j)` decays `S[i][j] *= alpha[i]`, then
+  accumulates `kS[i] += kn[j] * S[j][i]` by sweeping all rows of column `i`.
+- **vt computation**: `vt[i] = (vh[i] - kS[i]) * beta`.
+- **Pass 2** (state expand + output merge): Each thread `(i,j)` expands state
+  `S[i][j] += kn[i] * vt[j]`, then accumulates output `oh[j] += qn[i] * S[i][j]`.
+
+No threadgroup memory or barriers required — each pass uses a sequential loop within the thread
+over the dependent axis, while independent axes are parallelized across threadgroups.
+
+**New infrastructure in `backend_metal.h`:**
+| Addition | Purpose |
+|---|---|
+| `int coli_metal_kda_state(float *S, const float *meta_qn, const float *meta_kn, const float *meta_vh, const float *meta_alpha, const float *meta_beta, int H, int hd)` | Dispatch Metal state recurrence kernel for one chunk of C=1 tokens |
+
+**New infrastructure in `backend_metal.mm`:**
+| Addition | Purpose |
+|---|---|
+| `k3_kda_state` in SHADER string | Metal kernel: two-pass state recurrence |
+| `g_k3_kda_state` | Pipeline state global |
+| `P("k3_kda_state")` in `coli_metal_init()` | Pipeline compilation |
+| `coli_metal_kda_state()` dispatch function | Wraps host memory into SharedBuffers, binds 7 params, dispatches `[H,hd]` threadgroups |
+
+**Changes to `kda_forward()` (kimi_k3.c):**
+- Allocates per-token temp buffers `meta_qn[H*hd]`, `meta_kn[H*hd]`, `meta_alpha[H*hd]`, `meta_vh[H*hd]`,
+  `meta_beta[H]`, `meta_oh[H*hd]` — freed at end of token loop
+- When `g_k3_metal` is set:
+  - Serial loop (no OMP) fills Metal temp arrays: L2-normalize q/k, compute alpha/beta, prepare gated V
+  - `coli_metal_kda_state()` dispatches state sweep for all heads at once
+  - Post-loop: per-head RMSNorm + sigmoid gate readback from `meta_oh` into `on[t*h*hd:]`
+- When `g_k3_metal` is not set: existing CPU path (OMP parallel, AVX2 vectorized) is preserved
+- Conv1d+SiLU phase now Metal-dispatched via Phase 8.3 kernels
+
+**State binding model:** `S` is a pointer into host-allocated `m->kstate[li]` (`[H*hd*hd]`).
+SharedBuffers allow zero-copy GPU access — the kernel reads, decays, expands, and writes `S` in-place.
+No host-device synchronization of state tensor required.
+
+**Verification:**
+- Clean compile with `METAL=1` confirmed 2026-07-31.
+- Metal `colibri` and `kimi_k3` binaries build without warnings.
+- CPU fallback path (non-Metal) preserved for correctness oracle.
+
+### 8.3 — Conv1d + SiLU + L2 normalization ✅ DONE
+
+The per-token preparation phase between projections and the state sweep:
+(a) conv1d depthwise + SiLU gate on q/k/v, (b) per-head L2 normalization of q and k.
+
+**CPU implementation (replaced):** `#pragma omp parallel for` across P dims per conv, then per-head L2 loops.
+Operations are small per-token (P=2048, H=96, hd=128) but run every token.
+
+**Metal kernel design (IMPLEMENTED):**
+
+**`kda_conv_silu`** — One thread per dimension `d` in `[0, P)`. For each dimension:
+shift window `conv_win[d*K: d*K+K]` left by 1, store `vec[d]` at `K-1` (appends new input),
+compute dot product with `taps[d*K:d*K+K]`, apply SiLU (`x / (1 + exp(-x))`), write result to `vec[d]`.
+Dispatched once per projection (q, k, v → 3 total dispatches).
+
+**`kda_l2_norm`** — One thread per head `h` in `[0, H)`. For each head:
+sum `qh[i]^2` and `kh[i]^2` over `hd` dims, compute reciprocal square root `1/sqrt(sum + eps)`
+(`eps = 1e-6`), scale Q by `norm * qscale` (`qscale = 1/sqrt(hd)`) and K by `norm`.
+Writes q/k in-place. Single dispatch for all heads.
+
+**New infrastructure in `backend_metal.h`:**
+| Addition | Purpose |
+|---|---|
+| `int coli_metal_kda_conv_silu(float *conv_win, float *vec, const float *taps, int P, int K)` | Shift window, dot taps, SiLU gate — one projection |
+| `int coli_metal_kda_l2_norm(float *q, float *k, int H, int hd, float qscale)` | In-place L2 normalization per head for q and k |
+
+**New infrastructure in `backend_metal.mm`:**
+| Addition | Purpose |
+|---|---|
+| `kda_conv_silu` in SHADER string | Metal kernel: conv1d depthwise + SiLU for `[P]` dims |
+| `kda_l2_norm` in SHADER string | Metal kernel: L2 norm for `[H]` heads of Q and K |
+| `g_kda_conv_silu`, `g_kda_l2_norm` | Pipeline state globals |
+| `P("kda_conv_silu")`, `P("kda_l2_norm")` in `coli_metal_init()` | Pipeline compilation |
+| `coli_metal_kda_conv_silu()` | Host dispatch: binds 3 buffers + 2 scalar params, threads=P |
+| `coli_metal_kda_l2_norm()` | Host dispatch: binds 2 buffers + 3 scalar params, threads=H |
+
+**Changes to `kda_forward()` (kimi_k3.c):**
+- When `g_k3_metal` is set (inside per-token loop):
+  - Call `coli_metal_kda_conv_silu()` in a loop of 3 (q, k, v projections), replacing OMP conv loop
+  - Call `coli_metal_kda_l2_norm()` once for all H heads, replacing OMP L2 loops
+  - Subsequent state preparation (alpha, beta, gated V) runs on CPU, reading GPU-processed q/k
+- When `g_k3_metal` is not set: existing CPU path preserved
+
+**Buffer alignment:** Conv window state buffers (`m->cwq[li]`, `m->cwk[li]`, `m->cwv[li]`) are `calloc()`-
+allocated (not page-aligned). Metal's `wrap()` uses `MTLResourceStorageModeShared` with `parameters:nil`,
+which auto-registers arbitrary host addresses — no `falloc()` required.
+
+**Verification:**
+- Clean compile with `METAL=1` confirmed 2026-07-31.
+- Zero warnings across Metal shader and C/Objective-C++ sources.
+- CPU fallback path preserved for correctness oracle.
+
+### 8.4 — Fused KDA token step (one MTLCommandBuffer per token) ✅ DONE
+
+Each KDA token previously ran 5 separate Metal command buffers:
+3 × conv_silu + 1 × l2_norm + 1 × state. Each command buffer required
+create → encode → commit → waitUntilCompleted + readback, at ~150 μs per
+round-trip on macOS. Total overhead: ~750 μs/token just in dispatch
+overhead, before any kernel compute time.
+
+**Metal dispatch consolidation (IMPLEMENTED):** `coli_metal_kda_fused_token()`
+creates a single `MTLCommandBuffer`, encodes all 5 kernels sequentially into it
+(conv_silu×3 → l2_norm → state), then commits and waits once. This reduces
+the per-token Metal overhead from ~750 μs to ~150 μs — a ~5× overhead reduction.
+
+**CPU pre-computation:** The fused kernel still requires `alpha[H*hd]` (decay per-element)
+and `beta[H]` (gate per-head), computed from `graw` (raw gate projections), `dt`, `A`,
+and `c->gate_lb`. These are computed on CPU inside the per-token loop before the fused
+call. The CPU cost is O(H × hd) = O(12288), negligible compared to GPU dispatch time.
+Memory for alpha/beta is pre-allocated once per forward call (size C × P and C × H).
+
+**Buffer layout compatibility:** The conv_silu outputs (`qt`, `kt`, `tv` = `[H*hd]` each)
+have the same layout as what the state kernel expects for `qn`, `kn`, `vh`. The L2
+normalization pipeline rewrites `qt`/`kt` in-place into `qn`/`kn`. No intermediary
+host buffers needed between GPU kernels within one command buffer.
+
+**Post-processing (RMSNorm + sigmoid gate):** After the fused call, the state kernel
+writes `oh[H*hd]` into the `meta_oh` buffer. The CPU performs per-head RMSNorm +
+sigmoid(full-rank gate) to produce `on`, identical to the non-fused path.
+
+**Kernel pipeline binding model:** `S[m->kstate[li]]` `[H*hd*hd]` is the in-place
+attention state, shared between GPU and CPU via Metal's SharedBuffer unified memory.
+All GPU writes are visible to the CPU after `waitUntilCompleted` returns.
+
+**New infrastructure in `backend_metal.h`:**
+| Addition | Purpose |
+|---|---|
+| `int coli_metal_kda_fused_token(win_q, qt, win_k, kt, win_v, tv, taps_q, taps_k, taps_v, S, alpha, beta, oh, P, K, H, hd)` | Single-CB dispatch: conv_silu×3 + l2_norm + state recurrence |
+
+**New infrastructure in `backend_metal.mm`:**
+| Addition | Purpose |
+|---|---|
+| `coli_metal_kda_fused_token()` | Creates one `MTLCommandBuffer`, reuses existing `g_kda_conv_silu`, `g_kda_l2_norm`, `g_kda_state` pipelines, encodes 5 dispatches, commits, waits |
+
+**Changes to `kda_forward()` (kimi_k3.c):**
+- Pre-allocates `meta_oh[C*P]`, `meta_alpha[C*P]`, `meta_beta[C*H]` when `g_k3_metal` is set
+- Per-token Metal path:
+  1. CPU: compute `meta_alpha[t]` and `meta_beta[t]` from `graw[t]`, `dt`, `A`, `gate_lb`, `braw[t]`
+  2. Memzero `meta_oh[t]` for state kernel accumulation
+  3. GPU: `coli_metal_kda_fused_token()` dispatches all 5 kernels in one command buffer
+  4. CPU: per-head RMSNorm + sigmoid gate from `meta_oh[t]` → `on[t]`
+- If fused dispatch fails: sets `g_k3_metal = 0`, falls through to CPU path
+- Non-Metal CPU path: preserved, including OMP parallelism and AVX2 vectorization
+
+**Related fix:** `k3_matmul_f32()` parameter type changed from `ColiMetalTensor**` to `void*`
+to allow compilation when `COLI_METAL` is not defined. Cast sites updated accordingly.
+
+**Verification:**
+- Clean compile with `METAL=1` confirmed 2026-08-01.
+- Clean compile without Metal confirmed 2026-08-01.
+- Zero warnings across Metal shader and C/Objective-C++ sources.
+- CPU fallback path preserved for correctness oracle.
+
+**Functional test:** End-to-end KDA output comparison vs CPU reference, 2026-08-01.
+- Prompt "hello", 20 tokens decode (C=1 per token), `COLI_TEMP=0` for greedy sampling.
+- **Prefill** (C=2 tokens, chunked at default chunk=32): Metal output identical to CPU.
+- **Decode** (20 tokens, C=1): Metal output identical to CPU.
+- Result: `diff metal_out.txt cpu_out.txt` — zero differences. ✅ PASSED
+
+**Performance (Phase 10 confirmation, 2026-08-01):**
+- Single-token decode (K3_METAL=1, K3_CHUNK=1): 3663 tok/s effective decode speed
+- Non-fused path: 4 MTLCommandBuffers/token × ~150 μs/roundtrip = ~600 μs overhead/token (cmp. 150 μs for fused)
+- Fused path: 1 MTLCommandBuffer/token = ~150 μs overhead/token — ~4× overhead reduction vs non-fused
+- Metal-aware RSS: 11.1 GB (Metal) vs 43.6 GB (old non-fused path) — zero-copy management benefits
+
+### 8.5 — End-to-end full model (A/B Metal vs CPU) ✅ DONE [2026-08-01]
+
+All 93/93 layers run on Metal for full Kimi K3 inference. The Metal paths are wired inline
+within `kda_forward()` and `mla_forward()` via `g_k3_metal` gates — no separate
+`kda_forward_metal()` or `mla_forward_metal()` functions exist.
+
+**Metal path coverage per layer type:**
+| Component | Metal dispatch | Notes |
+|---|---|---|
+| KDA projections (q,k,v,g,o) | `w_matmul()` → `coli_metal_matmul()` | Phase 5, Phase 8.1 |
+| KDA low-rank (fa,fb,bp) | `k3_matmul_f32()` → `coli_metal_matmul(fmt=0)` | Phase 8.1 |
+| KDA conv_silu | `coli_metal_kda_conv_silu()` | Phase 8.3 |
+| KDA l2_norm | `coli_metal_kda_l2_norm()` | Phase 8.3 |
+| KDA state recurrence | `coli_metal_kda_fused_token()` | Phase 8.4, fused CB |
+| MLA KV cache (Lc/Rc) | `coli_metal_kv_write()` | Phase 7a |
+| MLA projections (qa,qb,kva,g,o) | `w_matmul()` → `coli_metal_matmul()` | Phase 5 |
+| MLA attention loop | CPU | Not Metal-dispatched |
+| MoE expert routing | CPU | Not Metal-dispatched |
+| MoE expert matmul | `coli_metal_moe_block()` | Phase 6 |
+| RMSNorm, res_mix, moe_forward | CPU | CPU-only |
+| lm_head (final projection) | `w_matmul()` → `coli_metal_matmul()` | Phase 5 |
+| KV cache clear/reset | `coli_metal_kv_clear()` | Phase 7a |
+
+**Fallback mechanism:**
+- KDA fused dispatch (`coli_metal_kda_fused_token`): explicit return value check at kimi_k3.c:824.
+  On failure, `g_k3_metal = 0`, falls through to CPU path. Self-healing.
+- MLA `coli_metal_kv_write`: CPU fallback only when `g_k3_metal == 0` (init failure). Return value
+  not checked — reliable in 6+ test runs without incident.
+- All other Metal dispatches: guarded by `g_k3_metal && coli_metal_available()`.
+
+**A/B test results (all `COLI_TEMP=0` for deterministic greedy sampling):**
+
+| Test | Prompt | Tokens | Prefill | Decode | Result |
+|---|---|---|---|---|---|
+| Short decode | "hello" | 20 | C=2, identical | 20 tokens identical | ✅ PASSED |
+| Long prefill | "Write a comprehensive explanation..." | 30 | 45+ tokens, identical | 30 tokens identical | ✅ PASSED |
+| Long decode | "The stock market crashed" | 50 | C=4, identical | 50 tokens identical | ✅ PASSED |
+| Chat mode | "Explain quantum computing" | 30 | 25 tokens, identical | 30 tokens identical | ✅ PASSED |
+| Single token prompt | `--ids "151657"` | 5 | — | 5 tokens identical | ✅ PASSED |
+
+**Chat mode timing (Metal):**
+- Prefill: 25 tokens in 91.4s (0.27 tok/s)
+- Decode: 30 tokens in 162.1s (0.19 tok/s), 5.5s/token avg
+- Expert cache: 5.7% hit rate (3316/58064)
+- I/O: 960.7 GB streamed, RSS 43.6 GB
+- Attention: 61.8s, MoE: 190.6s (expert load: 63.8s)
+
+**Chat mode timing (CPU):**
+- Prefill: 25 tokens in 92.5s (0.27 tok/s)
+- Decode: 30 tokens in 162.8s (0.18 tok/s), 5.6s/token avg
+- Expert cache: 5.7% hit rate (3316/58064)
+- I/O: 960.7 GB streamed, RSS 43.6 GB
+- Attention: 62.9s, MoE: 191.2s (expert load: 60.6s)
+
+**Observations:**
+- Output is identical across all test scenarios (greedy sampling, `diff` = zero differences)
+- Metal prefill is ~1s faster (91.4s vs 92.5s) — negligible for I/O-bound model
+- Metal decode is ~0.7s faster (162.1s vs 162.8s) — ~0.4% improvement in attention time
+- Performance bottleneck is disk I/O for MoE expert loading (960.7 GB), not GPU dispatch
+- Metal's benefit will become measurable once expert cache hit rate improves
+- **Memory overhead:** Non-fused Metal path (Phase 8.2+8.3) uses 4× command buffers per token (conv_silu×3 + l2_norm + state) with ~750 μs dispatch overhead. Phase 8.4 fused kernel eliminates this by consolidating to 1 CB/token. Fused kernel confirmed 3K+ tok/s on single-token decode (Phase 10).
+
+---
+
+## Phase 9 — End-to-end layer validation [2026-08-01] ✅ DONE
+
+**Objective:** Validate that per-layer intermediate tensors produced by Metal-backed `kda_forward()` and `mla_forward()` are numerically identical to their CPU counterparts, confirming correctness of all Metal-kernel paths (projections, fused KDA state, MoE experts, KV writes).
+
+**Implementation:** Added `K3_VALIDATE_LAYER=N` / `K3_VALIDATE_TOKEN=T` infrastructure in `kimi_k3.c` that dumps 5 intermediate tensors per layer at the target (token 0, selected layer) to ASCII file:
+
+1. `nrm_attn` — input to attention block (after RMSNorm of residual-mixed input)
+2. `att` — raw attention output (after `kda_forward`/`mla_forward`, before post-RMSNorm)
+3. `nrm_mlp` — input to MoE/dense block (after post-attention RMSNorm)
+4. `mlp` — raw MoE/dense output (before residual add)
+5. `hidden` — final layer output (after residual addition, feeds next layer)
+
+Each tensor: 7168 floats (D=7168), dumped as ASCII to `K3_VALIDATE_OUT` file.
+
+**Validation runs:** Three layers tested on both Metal and CPU with identical K3_X0-injected inputs (2 tokens, `COLI_TEMP=0`, greedy sampling):
+
+| Layer | Type | nrm_attn | att | nrm_mlp | mlp | hidden |
+|---|---|---|---|---|---|---|
+| 0 | KDA, MoE | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
+| 1 | KDA, MoE | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
+| 20 | MLA, MoE | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
+
+All values are maximum absolute error (maxAbs) across all 7168 dimensions per tensor.
+
+**Results:** All 15 tensor comparisons across 3 layers show **maxAbs = 0.00e+00** — bit-for-bit identical outputs between Metal and CPU paths.
+
+This confirms:
+- `coli_metal_kda_fused_token()` (fused conv_silu×3 + l2_norm + state recurrence) produces identical state and gate outputs
+- `coli_metal_kv_write()` produces identical KV cache entries
+- `coli_metal_matmul()` produces identical projections at all quantization levels (f32, q8, i4)
+- `coli_metal_moe_block()` produces identical expert outputs
+- No floating-point reordering effects from Metal's execution model
+
+**Code changes:** `c/kimi_k3.c` — added `g_k3_val_layer`, `g_k3_val_token`, `g_k3_val_fp` globals; `val_dump()` helper; capture hooks in `step_chunk()` layer loop; cleanup in `main()` exit paths.
+
+---
+
+## Phase 10 — Full model validation ✅ DONE [2026-08-01]
+
+End-to-end inference validation across the complete 93-layer Kimi K3 model on Metal GPU.
+
+**Critical bug discovered and fixed during Phase 10:**
+
+### fmt=0 scales NULL crash in `coli_metal_matmul()`
+
+**Symptom:** Metal inference crashed with SIGSEGV (exit 139) at `newBufferWithBytes` inside `wrap()` during the 5th matmul call per layer (tanh activation, `fmt=0`). All 4 quantized projections (fmt=4) succeeded; every layer crashed on the tanh call.
+
+**Root cause:** `fmt_scale_bytes(fmt=0, I=7168, O=128, gs)` returned `O * sizeof(float) = 512` bytes (non-zero), causing `wrap(scales=NULL, 512)` inside the tensor creation path. Metal's `newBufferWithBytes:NULL length:512` segfaulted when the GPU tried to read from address 0.
+
+The caller (`w_matmul()` in `kimi_k3.c:317`) correctly passes `scales=NULL` for fmt=0 (raw f32 has no scales). The bug was in `fmt_scale_bytes()` returning non-zero for fmt=0, making the Metal side assume scales existed when they don't.
+
+**Fix:** `fmt_scale_bytes()` now returns `0` for `fmt==0`. Also added explicit handling: `fmt==1` returns per-row scales (`O * sizeof(float)`), `fmt==4` returns grouped scales (`O * ceil(I/gs) * sizeof(float)`), `fmt==6` returns 2-byte group scales (`O * ceil(I/gs) * 2`).
+
+**Files changed:**
+- `c/backend_metal.mm:588` — `fmt_scale_bytes()` logic
+- `c/kimi_k3.c:317` — preserved `scales=NULL` for fmt=0 (was already correct)
+
+**Debug approach:** Layered dprintf tracing at every step inside `coli_metal_matmul()` revealed crash at `[MT3]` (post-weight-wrap, pre-scale-wrap). The pattern (4 fmt=4 calls succeed, 1 fmt=0 call crashes) was identical across all 93 layers.
+
+### Memory management fix: f_free on late-initialized buffers
+
+**Symptom:** `f_free(uq, 256*14336)` called on a stack-allocated buffer in the fused token kernel pre-computation path, corrupting `w_actual` and `w2_actual` pointers for subsequent calls.
+
+**Root cause:** Page-aligned buffers allocated after `k3_matmul_f32` for `w_actual`/`w2_actual` were freed prematurely by `_XLATE Case 8` in `w_addrow`, which invalidated pointers still in use by the fused kernel.
+
+**Fix:** Only `f_free()` when the buffer was actually heap-allocated (tracked allocation flag). Stack/inline buffers skip `f_free` to avoid pointer invalidation.
+
+### K3_X0=0 GPU fallback mode
+
+**Purpose:** When `K3_X0=0`, the GPU is used for the fused KDA kernel (conv_silu, l2_norm, state recurrence) but `w_matmul` falls back to CPU matmul. This provides a controlled path to isolate fused-kernel correctness from projection correctness.
+
+**Implementation:** `coli_metal_kda_fused_token()` dispatches normally under `g_k3_metal`, while `w_matmul()` checks `g_k3_metal && coli_metal_available()` and falls through to CPU when `K3_X0=0` unsets the GPU dispatch flag.
+
+**Performance:** `K3_X0=0` mode confirmed f_free fix — runs all 93 layers with GPU fused kernel + CPU projections without pointer corruption.
+
+**Procedure executed:**
+
+| Test | Configs | Prefill | Decode | Result |
+|---|---|---|---|---|
+| Single token (token 198) | `K3_METAL=1 K3_CHUNK=1` | 1/1 in 13.6s | 1 token, 3663 tok/s | ✅ Exit 0, output "bba" |
+| Single token (CPU reference) | no Metal | 1/1 in 11.8s | 1 token, 3424 tok/s | ✅ Exit 0, identical tokens |
+| Multi-token (6 tokens, 3 decode) | `K3_METAL=1 K3_CHUNK=1` | 6/6 in 44.8s | 3 tokens in 12.0s | ✅ Exit 0, context full |
+
+**Success criterion met:** Metal produces exit 0, generates correct tokens, full model (93 layers) runs end-to-end without crashes. Combined with Phase 8.5 and Phase 9 bit-for-bit validation, Metal-backed Kimi K3 inference is confirmed correct across all test scenarios.
+
+**Timing observations:**
+- Metal prefill: 13.6s (1 token) vs CPU: 11.8s — I/O bound, negligible GPU benefit at single-token scale
+- Metal decode: 3663 tok/s effective (but mostly attributed to initial warmup; sustainedDecode speed pending expert cache tuning)
+- Model RSS: 11.1 GB (Metal) vs 15.2 GB (CPU) — Metal's zero-copy buffer management uses less peak memory
+- I/O streaming: 25.8 GB for single-token run (dominated by MoE expert loading from disk)
+
+---
+
+## Phase 11 — Regression testing [2026-08-02, in progress]
+
+Verify existing Metal functionality remains unchanged after Kimi K3 integration.
+
+**Regression matrix:**
+
+| Model | CPU  | Metal |
+|---|---|---|---|
+| GLM | ✓ | ✓ |
+| Kimi K3 | ✓ | ✓ |
+
+The existing GLM Metal path should remain bit-for-bit identical or within established tolerances.
+
+### Current status (2026-08-02)
+
+**What is done:**
+- Phase 8.5 end-to-end: 93/93 layers run on Metal, output bit-identical to CPU (Phase 8.5 A/B tests)
+- Phase 9: Per-layer validation at layers 0, 1, 20 — all 15 tensor comparisons maxAbs = 0.00e+00
+- Phase 10: Full model validation exit-0, correct token generation, corrected fmt=0 scales crash
+- KDA fused kernel (Phase 8.4): conv_silu×3 + l2_norm + state recurrence in single MTLCommandBuffer
+- KDA conv_silu, l2_norm, state kernels verified correct (Phase 8.3, 8.2)
+- `coli_metal_init()` validated: `MTLCreateSystemDefaultDevice`, shader compile, all pipeline states
+
+**What is left to do:**
+- Phase 11: GLM Metal regression (GLM models still untested with Kimi K3 Metal changes)
+- Phase 11: Multi-token decode regression (tested single-token; multi-token with C>1 pending full validation)
+- Phase 12: Performance benchmarking with expert cache tuning
+- Phase 13: Optimization
+- DSA indexer Metal kernels (`dsa_kv_write`, `dsa_score`) — planned, not implemented
+- MLA attention loop Metal dispatch — CPU only, not Metal-dispatched
+- MoE expert routing Metal dispatch — CPU only
+
+**What is known:**
+- Metal requires `K3_METAL=1` env var to initialize (not `--metal` argv flag)
+- Debug output via `K3_DEBUG_OUT` env var writes per-dim Metal/CPU comparison to file
+- Model dims from `config.json`: `kda_proj=12288`, `kda_heads=96`, `kda_hd=128`, `conv_k=4`
+- Metal registers `g_dev`, `g_queue`, compiles SHADER, creates all pipeline states on init
+- Unified memory (SharedBuffer) allows zero-copy GPU access to host-allocated tensors
+- CPU fallback paths preserved at every Metal dispatch site
+- Metal state recurrence `oh` output for token 0 confirmed uniform to 9th decimal place across all 128 dims
+- `META_DOT_RATIO`: oh[i] / (vh[i] * beta) = ~5.432e-3 per-dim (all dims match within ~5e-10)
+- Input floats (qn, kn, vh, alpha, beta) verified matching between Metal and CPU to 6-7 digits
+
+**What is working:**
+- `coli_metal_kda_fused_token()`: All 5 kernels (conv_silu×3, l2_norm, state) execute in one command buffer
+- `coli_metal_kda_conv_silu()`: Conv1d depthwise + SiLU gate, 3 dispatches per token
+- `coli_metal_kda_l2_norm()`: Per-head L2 normalization for q and k
+- `coli_metal_kda_state()`: State recurrence with two-pass algorithm (decay+accumulate, expand+merge)
+- `coli_metal_matmul()`: All quantization formats (f32 fmt=0, q8 fmt=1, i4 grouped fmt=4)
+- `coli_metal_moe_block()`: Expert routing + block dispatch
+- `coli_metal_kv_write()`: KV cache write with rmsnorm + rope
+- `coli_metal_kv_clear()`: KV cache zeroing on model reset
+- Metal inference produces exit-0 with correct tokens (93 layers, 93/93 Metal-backed)
+
+**Active investigation:**
+- **Meta KDA dot ratio discrepancy**: CPU_DOT_RATIO ~8.054e-3 vs META_DOT_RATIO ~5.432e-3 (1.48x off). Metal output is uniform across all 128 dims, input floats verified matching to 6-7 digits. Root cause unknown — could be different qn/kn normalization, different dot product accumulation, or different vh/beta values between CPU and Metal code paths. Requires isolating CPU-side dot(qn,kn)*vh*beta to compare with Metal-side computation.
+
+**What is not working (or not yet tested):**
+- `--metal` CLI flag: Does not exist (compile-time `-DCOLI_METAL` + runtime `K3_METAL=1` env var only)
+- GLM Metal path: Not retested after Kimi K3 Metal integration
+- `kimi_k3.c` source: Was accidentally deleted and restored from git, then restored from Time Machine backup (08:16 AM, Aug 2) — verified backup contains all local modifications (2112 lines, K3_DEBUG_OUT, META_DIMS, CPU_DOT_RATIO, etc.)
+
+**Metal dispatch activation:**
+- Build: `make -C c kimi_k3 METAL=1` (pass `-DCOLI_METAL` to compiler)
+- Run: `K3_METAL=1 ./kimi_k3 /Volumes/4Tb990Pro/Kimi-K3 "prompt"`
+- Debug: `K3_DEBUG_OUT=/tmp/k3_debug.txt` for per-dim Metal/CPU comparison file
+- Max tokens: `K3_MAX_TOK=N` to limit generation for quick testing
+
+---
+
+## Phase 12 — Performance benchmarking
+
+Only after correctness is established.
+
+**Metrics to collect:**
+- First token latency
+- Decode tokens/sec
+- GPU utilization
+- Command buffer count
+- Kernel launches
+- Host/device transfers
+
+**Output:** `docs/kimi_metal_benchmarks.md`
+
+---
+
+## Phase 13 — Optimization
+
+Only optimize kernels that profiling identifies as bottlenecks.
+
+**Typical candidates:**
+- Fused RMSNorm + linear
+- Expert batching
+- Reduced buffer copies
+- Command buffer batching
+- Persistent threadgroups
+- Improved unified-memory access patterns
+
+Each optimization must have an associated benchmark demonstrating measurable improvement before merge.
+
+---
+
+## Recommended PR structure
+
+This project is well suited to many small, reviewable PRs. A simple coding agent succeeds with:
+
+1. Gap analysis and documentation
+2. Backend dispatch scaffolding (no inference changes)
+3. Metal implementations of dense primitives
+4. Metal MoE expert execution
+5. Metal KV cache support
+6. Metal KDA attention
+7. Full layer validation
+8. End-to-end Kimi K3 inference on Metal
+9. Performance optimization and benchmarking
+
+## Guiding principle
+
+**Never invent new algorithms.** Treat the CPU implementation as the correctness oracle, the Vulkan implementation as the GPU reference, and the existing Metal backend as the implementation template. Every PR should either add one Metal primitive or one test, and every new primitive must pass CPU-Vulkan-Metal numerical parity before moving on.
+
+This approach minimizes the architecture the agent must understand at any one time and keeps every step independently verifiable, making it well suited to a relatively simple autonomous coding agent working in a large C codebase.


### PR DESCRIPTION
**@RDouglasSharp's #790, rebased onto current `dev` by the maintainers** — commits and authorship are his; we only resolved the conflicts, because his August 8 rebase (done on request) was invalidated by 71 merges of our own silence. Details and apology on [#790](https://github.com/JustVugg/colibri/pull/790#issuecomment-5343790993).

## Conflicts resolved (4, in 3 files) — each stated so @RDouglasSharp can review the decision rather than redo the work

1. **`c/Makefile`** — union: dev's new `kv_prefix.h serve_codec.h` prerequisites **plus** his `$(METAL_OBJ)` in both the deps and the link line.
2. **`c/kimi_k3.c`, struct `W`** — union: dev's mmap fields (`data_map`, `scale_map`, `mapped`, from #965) **plus** his `void *metal`.
3. **`c/kimi_k3.c`, `g_k3_vk`** — **dropped his hunk**: dev already declares `static int g_k3_vk=0` (now line 334); re-adding his `__attribute__((unused))` copy would have been a duplicate definition. Verified there is exactly one declaration left.
4. **`c/tests/test_backend_metal.mm`** — **kept dev's Apple-Paravirtual skip guard** (it is what stops the CI runner hanging 47 minutes on Metal submissions, #947) and took his `printf` text, since the suite is now his op tests.

`backend_metal.mm` did **not** conflict this time — his earlier careful resolution still applies cleanly.

## What we verified, and what we cannot

- ✅ `kimi_k3`, `colibri`, `olmoe`, `qwen36` all build clean on Linux after the rebase (the CPU path is what a bad conflict resolution would break).
- ✅ macOS CI builds every engine on Apple Silicon runners and runs the `metal-test` target — so **compile coverage of the Metal path is real**.
- ❌ **We cannot verify runtime.** No maintainer has a Mac, and the CI runner's Paravirtual device cannot execute Metal submissions. @RDouglasSharp's measurements (1.7×/2.4× on the compute-bound KDA attention + projections; experts stay on CPU) stand as the runtime evidence, and a confirmation from him that the rebased branch still runs on his M5 Max is the last thing we would like before merge — though we will not hold it hostage to that if he is unavailable, given whose delay caused this.

Supersedes #790 on merge. Target: v1.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)