### PR TITLE
perf(dsv4): batch FP4 expert matmuls during prefill

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1208,6 +1208,7 @@ tests/test_native_quant$(EXE): tests/test_native_quant.c deepseek_v4.c native_qu
 ifeq ($(COLI_V4_SUPPORTED),1)
 include Makefile.deepseek-v4.units
 V4_HOT_TEST_OBJ = COLI_V4_UNIT_EXPERT_STORE_HOT_ROWS16_TEST.o
+V4_BATCH_TEST_OBJ = COLI_V4_UNIT_NATIVE_QUANT_BATCH_TEST.o
 V4_TEST_LINK_OBJS = \
 	COLI_V4_UNIT_ST.o \
 	COLI_V4_UNIT_CONFIG.o \
@@ -1215,9 +1216,12 @@ V4_TEST_LINK_OBJS = \
 	COLI_V4_UNIT_SPARSE_ATTENTION.o \
 	COLI_V4_UNIT_RESOURCE_PLAN.o \
 	COLI_V4_UNIT_PROMPT.o \
-	$(filter-out COLI_V4_UNIT_EXPERT_STORE.o,$(addsuffix .o,$(V4_TEST_UNITS))) \
+	$(filter-out COLI_V4_UNIT_EXPERT_STORE.o COLI_V4_UNIT_EXPERT.o,$(addsuffix .o,$(V4_TEST_UNITS))) \
 	$(V4_HOT_TEST_OBJ) \
+	$(V4_BATCH_TEST_OBJ) \
+	COLI_V4_UNIT_EXPERT_ROWS16.o \
 	COLI_V4_UNIT_NATIVE_QUANT.o \
+	COLI_V4_UNIT_NATIVE_QUANT_DUAL.o \
 	COLI_V4_UNIT_NATIVE_QUANT_ROWS16.o
 # Windows engine objects are compiled with -DCOLI_V4_GPU_TIER (the CUDA tier
 # is resolved from coli_cuda_dsv4*.dll at runtime), so the matvec references in
@@ -1233,8 +1237,10 @@ tests/test_deepseek_v4$(EXE): tests/test_deepseek_v4.c deepseek_v4.c deepseek_v4
 	$(MAKE) -f Makefile.deepseek-v4 ARCH=$(ARCH) deepseek-v4-test-objs \
 		COLI_V4_UNIT_ST.o COLI_V4_UNIT_CONFIG.o COLI_V4_UNIT_MATH.o COLI_V4_UNIT_SPARSE_ATTENTION.o \
 		COLI_V4_UNIT_RESOURCE_PLAN.o COLI_V4_UNIT_PROMPT.o COLI_V4_UNIT_NATIVE_QUANT.o \
-		COLI_V4_UNIT_NATIVE_QUANT_ROWS16.o \
+		COLI_V4_UNIT_NATIVE_QUANT_DUAL.o COLI_V4_UNIT_NATIVE_QUANT_ROWS16.o \
+		COLI_V4_UNIT_EXPERT_ROWS16.o \
 		$(V4_HOT_TEST_OBJ) \
+		$(V4_BATCH_TEST_OBJ) \
 		$(V4_TEST_EXTRA_TARGETS)
 	$(CC) $(CFLAGS) -DCOLI_V4_TEST_HOOKS $< $(V4_TEST_LINK_OBJS) \
 		-o $@ -pthread $(LDFLAGS)

--- a/c/Makefile.deepseek-v4
+++ b/c/Makefile.deepseek-v4
@@ -96,6 +96,10 @@ V4_BINARY := deepseek_v4
 V4_WIN_EXTRA_OBJS =
 endif
 
+# Keep recursive builds (notably the parent test-asan target) instrumented.
+CFLAGS += $(EXTRA_CFLAGS)
+LDFLAGS += $(EXTRA_LDFLAGS)
+
 LTO ?= 1
 ifeq ($(LTO),1)
 CFLAGS += -flto
@@ -166,6 +170,7 @@ include Makefile.deepseek-v4.units
 TARGET_OBJS = $(addsuffix .o,$(V4_TARGET_UNITS))
 TEST_UNIT_OBJS = $(addsuffix .o,$(V4_TEST_UNITS))
 V4_HOT_TEST_OBJ = COLI_V4_UNIT_EXPERT_STORE_HOT_ROWS16_TEST.o
