### PR TITLE
build(cuda): NVCC_ALLOW_UNSUPPORTED, so a host compiler newer than VS2022 is reachable

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -296,6 +296,23 @@ ifneq ($(LINUX),)
 NVCCFLAGS += -Xcompiler=-include,$(CURDIR)/glibc_c23_math_compat.h
 endif
 endif
+# CUDA 13.1 host_config.h accepts only Visual Studio 2019-2022 and refuses
+# anything newer outright, so on a box with VS Build Tools 18 (MSVC 19.50)
+# EVERY nvcc target fails at the first #include with C1189 -- cuda-test,
+# cuda-dll, all of it. nvcc offers -allow-unsupported-compiler to override the
+# check, but there was no way to get one flag in: NVCCFLAGS is the only handle
+# and replacing it wholesale discards $(CUDA_GENCODE), the -ccbin set above and
+# the -Xcompiler warning form that Windows specifically needs -- the same
+# argument that made NVCC_STD a variable rather than a rewrite.
+#
+# Defaults to 0: nvcc's own wording is "may cause compilation failure or
+# incorrect run time execution", so an unsupported host compiler is the
+# builder's decision to make explicitly, not a default this Makefile makes for
+# them. Any result produced with it set should say so.
+NVCC_ALLOW_UNSUPPORTED ?= 0
+ifeq ($(NVCC_ALLOW_UNSUPPORTED),1)
+NVCCFLAGS += -allow-unsupported-compiler
+endif
 # HIP=1 builds the SAME backend for AMD GPUs via ROCm: backend_cuda.cu is
 # compiled unchanged through backend_gpu_compat.h (one source, two vendors,
 # like compat.h does for Windows). HIP_ARCH=native targets the GPU in this

--- a/c/tests/test_cuda_test_makefile.py
+++ b/c/tests/test_cuda_test_makefile.py
@@ -15,6 +15,15 @@ def cuda_test_recipe(*variables):
     return result.stdout + result.stderr
 
 
+def nvcc_compile_line(recipe):
+    """First real nvcc invocation, skipping the `command -v "nvcc"` guard line
+    that a naive grep for "nvcc" matches first."""
+    return next(
+        (line for line in recipe.splitlines()
+         if "backend_cuda.cu" in line and " -o " in line and "command -v" not in line),
+        "")
+
+
 def mxfp4_link_line(recipe):
     return next(
         (line for line in recipe.splitlines()
@@ -52,6 +61,36 @@ class CudaTestMakefileTest(unittest.TestCase):
             "HIP=1", "HIP_ARCH=gfx1100", "HIPCC=hipcc"))
         self.assertTrue(line, "no MXFP4 HIP link command in dry-run recipe")
         self.assertNotIn("-fopenmp", line)
+
+    def test_allow_unsupported_compiler_is_off_by_default(self):
+        """nvcc's own wording for this flag is "may cause compilation failure or
+        incorrect run time execution", so it is never a default."""
+        line = nvcc_compile_line(cuda_test_recipe("CUDA=1", "NVCC=nvcc"))
+        self.assertTrue(line, "no nvcc compile command in dry-run recipe")
+        self.assertNotIn("-allow-unsupported-compiler", line)
+
+    def test_allow_unsupported_compiler_is_reachable(self):
+        """CUDA 13.1's host_config.h rejects any MSVC newer than VS2022, which
+        fails every nvcc target at the first #include with C1189. Before this
+        variable the only handle was NVCCFLAGS, and overriding that wholesale
+        drops the gencode, the -ccbin and the platform warning form."""
+        line = nvcc_compile_line(
+            cuda_test_recipe("CUDA=1", "NVCC=nvcc", "NVCC_ALLOW_UNSUPPORTED=1"))
+        self.assertTrue(line, "no nvcc compile command in dry-run recipe")
+        self.assertIn("-allow-unsupported-compiler", line)
+
+    def test_allow_unsupported_compiler_preserves_the_other_flags(self):
+        """The load-bearing one. Appending must not do what a wholesale
+        NVCCFLAGS override does, which is silently drop the arch and lose
+        -ftz=false -- and -ftz is a correctness flag here, not a tuning knob:
+        the fmt=8 kernels are cross-tier parity instruments and a flushed
+        subnormal diverges from the CPU reference."""
+        line = nvcc_compile_line(
+            cuda_test_recipe("CUDA=1", "NVCC=nvcc", "CUDA_ARCH=sm_86",
+                             "NVCC_ALLOW_UNSUPPORTED=1"))
+        self.assertTrue(line, "no nvcc compile command in dry-run recipe")
+        for flag in ("-ftz=false", "-std=c++17", "sm_86"):
+            self.assertIn(flag, line, f"{flag} lost when the override is set")
 
     def test_setup_openmp_probe_does_not_require_tmp(self):
         setup = (HERE / "setup.sh").read_text(encoding="utf-8")


