### PR TITLE
fix(tools): probe real RAM on win32 in datapoint.py (#1042)

### DIFF
--- a/c/tests/test_datapoint.py
+++ b/c/tests/test_datapoint.py
@@ -1,0 +1,53 @@
+"""machine_info() must report the machine's real RAM on win32 (#1042).
+
+ram_gb sizes the eviction write in evict_cache(): a hardcoded 8.0 on a
+128 GB box writes 9 GB, evicts nothing, and the run labelled "cold" is
+measured warm and published as cold. These tests run on any host by
+mocking sys.platform and the two win32 probes.
+"""
+import ctypes
+import sys
+import unittest
+from unittest import mock
+
+from tools import datapoint
+
+GB = 1073741824
+
+
+class MachineInfoWin32Test(unittest.TestCase):
+    def _win32_info(self, memstatus_ok, total_phys=128 * GB):
+        def fake_memstatus(argp):
+            if not memstatus_ok:
+                return 0
+            argp._obj.ullTotalPhys = total_phys
+            return 1
+
+        windll = mock.MagicMock()
+        windll.kernel32.GlobalMemoryStatusEx.side_effect = fake_memstatus
+        with mock.patch.object(sys, "platform", "win32"), \
+             mock.patch.object(ctypes, "windll", windll, create=True):
+            return datapoint.machine_info()
+
+    def test_win32_reports_real_ram(self):
+        info = self._win32_info(memstatus_ok=True)
+        self.assertAlmostEqual(info["ram_gb"], 128.0)
+        self.assertEqual(info["ram"], "128 GB")
+        self.assertTrue(info["os"].startswith("Windows"))
+
+    def test_win32_probe_failure_falls_back(self):
+        """A failed probe keeps the old conservative default rather than 0.0 —
+        an eviction write sized from 0 GB would silently evict nothing."""
+        info = self._win32_info(memstatus_ok=False)
+        self.assertEqual(info["ram_gb"], 8.0)
+        self.assertEqual(info["ram"], "?")
+
+    def test_unknown_platform_keeps_fallback(self):
+        with mock.patch.object(sys, "platform", "freebsd14"):
+            info = datapoint.machine_info()
+        self.assertEqual(info["ram_gb"], 8.0)
+        self.assertEqual(info["ram"], "?")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tools/datapoint.py
+++ b/c/tools/datapoint.py
@@ -56,6 +56,45 @@ def machine_info():
                     info["ram"] = f"{info['ram_gb']:.0f} GB"
                     break
         info["os"] = platform.platform()
+    elif sys.platform == "win32":
+        # ram_gb sizes the eviction write: a hardcoded 8.0 on a big box means the
+        # "cold" run is measured warm and published as cold (#1042). ctypes+winreg
+        # only — no new dependency.
+        try:
+            import ctypes
+
+            class _MEMSTATUS(ctypes.Structure):
+                _fields_ = [("dwLength", ctypes.c_ulong),
+                            ("dwMemoryLoad", ctypes.c_ulong),
+                            ("ullTotalPhys", ctypes.c_ulonglong),
+                            ("ullAvailPhys", ctypes.c_ulonglong),
+                            ("ullTotalPageFile", ctypes.c_ulonglong),
+                            ("ullAvailPageFile", ctypes.c_ulonglong),
+                            ("ullTotalVirtual", ctypes.c_ulonglong),
+                            ("ullAvailVirtual", ctypes.c_ulonglong),
+                            ("ullAvailExtendedVirtual", ctypes.c_ulonglong)]
+
+            st = _MEMSTATUS()
+            st.dwLength = ctypes.sizeof(_MEMSTATUS)
+            if not ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(st)):
+                raise OSError("GlobalMemoryStatusEx failed")
+            info["ram_gb"] = st.ullTotalPhys / 1073741824
+            info["ram"] = f"{info['ram_gb']:.0f} GB"
+        except Exception:
+            info["ram"] = "?"
+            info["ram_gb"] = 8.0
+
+        info["cpu"] = platform.processor() or "?"
+        try:
+            import winreg
+            k = winreg.OpenKey(
+                winreg.HKEY_LOCAL_MACHINE,
+                r"HARDWARE\DESCRIPTION\System\CentralProcessor\0")
+            info["cpu"] = winreg.QueryValueEx(k, "ProcessorNameString")[0].strip()
+            winreg.CloseKey(k)
+        except Exception:
+            pass
+        info["os"] = f"Windows {platform.release()} {platform.version()}"
     else:
         info["cpu"] = platform.processor() or "?"
         info["ram"] = "?"
@@ -101,6 +140,9 @@ def evict_cache(ram_gb, snap_dir=None):
 
     # Fallback: Write temp file larger than RAM
     size_mb = int(ram_gb) * 1024 + 1024
+    print(f"[datapoint] evicting page cache by writing {size_mb / 1024:.0f} GB "
+          f"to a temp file (no direct eviction on this platform; --no-evict skips)",
+          file=sys.stderr)
     try:
         with tempfile.NamedTemporaryFile(delete=True, suffix=".evict") as f:
             chunk = b"\0" * (1 << 20)


### PR DESCRIPTION
Fixes #1042.

Lands @Unknown-Findout's suggested branch essentially as written — the diagnosis and the fix are theirs. Two additions on top:

- **The `GlobalMemoryStatusEx` return value is checked.** The suggested code ignored it; on failure the struct stays zeroed, `ram_gb` becomes 0.0, and the eviction write is sized from zero — the same silent-wrong-label failure one layer down. A failed probe now falls back to the old conservative 8.0 (`ram` stays `?`, so the datapoint shows the probe failed).
- **The 'second thing worth a thought'** from the report: the portable fallback now prints a one-line notice before writing RAM+1 GB to a temp file, since on the reporter's box that is a surprising 129 GB write per run. `--no-evict` untouched.

Tests (`test_datapoint.py`, new) mock `sys.platform` and the two win32 probes per the `test_env_defaults.py` convention, so they run on any host: real-RAM path, probe-failure fallback, and the unknown-platform default. The winreg CPU-name probe degrades to `platform.processor()` off-Windows by its existing `except`.

What I could not do from this Linux box is execute the ctypes path against real `kernel32` — the CI Windows job will, and @Unknown-Findout offered a datapoint from the i9-14900K/128 GB machine once the tool runs correctly there, which would be the end-to-end confirmation.

Suite status: `make test-c` green; Python suite green except `test_cpu_vs_cpu_determinism`, which fails 4/5 runs on clean dev on this host (pre-existing wall-clock flake, unrelated — filing separately).