### PR TITLE
fix(tools): check temp free space before the eviction write in datapoint.py

### DIFF
--- a/c/tests/test_datapoint.py
+++ b/c/tests/test_datapoint.py
@@ -274,5 +274,43 @@ class PersistentDatapointTest(unittest.TestCase):
         self.assertTrue(all(family.has_gateway_adapter for family in FAMILIES))
 
 
+class EvictCacheSpaceTest(unittest.TestCase):
+    """The portable fallback must not fill the temp volume.
+
+    It is the only eviction route on Windows, and since #1042 it sizes the write
+    from the machine's real RAM rather than a hardcoded 8 GB. A 128 GB box whose
+    temp dir is on a drive with 124 GB free would write until that volume hit
+    zero and only then raise OSError.
+    """
+
+    def _run(self, ram_gb, free_gb, tmp="/tmp"):
+        usage = SimpleNamespace(free=int(free_gb * GB))
+        with mock.patch.object(sys, "platform", "win32"), \
+             mock.patch.object(datapoint.tempfile, "gettempdir", return_value=tmp), \
+             mock.patch.object(datapoint.shutil, "disk_usage", return_value=usage), \
+             mock.patch.object(datapoint.tempfile, "NamedTemporaryFile") as ntf:
+            return datapoint.evict_cache(ram_gb), ntf
+
+    def test_refuses_when_the_temp_volume_is_too_small(self):
+        result, ntf = self._run(ram_gb=128, free_gb=124)
+        self.assertFalse(result)
+        ntf.assert_not_called()          # nothing written, not even partially
+
+    def test_writes_when_there_is_room(self):
+        result, ntf = self._run(ram_gb=8, free_gb=500)
+        self.assertTrue(ntf.called)
+        self.assertTrue(result)
+
+    def test_unreadable_temp_volume_does_not_block_the_write(self):
+        """A failed disk_usage must not become a refusal. The pre-existing
+        OSError handler around the write is still the backstop."""
+        with mock.patch.object(sys, "platform", "win32"), \
+             mock.patch.object(datapoint.shutil, "disk_usage",
+                               side_effect=OSError("no stat")), \
+             mock.patch.object(datapoint.tempfile, "NamedTemporaryFile") as ntf:
+            self.assertTrue(datapoint.evict_cache(1))
+            self.assertTrue(ntf.called)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/c/tools/datapoint.py
+++ b/c/tools/datapoint.py
@@ -32,6 +32,7 @@ import argparse
 import os
 import platform
 import re
+import shutil
 import statistics
 import subprocess
 import sys
@@ -171,6 +172,24 @@ def evict_cache(ram_gb, snap_dir=None):
 
     # Fallback: Write temp file larger than RAM
     size_mb = int(ram_gb) * 1024 + 1024
+    # Confirm the temp volume can hold it before writing a byte. This is the only
+    # eviction route on Windows (macOS has purge, Linux has fadvise), and since
+    # #1042 it writes the machine's real RAM rather than a hardcoded 8 GB, so the
+    # write is now as large as the box. tempfile.gettempdir() is usually the
+    # system drive while the model lives elsewhere, so on a 128 GB machine with
+    # 124 GB free on C: this fills the system volume to zero and only then raises.
+    tmp_dir = tempfile.gettempdir()
+    need = size_mb * (1 << 20)
+    try:
+        free = shutil.disk_usage(tmp_dir).free
+    except OSError:
+        free = None
+    if free is not None and free < need:
+        print(f"[datapoint] cache eviction skipped: need {need / (1 << 30):.0f} GB "
+              f"free in {tmp_dir} but only {free / (1 << 30):.0f} GB available. "
+              f"Point TMPDIR (TEMP on Windows) at a larger volume, or pass "
+              f"--no-evict and label the run warm.", file=sys.stderr)
+        return False
     print(f"[datapoint] evicting page cache by writing {size_mb / 1024:.0f} GB "
           f"to a temp file (no direct eviction on this platform; --no-evict skips)",
           file=sys.stderr)


### PR DESCRIPTION
### What

`evict_cache()`'s portable fallback writes `ram_gb + 1` GB to `tempfile.gettempdir()` without first checking that the volume can hold it.

That fallback is the only eviction route on Windows: macOS gets `purge`, Linux gets `posix_fadvise(DONTNEED)` over the shards, and everything else falls through to the temp-file write.

### Why it matters more since #1042

Before that fix, `ram_gb` was hardcoded to `8.0` off darwin/linux, so the write was always about 9 GB and effectively always fit. #1042 made it the machine's real RAM, which is correct, and as a side effect the write is now as large as the box.

`tempfile.gettempdir()` is usually the system drive, while the model being benchmarked normally lives on another volume. On this machine:

```
RAM                128 GB   ->  eviction write needs 129 GB
C: free            124 GB       (system drive, where TEMP points)
D: free            994 GB       (where the 402 GB model actually lives)
```

The old code writes until C: reaches zero and only then raises `OSError`. Filling the Windows system volume is a considerably worse outcome than a skipped eviction, and the user gets no warning that it is about to happen.

### The change

Check `shutil.disk_usage(tmp_dir).free` before writing anything. If it will not fit, skip the eviction and say why, with both ways out:

```
[datapoint] cache eviction skipped: need 129 GB free in C:\Users\...\Temp but only
124 GB available. Point TMPDIR (TEMP on Windows) at a larger volume, or pass
--no-evict and label the run warm.
```

A `disk_usage` that itself raises is deliberately **not** treated as a refusal. It falls through to the write, where the pre-existing `OSError` handler is still the backstop. A probe failure should not stop a run that would otherwise have worked.

### Tests

Three, all host independent, mocking `sys.platform`, `gettempdir` and `disk_usage`:

- `test_refuses_when_the_temp_volume_is_too_small` - 128 GB RAM against 124 GB free refuses, and asserts `NamedTemporaryFile` is never called, so nothing is written even partially.
- `test_writes_when_there_is_room` - unchanged behaviour when it fits.
- `test_unreadable_temp_volume_does_not_block_the_write` - a raising `disk_usage` still writes.

Verified as a negative control rather than assumed: disabling the new branch makes `test_refuses_when_the_temp_volume_is_too_small` fail with `AssertionError: True is not false`. Restoring it passes. So the test measures the fix instead of passing vacuously.

Full file suite: `python -m unittest tests.test_datapoint` -> **Ran 15 tests, OK**.

### How it was found

Producing a GLM-5.2 datapoint on a 128 GB / i9-14900K / RTX 3090 Windows box, which is why the temp volume was the tight one and the model volume was not.
