### PR TITLE
fix(glm): label banner bit widths as compute, not storage

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -10765,7 +10765,11 @@ int main(int argc, char **argv){
             g_tq_codec ? "rotated int4 + Lloyd codebook (4-bit)" : "PolarQuant recursive-polar");
       }
     }
-    printf("== GLM C engine (glm_moe_dsa), cache=%d experts/layer | experts@%d-bit dense@%d-bit | idot: " IDOT_KERNEL " ==\n", cap, ebits, dbits);
+    /* ebits/dbits are the compute (dequant) width the idot kernels run at, not
+     * the stored weight format: a fmt=4 grouped-int4 container still computes at
+     * 8-bit here. Label it as compute so the banner is not misread as a storage
+     * claim (#1183). */
+    printf("== GLM C engine (glm_moe_dsa), cache=%d experts/layer | compute experts@%d-bit dense@%d-bit | idot: " IDOT_KERNEL " ==\n", cap, ebits, dbits);
     g_mem_avail_boot = mem_available_gb();
 #if !defined(_WIN32)
     if(getenv("CLUSTER_WORKERS") && *getenv("CLUSTER_WORKERS")){


### PR DESCRIPTION
From #1183.

The GLM startup banner printed:

```
== GLM C engine (glm_moe_dsa), cache=8 experts/layer | experts@8-bit dense@8-bit | idot: avx-vnni ==
```

`ebits`/`dbits` are the compute (dequant) width the idot kernels run at (`argv[2]`/`argv[3]`, default 8), **not** the stored weight format. On a `fmt=4` grouped-int4 g64 container the weights are stored as int4 while compute stays 8-bit, so the line reads as a storage claim. The reporter (a careful one, full 128-token PROF datapoint on i9-14900K + RTX 3090) nearly filed the datapoint with the wrong format because of it.

Fix: prefix the two widths with `compute`, so the banner reads `compute experts@8-bit dense@8-bit` right next to `idot:`. The stored format is unchanged and reported elsewhere. Verified `make colibri` builds clean; no test asserts the banner string.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>