### PR TITLE
fix(k3): K3_VALIDATE_OUT defaults to a hardcoded /tmp path

### DIFF
--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -1138,7 +1138,13 @@ static void model_init_range(Model *m, const char *snap, int layer_begin,
           g_k3_val_layer=-1;
         } else {
           const char *ofn=getenv("K3_VALIDATE_OUT");
-          if(!ofn) ofn="/tmp/k3_val";
+          /* CWD-relative, not a /tmp path: same rule as test_stops.c and
+             test_pipe_block.c, since the windows job builds native .exe
+             files that resolve Windows paths and /tmp is not one. The
+             chosen path is printed on both the success and the failure
+             branch below, so a caller relying on the old default is told
+             where the dump went. */
+          if(!ofn) ofn="k3_val";
           g_k3_val_fp=fopen(ofn,"w");
           if(!g_k3_val_fp){
             fprintf(stderr,"[K3-VAL] cannot open %s (%s) — disabled\n",ofn,strerror(errno));

--- a/c/tests/test_k3_validate_out_path.py
+++ b/c/tests/test_k3_validate_out_path.py
@@ -1,0 +1,57 @@
+"""The K3_VALIDATE_OUT fallback must not be rooted at /tmp.
+
+kimi_k3.c defaulted K3_VALIDATE_LAYER's dump target to "/tmp/k3_val" when
+K3_VALIDATE_OUT was unset. Same rule the repo already states twice in its own
+source: tests/test_stops.c and tests/test_pipe_block.c both say a path must be
+relative to the CWD and not rooted at /tmp, because the windows job builds
+native .exe files that resolve Windows paths, /tmp is not one, and the whole
+`make check` goes red on the windows job and only there. setup.sh was moved off
+its own /tmp probe for the same reason.
+
+fopen(..., "w") creates the file but not the directory, so the old default
+worked wherever /tmp already existed and failed where it did not.
+
+test_reports_the_path_it_chose is the one that makes the behaviour change safe
+rather than merely correct: the default moved, so anyone who relied on the old
+one has to be told where the dump went. Both branches print it, so they are.
+
+The source is read as text because building kimi_k3.c needs the full toolchain
+and running this path needs a K3 checkpoint, neither of which the python job
+has. Same approach as test_cuda_test_makefile's setup.sh probe test.
+"""
+import re
+import unittest
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "kimi_k3.c"
+
+
+class K3ValidateOutPathTest(unittest.TestCase):
+    def setUp(self):
+        self.src = SRC.read_text(encoding="utf-8")
+        # Scope to the K3-VAL init block so an unrelated /tmp elsewhere in this
+        # 1000+ line file does not silently pass or fail this test.
+        start = self.src.index('getenv("K3_VALIDATE_OUT")')
+        self.block = self.src[start:start + 1200]
+
+    def test_fallback_is_not_rooted_at_tmp(self):
+        hits = re.findall(r'ofn\s*=\s*"(/tmp/[^"]*)"', self.block)
+        self.assertEqual(hits, [], f"K3_VALIDATE_OUT falls back to a /tmp path: {hits}")
+
+    def test_fallback_is_cwd_relative(self):
+        m = re.search(r'if\s*\(\s*!\s*ofn\s*\)\s*ofn\s*=\s*"([^"]*)"', self.block)
+        self.assertIsNotNone(m, "no K3_VALIDATE_OUT fallback assignment found")
+        path = m.group(1)
+        self.assertFalse(path.startswith("/"), f"fallback {path!r} is absolute, not CWD-relative")
+        self.assertFalse(re.match(r"^[A-Za-z]:", path), f"fallback {path!r} is a Windows drive path")
+        self.assertTrue(path, "fallback is an empty path")
+
+    def test_reports_the_path_it_chose(self):
+        """The default moved, so the user must be told where the dump landed.
+        Both the success and the failure branch print it."""
+        self.assertIn("cannot open %s", self.block)
+        self.assertIn("output %s", self.block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
With `K3_VALIDATE_LAYER` set and `K3_VALIDATE_OUT` unset, `kimi_k3.c` dumps its per-layer validation tensors to a hardcoded path:

```c
const char *ofn=getenv("K3_VALIDATE_OUT");
if(!ofn) ofn="/tmp/k3_val";
```

## The rule is already written in this repo, twice

`tests/test_stops.c:84` and `tests/test_pipe_block.c:146`:

> Relative to the CWD, like test_compat_direct's TMPF - NOT "/tmp/...". These binaries are built by MinGW into native Windows .exe files, which resolve Windows paths: "/tmp" is not one, so mkdtemp there fails ENOENT and the whole `make check` goes red on the windows job (and only there).

And `setup.sh` was moved off its own `/tmp` probe to `OMP_PROBE=".colibri-omp-probe-$$"`, pinned by `test_cuda_test_makefile.test_setup_openmp_probe_does_not_require_tmp`.

## Why it went unnoticed

`fopen(..., "w")` creates the **file** but not the **directory**, so the old default works wherever `/tmp` already exists and fails where it does not. Git Bash creates `C:/tmp` on install, so plenty of Windows boxes have one.

And when it does fail it **degrades cleanly** - `[K3-VAL] cannot open ... disabled`, then carries on. So the symptom is not a crash, it is that the validation dump silently does not happen on exactly the platform the Metal/CPU comparison work in `docs/metal_implementation.md` most needs it on.

## No documented contract changes

`docs/metal_implementation.md:670` references the `K3_VALIDATE_OUT` **variable**, never its `/tmp` fallback. I grepped for every `K3_VALIDATE` reference in the tree to check that before touching it.

The chosen path is printed on both the success and the failure branch, so anyone relying on the old default is told where the dump went rather than having to guess. That is asserted by a test rather than left to review.

## Verification

**The C is compiled, not just edited.** gcc 16.2.0 (MSYS2), `-fsyntax-only -D_FILE_OFFSET_BITS=64`, clean on the patched file and on the unpatched one as a control.

**Full python suite, both states, with the tree state printed before each run** rather than assumed:

```
baseline (fallback = "/tmp/k3_val", new test absent)   Ran 700   OK (skipped=51)
patched  (fallback = "k3_val",      new test present)  Ran 703   OK (skipped=51)
```

The delta is exactly the 3 tests this branch adds. My first attempt at that baseline was bogus - `git stash push` does not stash an untracked file, so the "before" run had the new test in it and reported 703 both ways. Numbers matching when they should have differed is what caught it. Re-run with the file moved aside and the fallback string echoed first.

**Negative control:** reverting `kimi_k3.c` alone fails 2 of the 3 new tests:

```
AssertionError: fallback '/tmp/k3_val' is absolute, not CWD-relative
AssertionError: Lists differ: ['/tmp/k3_val'] != []
```

The third (`test_reports_the_path_it_chose`) passes on the old code **by design** - it guards existing behaviour so the printing cannot be dropped later, rather than detecting this change. Flagging that so the 2-of-3 is not read as a weak control.

**Not exercised:** the runtime path itself. Producing a dump needs a K3 checkpoint, which I do not have, so the tests read the source as text the way the `setup.sh` pin does. CI is the check that matters for the build.

Tested on Windows, RTX 3090 (sm_86), CUDA 13.1, gcc 16.2.0, Python 3.11.
