### PR TITLE
fix(qwen36): discover visible CUDA devices for default tier

### DIFF
--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -1231,6 +1231,12 @@ extern "C" int coli_cuda_init(const int *devices, int count) {
     return 1;
 }
 
+extern "C" int coli_cuda_available_device_count(void) {
+    int available = 0;
+    if (cudaGetDeviceCount(&available) != cudaSuccess) return 0;
+    return available;
+}
+
 extern "C" void coli_cuda_shutdown(void) {
     for (int i = 0; i < g_nctx; i++) {
         DeviceContext *ctx = &g_ctx[i];

--- a/c/backend_cuda.h
+++ b/c/backend_cuda.h
@@ -27,6 +27,9 @@ typedef struct ColiCudaTensor ColiCudaTensor;
 /* Devices are CUDA ordinals, not positions in the input list. */
 COLI_CUDA_DLLEXPORT int coli_cuda_init(const int *devices, int count);
 COLI_CUDA_DLLEXPORT void coli_cuda_shutdown(void);
+/* Number of CUDA devices visible to this process, before a device list is
+ * selected. Returns 0 when the runtime cannot discover any device. */
+COLI_CUDA_DLLEXPORT int coli_cuda_available_device_count(void);
 COLI_CUDA_DLLEXPORT int coli_cuda_device_count(void);
 COLI_CUDA_DLLEXPORT int coli_cuda_device_at(int index);
 COLI_CUDA_DLLEXPORT int coli_cuda_mem_info(int device, size_t *free_bytes, size_t *total_bytes);

--- a/c/qwen36_tier.c
+++ b/c/qwen36_tier.c
@@ -121,11 +121,19 @@ int qt_init(int nl, int ne, int D, int Ih, int cap, int topk, int expert_gs){
     memset(&G,0,sizeof G);
     G.nl=nl; G.ne=ne; G.D=D; G.Ih=Ih; G.topk=topk;
 
-    /* devices: COLI_GPUS="0,1" (default: 0,1 when present, else 0) */
+    /* devices: COLI_GPUS="0,1" (default: first two visible devices) */
     const char *gl=getenv("COLI_GPUS");
-    char buf[128]; snprintf(buf,sizeof buf,"%s", gl?gl:"0,1");
-    for(char *t=strtok(buf,","); t && G.ndev<QT_MAX_DEV; t=strtok(NULL,","))
-        G.dev[G.ndev++]=atoi(t);
+    if (gl && *gl) {
+        char buf[128]; snprintf(buf,sizeof buf,"%s",gl);
+        for(char *t=strtok(buf,","); t && G.ndev<QT_MAX_DEV; t=strtok(NULL,","))
+            G.dev[G.ndev++]=atoi(t);
+    } else {
+        int available=coli_cuda_available_device_count();
+        int want=available<2?available:2;
+        for(int i=0;i<want && i<QT_MAX_DEV;i++) G.dev[G.ndev++]=i;
+        fprintf(stderr,"[qtier] COLI_GPUS unset: selecting %d visible device(s)\n",G.ndev);
+    }
+    if(G.ndev<1){ fprintf(stderr,"[qtier] no visible CUDA devices -> CPU path\n"); return 0; }
     if(!coli_cuda_init(G.dev,G.ndev)){ fprintf(stderr,"[qtier] coli_cuda_init failed -> CPU path\n"); return 0; }
     int have=coli_cuda_device_count();
     if(have<G.ndev){ G.ndev=have; }


### PR DESCRIPTION
## Summary

When `COLI_GPUS` is unset, the Qwen3.6 CUDA tier currently defaults to device ordinals `0,1`.

This fails on hosts with only one visible CUDA device, including deployments using device masking. Device `1` is invalid, causing CUDA tier initialization to fail and silently falling back to the CPU path.

The default configuration should adapt to the devices visible to the current process.

## Solution

- Add a CUDA backend helper to query the number of visible devices.
- Select up to the first two visible devices when `COLI_GPUS` is unset.
- Preserve the existing behavior when `COLI_GPUS` is explicitly configured.
- Report a clear CPU fallback when no CUDA device is visible.

## Compatibility

- The default CPU build remains dependency-free.
- Explicit `COLI_GPUS` configurations are unchanged.
- No model formats or model files are affected.
