### PR TITLE
fix(telemetry): honour USAGE_SAVE=0 in every engine (#1039)

### DIFF
--- a/c/inkling.c
+++ b/c/inkling.c
@@ -1105,8 +1105,7 @@ static int usage_save(Model *m, const char *snap) {
     (void)m;                              /* the counters live in route_trace.h now */
     char up[2048];
     const char *env = getenv("PIN");
-    const char *sv = getenv("USAGE_SAVE");
-    if (sv && *sv == '0') return 0;
+    /* USAGE_SAVE=0 is honoured inside rt_save itself (#1039) */
     if (env && (!strcmp(env, "off") || !strcmp(env, "0"))) return 0;
     if (env) snprintf(up, sizeof(up), "%s", env);
     else snprintf(up, sizeof(up), "%s/.coli_usage", snap);

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -2712,9 +2712,8 @@ int main(int argc, char **argv){
      * rates this engine runs at). */
     printf("TUNE decode: %d tokens in %.3fs\n", ntok, dt);
     if(m.trace) fclose(m.trace);
-    { const char *sv=getenv("USAGE_SAVE");
-      if(!(sv && atoi(sv)==0) && g_k3_usage[0])
-          rt_save(g_k3_usage,0); }                   /* same bytes as every other engine */
+    if(g_k3_usage[0])                                /* USAGE_SAVE=0 honoured inside rt_save (#1039) */
+        rt_save(g_k3_usage,0);                       /* same bytes as every other engine */
     if(g_k3_val_fp){ fflush(g_k3_val_fp); fclose(g_k3_val_fp); g_k3_val_fp=NULL; }
     if(g_k3_val_lfp){ fflush(g_k3_val_lfp); fclose(g_k3_val_lfp); g_k3_val_lfp=NULL; }
 #ifdef COLI_METAL

--- a/c/route_trace.h
+++ b/c/route_trace.h
@@ -321,6 +321,12 @@ static void rt_decay(void){
 
 static int rt_save(const char *path, int quiet){
     if(!rt_c || !path || !*path) return 0;
+    /* USAGE_SAVE=0: read-only run — the history is loaded but never written back
+     * (#1039: benchmark loops must not skew the very profile they are measuring).
+     * Checked HERE so every engine honours the same switch with the same
+     * truthiness; a requested skip is a success, not a save failure. */
+    { const char *sv = getenv("USAGE_SAVE");
+      if(sv && atoi(sv)==0) return 1; }
     rt_decay();
     int64_t tot = 0, nz = 0;
     for(int i = 0; i <= rt_nl; i++){

--- a/c/tests/test_route_trace.c
+++ b/c/tests/test_route_trace.c
@@ -301,9 +301,37 @@ int main(void){
         }
     }
 
+    /* 8. USAGE_SAVE=0 is a read-only run (#1039): rt_save reports success but the
+     * file must not be touched — a benchmark loop relies on the profile it measures
+     * staying frozen. Enforced in rt_save itself so every engine gets it. */
+    {
+        rt_counts(3)[4] = 99;
+#ifdef _WIN32
+        _putenv_s("USAGE_SAVE", "0");
+#else
+        setenv("USAGE_SAVE", "0", 1);
+#endif
+        long before = fsize(TMP);
+        check(rt_save(TMP, 1) == 1, "USAGE_SAVE=0: a requested skip is not a failure");
+        check(fsize(TMP) == before, "USAGE_SAVE=0: the history file is not rewritten");
+#ifdef _WIN32
+        _putenv_s("USAGE_SAVE", "1");
+#else
+        setenv("USAGE_SAVE", "1", 1);
+#endif
+        check(rt_save(TMP, 1) == 1, "USAGE_SAVE=1: saving works again");
+        check(fsize(TMP) != before, "USAGE_SAVE=1: the new counter reaches the file");
+#ifdef _WIN32
+        _putenv_s("USAGE_SAVE", "");
+#else
+        unsetenv("USAGE_SAVE");
+#endif
+    }
+
     remove(TMP);
     if(g_nfails){ printf("route_trace: %d FAILED\n", g_nfails); return 1; }
     printf("route_trace: empty-history size, round trip, legacy read, refusals, "
-           "admitted-only totals, trusted read, dropped rows, old-reader contract ok\n");
+           "admitted-only totals, trusted read, dropped rows, old-reader contract, "
+           "USAGE_SAVE=0 read-only ok\n");
     return 0;
 }

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -361,6 +361,8 @@ documented with defaults in
 the ones you are most likely to set: `DSV4_CUDA` (GPU tier on/off),
 `COLI_CUDA_ATTN_BATCH=1`, `COLI_CUDA_MOE_BATCH=1`, `DSV4_CUDA_EXPERT_MIRRORS`,
 `V4_MOE_REFILL_GROUP`, `V4_PREFILL_SEGMENT`, `V4_PREFIX_CKPT*`, `CTX`.
+`COLI_V4_SAVE_USAGE=0` is an engine-specific alias that disables only V4's
+usage rewrite; the shared `USAGE_SAVE=0` covers this engine too.
 
 ## OLMoE engine (`olmoe`)
 


### PR DESCRIPTION
Fixes #1039.

@mohamedmastouri2000-boop's diagnosis is exact, and their suggested shape — fix it once in the shared code so every engine (and any future one) inherits it — is what this does, one level lower than proposed. The check lands in `rt_save()` itself rather than `telemetry.h`'s `usage_save()`: **every engine's history write already funnels through `rt_save`** (telemetry.h → `stats_dump_q` → `rt_save` for GLM; direct `rt_save` calls in olmoe, kimi_k3, inkling, deepseek_v4), so one definition covers all five, and `docs/ENVIRONMENT.md:23`'s claim that the variable lives in `route_trace.h` becomes true instead of aspirational.

Decisions that wanted a maintainer call, made explicit here so they're easy to veto:

- **Truthiness**: `sv && atoi(sv)==0` — the convention kimi_k3 and V4 already used (majority), rather than inkling's `*sv=='0'` (both accept the documented `=0`). The reporter deferred this choice to you.
- **A requested skip returns success (1), not failure (0)** — V4's `hot_usage_save` warns on `!rt_save(...)`; a read-only run the user asked for must not print `cannot-save-history`.
- **The engine-local checks in inkling and kimi_k3 are removed** — they became redundant with the shared check, and leaving them would mean two truthiness conventions for one variable.
- **`COLI_V4_SAVE_USAGE` keeps working** as a V4-only alias (someone may depend on it) and is now documented in `ENVIRONMENT.md`'s V4 section; `USAGE_SAVE` now covers V4 as well.

## Testing

- `test_route_trace.c` gains the read-only case: under `USAGE_SAVE=0`, `rt_save` returns success and the file is byte-for-byte untouched (size-checked); flipping back to `1` writes again. Portable env setting per the `test_stops.c` convention.
- `make test-c` all green; `colibri`/`inkling`/`kimi_k3`/`olmoe` build with no new warnings (the `quant.h` unused-variable ones are pre-existing — #1032).

Verification for the reporters: the md5-stability protocol from the issue (seed with `USAGE_SAVE=1`, rerun with `USAGE_SAVE=0`, hash must not move) should now hold on `glm_moe_dsa` and olmoe — @siongchin87's OLMoE repro is the same funnel.