### PR TITLE
fix(coli): detect the Linux DeepSeek V4 CUDA build, not just the Windows DLL

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -490,7 +490,7 @@ def env_for_engine(a, arch, plan=None):
         else:
             if arch == "deepseek_v4":
                 if not dsv4_cuda_available(a.model):
-                    sys.exit(f"{C.yel}--gpu needs the CUDA build:{C.r} build coli_cuda_dsv4.dll (make cuda-dsv4-dll)")
+                    sys.exit(f"{C.yel}--gpu needs the CUDA build:{C.r} {dsv4_cuda_build_hint()}")
             elif not cuda_binary():
                 sys.exit(f"{C.yel}--gpu needs the CUDA build:{C.r} the engine binary is CPU-only")
             env["COLI_CUDA"] = "1"
@@ -500,7 +500,7 @@ def env_for_engine(a, arch, plan=None):
     if vram and gpu != "none":
         if arch == "deepseek_v4":
             if not dsv4_cuda_available(a.model):
-                sys.exit(f"{C.yel}--vram needs the CUDA build:{C.r} build coli_cuda_dsv4.dll (make cuda-dsv4-dll)")
+                sys.exit(f"{C.yel}--vram needs the CUDA build:{C.r} {dsv4_cuda_build_hint()}")
         elif not cuda_binary():
             sys.exit(f"{C.yel}--vram needs the CUDA build:{C.r} the engine binary is CPU-only")
         env["COLI_CUDA"] = "1"
@@ -543,11 +543,27 @@ def env_for_engine(a, arch, plan=None):
     return env
 
 def dsv4_cuda_available(model=None):
-    if sys.platform != "win32":
-        return False
+    # Windows loads the tier as a runtime DLL next to the engine; Linux links
+    # it straight into the binary (nvcc, -lcudart), so the DLL check there
+    # rejected every valid `make deepseek-v4 CUDA=1` build (#1219). Detect the
+    # Linux build the same way cuda_binary() detects GLM's: a dynamic libcudart
+    # (or libamdhip64) entry in the binary's link table.
     eng = engine_for(model) if model else GLM
-    dll = os.path.join(os.path.dirname(eng), "coli_cuda_dsv4.dll")
-    return os.path.exists(dll)
+    if sys.platform == "win32":
+        dll = os.path.join(os.path.dirname(eng), "coli_cuda_dsv4.dll")
+        return os.path.exists(dll)
+    if sys.platform == "linux" and os.path.exists(eng):
+        try:
+            linked = subprocess.run(["ldd", eng], capture_output=True, text=True, timeout=3)
+            return any(("libcudart" in line or "libamdhip64" in line) and "not found" not in line
+                       for line in linked.stdout.splitlines())
+        except Exception:
+            return False
+    return False
+
+def dsv4_cuda_build_hint():
+    return ("build coli_cuda_dsv4.dll (make cuda-dsv4-dll)" if sys.platform == "win32"
+            else "make deepseek-v4 CUDA=1 (this binary is CPU-only)")
 
 def need_worker_model(model):
     require_model(model, file="config.json")

--- a/c/tests/test_env_defaults.py
+++ b/c/tests/test_env_defaults.py
@@ -169,5 +169,56 @@ class CudaAutoEnableTest(unittest.TestCase):
         self.assertNotIn("CUDA_EXPERT_GB", e)
 
 
+class Dsv4CudaDetectTest(unittest.TestCase):
+    """dsv4_cuda_available: the Windows check is a DLL next to the engine, but
+    Linux links the tier straight into the binary (nvcc, -lcudart), so the DLL
+    probe there rejected every valid `make deepseek-v4 CUDA=1` build (#1219)."""
+
+    def _detect(self, platform, ldd_stdout=None, dll=False, engine_exists=True):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        eng = Path(tmp.name) / "deepseek"
+        if engine_exists:
+            eng.write_bytes(b"")
+        if dll:
+            (Path(tmp.name) / "coli_cuda_dsv4.dll").write_bytes(b"")
+        fake_run = mock.Mock(return_value=types.SimpleNamespace(stdout=ldd_stdout or ""))
+        with mock.patch.object(sys, "platform", platform), \
+             mock.patch.object(coli, "engine_for", return_value=str(eng)), \
+             mock.patch.object(coli.subprocess, "run", fake_run):
+            return coli.dsv4_cuda_available(str(_MODEL))
+
+    def test_linux_cuda_link_detected(self):
+        out = "\tlibcudart.so.12 => /opt/cuda/lib64/libcudart.so.12 (0x00007f)\n"
+        self.assertTrue(self._detect("linux", ldd_stdout=out))
+
+    def test_linux_hip_link_detected(self):
+        out = "\tlibamdhip64.so.6 => /opt/rocm/lib/libamdhip64.so.6 (0x00007f)\n"
+        self.assertTrue(self._detect("linux", ldd_stdout=out))
+
+    def test_linux_cpu_build_rejected(self):
+        out = "\tlibc.so.6 => /usr/lib/libc.so.6 (0x00007f)\n"
+        self.assertFalse(self._detect("linux", ldd_stdout=out))
+
+    def test_linux_broken_link_rejected(self):
+        out = "\tlibcudart.so.12 => not found\n"
+        self.assertFalse(self._detect("linux", ldd_stdout=out))
+
+    def test_linux_missing_engine_rejected(self):
+        self.assertFalse(self._detect("linux", engine_exists=False))
+
+    def test_win32_dll_detected(self):
+        self.assertTrue(self._detect("win32", dll=True))
+
+    def test_win32_missing_dll_rejected(self):
+        self.assertFalse(self._detect("win32", dll=False))
+
+    def test_build_hint_names_the_right_build(self):
+        with mock.patch.object(sys, "platform", "linux"):
+            self.assertIn("make deepseek-v4 CUDA=1", coli.dsv4_cuda_build_hint())
+        with mock.patch.object(sys, "platform", "win32"):
+            self.assertIn("coli_cuda_dsv4.dll", coli.dsv4_cuda_build_hint())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #1219.

## The bug

`dsv4_cuda_available()` in `c/coli` gated `--gpu`/`--vram` for DeepSeek V4 by
looking for `coli_cuda_dsv4.dll` next to the engine, and returned False on
every non-Windows platform before even looking. On Linux the CUDA tier is not
a DLL at all: `make deepseek-v4 CUDA=1` links it straight into the binary
via nvcc (`-lcudart -lcuda -lcublasLt`). So a working Linux CUDA build was
refused with a hint about building a Windows DLL.

The gate arrived with the V4 CUDA tier wiring, whose first tag is v1.7.0,
which is exactly why the report says v1.6.1 worked and 1.7.0 does not.

## The fix

Detection now mirrors what `cuda_binary()` already does for GLM in the same
file: on Linux, `ldd` on the V4 engine binary must list `libcudart` (or
`libamdhip64`) and not as "not found". The Windows DLL probe is unchanged,
macOS keeps returning False (there is no V4 CUDA tier there). The error hint
now names the right build per platform: `make deepseek-v4 CUDA=1` on Linux,
the DLL target on Windows.

## Tests

Eight new unit tests in `tests/test_env_defaults.py`, following the file's
existing mock harness: CUDA and HIP dynamic links accepted, CPU-only builds
and "not found" links rejected, missing engine rejected, DLL present and
absent on Windows, and the per-platform hint text. Full launcher-adjacent
python suite green locally (37 passed, 12 skipped).
