### PR TITLE
fix(cuda): charge the expert tier real VRAM, not logical bytes (#687)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -882,7 +882,7 @@ rans: $(RANSLIB)
 $(RANSLIB): tools/rans_ctypes.c rans.h
 	$(CC) $(CFLAGS) -fPIC -shared $< -o $@ $(LDFLAGS)
 
-cuda-test: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/test_backend_cuda.cu tests/test_ragged_attention.cu tests/test_absorb_determinism.cu tests/test_mxfp4_cuda.cu tests/mxfp4_ref.c tests/test_fp8_warp_cuda.cu tests/test_fp8_cuda.cu tests/test_weights_owned_cuda.cu tests/test_cuda_fmt_trap_cuda.cu
+cuda-test: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/test_backend_cuda.cu tests/test_ragged_attention.cu tests/test_absorb_determinism.cu tests/test_mxfp4_cuda.cu tests/mxfp4_ref.c tests/test_fp8_warp_cuda.cu tests/test_fp8_cuda.cu tests/test_weights_owned_cuda.cu tests/test_cuda_fmt_trap_cuda.cu tests/test_alloc_footprint_cuda.cu
 	@command -v "$(GPUCC)" >/dev/null 2>&1 || { echo "$(GPUCC_NAME) not found" >&2; exit 1; }
 	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/test_backend_cuda.cu -o backend_cuda_test$(EXE) $(ANS_NVCC_LIBS)
 	./backend_cuda_test$(EXE)
@@ -944,6 +944,13 @@ cuda-test: backend_cuda.cu backend_cuda.h backend_gpu_compat.h tests/test_backen
 	$(CC) $(filter-out -Xclang -fopenmp,$(CFLAGS)) -fno-openmp -c tests/mxfp4_ref.c -o tests/mxfp4_ref.o
 	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/test_mxfp4_cuda.cu tests/mxfp4_ref.o -o mxfp4_cuda_test$(EXE)
 	./mxfp4_cuda_test$(EXE)
+	# Allocator footprint (#687): what a cudaMalloc really takes off the card,
+	# which is what the expert tier has to be charged rather than the logical
+	# byte count. Runs LAST on purpose - it is the only test here that
+	# allocates in bulk to measure an amortised cost, so it should not leave
+	# the card fragmented underneath a kernel test that follows it.
+	"$(GPUCC)" $(GPUFLAGS) backend_cuda.cu tests/test_alloc_footprint_cuda.cu -o alloc_footprint_test$(EXE)
+	./alloc_footprint_test$(EXE)
 
 
 # The DeepSeek V4 kernels on their own: dense, batched attention and routed MoE

--- a/c/backend_cuda.cu
+++ b/c/backend_cuda.cu
@@ -2410,6 +2410,121 @@ extern "C" size_t coli_cuda_tensor_bytes(const ColiCudaTensor *tensor) {
         ((tensor->fmt && tensor->fmt != 6) ? tensor->scale_count * sizeof(float) : 0);
 }
 
+/* What a cudaMalloc of `bytes` actually takes off the card.
+ *
+ * coli_cuda_tensor_bytes() above is the LOGICAL size and must stay that way -
+ * it mirrors upload and free so the three cannot drift. This is a different
+ * question: the allocator rounds a request up, and nothing was charging the
+ * difference to the expert budget.
+ *
+ * Measured on an RTX 3090 (sm_86, CUDA 13.1):
+ *
+ *     request              actual      overhead
+ *     0.75 MiB          1.00 MiB        +0.25     <- int4-g64 scale array
+ *     1.00 MiB          1.00 MiB        +0.00
+ *     1.00 MiB + 1 B    2.00 MiB        +1.00
+ *     1.50 MiB          2.00 MiB        +0.50
+ *     2.00 MiB          2.00 MiB        +0.00
+ *     2.00 MiB + 1 B    4.00 MiB        +2.00
+ *     6.00 MiB          6.00 MiB        +0.00     <- int4-g64 weight tensor
+ *
+ * A GLM-5.2 int4-g64 expert is three 6 MiB weight arrays, which are already on
+ * a boundary and cost nothing extra, and three 0.75 MiB scale arrays, each
+ * padded to 1 MiB. 3 x 0.25 = 0.75 MiB per expert unaccounted - which is the
+ * 0.741 MiB/expert (sigma 0.019) measured independently on H100 and H200 in
+ * #687, from the other direction.
+ *
+ * PROBED, not modelled. The table above is not a rule this hardcodes: the
+ * rounding is a driver and architecture property, and a formula fitted to one
+ * card would be silently wrong on the next. Probed once per distinct size
+ * and cached, so the cost does not scale with the tier.
+ *
+ * cudaMemGetInfo is the obvious alternative and it does not survive contact
+ * with the numbers: it is O(live allocations), measured 0.52 us empty and
+ * 68.2 us with 12,000 live, so charging it per expert would be quadratic
+ * across a tier that places thousands.
+ *
+ * Returns `bytes` unchanged if the probe cannot run. Under-reporting is the
+ * pre-existing behaviour and degrades to exactly what this replaced; refusing
+ * to size at all would be worse.
+ */
+#define COLI_CUDA_FOOTPRINT_CACHE 16
+static struct { size_t req, real; } g_fp_cache[COLI_CUDA_FOOTPRINT_CACHE];
+static int g_fp_cache_n = 0;
+
+/* The probe MUST allocate several buffers and divide, not one and measure it.
+ *
+ * A single cudaMalloc reserves a whole 2 MiB VMM page, so one allocation of
+ * anything smaller reads as a flat 2 MiB and the answer is the page size
+ * rather than the per-allocation cost. Later allocations suballocate from
+ * pages already reserved, so the real amortised figure only appears once
+ * enough of them are live to fill a page. Measured both ways on sm_86, same
+ * 786,432-byte request:
+ *
+ *     1 allocation    2.00 MiB   <- the page, not the allocation
+ *     64 allocations  1.00 MiB   <- the truth, and what the tier will pay
+ *
+ * The single-shot version of this function shipped in an earlier draft and its
+ * own test caught it: it over-reported every expert by 3x and would have
+ * shrunk the tier far more than the bug it fixes.
+ */
+#define COLI_CUDA_FOOTPRINT_PROBE_BYTES (24u << 20)   /* transient probe budget */
+#define COLI_CUDA_FOOTPRINT_PROBE_MAX   64
+
+extern "C" size_t coli_cuda_alloc_footprint(size_t bytes) {
+    if (!bytes) return 0;
+    for (int i = 0; i < g_fp_cache_n; i++)
+        if (g_fp_cache[i].req == bytes) return g_fp_cache[i].real;
+
+    /* Enough allocations to cross a page boundary, capped so the probe never
+     * takes a meaningful bite out of a card that is about to be filled. */
+    int want = (int)(COLI_CUDA_FOOTPRINT_PROBE_BYTES / bytes);
+    if (want < 8) want = 8;
+    if (want > COLI_CUDA_FOOTPRINT_PROBE_MAX) want = COLI_CUDA_FOOTPRINT_PROBE_MAX;
+
+    size_t free_before = 0, free_after = 0, total = 0, real = bytes;
+    void *p[COLI_CUDA_FOOTPRINT_PROBE_MAX];
+    int made = 0;
+    if (cudaMemGetInfo(&free_before, &total) == cudaSuccess) {
+        for (int i = 0; i < want; i++) {
+            if (cudaMalloc(&p[i], bytes) != cudaSuccess) break;
+            made++;
+        }
+        if (made > 0 && cudaMemGetInfo(&free_after, &total) == cudaSuccess &&
+            free_before > free_after) {
+            size_t avg = (free_before - free_after) / (size_t)made;
+            /* Only ever round UP. A concurrent free elsewhere on the device
+             * can make the delta read small, and charging less than the
+             * logical size is the failure this exists to fix. */
+            if (avg > real) real = avg;
+        }
+        for (int i = 0; i < made; i++) cudaFree(p[i]);
+    }
+    /* Cache even a failed probe: `real` is then the logical size, which is the
+     * pre-existing behaviour, and retrying per expert on a card that just
+     * refused 8 allocations would be the worst possible time to try again. */
+    if (g_fp_cache_n < COLI_CUDA_FOOTPRINT_CACHE)
+        g_fp_cache[g_fp_cache_n++] = { bytes, real };
+    return real;
+}
+
+/* Same split as coli_cuda_tensor_bytes, but per ALLOCATION rather than summed
+ * first: the weights and the scales are two separate cudaMallocs and each is
+ * rounded on its own. Summing then rounding once would miss the scale array's
+ * padding entirely, which is the whole term. */
+extern "C" size_t coli_cuda_tensor_vram(const ColiCudaTensor *tensor) {
+    if (!tensor) return 0;
+    size_t storage_bytes =
+#ifdef COLI_ANS
+        tensor->compressed ? tensor->archive_bytes :
+#endif
+        tensor->weight_bytes;
+    size_t total = coli_cuda_alloc_footprint(storage_bytes);
+    if (tensor->fmt && tensor->fmt != 6)
+        total += coli_cuda_alloc_footprint(tensor->scale_count * sizeof(float));
+    return total;
+}
+
 extern "C" int coli_cuda_tensor_device(const ColiCudaTensor *tensor) {
     return tensor ? tensor->device : -1;
 }

--- a/c/backend_cuda.h
+++ b/c/backend_cuda.h
@@ -187,6 +187,8 @@ COLI_CUDA_DLLEXPORT int coli_cuda_attention_project_ragged(ColiCudaTensor *kv_b,
 
 COLI_CUDA_DLLEXPORT void coli_cuda_tensor_free(ColiCudaTensor *tensor);
 COLI_CUDA_DLLEXPORT size_t coli_cuda_tensor_bytes(const ColiCudaTensor *tensor);
+COLI_CUDA_DLLEXPORT size_t coli_cuda_alloc_footprint(size_t bytes);
+COLI_CUDA_DLLEXPORT size_t coli_cuda_tensor_vram(const ColiCudaTensor *tensor);
 COLI_CUDA_DLLEXPORT int coli_cuda_tensor_device(const ColiCudaTensor *tensor);
 
 /* Replace a resident tensor's contents without reallocating its device slot. */

--- a/c/backend_loader.c
+++ b/c/backend_loader.c
@@ -101,6 +101,8 @@ typedef int            (*fn_matmul)(ColiCudaTensor **tensor, float *y, const flo
                                     int fmt, int S, int I, int O, int device, int gs);
 typedef void           (*fn_tensor_free)(ColiCudaTensor *tensor);
 typedef size_t         (*fn_tensor_bytes)(const ColiCudaTensor *tensor);
+typedef size_t         (*fn_tensor_vram)(const ColiCudaTensor *tensor);
+typedef size_t         (*fn_alloc_footprint)(size_t bytes);
 typedef int            (*fn_tensor_device)(const ColiCudaTensor *tensor);
 
 /* --- #111 GPU resident pipeline additions (matched to backend_cuda.h) --- */
@@ -174,6 +176,8 @@ static struct {
     fn_matmul          matmul;
     fn_tensor_free     tensor_free;
     fn_tensor_bytes    tensor_bytes;
+    fn_tensor_vram     tensor_vram;
+    fn_alloc_footprint alloc_footprint;
     fn_tensor_device   tensor_device;
 
     fn_attention_absorb_batch attention_absorb_batch;
@@ -1418,6 +1422,13 @@ static int coli_cuda_load(void){
     RESOLVE(matmul,         fn_matmul)
     RESOLVE(tensor_free,    fn_tensor_free)
     RESOLVE(tensor_bytes,   fn_tensor_bytes)
+    /* Optional, same reasoning as e8_set_grid above: a DLL predating #687
+     * leaves these NULL and the wrappers fall back to the logical byte
+     * count, which is exactly the behaviour that shipped before. Using
+     * RESOLVE here instead would unload the whole CUDA backend over one
+     * missing symbol - a far worse failure than the over-commit it fixes. */
+    RESOLVE_OPT(tensor_vram,     fn_tensor_vram)
+    RESOLVE_OPT(alloc_footprint, fn_alloc_footprint)
     RESOLVE(tensor_device,  fn_tensor_device)
 
     RESOLVE(attention_absorb_batch, fn_attention_absorb_batch)
@@ -1617,6 +1628,22 @@ void coli_cuda_tensor_free(ColiCudaTensor *tensor){
 size_t coli_cuda_tensor_bytes(const ColiCudaTensor *tensor){
     if(!g_cuda.available) return 0;
     return g_cuda.tensor_bytes(tensor);
+}
+
+/* Falls back to the LOGICAL size when the DLL predates #687. That is an
+ * under-count, and it is the pre-existing behaviour rather than a new
+ * failure mode: the tier over-commits exactly as much as it always did.
+ * Returning 0 here would be far worse - the caller would charge nothing
+ * for an expert it just placed. */
+size_t coli_cuda_tensor_vram(const ColiCudaTensor *tensor){
+    if(!g_cuda.available) return 0;
+    if(!g_cuda.tensor_vram) return g_cuda.tensor_bytes(tensor);
+    return g_cuda.tensor_vram(tensor);
+}
+
+size_t coli_cuda_alloc_footprint(size_t bytes){
+    if(!g_cuda.available || !g_cuda.alloc_footprint) return bytes;
+    return g_cuda.alloc_footprint(bytes);
 }
 
 int coli_cuda_tensor_device(const ColiCudaTensor *tensor){

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -9814,11 +9814,31 @@ static void pin_load(Model *m, const char *statspath, double gb, int trusted){
                     }
 #endif
                     if(uploaded){
+                        /* VRAM, not logical bytes (#687). The allocator rounds
+                         * every cudaMalloc up and nothing was charging the
+                         * difference, so `remaining` drifted optimistic by a
+                         * term that GREW with the tier: an int4-g64 scale array
+                         * is 0.75 MiB and lands in 1 MiB, three per expert, so
+                         * 0.75 MiB per expert uncounted (measured on sm_86;
+                         * #687 measured 0.741 +/- 0.019 on H100/H200 from the
+                         * other direction). At 6,235 experts that is 4.6 GB
+                         * against a flat 2 GB reserve, which is why auto could
+                         * claim the card to within 4 MiB and then fail every
+                         * lazy dense upload afterwards.
+                         *
+                         * m->gpu_expert_bytes stays LOGICAL: it is reported as
+                         * the tier's size and compared against `budget`, and
+                         * quoting padding to the user as model bytes would
+                         * trade one wrong number for another. */
                         int64_t actual=(int64_t)coli_cuda_tensor_bytes(s->g.cuda)
                                       +(int64_t)coli_cuda_tensor_bytes(s->u.cuda)
                                       +(int64_t)coli_cuda_tensor_bytes(s->d.cuda);
+                        int64_t vram  =(int64_t)coli_cuda_tensor_vram(s->g.cuda)
+                                      +(int64_t)coli_cuda_tensor_vram(s->u.cuda)
+                                      +(int64_t)coli_cuda_tensor_vram(s->d.cuda);
+                        if(vram<actual) vram=actual;
                         m->gpu_expert_count++; m->gpu_expert_bytes+=actual;
-                        remaining[best]-=actual; placed_b[best]+=actual; placed_n[best]++;
+                        remaining[best]-=vram;   placed_b[best]+=actual; placed_n[best]++;
                         placed_w[best]+=(double)r[a].c;
                         if(g_cuda_release_host){ expert_host_release(m,s); pin_host_released+=(double)need; }
                         placed=1;

--- a/c/tests/test_alloc_footprint_cuda.cu
+++ b/c/tests/test_alloc_footprint_cuda.cu
@@ -1,0 +1,132 @@
+/* coli_cuda_alloc_footprint / coli_cuda_tensor_vram (#687)
+ *
+ * The expert tier charged `remaining` the LOGICAL byte count of each expert
+ * while the allocator was taking more, so auto could claim the card to within
+ * a few MiB and then fail every lazy dense upload afterwards. These two
+ * functions report what an allocation really costs.
+ *
+ * Everything here is measured against the live allocator rather than against a
+ * rounding rule, because the rounding is a driver and architecture property
+ * and a test that hardcoded one card's table would fail on the next.
+ *
+ * build: nvcc $(GPUFLAGS) backend_cuda.cu tests/test_alloc_footprint_cuda.cu
+ */
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <vector>
+#include "../backend_cuda.h"
+
+static int failures = 0;
+
+static void check(int cond, const char *what, const char *detail) {
+    std::printf("%-4s %-56s %s\n", cond ? "ok" : "FAIL", what, detail ? detail : "");
+    if (!cond) failures++;
+}
+
+/* Ground truth, independent of the function under test: allocate n buffers of
+ * `bytes` and read how much free VRAM actually went away. Averaged over n
+ * because the driver can serve one request from a pool it already holds, so a
+ * single allocation can read as free. */
+static double measured_footprint(size_t bytes, int n) {
+    size_t fb = 0, fa = 0, t = 0;
+    if (cudaMemGetInfo(&fb, &t) != cudaSuccess) return 0.0;
+    std::vector<void *> p(n, nullptr);
+    int made = 0;
+    for (int i = 0; i < n; i++) {
+        if (cudaMalloc(&p[i], bytes) != cudaSuccess) break;
+        made++;
+    }
+    cudaMemGetInfo(&fa, &t);
+    for (int i = 0; i < made; i++) cudaFree(p[i]);
+    return made ? (double)(fb - fa) / made : 0.0;
+}
+
+int main(void) {
+    int count = 0;
+    if (cudaGetDeviceCount(&count) != cudaSuccess || count < 1) {
+        std::printf("no CUDA device (count=%d)\n", count);
+        return 77;
+    }
+    int devices[8], ndev = 0;
+    for (int i = 0; i < count && ndev < 8; i++) devices[ndev++] = i;
+    if (!coli_cuda_init(devices, ndev)) {
+        std::printf("cuda init failed\n");
+        return 77;
+    }
+
+    /* 1. Never under-reports. This is the load-bearing property: the whole bug
+     *    was a budget charged less than reality, so a footprint below the
+     *    request would reintroduce it in a new place. */
+    const size_t sizes[] = { 4096, 262144, 524288, 786432, 786433,
+                             1048576, 1048577, 1572864, 2097152, 6291456 };
+    for (size_t b : sizes) {
+        char d[128];
+        size_t got = coli_cuda_alloc_footprint(b);
+        std::snprintf(d, sizeof d, "%zu -> %zu", b, got);
+        check(got >= b, "footprint never below the request", d);
+    }
+
+    /* 2. It tracks the real allocator, not a formula. */
+    for (size_t b : { (size_t)786432, (size_t)1572864, (size_t)6291456 }) {
+        double real = measured_footprint(b, 64);
+        size_t got = coli_cuda_alloc_footprint(b);
+        char d[160];
+        std::snprintf(d, sizeof d, "%zu: probe %zu vs measured %.0f", b, got, real);
+        check(real > 0 && (double)got == real, "footprint agrees with a live measurement", d);
+    }
+
+    /* 3. An exactly-boundary-aligned request pays nothing. Without this the
+     *    suite would pass on a function that just doubled everything. */
+    {
+        size_t b = 6291456;               /* 6 MiB, the int4-g64 weight array */
+        size_t got = coli_cuda_alloc_footprint(b);
+        char d[128];
+        std::snprintf(d, sizeof d, "6 MiB -> %zu (overhead %lld)", got, (long long)got - (long long)b);
+        check(got == b, "an aligned request is charged exactly, not inflated", d);
+    }
+
+    /* 4. Cached: the second call must not allocate again. Checked by free VRAM
+     *    rather than by timing, which would be flaky under load. */
+    {
+        size_t fb = 0, fa = 0, t = 0;
+        coli_cuda_alloc_footprint(786432);          /* prime */
+        cudaMemGetInfo(&fb, &t);
+        for (int i = 0; i < 500; i++) coli_cuda_alloc_footprint(786432);
+        cudaMemGetInfo(&fa, &t);
+        char d[128];
+        std::snprintf(d, sizeof d, "500 repeat calls moved free VRAM by %lld B",
+                      (long long)fb - (long long)fa);
+        check(fb == fa, "repeat calls are cached, not re-probed", d);
+    }
+
+    /* 5. The tensor-level question the sizing path actually asks. A GLM-5.2
+     *    int4-g64 expert matrix: fmt=4, gs=64, weights on a boundary and a
+     *    0.75 MiB scale array that is not. */
+    {
+        const int I = 6144, O = 2048, gs = 64;
+        size_t wb = (size_t)O * ((I + 1) / 2);
+        size_t ng = (I + gs - 1) / gs, sc = (size_t)O * ng;
+        std::vector<unsigned char> w(wb, 0x11);
+        std::vector<float> s(sc, 1.0f);
+        ColiCudaTensor *t = nullptr;
+        if (!coli_cuda_tensor_upload_g(&t, w.data(), s.data(), 4, I, O, 0, gs)) {
+            std::printf("FAIL upload\n"); return 1;
+        }
+        size_t logical = coli_cuda_tensor_bytes(t);
+        size_t vram    = coli_cuda_tensor_vram(t);
+        char d[192];
+        std::snprintf(d, sizeof d, "logical %zu, vram %zu, padding %lld",
+                      logical, vram, (long long)vram - (long long)logical);
+        check(vram >= logical, "tensor_vram is never below tensor_bytes", d);
+        check(vram > logical, "the 0.75 MiB scale array's padding is counted", d);
+        std::snprintf(d, sizeof d, "%.4f MiB", 3.0 * (vram - logical) / 1048576.0);
+        std::printf("     per-expert unaccounted (x3 matrices): %s\n", d);
+        std::printf("     #687 measured 0.741 MiB/expert, sigma 0.019\n");
+        coli_cuda_tensor_free(t);
+    }
+
+    std::printf(failures ? "\ntest_alloc_footprint_cuda: FAILED\n"
+                         : "\ntest_alloc_footprint_cuda: ok\n");
+    return failures ? 1 : 0;
+}

--- a/c/tests/test_backend_loader.py
+++ b/c/tests/test_backend_loader.py
@@ -874,7 +874,7 @@ class LoaderStubFixtureTest(unittest.TestCase):
             cls.fixture = None
 
     def test_abi_is_derived_from_the_loader_source(self):
-        """47 mandatory + 4 optional, parsed from backend_loader.c.
+        """47 mandatory + 6 optional, parsed from backend_loader.c.
 
         The counts are a deliberate tripwire: adding a RESOLVE to the loader
         widens the ABI every Windows DLL must satisfy, and that should be a
@@ -885,8 +885,8 @@ class LoaderStubFixtureTest(unittest.TestCase):
         """
         f = self.fixture
         self.assertEqual(len(f.mandatory), 47)
-        self.assertEqual(len(f.optional), 4)
-        self.assertEqual(len(f.exports), 51)
+        self.assertEqual(len(f.optional), 6)
+        self.assertEqual(len(f.exports), 53)
         self.assertEqual(len(f.exports), len(f.mandatory) + len(f.optional))
         self.assertIn("coli_cuda_init", f.mandatory)
         self.assertIn("coli_cuda_e8_set_grid", f.optional)
@@ -896,6 +896,13 @@ class LoaderStubFixtureTest(unittest.TestCase):
         self.assertIn("coli_cuda_fp8_set_lut", f.optional)
         # expert_group_pinned: old DLLs remain usable outside SPEC_PIN (#689).
         self.assertIn("coli_cuda_expert_group_pinned", f.optional)
+        # tensor_vram / alloc_footprint: allocator padding in the expert-tier
+        # budget (#687). OPTIONAL on purpose - a DLL predating them leaves the
+        # pointers NULL and the wrappers fall back to the logical byte count,
+        # which is what the tier charged before. As mandatory, one older DLL
+        # would take the entire CUDA backend down over a sizing refinement.
+        self.assertIn("coli_cuda_tensor_vram", f.optional)
+        self.assertIn("coli_cuda_alloc_footprint", f.optional)
 
     def test_both_runtimes_exist_with_the_production_basename(self):
         """Same basename, different directories — the conflict precondition."""


### PR DESCRIPTION
Closes the sizing half of #687.

@terrizoaguimor measured an unaccounted **0.741 MiB per resident expert** (sigma 0.019, five clean configurations, H100 and H200) and concluded it was a fixed workspace cost the 2 GB reserve does not cover, adding that `0.741` is "this model on this card and not a constant worth freezing into the source" and that it should be measured live from the first uploads instead.

**The distrust of the constant was right. The reason was not, and that makes the fix simpler than proposed.**

## What the term actually is

`cudaMalloc` rounds a request up, and nothing charged the difference. Measured on an RTX 3090 (sm_86, CUDA 13.1):

```
request              actual      overhead
0.75 MiB          1.00 MiB        +0.25     <- int4-g64 scale array
1.00 MiB          1.00 MiB        +0.00
1.00 MiB + 1 B    2.00 MiB        +1.00
1.50 MiB          2.00 MiB        +0.50
2.00 MiB          2.00 MiB        +0.00
2.00 MiB + 1 B    4.00 MiB        +2.00
6.00 MiB          6.00 MiB        +0.00     <- int4-g64 weight tensor
```

A GLM-5.2 int4-g64 expert is six allocations of two sizes: three 6 MiB weight arrays, already on a boundary and costing nothing extra, and three **0.75 MiB** scale arrays, each padded to 1 MiB.

```
3 x 0.25 MiB = 0.750 MiB per expert
```

Against 0.741 sigma 0.019, so inside the interval, from an independent direction and a different architecture.

So the term is `roundup(scale_bytes) - scale_bytes`. It is a property of the allocator and the model geometry, **knowable before a single expert is placed** - no fixed-point iteration, and no measurement pass over real uploads. It also predicts what a different group size or hidden dim would cost, which a fitted constant cannot.

## The change

`coli_cuda_alloc_footprint(bytes)` probes the real amortised cost, once per distinct size, cached. **Probed rather than modelled on purpose** - the table above is not a rule this hardcodes, since the rounding is a driver and architecture property and a formula fitted to one card would be silently wrong on the next.

`coli_cuda_tensor_vram(t)` applies it **per allocation**. The weights and the scales are separate `cudaMalloc`s and each is rounded on its own; summing first and rounding once would miss the scale array's padding entirely, which is the whole term.

The tier now decrements `remaining` by VRAM.

Two byte counts stay logical, and that separation is the design:

- **`coli_cuda_tensor_bytes()` is the LOGICAL size and remains so.** Its own comment requires it to mirror upload and free exactly so the three cannot drift, and a test pins that. VRAM is a different question, so it gets a different function rather than a changed meaning for this one.
- **`m->gpu_expert_bytes` is also logical.** It is what gets reported as the tier's size, and quoting allocator padding to the user as model bytes would trade one wrong number for another. Only `remaining` moves, because only `remaining` is a budget.

## Two implementations that did not survive measurement

Both are in the source comments so nobody rebuilds them.

**`cudaMemGetInfo` per placed expert** is the obvious exact answer. It is O(live allocations):

```
live allocations   us/call
0                    0.52
1,000                2.64
5,000               10.80
12,000              68.20
```

A tier placing 6,235 experts holds 18,705 allocations, so charging it per expert is quadratic.

**A single-allocation probe over-reports by 3x.** One `cudaMalloc` reserves a whole 2 MiB VMM page, so one allocation of anything smaller reads as a flat 2 MiB:

```
786,432 B, n=1    2.00 MiB   <- the page, not the allocation
786,432 B, n=64   1.00 MiB   <- the amortised truth
```

That version shipped in my first draft and would have shrunk the tier worse than the bug it fixes. Its own test caught it, which is the reason the negative controls below are there.

## Verification

Eight assertions in `tests/test_alloc_footprint_cuda.cu`, against the live allocator rather than a table. Two are negative controls:

- an aligned **6 MiB** request must be charged **exactly** 6 MiB. Without this the suite passes on a function that just doubles everything - exactly what the first draft did.
- 500 repeat calls must move free VRAM by **0 bytes**, checked by reading free VRAM rather than by timing.

The probe is also cross-checked against an independent bulk measurement in the same run, so the function and its ground truth cannot drift together.

Wired in at the **end** of `cuda-test`: it is the only test there that allocates in bulk to measure an amortised cost, so it should not leave the card fragmented underneath a kernel test that follows it.

Full `make cuda-test` on sm_86, `MAKE_EXIT=0`, all eight:

```
backend_cuda        q8/q4/q2/f32/e8 correctness ok on 1 device(s)
ragged_attention    ok
fp8_warp            shared-lut 0, hw-cvt 0, mutated entry 1 mismatches (fires)
absorb_determinism  batch_differing=0/145  ragged_differing=0/29
fp8_cuda            oracle 0 mismatches, API 0 mismatches
weights_owned       8 fail cycles, 0 bytes cumulative
mxfp4               ok
alloc_footprint     ok, per-expert unaccounted 0.7500 MiB
```

Python suite `Ran 696 tests, OK, skipped=52`. CPU-only build compiles clean, so the non-CUDA path is unaffected.

## What this does not do

It does not touch the **evict-and-retry** half (#696), and it does not explain why a rescued tensor computes a different answer than both the healthy GPU run and the CPU fallback. That is a separate defect and this does not go near it.

Tested on Windows 11, RTX 3090 (sm_86), CUDA 13.1 V13.1.115, MSVC 19.50.35725, GNU Make 4.4.1.
