### PR TITLE
feat(planner): emit evidence-backed next actions

### DIFF
--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -788,6 +788,53 @@ def _auto_tune(bottleneck_class, projected_hit, gpus, cpu_sockets, plan_has_meta
     return tune
 
 
+def _next_actions(bottleneck_class, projected_hit, probe_state, probe_gbs,
+                  planning_gpus):
+    """Turn the capacity diagnosis into bounded, evidence-producing work.
+
+    These are deliberately not more automatic knobs.  The planner may spend
+    measured capacity, but it must not invent bandwidth or claim that a larger
+    tier will improve end-to-end decode without a run on this machine.
+    """
+    actions = []
+    if bottleneck_class == "disk":
+        if probe_gbs is None:
+            actions.append({
+                "id": "measure-storage",
+                "priority": "required",
+                "reason": "cold experts remain on disk and no trusted storage probe is available",
+                "command": "make -C c iobench && ./c/iobench",
+            })
+        actions.append({
+            "id": "measure-residency",
+            "priority": "recommended",
+            "reason": f"projected expert residency is {projected_hit:.0%}",
+            "command": "coli tune --model <model>",
+        })
+        if len(planning_gpus) > 1:
+            actions.append({
+                "id": "profile-interconnect",
+                "priority": "recommended",
+                "reason": "multiple GPU tiers can move the bottleneck from storage to interconnect",
+                "command": "PROF=1 coli run --auto-tier --model <model> <prompt>",
+            })
+    elif bottleneck_class == "mixed":
+        actions.append({
+            "id": "profile-overlap",
+            "priority": "recommended",
+            "reason": "CPU expert tail and GPU work must be timed separately before retuning placement",
+            "command": "PROF=1 coli run --auto-tier --model <model> <prompt>",
+        })
+    elif bottleneck_class in ("compute", "memory"):
+        actions.append({
+            "id": "measure-kernels",
+            "priority": "recommended",
+            "reason": "weights are resident; kernel and memory-bandwidth timings decide the next optimization",
+            "command": "PROF=1 coli run --auto-tier --model <model> <prompt>",
+        })
+    return actions
+
+
 POLICIES = {
     "quality": {"preserve_quantization": True, "preserve_router": True},
     "balanced": {"preserve_quantization": True, "preserve_router": True},
@@ -932,6 +979,8 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
     tune = _auto_tune(bottleneck_class, projected_hit, planning_gpus, cpu_sockets,
                       plan_has_metal=False)
     probe_state, probe_gbs = ssd_probe_state(info["path"])
+    actions = _next_actions(bottleneck_class, projected_hit, probe_state,
+                            probe_gbs, planning_gpus)
 
     return {
         "version": 2,
@@ -965,6 +1014,7 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
         "bottleneck_class": bottleneck_class,
         "projected_hit_rate": round(projected_hit, 4),
         "tune": tune,
+        "next_actions": actions,
         "decisions": [
             {"target": "VRAM", "reason": "profile-ranked hot experts"},
             {"target": "RAM", "reason": "warm experts execute on CPU without quality loss"},
@@ -1072,5 +1122,12 @@ def format_plan(plan):
         hint = tune.get("_numa_hint")
         if hint:
             lines.append(f"  hint: {hint}")
+    actions = plan.get("next_actions", [])
+    if actions:
+        lines.append("")
+        lines.append("next actions:")
+        for action in actions:
+            lines.append(f"  [{action['priority']}] {action['id']}: {action['reason']}")
+            lines.append(f"    {action['command']}")
     lines.extend(f"warn   {warning}" for warning in plan["warnings"])
     return "\n".join(lines)

--- a/c/tests/test_resource_plan.py
+++ b/c/tests/test_resource_plan.py
@@ -797,6 +797,40 @@ memInfo.free:                     23.50 GB (97%)
         self.assertIn("quality-preserving yes", format_plan(plan))
         self.assertIn("expected_bottleneck", plan)
 
+    def test_disk_plan_requires_probe_and_recommends_measured_tuning(self):
+        info = analyze_model(self.model)
+        info.update(expert_bytes=40 * GB, typical_expert_bytes=1 * GB,
+                    max_expert_bytes=1 * GB, per_cap_bytes=2 * GB)
+        with mock.patch("resource_plan.ssd_probe_state",
+                        return_value=("missing", None)), \
+             mock.patch("resource_plan.analyze_model", return_value=info):
+            plan = build_plan(self.model, ram_gb=4, available_memory=4 * GB,
+                              available_disk=1, gpus=[])
+        self.assertEqual([action["id"] for action in plan["next_actions"]],
+                         ["measure-storage", "measure-residency"])
+        self.assertEqual(plan["next_actions"][0]["priority"], "required")
+        text = format_plan(plan)
+        self.assertIn("next actions:", text)
+        self.assertIn("coli tune --model <model>", text)
+
+    def test_trusted_storage_probe_removes_probe_action(self):
+        info = analyze_model(self.model)
+        info.update(expert_bytes=40 * GB, typical_expert_bytes=1 * GB,
+                    max_expert_bytes=1 * GB, per_cap_bytes=2 * GB)
+        with mock.patch("resource_plan.ssd_probe_state",
+                        return_value=("trusted", 7.5)), \
+             mock.patch("resource_plan.analyze_model", return_value=info):
+            plan = build_plan(self.model, ram_gb=4, available_memory=4 * GB,
+                              available_disk=1, gpus=[])
+        self.assertEqual([action["id"] for action in plan["next_actions"]],
+                         ["measure-residency"])
+
+    def test_resident_plan_recommends_kernel_measurement(self):
+        plan = build_plan(self.model, ram_gb=64, available_memory=64 * GB,
+                          available_disk=1, gpus=[])
+        self.assertEqual(plan["bottleneck_class"], "compute")
+        self.assertEqual(plan["next_actions"][0]["id"], "measure-kernels")
+
 
 class PhysicalCpuCountTest(unittest.TestCase):
     """Regression for #325: --auto-tier pinned decode to one core because

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -40,6 +40,12 @@ tiers, the reason for each placement, and the expected bottleneck. The default
 and router decisions unless `--topk` or `--topp` is passed; those explicit lossy
 overrides print a warning and proceed.
 
+The plan also emits a machine-readable `next_actions` list and renders it in
+the terminal. A missing storage measurement is marked `required`; subsequent
+profiling and tuning work is `recommended`. These actions produce the evidence
+needed to improve a plan on this machine—they do not silently enable an
+unmeasured optimization.
+
 Auto-tier plans size OpenMP from physical cores and bind workers across cores.
 Memory-bound quantized kernels can regress sharply when SMT siblings compete for
 limited memory channels. The GLM, Kimi K3, and OLMoE engines also apply that


### PR DESCRIPTION
让资源规划器根据实际瓶颈输出机器可读的 next_actions，并在终端给出有优先级的测量或调优命令。磁盘带宽未知时只要求先采证，不会静默启用未经测量的优化。