+V4_BATCH_TEST_OBJ = COLI_V4_UNIT_NATIVE_QUANT_BATCH_TEST.o
 V4_OBJS = $(TARGET_OBJS) $(V4_WIN_EXTRA_OBJS) $(REGISTRY_OBJ)
 REGISTRY_OBJ = expert_store_registry.o
 V4_SERVE_TEST := tests/test_v4_serve_framing$(if $(IS_WIN),.exe,)
@@ -206,6 +211,11 @@ $(V4_HOT_TEST_OBJ): deepseek_v4.c deepseek_v4.h deepseek_v4_internal.h \
 	$(CC) $(CFLAGS) -DCOLI_V4_TEST_HOOKS \
 		-DCOLI_V4_UNIT_EXPERT_STORE_HOT_ROWS16 -c deepseek_v4.c -o $@
 
+$(V4_BATCH_TEST_OBJ): deepseek_v4.c deepseek_v4.h deepseek_v4_internal.h \
+		tensor.h quant.h native_quant.h native_quant_batch.h
+	$(CC) $(CFLAGS) -DCOLI_V4_TEST_HOOKS \
+		-DCOLI_V4_UNIT_NATIVE_QUANT_BATCH -c deepseek_v4.c -o $@
+
 COLI_V4_UNIT_GENERATE_STATS.o: serve_codec.h
 
 $(V4_SERVE_TEST): tests/test_v4_serve_framing.c deepseek_v4.c deepseek_v4.h \
@@ -238,4 +248,5 @@ test_expert_store_registry: test_expert_store_registry.c expert_store_registry.c
 
 deepseek-v4-clean:
 	rm -f $(V4_BINARY) $(V4_OBJS) $(TEST_UNIT_OBJS) $(V4_HOT_TEST_OBJ) \
+		$(V4_BATCH_TEST_OBJ) \
 		$(V4_SERVE_TEST) test_expert_store_registry

