### PR TITLE
feat(kimi_k3): wire up tool calling — XTML per Moonshot's reference renderer (#1143)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1102,6 +1102,9 @@ tests/test_inkling_serve_framing$(EXE): tests/test_inkling_serve_framing.c inkli
 tests/test_kimi_serve_framing$(EXE): tests/test_kimi_serve_framing.c kimi_k3.c kv_prefix.h serve_codec.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h omp_tune.h route_trace.h
 	$(CC) $(NOCUDA_CFLAGS) $< $(VK_OBJ) -o $@ $(NOCUDA_LDFLAGS)
 
+tests/test_k3_chat_tools$(EXE): tests/test_k3_chat_tools.c kimi_k3.c kv_prefix.h serve_codec.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h omp_tune.h route_trace.h
+	$(CC) $(NOCUDA_CFLAGS) $< $(VK_OBJ) -o $@ $(NOCUDA_LDFLAGS)
+
 # olmoe's matmul_q, not colibri's: compares the IDOT path against FP32
 # ACTIVATIONS rather than an integer reference. NOCUDA_* for the same reason
 # the olmoe target uses it -- olmoe.c contains no COLI_CUDA code.

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -2155,6 +2155,41 @@ static void chat_assistant(ChatB *b, const char *reasoning, const char *text){
     cb_close(b,"message"); cb_special(b,b->sp_eom);
 }
 
+/* ---- tool-call XTML (#1143) -----------------------------------------------
+ * Attribute segmentation mirrors the reference renderer (encoding_k3.py):
+ * " key", "=\"", the escaped value, and "\"" are each their OWN text segment.
+ * Segment boundaries are token boundaries under K3's rank-BPE, so the split
+ * is part of the format, not a style choice. Values escape & -> &amp; and
+ * " -> &quot;, exactly the reference's _escape_attr_value. */
+static void cb_attr(ChatB *b, const char *key, const char *val){
+    char kb[80]; snprintf(kb,sizeof kb," %s",key); cb_text(b,kb);
+    cb_text(b,"=\"");
+    size_t n=strlen(val), extra=0;
+    for(size_t i=0;i<n;i++) extra += val[i]=='&'?4u : val[i]=='"'?5u : 0u;
+    char *esc=malloc(n+extra+1);
+    if(!esc){ fprintf(stderr,"OOM chat attr\n"); exit(1); }
+    char *w=esc;
+    for(size_t i=0;i<n;i++){
+        if(val[i]=='&'){ memcpy(w,"&amp;",5); w+=5; }
+        else if(val[i]=='"'){ memcpy(w,"&quot;",6); w+=6; }
+        else *w++=val[i];
+    }
+    *w=0; cb_text(b,esc); free(esc);
+    cb_text(b,"\"");
+}
+/* open tag with caller-supplied attributes: cb_open_begin, cb_attr..., cb_end */
+static void cb_open_begin(ChatB *b, const char *tag){ cb_special(b,b->sp_open); cb_text(b,tag); }
+static void cb_end(ChatB *b){ cb_special(b,b->sp_sep); }
+
+/* Is a generated XTML tag part of the tool-call structure? Open tags carry
+ * attributes ("call tool=\"x\" index=\"1\""), close tags are the bare name. */
+static int k3_tool_tag(const char *t){
+    return (!strncmp(t,"tools",5)   &&(t[5]==0||t[5]==' ')) ||
+           (!strncmp(t,"call",4)    &&(t[4]==0||t[4]==' ')) ||
+           (!strncmp(t,"argument",8)&&(t[8]==0||t[8]==' ')) ||
+           (!strncmp(t,"json",4)    &&(t[4]==0||t[4]==' '));
+}
+
 /* Internal gateway payload. Length framing keeps arbitrary UTF-8/newlines in
  * message content while preserving the segment boundaries required by K3's
  * rank-BPE chat template:
@@ -2194,6 +2229,93 @@ static int chat_build_wire(Tok *T, const char *wire, int nwire, int *thinking,
             memcpy(text,nl+1+nr,(size_t)nt); text[nt]=0;
             chat_assistant(&b,reason,text);
             free(reason); free(text); p=nl+1+nr+nt; continue;
+        }
+        if(*p=='Y'){                /* typed system message (#1143): tool-declare / tool-choice */
+            int ntp=-1, nb=-1;
+            if(sscanf(p,"Y %d %d",&ntp,&nb)!=2||ntp<1||ntp>64||nb<0||nl+1+ntp+nb>end) return -1;
+            char *typ=malloc((size_t)ntp+1), *body=malloc((size_t)nb+1);
+            if(!typ||!body){ fprintf(stderr,"OOM chat typed-system\n"); exit(1); }
+            memcpy(typ,nl+1,(size_t)ntp); typ[ntp]=0;
+            memcpy(body,nl+1+ntp,(size_t)nb); body[nb]=0;
+            cb_open_begin(&b,"message"); cb_attr(&b,"role","system"); cb_attr(&b,"type",typ); cb_end(&b);
+            cb_text(&b,body);
+            cb_close(&b,"message"); cb_special(&b,b.sp_eom);
+            free(typ); free(body); p=nl+1+ntp+nb; continue;
+        }
+        if(*p=='O'){                /* tool result (#1143): O <index> <name-len> <content-len> */
+            int idx=-1, nn=-1, nb=-1;
+            if(sscanf(p,"O %d %d %d",&idx,&nn,&nb)!=3||idx<1||nn<1||nn>256||nb<0||nl+1+nn+nb>end) return -1;
+            char *name=malloc((size_t)nn+1), *body=malloc((size_t)nb+1);
+            if(!name||!body){ fprintf(stderr,"OOM chat tool-result\n"); exit(1); }
+            memcpy(name,nl+1,(size_t)nn); name[nn]=0;
+            memcpy(body,nl+1+nn,(size_t)nb); body[nb]=0;
+            char ib[16]; snprintf(ib,sizeof ib,"%d",idx);
+            cb_open_begin(&b,"message"); cb_attr(&b,"role","tool");
+            cb_attr(&b,"tool",name); cb_attr(&b,"index",ib); cb_end(&b);
+            cb_text(&b,body);
+            cb_close(&b,"message"); cb_special(&b,b.sp_eom);
+            free(name); free(body); p=nl+1+nn+nb; continue;
+        }
+        if(*p=='B'){                /* assistant WITH tool calls (#1143):
+                                     * B <think> <nr> <nt> <ncalls>\n<reason><text>
+                                     * then ncalls of  F <name-len> <nargs>\n<name>
+                                     *                   (+ nargs of V <key-len> <type-len> <val-len>\n<key><type><val>)
+                                     * or               J <name-len> <json-len>\n<name><json> */
+            int th=-1, nr=-1, nt=-1, nc=-1;
+            if(sscanf(p,"B %d %d %d %d",&th,&nr,&nt,&nc)!=4||th<0||th>1||nr<0||nt<0||
+               nc<1||nc>64||nl+1+nr+nt>end) return -1;
+            char *reason=malloc((size_t)nr+1), *text=malloc((size_t)nt+1);
+            if(!reason||!text){ fprintf(stderr,"OOM chat assistant-tools\n"); exit(1); }
+            memcpy(reason,nl+1,(size_t)nr); reason[nr]=0;
+            memcpy(text,nl+1+nr,(size_t)nt); text[nt]=0;
+            cb_open(&b,"message","assistant");
+            if(th){ cb_open(&b,"think",NULL); cb_text(&b,reason); cb_close(&b,"think"); }
+            cb_open(&b,"response",NULL); cb_text(&b,text); cb_close(&b,"response");
+            free(reason); free(text);
+            cb_open(&b,"tools",NULL);
+            p=nl+1+nr+nt;
+            for(int ci=0;ci<nc;ci++){
+                nl=memchr(p,'\n',(size_t)(end-p)); if(!nl) return -1;
+                char ib[16]; snprintf(ib,sizeof ib,"%d",ci+1);
+                if(*p=='J'){
+                    int nn=-1, nj=-1;
+                    if(sscanf(p,"J %d %d",&nn,&nj)!=2||nn<1||nn>256||nj<0||nl+1+nn+nj>end) return -1;
+                    char *name=malloc((size_t)nn+1), *js=malloc((size_t)nj+1);
+                    if(!name||!js){ fprintf(stderr,"OOM chat tool-call\n"); exit(1); }
+                    memcpy(name,nl+1,(size_t)nn); name[nn]=0;
+                    memcpy(js,nl+1+nn,(size_t)nj); js[nj]=0;
+                    cb_open_begin(&b,"call"); cb_attr(&b,"tool",name); cb_attr(&b,"index",ib); cb_end(&b);
+                    cb_open_begin(&b,"json"); cb_attr(&b,"type","object"); cb_end(&b);
+                    cb_text(&b,js); cb_close(&b,"json"); cb_close(&b,"call");
+                    free(name); free(js); p=nl+1+nn+nj;
+                } else if(*p=='F'){
+                    int nn=-1, na=-1;
+                    if(sscanf(p,"F %d %d",&nn,&na)!=2||nn<1||nn>256||na<0||na>64||nl+1+nn>end) return -1;
+                    char *name=malloc((size_t)nn+1);
+                    if(!name){ fprintf(stderr,"OOM chat tool-call\n"); exit(1); }
+                    memcpy(name,nl+1,(size_t)nn); name[nn]=0;
+                    cb_open_begin(&b,"call"); cb_attr(&b,"tool",name); cb_attr(&b,"index",ib); cb_end(&b);
+                    free(name); p=nl+1+nn;
+                    for(int ai=0;ai<na;ai++){
+                        nl=memchr(p,'\n',(size_t)(end-p)); if(!nl) return -1;
+                        int nk=-1, ntp=-1, nv=-1;
+                        if(sscanf(p,"V %d %d %d",&nk,&ntp,&nv)!=3||nk<1||nk>256||ntp<1||ntp>16||
+                           nv<0||nl+1+nk+ntp+nv>end) return -1;
+                        char *key=malloc((size_t)nk+1), *typ=malloc((size_t)ntp+1), *val=malloc((size_t)nv+1);
+                        if(!key||!typ||!val){ fprintf(stderr,"OOM chat tool-arg\n"); exit(1); }
+                        memcpy(key,nl+1,(size_t)nk); key[nk]=0;
+                        memcpy(typ,nl+1+nk,(size_t)ntp); typ[ntp]=0;
+                        memcpy(val,nl+1+nk+ntp,(size_t)nv); val[nv]=0;
+                        cb_open_begin(&b,"argument"); cb_attr(&b,"key",key); cb_attr(&b,"type",typ); cb_end(&b);
+                        cb_text(&b,val); cb_close(&b,"argument");
+                        free(key); free(typ); free(val); p=nl+1+nk+ntp+nv;
+                    }
+                    cb_close(&b,"call");
+                } else return -1;
+            }
+            cb_close(&b,"tools");
+            cb_close(&b,"message"); cb_special(&b,b.sp_eom);
+            continue;
         }
         char role[16]; int nb=-1;
         if(sscanf(p,"M %15s %d",role,&nb)!=2||nb<0||nl+1+nb>end) return -1;
