### PR TITLE
fix(tools): keep datapoint results when engine teardown outlasts the grace period

### DIFF
--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -2381,8 +2381,17 @@ class Engine:
             try:
                 self.process.wait(timeout=5)
             except subprocess.TimeoutExpired:
+                # A large resident cache (e.g. 111 GB at --memory-gb 126) can
+                # take longer than the grace period to unmap and free on
+                # SIGTERM. SIGKILL cannot be caught, so the process is already
+                # on its way out; a second timeout only means the reap has not
+                # landed yet. Teardown is best-effort: never raise from here, or
+                # a completed measurement is lost to a shutdown that succeeded.
                 self.process.kill()
-                self.process.wait(timeout=5)
+                try:
+                    self.process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass
         if self.dispatcher is not threading.current_thread():
             self.dispatcher.join(timeout=5)
 

--- a/c/tests/test_datapoint.py
+++ b/c/tests/test_datapoint.py
@@ -7,6 +7,7 @@ mocking sys.platform and the two win32 probes.
 """
 import ctypes
 import os
+import subprocess
 import sys
 import tempfile
 import threading
@@ -153,6 +154,34 @@ class PersistentDatapointTest(unittest.TestCase):
         self.assertEqual(campaign["warm"][0]["prompt_tokens"], 17)
         self.assertEqual(campaign["rotating_prompt_count"], 4)
         self.assertEqual(campaign["rotating_prompt_source"], "built-in")
+
+    def test_teardown_failure_does_not_discard_collected_results(self):
+        # At --memory-gb 126 the engine can outlast the close() grace period
+        # while it frees a large resident cache; the raised TimeoutExpired used
+        # to swallow the return and lose a complete run (#1154). A teardown that
+        # fails must still yield the measurements already gathered.
+        base = self._runtime()
+
+        class RaisingCloseEngine(base.Engine):
+            def close(self):
+                self.closed = True
+                raise subprocess.TimeoutExpired(cmd="engine", timeout=5)
+
+        runtime = self._runtime(engine_type=RaisingCloseEngine)
+        with tempfile.TemporaryDirectory() as tmp:
+            executable = Path(tmp) / "deepseek_v4"
+            executable.touch()
+            with mock.patch.dict(os.environ, {}, clear=True):
+                campaign = datapoint.run_persistent_engine(
+                    str(executable), "/model", "hello", 8, 0, 1, 16,
+                    memory_gb=126, runtime=runtime, physical_cores=8)
+
+        self.assertEqual(len(self.instances), 1)
+        self.assertTrue(self.instances[0].closed)
+        self.assertEqual(len(campaign["cold"]), 1)
+        self.assertEqual(len(campaign["warm"]), 1)
+        self.assertEqual([row["tok_s"] for row in campaign["rotating"]],
+                         [3.0, 4.0, 5.0, 6.0])
 
     def test_engine_is_closed_when_a_request_fails(self):
         instances = self.instances

--- a/c/tools/datapoint.py
+++ b/c/tools/datapoint.py
@@ -353,7 +353,16 @@ def run_persistent_engine(engine, snap, prompt, max_new, warmup_runs, warm_runs,
         tiers = dict(persistent.tiers) if getattr(persistent, "tiers", None) else None
         hwinfo = dict(persistent.hwinfo) if getattr(persistent, "hwinfo", None) else None
     finally:
-        persistent.close()
+        # All measurements above are already collected; a teardown that fails
+        # must not discard them. At --memory-gb 126 the engine can outlast the
+        # close() grace period while it frees a 111 GB resident cache, and a
+        # raised exception here would swallow the return and lose a complete run
+        # (observed on the EPYC 7282 datapoint, #1154).
+        try:
+            persistent.close()
+        except Exception as exc:  # noqa: BLE001 - teardown is best-effort
+            print(f"[datapoint] warning: engine teardown did not complete "
+                  f"cleanly, results are still valid: {exc}", file=sys.stderr)
 
     return {
         "mode": "persistent",


### PR DESCRIPTION
From the EPYC 7282 run in #1154.

## Problem

`run_persistent_engine` in `tools/datapoint.py` gathers a full campaign, then loses it whenever `persistent.close()` raises. The close lives in a `finally:` block, so a raised exception swallows the `return` that follows.

At `--memory-gb 126` the engine holds a ~111 GB resident cache. On `SIGTERM` it can take longer than the 5s grace period to unmap and free, so `close()` hits `TimeoutExpired`. acedogblast's 126 GB run measured all 8 rotating prompts (the progress lines printed), then crashed in `persistent.close()` with a traceback and produced no summary table. The 32 GB and 64 GB runs succeeded only because the smaller engine exits within 5s.

## Fix

Two best-effort guards, both host-side Python. The engine and on-disk format are unchanged.

- `PersistentEngine.close()` no longer raises after `SIGKILL`: a second `wait()` timeout only means the reap has not landed yet, and teardown must not fail a shutdown that already succeeded.
- `run_persistent_engine` catches any teardown error and warns, so the collected campaign is always returned.

## Test bites

`test_teardown_failure_does_not_discard_collected_results`: a `close()` that raises `TimeoutExpired` now still yields the rotating measurements. Verified as a negative control, reverting the `finally` guard fails the test with the results lost; restoring it passes. `python -m pytest tests/test_datapoint.py` -> 13 passed.

Independent of #1182 (that fixes `evict_cache()`, a different function); no overlap.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>