### PR DESCRIPTION
CUDA 13.1's `crt/host_config.h` accepts only Visual Studio 2019 to 2022 and refuses anything newer. On a host with VS Build Tools 18 (MSVC 19.50) every nvcc target dies at the first `#include`:

```
host_config.h(164): fatal error C1189: #error: -- unsupported Microsoft Visual
Studio version! Only the versions between 2019 and 2022 (inclusive) are supported!
```

That is `cuda-test`, `cuda-dll`, all of it. nvcc ships `-allow-unsupported-compiler` for exactly this case, but there was no way to get one flag into the command line: `NVCCFLAGS` is the only handle, and replacing it wholesale discards `$(CUDA_GENCODE)`, the `-ccbin` set above it, and the `-Xcompiler=-W3` warning form Windows specifically needs.

That is the same argument the `NVCC_STD` comment already makes a few lines up, so this follows its shape rather than inventing a new one.

```make
NVCC_ALLOW_UNSUPPORTED ?= 0
ifeq ($(NVCC_ALLOW_UNSUPPORTED),1)
NVCCFLAGS += -allow-unsupported-compiler
endif
```

**Defaults to 0 on purpose.** nvcc's own wording is "may cause compilation failure or incorrect run time execution", so running on an unsupported host compiler stays an explicit decision by the builder, and any result produced with it set should say so.

## What it unblocks

`make cuda-test` had never completed on this machine. With the variable set, the whole recipe runs:

```
make cuda-test CUDA_ARCH=sm_86 NVCC_ALLOW_UNSUPPORTED=1
...
MAKE_EXIT=0
```

All seven binaries built and passed on real sm_86 silicon:

```
backend_cuda        q8/q4/q2/f32/e8 correctness ok on 1 device(s)
ragged_attention    ok
fp8_warp            decode sweep [shared-lut] 0 mismatches
                    decode sweep [hw-cvt]     0 mismatches
                    mutated entry (must bite) 1 mismatches   <- negative control fires
absorb_determinism  batch_differing=0/145  ragged_differing=0/29
fp8_cuda            oracle 50 trials x 3 experts, 0 mismatches
                    API: LUT gate + dense + sync group + async, 0 mismatches
weights_owned       8 fail cycles, 0 bytes cumulative
mxfp4               14/14 ok, incl. fmt=-1 and fmt=1073741824 refused as predicted
```

Worth noting the fp8 suite carries its own negative control - the deliberately mutated LUT entry reports `1 mismatches`, so the zeros above come from a test that can fail.

## Verification

Three tests in `tests/test_cuda_test_makefile.py`, the file that already owns this recipe's build contract.

The load-bearing one is `test_allow_unsupported_compiler_preserves_the_other_flags`. Appending must not do what a wholesale `NVCCFLAGS` override does, which is silently drop the gencode and lose `-ftz=false` - and `-ftz` is a correctness flag on this recipe rather than a tuning knob, per the comment beside it: the fmt=8 kernels are cross-tier parity instruments and a flushed `scale*subnormal` contribution diverges from the CPU reference. A build that lost it would still compile and still pass; only the parity numbers would quietly move.

Negative control run rather than assumed. Reverting the Makefile alone fails exactly one of the three:

```
FAIL  test_allow_unsupported_compiler_is_reachable
ok    test_allow_unsupported_compiler_is_off_by_default
ok    test_allow_unsupported_compiler_preserves_the_other_flags
```

That split is the correct one - off-by-default and flag-preservation are both already true without this change, so only the third assertion should move.

Full python suite: `Ran 661 tests, OK, skipped=50`.

## One correction to my own first run

My first attempt reported the MXFP4 link failing with `unresolved external symbol GOMP_parallel`. That was **my** stale base, not a defect here: I had branched from a fork `dev` that was 115 commits behind and predated #1224. Rebased onto current `dev`, it links and passes. Recording it because the symptom is identical to the real bug #1224 fixed, and someone hitting it should check their base before filing.

Tested on Windows 11, RTX 3090 (sm_86), CUDA 13.1 V13.1.115, MSVC 19.50.35725, GNU Make 4.4.1, mingw-w64 gcc 16.2.0.
