### PR TITLE
docs: restore Inkling literal tokens

### DIFF
--- a/docs/inkling.md
+++ b/docs/inkling.md
@@ -84,9 +84,9 @@ help in proportion to the RAM you can give them.
 | Invocation | What it does |
 |---|---|
 | `-p "text" [-n N]` | streaming greedy generation (stops at eos or N tokens) |
-| `--chat -p "text"` | wraps the prompt in Inkling's chat template (role tokens plus the content and model-message markers as the generation prompt). Instruct models fed raw text are out of distribution and answer badly. `THINK=0..1` raises the reasoning effort (default 0) |
+| `--chat -p "text"` | wraps the prompt in Inkling's chat template (role tokens + `<\|content_text\|>`, `<\|message_model\|>` as the generation prompt). Instruct models fed raw text are out of distribution and answer badly. `THINK=<0..1>` raises the reasoning effort (default 0) |
 | `-f prompts.txt [-n N]` | one prompt per line (`#` comments skipped), single model load, state reset between prompts — the cache-warming workflow below |
-| `--audio file.dmel [-p "text"]` | spoken input: raw u8 DMel frames `[n_frames, 80]`, one audio-token position per frame (implies `--chat`) |
+| `--audio file.dmel [-p "text"]` | spoken input: raw u8 DMel frames `[n_frames, 80]`, one `<\|audio\|>` position per frame (implies `--chat`) |
 | `[cap] [bits] [ref.json]` | token-exact oracle harness against a `tools/make_tiny_inkling.py` fixture (CI-style validation; `tools/make_tiny_inkling_audio.py` for the audio path) |
 
 `coli chat` / `coli serve` / `coli web` render the same template through the


### PR DESCRIPTION
## Summary

- restore the literal Inkling chat-template tokens in `docs/inkling.md`
- escape the pipe characters so the tokens remain valid inside the Markdown table

The rendered Mintlify page displays `<|content_text|>`, `<|message_model|>`, and `<|audio|>` without the source-level backslashes.

## Validation

- `mint validate --telemetry=false`
- local Mintlify preview render checked for the exact displayed token strings

Follow-up to #1225.
