### PR TITLE
perf(iobench): sub-MB block sizes, and [threads] was a no-op on Windows

### DIFF
--- a/c/iobench.c
+++ b/c/iobench.c
@@ -2,6 +2,8 @@
  * Misura cio' che fa il motore davvero: N thread che leggono in parallelo
  * (expert_load sotto omp parallel for), buffered oppure O_DIRECT.
  * uso: ./iobench <file_grande> [blocco_MB] [n_letture] [threads] [direct 0/1]
+ * blocco_MB accetta frazioni: 0.75 = 768 KiB. Un expert di un MoE
+ * fine-grained sta sotto 1 MB, e atol() lo troncava a 0.
  * build: gcc -O2 -fopenmp iobench.c -o iobench */
 #define _GNU_SOURCE
 #include <stdio.h>
@@ -17,28 +19,42 @@
 #include <omp.h>
 #endif
 static double now(){ struct timespec t; clock_gettime(CLOCK_MONOTONIC,&t); return t.tv_sec+t.tv_nsec*1e-9; }
+/* Un fd PER THREAD, non uno condiviso. Su Windows compat_open_direct() apre un
+ * handle SINCRONO (FILE_FLAG_NO_BUFFERING senza FILE_FLAG_OVERLAPPED), e ReadFile
+ * su un handle sincrono viene serializzato dal lock dell'oggetto file: con un fd
+ * condiviso il parametro [threads] non aveva alcun effetto e la misura restava
+ * sempre a queue-depth 1. Su Linux/macOS la pread posizionale gia' concorre; un
+ * fd per thread e' comunque corretto e non costa nulla. */
+static int bench_open(const char *path, int *direct){
+#ifdef O_DIRECT
+    int fd=open(path,O_RDONLY|(*direct?O_DIRECT:0));
+    if(fd<0 && *direct){ fprintf(stderr,"O_DIRECT is unavailable (%s); using buffered I/O\n",strerror(errno));
+        *direct=0; fd=open(path,O_RDONLY); }
+#elif defined(_WIN32)
+    int fd = *direct ? compat_open_direct(path) : open(path,COMPAT_O_RDONLY);
+    if(fd<0 && *direct){ fprintf(stderr,"NO_BUFFERING is unavailable; using buffered I/O\n");
+        *direct=0; fd=open(path,COMPAT_O_RDONLY); }
+#else
+    int fd=open(path,O_RDONLY);                 /* macOS: F_NOCACHE ~ O_DIRECT */
+#ifdef __APPLE__
+    if(*direct && fd>=0) fcntl(fd,F_NOCACHE,1);
+#else
+    if(*direct){ fprintf(stderr,"O_DIRECT is unavailable; using buffered I/O\n"); *direct=0; }
+#endif
+#endif
+    return fd;
+}
+
 int main(int argc,char**argv){
     if(argc<2){fprintf(stderr,"usage: %s file [blkMB] [n] [threads] [direct 0/1]\n",argv[0]);return 1;}
-    long blk=(argc>2?atol(argv[2]):19)*1024*1024;
+    /* atof, non atol: atol("0.75") = 0 e il blocco sub-MB spariva.
+     * O_DIRECT vuole una lunghezza allineata al settore: arrotonda a 4096. */
+    long blk=(long)((argc>2?atof(argv[2]):19)*1024*1024);
+    blk=(blk+4095)&~4095L; if(blk<4096) blk=4096;
     int n=argc>3?atoi(argv[3]):64;
     int nth=argc>4?atoi(argv[4]):8;
     int direct=argc>5?atoi(argv[5]):1;
-#ifdef O_DIRECT
-    int fd=open(argv[1],O_RDONLY|(direct?O_DIRECT:0));
-    if(fd<0 && direct){ fprintf(stderr,"O_DIRECT is unavailable (%s); using buffered I/O\n",strerror(errno));
-        direct=0; fd=open(argv[1],O_RDONLY); }
-#elif defined(_WIN32)
-    int fd = direct ? compat_open_direct(argv[1]) : open(argv[1],COMPAT_O_RDONLY);
-    if(fd<0 && direct){ fprintf(stderr,"NO_BUFFERING is unavailable; using buffered I/O\n");
-        direct=0; fd=open(argv[1],COMPAT_O_RDONLY); }
-#else
-    int fd=open(argv[1],O_RDONLY);                 /* macOS: F_NOCACHE ~ O_DIRECT */
-#ifdef __APPLE__
-    if(direct && fd>=0) fcntl(fd,F_NOCACHE,1);
-#else
-    if(direct){ fprintf(stderr,"O_DIRECT is unavailable; using buffered I/O\n"); direct=0; }
-#endif
-#endif
+    int fd = bench_open(argv[1], &direct);
     if(fd<0){perror("open");return 1;}
 #ifdef _WIN32
     off_t sz=compat_fsize(fd);     /* CRT lseek(SEEK_END) ritorna -1 sui fd NO_BUFFERING */
@@ -55,15 +71,18 @@ int main(int argc,char**argv){
     #pragma omp parallel num_threads(nth) reduction(+:tot)
     {
         void *buf; if(posix_memalign(&buf,4096,blk)){perror("memalign");exit(1);}
+        int d2=direct, tfd=bench_open(argv[1],&d2);   /* fd privato: vedi bench_open */
+        if(tfd<0){perror("open");exit(1);}
         #pragma omp for schedule(dynamic,1)
         for(int i=0;i<n;i++){
-            ssize_t r=pread(fd,buf,blk,offs[i]);
+            ssize_t r=pread(tfd,buf,blk,offs[i]);
             if(r<0) perror("pread"); else tot+=r;
         }
+        close(tfd);
         compat_aligned_free(buf);   /* su Windows posix_memalign=_aligned_malloc: free() corrompe l'heap */
     }
     double dt=now()-t0;
-    printf("%s x%d threads: %d reads x %ldMB = %.1f GB in %.2fs -> %.2f GB/s (%.1f effective ms/block)\n",
-        direct?"O_DIRECT":"buffered", nth, n, blk/1024/1024, tot/1e9, dt, tot/1e9/dt, dt/n*1000);
+    printf("%s x%d threads: %d reads x %.4g MB = %.1f GB in %.2fs -> %.2f GB/s (%.1f effective ms/block)\n",
+        direct?"O_DIRECT":"buffered", nth, n, blk/1048576.0, tot/1e9, dt, tot/1e9/dt, dt/n*1000);
     close(fd); free(offs); return 0;
 }

--- a/c/tools/blocksweep.py
+++ b/c/tools/blocksweep.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Sweep iobench across block sizes and thread counts; print a datapoint block.
+
+An expert's on-disk size is fixed at conversion time by the model's geometry --
+``3 * d_model * moe_intermediate_size * bits/8`` for a SwiGLU expert -- and the engine
+reads one expert per request. So the architecture chooses where on the drive's
+block-size curve the whole streaming path operates, and that curve is not flat: on a
+consumer NVMe it is steep below ~1 MB and saturated above it.
+
+This walks that curve with the engine's own microbenchmark so the numbers are
+comparable with every other iobench figure in the tracker.
+
+Stdlib only, like tools/datapoint.py.
+
+Usage:
+  python tools/blocksweep.py --shard /path/to/out-00069.safetensors
+  python tools/blocksweep.py --shard <file> --threads 1 4 8 --reads 128 --repeats 5
+
+The default block list spans the expert sizes real MoE containers produce, from a
+fine-grained 128-wide expert up to GLM-5.2's ~19 MB.
+"""
+
+import argparse
+import os
+import re
+import statistics
+import subprocess
+import sys
+
+GBS = re.compile(r"->\s*([\d.]+)\s*GB/s")
+
+# expert bytes for a SwiGLU expert at int4, in MB, for a few (d_model, ff) shapes
+DEFAULT_BLOCKS = [0.1875, 0.375, 0.75, 1.5, 3.0, 6.0, 12.0, 19.0]
+
+
+def run(iobench, shard, blk, reads, threads, direct):
+    p = subprocess.run([iobench, shard, str(blk), str(reads), str(threads), str(direct)],
+                       capture_output=True, text=True)
+    m = GBS.search(p.stdout)
+    if not m:
+        sys.stderr.write(f"  ! no GB/s in output for blk={blk} t={threads}: "
+                         f"{(p.stdout + p.stderr)[:160]!r}\n")
+        return None
+    return float(m.group(1))
+
+
+def human(mb):
+    return f"{mb*1024:.0f} KB" if mb < 1 else (f"{mb:.0f} MB" if mb == int(mb)
+                                               else f"{mb:.1f} MB")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--iobench", default="./iobench", help="iobench binary")
+    ap.add_argument("--shard", required=True,
+                    help="a large file to read; a container shard is ideal")
+    ap.add_argument("--blocks", type=float, nargs="+", default=DEFAULT_BLOCKS,
+                    help="block sizes in MB (fractions allowed)")
+    ap.add_argument("--threads", type=int, nargs="+", default=[1, 4, 8])
+    ap.add_argument("--reads", type=int, default=128)
+    ap.add_argument("--repeats", type=int, default=3)
+    ap.add_argument("--buffered", action="store_true",
+                    help="also measure buffered reads (default: O_DIRECT only)")
+    a = ap.parse_args()
+
+    if not os.path.exists(a.shard):
+        sys.exit(f"no such file: {a.shard}")
+    if not (os.path.exists(a.iobench) or os.path.exists(a.iobench + ".exe")):
+        sys.exit(f"no iobench at {a.iobench} -- build it first:\n"
+                 f"  gcc -D_FILE_OFFSET_BITS=64 -O2 -fopenmp iobench.c -o iobench")
+
+    size_mb = os.path.getsize(a.shard) / (1 << 20)
+    blocks = [b for b in a.blocks if b * 2 <= size_mb]
+    if len(blocks) < len(a.blocks):
+        dropped = [human(b) for b in a.blocks if b not in blocks]
+        sys.stderr.write(f"note: {a.shard} is {size_mb:.0f} MB; iobench needs a file at "
+                         f"least 2x the block, so dropping {', '.join(dropped)}\n")
+
+    modes = [1, 0] if a.buffered else [1]
+    rows = []
+    for blk in blocks:
+        row = {"blk": blk}
+        for direct in modes:
+            for t in a.threads:
+                vals = [v for v in (run(a.iobench, a.shard, blk, a.reads, t, direct)
+                                    for _ in range(a.repeats)) if v is not None]
+                if vals:
+                    row[(direct, t)] = (statistics.median(vals), min(vals), max(vals))
+                print(f"  {human(blk):>9}  {'O_DIRECT' if direct else 'buffered':>8}  "
+                      f"{t:>2}T  {row.get((direct,t),(float('nan'),))[0]:.2f} GB/s",
+                      flush=True)
+        rows.append(row)
+
+    print()
+    print(f"**Drive block-size curve** — `{os.path.basename(a.shard)}`, "
+          f"{a.reads} reads, median of {a.repeats}, GB/s")
+    print()
+    for direct in modes:
+        if len(modes) > 1:
+            print(f"*{'O_DIRECT' if direct else 'buffered'}*")
+            print()
+        print("| expert size | " + " | ".join(f"{t} thread{'s' if t > 1 else ''}"
+                                              for t in a.threads) + " |")
+        print("|---" * (len(a.threads) + 1) + "|")
+        for r in rows:
+            cells = []
+            for t in a.threads:
+                v = r.get((direct, t))
+                cells.append(f"{v[0]:.2f} ± {(v[2]-v[1])/2:.2f}" if v else "—")
+            print(f"| {human(r['blk'])} | " + " | ".join(cells) + " |")
+        print()
+    print("Please also state: drive model, bus (PCIe 3/4/5), DRAM-less/HMB or not, "
+          "filesystem, and OS.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Two fixes to `c/iobench.c`, both of which change what it measures, plus a small tool that uses them.

Neither touches the engine. `iobench` is standalone and builds from its own make target.

## 1. Sub-MB block sizes were inexpressible

```c
long blk=(argc>2?atol(argv[2]):19)*1024*1024;
```

`atol("0.75")` is 0, so any fraction of a megabyte truncated away. GLM-5.2's experts are ~19 MB so this never mattered, but an expert's on-disk size is `3 · d_model · moe_intermediate_size · bits/8`, and a fine-grained MoE lands between roughly 0.2 and 1 MB — exactly the range the tool could not reach.

Now `atof`, rounded up to 4096 because `O_DIRECT` requires a sector-aligned length. The result line prints `%.4g MB` so a sub-MB block is legible instead of reading `0MB`.

## 2. `[threads]` did nothing on Windows

Every thread shared one fd. `compat_open_direct()` returns a **synchronous** handle — `FILE_FLAG_NO_BUFFERING` without `FILE_FLAG_OVERLAPPED` — and `ReadFile` on a synchronous handle serialises behind the file object lock. So the thread count had no effect and every Windows `iobench` figure was really a queue-depth-1 measurement.

`compat_pread()` itself is fine; the sharing was the problem. Each thread now opens its own fd via a small `bench_open()` helper (which is just the existing platform `#ifdef` block, factored out so it can be called twice).

Measured here, Phison 512 GB NVMe, Windows 11, 768 KiB blocks, `O_DIRECT`:

| | 1T | 2T | 4T | 8T | 16T |
|---|---|---|---|---|---|
| before | 1.09 | 1.07 | 1.07 | 1.02 | 1.02 |
| after | 1.02 | 2.31 | **2.91** | 2.78 | 2.58 |

GB/s. Cross-checked against an independent Python harness using `CreateFileW` + `FILE_FLAG_NO_BUFFERING` with per-thread handles: it reports 2.85–2.95 GB/s at 4–8 threads on the same file. The two agree after the fix and disagree by ~3× before it.

This is worth knowing when reading existing Windows datapoints. #1091's thread-scaling table (1T 9.57, 2T 9.90, 4T 9.85, 8T 10.65, 12T 10.72, 16T 9.57 GB/s on native Windows) is flat, which is the signature of this bug rather than a property of that drive — worth a re-run there.

Linux and macOS behaviour is unchanged: positional `pread` already concurs, and a private fd is correct there too.

## 3. `c/tools/blocksweep.py`

Walks the curve with `iobench` and prints a ready-to-paste markdown table. Stdlib only, like `tools/datapoint.py`.

```bash
python tools/blocksweep.py --shard /path/to/out-00069.safetensors
```

On the same drive (O_DIRECT, 128 reads, median of 3), against a plateau of 3.02 GB/s at ≥1.5 MB:

| expert size | 1 thread | 4 threads | 8 threads | vs plateau | QD1 cost |
|---|---|---|---|---|---|
| 192 KB | 0.45 | 1.70 | 1.95 | **−36%** | 4.33× |
| 384 KB | 0.84 | 2.45 | 2.50 | −17% | 2.98× |
| 768 KB | 1.27 | 2.88 | 2.73 | −10% | 2.15× |
| 1.5 MB | 1.58 | 2.99 | 2.94 | −3% | 1.86× |
| 3 MB | 1.91 | 3.01 | 2.96 | −2% | 1.55× |
| 6 MB | 2.44 | 3.15 | 3.13 | +3% | 1.28× |
| 12 MB | 2.55 | 3.07 | 3.07 | +1% | 1.20× |

Both effects are graded and monotone in expert size: smaller experts lose bandwidth outright, and lose proportionally more of it at low queue depth. There is no sharp knee — the penalty decays smoothly and is under 5% only above roughly 1.5 MB.

That last column is relevant to #441 (PILOT prefetch at queue depth 1): its cost is ~4× for a fine-grained container and ~1.2× for GLM-5.2's ~19 MB experts, so how much that issue matters depends strongly on the model being streamed.

**One drive, one platform.** The position of the roll-off depends on the controller, the NAND and whether the drive has DRAM, so none of this generalises until someone replicates it. That is why the script is here: it needs no model download and no engine build beyond `iobench`, so a datapoint costs a couple of minutes on any machine with an SSD and a large file.

## Checks

- `make iobench` builds with the repo's own CFLAGS, **0 warnings** (gcc 15, MinGW-w64, `-Wall -Wextra`).
- Backward compatible: an integer argument behaves as before (`19` → `19 MB`), the no-argument default is unchanged, and `tools/datapoint.py`'s `IOBENCH_RE` only captures the `-> N GB/s` field, which is untouched.
- Verified on Windows 11 / MSYS2. **Not yet built or run on Linux or macOS** — the changes are inside the existing per-platform `#ifdef` arms and only re-parenthesise them, but a second pair of eyes on those arms would be welcome.
