### PR TITLE
perf(dsv4): overlap hybrid fill DMA with host compute; pin slabs on Linux

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -457,6 +457,7 @@ ifneq (,$(LINUX))
 TEST_BINS += tests/test_uring$(EXE)
 endif
 ifeq ($(COLI_V4_SUPPORTED),1)
+TEST_BINS += tests/test_v4_hybrid_policy$(EXE)
 TEST_BINS += tests/test_deepseek_v4$(EXE) tests/test_v4_ownership$(EXE) \
 	tests/test_v4_serve_framing$(EXE)
 endif
@@ -1335,6 +1336,9 @@ tests/test_corpus_draft$(EXE): tests/test_corpus_draft.c colibri.c st.h uring.h 
 
 tests/test_cap_precedence$(EXE): tests/test_cap_precedence.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+tests/test_v4_hybrid_policy$(EXE): tests/test_v4_hybrid_policy.c deepseek_v4_hybrid.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
 tests/test_ram_clamp$(EXE): tests/test_ram_clamp.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 

--- a/c/backend_cuda_dsv4.cu
+++ b/c/backend_cuda_dsv4.cu
@@ -10,6 +10,9 @@
 #include <cstring>
 #include <climits>
 #include <vector>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
@@ -1918,8 +1921,35 @@ static bool host_pinned(const void*p,size_t len){
     g_pin_bytes+=size;g_pin_regions.push_back({base,size});
     return true;
 #else
-    (void)a;return false;
+    /* Linux/WSL: no VirtualQuery, but none is needed — cudaHostRegister pins
+     * whole pages, so register the requested range rounded out to page
+     * boundaries. The slot slabs are stable for the process lifetime (one
+     * posix_memalign per slot, freed only at store destroy), exactly like the
+     * Windows branch assumes. Overlapping ranges collapse into the
+     * already-registered success case; any failure (WSL builds without
+     * pinning support included) lands in g_pin_failed and every later upload
+     * from that slab takes the pageable path, same as before this branch
+     * existed. */
+    long page=sysconf(_SC_PAGESIZE);if(page<=0)page=4096;
+    uintptr_t base=a&~((uintptr_t)page-1);
+    size_t size=((a+len+page-1)&~((uintptr_t)page-1))-base;
+    static const size_t cap=(size_t)20<<30;
+    if(g_pin_bytes+size>cap){g_pin_failed.push_back({base,size});return false;}
+    cudaError_t err=cudaHostRegister((void*)base,size,cudaHostRegisterPortable);
+    if(err==cudaErrorHostMemoryAlreadyRegistered){cudaGetLastError();g_pin_regions.push_back({base,size});return true;}
+    if(err!=cudaSuccess){cudaGetLastError();g_pin_failed.push_back({base,size});return false;}
+    g_pin_bytes+=size;g_pin_regions.push_back({base,size});
+    return true;
 #endif
+}
+
+/* Drain the device's expert stream: the hybrid decode split enqueues its
+ * fill-set uploads asynchronously, computes the CPU subset while the DMA is
+ * in flight, and closes the pipeline here before the GPU group runs. */
+extern "C" int dsv4_cuda_stream_drain(int device){
+    Dev*c=ctx(device);if(!c)return 0;
+    if(!ok(cudaSetDevice(device),"select drain device"))return 0;
+    return ok(cudaStreamSynchronize(c->stream),"hybrid drain")?1:0;
 }
 
 extern "C" int dsv4_cuda_expert_bank_upload(Dsv4CudaExpertSet*set,int e,

--- a/c/backend_cuda_dsv4.h
+++ b/c/backend_cuda_dsv4.h
@@ -64,6 +64,10 @@ int dsv4_cuda_fp8_ref_matmul(int device,const uint8_t *w,const float *bscale,
 int dsv4_cuda_backend_arch_ok(int device);
 const char *dsv4_cuda_backend_name(void);
 long long dsv4_cuda_mem_free_mb(int device);
+/* Drain the device's expert stream (hybrid split: async fill DMA is enqueued,
+ * the CPU subset computes meanwhile, this closes the pipeline). Returns 1 on
+ * success, 0 when the backend is unavailable. */
+int dsv4_cuda_stream_drain(int device);
 int dsv4_cuda_kv_ring_append(int device,int layer,const float *rows,int start_pos,
                              int count,int window,int dim);
 int dsv4_cuda_kv_comp_append(int device,int layer,const float *rows,int start_idx,

--- a/c/backend_loader_dsv4.c
+++ b/c/backend_loader_dsv4.c
@@ -172,6 +172,7 @@ typedef int             (*fn_tensor_refill_fp4)(Dsv4CudaTensor *t, const uint8_t
 typedef int             (*fn_backend_arch_ok)(int device);
 typedef const char     *(*fn_backend_name)(void);
 typedef long long       (*fn_mem_free_mb)(int device);
+typedef int             (*fn_stream_drain)(int device);
 typedef int             (*fn_kv_ring_append)(int device, int layer, const float *rows,
                                              int start_pos, int count, int window, int dim);
 typedef int             (*fn_kv_comp_append)(int device, int layer, const float *rows,
@@ -307,6 +308,7 @@ static struct {
     fn_backend_name backend_name;         /* optional */
     char loaded_name[64];
     fn_mem_free_mb mem_free_mb;
+    fn_stream_drain stream_drain;                /* optional (older DLLs) */
     fn_kv_ring_append kv_ring_append;
     fn_kv_comp_append kv_comp_append;
     fn_head_argmax     head_argmax;
@@ -485,6 +487,9 @@ static int dsv4_cuda_resolve(const char *dllname){
     _Pragma("GCC diagnostic push")
     _Pragma("GCC diagnostic ignored \"-Wcast-function-type\"")
     g_dsv4.backend_arch_ok = (fn_backend_arch_ok)GetProcAddress(g_dsv4.dll, "dsv4_cuda_backend_arch_ok");
+    /* optional: an older DLL without the export keeps the whole tier alive;
+     * the engine probes this and simply stays on synchronous attaches. */
+    g_dsv4.stream_drain = (fn_stream_drain)GetProcAddress(g_dsv4.dll, "dsv4_cuda_stream_drain");
     g_dsv4.backend_name = (fn_backend_name)GetProcAddress(g_dsv4.dll, "dsv4_cuda_backend_name");
     _Pragma("GCC diagnostic pop")
     return 1;
@@ -830,6 +835,16 @@ const char *dsv4_cuda_backend_name(void){
 long long dsv4_cuda_mem_free_mb(int device){
     if(!g_dsv4.available) return -1;
     return g_dsv4.mem_free_mb(device);
+}
+
+int dsv4_cuda_stream_drain(int device){
+    /* Without the DLL there is never in-flight DMA to wait for, so a drain
+     * trivially succeeds. With an older DLL that lacks the export, report
+     * failure instead: the engine probes this once and keeps every attach
+     * synchronous, so nothing is ever enqueued that could not be drained. */
+    if(!g_dsv4.available) return 1;
+    if(!g_dsv4.stream_drain) return 0;
+    return g_dsv4.stream_drain(device);
 }
 
 int dsv4_cuda_kv_ring_append(int device, int layer, const float *rows, int start_pos,

--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -4202,6 +4202,7 @@ int coli_v4_sparse_attention_ref(float *output, const float *queries,
 #define coli_v4_block_window_token_ref coli_v4_block_window_token_serial_ref
 /* ---- begin include deepseek_v4_block.c ---- */
 #include "deepseek_v4_internal.h"
+#include "deepseek_v4_hybrid.h"
 
 #include <stdarg.h>
 #include <stdint.h>
@@ -4831,6 +4832,29 @@ static int profiled_expert_load_finish(ExpertLoadHandle *handle) {
     return result;
 }
 
+#ifdef COLI_V4_GPU_TIER
+/* DSV4_HYBRID=1 (opt-in): on a decode miss, split the missing experts between
+ * a PCIe-fill set (upload, compute on GPU with the residents) and a host set
+ * (compute on CPU) instead of today's all-or-nothing, sized by the q* policy
+ * in deepseek_v4_hybrid.h from live bandwidth EMAs. Off by default until the
+ * split is validated on real GPUs; when off, the engine byte-for-byte keeps
+ * its historical behaviour. */
+int coli_v4_hybrid_enabled(void) {
+    static int on = -1;
+    if (on < 0) {
+        const char *setting = getenv("DSV4_HYBRID");
+        on = setting && atoi(setting) != 0;
+    }
+    return on;
+}
+/* Non-static on purpose: the serve unit prints these counters, and under the
+ * per-unit amalgam build that is a different object file. */
+double g_v4_hyb_fill_bw;   /* experts/s uploaded, EMA */
+double g_v4_hyb_host_bw;   /* experts/s host-computed, EMA */
+unsigned long long g_v4_hyb_gpu_n, g_v4_hyb_cpu_n;
+unsigned long long g_v4_hyb_upload_n, g_v4_hyb_skip_n;
+#endif
+
 static int moe_token_pipeline(float *output,
                               const ColiDeepSeekV4LayerWeights *weights,
                               const ColiDeepSeekV4Config *config,
@@ -4984,8 +5008,14 @@ static int moe_token_pipeline(float *output,
             if (jobs[slot].result) { result = -1; break; }
             views[current] = jobs[slot].view;
 #ifdef COLI_V4_GPU_TIER
-            if (store->gpu)
-                coli_v4_gpu_expert_attach(store, &views[current]);
+            if (store->gpu) {
+                if (coli_v4_hybrid_enabled())
+                    /* peek only: uploads are decided once the token's full
+                     * miss count is known, by the q* pass below */
+                    coli_v4_gpu_expert_peek(store, &views[current]);
+                else
+                    coli_v4_gpu_expert_attach(store, &views[current]);
+            }
 #endif
             if (!views[current].gate.gpu || !views[current].up.gpu ||
                 !views[current].down.gpu)
@@ -5013,6 +5043,51 @@ static int moe_token_pipeline(float *output,
             }
     }
 #ifdef COLI_V4_GPU_TIER
+    int hybrid_gpu_count = 0;
+    if (!result && coli_v4_hybrid_enabled() && store->gpu && !gpu_compute) {
+        /* q* pass: the peeks above established which of the token's experts
+         * are already resident. Upload only fill = q*(m) of the m misses;
+         * the rest stay host-side on purpose. Uploads are timed to feed the
+         * fill-bandwidth EMA. While the host bandwidth is still unmeasured,
+         * leave one expert on the CPU so it CAN be measured, otherwise
+         * fill == m forever and the policy never engages. */
+        int *missing = malloc((size_t)selected * sizeof(*missing));
+        if (missing) {
+            int miss_n = 0;
+            for (int i = 0; i < selected; i++)
+                if (!views[i].gate.gpu || !views[i].up.gpu ||
+                    !views[i].down.gpu)
+                    missing[miss_n++] = i;
+            int fill = coli_v4_hybrid_fill_count(
+                miss_n, g_v4_hyb_fill_bw, g_v4_hyb_host_bw);
+            if (g_v4_hyb_host_bw <= 0.0 && fill >= miss_n && miss_n > 1)
+                fill = miss_n - 1;
+            for (int i = 0; i < fill; i++) {
+                int v = missing[i];
+                struct timespec f0, f1;
+                clock_gettime(CLOCK_MONOTONIC, &f0);
+                if (coli_v4_gpu_expert_attach(store, &views[v]) == 0 &&
+                    views[v].gate.gpu && views[v].up.gpu &&
+                    views[v].down.gpu) {
+                    clock_gettime(CLOCK_MONOTONIC, &f1);
+                    double dt = (f1.tv_sec - f0.tv_sec) +
+                                (f1.tv_nsec - f0.tv_nsec) * 1e-9;
+                    if (dt > 0.0)
+                        g_v4_hyb_fill_bw = coli_v4_hybrid_ema(
+                            g_v4_hyb_fill_bw, 1.0 / dt);
+                    g_v4_hyb_upload_n++;
+                }
+            }
+            if (miss_n > fill)
+                g_v4_hyb_skip_n += (unsigned long long)(miss_n - fill);
+            free(missing);
+        }
+        for (int i = 0; i < selected; i++)
+            if (views[i].gate.gpu && views[i].up.gpu && views[i].down.gpu)
+                hybrid_gpu_count++;
+        if (hybrid_gpu_count == selected)
+            gpu_compute = 1;    /* every expert made it: use the fused path */
+    }
     if (!result && gpu_compute && store->gpu) {
         void *sg = coli_v4_layer_gpu(weights, "ffn.shared_experts.w1");
         void *su = coli_v4_layer_gpu(weights, "ffn.shared_experts.w2");
@@ -5055,6 +5130,73 @@ static int moe_token_pipeline(float *output,
                     output[i] = coli_bf16_round(expert_output[i]);
         }
         free(gates); free(ups); free(downs);
+    } else if (!result && hybrid_gpu_count > 0 && store->gpu) {
+        /* Hybrid split: the GPU computes the resident subset as one weighted
+         * group while the CPU computes the rest; the two partial sums merge
+         * by addition, the same order-of-addition class that already
+         * separates the fused GPU path from the CPU reference. The CPU half
+         * is timed to feed the host-bandwidth EMA. A backend failure on the
+         * GPU half degrades that subset to the CPU loop instead of failing
+         * the token. */
+        int gpu_n = hybrid_gpu_count, cpu_n = selected - hybrid_gpu_count;
+        void **gates = malloc((size_t)gpu_n * sizeof(*gates));
+        void **ups = malloc((size_t)gpu_n * sizeof(*ups));
+        void **downs = malloc((size_t)gpu_n * sizeof(*downs));
+        float *gpu_weights = malloc((size_t)gpu_n * sizeof(*gpu_weights));
+        float *gpu_sum = malloc((size_t)d * sizeof(*gpu_sum));
+        int gpu_ok = gates && ups && downs && gpu_weights && gpu_sum;
+        if (gpu_ok) {
+            int k = 0;
+            for (int i = 0; i < selected; i++)
+                if (views[i].gate.gpu && views[i].up.gpu &&
+                    views[i].down.gpu) {
+                    gates[k] = views[i].gate.gpu;
+                    ups[k] = views[i].up.gpu;
+                    downs[k] = views[i].down.gpu;
+                    gpu_weights[k] = expert_weights[i];
+                    k++;
+                }
+            extern int dsv4_cuda_expert_group(
+                void *const *gate, void *const *up, void *const *down,
+                const float *weights, int count, float limit,
+                float *y, const float *x);
+            if (!dsv4_cuda_expert_group(gates, ups, downs, gpu_weights,
+                gpu_n, config->swiglu_limit, gpu_sum, input)) gpu_ok = 0;
+        }
+        struct timespec h0, h1;
+        clock_gettime(CLOCK_MONOTONIC, &h0);
+        for (int current = 0; !result && current < selected; current++) {
+            int on_gpu = views[current].gate.gpu && views[current].up.gpu &&
+                         views[current].down.gpu;
+            if (on_gpu && gpu_ok) continue;   /* covered by the group above */
+            result = coli_v4_expert_forward_ref(
+                expert_output, &views[current], input,
+                expert_weights[current], config->swiglu_limit);
+            if (!result)
+                for (int i = 0; i < d; i++) output[i] += expert_output[i];
+        }
+        if (!result && gpu_ok && cpu_n > 0) {
+            clock_gettime(CLOCK_MONOTONIC, &h1);
+            double dt = (h1.tv_sec - h0.tv_sec) +
+                        (h1.tv_nsec - h0.tv_nsec) * 1e-9;
+            if (dt > 0.0)
+                g_v4_hyb_host_bw = coli_v4_hybrid_ema(
+                    g_v4_hyb_host_bw, (double)cpu_n / dt);
+        }
+        if (!result) {
+            if (gpu_ok) {
+                for (int i = 0; i < d; i++)
+                    output[i] = coli_bf16_round(
+                        output[i] + gpu_sum[i] + shared_output[i]);
+                g_v4_hyb_gpu_n += (unsigned long long)gpu_n;
+                g_v4_hyb_cpu_n += (unsigned long long)cpu_n;
+            } else {
+                for (int i = 0; i < d; i++)
+                    output[i] = coli_bf16_round(output[i] + shared_output[i]);
+            }
+        }
+        free(gates); free(ups); free(downs);
+        free(gpu_weights); free(gpu_sum);
     } else
 #endif
     {
@@ -10023,6 +10165,32 @@ int coli_v4_gpu_expert_attach(ColiExpertStore *store, ColiExpertView *view) {
         (V4GpuExpertMirrorCache *)store->gpu, view);
 }
 
+/* Lookup-only twin of attach: report whether {layer, expert} is already
+ * mirrored, touching its LRU stamp, but NEVER uploading on a miss. The
+ * hybrid decode split peeks the whole token first and decides its uploads
+ * afterwards with the q* policy, instead of paying a blocking PCIe copy per
+ * miss the moment it is discovered. */
+int coli_v4_gpu_expert_peek(ColiExpertStore *store, ColiExpertView *view) {
+    if (!store || !view || !store->gpu) return -1;
+    V4GpuExpertMirrorCache *cache = (V4GpuExpertMirrorCache *)store->gpu;
+    pthread_mutex_lock(&cache->mutex);
+    for (int i = 0; i < cache->count; i++) {
+        if (cache->entries[i].layer == view->key.layer &&
+            cache->entries[i].expert == view->key.expert &&
+            cache->entries[i].gate && cache->entries[i].up &&
+            cache->entries[i].down) {
+            cache->entries[i].clock = ++cache->clock;
+            view->gate.gpu = cache->entries[i].gate;
+            view->up.gpu = cache->entries[i].up;
+            view->down.gpu = cache->entries[i].down;
+            pthread_mutex_unlock(&cache->mutex);
+            return 0;
+        }
+    }
+    pthread_mutex_unlock(&cache->mutex);
+    return -1;
+}
+
 int coli_v4_gpu_dspark_expert_attach(void *cache, ColiExpertView *view) {
     if (!view) return -1;
     return v4_gpu_expert_attach_cached((V4GpuExpertMirrorCache *)cache, view);
@@ -13394,6 +13562,15 @@ static int v4_serve_one(ColiV4Engine *engine, ColiV4Session *session,
         : 0.0;
     v4_prof_emit(elapsed, stats.prompt_tokens, completion,
                  expert_disk_s, expert_matmul_s);
+#ifdef COLI_V4_GPU_TIER
+    if (coli_v4_hybrid_enabled() && (g_v4_hyb_gpu_n + g_v4_hyb_cpu_n +
+                           g_v4_hyb_upload_n + g_v4_hyb_skip_n))
+        fprintf(stderr, "v4_hybrid gpu=%llu cpu=%llu uploads=%llu "
+                        "skipped=%llu fill_bw=%.1f/s host_bw=%.1f/s "
+                        "(cumulative)\n",
+                g_v4_hyb_gpu_n, g_v4_hyb_cpu_n, g_v4_hyb_upload_n,
+                g_v4_hyb_skip_n, g_v4_hyb_fill_bw, g_v4_hyb_host_bw);
+#endif
     coli_v4_expert_store_emit_hits(engine->experts);
     coli_v4_expert_store_emit_emap(engine->experts);
     coli_v4_expert_store_emit_tiers(engine->experts);

--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -5044,6 +5044,9 @@ static int moe_token_pipeline(float *output,
     }
 #ifdef COLI_V4_GPU_TIER
     int hybrid_gpu_count = 0;
+    int hybrid_pending_drain = 0;   /* async DMA enqueued, not yet drained */
+    int hybrid_uploads = 0;
+    struct timespec hybrid_fill_t0 = {0, 0};
     if (!result && coli_v4_hybrid_enabled() && store->gpu && !gpu_compute) {
         /* q* pass: the peeks above established which of the token's experts
          * are already resident. Upload only fill = q*(m) of the m misses;
@@ -5062,19 +5065,29 @@ static int moe_token_pipeline(float *output,
                 miss_n, g_v4_hyb_fill_bw, g_v4_hyb_host_bw);
             if (g_v4_hyb_host_bw <= 0.0 && fill >= miss_n && miss_n > 1)
                 fill = miss_n - 1;
+            /* Fill uploads are ENQUEUED, not drained: the CPU subset below
+             * computes while the DMA is in flight — the very overlap the q*
+             * balance assumes. The fill branch is timed as a whole at the
+             * drain point; per-upload wall clocks here would only measure
+             * enqueue latency. */
+            /* Async needs a drainable stream. An older Windows DLL exports
+             * the refill but not the drain: probe once (a drain on an empty
+             * stream is a no-op) and stay fully synchronous there, so
+             * nothing is ever enqueued that could not be waited on. */
+            static int hybrid_async_ok = -1;
+            if (hybrid_async_ok < 0)
+                hybrid_async_ok = coli_v4_gpu_expert_drain(store) == 0;
+            clock_gettime(CLOCK_MONOTONIC, &hybrid_fill_t0);
             for (int i = 0; i < fill; i++) {
                 int v = missing[i];
-                struct timespec f0, f1;
-                clock_gettime(CLOCK_MONOTONIC, &f0);
-                if (coli_v4_gpu_expert_attach(store, &views[v]) == 0 &&
+                int attached = hybrid_async_ok
+                    ? coli_v4_gpu_expert_attach_async(store, &views[v])
+                    : coli_v4_gpu_expert_attach(store, &views[v]);
+                if (attached == 0 &&
                     views[v].gate.gpu && views[v].up.gpu &&
                     views[v].down.gpu) {
-                    clock_gettime(CLOCK_MONOTONIC, &f1);
-                    double dt = (f1.tv_sec - f0.tv_sec) +
-                                (f1.tv_nsec - f0.tv_nsec) * 1e-9;
-                    if (dt > 0.0)
-                        g_v4_hyb_fill_bw = coli_v4_hybrid_ema(
-                            g_v4_hyb_fill_bw, 1.0 / dt);
+                    hybrid_uploads++;
+                    hybrid_pending_drain = hybrid_async_ok;
                     g_v4_hyb_upload_n++;
                 }
             }
@@ -5145,6 +5158,49 @@ static int moe_token_pipeline(float *output,
         float *gpu_weights = malloc((size_t)gpu_n * sizeof(*gpu_weights));
         float *gpu_sum = malloc((size_t)d * sizeof(*gpu_sum));
         int gpu_ok = gates && ups && downs && gpu_weights && gpu_sum;
+        /* CPU subset FIRST: it computes while the fill DMA enqueued by the
+         * q* pass is still in flight. The host bandwidth EMA is measured
+         * right here, under bus contention — which is exactly the number the
+         * balance needs. */
+        struct timespec h0, h1;
+        clock_gettime(CLOCK_MONOTONIC, &h0);
+        for (int current = 0; !result && current < selected; current++) {
+            int on_gpu = views[current].gate.gpu && views[current].up.gpu &&
+                         views[current].down.gpu;
+            if (on_gpu && gpu_ok) continue;   /* covered by the group below */
+            result = coli_v4_expert_forward_ref(
+                expert_output, &views[current], input,
+                expert_weights[current], config->swiglu_limit);
+            if (!result)
+                for (int i = 0; i < d; i++) output[i] += expert_output[i];
+        }
+        if (!result && cpu_n > 0) {
+            clock_gettime(CLOCK_MONOTONIC, &h1);
+            double dt = (h1.tv_sec - h0.tv_sec) +
+                        (h1.tv_nsec - h0.tv_nsec) * 1e-9;
+            if (dt > 0.0)
+                g_v4_hyb_host_bw = coli_v4_hybrid_ema(
+                    g_v4_hyb_host_bw, (double)cpu_n / dt);
+        }
+        /* Close the fill pipeline. The whole window (enqueue -> drained) is
+         * the fill branch's wall time; a sample is taken only when the drain
+         * actually waited, otherwise the transfers finished under the CPU
+         * work and the window would say nothing about the bus. */
+        if (hybrid_pending_drain) {
+            struct timespec d0, d1;
+            clock_gettime(CLOCK_MONOTONIC, &d0);
+            coli_v4_gpu_expert_drain(store);
+            clock_gettime(CLOCK_MONOTONIC, &d1);
+            hybrid_pending_drain = 0;
+            double waited = (d1.tv_sec - d0.tv_sec) +
+                            (d1.tv_nsec - d0.tv_nsec) * 1e-9;
+            double window = (d1.tv_sec - hybrid_fill_t0.tv_sec) +
+                            (d1.tv_nsec - hybrid_fill_t0.tv_nsec) * 1e-9;
+            if (hybrid_uploads > 0 && window > 0.0 &&
+                waited > window * 0.05)
+                g_v4_hyb_fill_bw = coli_v4_hybrid_ema(
+                    g_v4_hyb_fill_bw, (double)hybrid_uploads / window);
+        }
         if (gpu_ok) {
             int k = 0;
             for (int i = 0; i < selected; i++)
@@ -5163,26 +5219,21 @@ static int moe_token_pipeline(float *output,
             if (!dsv4_cuda_expert_group(gates, ups, downs, gpu_weights,
                 gpu_n, config->swiglu_limit, gpu_sum, input)) gpu_ok = 0;
         }
-        struct timespec h0, h1;
-        clock_gettime(CLOCK_MONOTONIC, &h0);
-        for (int current = 0; !result && current < selected; current++) {
-            int on_gpu = views[current].gate.gpu && views[current].up.gpu &&
-                         views[current].down.gpu;
-            if (on_gpu && gpu_ok) continue;   /* covered by the group above */
-            result = coli_v4_expert_forward_ref(
-                expert_output, &views[current], input,
-                expert_weights[current], config->swiglu_limit);
-            if (!result)
-                for (int i = 0; i < d; i++) output[i] += expert_output[i];
-        }
-        if (!result && gpu_ok && cpu_n > 0) {
-            clock_gettime(CLOCK_MONOTONIC, &h1);
-            double dt = (h1.tv_sec - h0.tv_sec) +
-                        (h1.tv_nsec - h0.tv_nsec) * 1e-9;
-            if (dt > 0.0)
-                g_v4_hyb_host_bw = coli_v4_hybrid_ema(
-                    g_v4_hyb_host_bw, (double)cpu_n / dt);
-        }
+        /* Backend failure on the group: the CPU loop above deliberately
+         * skipped these experts, so compute them here — degrade, don't drop
+         * (nor fail the token). */
+        if (!gpu_ok)
+            for (int current = 0; !result && current < selected; current++) {
+                if (!(views[current].gate.gpu && views[current].up.gpu &&
+                      views[current].down.gpu))
+                    continue;   /* already computed by the CPU loop above */
+                result = coli_v4_expert_forward_ref(
+                    expert_output, &views[current], input,
+                    expert_weights[current], config->swiglu_limit);
+                if (!result)
+                    for (int i = 0; i < d; i++)
+                        output[i] += expert_output[i];
+            }
         if (!result) {
             if (gpu_ok) {
                 for (int i = 0; i < d; i++)
@@ -5211,6 +5262,13 @@ static int moe_token_pipeline(float *output,
             for (int i = 0; i < d; i++)
                 output[i] = coli_bf16_round(output[i] + shared_output[i]);
     }
+#ifdef COLI_V4_GPU_TIER
+    /* If an error or the fused path skipped the hybrid branch while async
+     * fill DMA was still enqueued, drain before releasing the host slabs the
+     * copies read from. (The fused kernels sync internally, so this is only
+     * ever a wait on already-finished work — never a correctness gamble.) */
+    if (hybrid_pending_drain) coli_v4_gpu_expert_drain(store);
+#endif
     for (int current = 0; current < selected; current++)
         coli_expert_release(store, &views[current]);
     free(views);
@@ -9482,8 +9540,8 @@ static V4GpuExpertMirrorCache *v4_gpu_expert_mirrors_create_capacity(
 static V4GpuExpertMirrorCache *v4_gpu_expert_mirrors_create(int device,
                                                             int suggested);
 static void v4_gpu_expert_mirrors_free(V4GpuExpertMirrorCache *cache);
-static int v4_gpu_expert_attach_cached(V4GpuExpertMirrorCache *cache,
-                                       ColiExpertView *view);
+static int v4_gpu_expert_attach_cached_ex(V4GpuExpertMirrorCache *cache,
+                                          ColiExpertView *view, int sync);
 
 int coli_v4_gpu_engine_open(ColiV4Engine *engine) {
     if (!engine) return -1;
@@ -10015,8 +10073,8 @@ static void v4_gpu_expert_mirrors_free(V4GpuExpertMirrorCache *cache) {
     free(cache);
 }
 
-static int v4_gpu_expert_attach_cached(V4GpuExpertMirrorCache *cache,
-                                       ColiExpertView *view) {
+static int v4_gpu_expert_attach_cached_ex(V4GpuExpertMirrorCache *cache,
+                                          ColiExpertView *view, int sync) {
     if (!cache || !view) return -1;
     if (view->gate.block_rows != 1 || view->up.block_rows != 1 ||
         view->down.block_rows != 1)
@@ -10093,7 +10151,7 @@ static int v4_gpu_expert_attach_cached(V4GpuExpertMirrorCache *cache,
                 dsv4_cuda_tensor_refill_fp4(
                     cache->entries[found].down, (const uint8_t *)view->down.data,
                     (const uint8_t *)view->down.scales, (int)view->down.rows,
-                    (int)view->down.columns, 1)) {
+                    (int)view->down.columns, sync)) {
                 cache->entries[found].layer = view->key.layer;
                 cache->entries[found].expert = view->key.expert;
                 cache->entries[found].clock = ++cache->clock;
@@ -10161,8 +10219,27 @@ static int v4_gpu_expert_attach_cached(V4GpuExpertMirrorCache *cache,
 
 int coli_v4_gpu_expert_attach(ColiExpertStore *store, ColiExpertView *view) {
     if (!store || !view) return -1;
-    return v4_gpu_expert_attach_cached(
-        (V4GpuExpertMirrorCache *)store->gpu, view);
+    return v4_gpu_expert_attach_cached_ex(
+        (V4GpuExpertMirrorCache *)store->gpu, view, 1);
+}
+
+/* Async twin: the upload is ENQUEUED on the device stream and may still be
+ * in flight when this returns. Safe because later work on the same stream
+ * (the expert group, the fused MoE) is ordered after it, and because the
+ * caller holds the expert leases until after compute; anyone releasing the
+ * host slabs earlier must drain first (coli_v4_gpu_expert_drain). */
+int coli_v4_gpu_expert_attach_async(ColiExpertStore *store,
+                                    ColiExpertView *view) {
+    if (!store || !view) return -1;
+    return v4_gpu_expert_attach_cached_ex(
+        (V4GpuExpertMirrorCache *)store->gpu, view, 0);
+}
+
+extern int dsv4_cuda_stream_drain(int device);
+int coli_v4_gpu_expert_drain(ColiExpertStore *store) {
+    if (!store || !store->gpu) return 0;
+    V4GpuExpertMirrorCache *cache = (V4GpuExpertMirrorCache *)store->gpu;
+    return dsv4_cuda_stream_drain(cache->device) ? 0 : -1;
 }
 
 /* Lookup-only twin of attach: report whether {layer, expert} is already
@@ -10193,7 +10270,7 @@ int coli_v4_gpu_expert_peek(ColiExpertStore *store, ColiExpertView *view) {
 
 int coli_v4_gpu_dspark_expert_attach(void *cache, ColiExpertView *view) {
     if (!view) return -1;
-    return v4_gpu_expert_attach_cached((V4GpuExpertMirrorCache *)cache, view);
+    return v4_gpu_expert_attach_cached_ex((V4GpuExpertMirrorCache *)cache, view, 1);
 }
 
 /* Lazy dspark mirror cache. Kept separate from the target model's expert

--- a/c/deepseek_v4_hybrid.h
+++ b/c/deepseek_v4_hybrid.h
@@ -1,0 +1,54 @@
+/* deepseek_v4_hybrid.h — the q* fill/execute split for GPU expert misses.
+ *
+ * On a decode step some routed experts are resident in VRAM and some are not.
+ * Today the engine is all-or-nothing: one missing expert sends the WHOLE
+ * token's routed MoE to the CPU, and every miss is uploaded over PCIe
+ * unconditionally. The hybrid split partitions the m missing experts into a
+ * fill set (upload to VRAM, compute on GPU) and a host set (compute on CPU),
+ * sized so the two branches take the same time:
+ *
+ *     T_fill(q)  ~= q * S / B_P          (PCIe transfer of q experts)
+ *     T_host(m-q)~= (m-q) * S / (B_H-B_P) (host compute of the rest)
+ *
+ * Balancing the two gives the closed form
+ *
+ *     q* = m * B_P / B_H
+ *
+ * with B_P the measured fill bandwidth and B_H the measured host execution
+ * bandwidth. As B_H approaches B_P, q* approaches m and the split degenerates
+ * into plain upload-everything — which is also the answer while the
+ * bandwidths are still unmeasured. Both bandwidths are live EMAs of the
+ * engine's own uploads and expert forwards, never assumptions.
+ *
+ * Everything in this header is pure arithmetic so the CI can test the policy
+ * on machines with no GPU at all; the CUDA wiring lives in deepseek_v4.c
+ * behind DSV4_HYBRID=1. */
+#ifndef DEEPSEEK_V4_HYBRID_H
+#define DEEPSEEK_V4_HYBRID_H
+
+/* How many of `missing` experts to upload-and-run-on-GPU; the caller computes
+ * the rest on the CPU. Bandwidths are in experts/second (only their RATIO
+ * matters, so any consistent unit works). Unmeasured or nonsensical
+ * bandwidths fall back to `missing` — the engine's historical
+ * upload-everything behaviour, never something new. */
+static inline int coli_v4_hybrid_fill_count(int missing, double fill_bw,
+                                            double host_bw) {
+    if (missing <= 0) return 0;
+    if (fill_bw <= 0.0 || host_bw <= 0.0) return missing;
+    double ideal = (double)missing * fill_bw / host_bw;   /* q* = m*B_P/B_H */
+    int fill = (int)(ideal + 0.5);
+    if (fill < 0) fill = 0;
+    if (fill > missing) fill = missing;
+    return fill;
+}
+
+/* One-pole EMA for the live bandwidth estimates. A non-positive sample is
+ * ignored (a failed or zero-length measurement must not poison the state);
+ * the first valid sample seeds the average directly. */
+static inline double coli_v4_hybrid_ema(double previous, double sample) {
+    if (sample <= 0.0) return previous;
+    if (previous <= 0.0) return sample;
+    return previous * 0.8 + sample * 0.2;
+}
+
+#endif /* DEEPSEEK_V4_HYBRID_H */

--- a/c/deepseek_v4_internal.h
+++ b/c/deepseek_v4_internal.h
@@ -848,6 +848,14 @@ int coli_v4_gpu_route(float *route_weights, int *indices, const float *input,
  * fp4 path. Only block_rows==1 views are mirrored; rows16-packed slots are
  * skipped. */
 int coli_v4_gpu_expert_attach(ColiExpertStore *store, ColiExpertView *view);
+/* lookup-only twin: reports residency, never uploads (hybrid q* split) */
+int coli_v4_gpu_expert_peek(ColiExpertStore *store, ColiExpertView *view);
+/* DSV4_HYBRID=1 gate plus its cross-unit counters/EMAs: defined in the block
+ * unit, read by the serve unit's per-turn stderr line. */
+int coli_v4_hybrid_enabled(void);
+extern double g_v4_hyb_fill_bw, g_v4_hyb_host_bw;
+extern unsigned long long g_v4_hyb_gpu_n, g_v4_hyb_cpu_n;
+extern unsigned long long g_v4_hyb_upload_n, g_v4_hyb_skip_n;
 /* Dspark (MTP) resident-expert mirrors: a separate bounded LRU so drafting can
  * never evict the target model's learned expert mirrors. ensure() lazily
  * allocates the cache on the first V4_MTP_GPU=1 draft; attach mirrors one

--- a/c/deepseek_v4_internal.h
+++ b/c/deepseek_v4_internal.h
@@ -853,6 +853,10 @@ int coli_v4_gpu_expert_peek(ColiExpertStore *store, ColiExpertView *view);
 /* DSV4_HYBRID=1 gate plus its cross-unit counters/EMAs: defined in the block
  * unit, read by the serve unit's per-turn stderr line. */
 int coli_v4_hybrid_enabled(void);
+/* async attach (enqueue only; drain closes the pipeline before compute) */
+int coli_v4_gpu_expert_attach_async(ColiExpertStore *store,
+                                    ColiExpertView *view);
+int coli_v4_gpu_expert_drain(ColiExpertStore *store);
 extern double g_v4_hyb_fill_bw, g_v4_hyb_host_bw;
 extern unsigned long long g_v4_hyb_gpu_n, g_v4_hyb_cpu_n;
 extern unsigned long long g_v4_hyb_upload_n, g_v4_hyb_skip_n;

--- a/c/dsv4.def
+++ b/c/dsv4.def
@@ -53,6 +53,7 @@ EXPORTS
     dsv4_cuda_backend_name
     dsv4_cuda_kv_ring_append
     dsv4_cuda_mem_free_mb
+    dsv4_cuda_stream_drain
     dsv4_cuda_kv_comp_append
     dsv4_cuda_head_argmax
     dsv4_cuda_final_argmax

--- a/c/tests/test_v4_hybrid_policy.c
+++ b/c/tests/test_v4_hybrid_policy.c
@@ -1,0 +1,56 @@
+/* test_v4_hybrid_policy.c — the q* fill/execute split contract.
+ *
+ * coli_v4_hybrid_fill_count() decides, out of m missing experts, how many to
+ * upload-and-run-on-GPU versus compute on the host: q* = m * B_P / B_H,
+ * clamped to [0, m], with every unmeasured or degenerate input falling back
+ * to m — the engine's historical upload-everything behaviour, never a new
+ * one. Pure arithmetic, so this runs on machines with no GPU: the CUDA
+ * wiring in deepseek_v4.c is validated on real hardware separately. */
+#include <stdio.h>
+#include "../deepseek_v4_hybrid.h"
+
+static int failures;
+#define CHECK(cond, ...) do { if (!(cond)) { \
+    fprintf(stderr, "FAIL %s:%d: ", __FILE__, __LINE__); \
+    fprintf(stderr, __VA_ARGS__); fputc('\n', stderr); failures++; } } while (0)
+
+int main(void) {
+    /* no misses: nothing to decide */
+    CHECK(coli_v4_hybrid_fill_count(0, 5.0, 5.0) == 0, "m=0 must fill 0");
+    CHECK(coli_v4_hybrid_fill_count(-3, 5.0, 5.0) == 0, "m<0 must fill 0");
+
+    /* unmeasured bandwidths: legacy upload-everything, never something new */
+    CHECK(coli_v4_hybrid_fill_count(6, 0.0, 7.0) == 6, "no fill bw -> all");
+    CHECK(coli_v4_hybrid_fill_count(6, 7.0, 0.0) == 6, "no host bw -> all");
+    CHECK(coli_v4_hybrid_fill_count(6, -1.0, -1.0) == 6, "bad bw -> all");
+
+    /* the closed form: q* = m * B_P / B_H */
+    CHECK(coli_v4_hybrid_fill_count(6, 5.0, 10.0) == 3, "half ratio -> m/2");
+    CHECK(coli_v4_hybrid_fill_count(6, 1.0, 4.0) == 2,  "6*0.25 -> 2 (round)");
+    CHECK(coli_v4_hybrid_fill_count(6, 1.0, 1000.0) == 0,
+          "host vastly faster -> compute everything there");
+
+    /* degenerate limit: as B_H approaches (or drops below) B_P the split
+     * collapses into plain upload-everything */
+    CHECK(coli_v4_hybrid_fill_count(6, 5.0, 5.0) == 6, "equal bw -> all fill");
+    CHECK(coli_v4_hybrid_fill_count(6, 10.0, 5.0) == 6, "bus faster -> clamp m");
+
+    /* monotone in the fill bandwidth: a faster bus never fills fewer */
+    int previous = 0;
+    for (int step = 1; step <= 20; step++) {
+        int fill = coli_v4_hybrid_fill_count(8, 0.5 * step, 10.0);
+        CHECK(fill >= previous, "fill must be monotone in B_P (step %d)", step);
+        previous = fill;
+    }
+
+    /* EMA: first valid sample seeds, invalid samples never poison */
+    CHECK(coli_v4_hybrid_ema(0.0, 4.0) == 4.0, "first sample seeds");
+    CHECK(coli_v4_hybrid_ema(4.0, 0.0) == 4.0, "zero sample ignored");
+    CHECK(coli_v4_hybrid_ema(4.0, -1.0) == 4.0, "negative sample ignored");
+    double smoothed = coli_v4_hybrid_ema(4.0, 8.0);
+    CHECK(smoothed > 4.0 && smoothed < 8.0, "EMA moves between old and new");
+
+    if (failures) { fprintf(stderr, "%d failure(s)\n", failures); return 1; }
+    printf("test_v4_hybrid_policy: ok\n");
+    return 0;
+}


### PR DESCRIPTION
Second half of the hybrid split — **stacked on #1202** (shows both commits until that merges; review here = the overlap commit). Still entirely behind `DSV4_HYBRID=1`.

## Why

The q* balance in #1202 assumes the fill branch (PCIe) and the host branch (CPU) run **concurrently**. Until now they could not:

- host pinning existed only on Windows (`VirtualQuery` region bounds) — on Linux every expert upload was a blocking pageable `cudaMemcpy`;
- each upload drained the stream before returning, so transfer and compute were strictly serialized.

## What changes

1. **Linux host pinning.** `host_pinned()` gains a Linux branch: `cudaHostRegister` on the requested range rounded to page boundaries. The slot slabs are stable for the process lifetime (one `posix_memalign` per slot, freed only at store destroy) — exactly what the Windows branch already assumes. Any failure, WSL builds without pinning support included, falls back to pageable copies as before; the 20 GiB cap applies unchanged.
2. **Enqueue, compute, drain.** The hybrid q* pass now ENQUEUES its fill uploads (an async attach twin whose refill skips the trailing drain); the compute branch runs the **CPU subset first, while the DMA is in flight**; an explicit `dsv4_cuda_stream_drain` closes the pipeline before the GPU group runs. If the group then fails, the skipped experts are computed on the CPU after the fact — degrade, never drop.
3. **Honest bandwidth samples.** The host EMA is measured under bus contention (the number the balance actually needs). The fill EMA samples the whole enqueue-to-drained window **only when the drain really waited** — transfers that finish under the CPU work say nothing about the bus, so they are not sampled.

## Safety

Leases are held until after compute; later same-stream work is ordered after the copies; an error or fused-path exit drains before any slab is released (never a correctness gamble — the fused kernels sync internally, so that drain only ever waits on finished work).

## Validation here vs on hardware

No GPU on this machine: normal build clean, `COLI_V4_GPU_TIER` syntax pass clean, policy unit test and V4 tiny oracle green, and the two build warnings pre-exist on dev at the same sites (verified against a pristine dev build). The default stays off until real-GPU numbers exist — same candidates as the parent (#1183's 3090, #1199's 5060 Ti), and the `v4_hybrid` counters plus the `fill_bw`/`host_bw` EMAs make a single log self-explanatory.