### PR TITLE
fix(tune): resolve the cap from the plan when --cap is not given

### DIFF
--- a/c/autotune.py
+++ b/c/autotune.py
@@ -229,6 +229,18 @@ def run_tune(engine: str, cap: int, base_env: dict, plan: dict, model: str,
              progress=None) -> tuple[dict, Path]:
     """Coordinate-descent tuning with a reverse-order confirmation gate."""
     progress = progress or (lambda _message: None)
+    if cap is None:
+        # --cap has default=None ("auto"). str(None) used to reach the engine
+        # as argv[1]="None", which atoi() turns into 0: qwen36 refuses it and
+        # tuning dies with "calibration failed (1)", while GLM silently swept
+        # its platform default instead of the cap the plan just resolved
+        # (#1190). The plan is authoritative here, exactly like `coli chat`;
+        # a plan without a resolved cap is a loud error, never "None".
+        cap = plan.get("tiers", {}).get("ram", {}).get("cache_slots_per_layer")
+        if cap is None:
+            raise ValueError(
+                "--cap not given and the resource plan carries no resolved "
+                "cache_slots_per_layer")
     replay, _ = create_replay(engine, cap, base_env, prompt, tokens, timeout)
     with tempfile.TemporaryDirectory(prefix="coli-tune-") as directory:
         ref = Path(directory) / "replay.json"

--- a/c/tests/test_autotune.py
+++ b/c/tests/test_autotune.py
@@ -148,6 +148,44 @@ class AutotuneUnitTest(unittest.TestCase):
 
 
 class AutotuneIntegrationTest(unittest.TestCase):
+    def test_unset_cap_resolves_from_the_plan_not_str_none(self):
+        # --cap has default=None; str(None) used to reach every engine as
+        # argv[1]="None" -> atoi -> 0: qwen36 aborted, GLM silently swept the
+        # platform default instead of the plan's cap (#1190).
+        with tempfile.TemporaryDirectory() as directory:
+            engine = Path(directory) / "cap-recorder.py"
+            caps = Path(directory) / "caps"
+            engine.write_text(
+                "#!/usr/bin/env python3\n"
+                "import os,sys\n"
+                f"open({str(caps)!r},'a').write(sys.argv[1]+'\\n')\n"
+                "if os.environ.get('PROMPT'):\n"
+                " print('[PROMPT_TOKENS] 3: 10 11 12')\n"
+                " print('[TOKENS] 4 generated: 20 21 22 23')\n"
+                "else:\n"
+                " print('REPLAY decode: 4 tokens | 10.00 tok/s | expert hit 95.0%')\n"
+                " print('[PROF] decode forwards: 4 | latency p50 80.0 ms "
+                "| p90 90.0 ms | p99 100.0 ms | max 100.0 ms')\n",
+                encoding="utf-8",
+            )
+            engine.chmod(engine.stat().st_mode | stat.S_IXUSR)
+            p = plan(cores=1)
+            p["tiers"]["ram"] = {"cache_slots_per_layer": 84}
+            run_tune(
+                str(engine), None, dict(os.environ), p, directory, "prompt",
+                tokens=4, repeats=1, timeout=5, min_gain=0.03,
+                profile_dir=directory,
+            )
+            seen = set(caps.read_text().split())
+            self.assertEqual(seen, {"84"},
+                             f"engine saw caps {seen}, expected the plan's 84")
+
+    def test_unset_cap_with_capless_plan_refuses_loudly(self):
+        with self.assertRaises(ValueError):
+            run_tune("/nonexistent-engine", None, dict(os.environ),
+                     plan(cores=1), "/tmp", "prompt", tokens=4, repeats=1,
+                     timeout=5, min_gain=0.03)
+
     def test_fixed_replay_selects_and_persists_winner(self):
         with tempfile.TemporaryDirectory() as directory:
             engine = Path(directory) / "fake-engine.py"


### PR DESCRIPTION
Fixes #1190.

`--cap` has `default=None` and `run_tune` stringified it into the engine argv, so every default `coli tune` launched the engine with `argv[1]="None"` → `atoi` → 0:

- **qwen36** refuses cap 0, so tuning died with the unhelpful `calibration failed (1)` (the reporter's trace);
- **GLM** has no guard and **silently swept its platform default** instead of the cap the plan had just resolved — the sweep measured a workload the user never asked for. That silent half is the worse bug.

## Fix

The plan is authoritative, exactly like `coli chat`: when `cap is None`, `run_tune` takes `tiers.ram.cache_slots_per_layer` from the plan it already receives, and refuses loudly (`ValueError`) if the plan carries no resolved cap — `"None"` can never reach an engine again.

## Tests bite

- a recorder engine asserts the plan's cap (84) is what `argv[1]` actually receives on every launch;
- a capless plan raises instead of stringifying None.

Negative control verified: reverting the fix fails both tests. `pytest tests/test_autotune.py`: 14 passed.

Credit to @bigmarketgroup for the precise line-by-line diagnosis.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>