--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -5239,6 +5239,63 @@ int coli_v4_block_window_token_ref(
  *
  * V4_EXPERT_UNION=0 restores the per-position path for A/B timing.
  * ========================================================================= */
+enum { V4_EXPERT_BATCH_MAX = 128 };
+
+static int v4_flush_expert_batch(
+    float *outputs, ColiExpertStore *store, const ColiExpertView *view,
+    const float *batch_inputs, const float *batch_weights,
+    const int *batch_items, float *batch_outputs, int count, int dimension,
+    float swiglu_limit) {
+    if (count < 1) return 0;
+    double began = v4_now_mono();
+    int result = count == 1
+        ? coli_v4_expert_forward_ref(batch_outputs, view, batch_inputs,
+                                     batch_weights[0], swiglu_limit)
+        : coli_v4_expert_forward_batch_ref(
+              batch_outputs, view, batch_inputs, batch_weights, count,
+              swiglu_limit);
+    coli_v4_expert_store_add_matmul(store, v4_now_mono() - began);
+    if (result) return -1;
+    /* Matches were gathered in ascending (item, rank) order.  Accumulate in
+     * that same order so duplicate routes retain scalar-path FP ordering. */
+    for (int match = 0; match < count; match++)
+        for (int column = 0; column < dimension; column++)
+            outputs[(size_t)batch_items[match] * dimension + column] +=
+                batch_outputs[(size_t)match * dimension + column];
+    return 0;
+}
+
+static int v4_apply_expert_batch(
+    float *outputs, ColiExpertStore *store, const ColiExpertView *view,
+    const float *inputs, const int *indices, const float *route_weights,
+    int batch, int topk, int dimension, float swiglu_limit,
+    float *batch_inputs, float *batch_route_weights, int *batch_items,
+    float *batch_outputs, int batch_capacity) {
+    int count = 0;
+    int expert = view->key.expert;
+    for (int item = 0; item < batch; item++)
+        for (int rank = 0; rank < topk; rank++) {
+            size_t route = (size_t)item * topk + rank;
+            if (indices[route] != expert) continue;
+            memcpy(batch_inputs + (size_t)count * dimension,
+                   inputs + (size_t)item * dimension,
+                   (size_t)dimension * sizeof(*batch_inputs));
+            batch_route_weights[count] = route_weights[route];
+            batch_items[count++] = item;
+            if (count == batch_capacity) {
+                if (v4_flush_expert_batch(
+                        outputs, store, view, batch_inputs,
+                        batch_route_weights, batch_items, batch_outputs,
+                        count, dimension, swiglu_limit))
+                    return -1;
+                count = 0;
+            }
+        }
+    return v4_flush_expert_batch(
+        outputs, store, view, batch_inputs, batch_route_weights, batch_items,
+        batch_outputs, count, dimension, swiglu_limit);
+}
+
 static int v4_moe_batch_union(
     float *outputs, const ColiDeepSeekV4LayerWeights *weights,
     const ColiDeepSeekV4Config *config, ColiExpertStore *store,
@@ -5258,12 +5315,24 @@ static int v4_moe_batch_union(
     float *route_weights = malloc((size_t)batch * topk * sizeof(*route_weights));
     int *indices = malloc((size_t)batch * topk * sizeof(*indices));
     float *shared = malloc((size_t)batch * d * sizeof(*shared));
-    float *expert_output = malloc((size_t)d * sizeof(*expert_output));
+    size_t route_count = (size_t)batch * topk;
+    int expert_batch_capacity = route_count < V4_EXPERT_BATCH_MAX
+        ? (int)route_count : V4_EXPERT_BATCH_MAX;
+    float *expert_inputs = malloc(
+        (size_t)expert_batch_capacity * d * sizeof(*expert_inputs));
+    float *expert_outputs = malloc(
+        (size_t)expert_batch_capacity * d * sizeof(*expert_outputs));
+    float *expert_weights = malloc(
+        (size_t)expert_batch_capacity * sizeof(*expert_weights));
+    int *expert_items = malloc(
+        (size_t)expert_batch_capacity * sizeof(*expert_items));
     unsigned char *used = calloc((size_t)n, 1);
     ColiExpertKey *keys = malloc((size_t)n * sizeof(*keys));
     if (missing_gate || !route_weights || !indices || !shared ||
-        !expert_output || !used || !keys) {
-        free(keys); free(used); free(expert_output); free(shared);
+        !expert_inputs || !expert_outputs || !expert_weights ||
+        !expert_items || !used || !keys) {
+        free(keys); free(used); free(expert_items); free(expert_weights);
+        free(expert_outputs); free(expert_inputs); free(shared);
         free(indices); free(route_weights); free(gate);
         return -1;
     }
@@ -5357,19 +5426,12 @@ static int v4_moe_batch_union(
             else
                 active[slot] = 1;
         }
-        int expert = view.key.expert;
-        for (int item = 0; !result && item < batch; item++)
-            for (int rank = 0; !result && rank < topk; rank++) {
-                if (indices[(size_t)item * topk + rank] != expert) continue;
-                result = coli_v4_expert_forward_ref(
-                    expert_output, &view, inputs + (size_t)item * d,
-                    route_weights[(size_t)item * topk + rank],
-                    config->swiglu_limit);
-                if (!result)
-                    for (int column = 0; column < d; column++)
-                        outputs[(size_t)item * d + column] +=
-                            expert_output[column];
-            }
+        if (!result)
+            result = v4_apply_expert_batch(
+                outputs, store, &view, inputs, indices, route_weights,
+                batch, topk, d, config->swiglu_limit, expert_inputs,
+                expert_weights, expert_items, expert_outputs,
+                expert_batch_capacity);
         coli_expert_release(store, &view);
     }
     for (int slot = 0; slot < dual_loader_lanes(); slot++)
@@ -5384,19 +5446,11 @@ static int v4_moe_batch_union(
             result = -1;
             break;
         }
-        int expert = keys[current].expert;
-        for (int item = 0; !result && item < batch; item++)
-            for (int rank = 0; !result && rank < topk; rank++) {
-                if (indices[(size_t)item * topk + rank] != expert) continue;
-                result = coli_v4_expert_forward_ref(
-                    expert_output, &view, inputs + (size_t)item * d,
-                    route_weights[(size_t)item * topk + rank],
-                    config->swiglu_limit);
-                if (!result)
-                    for (int column = 0; column < d; column++)
-                        outputs[(size_t)item * d + column] +=
-                            expert_output[column];
-            }
+        result = v4_apply_expert_batch(
+            outputs, store, &view, inputs, indices, route_weights,
+            batch, topk, d, config->swiglu_limit, expert_inputs,
+            expert_weights, expert_items, expert_outputs,
+            expert_batch_capacity);
         coli_expert_release(store, &view);
     }
 #endif
@@ -5406,7 +5460,8 @@ static int v4_moe_batch_union(
                 outputs[(size_t)item * d + column] +
                 shared[(size_t)item * d + column]);
 
-    free(keys); free(used); free(expert_output); free(shared);
+    free(keys); free(used); free(expert_items); free(expert_weights);
+    free(expert_outputs); free(expert_inputs); free(shared);
     free(indices); free(route_weights); free(gate);
     return result ? -1 : 0;
 }