@@ -2426,7 +2548,7 @@ static int serve_one(Model *m, Tok *T, ServeReq *q){
         return poll.fatal?-1:0;
     }
     int gen=0, limited=1, cancelled=0, xsup=0, xopen=0, xtl=0;
-    char buf[512], xtag[64];
+    char buf[512], xtag[320];   /* tool-call open tags carry attributes: call tool="..." index="..." (#1143) */
     double tg=now_s();
     for(int s=0;s<q->max_tok&&!cancelled;s++){
         int tk=sample_tok(lo,m->c.vocab,q->temp,q->top_p);
@@ -2441,6 +2563,15 @@ static int serve_one(Model *m, Tok *T, ServeReq *q){
                     xsup=0; xtag[xtl]=0;
                     if(xopen&&!strcmp(xtag,"response")&&thinking)
                         serve_data(q->id,"</think>",8);
+                    else if(k3_tool_tag(xtag)){
+                        /* #1143: re-emit tool-call structure literally so the gateway can
+                         * parse it back into OpenAI tool_calls. Everything else XTML stays
+                         * suppressed as before; the gateway strips these markers from the
+                         * client-visible deltas the same way the GLM path does. */
+                        char lb[352];
+                        int n=snprintf(lb,sizeof lb,"%s%s<|sep|>",xopen?"<|open|>":"<|close|>",xtag);
+                        if(n>0&&n<(int)sizeof lb) serve_data(q->id,lb,n);
+                    }
                 }
                 show=0;
             } else if(xsup){

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -455,10 +455,76 @@ def parse_dsv4_tool_calls(reply):
     return content.strip(), calls
 
 
+# K3 tool-call markers as re-emitted literally by kimi_k3.c's serve loop (#1143): the
+# structural XTML runs the engine would otherwise suppress come through as literal text.
+K3_TOOLS_OPEN = "<|open|>tools<|sep|>"
+_K3_TOOLS_RE = re.compile(r"<\|open\|>tools<\|sep\|>(.*?)<\|close\|>tools<\|sep\|>", re.DOTALL)
+_K3_CALL_RE = re.compile(
+    r'<\|open\|>call tool="([^"]*)" index="(\d+)"<\|sep\|>(.*?)<\|close\|>call<\|sep\|>', re.DOTALL)
+_K3_ARG_RE = re.compile(
+    r'<\|open\|>argument key="([^"]*)" type="([^"]*)"<\|sep\|>(.*?)<\|close\|>argument<\|sep\|>',
+    re.DOTALL)
+_K3_JSON_RE = re.compile(r'<\|open\|>json type="object"<\|sep\|>(.*?)<\|close\|>json<\|sep\|>',
+                         re.DOTALL)
+
+
+def _k3_unescape_attr(s):
+    return s.replace("&quot;", '"').replace("&amp;", "&")   # &amp; last, mirroring the escape
+
+
+def parse_k3_tool_calls(reply, tools=None):
+    """Return (content, tool_calls) from K3's literally re-emitted XTML tool block."""
+    calls = []
+    blocks = [m.group(1) for m in _K3_TOOLS_RE.finditer(reply)]
+    text = _K3_TOOLS_RE.sub("", reply)
+    # An opened-but-unclosed tools block (token budget ran out): parse the complete
+    # calls inside it, drop the fragment from the visible text — same recovery
+    # posture as the GLM path's _unclosed_tail.
+    tail_at = text.rfind(K3_TOOLS_OPEN)
+    if tail_at >= 0:
+        blocks.append(text[tail_at + len(K3_TOOLS_OPEN):])
+        text = text[:tail_at]
+    for block in blocks:
+        for m in _K3_CALL_RE.finditer(block):
+            name = _k3_unescape_attr(m.group(1))
+            inner = m.group(3)
+            jm = _K3_JSON_RE.search(inner)
+            if jm is not None:
+                arguments = jm.group(1)
+            else:
+                args = {}
+                for am in _K3_ARG_RE.finditer(inner):
+                    key = _k3_unescape_attr(am.group(1))
+                    typ, val = am.group(2), am.group(3)
+                    if typ == "string":
+                        args[key] = val
+                    else:
+                        try:
+                            args[key] = json.loads(val)
+                        except (json.JSONDecodeError, ValueError):
+                            args[key] = val
+                arguments = json.dumps(args, ensure_ascii=False)
+            calls.append({"id": "call_" + uuid.uuid4().hex[:24], "type": "function",
+                          "function": {"name": name, "arguments": arguments}})
+    if THINK_CLOSE in text:
+        text = text.split(THINK_CLOSE, 1)[1]
+    text = text.replace(THINK_OPEN, "").replace(THINK_CLOSE, "")
+    if calls:
+        sys.stderr.write("[api] tool-calls: %d total (kimi_k3 XTML)\n" % len(calls))
+        sys.stderr.flush()
+    elif tools and K3_TOOLS_OPEN in reply:
+        sys.stderr.write("[api] K3 tool markers present but no call parsed -- "
+                         "possibly truncated or mangled output\n")
+        sys.stderr.flush()
+    return text.strip(), calls
+
+
 def parse_arch_tool_calls(reply, tools):
     """Architecture-appropriate tool-call parser. Returns (content, tool_calls)."""
     if ARCH == "deepseek_v4":
         return parse_dsv4_tool_calls(reply)
+    if ARCH == "kimi":
+        return parse_k3_tool_calls(reply, tools)
     return parse_tool_calls(reply, tools)
 
 
@@ -466,6 +532,8 @@ def _tool_stream_markers():
     """Marker(s) that open a model tool-call block, in match order (arch-specific)."""
     if ARCH == "deepseek_v4":
         return ("<" + DSV4_DSML + "tool_calls", "<" + DSV4_DSML + "invoke")
+    if ARCH == "kimi":
+        return (K3_TOOLS_OPEN,)
     return (BOX_START,)
 
 
@@ -735,6 +803,136 @@ def inkling_content_segments(content, param, audio_out):
     return segments
 
 
+# ---- Kimi K3 tool calling (#1143) ----------------------------------------------------------
+# K3's normative renderer is encoding_k3.py in the checkpoint repo: tools are pure XTML over
+# the four special tokens. The gateway ships typed K3CHAT1 records; kimi_k3.c constructs the
+# XTML (tags/attrs are ordinary text whose segment boundaries are token boundaries).
+#   Y <type-len> <body-len>       typed system message (tool-declare / tool-choice)
+#   O <index> <name-len> <n>      tool-result message
+#   B <think> <nr> <nt> <ncalls>  assistant turn with tool calls, then per call
+#     F <name-len> <nargs>          + nargs of  V <key-len> <type-len> <val-len>
+#     J <name-len> <json-len>       json fallback for an unparseable arguments string
+
+def _k3_xtml_type(value):
+    if isinstance(value, bool): return "boolean"
+    if value is None: return "null"
+    if isinstance(value, (int, float)): return "number"
+    if isinstance(value, str): return "string"
+    if isinstance(value, dict): return "object"
+    return "array"
+
+
+def _k3_parse_arguments(raw):
+    """OpenAI `arguments` -> list of (key, xtml_type, text), or None for the json fallback.
+
+    Mirrors the reference's one-level-deep parse: non-string values keep their exact JSON
+    bytes (1e2 stays 1e2), string values are the decoded string. A dict input is rendered
+    per-argument with compact re-serialization for nested values (no original bytes exist).
+    """
+    if isinstance(raw, dict):
+        return [(k, _k3_xtml_type(v),
+                 v if isinstance(v, str) else json.dumps(v, ensure_ascii=False, separators=(",", ":")))
+                for k, v in raw.items()]
+    if raw is None or raw == "":
+        return []
+    if not isinstance(raw, str):
+        return None
+    s, idx = raw, 0
+    dec = json.JSONDecoder(strict=False)
+    def skip():
+        nonlocal idx
+        while idx < len(s) and s[idx] in " \t\n\r": idx += 1
+    skip()
+    if idx >= len(s) or s[idx] != "{": return None
+    idx += 1; skip()
+    if idx < len(s) and s[idx] == "}": return []
+    out = []
+    try:
+        while True:
+            key, idx = dec.raw_decode(s, idx)
+            if not isinstance(key, str): return None
+            skip()
+            if idx >= len(s) or s[idx] != ":": return None
+            idx += 1; skip()
+            vstart = idx
+            value, idx = dec.raw_decode(s, idx)
+            text = value if isinstance(value, str) else s[vstart:idx]
+            out.append((key, _k3_xtml_type(value), text))
+            skip()
+            if idx >= len(s): return None
+            c = s[idx]; idx += 1; skip()
+            if c == "}": return out
+            if c != ",": return None
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def _k3_call_records(tool_calls, where):
+    """K3CHAT1 records for one assistant message's tool_calls (F/V or J per call)."""
+    parts = []
+    for ci, tc in enumerate(tool_calls):
+        if not isinstance(tc, dict):
+            raise APIError(400, "Each tool call must be an object.", f"{where}.{ci}")
+        fn = tc.get("function", tc)
+        name = fn.get("name") if isinstance(fn, dict) else None
+        if not isinstance(name, str) or not name or len(name.encode("utf-8")) > 256:
+            raise APIError(400, "Tool call needs a function name (<=256 bytes).",
+                           f"{where}.{ci}.function.name")
+        args = _k3_parse_arguments(fn.get("arguments") if isinstance(fn, dict) else None)
+        nb = name.encode("utf-8")
+        if args is None:
+            js = fn.get("arguments")
+            js = js if isinstance(js, str) else json.dumps(js or {}, ensure_ascii=False)
+            jb = js.encode("utf-8")
+            parts.append(f"J {len(nb)} {len(jb)}\n{name}{js}")
+        else:
+            if len(args) > 64:
+                raise APIError(400, "Too many arguments for one tool call (max 64).",
+                               f"{where}.{ci}.function.arguments")
+            parts.append(f"F {len(nb)} {len(args)}\n{name}")
+            for key, typ, text in args:
+                kb, tb, vb = key.encode("utf-8"), typ.encode("utf-8"), text.encode("utf-8")
+                if len(kb) < 1 or len(kb) > 256:
+                    raise APIError(400, "Argument keys must be 1..256 bytes.",
+                                   f"{where}.{ci}.function.arguments")
+                parts.append(f"V {len(kb)} {len(tb)} {len(vb)}\n{key}{typ}{text}")
+    return parts
+
+
+def _k3_order_tool_results(messages):
+    """Re-sort each run of tool messages into the preceding assistant's tool_calls order,
+    resolving names from tool_call_id — the reference renderer's normalization. A run with
+    any unresolvable id is left untouched (order-based name fallback still applies)."""
+    out, index_map, i = [], {}, 0
+    while i < len(messages):
+        msg = messages[i]
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            index_map = {}
+            for pos, tc in enumerate(msg.get("tool_calls") or [], start=1):
+                if isinstance(tc, dict) and tc.get("id") is not None:
+                    fn = tc.get("function", tc)
+                    nm = fn.get("name") if isinstance(fn, dict) else None
+                    index_map[str(tc["id"])] = (pos, nm)
+            out.append(msg); i += 1; continue
+        if not (isinstance(msg, dict) and msg.get("role") == "tool"):
+            out.append(msg); i += 1; continue
+        run = []
+        while i < len(messages) and isinstance(messages[i], dict) and messages[i].get("role") == "tool":
+            tm = messages[i]
+            hit = index_map.get(str(tm.get("tool_call_id"))) if tm.get("tool_call_id") is not None else None
+            run.append((hit[0] if hit else None, len(run), tm, hit[1] if hit else None))
+            i += 1
+        if any(pos is None for pos, _, _, _ in run):
+            out.extend(tm for _, _, tm, _ in run)
+        else:
+            run.sort()
+            for _, _, tm, nm in run:
+                fixed = dict(tm)
+                if nm: fixed["name"] = nm
+                out.append(fixed)
+    return out
+
+
 def render_chat_kimi(messages, enable_thinking=False, reasoning_effort=None, tools=None,
                      tool_choice=None):
     """Validated multi-turn K3 payload for the C engine.
@@ -745,28 +943,78 @@ def render_chat_kimi(messages, enable_thinking=False, reasoning_effort=None, too
     """
     if not isinstance(messages, list) or not messages:
         raise APIError(400, "`messages` must be a non-empty array.", "messages")
-    if tools or tool_choice not in (None, "none"):
-        raise APIError(400, "Tool use is not wired up for the Kimi K3 engine yet.",
-                       "tools", "unsupported_parameter")
+    forced = None
+    if isinstance(tool_choice, dict):
+        forced = ((tool_choice.get("function") or {}).get("name") or tool_choice.get("name"))
+        if forced:
+            tools = [t for t in (tools or [])
+                     if ((t.get("function", t) if isinstance(t, dict) else {}).get("name") == forced)]
+    elif tool_choice == "none":
+        tools = None                              # the client forbade tools: do not offer them
+    messages = _k3_order_tool_results(messages)
     parts = ["K3CHAT1\n"]
+    if tools:
+        body = ("# Tools\nHere are the available tools, described in JSONSchema.\n\n"
+                "```json\n" + json.dumps(tools, ensure_ascii=False, separators=(",", ":"),
+                                         sort_keys=True) + "\n```")
+        parts.append(f"Y 12 {len(body.encode('utf-8'))}\ntool-declare{body}")
+    tool_index = 0
+    last_calls = []
     for index, message in enumerate(messages):
         if not isinstance(message, dict):
             raise APIError(400, "Each message must be an object.", f"messages.{index}")
         role = message.get("role")
-        if role not in ("system", "developer", "user", "assistant"):
+        if role not in ("system", "developer", "user", "assistant", "tool"):
             raise APIError(400, f"Unsupported role {role!r}.", f"messages.{index}.role")
         raw = message.get("content")
         text = content_text(raw, f"messages.{index}.content") if raw is not None else ""
+        if role == "tool":
+            tool_index += 1
+            name = message.get("name") or message.get("tool")
+            if not name and tool_index <= len(last_calls):
+                fn = last_calls[tool_index - 1]
+                fn = fn.get("function", fn) if isinstance(fn, dict) else {}
+                name = fn.get("name")
+            if not isinstance(name, str) or not name:
+                raise APIError(400, "Kimi K3 tool messages need a resolvable tool name: "
+                               "carry `name`, or match a preceding assistant tool_call "
+                               "by id or order.", f"messages.{index}.name")
+            nb = name.encode("utf-8")
+            if len(nb) > 256:
+                raise APIError(400, "Tool name too long (max 256 bytes).", f"messages.{index}.name")
+            parts.append(f"O {tool_index} {len(nb)} {len(text.encode('utf-8'))}\n{name}{text}")
+            continue
         reasoning = message.get("reasoning_content") if role == "assistant" else None
         if reasoning is not None and not isinstance(reasoning, str):
             raise APIError(400, "`reasoning_content` must be a string.",
                            f"messages.{index}.reasoning_content")
-        if role == "assistant" and enable_thinking:
+        calls = message.get("tool_calls") if role == "assistant" else None
+        if role == "assistant":
+            last_calls = calls or []
+            tool_index = 0
+        if calls:
+            if len(calls) > 64:
+                raise APIError(400, "Too many tool calls in one message (max 64).",
+                               f"messages.{index}.tool_calls")
+            reasoning = reasoning or ""
+            parts.append(f"B {1 if enable_thinking else 0} {len(reasoning.encode('utf-8'))} "
+                         f"{len(text.encode('utf-8'))} {len(calls)}\n{reasoning}{text}")
+            parts.extend(_k3_call_records(calls, f"messages.{index}.tool_calls"))
+        elif role == "assistant" and enable_thinking:
             reasoning = reasoning or ""
             parts.append(f"A {len(reasoning.encode('utf-8'))} {len(text.encode('utf-8'))}\n"
                          f"{reasoning or ''}{text}")
         else:
-            parts.append(f"M {role} {len(text.encode('utf-8'))}\n{text}")
+            r = "system" if role == "developer" else role
+            parts.append(f"M {r} {len(text.encode('utf-8'))}\n{text}")
+    if tool_choice == "required" and tools:
+        body = ("The system is invoked with `tool_choice=required`.\n"
+                "You MUST call tools in the next message.")
+        parts.append(f"Y 11 {len(body.encode('utf-8'))}\ntool-choice{body}")
+    elif forced and tools:
+        body = (f"The system is invoked with a forced tool choice.\n"
+                f"You MUST call the tool `{forced}` in the next message.")
+        parts.append(f"Y 11 {len(body.encode('utf-8'))}\ntool-choice{body}")
     parts.append(f"G {1 if enable_thinking else 0}\n")
     return "".join(parts)
 

--- a/c/tests/test_anthropic_messages.py
+++ b/c/tests/test_anthropic_messages.py
@@ -168,8 +168,9 @@ class MessagesHTTPTest(unittest.TestCase):
                 self.assertEqual(self.engine.prompts[-1], renderer(messages))
 
     def test_non_glm_architectures_reject_tools_before_generation(self):
+        # kimi left this list in #1143: K3 tool calling is wired up now.
         body = self.base_body(tools=[{"name": "f", "input_schema": {"type": "object"}}])
-        for arch in ("inkling", "kimi"):
+        for arch in ("inkling",):
             with self.subTest(arch=arch), patch("openai_server.ARCH", arch):
                 before = len(self.engine.prompts)
                 with self.assertRaises(HTTPError) as caught:
@@ -178,6 +179,18 @@ class MessagesHTTPTest(unittest.TestCase):
                 self.assertEqual(caught.exception.code, 400)
                 self.assertIn("tool", json.load(caught.exception)["error"]["message"].lower())
                 self.assertEqual(len(self.engine.prompts), before)
+
+    def test_kimi_renders_tools_as_k3chat1_records(self):
+        body = self.base_body(tools=[{"name": "f", "input_schema": {
+            "type": "object", "properties": {"x": {"type": "string"}}}}])
+        with patch("openai_server.ARCH", "kimi"):
+            with self.post(body) as response:
+                self.assertEqual(response.status, 200)
+        prompt = self.engine.prompts[-1]
+        self.assertIn("K3CHAT1", prompt)
+        self.assertIn("tool-declare# Tools", prompt)
+        self.assertIn('"name":"f"', prompt)
+        self.assertNotIn("<|open|>", prompt)   # records, never raw XTML
 
     def test_deepseek_v4_renders_tools_as_dsml_block(self):
         body = self.base_body(tools=[{"name": "f", "input_schema": {

--- a/c/tests/test_k3_chat_tools.c
+++ b/c/tests/test_k3_chat_tools.c
@@ -1,0 +1,136 @@
+/* chat_build_wire's tool-call records (#1143) against the tiny Kimi tokenizer.
+ *
+ * The expected XTML below is derived from Moonshot's reference renderer
+ * (encoding_k3.py in the Kimi-K3 checkpoint repo): tool declarations are a
+ * `message role="system" type="tool-declare"` turn, assistant calls render as
+ * tools > call > argument tags with per-argument XTML types, tool results are
+ * `message role="tool" tool="..." index="..."` turns, and attribute values
+ * escape & -> &amp; and " -> &quot;. Only <|open|>/<|close|>/<|sep|>/
+ * <|end_of_msg|> are special tokens; everything else is ordinary text, so the
+ * round trip below (encode via chat_build_wire, decode id-by-id) must
+ * reproduce the reference byte stream exactly. */
+#define main coli_k3_main_unused
+#include "../kimi_k3.c"
+#undef main
+
+#include <stdio.h>
+#include <string.h>
+
+static int fails;
+
+static void render(Tok *T, const char *wire, char *out, size_t cap){
+    int ids[4096], sp[4], thinking=0;
+    int n=chat_build_wire(T,wire,(int)strlen(wire),&thinking,ids,4096,sp);
+    if(n<0){ snprintf(out,cap,"<chat_build_wire failed: %d>",n); return; }
+    size_t w=0; out[0]=0;
+    for(int i=0;i<n && w+64<cap;i++){
+        const char *lit = ids[i]==sp[0]?"<|open|>" : ids[i]==sp[1]?"<|close|>" :
+                          ids[i]==sp[2]?"<|sep|>"  : ids[i]==sp[3]?"<|end_of_msg|>" : NULL;
+        if(lit){ size_t l=strlen(lit); memcpy(out+w,lit,l); w+=l; out[w]=0; continue; }
+        char buf[64];
+        int nb=tok_decode(T,&ids[i],1,buf,sizeof(buf)-1);
+        if(nb>0){ memcpy(out+w,buf,(size_t)nb); w+=(size_t)nb; out[w]=0; }
+    }
+}
+
+static void expect(Tok *T, const char *what, const char *wire, const char *want){
+    char got[8192];
+    render(T,wire,got,sizeof(got));
+    if(strcmp(got,want)){
+        printf("  FAIL %s\n    want: %s\n    got:  %s\n",what,want,got);
+        fails++;
+    } else printf("  ok   %s\n",what);
+}
+
+int main(void){
+    Tok T;
+    tok_load(&T,"tests/tok_kimi_tiny.json");
+
+    /* Every wire ends with the generation prompt the caller appends. */
+    const char *tail_think="<|open|>message role=\"assistant\"<|sep|><|open|>think<|sep|>";
+    const char *tail_plain="<|open|>message role=\"assistant\"<|sep|><|open|>response<|sep|>";
+
+    /* Y: typed system message (tool-declare shape; body abbreviated). */
+    {
+        char want[1024];
+        snprintf(want,sizeof(want),
+            "<|open|>message role=\"system\" type=\"tool-declare\"<|sep|>"
+            "# Tools body"
+            "<|close|>message<|sep|><|end_of_msg|>%s",tail_plain);
+        expect(&T,"Y renders a typed system message",
+               "K3CHAT1\nY 12 12\ntool-declare# Tools body"
+               "G 0\n",want);
+    }
+
+    /* O: tool result with name and index attributes. */
+    {
+        char want[1024];
+        snprintf(want,sizeof(want),
+            "<|open|>message role=\"tool\" tool=\"get_weather\" index=\"1\"<|sep|>"
+            "sunny"
+            "<|close|>message<|sep|><|end_of_msg|>%s",tail_plain);
+        expect(&T,"O renders a tool-result message",
+               "K3CHAT1\nO 1 11 5\nget_weathersunny"
+               "G 0\n",want);
+    }
+
+    /* B+F+V: assistant turn with one call, two typed arguments, thinking on. */
+    {
+        char want[2048];
+        snprintf(want,sizeof(want),
+            "<|open|>message role=\"assistant\"<|sep|>"
+            "<|open|>think<|sep|>why<|close|>think<|sep|>"
+            "<|open|>response<|sep|>ok<|close|>response<|sep|>"
+            "<|open|>tools<|sep|>"
+            "<|open|>call tool=\"get_weather\" index=\"1\"<|sep|>"
+            "<|open|>argument key=\"city\" type=\"string\"<|sep|>Rome<|close|>argument<|sep|>"
+            "<|open|>argument key=\"days\" type=\"number\"<|sep|>1e2<|close|>argument<|sep|>"
+            "<|close|>call<|sep|>"
+            "<|close|>tools<|sep|>"
+            "<|close|>message<|sep|><|end_of_msg|>%s",tail_think);
+        expect(&T,"B/F/V render calls with typed arguments",
+               "K3CHAT1\n"
+               "B 1 3 2 1\nwhyok"
+               "F 11 2\nget_weather"
+               "V 4 6 4\ncitystringRome"
+               "V 4 6 3\ndaysnumber1e2"
+               "G 1\n",want);
+    }
+
+    /* J: json fallback block, plus attribute escaping in the tool name. */
+    {
+        char want[1024];
+        snprintf(want,sizeof(want),
+            "<|open|>message role=\"assistant\"<|sep|>"
+            "<|open|>response<|sep|><|close|>response<|sep|>"
+            "<|open|>tools<|sep|>"
+            "<|open|>call tool=\"a&amp;b&quot;c\" index=\"1\"<|sep|>"
+            "<|open|>json type=\"object\"<|sep|>{\"x\":1}<|close|>json<|sep|>"
+            "<|close|>call<|sep|>"
+            "<|close|>tools<|sep|>"
+            "<|close|>message<|sep|><|end_of_msg|>%s",tail_plain);
+        expect(&T,"J renders a json block and escapes attributes",
+               "K3CHAT1\n"
+               "B 0 0 0 1\n"
+               "J 5 7\na&b\"c{\"x\":1}"
+               "G 0\n",want);
+    }
+
+    /* Malformed records are refused, not misread. */
+    {
+        int ids[256], sp[4], thinking=0;
+        const char *bad[]={
+            "K3CHAT1\nY 200 4\nshortG 0\n",              /* lengths past the payload */
+            "K3CHAT1\nO 0 3 2\nfooxxG 0\n",              /* index < 1 */
+            "K3CHAT1\nB 0 0 0 1\nX 3 0\nfooG 0\n",       /* unknown call record */
+        };
+        for(size_t i=0;i<sizeof(bad)/sizeof(*bad);i++){
+            int n=chat_build_wire(&T,bad[i],(int)strlen(bad[i]),&thinking,ids,256,sp);
+            if(n!=-1){ printf("  FAIL malformed record %zu accepted (n=%d)\n",i,n); fails++; }
+            else printf("  ok   malformed record %zu refused\n",i);
+        }
+    }
+
+    printf(fails?"test_k3_chat_tools: %d failure(s)\n":"test_k3_chat_tools: ok\n",fails);
+    return fails!=0;
+}

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -19,6 +19,7 @@ from openai_server import (APIError, APIHandler, APIServer, ClientCancelled,
                            READY, Engine, InklingStreamSplit, StopFilter, ThinkingStreamSplit,
                            _engine_error, cap_for_arch, conversation_cache_slot, model_arch,
                            generation_options, parse_tool_calls, parse_dsv4_tool_calls,
+                           parse_k3_tool_calls,
                            read_engine_turn, render_chat, render_chat_kimi, render_chat_olmoe,
                            render_chat_v4, _dsv4_tool_calls, serve, split_thinking_reply,
                            stop_policy, tune_child_env)
@@ -101,12 +102,100 @@ class TemplateTest(unittest.TestCase):
             "G 1\n",
         )
 
-    def test_kimi_rejects_tools_and_unknown_roles(self):
-        with self.assertRaisesRegex(APIError, "Tool use"):
-            render_chat_kimi([{"role": "user", "content": "Hi"}],
-                             tools=[{"type": "function"}])
+    def test_kimi_renders_tool_declaration_and_choice(self):
+        tools = [{"type": "function", "function": {
+            "name": "get_weather", "parameters": {"type": "object"}}}]
+        body = ("# Tools\nHere are the available tools, described in JSONSchema.\n\n"
+                "```json\n" + json.dumps(tools, ensure_ascii=False, separators=(",", ":"),
+                                         sort_keys=True) + "\n```")
+        prompt = render_chat_kimi([{"role": "user", "content": "Hi"}], tools=tools)
+        self.assertEqual(prompt, "K3CHAT1\n"
+                         f"Y 12 {len(body.encode('utf-8'))}\ntool-declare{body}"
+                         "M user 2\nHi"
+                         "G 0\n")
+        # tool_choice=none: the tools are not offered at all
+        self.assertEqual(render_chat_kimi([{"role": "user", "content": "Hi"}],
+                                          tools=tools, tool_choice="none"),
+                         "K3CHAT1\nM user 2\nHiG 0\n")
+        # tool_choice=required appends the reference's tool-choice system message
+        prompt = render_chat_kimi([{"role": "user", "content": "Hi"}],
+                                  tools=tools, tool_choice="required")
+        self.assertIn("\ntool-choiceThe system is invoked with `tool_choice=required`.", prompt)
+        self.assertTrue(prompt.endswith("G 0\n"))
+
+    def test_kimi_renders_tool_calls_and_results(self):
+        messages = [
+            {"role": "user", "content": "Weather in Rome?"},
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {
+                    "name": "get_weather",
+                    "arguments": '{"city": "Rome", "days": 1e2, "metric": true}'}}]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "sunny"},
+        ]
+        prompt = render_chat_kimi(messages)
+        # B: assistant turn carrying the call; V records keep the exact JSON
+        # literal for non-strings (1e2 stays 1e2) and decode strings.
+        self.assertIn("B 0 0 0 1\n", prompt)
+        self.assertIn("F 11 3\nget_weather", prompt)
+        self.assertIn("V 4 6 4\ncitystringRome", prompt)
+        self.assertIn("V 4 6 3\ndaysnumber1e2", prompt)
+        self.assertIn("V 6 7 4\nmetricbooleantrue", prompt)
+        # O: the result resolves its name through tool_call_id
+        self.assertIn("O 1 11 5\nget_weathersunny", prompt)
+
+    def test_kimi_tool_results_resort_by_call_id(self):
+        messages = [
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "a", "type": "function",
+                 "function": {"name": "first", "arguments": "{}"}},
+                {"id": "b", "type": "function",
+                 "function": {"name": "second", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "b", "content": "B"},
+            {"role": "tool", "tool_call_id": "a", "content": "A"},
+        ]
+        prompt = render_chat_kimi(messages)
+        # Results are re-sorted into tool_calls order, names resolved from ids.
+        self.assertIn("O 1 5 1\nfirstA", prompt)
+        self.assertIn("O 2 6 1\nsecondB", prompt)
+        self.assertLess(prompt.index("O 1 5 1"), prompt.index("O 2 6 1"))
+
+    def test_kimi_json_fallback_for_unparseable_arguments(self):
+        prompt = render_chat_kimi([
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "x", "type": "function", "function": {
+                    "name": "fn", "arguments": "not json"}}]}])
+        self.assertIn("J 2 8\nfnnot json", prompt)
+
+    def test_kimi_still_rejects_unknown_roles(self):
         with self.assertRaisesRegex(APIError, "Unsupported role"):
