### PR TITLE
fix(make): build qwen36 before install

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1427,7 +1427,7 @@ check:
 	$(MAKE) portable
 	$(MAKE) test
 
-install: colibri$(EXE) inkling$(EXE) kimi_k3$(EXE) olmoe$(EXE) \
+install: colibri$(EXE) inkling$(EXE) kimi_k3$(EXE) olmoe$(EXE) qwen36$(EXE) \
 	$(if $(filter 1,$(COLI_V4_SUPPORTED)),deepseek-v4,)
 	$(INSTALL) -d $(DESTDIR)$(BINDIR)
 	$(INSTALL) -d $(DESTDIR)$(LIBEXECDIR)

--- a/c/tests/test_family_registry.py
+++ b/c/tests/test_family_registry.py
@@ -900,11 +900,21 @@ class FamilyRegistryTest(unittest.TestCase):
         release = (repo / ".github" / "workflows" / "release.yml").read_text(
             encoding="utf-8")
         docker = (repo / "docker" / "Dockerfile.slim").read_text(encoding="utf-8")
+        make_rules = re.sub(r"\\\n[ \t]*", " ", makefile)
+        install_rule = re.search(r"(?m)^install:\s*(.*)$", make_rules)
+        self.assertIsNotNone(install_rule)
+        install_prerequisites = install_rule.group(1).split("#", 1)[0]
         for family in FAMILIES:
             with self.subTest(family=family.id):
                 self.assertRegex(
                     makefile,
                     rf"(?m)^{re.escape(family.build_target)}(?:\$\(EXE\))?:")
+                install_target = family.build_target
+                if family.id != "deepseek_v4":
+                    install_target += "$(EXE)"
+                self.assertRegex(
+                    install_prerequisites,
+                    rf"(?<![\w.-]){re.escape(install_target)}(?![\w.-])")
                 if family.id != "deepseek_v4":
                     self.assertIn(family.build_target,
                                   re.search(r'ENGINES="([^"]+)"', ci).group(1).split())


### PR DESCRIPTION
## Summary

`make install` copies `qwen36$(EXE)`, but did not declare it as an install prerequisite. On a clean tree, Make therefore reached the copy without building the engine.

Add `qwen36$(EXE)` to the `install` prerequisites and extend the registry packaging test to require every registered family's build target in the install dependency graph.

## Validation

- [x] `make -C c check` (via the root `make check` target)
- [x] Targeted registry packaging test
- [x] Clean-tree `make -n install` schedules the qwen36 compile before its copy
- [ ] CUDA changes were tested with `make -C c cuda-test` (not applicable)
- [ ] Performance claims include hardware, commands, and repeatable measurements (not applicable)

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included