### PR TITLE
fix(uring): read experts from their mirror replica (#1165)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -3244,6 +3244,16 @@ static int uring_load_add(UringBatch *b,Model *m,int layer,int eid,ESlot *s,int 
         s->fslab_cap=ftot;
 #endif
     }
+    /* DUAL-SSD (#1165): pick this expert's replica exactly as the blocking
+     * path does. The uring path used the primary fd unconditionally, so
+     * URING=1 read every expert from drive 0 and COLI_MODEL_MIRROR bought
+     * nothing -- visible as an idle mirror in iostat while URING=0 lit it up.
+     * Same deterministic hash of (layer,eid), so an expert always comes from
+     * the same drive and PILOT's readahead lands where the demand read will.
+     * Partial mirrors fall back to the primary per shard, as at the blocking
+     * site. */
+    int rep=expert_route(layer,eid);
+    if(rep && st_fd_rep(&m->S,l->tw[0]->fd,rep)<0) rep=0;
     int ord[3]={0,1,2};
     for(int a=0;a<3;a++) for(int z=a+1;z<3;z++) if(l->tw[ord[z]]->off<l->tw[ord[a]]->off){int t=ord[a];ord[a]=ord[z];ord[z]=t;}
     int contig=l->tw[ord[0]]->fd==l->tw[ord[1]]->fd && l->tw[ord[1]]->fd==l->tw[ord[2]]->fd