-            render_chat_kimi([{"role": "tool", "content": "result"}])
+            render_chat_kimi([{"role": "critic", "content": "hm"}])
+        with self.assertRaisesRegex(APIError, "resolvable tool name"):
+            render_chat_kimi([{"role": "tool", "content": "orphan result"}])
+
+    def test_kimi_parses_generated_tool_calls(self):
+        reply = ('Sure.<|open|>tools<|sep|>'
+                 '<|open|>call tool="get_weather" index="1"<|sep|>'
+                 '<|open|>argument key="city" type="string"<|sep|>Rome<|close|>argument<|sep|>'
+                 '<|open|>argument key="days" type="number"<|sep|>1e2<|close|>argument<|sep|>'
+                 '<|close|>call<|sep|>'
+                 '<|close|>tools<|sep|>')
+        text, calls = parse_k3_tool_calls(reply)
+        self.assertEqual(text, "Sure.")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["function"]["name"], "get_weather")
+        self.assertEqual(json.loads(calls[0]["function"]["arguments"]),
+                         {"city": "Rome", "days": 100.0})
+
+    def test_kimi_parses_json_block_and_unclosed_tail(self):
+        reply = ('<|open|>tools<|sep|>'
+                 '<|open|>call tool="a&amp;b" index="1"<|sep|>'
+                 '<|open|>json type="object"<|sep|>{"x":1}<|close|>json<|sep|>'
+                 '<|close|>call<|sep|>')       # tools block never closed: budget ran out
+        text, calls = parse_k3_tool_calls(reply)
+        self.assertEqual(text, "")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["function"]["name"], "a&b")
+        self.assertEqual(calls[0]["function"]["arguments"], '{"x":1}')
 
     def test_kimi_preserves_prior_reasoning_channel(self):
         self.assertEqual(

--- a/c/tests/test_openai_tools_k3_e2e.py
+++ b/c/tests/test_openai_tools_k3_e2e.py
@@ -1,0 +1,182 @@
+"""End-to-end tool-calling test for the Kimi K3 gateway path (#1143).
+
+Same harness shape as test_openai_tools_e2e.py: openai_server.py runs as a real
+subprocess against a mock engine speaking the SERVE wire protocol, exercised
+over real HTTP. What is K3-specific and pinned here: the K3CHAT1 tool records
+in the rendered payload (declaration, B/F/V call history, O results), the
+literal XTML markers the engine re-emits for a generated call, their
+suppression in streamed deltas across chunk boundaries, and tool_calls in both
+response shapes.
+"""
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import unittest
+import urllib.request
+from pathlib import Path
+
+SERVER = Path(__file__).resolve().parent.parent / "openai_server.py"
+
+MOCK_ENGINE = r'''#!/usr/bin/env python3
+import sys, os
+out, inp = sys.stdout.buffer, sys.stdin.buffer
+out.write(b"\x01\x01READY\x01\x01\n" + b"STAT 0 0 0 0 0\n"); out.flush()
+
+def reply(rid, text, chunks=1):
+    data = text.encode("utf-8")
+    n = max(1, len(data) // chunks)
+    for i in range(0, len(data), n):
+        part = data[i:i+n]
+        out.write(("DATA %s %d\n" % (rid, len(part))).encode() + part + b"\n"); out.flush()
+    out.write(("DONE %s STAT %d 1.0 50.0 10.0 42 0\n" % (rid, len(text.split()))).encode())
+    out.flush()
+
+CALL = ('<|open|>tools<|sep|>'
+        '<|open|>call tool="get_weather" index="1"<|sep|>'
+        '<|open|>argument key="city" type="string"<|sep|>Rome<|close|>argument<|sep|>'
+        '<|close|>call<|sep|>'
+        '<|close|>tools<|sep|>')
+
+while True:
+    line = inp.readline()
+    if not line: break
+    f = line.decode().strip().split()
+    if not f or f[0] != "SUBMIT": continue
+    rid, plen = f[1], int(f[3])
+    prompt = inp.read(plen).decode("utf-8", "replace"); inp.read(1)
+    with open(os.environ["MOCK_LOG"], "a") as log:
+        log.write(prompt + "\n\x00\n")
+    if "O 1 11 5\nget_weathersunny" in prompt:
+        reply(rid, "25 degrees and sunny in Rome.")
+    elif "weather in Rome" in prompt:
+        reply(rid, CALL)
+    elif "weather in Milan" in prompt:
+        # the markers straddle many tiny DATA chunks: streamed suppression must hold
+        reply(rid, "Checking. " + CALL.replace("Rome", "Milan"), chunks=25)
+    else:
+        reply(rid, "Hello from the mock K3 engine.")
+'''
+
+TOOLS = [{"type": "function", "function": {
+    "name": "get_weather",
+    "description": "Current weather for a city",
+    "parameters": {"type": "object",
+                   "properties": {"city": {"type": "string"}},
+                   "required": ["city"]}}}]
+
+
+@unittest.skipUnless(os.name == "posix",
+                     "the mock engine is a shebang script the gateway execs directly; "
+                     "Windows CreateProcess cannot run it. The gateway logic under test "
+                     "is platform-independent and covered by the POSIX CI jobs.")
+class K3ToolCallingE2E(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.TemporaryDirectory()
+        (Path(cls.tmp.name) / "config.json").write_text(
+            json.dumps({"model_type": "kimi_k3"}), encoding="utf-8")
+        mock = Path(cls.tmp.name) / "mock_engine.py"
+        mock.write_text(MOCK_ENGINE)
+        mock.chmod(0o755)
+        cls.mock_log = Path(cls.tmp.name) / "prompts.log"
+        cls.mock_log.touch()
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            cls.port = probe.getsockname()[1]
+        env = dict(os.environ, MOCK_LOG=str(cls.mock_log))
+        cls.server = subprocess.Popen(
+            [sys.executable, str(SERVER), "--model", cls.tmp.name,
+             "--engine", str(mock), "--port", str(cls.port)],
+            env=env, stderr=subprocess.DEVNULL)
+        cls.base = f"http://127.0.0.1:{cls.port}/v1"
+        for _ in range(100):
+            try:
+                with urllib.request.urlopen(cls.base + "/models", timeout=2) as resp:
+                    cls.model_id = json.loads(resp.read())["data"][0]["id"]
+                return
+            except OSError:
+                if cls.server.poll() is not None:
+                    raise RuntimeError("gateway exited during startup")
+                import time
+                time.sleep(0.1)
+        raise RuntimeError("gateway did not come up")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.terminate()
+        cls.server.wait(timeout=5)
+        cls.tmp.cleanup()
+
+    def post(self, body, stream=False):
+        req = urllib.request.Request(
+            self.base + "/chat/completions", json.dumps(body).encode(),
+            {"Content-Type": "application/json"})
+        resp = urllib.request.urlopen(req, timeout=30)
+        if stream:
+            return resp.read().decode()
+        return json.loads(resp.read().decode())
+
+    def prompts(self):
+        return [p for p in self.mock_log.read_text().split("\n\x00\n") if p]
+
+    def test_declaration_reaches_the_wire_and_call_parses(self):
+        out = self.post({"model": self.model_id, "tools": TOOLS,
+                         "messages": [{"role": "user",
+                                       "content": "What is the weather in Rome?"}]})
+        msg = out["choices"][0]["message"]
+        self.assertEqual(out["choices"][0]["finish_reason"], "tool_calls")
+        self.assertEqual(len(msg["tool_calls"]), 1)
+        call = msg["tool_calls"][0]["function"]
+        self.assertEqual(call["name"], "get_weather")
+        self.assertEqual(json.loads(call["arguments"]), {"city": "Rome"})
+        # the rendered K3CHAT1 payload carried the tool declaration record
+        last = self.prompts()[-1]
+        self.assertIn("Y 12 ", last)
+        self.assertIn("tool-declare# Tools", last)
+        self.assertNotIn("<|open|>", last)   # gateway ships records, never raw XTML
+
+    def test_round_trip_renders_call_history_and_result(self):
+        out = self.post({"model": self.model_id, "tools": TOOLS, "messages": [
+            {"role": "user", "content": "What is the weather in Rome?"},
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {
+                    "name": "get_weather", "arguments": '{"city": "Rome"}'}}]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "sunny"},
+        ]})
+        msg = out["choices"][0]["message"]
+        self.assertIn("sunny", msg["content"])
+        self.assertFalse(msg.get("tool_calls"))
+        last = self.prompts()[-1]
+        self.assertIn("B 0 0 0 1\n", last)
+        self.assertIn("F 11 1\nget_weather", last)
+        self.assertIn("V 4 6 4\ncitystringRome", last)
+        self.assertIn("O 1 11 5\nget_weathersunny", last)
+
+    def test_streamed_markers_are_suppressed_across_chunks(self):
+        raw = self.post({"model": self.model_id, "tools": TOOLS, "stream": True,
+                         "messages": [{"role": "user",
+                                       "content": "What is the weather in Milan?"}]},
+                        stream=True)
+        self.assertNotIn("<|open|>", raw)
+        self.assertNotIn("<|sep|>", raw)
+        deltas = [json.loads(l[len("data: "):]) for l in raw.splitlines()
+                  if l.startswith("data: ") and l != "data: [DONE]"]
+        text = "".join(d["choices"][0]["delta"].get("content") or "" for d in deltas)
+        self.assertEqual(text.strip(), "Checking.")
+        calls = [d for d in deltas if d["choices"][0]["delta"].get("tool_calls")]
+        self.assertTrue(calls, "no tool_calls delta in the stream")
+        fn = calls[0]["choices"][0]["delta"]["tool_calls"][0]["function"]
+        self.assertEqual(fn["name"], "get_weather")
+
+    def test_tool_choice_none_omits_declaration(self):
+        self.post({"model": self.model_id, "tools": TOOLS, "tool_choice": "none",
+                   "messages": [{"role": "user", "content": "Hello"}]})
+        last = self.prompts()[-1]
+        self.assertNotIn("tool-declare", last)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tests/tok_kimi_tiny.json
+++ b/c/tests/tok_kimi_tiny.json
@@ -20,6 +20,42 @@
    "rstrip": false,
    "normalized": false,
    "special": true
