### PR TITLE
fix(dsv4): reference matvec adopts the rows16 accumulation order (#1136)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1203,7 +1203,8 @@ V4_TEST_LINK_OBJS = \
 	COLI_V4_UNIT_RESOURCE_PLAN.o \
 	COLI_V4_UNIT_PROMPT.o \
 	$(addsuffix .o,$(V4_TEST_UNITS)) \
-	COLI_V4_UNIT_NATIVE_QUANT.o
+	COLI_V4_UNIT_NATIVE_QUANT.o \
+	COLI_V4_UNIT_NATIVE_QUANT_ROWS16.o
 # Windows engine objects are compiled with -DCOLI_V4_GPU_TIER (the CUDA tier
 # is resolved from coli_cuda_dsv4*.dll at runtime), so the matvec references in
 # native_quant.h resolve through the GPU unit + the DLL loader. Both are inert
@@ -1218,6 +1219,7 @@ tests/test_deepseek_v4$(EXE): tests/test_deepseek_v4.c deepseek_v4.c deepseek_v4
 	$(MAKE) -f Makefile.deepseek-v4 ARCH=$(ARCH) deepseek-v4-test-objs \
 		COLI_V4_UNIT_ST.o COLI_V4_UNIT_CONFIG.o COLI_V4_UNIT_MATH.o COLI_V4_UNIT_SPARSE_ATTENTION.o \
 		COLI_V4_UNIT_RESOURCE_PLAN.o COLI_V4_UNIT_PROMPT.o COLI_V4_UNIT_NATIVE_QUANT.o \
+		COLI_V4_UNIT_NATIVE_QUANT_ROWS16.o \
 		$(V4_TEST_EXTRA_TARGETS)
 	$(CC) $(CFLAGS) $< $(V4_TEST_LINK_OBJS) -o $@ -pthread $(LDFLAGS)
 

--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -14744,6 +14744,136 @@ int coli_v4_qdq_scratch(size_t activation_count, size_t scales_count,
     return 0;
 }
 
+/* ---- #1136 convergence: the reference matvec accumulates in the rows16 order.
+ *
+ * The rows16 kernels and matmul_mxfp4 compute the same math in two float
+ * orders: rows16 folds (x*w)*scale straight into the row accumulator column
+ * by column (identical per-row order on AVX-512, AVX2 and NEON — mul, mul,
+ * add, never fused); matmul_mxfp4 builds 32-column partial sums and scales
+ * them afterwards (plus an 8-lane horizontal reduction on AVX2). Which expert
+ * takes which kernel follows cache residency, so greedy output moved run to
+ * run (#1136). Per the maintainer's call there, the reference path adopts the
+ * rows16 order — same shape as the K1 f32 planar-tail fix — so a hot
+ * (rows16-packed) and a cold (row-major) expert produce identical bits.
+ *
+ * Only rows%16==0 matrices can ever be rows16-packed (the packer refuses the
+ * rest), so the old order is kept verbatim where no divergence is possible.
+ * The AVX2 arm vectorizes ACROSS rows (16 rows = two 8-lane vectors, columns
+ * in order), which preserves each row's scalar operation order exactly — the
+ * rows16 kernels' own trick. The scalar arm splits the two multiplies and the
+ * add into separate statements so no compiler contracts them into an FMA:
+ * every rows16 ISA rounds the product before the add. */
+void coli_fp4_matvec_rows16_order(float *y, const uint8_t *q4,
+                                    const uint8_t *e8s, const float *x,
+                                    int I, int O) {
+    int rb = I / 2, ng = I / 32;
+#ifdef __AVX2__
+    /* Nibble decode borrows matmul_mxfp4's trick — doubled e2m1 values are
+     * exact int8, one pshufb decodes a 16-byte row into 32 codes — but the
+     * 0.5 un-doubling multiplies the DECODED VALUE here (exact: d*0.5 is a
+     * pure exponent shift), never the scale: the accumulation must see the
+     * same w as coli_e2m1_decode so (x*w)*scale rounds identically to the
+     * rows16 kernels. Rows decode row-major (streaming loads), then 8x8
+     * transposes turn them column-major so 16 rows ride two 8-lane vectors
+     * down the column loop in the rows16 per-row order: mul, mul, add. */
+    float e8lut[256];
+    for (int v = 0; v < 256; v++) e8lut[v] = coli_e8m0_decode((uint8_t)v);
+    #pragma omp parallel for schedule(static)
+    for (int64_t tile = 0; tile < O / 16; tile++) {
+        const __m128i lut2 = _mm_setr_epi8(0,1,2,3,4,6,8,12,0,-1,-2,-3,-4,-6,-8,-12);
+        const __m128i m4 = _mm_set1_epi8(0x0F);
+        const __m256 half = _mm256_set1_ps(0.5f);
+        __m256 sum0 = _mm256_setzero_ps(), sum1 = _mm256_setzero_ps();
+        for (int base = 0; base < I; base += 32) {
+            float sc[16], tmp[2][32][8];
+            for (int half_rows = 0; half_rows < 2; half_rows++) {
+                __m256 rowv[8][4];
+                for (int r8 = 0; r8 < 8; r8++) {
+                    int64_t row = tile * 16 + half_rows * 8 + r8;
+                    sc[half_rows * 8 + r8] = e8lut[e8s[row * ng + base / 32]];
+                    __m128i by = _mm_loadu_si128(
+                        (const __m128i *)(q4 + row * rb + base / 2));
+                    __m128i lo = _mm_and_si128(by, m4);
+                    __m128i hi = _mm_and_si128(_mm_srli_epi16(by, 4), m4);
+                    __m128i n0 = _mm_shuffle_epi8(lut2, _mm_unpacklo_epi8(lo, hi));
+                    __m128i n1 = _mm_shuffle_epi8(lut2, _mm_unpackhi_epi8(lo, hi));
+                    rowv[r8][0] = _mm256_mul_ps(_mm256_cvtepi32_ps(
+                        _mm256_cvtepi8_epi32(n0)), half);
+                    rowv[r8][1] = _mm256_mul_ps(_mm256_cvtepi32_ps(
+                        _mm256_cvtepi8_epi32(_mm_srli_si128(n0, 8))), half);
+                    rowv[r8][2] = _mm256_mul_ps(_mm256_cvtepi32_ps(
+                        _mm256_cvtepi8_epi32(n1)), half);
+                    rowv[r8][3] = _mm256_mul_ps(_mm256_cvtepi32_ps(
+                        _mm256_cvtepi8_epi32(_mm_srli_si128(n1, 8))), half);
+                }
+                for (int cb = 0; cb < 4; cb++) {
+                    __m256 blk[8];
+                    for (int r8 = 0; r8 < 8; r8++) blk[r8] = rowv[r8][cb];
+                    __m256 t0 = _mm256_unpacklo_ps(blk[0], blk[1]);
+                    __m256 t1 = _mm256_unpackhi_ps(blk[0], blk[1]);
+                    __m256 t2 = _mm256_unpacklo_ps(blk[2], blk[3]);
+                    __m256 t3 = _mm256_unpackhi_ps(blk[2], blk[3]);
+                    __m256 t4 = _mm256_unpacklo_ps(blk[4], blk[5]);
+                    __m256 t5 = _mm256_unpackhi_ps(blk[4], blk[5]);
+                    __m256 t6 = _mm256_unpacklo_ps(blk[6], blk[7]);
+                    __m256 t7 = _mm256_unpackhi_ps(blk[6], blk[7]);
+                    __m256 s0 = _mm256_shuffle_ps(t0, t2, _MM_SHUFFLE(1,0,1,0));
+                    __m256 s1 = _mm256_shuffle_ps(t0, t2, _MM_SHUFFLE(3,2,3,2));
+                    __m256 s2 = _mm256_shuffle_ps(t1, t3, _MM_SHUFFLE(1,0,1,0));
+                    __m256 s3 = _mm256_shuffle_ps(t1, t3, _MM_SHUFFLE(3,2,3,2));
+                    __m256 s4 = _mm256_shuffle_ps(t4, t6, _MM_SHUFFLE(1,0,1,0));
+                    __m256 s5 = _mm256_shuffle_ps(t4, t6, _MM_SHUFFLE(3,2,3,2));
+                    __m256 s6 = _mm256_shuffle_ps(t5, t7, _MM_SHUFFLE(1,0,1,0));
+                    __m256 s7 = _mm256_shuffle_ps(t5, t7, _MM_SHUFFLE(3,2,3,2));
+                    _mm256_storeu_ps(tmp[half_rows][cb * 8 + 0],
+                                     _mm256_permute2f128_ps(s0, s4, 0x20));
+                    _mm256_storeu_ps(tmp[half_rows][cb * 8 + 1],
+                                     _mm256_permute2f128_ps(s1, s5, 0x20));
+                    _mm256_storeu_ps(tmp[half_rows][cb * 8 + 2],
+                                     _mm256_permute2f128_ps(s2, s6, 0x20));
+                    _mm256_storeu_ps(tmp[half_rows][cb * 8 + 3],
+                                     _mm256_permute2f128_ps(s3, s7, 0x20));
+                    _mm256_storeu_ps(tmp[half_rows][cb * 8 + 4],
+                                     _mm256_permute2f128_ps(s0, s4, 0x31));
+                    _mm256_storeu_ps(tmp[half_rows][cb * 8 + 5],
+                                     _mm256_permute2f128_ps(s1, s5, 0x31));
+                    _mm256_storeu_ps(tmp[half_rows][cb * 8 + 6],
+                                     _mm256_permute2f128_ps(s2, s6, 0x31));
+                    _mm256_storeu_ps(tmp[half_rows][cb * 8 + 7],
+                                     _mm256_permute2f128_ps(s3, s7, 0x31));
+                }
+            }
+            __m256 sc0 = _mm256_loadu_ps(sc), sc1 = _mm256_loadu_ps(sc + 8);
+            for (int c = 0; c < 32; c++) {
+                __m256 xv = _mm256_set1_ps(x[base + c]);
+                sum0 = _mm256_add_ps(sum0, _mm256_mul_ps(
+                    _mm256_mul_ps(xv, _mm256_loadu_ps(tmp[0][c])), sc0));
+                sum1 = _mm256_add_ps(sum1, _mm256_mul_ps(
+                    _mm256_mul_ps(xv, _mm256_loadu_ps(tmp[1][c])), sc1));
+            }
+        }
+        _mm256_storeu_ps(y + tile * 16, sum0);
+        _mm256_storeu_ps(y + tile * 16 + 8, sum1);
+    }
+#else
+    #pragma omp parallel for schedule(static)
+    for (int o = 0; o < O; o++) {
+        const uint8_t *w = q4 + (int64_t)o * rb;
+        const uint8_t *scl = e8s + (int64_t)o * ng;
+        float sum = 0.0f;
+        for (int c = 0; c < I; c++) {
+            uint8_t byte = w[c >> 1];
+            float wv = coli_e2m1_decode((c & 1) ? (uint8_t)(byte >> 4)
+                                                : (uint8_t)(byte & 0xF));
+            float t = x[c] * wv;                 /* separate statements: the   */
+            t = t * coli_e8m0_decode(scl[c / 32]); /* product must round before */
+            sum = sum + t;                       /* the add, as on every ISA   */
+        }
+        y[o] = sum;
+    }
+#endif
+}
+
 int coli_fp4_matvec_ref(float *output, const ColiTensorView *weight,
                         const float *input) {
     if (!output || !weight || !input ||
@@ -14777,8 +14907,12 @@ int coli_fp4_matvec_ref(float *output, const ColiTensorView *weight,
                                     input, columns, 128) != 0) {
         return -1;
     }
-    matmul_mxfp4(output, activation, weight->data, weight->scales,
-                 1, (int)columns, (int)rows);
+    if (rows % 16 == 0)          /* rows16-packable shape: converge (#1136) */
+        coli_fp4_matvec_rows16_order(output, weight->data, weight->scales,
+                                activation, (int)columns, (int)rows);
+    else
+        matmul_mxfp4(output, activation, weight->data, weight->scales,
+                     1, (int)columns, (int)rows);
     return 0;
 }
 
@@ -14952,10 +15086,17 @@ int coli_fp4_dual_matvec_ref(float *output_a, float *output_b,
                                     input, columns, 128) != 0) {
         return -1;
     }
