### PR TITLE
fix(coli): harden DeepSeek V4 CUDA detection

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -546,8 +546,9 @@ def dsv4_cuda_available(model=None):
     # Windows loads the tier as a runtime DLL next to the engine; Linux links
     # it straight into the binary (nvcc, -lcudart), so the DLL check there
     # rejected every valid `make deepseek-v4 CUDA=1` build (#1219). Detect the
-    # Linux build the same way cuda_binary() detects GLM's: a dynamic libcudart
-    # (or libamdhip64) entry in the binary's link table.
+    # Linux build through the dynamic libcudart entry added by the in-tree
+    # CUDA=1 target. DeepSeek V4 has no HIP backend, so libamdhip64 alone must
+    # not make a CPU engine look GPU-capable.
     eng = engine_for(model) if model else GLM
     if sys.platform == "win32":
         dll = os.path.join(os.path.dirname(eng), "coli_cuda_dsv4.dll")
@@ -555,15 +556,18 @@ def dsv4_cuda_available(model=None):
     if sys.platform == "linux" and os.path.exists(eng):
         try:
             linked = subprocess.run(["ldd", eng], capture_output=True, text=True, timeout=3)
-            return any(("libcudart" in line or "libamdhip64" in line) and "not found" not in line
+            return any("libcudart" in line and "not found" not in line
                        for line in linked.stdout.splitlines())
-        except Exception:
+        except (OSError, subprocess.SubprocessError):
             return False
     return False
 
 def dsv4_cuda_build_hint():
-    return ("build coli_cuda_dsv4.dll (make cuda-dsv4-dll)" if sys.platform == "win32"
-            else "make deepseek-v4 CUDA=1 (this binary is CPU-only)")
+    if sys.platform == "win32":
+        return "build coli_cuda_dsv4.dll (make cuda-dsv4-dll)"
+    if sys.platform == "linux":
+        return "make deepseek-v4 CUDA=1 (this binary is CPU-only)"
+    return "the DeepSeek V4 CUDA tier is supported only on Linux and Windows"
 
 def need_worker_model(model):
     require_model(model, file="config.json")

--- a/c/tests/test_env_defaults.py
+++ b/c/tests/test_env_defaults.py
@@ -10,6 +10,7 @@ import importlib.machinery
 import importlib.util
 import os
 import json
+import subprocess
 import sys
 import tempfile
 import types
@@ -174,7 +175,8 @@ class Dsv4CudaDetectTest(unittest.TestCase):
     Linux links the tier straight into the binary (nvcc, -lcudart), so the DLL
     probe there rejected every valid `make deepseek-v4 CUDA=1` build (#1219)."""
 
-    def _detect(self, platform, ldd_stdout=None, dll=False, engine_exists=True):
+    def _detect(self, platform, ldd_stdout=None, dll=False, engine_exists=True,
+                ldd_error=None):
         tmp = tempfile.TemporaryDirectory()
         self.addCleanup(tmp.cleanup)
         eng = Path(tmp.name) / "deepseek"
@@ -182,7 +184,8 @@ class Dsv4CudaDetectTest(unittest.TestCase):
             eng.write_bytes(b"")
         if dll:
             (Path(tmp.name) / "coli_cuda_dsv4.dll").write_bytes(b"")
-        fake_run = mock.Mock(return_value=types.SimpleNamespace(stdout=ldd_stdout or ""))
+        fake_run = mock.Mock(return_value=types.SimpleNamespace(stdout=ldd_stdout or ""),
+                             side_effect=ldd_error)
         with mock.patch.object(sys, "platform", platform), \
              mock.patch.object(coli, "engine_for", return_value=str(eng)), \
              mock.patch.object(coli.subprocess, "run", fake_run):
@@ -192,9 +195,9 @@ class Dsv4CudaDetectTest(unittest.TestCase):
         out = "\tlibcudart.so.12 => /opt/cuda/lib64/libcudart.so.12 (0x00007f)\n"
         self.assertTrue(self._detect("linux", ldd_stdout=out))
 
-    def test_linux_hip_link_detected(self):
+    def test_linux_hip_link_is_not_dsv4_cuda(self):
         out = "\tlibamdhip64.so.6 => /opt/rocm/lib/libamdhip64.so.6 (0x00007f)\n"
-        self.assertTrue(self._detect("linux", ldd_stdout=out))
+        self.assertFalse(self._detect("linux", ldd_stdout=out))
 
     def test_linux_cpu_build_rejected(self):
         out = "\tlibc.so.6 => /usr/lib/libc.so.6 (0x00007f)\n"
@@ -207,17 +210,34 @@ class Dsv4CudaDetectTest(unittest.TestCase):
     def test_linux_missing_engine_rejected(self):
         self.assertFalse(self._detect("linux", engine_exists=False))
 
+    def test_linux_ldd_failures_are_rejected(self):
+        for error in (FileNotFoundError("ldd"),
+                      subprocess.TimeoutExpired(["ldd", "deepseek"], 3)):
+            with self.subTest(error=type(error).__name__):
+                self.assertFalse(self._detect("linux", ldd_error=error))
+
+    def test_unexpected_ldd_errors_are_not_hidden(self):
+        with self.assertRaises(RuntimeError):
+            self._detect("linux", ldd_error=RuntimeError("test bug"))
+
     def test_win32_dll_detected(self):
         self.assertTrue(self._detect("win32", dll=True))
 
     def test_win32_missing_dll_rejected(self):
         self.assertFalse(self._detect("win32", dll=False))
 
+    def test_macos_has_no_dsv4_cuda_tier(self):
+        self.assertFalse(self._detect("darwin", ldd_stdout="libcudart.so"))
+
     def test_build_hint_names_the_right_build(self):
         with mock.patch.object(sys, "platform", "linux"):
             self.assertIn("make deepseek-v4 CUDA=1", coli.dsv4_cuda_build_hint())
         with mock.patch.object(sys, "platform", "win32"):
             self.assertIn("coli_cuda_dsv4.dll", coli.dsv4_cuda_build_hint())
+        with mock.patch.object(sys, "platform", "darwin"):
+            hint = coli.dsv4_cuda_build_hint()
+            self.assertIn("only on Linux and Windows", hint)
+            self.assertNotIn("CUDA=1", hint)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up hardening for #1220 and #1219.

- Accept only libcudart for the in-tree DeepSeek V4 CUDA backend; an unrelated ROCm library no longer produces a false positive.
- Catch expected ldd execution failures without hiding programming errors.
- Give macOS and other unsupported hosts an accurate Linux/Windows-only message.
- Extend coverage for CUDA, CPU-only, broken linkage, missing ldd, timeout, unexpected errors, Windows DLL, and unsupported platforms.

Validation:
- DeepSeek CUDA detector: 11 tests passed.
- Related launcher tests: 63 tests passed.
- Full Python suite: 679 tests passed, 32 skipped.

This changes launcher detection only; it does not touch inference kernels or model output.