### PR TITLE
fix(web): actually pass onReasoning to streamChat (#1148)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -211,6 +211,19 @@ export default function App() {
         enableThinking: thinking,
         cacheSlot: supportsCacheSlots(health) ? cacheSlot : undefined,
         signal: controller.signal,
+        /* Reasoning tokens are tokens: they count toward the rate, and the
+           first one is the real time-to-first-token — the answer's first
+           token arrives much later on a reasoning model. */
+        onReasoning: (delta) => {
+          if (firstToken) { setTtft(performance.now() - t0); setStreamStart(performance.now()); firstToken = false }
+          count++
+          setTokenCount(count)
+          const elapsed = (performance.now() - t0) / 1000
+          if (elapsed > 0.3) setTokPerSec(count / elapsed)
+          updateMessages((current) => current.map((item) =>
+            item.id === assistant.id ? { ...item, reasoning: (item.reasoning ?? "") + delta } : item,
+          ))
+        },
         onDelta: (delta) => {
           if (firstToken) { setTtft(performance.now() - t0); setStreamStart(performance.now()); firstToken = false }
           count++


### PR DESCRIPTION
Reopens and finishes #1148. **@uvtzxpm was right: #1153 did not fix it.**

`api.ts` got the `onReasoning` callback and `App.tsx` got the `reasoning` field, the render block and the cleanup filters — but the one line that connects them, passing `onReasoning` into the `streamChat` options, never landed. So `options.onReasoning?.(reasoning)` fired against an undefined callback and the field stayed empty. The symptom was byte-for-byte identical to the original bug.

**How it got past me, since the mechanism is reusable:** the edit script printed its success message *before* writing the file, and a later assertion in the same block aborted it — so "ok" appeared on screen and the write never happened. I then verified with `grep -c "item.reasoning"`, which matched the render and the filters and returned a number that looked right. I never grepped for `onReasoning` in `App.tsx`. Verifying the thing I could see rather than the thing that was missing.

**One change beyond the paste:** reasoning deltas now also increment the token count and set TTFT. On a reasoning model the first thinking token *is* the first generated token, so measuring TTFT to the first answer token overstates it by the whole thinking phase, and a rate that excludes thinking understates what the engine produced. @uvtzxpm's diff had this too — it is the right call and I am noting it rather than absorbing it silently.

Verified: `tsc --noEmit` clean, `npm run build` succeeds. @uvtzxpm, a run on this branch would close it for real this time.