### PR TITLE
docs: cross-reference the V4 reproducible-run recipe from ENVIRONMENT.md (#1136)

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -364,6 +364,16 @@ the ones you are most likely to set: `DSV4_CUDA` (GPU tier on/off),
 `COLI_V4_SAVE_USAGE=0` is an engine-specific alias that disables only V4's
 usage rewrite; the shared `USAGE_SAVE=0` covers this engine too.
 
+**Reproducible greedy runs (#1136):** on this engine, greedy text legitimately
+varies with the expert-cache state — hot experts run the vectorized `rows16`
+kernel, cold ones run the reference matvec, the two accumulate in different
+orders, and which experts are hot follows the autopin history (`.coli_usage`,
+rewritten by every run). For byte-identical output across runs, either freeze
+the history (`USAGE_SAVE=0`, after seeding it once) or remove the variable
+entirely (`COLI_V4_ROWS16=0 COLI_V4_AUTOPIN=0 USAGE_SAVE=0`: reference kernels
+only, no history). Details in
+[deepseek-v4.md — CPU-only behaviour](deepseek-v4.md).
+
 ## OLMoE engine (`olmoe`)
 
 Read **only** by `c/olmoe.c`. This is the sister engine used for streaming-cache research, so most of these are experiment knobs.


### PR DESCRIPTION
Companion to my comment on #1136 — the mechanism the reporter hypothesized is confirmed in-tree (`deepseek_v4.c:7650`'s comment on `hot_rows16_wanted()`, measured upstream 2026-08-15), and the recipe they asked for already exists in `deepseek-v4.md`'s CPU-only section. What's missing is discoverability: #1136's reporter read the knob tables in ENVIRONMENT.md and reconstructed the whole mechanism experimentally, snapshot/restore and all, because nothing there points at the recipe.

One paragraph in the V4 section of ENVIRONMENT.md, next to the usage-save note from #1122: what varies and why (rows16 vs reference accumulation order, selected by the autopin history), the freeze-the-history option (`USAGE_SAVE=0`, which covers V4 since #1122), the remove-the-variable option (`COLI_V4_ROWS16=0 COLI_V4_AUTOPIN=0 USAGE_SAVE=0`), and the pointer to the full discussion.

Docs only, no code change.