### PR TITLE
fix(tools): k3_tokenizer --ctest writes its fixture to a hardcoded /tmp path

### DIFF
--- a/c/tests/test_k3_tokenizer_tmp.py
+++ b/c/tests/test_k3_tokenizer_tmp.py
@@ -1,0 +1,60 @@
+"""k3_tokenizer.py --ctest must not write to a hardcoded /tmp path.
+
+Same bug the repo already fixed twice elsewhere, surviving in a third file.
+
+tests/test_stops.c and tests/test_pipe_block.c both carry the rule in the
+source: 'Relative to the CWD [...] NOT "/tmp/..."', because the windows job
+builds native .exe files that resolve Windows paths, "/tmp" is not one, and
+"the whole `make check` goes red on the windows job (and only there)".
+setup.sh was moved off its own /tmp probe to OMP_PROBE=".colibri-omp-probe-$$"
+for the same reason, and test_cuda_test_makefile.py's
+test_setup_openmp_probe_does_not_require_tmp pins it there. This file is that
+same pin for tools/k3_tokenizer.py.
+
+Note the failure is conditional rather than universal: fopen(..., "w") creates
+the FILE but not the directory, so on a box where something has already created
+C:/tmp (Git Bash does) the old code writes fine, and on a clean runner it does
+not. Measured both ways rather than assumed.
+
+A fixed FILENAME is a second, platform-independent bug: two concurrent runs
+collide on it, and nothing ever deleted it.
+
+The source is read as text rather than executed because --ctest needs tiktoken
+and a compiled C binary, neither of which CI has here.
+"""
+import re
+import unittest
+from pathlib import Path
+
+TOOL = Path(__file__).resolve().parent.parent / "tools" / "k3_tokenizer.py"
+
+
+class K3TokenizerTempPathTest(unittest.TestCase):
+    def setUp(self):
+        self.src = TOOL.read_text(encoding="utf-8")
+
+    def test_no_hardcoded_tmp_path(self):
+        hits = re.findall(r'["\']/tmp/[^"\']*["\']', self.src)
+        self.assertEqual(hits, [], f"hardcoded /tmp path(s) back in k3_tokenizer.py: {hits}")
+
+    def test_uses_tempfile_for_the_ctest_cases(self):
+        # assertTrue, not assertIn: assertIn dumps the whole 8 KB source into
+        # the failure message, which buries the actual reason in CI output.
+        self.assertTrue("import tempfile" in self.src, "tempfile is not imported")
+        self.assertTrue("tempfile.mkstemp" in self.src,
+                        "the --ctest cases file is not created via tempfile.mkstemp")
+
+    def test_the_cases_file_is_cleaned_up(self):
+        """os.unlink must sit in a finally, so a ctest that raises still tidies
+        up rather than leaving the file behind."""
+        self.assertTrue("os.unlink(cases)" in self.src,
+                        "the --ctest cases file is never removed")
+        body = self.src[self.src.index("tempfile.mkstemp"):]
+        finally_at = body.find("finally:")
+        unlink_at = body.find("os.unlink(cases)")
+        self.assertNotEqual(finally_at, -1, "no finally: guarding the cleanup")
+        self.assertLess(finally_at, unlink_at, "os.unlink is not inside the finally block")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tools/k3_tokenizer.py
+++ b/c/tools/k3_tokenizer.py
@@ -27,6 +27,7 @@ import base64
 import json
 import os
 import sys
