### PR TITLE
fix(qwen36): skip discarded final decode

### DIFF
--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -2280,6 +2280,10 @@ static void serve_one(Model *m, ServeReq *q){
         unsigned char chunk[256]; int cn=0; utf8_drain(sbuf,&sbn,tmp,tn,chunk,&cn);
         if(cn>0) serve_data(q->id,(char*)chunk,cn);
         gen++;
+        /* The next logits are not needed after the final requested token.
+         * serve_one() resets the recurrent/KV state for every request, so
+         * stepping here would only run a full discarded decode pass. */
+        if(s == q->max_tok - 1) break;
         lo = step(m, &tk, 1, np+s);
     }
     if(sbn>0) serve_data(q->id,(char*)sbuf,sbn);   /* flush trailing partial UTF-8 */


### PR DESCRIPTION
## Summary

The Qwen3.6 serve loop performs a `step()` after every generated token, including the final token allowed by `max_tokens`.

After the final token, no subsequent logits are consumed. Since the recurrent and KV state is reset for each request, this extra forward pass is discarded entirely. Requests that finish because they reach the generation limit therefore pay for one unnecessary full decode step.

## Solution

Stop the serve loop immediately after emitting the final requested token.

Intermediate tokens continue to execute `step()` normally, so generation behavior is unchanged. EOS handling, token accounting, and response framing are also preserved.

This removes an unnecessary attention, DeltaNet, and MoE forward pass from requests that terminate at the configured output limit.

## Compatibility

- The default CPU build remains dependency-free.
- Requests stopping before `max_tokens` are unchanged.
- No model formats or model files are affected.
