### PR TITLE
docs(readme): the sixth family, and one logo across every translation

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/colibri.svg" width="500" alt="colibrì — motore piccolo, modello immenso">
+  <img src="assets/colibri-logo.svg" width="560" alt="colibrì — motore piccolo, modello immenso">
 </p>
 
 <p align="center">
@@ -12,9 +12,9 @@ miliardi a 2,8 mila miliardi di parametri** — su hardware consumer ed eterogen
 in C puro e senza dipendenze del motore, trattando storage, RAM e VRAM come
 un'unica gerarchia di inferenza.
 
-Oggi girano quattro famiglie: **GLM-5.2** (744B), **Inkling** (975B), **Kimi K3**
-(2,8T) e **OLMoE** (7B) — un file C ciascuna, la stessa interfaccia `coli chat` /
-`coli serve` / `coli web`. [Elenco completo](README.md#other-supported-models)
+Oggi girano sei famiglie: **GLM-5.2** (744B), **Inkling** (975B), **Kimi K3**
+(2,8T), **DeepSeek V4 Flash** (284B), **Qwen3.6** (35B-A3B) e **OLMoE** (7B) — un
+file C ciascuna, la stessa interfaccia `coli chat` / `coli serve` / `coli web`. [Elenco completo](README.md#other-supported-models)
 
 > **Colibrì è un motore di inferenza che puoi usare oggi, e una piattaforma di
 > ricerca aperta.** Il suo obiettivo principale è migliorare le prestazioni di

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ parameters** — on consumer and heterogeneous hardware, in pure C with zero
 engine dependencies, by treating storage, RAM, and VRAM as a single inference
 hierarchy (AI memory multitiering).
 
-Five families run today: **GLM-5.2** (744B), **Inkling** (975B), **Kimi K3**
-(2.8T), **DeepSeek V4 Flash** (284B) and **OLMoE** (7B) — one C file each, the
-same `coli chat` / `coli serve` / `coli web` front end.
+Six families run today: **GLM-5.2** (744B), **Inkling** (975B), **Kimi K3**
+(2.8T), **DeepSeek V4 Flash** (284B), **Qwen3.6** (35B-A3B) and **OLMoE** (7B) —
+one C file each, the same `coli chat` / `coli serve` / `coli web` front end.
 [Full roster ↓](#other-supported-models)
 
 > **Colibrì is an inference engine you can run today, and an open research
@@ -390,7 +390,7 @@ the full 756 GB on disk at once:
 
 #### Other supported models
 
-GLM-5.2 is the reference model, but the same streaming approach runs three more
+GLM-5.2 is the reference model, but the same streaming approach runs five more
 families. Each is a **sibling engine** — one C file, its own architecture, the same
 `coli chat` / `coli serve` / `coli web` front end (the launcher picks the binary from
 the model's `config.json`):
@@ -407,6 +407,7 @@ the model's `config.json`):
 > | **Inkling** | ~469 GB | 25 GB with the int4 dense container, ~120 GB without | not needed |
 > | **Kimi K3** | ~1.6 TB | 32 GB+ | not needed |
 > | **DeepSeek V4 Flash** | ~167 GB | 16 GB min, 32 GB comfortable | optional; an NVIDIA card (any sm_80+, best on RTX 50) makes prefill 5-10x and decode ~2.5x faster |
+> | **Qwen3.6-35B-A3B** | ~20 GB (int4-gs64 container) | 24 GB (needs full RAM residency) | optional; the CUDA VRAM expert tier measured **1.44 -> 10.05 tok/s (7.0x)** on two 8 GB cards, output bit-identical to CPU |
 >
 > A GPU only ever makes it faster. Speed is set by your disk, because the experts
 > are streamed from it — expect a fraction of a token per second on a slow drive
@@ -418,7 +419,16 @@ the model's `config.json`):
 | **Inkling** (Thinking Machines) | 975B / 41B | [`nbeerbower/Inkling-colibri-int4`](https://huggingface.co/nbeerbower/Inkling-colibri-int4) (469 GB) | `make -C c inkling` | [inkling.md](docs/inkling.md) |
 | **Kimi K3** (Moonshot) | 2.8T / 104B | [`moonshotai/Kimi-K3`](https://huggingface.co/moonshotai/Kimi-K3) — original checkpoint, routed experts stay **native MXFP4** | `make -C c kimi_k3` | [kimi_k3.md](docs/kimi_k3.md) |
 | **DeepSeek V4 Flash** | 284B / 13B | official sharded checkpoint — routed experts stay **native fp4**, dense stays fp8-e4m3 | `make -C c deepseek-v4` | [deepseek-v4.md](docs/deepseek-v4.md) |
+| **Qwen3.6** (Alibaba) | 35B / 3B | [`Kreuzzelg/qwen36-35b-a3b-colibri-i4-gs64`](https://huggingface.co/Kreuzzelg/qwen36-35b-a3b-colibri-i4-gs64) (~20 GB, **recommended**) — hybrid Gated Attention + Gated DeltaNet | `make -C c qwen36` (`CUDA=1` for the VRAM expert tier) | [qwen36.md](docs/qwen36.md) |
 | **OLMoE** (AI2) | 7B / 1B | converted with `c/tools/convert_olmoe_merged.py` — **int8** container, ~7 GB | `make -C c olmoe` | — |
+
+Qwen3.6 ships three pre-converted containers: **int4-gs64** (recommended — measured
+cosine to the int8 anchor 0.98777 → 0.99313 and KL 0.109 → 0.080 against per-row, i.e.
+~44% less quantization error), [int4 per-row](https://huggingface.co/Kreuzzelg/qwen36-35b-a3b-colibri-i4)
+as the A/B baseline, and [KAT-Coder v2.5](https://huggingface.co/Kreuzzelg/kat-coder-v2.5-dev-colibri-i4-gs64),
+which the same engine runs unchanged — any architecture-identical checkpoint works
+without a code path of its own. With `CUDA=1` the VRAM expert tier measured
+**1.44 → 10.05 tok/s (7.0×) on two 8 GB cards**, output bit-identical to the CPU path.
 
 Kimi K3 needs no conversion: its QAT-trained MXFP4 experts are streamed straight from
 the original Hugging Face shards, and the bf16 dense set is quantized at load time.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/colibri.svg" width="500" alt="colibrì——小巧引擎，庞大模型">
+  <img src="assets/colibri-logo.svg" width="560" alt="colibrì——小巧引擎，庞大模型">
 </p>
 
 <p align="center">
@@ -10,9 +10,9 @@
 **小巧引擎，庞大模型。**在消费级与异构硬件上运行**前沿 MoE 模型——从 744B 到
 2.8T 参数**——以引擎零依赖的纯 C 实现，将存储、RAM 与 VRAM 视为统一的推理层级。
 
-目前可运行四个模型家族：**GLM-5.2**（744B）、**Inkling**（975B）、**Kimi K3**
-（2.8T）与 **OLMoE**（7B）——各自一个 C 文件，共用同一套 `coli chat` /
-`coli serve` / `coli web` 前端。[完整列表](README.md#other-supported-models)
+目前可运行六个模型家族：**GLM-5.2**（744B）、**Inkling**（975B）、**Kimi K3**
+（2.8T）、**DeepSeek V4 Flash**（284B）、**Qwen3.6**（35B-A3B）与 **OLMoE**（7B）
+——各自一个 C 文件，共用同一套 `coli chat` / `coli serve` / `coli web` 前端。[完整列表](README.md#other-supported-models)
 
 > **Colibrì 既是今天就能运行的推理引擎，也是一个开放的研究平台。**它的首要目标是在
 > 完整的软硬件边界上追求推理侧性能——模型格式、内存层级、存储 I/O、放置、调度、内核、

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/colibri.svg" width="500" alt="colibrì——小巧引擎，龐大模型">
+  <img src="assets/colibri-logo.svg" width="560" alt="colibrì——小巧引擎，龐大模型">
 </p>
 
 <p align="center">
@@ -10,9 +10,9 @@
 **小巧引擎，龐大模型。**在消費級與異質硬體上執行**前沿 MoE 模型——從 744B 到
 2.8T 參數**——以引擎零相依套件的純 C 實作，將儲存、RAM 與 VRAM 視為統一的推論階層。
 
-目前可執行四個模型家族：**GLM-5.2**（744B）、**Inkling**（975B）、**Kimi K3**
-（2.8T）與 **OLMoE**（7B）——各自一個 C 檔案，共用同一套 `coli chat` /
-`coli serve` / `coli web` 前端。[完整清單](README.md#other-supported-models)
+目前可執行六個模型家族：**GLM-5.2**（744B）、**Inkling**（975B）、**Kimi K3**
+（2.8T）、**DeepSeek V4 Flash**（284B）、**Qwen3.6**（35B-A3B）與 **OLMoE**（7B）
+——各自一個 C 檔案，共用同一套 `coli chat` / `coli serve` / `coli web` 前端。[完整清單](README.md#other-supported-models)
 
 > **Colibrì 既是今天就能執行的推論引擎，也是一個開放的研究平台。**它的首要目標是在
 > 完整的軟硬體邊界上追求推論側效能——模型格式、記憶體階層、儲存 I/O、配置、排程、核心、


### PR DESCRIPTION
Three things the READMEs had fallen behind on.

**1. Family count.** The English README said *five*; the Italian and both Chinese translations still said **four** — they had never picked up DeepSeek V4 from v1.5.0. All four now say **six** and name the same six families.

**2. Qwen3.6 was missing entirely.** Added to the model table with its three pre-converted containers — int4-gs64 (recommended: measured cosine to the int8 anchor 0.98777 → 0.99313, KL 0.109 → 0.080 vs per-row, ~44% less quantization error), the per-row A/B baseline, and KAT-Coder v2.5 which the same engine runs unchanged. Plus the requirements row and the CUDA tier's **1.44 → 10.05 tok/s (7.0×) on two 8 GB cards, bit-identical to CPU**.

**3. One logo everywhere.** `assets/colibri-logo.svg` at 560px was only in the English README; the three translations still pointed at the old `assets/colibri.svg` at 500px. Now identical across all four, alt text preserved per language.

Docs only — no code, no behaviour. Targets `dev`; goes to `main` with the next release.