### PR TITLE
fix(cache): make LRU victim selection respect a lowered ecap (#1034)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -390,9 +390,23 @@ static void eslot_release(ESlot *s){
 static int eslot_busy(const ESlot *s){ return __atomic_load_n(&s->in_flight,__ATOMIC_ACQUIRE)!=0; }
 static void eslots_acquire(ESlot **slots,int n){ for(int i=0;i<n;i++) eslot_acquire(slots[i]); }
 static void eslots_release(ESlot **slots,int n){ for(int i=0;i<n;i++) eslot_release(slots[i]); }
-static int eslot_lru_victim(ESlot *slots,int n){
-    int lru=-1;
-    for(int i=0;i<n;i++) if(!eslot_busy(&slots[i])&&(lru<0||slots[i].used<slots[lru].used)) lru=i;
+/* Victim per una riga piena (#1034): uno slot svuotato da rss_guard (eid=-1,
+ * slab=NULL) e' riusabile SOLO finche' gli slab vivi della riga stanno sotto
+ * ecap — riusarlo rialloca uno slab, quindi e' crescita, non eviction. Le
+ * prenotazioni in volo (eid<-1) contano come vive: stanno per possederne uno.
+ * EN: reusing a slab-less slot re-allocates, so it only counts as eviction
+ * EN: while the row's live-slab count is under ecap; else pick a slab owner. */
+static int eslot_lru_victim(ESlot *slots,int n,int ecap){
+    int lru=-1, empty=-1, live=0;
+    for(int i=0;i<n;i++){
+        ESlot *s=&slots[i];
+        if(s->slab || s->eid<-1) live++;
+        if(eslot_busy(s) || s->eid<-1) continue;
+        if(!s->slab){ if(s->eid==-1 && empty<0) empty=i; continue; }
+        if(s->eid==-1) return i;              /* slot libero che possiede ancora lo slab */
+        if(lru<0 || s->used<slots[lru].used) lru=i;
+    }
+    if(empty>=0 && live<ecap) return empty;   /* sotto il tetto: meglio il vuoto che sfrattare */
     return lru;
 }
 
@@ -5555,9 +5569,9 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out, int 
           int promo = nmiss<m->ecap ? nmiss : m->ecap;
           for(int a=0;a<promo;a++){ int q=nmiss-1-a; ESlot *dst;
               if(*nn<m->ecap) dst=&Sl[(*nn)++];
-              else { int lru=eslot_lru_victim(Sl,*nn);
+              else { int lru=eslot_lru_victim(Sl,*nn,m->ecap);
                      if(lru<0){ static int warned;
-                         if(!warned){ warned=1; fprintf(stderr,"[CUDA] all LRU expert slots are in flight; skipping cache promotion\n"); }
+                         if(!warned){ warned=1; fprintf(stderr,"[CUDA] no reusable LRU expert slot (in flight or cap reached); skipping cache promotion\n"); }
                          continue; }
                      dst=&Sl[lru]; }
               ESlot tmp=*dst; *dst=m->ws[q]; m->ws[q]=tmp; dst->used=(uint64_t)__atomic_add_fetch(&m->eclock,1,__ATOMIC_RELAXED); }
@@ -5749,15 +5763,9 @@ static void pilot_realload(Model *m, int layer, int eid){
     int slot,isnew=0;
     if(nn<m->ecap){ slot=nn; isnew=1; m->ecn[layer]=nn+1; }   /* cresci: pubblica subito lo slot (marcato prenotato) */
     else {
-        slot=-1;
-        for(int z=0;z<nn;z++){
-            if(eslot_busy(&Sl[z])) continue;             /* borrowed by an async GPU read */
-            if(Sl[z].eid==-1){ slot=z; break; }         /* riusa uno slot libero/fallito */
-            if(Sl[z].eid< -1) continue;                 /* prenotazione di un ALTRO worker: mai vittima */
-            if(slot<0 || Sl[z].used<Sl[slot].used) slot=z;
-        }
+        slot=eslot_lru_victim(Sl,nn,m->ecap);           /* riusa libero-con-slab, poi LRU; slot svuotati solo sotto ecap (#1034) */
         if(slot<0){ atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed);
-                    pthread_mutex_unlock(&g_pilot_mx); return; }   /* tutti gli slot sono in volo */
+                    pthread_mutex_unlock(&g_pilot_mx); return; }   /* tutti in volo, o cap raggiunto */
         /* LFRU eviction guard (#441, narrowed by #497 — folded into the SPMC selection):
          * protect the victim only when genuinely WARM (>=2 demand accesses) AND clearly
          * hotter than the speculation by tier_pick_lfru's 25%+4-freq hysteresis; the
@@ -5828,15 +5836,7 @@ static void pilot_uring_batch(Model *m){
         if(found){ pthread_mutex_unlock(&g_pilot_mx); continue; }
         int slot;
         if(nn<m->ecap){ slot=nn; m->ecn[layer]=nn+1; }
-        else{
-            slot=-1;
-            for(int z=0;z<nn;z++){
-                if(eslot_busy(&Sl[z])) continue;      /* borrowed by an async GPU read */
-                if(Sl[z].eid==-1){ slot=z; break; }
-                if(Sl[z].eid< -1) continue;          /* URING reservation in flight */
-                if(slot<0 || Sl[z].used<Sl[slot].used) slot=z;
-            }
-        }
+        else slot=eslot_lru_victim(Sl,nn,m->ecap);    /* riusa libero-con-slab, poi LRU; slot svuotati solo sotto ecap (#1034) */
         if(slot<0){ atomic_fetch_add_explicit(&g_pilot_drops,1,memory_order_relaxed); pthread_mutex_unlock(&g_pilot_mx); continue; }
         /* LFRU eviction guard (#441, narrowed by #497): protect only a genuinely WARM
          * resident (>=2 accesses) that is clearly hotter (see pilot_realload) */

--- a/c/tests/test_eslot_inflight.c
+++ b/c/tests/test_eslot_inflight.c
@@ -1,5 +1,8 @@
 /* Async CUDA groups may borrow an LRU slot until stream completion.  The
- * oldest slot is therefore not necessarily an eligible eviction victim. */
+ * oldest slot is therefore not necessarily an eligible eviction victim.
+ * And a slot whose slab was freed by rss_guard (#1034) is only reusable
+ * while the row's live-slab count stays under ecap: reusing it re-allocates
+ * a slab, which is growth, not eviction. */
 #define main coli_glm_main_unused
 #include "../colibri.c"
 #undef main
@@ -7,17 +10,33 @@
 #include <stdio.h>
 
 int main(void){
+    uint8_t dummy[4];
     ESlot slots[3]={0};
-    slots[0].used=1; slots[1].used=2; slots[2].used=3;
+    for(int i=0;i<3;i++){ slots[i].slab=dummy; slots[i].used=(uint64_t)i+1; }
 
-    if(eslot_lru_victim(slots,3)!=0) return 1;
+    if(eslot_lru_victim(slots,3,3)!=0) return 1;
     eslot_acquire(&slots[0]);
-    if(eslot_lru_victim(slots,3)!=1) return 2;
+    if(eslot_lru_victim(slots,3,3)!=1) return 2;
     eslot_acquire(&slots[1]); eslot_acquire(&slots[2]);
-    if(eslot_lru_victim(slots,3)!=-1) return 3;
+    if(eslot_lru_victim(slots,3,3)!=-1) return 3;
 
     eslot_release(&slots[0]); eslot_release(&slots[1]); eslot_release(&slots[2]);
-    if(eslot_lru_victim(slots,3)!=0) return 4;
+    if(eslot_lru_victim(slots,3,3)!=0) return 4;
+
+    /* #1034: slot svuotato da rss_guard (eid=-1, slab=NULL) */
+    slots[1].eid=-1; slots[1].slab=NULL;
+    if(eslot_lru_victim(slots,3,2)!=0) return 5;   /* live=2>=ecap=2: eviction, non crescita */
+    if(eslot_lru_victim(slots,3,3)!=1) return 6;   /* live=2<ecap=3: il vuoto si puo' riusare */
+
+    /* slot libero che possiede ancora lo slab: riuso a costo zero, sempre preferito */
+    slots[0].eid=-1;
+    if(eslot_lru_victim(slots,3,2)!=0) return 7;
+
+    /* prenotazione in volo (eid<-1): mai vittima, e conta come slab vivo */
+    slots[0].eid=0; slots[2].eid=-5;
+    if(eslot_lru_victim(slots,3,2)!=0) return 8;   /* live=2 (slot0 + prenotazione) >= ecap */
+    if(eslot_lru_victim(slots,3,3)!=1) return 9;   /* live=2<ecap=3: di nuovo il vuoto */
+
     puts("test_eslot_inflight: ok");
     return 0;
 }


### PR DESCRIPTION
Fixes #1034.

## Root cause

`rss_guard` frees LRU slabs in place and lowers `m->ecap`, but the emptied slots stay inside `ecn[layer]` (they can't be compacted away — PILOT_REAL workers hold pointers into `ecache[]`). All three victim scans then treat an emptied slot (`eid=-1`, `slab=NULL`) as the *best* victim:

- demand-swap promotion (`eslot_lru_victim`, picked via `used=0`),
- `pilot_realload` (`if(Sl[z].eid==-1){ slot=z; break; }`),
- `pilot_uring_batch` (same shape).

Reusing a slab-less slot sends it back through `expert_load`, which `posix_memalign`s a fresh slab — so every guard pass is undone by the next few misses, RSS climbs back over budget, and the guard keeps firing and walking the cap down without ever containing memory. Exactly the `n=1444 / 1292` vs `LRU contains 1444 entries` loop in the issue's logs. `ecap` only gated the *growth* branch (`nn < ecap`), never the reuse path.

## Fix

The three duplicated scans are folded into `eslot_lru_victim`, which now knows the cap:

- a slot that still **owns a slab** is always a valid victim (eviction — memory can't grow);
- an **emptied** slot is only reusable while the row's live-slab count is under `ecap` (reuse = re-allocation = growth);
- in-flight reservations (`eid < -1`) count as live, since they are about to own a slab, and are never victims (unchanged);
- below the cap the empty slot is still preferred over evicting a resident expert, so steady-state behavior away from the guard is unchanged.

Net effect: after `rss_guard` drops slabs, the row's live-slab count can only go down toward the new cap, never back up past it.

## Testing

- `tests/test_eslot_inflight.c` extended: emptied slot refused at `live >= ecap`, allowed under it; free-slot-with-slab still preferred; reservations count as live and are never picked. Passes.
- `make test-c`: all green (0 failures), zero-warning build.

I don't have a 40 GB+ MoE setup on this box to reproduce the original RSS creep end-to-end; @tonnthuir, if you still have the debug harness from the report, a run with this patch should show the `n=... / ...` pair converging instead of the drop/refill loop.