### PR TITLE
ci(macos): compile every Metal-capable engine with METAL=1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,25 @@ jobs:
           done
           exit $rc
       - if: matrix.os == 'macos-latest'
+        name: Build every Metal-capable engine with METAL=1
+        # `make <engine>` above builds the CPU path only: everything behind
+        # COLI_METAL is invisible to it. That is how #1150 survived a month --
+        # inkling.c kept calling coli_metal_moe_block with the pre-qgs
+        # signature from v1.6.0 onward and no job ever compiled the call.
+        # Compile-only by necessity: the runner's Apple Paravirtual device
+        # cannot execute Metal submissions (see the note below), but signature
+        # drift is a compile error, which is exactly what this catches.
+        run: |
+          cd c
+          rc=0
+          for t in colibri inkling kimi_k3; do
+            echo "::group::$t METAL=1"
+            make clean >/dev/null 2>&1 || true
+            make $t METAL=1 || { echo "FAILED: $t METAL=1"; rc=1; }
+            echo "::endgroup::"
+          done
+          exit $rc
+      - if: matrix.os == 'macos-latest'
         name: Metal backend tests
         # The Metal backend suite is its own target (metal-test) and is not
         # part of `make check`: TEST_BINS is derived from tests/test_*.$(EXE)


### PR DESCRIPTION
**This PR exists to answer a question I could not answer myself:** does #1152 actually make Inkling build on macOS? I have no Mac, so I fixed the three callsites from the header's documented contract (`qgs` is the fmt=4 group size, pass 0 otherwise) and could not compile the result.

**And our CI could not answer it either, which is the real defect here.** The macOS job runs `make <engine>` with METAL off, so every line behind `COLI_METAL` is invisible to it; `metal-test` compiles `backend_metal.mm` and its own test, not the engines that call into it.

That is how #1150 lasted a month. `backend_metal.h` grew the `qgs` parameter in **v1.6.0** (`19d4004`, 2026-07-24) and `inkling.c` was never updated. macOS users could not build Inkling with `METAL=1` for four weeks, through two releases, and CI stayed green the whole time.

**What this adds:** a compile-only pass over `colibri`, `inkling` and `kimi_k3` with `METAL=1` on the Apple Silicon runner. Compile-only is not a compromise here — the runner's Paravirtual device cannot execute Metal submissions (the existing `metal-test` step already skips execution for that reason), but signature drift **is** a compile error, and that is the entire class this catches.

Same shape as the ARM job (#1083), and for the same reason: a path nothing compiles is a path that rots silently. Once this is green on a branch containing #1152, the answer to "is Inkling buildable on macOS again" stops being an assumption.