+import tempfile
 
 PAT = "|".join([
     r"""[\p{Han}]+""",
@@ -155,13 +156,30 @@ def main():
             return
         enc = tiktoken.Encoding(name="k3", pat_str=PAT,
                                 mergeable_ranks=ranks, special_tokens={})
-        cases = "/tmp/k3_tok_cases.bin"
-        with open(cases, "wb") as f:
-            f.write(_st.pack("<I", len(corpus)))
-            for t in corpus:
-                b = t.encode("utf-8")
-                f.write(_st.pack("<I", len(b)) + b)
-        r = subprocess.run([a.ctest, out, cases], capture_output=True, text=True)
+        # Next to the output rather than a hardcoded /tmp, and removed
+        # after. Same rule as test_stops.c and test_pipe_block.c, which say
+        # not to root a path at /tmp because the windows job builds native
+        # .exe files and that is not a Windows path, and as the setup.sh
+        # OMP probe. fopen("w") creates the file but not the directory, so
+        # this fails wherever /tmp does not already exist. A fixed FILENAME
+        # is also a collision between two concurrent runs, and nothing here
+        # ever deleted it.
+        fd, cases = tempfile.mkstemp(prefix=".colibri-k3-cases-", suffix=".bin",
+                                     dir=os.path.dirname(os.path.abspath(out)))
+        os.close(fd)
+        try:
+            with open(cases, "wb") as f:
+                f.write(_st.pack("<I", len(corpus)))
+                for t in corpus:
+                    b = t.encode("utf-8")
+                    f.write(_st.pack("<I", len(b)) + b)
+            r = subprocess.run([a.ctest, out, cases], capture_output=True, text=True)
+        finally:
+            # try/finally so a failing ctest does not leave the file behind
+            try:
+                os.unlink(cases)
+            except OSError:
+                pass
         print(r.stderr.strip(), file=sys.stderr)
         got = [([int(x) for x in ln.split()] if ln else [])
                for ln in r.stdout.splitlines()]


### PR DESCRIPTION
`k3_tokenizer.py --ctest` writes its case fixture to a hardcoded path:

```python
cases = "/tmp/k3_tok_cases.bin"
with open(cases, "wb") as f:
```

This is the same pattern the repo has already moved away from twice, and I only found it because the existing pins pointed at it.

## The rule is already written in this repo, twice

`tests/test_stops.c:84` and `tests/test_pipe_block.c:146`:

> Relative to the CWD, like test_compat_direct's TMPF - NOT "/tmp/...". These binaries are built by MinGW into native Windows .exe files, which resolve Windows paths: "/tmp" is not one, so mkdtemp there fails ENOENT and the whole `make check` goes red on the windows job (and only there).

And `setup.sh` was moved off its own `/tmp` probe to `OMP_PROBE=".colibri-omp-probe-$$"`, with `test_cuda_test_makefile.test_setup_openmp_probe_does_not_require_tmp` pinning it there. `tools/k3_tokenizer.py` is the file that pass missed.

## One correction to the obvious framing, because I checked

I expected this to fail outright on Windows and it did not. `fopen(..., "w")` creates the **file** but not the **directory**, and Git Bash creates `C:/tmp` on install, so on my box the old line writes fine. The failure is conditional on whether `/tmp` already exists, which is exactly why it survived this long: it works on most dev machines and breaks on clean ones. I measured it both ways rather than assuming, since assuming is what would have made this a bogus report.

The **fixed filename** is the platform-independent half, and it is unconditional: two concurrent `--ctest` runs collide on the same path, and nothing ever removed the file.

## The change

`tempfile.mkstemp` next to the output file, in a `try/finally`:

```python
fd, cases = tempfile.mkstemp(prefix=".colibri-k3-cases-", suffix=".bin",
                             dir=os.path.dirname(os.path.abspath(out)))
```

The output directory rather than the system temp dir on purpose: it is **provably writable**, because `tokenizer.json` was written to it successfully a few lines earlier. So this cannot trade one unwritable location for another.

## Verification

Three tests in `tests/test_k3_tokenizer_tmp.py`, same shape as the existing `setup.sh` pin: no quoted `/tmp` path in the file, the fixture goes through `mkstemp`, and `os.unlink` sits inside the `finally` rather than on the happy path.

Negative control run rather than assumed - reverting `tools/k3_tokenizer.py` alone fails all three, restoring it passes all three:

```
revert tool -> FAILED (failures=3)
restore     -> OK
```

Full python suite, before and after:

```
Ran 591 tests   errors=2, skipped=64      (identical both ways)
```

Both errors are pre-existing and unrelated: `test_cuda_test_makefile` shells out to `make`, which is absent on this host.

The `--ctest` path itself is **not** exercised here, and I want to be straight about that - it needs `tiktoken` plus a compiled `test_tok_kimi`, so the tests read the source as text the way the `setup.sh` pin does. The edit is small enough to read, but CI is the check that matters for the runtime path.

Tested on Windows, RTX 3090 (sm_86), CUDA 13.1, Python 3.11.