@@ -3251,7 +3261,7 @@ static int uring_load_add(UringBatch *b,Model *m,int layer,int eid,ESlot *s,int 
         && l->tw[ord[1]]->off+l->tw[ord[1]]->nbytes==l->tw[ord[2]]->off;
     if(contig){
         int64_t off0=l->tw[ord[0]]->off;
-        int dfd=g_direct?st_direct_fd(&m->S,l->tw[ord[0]]->fd):-1;
+        int dfd=g_direct?st_direct_fd_rep(&m->S,l->tw[ord[0]]->fd,rep):-1;
         if(dfd>=0){
             int64_t base=off0&~4095LL,need=(off0-base)+wtot,len=(need+4095)&~4095LL;
             l->pos[ord[0]]=off0-base; l->pos[ord[1]]=l->pos[ord[0]]+l->tw[ord[0]]->nbytes;
@@ -3261,20 +3271,20 @@ static int uring_load_add(UringBatch *b,Model *m,int layer,int eid,ESlot *s,int 
         }else{
             l->pos[ord[0]]=0; l->pos[ord[1]]=l->tw[ord[0]]->nbytes;
             l->pos[ord[2]]=l->pos[ord[1]]+l->tw[ord[1]]->nbytes;
-            if(uring_add_read(b,li,l->tw[ord[0]]->fd,s->slab,(size_t)wtot,off0,(size_t)wtot))
+            if(uring_add_read(b,li,rep_bfd(&m->S,l->tw[ord[0]]->fd,rep),s->slab,(size_t)wtot,off0,(size_t)wtot))
                 return uring_load_error(l,errno,"io_uring expert read"),li;
         }
     }else{
         int64_t o=0;
         for(int a=0;a<3;a++){ int k=ord[a]; l->pos[k]=o;
-            if(uring_add_read(b,li,l->tw[k]->fd,s->slab+o,(size_t)l->tw[k]->nbytes,l->tw[k]->off,(size_t)l->tw[k]->nbytes))
+            if(uring_add_read(b,li,rep_bfd(&m->S,l->tw[k]->fd,rep),s->slab+o,(size_t)l->tw[k]->nbytes,l->tw[k]->off,(size_t)l->tw[k]->nbytes))
                 return uring_load_error(l,errno,"io_uring expert read"),li;
             o+=l->tw[k]->nbytes;
         }
     }
     int64_t fo=0;
     for(int k=0;k<3;k++){
-        if(uring_add_read(b,li,l->tq[k]->fd,s->fslab+fo,(size_t)l->tq[k]->nbytes,l->tq[k]->off,(size_t)l->tq[k]->nbytes))
+        if(uring_add_read(b,li,rep_bfd(&m->S,l->tq[k]->fd,rep),s->fslab+fo,(size_t)l->tq[k]->nbytes,l->tq[k]->off,(size_t)l->tq[k]->nbytes))
             return uring_load_error(l,errno,"io_uring expert scale read"),li;
         fo+=l->tq[k]->nbytes/4;
     }

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -3150,6 +3150,9 @@ static int cluster_worker_run(const char *snap,int port,int ebits,int dbits){
 #define URING_REQ_MAX  512
 typedef struct {
     int load, expect;
+    int fd, primary_fd, rep;
+    void *buf;
+    int64_t off;
 } UringRead;
 typedef struct {
     Model *m; ESlot *s; int layer,eid,fatal;
@@ -3177,14 +3180,26 @@ static int uring_load_error(UringLoad *l,int err,const char *what){
     if(l->fatal){ errno=l->error; perror(what); exit(1); }
     return -1;
 }
-static int uring_add_read(UringBatch *b,int li,int fd,void *buf,size_t len,
-                          int64_t off,size_t expect){
+static int uring_add_read(UringBatch *b,int li,int fd,int primary_fd,int rep,
+                          void *buf,size_t len,int64_t off,size_t expect){
     if(b->nreq>=URING_REQ_MAX || expect>INT_MAX){ errno=E2BIG; return -1; }
+    if(rep<0 || rep>=MIR_REPS){ errno=EINVAL; return -1; }
     int ri=b->nreq++;
-    b->req[ri]=(UringRead){li,(int)expect};
+    b->req[ri]=(UringRead){li,(int)expect,fd,primary_fd,rep,buf,off};
     if(coli_uring_prep_read(&b->ring,fd,buf,len,off,(uint64_t)ri+1)) return -1;
     b->load[li].pending++;
     return 0;
+}
+/* Buffered replica read with per-shard fallback.  Keep the actual source in
+ * UringRead: completion accounting, DROP and runtime error fallback must all
+ * describe the fd that was really submitted, not recompute a route later. */
+static int uring_add_rep_read(UringBatch *b,int li,shards *S,int primary_fd,
+                              int rep,void *buf,size_t len,int64_t off,
+                              size_t expect){
+    int fd=st_fd_rep(S,primary_fd,rep);
+    int used=(rep && fd>=0)?rep:0;
+    if(fd<0) fd=primary_fd;
+    return uring_add_read(b,li,fd,primary_fd,used,buf,len,off,expect);
 }
 /* Returns the load index. URING is intentionally a quantized streaming path;
  * unsupported layouts fail instead of silently dropping back to pread. */
@@ -3266,25 +3281,31 @@ static int uring_load_add(UringBatch *b,Model *m,int layer,int eid,ESlot *s,int 
             int64_t base=off0&~4095LL,need=(off0-base)+wtot,len=(need+4095)&~4095LL;
             l->pos[ord[0]]=off0-base; l->pos[ord[1]]=l->pos[ord[0]]+l->tw[ord[0]]->nbytes;
             l->pos[ord[2]]=l->pos[ord[1]]+l->tw[ord[1]]->nbytes;
-            if(uring_add_read(b,li,dfd,s->slab,(size_t)len,base,(size_t)need))
+            if(uring_add_read(b,li,dfd,l->tw[ord[0]]->fd,rep,
+                              s->slab,(size_t)len,base,(size_t)need))
                 return uring_load_error(l,errno,"io_uring direct expert read"),li;
         }else{
             l->pos[ord[0]]=0; l->pos[ord[1]]=l->tw[ord[0]]->nbytes;
             l->pos[ord[2]]=l->pos[ord[1]]+l->tw[ord[1]]->nbytes;
-            if(uring_add_read(b,li,rep_bfd(&m->S,l->tw[ord[0]]->fd,rep),s->slab,(size_t)wtot,off0,(size_t)wtot))
+            if(uring_add_rep_read(b,li,&m->S,l->tw[ord[0]]->fd,rep,
+                                  s->slab,(size_t)wtot,off0,(size_t)wtot))
                 return uring_load_error(l,errno,"io_uring expert read"),li;
         }
     }else{
         int64_t o=0;
         for(int a=0;a<3;a++){ int k=ord[a]; l->pos[k]=o;
-            if(uring_add_read(b,li,rep_bfd(&m->S,l->tw[k]->fd,rep),s->slab+o,(size_t)l->tw[k]->nbytes,l->tw[k]->off,(size_t)l->tw[k]->nbytes))
+            if(uring_add_rep_read(b,li,&m->S,l->tw[k]->fd,rep,
+                                  s->slab+o,(size_t)l->tw[k]->nbytes,
+                                  l->tw[k]->off,(size_t)l->tw[k]->nbytes))
                 return uring_load_error(l,errno,"io_uring expert read"),li;
             o+=l->tw[k]->nbytes;
         }
     }
     int64_t fo=0;
     for(int k=0;k<3;k++){
-        if(uring_add_read(b,li,rep_bfd(&m->S,l->tq[k]->fd,rep),s->fslab+fo,(size_t)l->tq[k]->nbytes,l->tq[k]->off,(size_t)l->tq[k]->nbytes))
+        if(uring_add_rep_read(b,li,&m->S,l->tq[k]->fd,rep,
+                              s->fslab+fo,(size_t)l->tq[k]->nbytes,
+                              l->tq[k]->off,(size_t)l->tq[k]->nbytes))
             return uring_load_error(l,errno,"io_uring expert scale read"),li;
         fo+=l->tq[k]->nbytes/4;
     }
@@ -3295,7 +3316,25 @@ static void uring_reap(UringBatch *b){
     while(coli_uring_peek(&b->ring,&cqe)){
         if(!cqe.user_data || cqe.user_data>(uint64_t)b->nreq) continue;
         UringRead *r=&b->req[cqe.user_data-1]; UringLoad *l=&b->load[r->load];
-        if(cqe.res<r->expect && !l->error) l->error=cqe.res<0?-cqe.res:EIO;
+        int served=cqe.res>=r->expect;
+        if(!served && r->rep){
+            /* Match mir_pread's availability contract. A missing replica file
+             * is handled before submission; an I/O error or short completion
+             * discovered here gets one synchronous retry on the primary. This
+             * path is exceptional, so preserving inference is more important
+             * than retaining queue depth while a mirror is degraded. */
+            static _Atomic int warned;
+            if(!atomic_exchange(&warned,1))
+                fprintf(stderr,"[MIRROR] io_uring read error on the mirror copy — falling back to the primary drive\n");
+            if(!pread_full(r->primary_fd,r->buf,r->expect,r->off,
+                           "io_uring mirror fallback")){
+                r->fd=r->primary_fd; r->rep=0; cqe.res=r->expect; served=1;
+            }
+        }
+        if(served){
+            atomic_fetch_add_explicit(&g_mir_bytes[r->rep],cqe.res,memory_order_relaxed);
+            atomic_fetch_add_explicit(&g_mir_nread[r->rep],1,memory_order_relaxed);
+        }else if(!l->error) l->error=cqe.res<0?-cqe.res:EIO;
         if(l->pending>0) l->pending--;
         if(l->pending==0) l->done=1;
     }
@@ -3317,10 +3356,12 @@ static int uring_finalize_load(UringBatch *b,int li,int publish_eid){
     if(l->finalized) return 0;
     if(uring_wait_load(b,li)<0){ errno=l->error; if(l->fatal){perror("io_uring expert completion");exit(1);} return -1; }
     if(g_drop){
-        int ord0=0; for(int k=1;k<3;k++) if(l->tw[k]->off<l->tw[ord0]->off) ord0=k;
-        int64_t wtot=l->tw[0]->nbytes+l->tw[1]->nbytes+l->tw[2]->nbytes;
-        posix_fadvise(l->tw[ord0]->fd,l->tw[ord0]->off,wtot,POSIX_FADV_DONTNEED);
-        for(int k=0;k<3;k++) posix_fadvise(l->tq[k]->fd,l->tq[k]->off,l->tq[k]->nbytes,POSIX_FADV_DONTNEED);
+        /* Each request remembers its final source (mirror, per-shard primary,
+         * or primary after an error retry). Dropping tensor metadata's primary
+         * fd here left the pages actually read from a mirror resident forever. */
+        for(int ri=0;ri<b->nreq;ri++) if(b->req[ri].load==li)
+            posix_fadvise(b->req[ri].fd,b->req[ri].off,
+                          (off_t)b->req[ri].expect,POSIX_FADV_DONTNEED);
     }
     Cfg *c=&l->m->c; int I=c->moe_inter,D=c->hidden; float *fp[3]; int64_t fo=0;
     QT *qt[3]={&s->g,&s->u,&s->d}; int OO[3]={I,I,D},II[3]={D,D,I};
@@ -3334,6 +3375,9 @@ static int uring_finalize_load(UringBatch *b,int li,int publish_eid){
         qt[k]->fmt=fmt; qt[k]->O=OO[k]; qt[k]->I=II[k]; qt[k]->gs=gs; qt[k]->qf=NULL;
         qt[k]->q8=(int8_t*)(s->slab+l->pos[k]); qt[k]->q4=s->slab+l->pos[k]; qt[k]->s=fp[k];
     }
+    atomic_fetch_add_explicit(&g_prof_io,
+        l->tw[0]->nbytes+l->tw[1]->nbytes+l->tw[2]->nbytes+fo*4,
+        memory_order_relaxed);
     if(publish_eid) s->eid=l->eid;
     l->finalized=1; return 0;
 }

--- a/c/tests/test_uring.c
+++ b/c/tests/test_uring.c
@@ -11,6 +11,23 @@
 
 static int fail(const char *s){ fprintf(stderr,"FAIL: %s\n",s); return 1; }
 
+static int expert_slot_matches(const ESlot *slot,const unsigned char *data,
+                               const float *scales,int eid){
+    return slot->eid==eid && slot->g.fmt==1 && slot->u.fmt==1 && slot->d.fmt==1
+        && !memcmp(slot->g.q8,data,12) && !memcmp(slot->u.q8,data+12,12)
+        && !memcmp(slot->d.q8,data+24,12)
+        && !memcmp(slot->g.s,scales,12) && !memcmp(slot->u.s,scales+3,12)
+        && !memcmp(slot->d.s,scales+6,16);
+}
+
+static void mirror_stats_reset(void){
+    for(int r=0;r<MIR_REPS;r++){
+        atomic_store(&g_mir_bytes[r],0);
+        atomic_store(&g_mir_nread[r],0);
+    }
+    atomic_store(&g_prof_io,0);
+}
+
 static int test_expert_layout(int fd){
     Model m={0}; ESlot slot={0}; UringBatch batch={0};
     m.c.hidden=4; m.c.moe_inter=3; m.ebits=8;
@@ -39,12 +56,76 @@ static int test_expert_layout(int fd){
     if(li!=0 || uring_submit_batch(&batch) || uring_finalize_load(&batch,li,1)){
         coli_uring_close(&batch.ring); free(m.S.t); return fail("expert batch load");
     }
-    int bad=slot.eid!=7 || slot.g.fmt!=1 || slot.u.fmt!=1 || slot.d.fmt!=1
-        || memcmp(slot.g.q8,data,12) || memcmp(slot.u.q8,data+12,12) || memcmp(slot.d.q8,data+24,12)
-        || memcmp(slot.g.s,scales,12) || memcmp(slot.u.s,scales+3,12) || memcmp(slot.d.s,scales+6,16);
+    int bad=!expert_slot_matches(&slot,data,scales,7);
     coli_uring_close(&batch.ring);
     compat_aligned_free(slot.slab); free(slot.fslab);
     if(bad){ for(int i=0;i<m.S.n;i++) free(m.S.t[i].name); free(m.S.t); return fail("expert tensor views"); }
+
+    /* #1165: a real second fd with different bytes proves URING reads the
+     * routed replica. The completion counters and request source also make the
+     * PROF/DROP contract observable without requiring two physical SSDs. */
+    char mirror_path[]="/tmp/coli-uring-mirror-XXXXXX";
+    int mirror_fd=mkstemp(mirror_path);
+    if(mirror_fd<0){ free(m.S.t); return fail("mirror mkstemp"); }
+    unlink(mirror_path);
+    unsigned char mirror_data[76];
+    memcpy(mirror_data,data,sizeof(mirror_data));
+    for(int i=0;i<36;i++) mirror_data[i]^=0x5a;
+    float mirror_scales[10];
+    for(int i=0;i<10;i++) mirror_scales[i]=(float)i+20.5f;
+    memcpy(mirror_data+36,mirror_scales,sizeof(mirror_scales));
+    if(pwrite(mirror_fd,mirror_data,sizeof(mirror_data),0)!=(ssize_t)sizeof(mirror_data))
+        return fail("mirror fixture write");
+    m.S.nfd=1; m.S.fds[0]=fd; m.S.dfds[0]=-1; m.S.nrep=1;
+    m.S.mfds[0][0]=mirror_fd; m.S.mdfds[0][0]=-1;
+    g_mirror=1; g_mir_nrep=2; g_mir_cut[0]=0; g_mir_cut[1]=256;
+    g_direct=0; g_drop=1; mirror_stats_reset();
+
+    ESlot mirror_slot={0}; UringBatch mirror_batch={0};
+    if(uring_batch_init(&mirror_batch)) return fail("mirror ring init");
+    li=uring_load_add(&mirror_batch,&m,1,7,&mirror_slot,1);
+    if(li!=0 || uring_submit_batch(&mirror_batch) ||
+       uring_finalize_load(&mirror_batch,li,1))
+        return fail("mirror expert batch load");
+    bad=!expert_slot_matches(&mirror_slot,mirror_data,mirror_scales,7)
+        || mirror_batch.nreq!=4
+        || atomic_load(&g_mir_bytes[0])!=0
+        || atomic_load(&g_mir_nread[0])!=0
+        || atomic_load(&g_mir_bytes[1])!=(int64_t)sizeof(mirror_data)
+        || atomic_load(&g_mir_nread[1])!=4
+        || atomic_load(&g_prof_io)!=(int64_t)sizeof(mirror_data);
+    for(int i=0;i<mirror_batch.nreq;i++)
+        if(mirror_batch.req[i].fd!=mirror_fd || mirror_batch.req[i].rep!=1)
+            bad=1;
+    coli_uring_close(&mirror_batch.ring);
+    compat_aligned_free(mirror_slot.slab); free(mirror_slot.fslab);
+    if(bad) return fail("mirror routing/accounting");
+
+    /* A replica can disappear after submission metadata was prepared. Closing
+     * its fd forces -EBADF completions; every request must retry on the primary
+     * and publish the primary bytes instead of aborting inference. */
+    ESlot fallback_slot={0}; UringBatch fallback_batch={0};
+    if(uring_batch_init(&fallback_batch)) return fail("mirror fallback ring init");
+    li=uring_load_add(&fallback_batch,&m,1,7,&fallback_slot,1);
+    close(mirror_fd);
+    mirror_stats_reset();
+    if(li!=0 || uring_submit_batch(&fallback_batch) ||
+       uring_finalize_load(&fallback_batch,li,1))
+        return fail("mirror fallback expert load");
+    bad=!expert_slot_matches(&fallback_slot,data,scales,7)
+        || atomic_load(&g_mir_bytes[0])!=(int64_t)sizeof(data)
+        || atomic_load(&g_mir_nread[0])!=4
+        || atomic_load(&g_mir_bytes[1])!=0
+        || atomic_load(&g_mir_nread[1])!=0
+        || atomic_load(&g_prof_io)!=(int64_t)sizeof(data);
+    for(int i=0;i<fallback_batch.nreq;i++)
+        if(fallback_batch.req[i].fd!=fd || fallback_batch.req[i].rep!=0)
+            bad=1;
+    coli_uring_close(&fallback_batch.ring);
+    compat_aligned_free(fallback_slot.slab); free(fallback_slot.fslab);
+    if(bad) return fail("mirror runtime fallback");
+    m.S.nrep=0; m.S.mfds[0][0]=-1; m.S.mdfds[0][0]=-1;
+    g_mirror=0; g_mir_nrep=1; g_mir_cut[0]=256; g_drop=0;
 
     m.c.n_experts=8; m.c.n_layers=2; m.ecap=2;
     m.pin=calloc(3,sizeof(ESlot*)); m.npin=calloc(3,sizeof(int));


### PR DESCRIPTION
Fixes #1165, reported by @tonnthuir: the mirror drive was active under `URING=0` but idle under `URING=1`, independently of `DIRECT`.

## The defect

`uring_load_add` submitted reads against tensor fds from the primary index and never called `expert_route`. Consequently, `URING=1` read every expert from drive 0 and ignored the bandwidth provided by `COLI_MODEL_MIRROR`.

The blocking path was already replica-aware:

```c
/* blocking */
int dfd = g_direct ? st_direct_fd_rep(&m->S, tw[ord[0]]->fd, rep) : -1;

/* uring before this PR */
int dfd = g_direct ? st_direct_fd(&m->S, l->tw[ord[0]]->fd) : -1;
```

## The fix

Select the replica once from `(layer, eid)` and route every io_uring submission through it:

- contiguous O_DIRECT weight reads;
- contiguous buffered weight reads;
- split weight reads;
- `.qs` scale reads.

The deterministic route is preserved, so PILOT readahead and the later demand read target the same drive. Partial mirrors still fall back per shard to the primary.

Each queued request now records the fd and replica actually submitted. This also fixes the surrounding I/O semantics:

- successful CQEs update `MIRROR:` bytes/read counters;
- `PROF=1` includes logical io_uring expert bytes in `g_prof_io`;
- `DROP=1` evicts pages from the fd actually read instead of always advising the primary metadata fd;
- a mirror I/O error or short CQE retries that request once from the primary, matching the blocking mirror path.

## Verification

`test_uring` now creates two real file descriptors containing different 76-byte expert fixtures and forces routing to replica 1. It proves that:

- the published weights and scales come from the mirror;
- all four completions are charged to the mirror (76 bytes total);
- closing the mirror fd before submission triggers primary fallback and publishes primary bytes;
- accounting follows the final source and `g_prof_io` remains exactly 76 logical bytes.

Verified locally with the optimized test and with ASan + UBSan. The full serial C suite passes; `test_cluster_protocol` and `test_uring`, whose syscalls are denied by the local sandbox, were also run successfully outside it. The fixture is intentionally tiny and requires no multi-drive hardware or material RAM.

For a hardware verification, run with `COLI_MODEL_MIRROR`, `URING=1`, and `PROF=1`: both drives should show activity in `iostat`, and the `MIRROR:` line should report bytes and reads on each routed drive.