@@ -8381,6 +8436,71 @@ int coli_v4_expert_forward_ref(float *output, const ColiExpertView *expert,
     free(activated); free(up); free(gate);
     return result ? -1 : 0;
 #endif
+}
+
+int coli_v4_expert_forward_batch_ref(float *outputs,
+                                     const ColiExpertView *expert,
+                                     const float *inputs,
+                                     const float *route_weights,
+                                     int batch, float swiglu_limit) {
+    if (!outputs || !expert || !inputs || !route_weights || batch < 1 ||
+        batch > 128 || swiglu_limit < 0.0f || expert->gate.rows < 1 ||
+        expert->gate.columns < 1 || expert->gate.rows != expert->up.rows ||
+        expert->gate.columns != expert->up.columns ||
+        expert->down.columns != expert->gate.rows ||
+        expert->down.rows != expert->gate.columns)
+        return -1;
+
+    /* Hot pinned experts use the private rows16 layout.  Its scalar kernel is
+     * already bit-converged with row-major FP4, but the batch kernel does not
+     * understand that packing yet, so preserve the established path. */
+    if (expert->gate.block_rows != 1 || expert->up.block_rows != 1 ||
+        expert->down.block_rows != 1) {
+        for (int item = 0; item < batch; item++)
+            if (coli_v4_expert_forward_ref(
+                    outputs + (size_t)item * expert->down.rows, expert,
+                    inputs + (size_t)item * expert->gate.columns,
+                    route_weights[item], swiglu_limit))
+                return -1;
+        return 0;
+    }
+
+    size_t intermediate = (size_t)expert->gate.rows;
+    if ((size_t)batch > SIZE_MAX / intermediate) return -1;
+    size_t cells = (size_t)batch * intermediate;
+    if (cells > SIZE_MAX / (3 * sizeof(float))) return -1;
+    float *workspace = malloc(3 * cells * sizeof(*workspace));
+    if (!workspace) return -1;
+    float *gate = workspace;
+    float *up = gate + cells;
+    float *activated = up + cells;
+
+    int result = coli_fp4_matmul_batch_ref(
+        gate, &expert->gate, inputs, batch);
+    if (!result)
+        result = coli_fp4_matmul_batch_ref(
+            up, &expert->up, inputs, batch);
+    for (int item = 0; !result && item < batch; item++) {
+        float *item_gate = gate + (size_t)item * intermediate;
+        float *item_up = up + (size_t)item * intermediate;
+        float *item_activated = activated + (size_t)item * intermediate;
+        coli_bf16_round_array(item_gate, intermediate);
+        coli_bf16_round_array(item_up, intermediate);
+        result = coli_v4_swiglu(item_activated, item_gate, item_up,
+                                (int)intermediate, swiglu_limit);
+        if (!result)
+            for (size_t column = 0; column < intermediate; column++)
+                item_activated[column] = coli_bf16_round(
+                    item_activated[column] * route_weights[item]);
+    }
+    if (!result)
+        result = coli_fp4_matmul_batch_ref(
+            outputs, &expert->down, activated, batch);
+    if (!result)
+        coli_bf16_round_array(
+            outputs, (size_t)batch * (size_t)expert->down.rows);
+    free(workspace);
+    return result ? -1 : 0;
 }
 #endif /* COLI_V4_UNIT_EXPERT_ROWS16 */
 
@@ -14810,10 +14930,12 @@ int coli_v4_qdq_scratch(size_t activation_count, size_t scales_count,
  * in order), which preserves each row's scalar operation order exactly — the
  * rows16 kernels' own trick. The scalar arm splits the two multiplies and the
  * add into separate statements so no compiler contracts them into an FMA:
- * every rows16 ISA rounds the product before the add. */
-void coli_fp4_matvec_rows16_order(float *y, const uint8_t *q4,
-                                    const uint8_t *e8s, const float *x,
-                                    int I, int O) {
+ * every rows16 ISA rounds the product before the add.  The batch form keeps
+ * one accumulator per activation while decoding each weight tile once, so it
+ * preserves that order without streaming the matrix once per activation. */
+void coli_fp4_matmul_batch_rows16_order(float *y, const uint8_t *q4,
+                                        const uint8_t *e8s, const float *x,
+                                        int S, int I, int O) {
     int rb = I / 2, ng = I / 32;
 #ifdef __AVX2__
     /* Nibble decode borrows matmul_mxfp4's trick — doubled e2m1 values are
@@ -14831,7 +14953,11 @@ void coli_fp4_matvec_rows16_order(float *y, const uint8_t *q4,
         const __m128i lut2 = _mm_setr_epi8(0,1,2,3,4,6,8,12,0,-1,-2,-3,-4,-6,-8,-12);
         const __m128i m4 = _mm_set1_epi8(0x0F);
         const __m256 half = _mm256_set1_ps(0.5f);
-        __m256 sum0 = _mm256_setzero_ps(), sum1 = _mm256_setzero_ps();
+        __m256 sum0[128], sum1[128];
+        for (int s = 0; s < S; s++) {
+            sum0[s] = _mm256_setzero_ps();
+            sum1[s] = _mm256_setzero_ps();
+        }
         for (int base = 0; base < I; base += 32) {
             float sc[16], tmp[2][32][8];
             for (int half_rows = 0; half_rows < 2; half_rows++) {
@@ -14893,33 +15019,49 @@ void coli_fp4_matvec_rows16_order(float *y, const uint8_t *q4,
             }
             __m256 sc0 = _mm256_loadu_ps(sc), sc1 = _mm256_loadu_ps(sc + 8);
             for (int c = 0; c < 32; c++) {
-                __m256 xv = _mm256_set1_ps(x[base + c]);
-                sum0 = _mm256_add_ps(sum0, _mm256_mul_ps(
-                    _mm256_mul_ps(xv, _mm256_loadu_ps(tmp[0][c])), sc0));
-                sum1 = _mm256_add_ps(sum1, _mm256_mul_ps(
-                    _mm256_mul_ps(xv, _mm256_loadu_ps(tmp[1][c])), sc1));
+                __m256 weight0 = _mm256_loadu_ps(tmp[0][c]);
+                __m256 weight1 = _mm256_loadu_ps(tmp[1][c]);
+                for (int s = 0; s < S; s++) {
+                    __m256 xv = _mm256_set1_ps(
+                        x[(int64_t)s * I + base + c]);
+                    sum0[s] = _mm256_add_ps(sum0[s], _mm256_mul_ps(
+                        _mm256_mul_ps(xv, weight0), sc0));
+                    sum1[s] = _mm256_add_ps(sum1[s], _mm256_mul_ps(
+                        _mm256_mul_ps(xv, weight1), sc1));
+                }
             }
         }
-        _mm256_storeu_ps(y + tile * 16, sum0);
-        _mm256_storeu_ps(y + tile * 16 + 8, sum1);
+        for (int s = 0; s < S; s++) {
+            _mm256_storeu_ps(y + (int64_t)s * O + tile * 16, sum0[s]);
+            _mm256_storeu_ps(y + (int64_t)s * O + tile * 16 + 8, sum1[s]);
+        }
     }
 #else
     #pragma omp parallel for schedule(static)
     for (int o = 0; o < O; o++) {
         const uint8_t *w = q4 + (int64_t)o * rb;
         const uint8_t *scl = e8s + (int64_t)o * ng;
-        float sum = 0.0f;
+        float sums[128] = {0};
         for (int c = 0; c < I; c++) {
             uint8_t byte = w[c >> 1];
             float wv = coli_e2m1_decode((c & 1) ? (uint8_t)(byte >> 4)
                                                 : (uint8_t)(byte & 0xF));
-            float t = x[c] * wv;                 /* separate statements: the   */
-            t = t * coli_e8m0_decode(scl[c / 32]); /* product must round before */
-            sum = sum + t;                       /* the add, as on every ISA   */
+            float scale = coli_e8m0_decode(scl[c / 32]);
+            for (int s = 0; s < S; s++) {
+                float t = x[(int64_t)s * I + c] * wv;
+                t = t * scale;
+                sums[s] = sums[s] + t;
+            }
         }
-        y[o] = sum;
+        for (int s = 0; s < S; s++) y[(int64_t)s * O + o] = sums[s];
     }
 #endif
