### PR TITLE
perf(dsv4): make resident expert lookup O(1)

### DIFF
--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -6980,7 +6980,8 @@ typedef struct {
     uint64_t record_bytes;
     V4ExpertRecord *records;
     V4ExpertSlot *slots;
-    int *slot_by_expert; /* global slot index for resident or in-flight expert */
+    int *slot_by_expert; /* resident/in-flight slot; every StoreOps variant that
+                          * mutates slot identity must maintain this index */
     uint64_t clock;
     unsigned active_leases;
     ColiExpertStoreStats stats;

--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -6980,6 +6980,7 @@ typedef struct {
     uint64_t record_bytes;
     V4ExpertRecord *records;
     V4ExpertSlot *slots;
+    int *slot_by_expert; /* global slot index for resident or in-flight expert */
     uint64_t clock;
     unsigned active_leases;
     ColiExpertStoreStats stats;
@@ -7078,6 +7079,47 @@ static V4ExpertSlot *layer_slots(V4ExpertStoreState *state, int layer) {
     return state->slots + (size_t)layer * state->slots_per_layer;
 }
 
+/* All index helpers are called with state->mutex held.  A single table entry
+ * covers both a published expert and its in-flight reservation, so the hot
+ * path and the single-flight path are O(1) in cache capacity. */
+static size_t expert_cell(const V4ExpertStoreState *state, int layer,
+                          int expert) {
+    return (size_t)layer * state->experts_per_layer + expert;
+}
+
+static V4ExpertSlot *indexed_expert_slot(V4ExpertStoreState *state,
+                                         ColiExpertKey key) {
+    int slot_index = state->slot_by_expert[expert_cell(
+        state, key.layer, key.expert)];
+    size_t layer_begin = (size_t)key.layer * state->slots_per_layer;
+    size_t layer_end = layer_begin + state->slots_per_layer;
+    if (slot_index < 0 || (size_t)slot_index < layer_begin ||
+        (size_t)slot_index >= layer_end) return NULL;
+    V4ExpertSlot *slot = &state->slots[slot_index];
+    if (slot->expert != key.expert && slot->loading_expert != key.expert)
+        return NULL;
+    return slot;
+}
+
+static void unindex_expert_slot(V4ExpertStoreState *state,
+                                V4ExpertSlot *slot) {
+    int slot_index = (int)(slot - state->slots);
+    int experts[2] = {slot->expert, slot->loading_expert};
+    for (int i = 0; i < 2; i++) {
+        int expert = experts[i];
+        if (expert < 0 || expert >= state->experts_per_layer) continue;
+        int layer = slot_index / state->slots_per_layer;
+        int *entry = &state->slot_by_expert[expert_cell(state, layer, expert)];
+        if (*entry == slot_index) *entry = -1;
+    }
+}
+
+static void index_expert_slot(V4ExpertStoreState *state, int layer,
+                              int expert, V4ExpertSlot *slot) {
+    state->slot_by_expert[expert_cell(state, layer, expert)] =
+        (int)(slot - state->slots);
+}
+
 static void fill_tensor_view(ColiTensorView *view,
                              const V4ExpertRecord *record,
                              const V4ExpertSlot *slot, int matrix) {
@@ -7112,14 +7154,11 @@ static int lookup(ColiExpertStore *store, ColiExpertKey key,
     pthread_mutex_lock(&state->mutex);
     state->stats.requests++;
     V4ExpertSlot *slots = layer_slots(state, key.layer);
-    V4ExpertSlot *slot = NULL;
-    for (int i = 0; i < state->slots_per_layer; i++) {
-        if (slots[i].slab && slots[i].expert == key.expert) {
-            slot = &slots[i];
-            state->stats.hits++;
-            break;
-        }
-    }
+    V4ExpertSlot *slot = indexed_expert_slot(state, key);
+    if (slot && slot->slab && slot->expert == key.expert)
+        state->stats.hits++;
+    else
+        slot = NULL;
     if (!slot) {
         for (int i = 0; i < state->slots_per_layer; i++) {
             if (!slots[i].references && (!slot || !slots[i].slab ||
@@ -7141,6 +7180,7 @@ static int lookup(ColiExpertStore *store, ColiExpertKey key,
             state->stats.resident_bytes += state->record_bytes;
         }
         /* A short read must never expose a partially overwritten old slot. */
+        unindex_expert_slot(state, slot);
         slot->expert = -1;
         /* DUAL-SSD: this expert's replica (deterministic per layer,eid). */
         int rep = coli_st_expert_route(key.layer, key.expert);
@@ -7170,6 +7210,7 @@ static int lookup(ColiExpertStore *store, ColiExpertKey key,
                 (disk_t1.tv_nsec - disk_t0.tv_nsec) * 1e-9;
         }
         slot->expert = key.expert;
+        index_expert_slot(state, key.layer, key.expert, slot);
         state->stats.misses++;
         state->stats.bytes_read += record->record_bytes;
     }
@@ -7225,12 +7266,8 @@ static int prefetch(ColiExpertStore *store, const ColiExpertKey *keys,
     for (size_t i = 0; i < count; i++) {
         V4ExpertRecord *record = get_record(state, keys[i]);
         if (!record) continue;
-        int resident = 0;
-        V4ExpertSlot *slots = layer_slots(state, keys[i].layer);
-        for (int slot = 0; slot < state->slots_per_layer; slot++)
-            if (slots[slot].slab && slots[slot].expert == keys[i].expert) {
-                resident = 1; break;
-            }
+        V4ExpertSlot *slot = indexed_expert_slot(state, keys[i]);
+        int resident = slot && slot->slab && slot->expert == keys[i].expert;
         if (resident) continue;
         shards[ranges] = record->shard;
         offsets[ranges] = record->scale_offset;
@@ -7290,6 +7327,7 @@ static void destroy(ColiExpertStore *store) {
         coli_st_index_close(state->index);
         free(state->records);
         free(state->slots);
+        free(state->slot_by_expert);
         free(state->ehit);
         free(state->eheat);
         free(state);
@@ -7377,12 +7415,16 @@ int coli_deepseek_v4_expert_store_open(
     }
     size_t telemetry_cells =
         (size_t)state->layers * state->experts_per_layer;
+    state->slot_by_expert = malloc(
+        telemetry_cells * sizeof(*state->slot_by_expert));
     state->ehit = calloc(telemetry_cells, sizeof(*state->ehit));
     state->eheat = calloc(telemetry_cells, sizeof(*state->eheat));
-    if (!state->ehit || !state->eheat) {
-        set_error(error, error_size, "out of memory creating expert telemetry");
+    if (!state->slot_by_expert || !state->ehit || !state->eheat) {
+        set_error(error, error_size, "out of memory creating expert index/telemetry");
         goto fail;
     }
+    for (size_t i = 0; i < telemetry_cells; i++)
+        state->slot_by_expert[i] = -1;
     state->stats.capacity_bytes = (uint64_t)state->layers *
                                   state->slots_per_layer * state->record_bytes;
     store->ops = &operations;
@@ -7393,6 +7435,7 @@ int coli_deepseek_v4_expert_store_open(
 fail:
     if (state->slots) free(state->slots);
     free(state->records);
+    free(state->slot_by_expert);
     free(state->ehit);
     free(state->eheat);
     coli_st_index_close(state->index);
@@ -7803,11 +7846,14 @@ static void hot_repin_locked(V4HotPolicy *policy, V4ExpertStoreState *state,
         }
         pins[rank] = best;
     }
-    V4ExpertSlot *slots = layer_slots(state, layer);
-    for (int i = 0; i < state->slots_per_layer; i++)
-        if (slots[i].slab && slots[i].expert >= 0 &&
-            hot_is_pinned(policy, layer, slots[i].expert))
-            slots[i].used = ++state->clock;
+    for (int rank = 0; rank < policy->pin_count; rank++) {
+        int expert = pins[rank];
+        if (expert < 0) continue;
+        V4ExpertSlot *slot = indexed_expert_slot(
+            state, (ColiExpertKey){layer, expert});
+        if (slot && slot->slab && slot->expert == expert)
+            slot->used = ++state->clock;
+    }
     uint64_t decay_interval = policy->repin_interval * 64;
     if (decay_interval && policy->layer_requests[layer] &&
         policy->layer_requests[layer] % decay_interval == 0)
@@ -7847,39 +7893,35 @@ static int lookup_hot(ColiExpertStore *store, ColiExpertKey key,
     V4ExpertSlot *slots = layer_slots(state, key.layer);
     V4ExpertSlot *slot;
 retry_lookup:
-    slot = NULL;
-    for (int i = 0; i < state->slots_per_layer; i++) {
-        if (slots[i].slab && slots[i].expert == key.expert) {
-            slot = &slots[i]; slot->references++;
-            state->active_leases++;
-            slot->used = ++state->clock; state->stats.hits++;
-            if (hot_is_pinned(policy, key.layer, key.expert) && !store->gpu)
-                hot_pack_slot_locked(policy, state, record, slot);
-            memset(view, 0, sizeof(*view)); view->key = key;
-            hot_fill_view(&view->gate, record, slot, V4_W1, policy, state);
-            hot_fill_view(&view->down, record, slot, V4_W2, policy, state);
-            hot_fill_view(&view->up, record, slot, V4_W3, policy, state);
-            view->lease = slot;
-            pthread_mutex_unlock(&state->mutex); return 0;
-        }
+    slot = indexed_expert_slot(state, key);
+    if (slot && slot->slab && slot->expert == key.expert) {
+        slot->references++;
+        state->active_leases++;
+        slot->used = ++state->clock; state->stats.hits++;
+        if (hot_is_pinned(policy, key.layer, key.expert) && !store->gpu)
+            hot_pack_slot_locked(policy, state, record, slot);
+        memset(view, 0, sizeof(*view)); view->key = key;
+        hot_fill_view(&view->gate, record, slot, V4_W1, policy, state);
+        hot_fill_view(&view->down, record, slot, V4_W2, policy, state);
+        hot_fill_view(&view->up, record, slot, V4_W3, policy, state);
+        view->lease = slot;
+        pthread_mutex_unlock(&state->mutex); return 0;
     }
     /* Another caller may already be filling a cache slot for this expert.
      * Wait for that single loader to publish (or abandon) the slot instead
      * of issuing the same SSD read into a second slab. Different experts do
      * not match this reservation and continue to load concurrently. */
-    for (int i = 0; i < state->slots_per_layer; i++) {
-        if (slots[i].loading_expert == key.expert) {
+    if (slot && slot->loading_expert == key.expert) {
 #ifdef COLI_V4_TEST_HOOKS
-            if (coli_v4_test_expert_wait_hook)
-                coli_v4_test_expert_wait_hook(key);
+        if (coli_v4_test_expert_wait_hook)
+            coli_v4_test_expert_wait_hook(key);
 #endif
-            if (pthread_cond_wait(&state->load_ready, &state->mutex) != 0) {
-                pthread_mutex_unlock(&state->mutex);
-                memset(view, 0, sizeof(*view));
-                return -1;
-            }
-            goto retry_lookup;
+        if (pthread_cond_wait(&state->load_ready, &state->mutex) != 0) {
+            pthread_mutex_unlock(&state->mutex);
+            memset(view, 0, sizeof(*view));
+            return -1;
         }
+        goto retry_lookup;
     }
     for (int i = 0; i < state->slots_per_layer; i++)
         if (!slots[i].references && !slots[i].slab) { slot = &slots[i]; break; }
@@ -7909,7 +7951,9 @@ retry_lookup:
         state->stats.resident_bytes += state->record_bytes;
     }
     policy->packed[hot_slot_index(state, slot)] = 0;
+    unindex_expert_slot(state, slot);
     slot->expert = -1; slot->loading_expert = key.expert;
+    index_expert_slot(state, key.layer, key.expert, slot);
     slot->references = 1;
     state->active_leases++;
     slot->used = ++state->clock;
@@ -7938,6 +7982,7 @@ retry_lookup:
         (double)(disk_t1.tv_sec - disk_t0.tv_sec) +
         (disk_t1.tv_nsec - disk_t0.tv_nsec) * 1e-9;
     if (read_result) {
+        unindex_expert_slot(state, slot);
         slot->references = 0; slot->expert = -1;
         slot->loading_expert = -1;
         if (state->active_leases) state->active_leases--;
@@ -7960,6 +8005,20 @@ retry_lookup:
     pthread_cond_broadcast(&state->load_ready);
     pthread_mutex_unlock(&state->mutex); return 0;
 }
+
+#ifdef COLI_V4_TEST_HOOKS
+int coli_v4_test_expert_slot_index(ColiExpertStore *store, ColiExpertKey key) {
+    if (!store || !store->state || key.layer < 0 || key.expert < 0) return -1;
+    V4ExpertStoreState *state = store->state;
+    if (key.layer >= state->layers || key.expert >= state->experts_per_layer)
+        return -1;
+    pthread_mutex_lock(&state->mutex);
+    V4ExpertSlot *slot = indexed_expert_slot(state, key);
+    int result = slot ? (int)(slot - state->slots) : -1;
+    pthread_mutex_unlock(&state->mutex);
+    return result;
+}
+#endif
 
 static void destroy_hot(ColiExpertStore *store) {
     pthread_mutex_lock(&hot_policies_mutex);

--- a/c/deepseek_v4_internal.h
+++ b/c/deepseek_v4_internal.h
@@ -956,6 +956,7 @@ extern int coli_v4_test_skip_expert_store_open;
 extern int coli_v4_test_closed_owned_index;
 extern void (*coli_v4_test_expert_read_hook)(ColiExpertKey key);
 extern void (*coli_v4_test_expert_wait_hook)(ColiExpertKey key);
+int coli_v4_test_expert_slot_index(ColiExpertStore *store, ColiExpertKey key);
 
 ColiV4Session *coli_v4_test_session_bare_create(ColiV4Engine *engine);
 void coli_v4_test_session_bare_destroy(ColiV4Session *session);

--- a/c/tests/test_deepseek_v4.c
+++ b/c/tests/test_deepseek_v4.c
@@ -299,31 +299,44 @@ static int write_all(int fd, const void *data, size_t length) {
 }
 
 static int write_fixture(const char *path) {
-    static const char header[] =
-        "{"
-        "\"layers.0.ffn.experts.0.w1.scale\":{\"dtype\":\"F8_E8M0\",\"shape\":[1,1],\"data_offsets\":[0,1]},"
-        "\"layers.0.ffn.experts.0.w2.scale\":{\"dtype\":\"F8_E8M0\",\"shape\":[1,1],\"data_offsets\":[1,2]},"
-        "\"layers.0.ffn.experts.0.w3.scale\":{\"dtype\":\"F8_E8M0\",\"shape\":[1,1],\"data_offsets\":[2,3]},"
-        "\"resident\":{\"dtype\":\"F32\",\"shape\":[1],\"data_offsets\":[3,7]},"
-        "\"layers.0.ffn.experts.0.w1.weight\":{\"dtype\":\"I8\",\"shape\":[1,16],\"data_offsets\":[7,23]},"
-        "\"layers.0.ffn.experts.0.w2.weight\":{\"dtype\":\"I8\",\"shape\":[1,16],\"data_offsets\":[23,39]},"
-        "\"layers.0.ffn.experts.0.w3.weight\":{\"dtype\":\"I8\",\"shape\":[1,16],\"data_offsets\":[39,55]},"
-        "\"layers.0.ffn.experts.1.w1.scale\":{\"dtype\":\"F8_E8M0\",\"shape\":[1,1],\"data_offsets\":[55,56]},"
-        "\"layers.0.ffn.experts.1.w2.scale\":{\"dtype\":\"F8_E8M0\",\"shape\":[1,1],\"data_offsets\":[56,57]},"
-        "\"layers.0.ffn.experts.1.w3.scale\":{\"dtype\":\"F8_E8M0\",\"shape\":[1,1],\"data_offsets\":[57,58]},"
-        "\"layers.0.ffn.experts.1.w1.weight\":{\"dtype\":\"I8\",\"shape\":[1,16],\"data_offsets\":[58,74]},"
-        "\"layers.0.ffn.experts.1.w2.weight\":{\"dtype\":\"I8\",\"shape\":[1,16],\"data_offsets\":[74,90]},"
-        "\"layers.0.ffn.experts.1.w3.weight\":{\"dtype\":\"I8\",\"shape\":[1,16],\"data_offsets\":[90,106]},"
-        "\"layers.0.ffn.experts.2.w1.scale\":{\"dtype\":\"F8_E8M0\",\"shape\":[1,1],\"data_offsets\":[106,107]},"
-        "\"layers.0.ffn.experts.2.w2.scale\":{\"dtype\":\"F8_E8M0\",\"shape\":[1,1],\"data_offsets\":[107,108]},"
-        "\"layers.0.ffn.experts.2.w3.scale\":{\"dtype\":\"F8_E8M0\",\"shape\":[1,1],\"data_offsets\":[108,109]},"
-        "\"layers.0.ffn.experts.2.w1.weight\":{\"dtype\":\"I8\",\"shape\":[1,16],\"data_offsets\":[109,125]},"
-        "\"layers.0.ffn.experts.2.w2.weight\":{\"dtype\":\"I8\",\"shape\":[1,16],\"data_offsets\":[125,141]},"
-        "\"layers.0.ffn.experts.2.w3.weight\":{\"dtype\":\"I8\",\"shape\":[1,16],\"data_offsets\":[141,157]}"
-        "}";
-    unsigned char payload[157];
-    for (int i = 0; i < 157; i++) payload[i] = (unsigned char)i;
-    uint64_t header_length = sizeof(header) - 1;
+    static const char *matrix_names[3] = {"w1", "w2", "w3"};
+    char header[16384];
+    size_t used = (size_t)snprintf(
+        header, sizeof(header),
+        "{\"resident\":{\"dtype\":\"F32\",\"shape\":[1],"
+        "\"data_offsets\":[3,7]}");
+    for (int expert = 0; expert < 7; expert++) {
+        int scale = expert ? 4 + expert * 51 : 0;
+        int weight = scale + 3 + (expert ? 0 : 4);
+        for (int matrix = 0; matrix < 3; matrix++) {
+            int count = snprintf(
+                header + used, sizeof(header) - used,
+                ",\"layers.0.ffn.experts.%d.%s.scale\":{"
+                "\"dtype\":\"F8_E8M0\",\"shape\":[1,1],"
+                "\"data_offsets\":[%d,%d]}",
+                expert, matrix_names[matrix], scale + matrix,
+                scale + matrix + 1);
+            if (count < 0 || (size_t)count >= sizeof(header) - used) return -1;
+            used += (size_t)count;
+        }
+        for (int matrix = 0; matrix < 3; matrix++) {
+            int count = snprintf(
+                header + used, sizeof(header) - used,
+                ",\"layers.0.ffn.experts.%d.%s.weight\":{"
+                "\"dtype\":\"I8\",\"shape\":[1,16],"
+                "\"data_offsets\":[%d,%d]}",
+                expert, matrix_names[matrix], weight + matrix * 16,
+                weight + (matrix + 1) * 16);
+            if (count < 0 || (size_t)count >= sizeof(header) - used) return -1;
+            used += (size_t)count;
+        }
+    }
+    if (used + 1 >= sizeof(header)) return -1;
+    header[used++] = '}';
+    header[used] = '\0';
+    unsigned char payload[361];
+    for (int i = 0; i < 361; i++) payload[i] = (unsigned char)i;
+    uint64_t header_length = used;
     int fd = open(path, O_CREAT | O_TRUNC | O_WRONLY | COMPAT_O_BINARY, 0600);
     if (fd < 0) return -1;
     int result = write_all(fd, &header_length, sizeof(header_length)) ||
@@ -331,6 +344,22 @@ static int write_fixture(const char *path) {
                  write_all(fd, payload, sizeof(payload));
     close(fd);
     return result ? -1 : 0;
+}
+
+static int expect_fixture_expert(const ColiExpertView *view, int expert) {
+    int scale = expert ? 4 + expert * 51 : 0;
+    int weight = scale + 3 + (expert ? 0 : 4);
+    return view->gate.format == COLI_TENSOR_FP4_NATIVE_BLOCK &&
+           view->gate.rows == 1 && view->gate.columns == 32 &&
+           view->gate.data_bytes == 16 && view->gate.scale_bytes == 1 &&
+           ((const unsigned char *)view->gate.scales)[0] ==
+               (unsigned char)scale &&
+           ((const unsigned char *)view->gate.data)[0] ==
+               (unsigned char)weight &&
+           ((const unsigned char *)view->down.data)[0] ==
+               (unsigned char)(weight + 16) &&
+           ((const unsigned char *)view->up.data)[0] ==
+               (unsigned char)(weight + 32);
 }
 
 enum {
@@ -451,7 +480,7 @@ static int test_expert_store(void) {
     if (write_fixture(path) != 0) { perror("write_fixture"); return 1; }
 
     ColiDeepSeekV4ExpertStoreOptions options = {
-        directory, 1, 3, 153, -1, 0
+        directory, 1, 7, 306, -1, 0
     };
     ColiExpertStore *store = NULL;
     if (coli_deepseek_v4_expert_store_open(&options, &store,
@@ -478,13 +507,7 @@ static int test_expert_store(void) {
         return 1;
     }
     ColiExpertView *loaded = &same[0].view;
-    if (loaded->gate.format != COLI_TENSOR_FP4_NATIVE_BLOCK ||
-        loaded->gate.rows != 1 || loaded->gate.columns != 32 ||
-        loaded->gate.data_bytes != 16 || loaded->gate.scale_bytes != 1 ||
-        ((const unsigned char *)loaded->gate.scales)[0] != 0 ||
-        ((const unsigned char *)loaded->gate.data)[0] != 7 ||
-        ((const unsigned char *)loaded->down.data)[0] != 23 ||
-        ((const unsigned char *)loaded->up.data)[0] != 39)
+    if (!expect_fixture_expert(loaded, 0))
         { fprintf(stderr, "expert view mismatch: format=%d rows=%lld columns=%lld data=%zu scales=%zu bytes=%u/%u/%u/%u\n",
                   (int)loaded->gate.format, (long long)loaded->gate.rows,
                   (long long)loaded->gate.columns, loaded->gate.data_bytes,
@@ -518,7 +541,7 @@ static int test_expert_store(void) {
     store->ops->stats(store, &stats);
     if (stats.requests != 2 || stats.hits != 1 || stats.misses != 1 ||
         stats.prefetched != 1 || stats.bytes_read != 51 ||
-        stats.resident_bytes != 51 || stats.capacity_bytes != 153)
+        stats.resident_bytes != 51 || stats.capacity_bytes != 306)
         { fprintf(stderr, "expert stats mismatch: requests=%llu hits=%llu misses=%llu prefetched=%llu bytes=%llu resident=%llu capacity=%llu\n",
                   (unsigned long long)stats.requests,
                   (unsigned long long)stats.hits,
@@ -547,9 +570,68 @@ static int test_expert_store(void) {
     store->ops->stats(store, &stats);
     if (stats.requests != 4 || stats.hits != 1 || stats.misses != 3 ||
         stats.prefetched != 1 || stats.bytes_read != 153 ||
-        stats.resident_bytes != 153 || stats.capacity_bytes != 153) {
+        stats.resident_bytes != 153 || stats.capacity_bytes != 306) {
         fprintf(stderr,
                 "concurrent expert stats mismatch: requests=%llu hits=%llu misses=%llu bytes=%llu resident=%llu capacity=%llu\n",
+                (unsigned long long)stats.requests,
+                (unsigned long long)stats.hits,
+                (unsigned long long)stats.misses,
+                (unsigned long long)stats.bytes_read,
+                (unsigned long long)stats.resident_bytes,
+                (unsigned long long)stats.capacity_bytes);
+        return 1;
+    }
+
+    /* Fill the six-slot cache, make the LRU order deterministic, then force
+     * an eviction. The direct index must forget expert 1, retain expert 2,
+     * and publish expert 6 in the reused slot. */
+    for (int expert = 1; expert <= 2; expert++) {
+        ColiExpertView touched;
+        if (coli_expert_lookup(store, (ColiExpertKey){0, expert}, &touched) ||
+            !expect_fixture_expert(&touched, expert))
+            { fprintf(stderr, "indexed cache hit mismatch: expert=%d\n", expert); return 1; }
+        coli_expert_release(store, &touched);
+    }
+    for (int expert = 3; expert <= 5; expert++) {
+        ColiExpertView filled;
+        if (coli_expert_lookup(store, (ColiExpertKey){0, expert}, &filled) ||
+            !expect_fixture_expert(&filled, expert))
+            { fprintf(stderr, "cache fill mismatch: expert=%d\n", expert); return 1; }
+        coli_expert_release(store, &filled);
+    }
+    if (coli_expert_lookup(store, key, &view) ||
+        !expect_fixture_expert(&view, 0))
+        { fprintf(stderr, "failed to refresh expert 0 LRU\n"); return 1; }
+    coli_expert_release(store, &view);
+
+    if (coli_expert_lookup(store, (ColiExpertKey){0, 6}, &view) ||
+        !expect_fixture_expert(&view, 6))
+        { fprintf(stderr, "eviction load mismatch\n"); return 1; }
+    coli_expert_release(store, &view);
+    if (coli_v4_test_expert_slot_index(store, (ColiExpertKey){0, 1}) != -1 ||
+        coli_v4_test_expert_slot_index(store, (ColiExpertKey){0, 2}) < 0 ||
+        coli_v4_test_expert_slot_index(store, (ColiExpertKey){0, 6}) < 0) {
+        fprintf(stderr, "expert index did not track eviction\n");
+        return 1;
+    }
+    if (coli_expert_lookup(store, (ColiExpertKey){0, 2}, &view) ||
+        !expect_fixture_expert(&view, 2))
+        { fprintf(stderr, "surviving index entry mismatch\n"); return 1; }
+    coli_expert_release(store, &view);
+    if (coli_expert_lookup(store, (ColiExpertKey){0, 1}, &view) ||
+        !expect_fixture_expert(&view, 1))
+        { fprintf(stderr, "reloaded index entry mismatch\n"); return 1; }
+    coli_expert_release(store, &view);
+    if (coli_v4_test_expert_slot_index(store, (ColiExpertKey){0, 1}) < 0) {
+        fprintf(stderr, "reloaded expert was not indexed\n");
+        return 1;
+    }
+    store->ops->stats(store, &stats);
+    if (stats.requests != 13 || stats.hits != 5 || stats.misses != 8 ||
+        stats.prefetched != 1 || stats.bytes_read != 408 ||
+        stats.resident_bytes != 306 || stats.capacity_bytes != 306) {
+        fprintf(stderr,
+                "indexed eviction stats mismatch: requests=%llu hits=%llu misses=%llu bytes=%llu resident=%llu capacity=%llu\n",
                 (unsigned long long)stats.requests,
                 (unsigned long long)stats.hits,
                 (unsigned long long)stats.misses,


### PR DESCRIPTION
## Why

DeepSeek V4 keeps expert slots partitioned per layer. Before this change, every resident hit scanned every slot in that layer, and the single-flight path added another full scan to find an in-flight load. The cost therefore grew with the RAM budget: the host in #1154 has about 219 slots per layer, versus about 55 on the smaller comparison host.

#1162 removed duplicate concurrent reads and let different expert loads overlap. This follow-up removes the remaining capacity-dependent presence scans from the same critical section.

## What changed

- Add a compact `(layer, expert) -> global slot` table to the production V4 CPU expert store.
- Use it for resident hits and in-flight single-flight reservations, making both presence checks O(1) in cache capacity.
- Clear the old entry before slot reuse or a failed read, and publish the reservation before unlocking for I/O.
- Validate that every indexed slot belongs to the requested layer and still contains or loads the requested expert.
- Use the same index when refreshing resident pinned experts during repinning.

The existing LRU victim selection on a miss is intentionally unchanged and still scans the layer. This PR removes the scan paid by every hit; eviction policy can remain a separate change.

For a 61-layer, 256-expert V4 checkpoint, the table is about 62 KiB regardless of expert-cache size.

## Performance and correctness contract

This changes metadata lookup only. Routing, tensor bytes, cache capacity, disk reads, accumulation order, and generated values are unchanged. In an A/B run, `bytes=`, misses, and token output should remain identical. The expected benefit is largest for high-RAM, high-hit-rate configurations such as #1154, but this PR does not claim an end-to-end tok/s number without that hardware measurement.

## Tests

The model-free V4 fixture now has seven experts and six cache slots. It covers:

- same-expert single-flight and distinct-expert concurrent loads;
- indexed resident hits;
- deterministic LRU eviction;
- removal of the evicted mapping;
- survival of unrelated mappings;
- correct bytes after slot reuse and reload;
- unchanged hit, miss, byte, residency, and capacity accounting.

Validation:

- `make deepseek-v4`
- `make tests/test_deepseek_v4 && ./tests/test_deepseek_v4`
- `make test-asan`: full C suite clean under ASan + UBSan
- Python suite: 601 passed, 32 skipped
- `git diff --check`

Refs #1154 and the analysis in #1157. Builds on #1162.

Base branch: `dev`. `main` is not targeted.