+  },
+  {
+   "id": 276,
+   "content": "<|open|>",
+   "single_word": false,
+   "lstrip": false,
+   "rstrip": false,
+   "normalized": false,
+   "special": true
+  },
+  {
+   "id": 277,
+   "content": "<|close|>",
+   "single_word": false,
+   "lstrip": false,
+   "rstrip": false,
+   "normalized": false,
+   "special": true
+  },
+  {
+   "id": 278,
+   "content": "<|sep|>",
+   "single_word": false,
+   "lstrip": false,
+   "rstrip": false,
+   "normalized": false,
+   "special": true
+  },
+  {
+   "id": 279,
+   "content": "<|end_of_msg|>",
+   "single_word": false,
+   "lstrip": false,
+   "rstrip": false,
+   "normalized": false,
+   "special": true
   }
  ],
  "normalizer": null,

--- a/docs/api.md
+++ b/docs/api.md
@@ -54,7 +54,7 @@ exposing the server beyond the machine.
 | GLM-5.2 (`colibri`) | yes | yes | `<tool_call>` blocks |
 | DeepSeek V4 | yes | yes | native DSML tool-call blocks |
 | Inkling | no | no | active tool declarations/choices return HTTP 400 |
-| Kimi K3 | no | no | active tool declarations/choices return HTTP 400 |
+| Kimi K3 | yes | yes | native XTML `tools`/`call`/`argument` blocks (#1143) |
 | OLMoE | no | no | active tool declarations/choices return HTTP 400 |
 
 On supported engines, pass OpenAI `tools` and optionally `tool_choice` to


### PR DESCRIPTION
Implements #1143 (closes #1029's last flagship gap), option **(a)** from the design write-up — literal re-emission, GLM-precedent marker suppression. If (b) is preferred I'll rework the output side; everything else is independent of that choice.

## What's in

**Format** — verified against `encoding_k3.py` in the Kimi-K3 checkpoint repo (the normative renderer; K3 has no jinja template). All four surfaces: `tool-declare` system turn, `tools > call > argument` blocks with per-argument XTML types (non-strings keep their exact JSON literal — `1e2` stays `1e2`, one-level-deep parse mirrored from the reference), `role="tool"` result turns re-sorted into `tool_calls` order by `tool_call_id` (the reference's normalization), `tool_choice` required/none/forced.

**Gateway** — `K3CHAT1` grows typed records (`Y`/`O`/`B`/`F`/`V`/`J`) instead of pre-rendered text: K3's rank-BPE segment boundaries are the tokenizer contract, so tags keep being constructed engine-side. `parse_k3_tool_calls` + the stream-marker machinery handle the return path, with the GLM path's unclosed-block recovery posture.

**Engine** — `chat_build_wire` parses the records through the existing `ChatB` primitives plus `cb_attr` (attribute segmentation matches the reference exactly: `" key"`, `'="'`, escaped value, `'"'` each their own segment; `&`/`"` → `&amp;`/`&quot;`). The serve loop re-emits **tool-structural runs only** literally; every other XTML run stays suppressed exactly as before, so non-tool traffic is byte-identical to today.

## Tests (three layers)

- `test_k3_chat_tools.c` — golden: records rendered against the tiny Kimi tokenizer (which now carries the four XTML tokens) must reproduce the reference byte stream exactly, incl. attr escaping and malformed-record refusal. 7/7.
- Gateway units — declaration/choice modes, call history, argument typing, json fallback, id-based result re-sort, generated-call parsing, unclosed-tail recovery. 11/11 (kimi-filtered).
- `test_openai_tools_k3_e2e.py` — real gateway subprocess vs mock SERVE engine: both response shapes, chunk-straddling stream suppression (markers split across 25 DATA frames), `tool_choice=none` omits the declaration. 4/4.
- Full regressions: `test_openai*` 163/163, Anthropic surface 28/28 (kimi moved from the reject-list test to a render assertion), `make test-c` green, zero-warning builds.

## Stated limits

- **Not executed against the real 2.8T checkpoint** — the e2e layer is engine-mocked by design (same as the GLM suite). A real-model smoke on a K3-capable host is the honest final gate before this ships in a release; happy to coordinate.
- `tool_choice=none` follows the V4 gateway precedent (tools simply not offered) rather than the reference's MUST-NOT message — noted in #1143, trivially changeable if you'd rather mirror the reference.
- docs/api.md matrix updated; ENVIRONMENT.md untouched (no new env vars).