### PR TITLE
fix(tune): report Metal backend in plan label on Apple Silicon

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -619,7 +619,17 @@ def env_for(a):
                 print(f"  {C.dim}[TUNE] applied measured profile · +{gain:.1f}% calibration throughput{C.r}",
                       file=sys.stderr)
         rt=plan["tiers"]["ram"]; vt=plan["tiers"]["vram"]
-        gpu=f" · VRAM {format_bytes(vt['budget_bytes'])}" if has_cuda and vt["devices"] else " · CPU"
+        # The plan label used to derive the backend from CUDA alone, so on
+        # Apple Silicon it printed " · CPU" even when the calibration child
+        # processes ran on Metal (COLI_METAL is inherited through env_for and
+        # environment_for_plan, so the measurements are real). Report the
+        # active backend: CUDA VRAM first, then Metal, then CPU.
+        if has_cuda and vt["devices"]:
+            gpu=f" · VRAM {format_bytes(vt['budget_bytes'])}"
+        elif str(e.get("COLI_METAL","")).strip() not in ("","0"):
+            gpu=" · Metal (unified memory)"
+        else:
+            gpu=" · CPU"
         print(f"  {C.dim}[PLAN] RAM {format_bytes(rt['budget_bytes'])} · cap {rt['cache_slots_per_layer']}/layer{gpu}{C.r}",file=sys.stderr)
     else:
         # Windows: a bare `coli chat` (no --gpu/--vram/--auto-tier) used to ALWAYS


### PR DESCRIPTION
Fixes #1172.

`coli tune` derived the `[PLAN]` backend label from CUDA detection alone. On Apple Silicon `cuda_binary()` is false and the plan has no discrete VRAM devices, so the summary printed ` · CPU` even when `COLI_METAL=1` was set and the calibration child processes were running on Metal (they inherit `COLI_METAL` through `env_for` / `environment_for_plan`).

The measurements were always real Metal runs; only the summary line was wrong, which pushed users to retune or reconfigure needlessly (per the reporter).

**Change:** the label now reports the active backend in order: CUDA VRAM, then a truthy `COLI_METAL` as `Metal (unified memory)`, then `CPU`. Label-only, in `c/coli`; the calibration processes run exactly as before.

Reported and diagnosed by @trigger2k20 (Mac Studio, M4 Max, macOS 26.6.2).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>