### PR TITLE
fix(tools): label Windows 11 correctly in datapoint machine_info (#1042)

### DIFF
--- a/c/tests/test_datapoint.py
+++ b/c/tests/test_datapoint.py
@@ -42,6 +42,19 @@ class MachineInfoWin32Test(unittest.TestCase):
         self.assertEqual(info["ram"], "128 GB")
         self.assertTrue(info["os"].startswith("Windows"))
 
+    def test_win32_build_number_disambiguates_windows_11(self):
+        # platform.release() says "10" on Windows 11; build >= 22000 is the tell
+        import platform as plat
+        from unittest import mock as m2
+        with m2.patch.object(plat, "release", return_value="10"), \
+             m2.patch.object(plat, "version", return_value="10.0.26200"):
+            info = self._win32_info(memstatus_ok=True)
+        self.assertTrue(info["os"].startswith("Windows 11"), info["os"])
+        with m2.patch.object(plat, "release", return_value="10"), \
+             m2.patch.object(plat, "version", return_value="10.0.19045"):
+            info = self._win32_info(memstatus_ok=True)
+        self.assertTrue(info["os"].startswith("Windows 10"), info["os"])
+
     def test_win32_probe_failure_falls_back(self):
         """A failed probe keeps the old conservative default rather than 0.0 —
         an eviction write sized from 0 GB would silently evict nothing."""

--- a/c/tools/datapoint.py
+++ b/c/tools/datapoint.py
@@ -126,7 +126,18 @@ def machine_info():
             winreg.CloseKey(k)
         except Exception:
             pass
-        info["os"] = f"Windows {platform.release()} {platform.version()}"
+        # platform.release() says "10" on Windows 11: Microsoft never moved the
+        # internal version off 10.0, so the BUILD number is the only tell —
+        # 22000 and up is Windows 11 (#1042 follow-up: every Win11 datapoint in
+        # the tracker was being filed as Windows 10).
+        release = platform.release()
+        try:
+            build = int(platform.version().split(".")[2])
+            if release == "10" and build >= 22000:
+                release = "11"
+        except (IndexError, ValueError):
+            pass
+        info["os"] = f"Windows {release} {platform.version()}"
     else:
         info["cpu"] = platform.processor() or "?"
         info["ram"] = "?"


### PR DESCRIPTION
Second finding from @Unknown-Findout's real-hardware confirmation on #1042: their Windows 11 box printed `Windows 10 10.0.26200` — `platform.release()` is stuck on '10' because Microsoft never moved the internal version, and build ≥22000 is the only reliable tell. Every Windows 11 datapoint in the tracker is currently filed as Windows 10.

One branch in the win32 arm, both sides of the 22000 cutoff pinned in tests (26200 → Windows 11, 19045 → Windows 10). 17/17 suite green.

Their first finding — that every pre-#1131 Windows datapoint was measured warm-labelled-cold and `main`/v1.3.0 still carry the old probe — is a curation call rather than a code fix, so I'm leaving it to you whether the datapoint template gets a caveat line; happy to write it if wanted.