### PR TITLE
fix: clamp explicit RAM_GB to the memory actually available (#759)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1274,6 +1274,8 @@ tests/test_corpus_draft$(EXE): tests/test_corpus_draft.c colibri.c st.h uring.h 
 
 tests/test_cap_precedence$(EXE): tests/test_cap_precedence.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+tests/test_ram_clamp$(EXE): tests/test_ram_clamp.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_cap_mixed_width$(EXE): tests/test_cap_mixed_width.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h route_trace.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -8902,6 +8902,7 @@ static void pin_arena_bind(Model *m, PinRec *r, int *slot_of, int from, int to){
 #endif
 static double expert_avail(Model *m, double ram_gb, int ebits, int max_ctx);  /* def. sotto */
 static double g_mem_avail_boot;   /* def. sotto (#653: corretta qui su GPU integrate) */
+static double coli_clamp_ram_gb(double ram_gb, double mem_avail_gb, int overcommit);  /* def. sotto (#759) */
 /* Admission test unchanged; it just runs from route_trace.h's reader now, so PIN=<file>
  * accepts every history layout an engine can write instead of only sparse text (#700). */
 typedef struct { Model *m; PinRec *r; int *n, cap; unsigned char *seen; } PinCollect;
@@ -8945,6 +8946,12 @@ static void pin_load(Model *m, const char *statspath, double gb, int trusted){
     double pin_budget_b;
     if(gb<0){
         double ram_env=getenv("RAM_GB")?atof(getenv("RAM_GB")):0.0;
+        /* #759: same clamp as cap_for_ram; here the snapshot is still the
+         * uncorrected boot value (#653 runs later in this function), so on
+         * unified-memory hosts this only rejects budgets larger than physical
+         * RAM at boot -- never smaller than what the tier will leave behind. */
+        ram_env=coli_clamp_ram_gb(ram_env,g_mem_avail_boot,
+            getenv("COLI_RAM_OVERCOMMIT")?atoi(getenv("COLI_RAM_OVERCOMMIT")):0);
         int est_ctx=getenv("CTX")?atoi(getenv("CTX")):4096;   /* stesso default del call site */
         double avail=expert_avail(m,ram_env,m->ebits,est_ctx);
         pin_budget_b=avail>0?avail:0.0;
@@ -9229,6 +9236,21 @@ static double expert_cache_bytes_per_slot(Model *m, int ebits){
     return expert_cache_row_bytes(m,ebits);
 }
 
+
+
+/* #759: an explicit RAM_GB used to be honored literally even when it named more
+ * physical memory than the machine actually has. On unified-memory hosts the
+ * #653 correction shrinks the boot snapshot by the VRAM expert tier, so the gap
+ * between the requested budget and reality is easy to hit; CAP_RAISE then scaled
+ * the LRU against that phantom budget and the kernel OOM-killed mid-prefill.
+ * Pure function (no I/O, no globals) so tests can drive it directly, same
+ * contract style as coli_resolve_cap(). */
+static double coli_clamp_ram_gb(double ram_gb, double mem_avail_gb, int overcommit){
+    if(!overcommit && ram_gb>0 && mem_avail_gb>0 && ram_gb>mem_avail_gb)
+        return mem_avail_gb;
+    return ram_gb;
+}
+
 /* clampa la cache expert a un budget RAM (GB): cap t.c. residente + cache + slack <= budget.
  * ram_gb<=0 -> budget AUTO = 88% della RAM disponibile adesso (lascia respiro a OS+wrapper:
  * sforare = OOM-kill del kernel a meta' generazione, molto peggio di una cache piu' piccola). */
@@ -9245,6 +9267,19 @@ static void cap_for_ram(Model *m, double ram_gb, int ebits, int max_ctx){
     if(auto_b){ ram_gb = g_mem_avail_boot*0.88;   /* misurata PRIMA del load: il residente gia'
                                                    * allocato viene sottratto sotto, non due volte */
         if(ram_gb<4){ fprintf(stderr,"[RAM] MemAvailable is unreadable or too low; assuming 8 GB\n"); ram_gb=8; } }
+    else{
+        /* #759: an explicit budget larger than what is really available (the
+         * #653-corrected snapshot on unified memory) would only ever be caught
+         * by the OOM killer, after CAP_RAISE had scaled the LRU up against it. */
+        int oc = getenv("COLI_RAM_OVERCOMMIT")?atoi(getenv("COLI_RAM_OVERCOMMIT")):0;
+        double clamped = coli_clamp_ram_gb(ram_gb,g_mem_avail_boot,oc);
+        if(clamped<ram_gb){
+            fprintf(stderr,"[RAM_GB=%.1f] clamped to %.1f GB: that is the MemAvailable this run "
+                "can actually use (#653 snapshot; COLI_RAM_OVERCOMMIT=1 keeps the literal budget)\n",
+                ram_gb,clamped);
+            ram_gb=clamped;
+        }
+    }
     g_ram_budget_gb = ram_gb;                    /* #403: la RSS-guard usa il budget RISOLTO */
     /* slack ONESTO, non forfettario (l'OOM del 2026-07-04 veniva da qui):
      *  ws[64] slab del working-set (si materializzano TUTTI nel prefill batch-union),

--- a/c/tests/test_ram_clamp.c
+++ b/c/tests/test_ram_clamp.c
@@ -1,0 +1,47 @@
+/* test_ram_clamp.c -- #759 explicit RAM_GB vs physical memory contract.
+ * coli_clamp_ram_gb() (colibri.c) must implement exactly: an explicit budget
+ * larger than the memory actually available is clamped down to it, an explicit
+ * budget that fits passes through untouched, the <=0 "auto" sentinel always
+ * passes through, an unreadable snapshot (0) keeps the literal budget, and
+ * COLI_RAM_OVERCOMMIT=1 restores take-it-literally behaviour for benchmarking.
+ * It is a pure function (no I/O, no globals), so this exercises it directly
+ * with fabricated inputs -- no model, no probe, no GPU hardware needed.
+ * Portable: builds and runs on every platform, same as test_cap_precedence.c. */
+#define main coli_glm_main_unused
+#include "../colibri.c"
+#undef main
+
+static int failures = 0;
+
+static void check(const char *label, double ram_gb, double avail, int oc, double want){
+    double got = coli_clamp_ram_gb(ram_gb, avail, oc);
+    if(fabs(got-want) > 1e-9){
+        fprintf(stderr, "FAIL %-34s ram=%.1f avail=%.1f oc=%d -> %.1f (want %.1f)\n",
+                label, ram_gb, avail, oc, got, want);
+        failures++;
+    }
+}
+
+int main(void){
+    /* #759 repro shape: unified-memory host, #653 shrank the snapshot below the
+     * user's explicit budget -- that budget must come down to what exists. */
+    check("oversized budget clamps",        100.0, 59.0, 0, 59.0);
+    check("oversized on discrete too",      200.0, 120.0, 0, 120.0);
+
+    /* a budget that fits is honored literally */
+    check("fitting budget untouched",       100.0, 128.0, 0, 100.0);
+    check("exact fit untouched",             59.0, 59.0, 0, 59.0);
+
+    /* auto sentinel and degenerate inputs pass through */
+    check("auto sentinel untouched",         0.0, 59.0, 0, 0.0);
+    check("negative sentinel untouched",    -1.0, 59.0, 0, -1.0);
+    check("unreadable snapshot keeps literal", 100.0, 0.0, 0, 100.0);
+
+    /* documented escape hatch: COLI_RAM_OVERCOMMIT=1 keeps the literal budget */
+    check("overcommit keeps oversized",     100.0, 59.0, 1, 100.0);
+    check("overcommit keeps fitting",       100.0, 128.0, 1, 100.0);
+
+    if(failures){ fprintf(stderr, "%d failure(s)\n", failures); return 1; }
+    printf("test_ram_clamp: ok\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #759

## Summary

An explicit `RAM_GB` is now clamped to the memory this run can actually use before any projection or CAP_RAISE math runs, so the documented overcommit guard catches oversized budgets instead of leaving them to the kernel OOM killer.

## Root cause

`cap_for_ram()` honored an explicit `RAM_GB` literally. On unified-memory hosts where #653 already shrank `g_mem_avail_boot` by the VRAM expert tier, that budget could exceed physical RAM; CAP_RAISE then raised the LRU cap against it (`cap raised 8->25: budget allows it (projected peak 98.5 GB)` against 59 GB of real headroom), and the process died mid-prefill under SIGKILL (257 GB RSS in the issue). The existing `exit(2)` guard only ran inside the `floored` (cap=1) branch, so every plan that could afford at least one expert row per layer was never compared to physical memory.

## What changed

- New pure helper `coli_clamp_ram_gb(ram_gb, mem_avail_gb, overcommit)`: clamps an explicit budget down to the corrected snapshot; auto sizing (`RAM_GB<=0`), unreadable snapshots (`0`), and fitting budgets pass through untouched; `COLI_RAM_OVERCOMMIT=1` restores the literal budget.
- `cap_for_ram()` applies it after the auto-resolution point, which provably runs post-#653, and logs the clamp with the override hint.
- The `PIN_GB=all` budget path applies the same clamp (against the boot snapshot, which at that point has not yet seen the #653 correction - noted in a comment).

## Verification

- New portable unit test `c/tests/test_ram_clamp.c` (9 cases: clamp engages, exact fit, both sentinels, unreadable snapshot, overcommit escape hatch) wired into the Makefile gate next to `test_cap_precedence`. All pass.
- `make tests/test_cap_precedence tests/test_cap_mixed_width` still pass.

This change was prepared with AI assistance under human direction and review.
