### PR TITLE
fix(family_registry): accept compress_ratios longer than num_hidden_layers

### DIFF
--- a/c/family_registry.py
+++ b/c/family_registry.py
@@ -364,17 +364,17 @@ def _dsv4_geometry(config, context, _model_dir):
     index_hd = _required_int(config, "index_head_dim", "deepseek_v4")
 
     ratios = config.get("compress_ratios")
-    if not isinstance(ratios, list) or len(ratios) != layers:
+    if not isinstance(ratios, list) or len(ratios) < layers:
         raise ValueError(
-            "deepseek_v4: compress_ratios must be a list matching "
-            "num_hidden_layers")
+            "deepseek_v4: compress_ratios must be a list of at least "
+            "num_hidden_layers entries")
 
     # Fixed window ring: n_layers * window * head_dim fp32.
     fixed = layers * window * head_dim * 4
 
     # Compressor + indexer states, scaling with context / ratio.
     state = 0
-    for ratio in ratios:
+    for ratio in ratios[:layers]:
         if not isinstance(ratio, bool) and isinstance(ratio, int) and ratio > 0:
             compressed = (context + ratio - 1) // ratio
             state += compressed * head_dim * 4


### PR DESCRIPTION
## Problem

`coli doctor` fails with:

```
[fail] model.shards       deepseek_v4: compress_ratios must be a list matching num_hidden_layers
```

The DS-V4-Flash model (e.g. `ds-v4-flash-0731`) ships `compress_ratios` with 46 entries for `num_hidden_layers = 43`. The C engine (`deepseek_v4.c:14443`) only requires `compress_ratio_count >= num_hidden_layers` and ignores trailing extras, but the Python planner (`family_registry.py` `_dsv4_geometry`) demanded an exact `len == num_hidden_layers` match, breaking every doctor/plan run for this model.

## Fix

- Relax the check from exact match to `len(ratios) >= num_hidden_layers`.
- Iterate only `ratios[:layers]` when projecting compressor/indexer memory, mirroring the C engine's per-layer reads.

## Verification

- `coli doctor`: `model.shards` now passes; full suite of family_registry tests still green (35 passed).