### PR TITLE
test: split the tok/s bound out of test_cpu_vs_cpu_determinism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,19 +501,20 @@ jobs:
         # that before reading anything else out of a run.
         run: cd c && SNAP=./glm_tiny TF=1 COLI_TEMP=0 ./colibri 64 16 16
       - name: Structural efficiency tests
-        # test_cpu_vs_cpu_determinism is NOT in this list. Despite the name its
-        # second assertion is a tok/s stability bound (two runs within 25%), and
-        # the tiny replay is 15 ms end to end -- it measured 38.8% between two
-        # identical runs on a quiet local box, so a shared runner would make it
-        # flaky on day one. Its first assertion (hit-rate identical) IS a real
-        # determinism check and does hold; splitting the two is worth doing, but
-        # not silently from a CI change.
+        # test_cpu_vs_cpu_tok_s_stability is NOT in this list: it is a tok/s
+        # bound (two runs within 25%) over a ~15 ms tiny replay -- it measured
+        # 38.8% between two identical runs on a quiet local box, so a shared
+        # runner would make it flaky on day one. The determinism test (hit-rate
+        # identical across two greedy replays) carries no timing assertion any
+        # more, so it CAN run here -- and it is the one that catches stray
+        # threading / uninitialized state.
         run: |
           cd c
           python3 -m unittest -v \
             tests.test_inefficiency.TinyEfficiencyTest.test_telemetry_parses \
             tests.test_inefficiency.TinyEfficiencyTest.test_profile_phases_present_and_nonneg \
-            tests.test_inefficiency.TinyEfficiencyTest.test_disk_wait_not_dominant
+            tests.test_inefficiency.TinyEfficiencyTest.test_disk_wait_not_dominant \
+            tests.test_inefficiency.TinyEfficiencyTest.test_cpu_vs_cpu_determinism
 
   # The token-exact parity gate from #7 (c/tests/test_cluster_sharding.py): the
   # engine's local CPU run must already reproduce the transformers oracle

--- a/c/tests/test_inefficiency.py
+++ b/c/tests/test_inefficiency.py
@@ -166,16 +166,32 @@ class TinyEfficiencyTest(unittest.TestCase):
     def test_cpu_vs_cpu_determinism(self):
         """Two greedy REPLAY runs with the same seed produce identical telemetry.
 
-        TEMP=0 = greedy (no sampling), so tok/s and hit-rate must be reproducible.
+        TEMP=0 = greedy (no sampling), so the hit-rate must be reproducible.
         A drift here means non-determinism crept into the decode path (stray
         threading, uninitialized state) — which on a real model would make A/B
-        comparisons meaningless."""
+        comparisons meaningless. Deliberately NO timing assertion: determinism
+        is about what is computed, not how fast (that lives in the stability
+        test below), which is what lets this one run on shared CI runners."""
         a = self._run(REPLAY="1", TEMP="0", NGEN="8", SEED="1")
         b = self._run(REPLAY="1", TEMP="0", NGEN="8", SEED="1")
         self.assertEqual(a["returncode"], 0)
         self.assertEqual(b["returncode"], 0)
         self.assertEqual(a["hit_pct"], b["hit_pct"], "greedy hit-rate drifted between runs")
-        # tok/s within 25% — exact equality is too strict across scheduler noise.
+
+    def test_cpu_vs_cpu_tok_s_stability(self):
+        """Two identical runs land within 25% in tok/s.
+
+        A wall-clock bound, NOT a determinism check: the tiny replay is ~15 ms
+        end to end, so a single scheduler stall can blow the band (38.8%
+        measured between identical runs on a quiet box; ~10x observed under
+        WSL2). Kept for quiet local machines, where a huge gap still flags a
+        real problem (a run that reloaded weights, a poisoned cache) — but it
+        is expected to be noisy on shared or virtualized hosts, and CI does
+        not run it."""
+        a = self._run(REPLAY="1", TEMP="0", NGEN="8", SEED="1")
+        b = self._run(REPLAY="1", TEMP="0", NGEN="8", SEED="1")
+        self.assertEqual(a["returncode"], 0)
+        self.assertEqual(b["returncode"], 0)
         self.assertLess(abs(a["tok_s"] - b["tok_s"]) / max(a["tok_s"], b["tok_s"]), 0.25)
 
 


### PR DESCRIPTION
Does the split that `ci.yml`'s own comment says is worth doing but should not happen silently from a CI change — so here it is as its own PR.

## How it surfaced

While verifying #1123 the Python suite went red on `test_cpu_vs_cpu_determinism`. Bisecting fear turned into a control experiment: on a **clean `upstream/dev` worktree** (fresh `make colibri`, same `glm_tiny` fixture) it fails **4 runs out of 5** on this host (WSL2), always on the tok/s assertion — `0.971 not less than 0.25`, i.e. one run ~30× the other. The tiny replay is ~15 ms end to end; a single scheduler stall dominates it. The hit-rate assertion never failed once.

## What changes

- **`test_cpu_vs_cpu_determinism`** keeps the name, the docstring's threat model (stray threading, uninitialized state) and only the hit-rate equality — that's the assertion that actually tests determinism (what is computed, not how fast). Verified stable 5/5 on the same host that flaked 4/5 before. It joins the CI structural-efficiency list, which until now had to exclude it wholesale to avoid the timing half — so CI gains a real determinism gate it wasn't running.
- **`test_cpu_vs_cpu_tok_s_stability`** (new name) holds the 25% wall-clock bound, with a docstring saying what it is and where it's expected to be noisy. Stays out of CI per the existing comment's reasoning.

## Left for you to call

The stability test still runs under `make test-python`, so a local suite on a loaded/virtualized box can still go red on it (that's how this was found). If you'd rather it were opt-in there too — an env gate, or skip-under-WSL — happy to add whichever; I didn't want to bundle that policy call into a mechanical split.