### PR TITLE
fix(CUDA): fmt=8/fmt=6 scale-byte accounting — rebase of #1100 by @monotophic

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -839,7 +839,7 @@ rans: $(RANSLIB)
 $(RANSLIB): tools/rans_ctypes.c rans.h
 	$(CC) $(CFLAGS) -fPIC -shared $< -o $@ $(LDFLAGS)
 
-cuda-test: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/test_backend_cuda.cu tests/test_ragged_attention.cu tests/test_absorb_determinism.cu tests/test_mxfp4_cuda.cu tests/mxfp4_ref.c tests/test_fp8_warp_cuda.cu
+cuda-test: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/test_backend_cuda.cu tests/test_ragged_attention.cu tests/test_absorb_determinism.cu tests/test_mxfp4_cuda.cu tests/mxfp4_ref.c tests/test_fp8_warp_cuda.cu tests/test_fp8_cuda.cu
 	@command -v "$(GPUCC)" >/dev/null 2>&1 || { echo "$(GPUCC_NAME) not found" >&2; exit 1; }
 	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/test_backend_cuda.cu -o backend_cuda_test$(EXE) $(ANS_NVCC_LIBS)
 	./backend_cuda_test$(EXE)
@@ -864,6 +864,11 @@ cuda-test: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/test_backen
 	# one is expected to fail.
 	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/test_absorb_determinism.cu -o absorb_determinism_test$(EXE)
 	./absorb_determinism_test$(EXE)
+	# fmt=8 (fp8-e4m3) kernel oracle + public API (LUT gate, dense, expert
+	# group, byte accounting). Includes backend_cuda.cu itself, so only the
+	# test file is compiled. Also runs BEFORE the MXFP4 test (same reason).
+	"$(GPUCC)" $(GPUFLAGS) tests/test_fp8_cuda.cu -o fp8_cuda_test$(EXE) $(ANS_NVCC_LIBS)
+	./fp8_cuda_test$(EXE)
 	# MXFP4 (fmt=7) against the CPU decoder in quant.h. The reference is built
 	# as C on purpose: quant.h uses _Thread_local, which nvcc's C++ front end
 	# rejects, and re-implementing it for the test would defeat the comparison.

