### PR TITLE
fix(inkling): pass qgs at the Metal MoE callsites (#1150)

### DIFF
--- a/c/inkling.c
+++ b/c/inkling.c
@@ -1383,7 +1383,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
             }
         }
         sxoff[ns] = ns*S;
-        sh_h = coli_metal_moe_block_begin(ns, D, I, 5, sgp, sup, sdp,
+        sh_h = coli_metal_moe_block_begin(ns, D, I, 5, 0, sgp, sup, sdp,
                                           sscale, sscale, sscale,
                                           sxg, sxoff, snr, srows, srw);
         free(srows);
@@ -1466,7 +1466,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
                  * the round; shared_done stays set either way. */
                 if (base + cap >= npair && !sh_h) {
                     ColiMetalMoeHandle *h = coli_metal_moe_block_begin(
-                        nb, D, I, q4 ? 2 : 1, mgp, mup, mdp, mgs, mus, mds,
+                        nb, D, I, q4 ? 2 : 1, 0, mgp, mup, mdp, mgs, mus, mds,
                         mxg, mxoff, mnr, mrows, mrw);
                     if (h) {
                         double ts = now_s();
@@ -1480,7 +1480,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
                         te = now_s();                      /* fault: CPU redo below */
                     }
                 }
-                if (coli_metal_moe_block(nb, D, I, q4 ? 2 : 1, mgp, mup, mdp, mgs, mus, mds,
+                if (coli_metal_moe_block(nb, D, I, q4 ? 2 : 1, 0, mgp, mup, mdp, mgs, mus, mds,
                                          mxg, mxoff, mnr, mrows, mrw, out, S)) {
                     m->t_expert += now_s() - te;
                     continue;                              /* round done on the GPU */


### PR DESCRIPTION
Fixes #1150 (reported by @jerome-benoit, with the exact error output and the two failing lines — that is what made this a five-minute fix).

`backend_metal.h` declares `qgs` after `fmt` for both `coli_metal_moe_block` and `coli_metal_moe_block_begin`; `inkling.c` had not been updated, so `METAL=1` builds fail with `too few arguments`.

**The value is documented rather than inferred.** The header says: *"qgs is the fmt=4 group size (ignored, pass 0, for fmt!=4)"*. Inkling uses fmt=5 for the shared expert and fmt=1/2 for the routed ones — all non-4, so `0` at every site, and the kernel ignores it there anyway.

**Three callsites, not two.** The report lists `:1386` (shared, fmt=5) and `:1483` (routed sync). The async `coli_metal_moe_block_begin` in the routed path at `:1468` has the same signature and the same omission — it was invisible in the report because the compiler stops before reaching it.

Verified the CPU build stays clean (zero errors, zero warnings). The Metal path itself I cannot build here; CI's macOS job builds every engine, which is the gate that would have caught this in the first place had Inkling's Metal path been in it.

@jerome-benoit — if you have the Mac handy, a `METAL=1` build on this branch would confirm it before merge.