-    matmul_mxfp4(output_a, activation, a->data, a->scales,
-                 1, (int)columns, (int)rows);
-    matmul_mxfp4(output_b, activation, b->data, b->scales,
-                 1, (int)columns, (int)rows);
+    if (rows % 16 == 0) {        /* rows16-packable shape: converge (#1136) */
+        coli_fp4_matvec_rows16_order(output_a, a->data, a->scales,
+                                activation, (int)columns, (int)rows);
+        coli_fp4_matvec_rows16_order(output_b, b->data, b->scales,
+                                activation, (int)columns, (int)rows);
+    } else {
+        matmul_mxfp4(output_a, activation, a->data, a->scales,
+                     1, (int)columns, (int)rows);
+        matmul_mxfp4(output_b, activation, b->data, b->scales,
+                     1, (int)columns, (int)rows);
+    }
     return 0;
 }
 

--- a/c/native_quant.h
+++ b/c/native_quant.h
@@ -34,6 +34,16 @@ int coli_hadamard_bf16_ref(float *values, size_t length);
 int coli_fp4_matvec_ref(float *output, const ColiTensorView *weight,
                         const float *input);
 
+/* #1136 convergence core: row-major fp4 matvec accumulating in the rows16
+ * kernels' per-row order — (x*w)*scale folded straight into the row
+ * accumulator, column by column, product rounded before the add — so a
+ * rows16-packed and a row-major copy of the same matrix produce identical
+ * bits. Requires I%32==0 and O%16==0 (the only shapes rows16 can pack);
+ * `x` is the already-qdq'd activation. */
+void coli_fp4_matvec_rows16_order(float *y, const uint8_t *q4,
+                                  const uint8_t *e8s, const float *x,
+                                  int I, int O);
+
 /* Correctness-first FP8 matvec for native 128x128 E4M3 weight blocks with
  * UE8M0 scales and dynamically quantized E4M3 activations. */
 int coli_fp8_matvec_ref(float *output, const ColiTensorView *weight,

--- a/c/tests/test_deepseek_v4.c
+++ b/c/tests/test_deepseek_v4.c
@@ -2,6 +2,7 @@
 #include "../deepseek_v4_internal.h"
 #include "../compat.h"
 #include "../native_quant.h"
+#include "../native_quant_fp4_rows16.h"
 
 #include <assert.h>
 #include <fcntl.h>
@@ -215,6 +216,63 @@ static int test_expert(void) {
     if (!(output[0] > 0.0f)) return 1;
     puts("DeepSeek-V4 expert tests: ok");
     return 0;
+}
+
+/* #1136: a rows16-packed copy and the row-major original of the SAME matrix
+ * must produce bit-identical matvec outputs — the reference path accumulates
+ * in the rows16 order now, so which kernel an expert takes (cache residency)
+ * can no longer move greedy text. Varied nibbles AND varied per-group scales:
+ * uniform data would let the old group-partial-sum order pass by accident. */
+static int test_rows16_convergence(void) {
+#ifndef COLI_FP4_ROWS16_KERNEL
+    puts("DeepSeek-V4 rows16 convergence: skipped (no rows16 kernel on this ISA)");
+    return 0;
+#else
+    enum { ROWS = 32, COLUMNS = 128 };
+    static uint8_t data[ROWS * COLUMNS / 2], scales[ROWS * COLUMNS / 32];
+    static uint8_t packed_data[ROWS * COLUMNS / 2], packed_scales[ROWS * COLUMNS / 32];
+    uint32_t state = 0x1136u;
+    for (size_t i = 0; i < sizeof(data); i++) {
+        state = state * 1664525u + 1013904223u;
+        data[i] = (uint8_t)(state >> 24);
+    }
+    for (size_t i = 0; i < sizeof(scales); i++) {
+        state = state * 1664525u + 1013904223u;
+        scales[i] = (uint8_t)(120 + ((state >> 24) & 15));   /* e8m0 near 1.0 */
+    }
+    ColiTensorView source = {
+        COLI_TENSOR_FP4_NATIVE_BLOCK, COLI_SCALE_UE8M0,
+        data, scales, sizeof(data), sizeof(scales), ROWS, COLUMNS, 1, 32, NULL
+    };
+    if (coli_fp4_pack_rows16_v10(packed_data, packed_scales, &source) != 0)
+        return 1;
+    ColiTensorView packed = source;
+    packed.data = packed_data; packed.scales = packed_scales;
+    packed.block_rows = 16;
+    float input[COLUMNS];
+    for (int i = 0; i < COLUMNS; i++)
+        input[i] = 0.05f * (float)((i * 7) % 13 - 6);
+    /* the rows16 kernel qdq's internally; feed the converged core the same
+     * qdq'd activation the ref path would use */
+    float activation[COLUMNS]; uint8_t activation_scales[COLUMNS / 128];
+    if (coli_fp8_activation_qdq_ref(activation, activation_scales,
+                                    input, COLUMNS, 128) != 0) return 1;
+    float hot[ROWS], cold[ROWS], ref[ROWS];
+    if (coli_fp4_matvec_rows16_v10(hot, &packed, input) != 0) return 1;
+    coli_fp4_matvec_rows16_order(cold, data, scales, activation, COLUMNS, ROWS);
+    if (memcmp(hot, cold, sizeof(hot)) != 0) {
+        for (int r = 0; r < ROWS; r++)
+            if (hot[r] != cold[r])
+                fprintf(stderr, "  row %d: rows16 %.9g vs converged ref %.9g\n",
+                        r, (double)hot[r], (double)cold[r]);
+        return 1;
+    }
+    /* and the public entry point routes rows%16==0 through the converged core */
+    if (coli_fp4_matvec_ref(ref, &source, input) != 0) return 1;
+    if (memcmp(hot, ref, sizeof(hot)) != 0) return 1;
+    puts("DeepSeek-V4 rows16 convergence: ok (hot and cold bits identical)");
+    return 0;
+#endif
 }
 /* ==== end test_deepseek_v4_expert.c ==== */
 
@@ -789,6 +847,10 @@ int main(int argc, char **argv) {
     }
     if (test_expert() != 0) {
         fprintf(stderr, "FAIL: test_expert\n");
+        return 1;
+    }
+    if (test_rows16_convergence() != 0) {
+        fprintf(stderr, "FAIL: test_rows16_convergence\n");
         return 1;
     }
     if (test_expert_store() != 0) {


### PR DESCRIPTION
Implements the convergence fix from your #1136 verdict: the reference fp4 matvec now accumulates in the rows16 order, so a hot (rows16-packed) and a cold (row-major) expert produce **identical bits**, and cache residency can no longer move greedy text.

## Why matvec convergence is whole-expert convergence

The v17 FFN fallback and the rows16 expert forward are step-identical around the matvecs — same activation qdq, same bf16 rounds after gate/up and output, same swiglu, same route-weight fold. The only divergence was the matmul float order: rows16 folds `(x*w)*scale` straight into the row accumulator column by column (per-row order identical on AVX-512, AVX2 and NEON — mul, mul, add, never fused); `matmul_mxfp4` builds 32-column partial sums, scales them afterwards, and on AVX2 adds an 8-lane horizontal reduction. Converge the matvec and the whole expert converges.

## What changed

- `coli_fp4_matvec_rows16_order` (new, prototyped in native_quant.h): row-major fp4 matvec in the rows16 per-row order. AVX2 arm vectorizes **across rows** (16 rows = two 8-lane vectors, columns in order — the rows16 kernels' own trick, so each row's scalar operation order is preserved exactly); nibble decode reuses `matmul_mxfp4`'s doubled-int8 pshufb, but un-doubles the decoded **value** (exact exponent shift) rather than folding 0.5 into the scale — the accumulation must see the same `w` as `coli_e2m1_decode`. Scalar arm splits the two multiplies and the add into separate statements so no compiler contracts them into an FMA (every rows16 ISA rounds the product before the add).
- `coli_fp4_matvec_ref` and `coli_fp4_dual_matvec_ref` route every `rows%16==0` matrix through it. Those are the **only** shapes the rows16 packer accepts, so where no divergence was ever possible the old `matmul_mxfp4` order is kept verbatim (and K3's own mxfp4 uses are untouched).

## Verification

- **`test_rows16_convergence`** (new, in test_deepseek_v4.c): packs a matrix with varied nibbles **and varied per-group scales** (uniform data would let the old group-partial order pass by accident), then asserts `coli_fp4_matvec_rows16_v10` on the packed copy and the converged reference on the row-major original agree **to the bit**, through both the core and the public entry. Passes on AVX2; the test links the ROWS16 unit into test_deepseek_v4 (Makefile).
- Full `make test-c` green, zero new warnings.
- **CI heads-up:** the v4-tiny torch oracle compares against a fixed reference under the OLD cold-path order. If any position sat on a rounding knife-edge, this PR moves it — that would be the expected baseline migration of a convergence fix, not a regression; the bit-equal test above is the property that matters now.

## Cost, stated plainly

Measured on a quiet 24-thread run, 4096×2048 (V4-Flash-ish expert shape): **155 GFLOP/s vs matmul_mxfp4's 235 — 0.66×** on the matvec. By #1119's profile (expert-matmul 19% of CPU decode), that is roughly **6–9% end-to-end** on a cold-dominant host, traded for run-to-run determinism per the house rule. Two honest notes: my benchmark runs on WSL2 and jitters badly under scheduler noise (the 0.66× is the clean best-of run); and there is headroom left — an AVX-512 arm and decode/accumulate interleaving are the obvious next cuts if the 0.66× matters in practice. If you'd rather gate the convergence behind the interim `COLI_V4_ROWS16=0`-era switches until the perf gap closes, say so — but my read of the verdict is that determinism wins the default.

Companion: #1145 (the ENVIRONMENT.md table entry) covers the interim documentation half.