--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -2287,17 +2287,19 @@ extern "C" void coli_cuda_tensor_free(ColiCudaTensor *tensor) {
     DeviceContext *ctx = find_ctx(tensor->device);
     if (ctx) select_ctx(ctx);
     if (tensor->tracked && ctx) {
-        int ng = tensor->ng > 0 ? tensor->ng : 1;
-        /* Must mirror the upload's accounting exactly: fmt=6 never charged for a
-         * scale buffer, and over-subtracting here trips the >= guard below, which
-         * silently leaves the tensor's bytes on the device counter forever. */
+        /* Must mirror the upload's accounting exactly -- literally the same
+         * expression upload uses to charge (scale_count * sizeof(float), gated
+         * on fmt=6 never having a separate scale buffer), so the two can no
+         * longer drift independently. Over-subtracting here trips the >= guard
+         * below, which silently leaves the tensor's bytes on the device counter
+         * forever. */
         size_t storage_bytes =
 #ifdef COLI_ANS
             tensor->compressed ? tensor->archive_bytes :
 #endif
             tensor->weight_bytes;
         size_t bytes = storage_bytes +
-            ((tensor->fmt && tensor->fmt != 6) ? (size_t)tensor->O * ng * sizeof(float) : 0);
+            ((tensor->fmt && tensor->fmt != 6) ? tensor->scale_count * sizeof(float) : 0);
         if (ctx->tensor_count) ctx->tensor_count--;
         if (ctx->tensor_bytes >= bytes) ctx->tensor_bytes -= bytes;
     }

--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -2311,13 +2311,19 @@ extern "C" void coli_cuda_tensor_free(ColiCudaTensor *tensor) {
 
 extern "C" size_t coli_cuda_tensor_bytes(const ColiCudaTensor *tensor) {
     if (!tensor) return 0;
-    int ng = tensor->ng > 0 ? tensor->ng : 1;
+    /* Must mirror upload's and free's accounting exactly -- literally the same
+     * expression they use (scale_count * sizeof(float), gated on fmt=6 never
+     * having a separate scale buffer) -- so all three can no longer drift
+     * independently. The prior `O * ng` shape over-reported for fmt=8 (real
+     * footprint is (O+127)/128 * ng block scales, not O * ng) and for fmt=6
+     * (which has no separate scale buffer at all). */
     size_t storage_bytes =
 #ifdef COLI_ANS
         tensor->compressed ? tensor->archive_bytes :
 #endif
         tensor->weight_bytes;
-    return storage_bytes + (tensor->fmt ? (size_t)tensor->O * ng * sizeof(float) : 0);
+    return storage_bytes +
+        ((tensor->fmt && tensor->fmt != 6) ? tensor->scale_count * sizeof(float) : 0);
 }
 
 extern "C" int coli_cuda_tensor_device(const ColiCudaTensor *tensor) {

--- a/c/tests/test_fp8_cuda.cu
+++ b/c/tests/test_fp8_cuda.cu
@@ -283,6 +283,16 @@ int main(void){
                     got,want,bt->weight_bytes,bt->scale_count);
                 return 1;
             }
+            /* Independent oracle: fmt=8 footprint from quant.h's documented
+             * layout -- O*I raw e4m3 bytes + ceil(O/128)*ceil(I/128) f32 block
+             * scales (hs_n above) -- no struct fields, so the accessor cannot
+             * validate itself against the counts upload happened to store. */
+            size_t indep=(size_t)I*D+(size_t)hs_n*sizeof(float);
+            if(got!=indep||bt->scale_count!=(size_t)hs_n){
+                printf("FAIL bytes-check fmt8 independent: got %zu want %zu (%d*%d + %d*4), scale_count %zu (want %d)\n",
+                    got,indep,I,D,hs_n,bt->scale_count,hs_n);
+                return 1;
+            }
             coli_cuda_tensor_free(bt);
             free(bw);free(bs);
 

--- a/c/tests/test_fp8_cuda.cu
+++ b/c/tests/test_fp8_cuda.cu
@@ -218,8 +218,50 @@ int main(void){
         for(int c=0;c<COUNT;c++){ coli_cuda_tensor_free(tg[c]);coli_cuda_tensor_free(tu[c]);coli_cuda_tensor_free(td[c]);
             free(hg[c]);free(hu[c]);free(hd[c]);free(hgs[c]);free(hus[c]);free(hds[c]); }
         free(x);free(ysync);free(hw);free(hsc);
-        coli_cuda_shutdown();
         if(api_bad){ printf("FAIL\n"); return 1; }
+
+        /* ---- Byte-accounting regression: coli_cuda_tensor_free must undo
+         * exactly what upload charged, per scale shape. fmt=8's 128x128 block
+         * scale_count ((O+127)/128 blocks, not O rows) is the shape that once
+         * made free() over-count and trip the tensor_bytes >= bytes guard,
+         * leaving the diagnostic counter stuck non-zero forever; fmt=4 grouped
+         * (O*ng row-group scales) is covered alongside since it shares the same
+         * free()-side expression. */
+        {
+            size_t c0,b0,c1,b1;
+            coli_cuda_stats(0,&c0,&b0);
+            ColiCudaTensor *bt=nullptr;
+            uint8_t *bw=(uint8_t*)malloc((size_t)I*D); float *bs=(float*)malloc(hs_n*4);
+            for(size_t i=0;i<(size_t)I*D;i++) bw[i]=rnd_e4m3();
+            for(int i=0;i<hs_n;i++) bs[i]=ldexpf(1.f+rand()/(float)RAND_MAX,-12);
+            if(!coli_cuda_tensor_upload(&bt,bw,bs,8,D,I,0)){ printf("FAIL byte-check fmt8 upload\n"); return 1; }
+            coli_cuda_tensor_free(bt);
+            coli_cuda_stats(0,&c1,&b1);
+            if(c1!=c0||b1!=b0){
+                printf("FAIL byte-check fmt8: count %zu->%zu bytes %zu->%zu (want unchanged)\n",c0,c1,b0,b1);
+                return 1;
+            }
+            free(bw);free(bs);
+
+            const int GI=64,GO=32,GS=32;
+            int gng=(GI+GS-1)/GS;
+            ColiCudaTensor *gt=nullptr;
+            uint8_t *gw=(uint8_t*)malloc((size_t)((GI+1)/2)*GO);
+            float *gsc=(float*)malloc((size_t)GO*gng*4);
+            for(size_t i=0;i<(size_t)((GI+1)/2)*GO;i++) gw[i]=(uint8_t)rand();
+            for(int i=0;i<GO*gng;i++) gsc[i]=ldexpf(1.f+rand()/(float)RAND_MAX,-4);
+            coli_cuda_stats(0,&c0,&b0);
+            if(!coli_cuda_tensor_upload_g(&gt,gw,gsc,4,GI,GO,0,GS)){ printf("FAIL byte-check fmt4g upload\n"); return 1; }
+            coli_cuda_tensor_free(gt);
+            coli_cuda_stats(0,&c1,&b1);
+            if(c1!=c0||b1!=b0){
+                printf("FAIL byte-check fmt4g: count %zu->%zu bytes %zu->%zu (want unchanged)\n",c0,c1,b0,b1);
+                return 1;
+            }
+            free(gw);free(gsc);
+            printf("byte accounting: fmt=8 dense + fmt=4 grouped free() restores stats exactly\n");
+        }
+        coli_cuda_shutdown();
     }
     printf("OK\n"); return 0;
 }

--- a/c/tests/test_fp8_cuda.cu
+++ b/c/tests/test_fp8_cuda.cu
@@ -261,6 +261,66 @@ int main(void){
             free(gw);free(gsc);
             printf("byte accounting: fmt=8 dense + fmt=4 grouped free() restores stats exactly\n");
         }
+
+        /* ---- coli_cuda_tensor_bytes() regression: the live-tensor byte report
+         * must equal weight_bytes + scale_count*sizeof(float) exactly (fmt=6
+         * excepted: no separate scale buffer, so weight_bytes alone). The old
+         * `O * ng` shape over-reported fmt=8 (real footprint is (O+127)/128 * ng
+         * block scales, not O*ng) and charged fmt=6 a phantom O*ng*4 scale
+         * buffer it never allocates -- this is the same shape bug F4 fixed in
+         * tensor_free(), here in the sibling accessor most callers actually use
+         * for GPU-tier budget bookkeeping (c/colibri.c). */
+        {
+            ColiCudaTensor *bt=nullptr;
+            uint8_t *bw=(uint8_t*)malloc((size_t)I*D); float *bs=(float*)malloc(hs_n*4);
+            for(size_t i=0;i<(size_t)I*D;i++) bw[i]=rnd_e4m3();
+            for(int i=0;i<hs_n;i++) bs[i]=ldexpf(1.f+rand()/(float)RAND_MAX,-12);
+            if(!coli_cuda_tensor_upload(&bt,bw,bs,8,D,I,0)){ printf("FAIL bytes-check fmt8 upload\n"); return 1; }
+            size_t want=bt->weight_bytes+bt->scale_count*sizeof(float);
+            size_t got=coli_cuda_tensor_bytes(bt);
+            if(got!=want){
+                printf("FAIL bytes-check fmt8: got %zu want %zu (weight_bytes %zu + scale_count %zu*4)\n",
+                    got,want,bt->weight_bytes,bt->scale_count);
+                return 1;
+            }
+            coli_cuda_tensor_free(bt);
+            free(bw);free(bs);
+
+            const int SI=256,SO=32;   /* fmt=6: one exact 256-wide in-block, no tail */
+            size_t srb=row_bytes(6,SI);
+            ColiCudaTensor *st=nullptr;
+            uint8_t *sw=(uint8_t*)malloc(srb*SO);
+            for(size_t i=0;i<srb*(size_t)SO;i++) sw[i]=(uint8_t)rand();
+            if(!coli_cuda_tensor_upload(&st,sw,nullptr,6,SI,SO,0)){ printf("FAIL bytes-check fmt6 upload\n"); return 1; }
+            want=st->weight_bytes;
+            got=coli_cuda_tensor_bytes(st);
+            if(got!=want||st->scale_count!=0){
+                printf("FAIL bytes-check fmt6: got %zu want %zu scale_count %zu (want 0)\n",
+                    got,want,st->scale_count);
+                return 1;
+            }
+            coli_cuda_tensor_free(st);
+            free(sw);
+
+            const int GI=64,GO=32,GS=32;             /* fmt=4 grouped: unchanged regression */
+            int gng=(GI+GS-1)/GS;
+            ColiCudaTensor *gt=nullptr;
+            uint8_t *gw=(uint8_t*)malloc((size_t)((GI+1)/2)*GO);
+            float *gsc=(float*)malloc((size_t)GO*gng*4);
+            for(size_t i=0;i<(size_t)((GI+1)/2)*GO;i++) gw[i]=(uint8_t)rand();
+            for(int i=0;i<GO*gng;i++) gsc[i]=ldexpf(1.f+rand()/(float)RAND_MAX,-4);
+            if(!coli_cuda_tensor_upload_g(&gt,gw,gsc,4,GI,GO,0,GS)){ printf("FAIL bytes-check fmt4g upload\n"); return 1; }
+            want=gt->weight_bytes+gt->scale_count*sizeof(float);
+            got=coli_cuda_tensor_bytes(gt);
+            if(got!=want||gt->scale_count!=(size_t)GO*gng){
+                printf("FAIL bytes-check fmt4g: got %zu want %zu scale_count %zu (want %d)\n",
+                    got,want,gt->scale_count,GO*gng);
+                return 1;
+            }
+            coli_cuda_tensor_free(gt);
+            free(gw);free(gsc);
+            printf("tensor_bytes: fmt=8 dense + fmt=6 + fmt=4 grouped report exact footprint\n");
+        }
         coli_cuda_shutdown();
     }
     printf("OK\n"); return 0;


### PR DESCRIPTION
@monotophic's #1100, rebased onto `dev` by the maintainers — commits and authorship theirs. It went conflicting the moment #1098 (their own `__syncthreads()` fix) merged, since both add a test to the `cuda-test` target.

**Conflict resolution: pure union, both mechanical** — the `cuda-test` dependency line now lists both `test_absorb_determinism.cu` (from #1098) and `test_fp8_cuda.cu` (this PR), and both recipe bodies are kept in their intended order (fp8 before MXFP4, absorb-determinism last, per each test's own comment about schedule sensitivity).

Fix and its regression test unchanged. Targeting v1.7.0. Supersedes #1100 on merge.