+}
+
+void coli_fp4_matvec_rows16_order(float *y, const uint8_t *q4,
+                                  const uint8_t *e8s, const float *x,
+                                  int I, int O) {
+    coli_fp4_matmul_batch_rows16_order(y, q4, e8s, x, 1, I, O);
 }
 
 int coli_fp4_matvec_ref(float *output, const ColiTensorView *weight,
@@ -15250,6 +15392,10 @@ int coli_fp8_dual_matvec_ref(float *output_a, float *output_b,
 #pragma GCC diagnostic pop
 #endif
 
+#ifdef COLI_V4_TEST_HOOKS
+uint64_t coli_v4_test_fp4_batch_calls;
+#endif
+
 /* Validazione condivisa fra _ref e _pre (stessi controlli di sempre).
  * EN: shared shape/format validation between _ref and _pre. */
 static int fp8_batch_validate(const ColiTensorView *weight, int batch) {
@@ -15380,6 +15526,9 @@ int coli_fp4_matmul_batch_ref(float *outputs, const ColiTensorView *weight,
         !weight->data || !weight->scales || weight->rows < 1 ||
         weight->columns < 1 || weight->columns % 128 ||
         weight->block_rows != 1 || weight->block_columns != 32) return -1;
+#ifdef COLI_V4_TEST_HOOKS
+    coli_v4_test_fp4_batch_calls++;
+#endif
     size_t rows = (size_t)weight->rows, columns = (size_t)weight->columns;
     size_t packed_stride = columns / 2, scale_stride = columns / 32;
     if (weight->data_bytes != rows * packed_stride ||
@@ -15395,8 +15544,13 @@ int coli_fp4_matmul_batch_ref(float *outputs, const ColiTensorView *weight,
                 inputs + (size_t)item * columns, columns, 128) != 0) {
             return -1;
         }
-    matmul_mxfp4(outputs, activations, weight->data, weight->scales,
-                 batch, (int)columns, (int)rows);
+    if (rows % 16 == 0)
+        coli_fp4_matmul_batch_rows16_order(
+            outputs, weight->data, weight->scales, activations,
+            batch, (int)columns, (int)rows);
+    else
+        matmul_mxfp4(outputs, activations, weight->data, weight->scales,
+                     batch, (int)columns, (int)rows);
     return 0;
 }
 #endif /* COLI_V4_UNIT_NATIVE_QUANT_BATCH */

--- a/c/deepseek_v4_internal.h
+++ b/c/deepseek_v4_internal.h
@@ -563,6 +563,15 @@ int coli_v4_expert_forward_ref(float *output, const ColiExpertView *expert,
                                const float *input, float route_weight,
                                float swiglu_limit);
 
+/* Batch-major routed-expert forward.  The row-major FP4 path streams each
+ * matrix once for all items; unsupported packed layouts fall back to the
+ * scalar entry point without changing its numerical contract. */
+int coli_v4_expert_forward_batch_ref(float *outputs,
+                                     const ColiExpertView *expert,
+                                     const float *inputs,
+                                     const float *route_weights,
+                                     int batch, float swiglu_limit);
+
 int coli_v4_shared_expert_forward_ref(float *output,
                                       const ColiTensorView *gate,
                                       const ColiTensorView *down,
@@ -956,6 +965,7 @@ extern int coli_v4_test_skip_expert_store_open;
 extern int coli_v4_test_closed_owned_index;
 extern void (*coli_v4_test_expert_read_hook)(ColiExpertKey key);
 extern void (*coli_v4_test_expert_wait_hook)(ColiExpertKey key);
+extern uint64_t coli_v4_test_fp4_batch_calls;
 
 ColiV4Session *coli_v4_test_session_bare_create(ColiV4Engine *engine);
 void coli_v4_test_session_bare_destroy(ColiV4Session *session);

--- a/c/native_quant.h
+++ b/c/native_quant.h
@@ -43,6 +43,11 @@ int coli_fp4_matvec_ref(float *output, const ColiTensorView *weight,
 void coli_fp4_matvec_rows16_order(float *y, const uint8_t *q4,
                                   const uint8_t *e8s, const float *x,
                                   int I, int O);
+/* Batch-major companion: independent scalar-order accumulators share each
+ * decoded weight tile, so the matrix is streamed once for the whole batch. */
+void coli_fp4_matmul_batch_rows16_order(float *y, const uint8_t *q4,
+                                        const uint8_t *e8s, const float *x,
+                                        int batch, int I, int O);
 
 /* Correctness-first FP8 matvec for native 128x128 E4M3 weight blocks with
  * UE8M0 scales and dynamically quantized E4M3 activations. */

--- a/c/tests/test_deepseek_v4.c
+++ b/c/tests/test_deepseek_v4.c
@@ -219,6 +219,81 @@ static int test_expert(void) {
     return 0;
 }
 
+/* The production prefill path must use the dormant FP4 batch kernel without
+ * moving a single result bit.  Varied packed nibbles, scales, activations and
+ * route weights prevent a uniform fixture from hiding an ordering change. */
+static int test_expert_batch(void) {
+    /* 4096 columns are intentional: the old 32-column-partial batch order
+     * matched a 128-column toy by accident but diverged at Flash width. */
+    enum { DIMENSION = 4096, INTERMEDIATE = 128, BATCH = 5 };
+    static uint8_t gate_data[INTERMEDIATE * DIMENSION / 2];
+    static uint8_t up_data[INTERMEDIATE * DIMENSION / 2];
+    static uint8_t down_data[DIMENSION * INTERMEDIATE / 2];
+    static uint8_t gate_scale[INTERMEDIATE * DIMENSION / 32];
+    static uint8_t up_scale[INTERMEDIATE * DIMENSION / 32];
+    static uint8_t down_scale[DIMENSION * INTERMEDIATE / 32];
+    ColiExpertView expert = {0};
+    make_tensor(&expert.gate, gate_data, gate_scale,
+                INTERMEDIATE, DIMENSION, 0);
+    make_tensor(&expert.up, up_data, up_scale,
+                INTERMEDIATE, DIMENSION, 0);
+    make_tensor(&expert.down, down_data, down_scale,
+                DIMENSION, INTERMEDIATE, 0);
+    uint32_t state = 0x1159u;
+    uint8_t *data[] = {gate_data, up_data, down_data};
+    uint8_t *scales[] = {gate_scale, up_scale, down_scale};
+    for (int matrix = 0; matrix < 3; matrix++) {
+        for (size_t i = 0; i < sizeof(gate_data); i++) {
+            state = state * 1664525u + 1013904223u;
+            data[matrix][i] = (uint8_t)(state >> 24);
+        }
+        for (size_t i = 0; i < sizeof(gate_scale); i++) {
+            state = state * 1664525u + 1013904223u;
+            scales[matrix][i] = (uint8_t)(125 + ((state >> 24) % 5));
+        }
+    }
+    float inputs[BATCH * DIMENSION];
+    float route_weights[BATCH] = {0.125f, 0.5f, 0.75f, 1.0f, 1.375f};
+    float scalar[BATCH * DIMENSION], batched[BATCH * DIMENSION];
+    for (int item = 0; item < BATCH; item++)
+        for (int column = 0; column < DIMENSION; column++)
+            inputs[(size_t)item * DIMENSION + column] =
+                0.0078125f * (float)(((item + 3) * (column + 5)) % 29 - 14);
+    for (int item = 0; item < BATCH; item++)
+        if (coli_v4_expert_forward_ref(
+                scalar + (size_t)item * DIMENSION, &expert,
+                inputs + (size_t)item * DIMENSION, route_weights[item],
+                10.0f))
+            return 1;
+    coli_v4_test_fp4_batch_calls = 0;
+    if (coli_v4_expert_forward_batch_ref(
+            batched, &expert, inputs, route_weights, BATCH, 10.0f))
+        return 1;
+    if (coli_v4_test_fp4_batch_calls != 3) {
+        fprintf(stderr, "expected 3 FP4 batch matrices, got %llu\n",
+                (unsigned long long)coli_v4_test_fp4_batch_calls);
+        return 1;
+    }
+    if (memcmp(scalar, batched, sizeof(scalar)) != 0) {
+        for (int i = 0; i < BATCH * DIMENSION; i++)
+            if (scalar[i] != batched[i]) {
+                fprintf(stderr,
+                        "expert batch mismatch item=%d column=%d: %.9g vs %.9g\n",
+                        i / DIMENSION, i % DIMENSION,
+                        (double)scalar[i], (double)batched[i]);
+                break;
+            }
+        return 1;
+    }
+    uint64_t calls = coli_v4_test_fp4_batch_calls;
+    if (coli_v4_expert_forward_batch_ref(
+            batched, &expert, inputs, route_weights, 0, 10.0f) == 0 ||
+        coli_v4_test_fp4_batch_calls != calls)
+        return 1;
+    puts("DeepSeek-V4 expert batch: ok (3 matrices, scalar-exact bits)");
+    return 0;
+}
+
 /* #1136: a rows16-packed copy and the row-major original of the SAME matrix
  * must produce bit-identical matvec outputs — the reference path accumulates
  * in the rows16 order now, so which kernel an expert takes (cache residency)
@@ -1010,6 +1085,10 @@ int main(int argc, char **argv) {
     }
     if (test_expert() != 0) {
         fprintf(stderr, "FAIL: test_expert\n");
+        return 1;
+    }
+    if (test_expert_batch() != 0) {
+        fprintf(stderr, "FAIL: test_expert_batch\n");
         return 1;
     }
     if (test_rows16_convergence() != 0) {


### PR DESCRIPTION
## Why

The expert union loads each distinct routed expert once, but it still applies that expert to every matching prompt position through independent matvecs. At Flash geometry each application re-walks 13,369,344 bytes of weights from memory/cache.

This implements the optimization recorded in #1159 and wires the previously unused FP4 batch path into routed-MoE prefill.

## What changed

- gather matching `(position, rank)` routes for each leased expert and evaluate them together, in chunks of at most 128
- batch gate, up, and down FP4 matrices while decoding/streaming each weight tile once
- preserve scalar accumulation order with one independent accumulator per activation
- preserve ascending `(position, rank)` output accumulation, including duplicate routes
- keep the scalar fast path for a single match and for private rows16 hot-pinned layouts
- size scratch from the actual route count rather than reserving the maximum
- link the production rows16 expert unit into the DeepSeek V4 test and propagate ASan/UBSan flags into recursive V4 builds

The existing batch implementation happened to match a 128-column toy but diverged at the real 4096-column width. The new wide oracle catches that and requires byte-identical outputs plus exactly three FP4 batch calls.

## Measurement

Standalone expert microbenchmark, Flash shapes (`hidden=4096`, `intermediate=2048`), 13,369,344 expert bytes, distinct activations, 6 OpenMP threads, median of 3 runs:

| positions using one expert | scalar | batch | speedup |
| ---: | ---: | ---: | ---: |
| 2 | 5.781 ms | 2.975 ms | 1.943x |
| 4 | 10.636 ms | 3.897 ms | 2.729x |
| 8 | 21.894 ms | 6.623 ms | 3.306x |

Every row passed exact `memcmp` against independent scalar forwards.

Tiny end-to-end A/B with the same varied-token prompt:

- union batch: 11 reads, 287,232 payload bytes, output `<t009>`
- scalar union disabled: 11 reads, 287,232 payload bytes, output `<t009>`

Disk bytes therefore do not move. Expert request counters differ by design because one side leases per distinct expert and the other leases per route.

## Scope

This improves routed-MoE prefill compute and can reduce TTFT when multiple prompt positions select the same expert. Decode remains batch-one and is unchanged. End-to-end tok/s improvement depends on how much runtime the workload spends in this phase; the kernel speedups above are not presented as whole-engine tok/s gains.

## Verification

- `make test` (all tests pass; cluster socket test also passed when rerun outside the filesystem/network sandbox)
- `make deepseek-v4-tiny-check`
- targeted DeepSeek V4 ASan + UBSan build and test
- optimized DeepSeek V4 build
- 4096-column scalar-exact production-unit oracle
- tiny end-to-end union on/off bytes and token A/B