### PR TITLE
feat: add universal model edge runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ Two things that differ per model, both documented in the per-model page:
 | Apple Silicon Metal backend | [docs/metal.md](docs/metal.md) |
 | OpenAI-compatible API, KV slots, web dashboard | [docs/api.md](docs/api.md) |
 | Experimental layer-segment embedding ABI | [docs/segment-runtime.md](docs/segment-runtime.md) |
+| Experimental tokenizer/embedding/head Edge ABI | [docs/edge-runtime.md](docs/edge-runtime.md) |
 | Grammar-forced drafts (structured output) | [docs/grammar-draft.md](docs/grammar-draft.md) |
 | Environment variable inventory | [docs/ENVIRONMENT.md](docs/ENVIRONMENT.md) |
 

--- a/c/Makefile
+++ b/c/Makefile
@@ -1293,7 +1293,7 @@ include Makefile.deepseek-v4.units
 # is advertised only after an adapter has a real backend implementation.
 SEGMENT_BUILD_DIR = build/segment
 SEGMENT_CPU_CFLAGS = $(filter-out -DCOLI_CUDA -DCOLI_ANS -DCOLI_METAL \
-	-DCOLI_VULKAN,$(CFLAGS)) -D_GNU_SOURCE -include pthread.h \
+	-DCOLI_VULKAN,$(CFLAGS)) -include pthread.h \
 	-DCOLI_SEGMENT_ADAPTER -DCOLI_EDGE_ADAPTER
 SEGMENT_ENGINE_OBJS = \
 	$(SEGMENT_BUILD_DIR)/glm.o \
@@ -1307,6 +1307,10 @@ SEGMENT_V4_OBJS = $(addprefix $(SEGMENT_BUILD_DIR)/,$(addsuffix .o,$(SEGMENT_V4_
 SEGMENT_V4_REGISTRY_OBJ = $(SEGMENT_BUILD_DIR)/expert_store_registry.o
 SEGMENT_ALL_OBJS = $(SEGMENT_ENGINE_OBJS) $(SEGMENT_V4_OBJS) \
 	$(SEGMENT_V4_REGISTRY_OBJ)
+SEGMENT_RUNTIME_OBJS = \
+	$(SEGMENT_BUILD_DIR)/segment_runtime.o \
+	$(SEGMENT_BUILD_DIR)/edge_runtime.o
+SEGMENT_RUNTIME_LIB = $(SEGMENT_BUILD_DIR)/libcolibri_segment_edge.a
 
 $(SEGMENT_BUILD_DIR):
 	mkdir -p $@
@@ -1345,6 +1349,18 @@ $(SEGMENT_V4_OBJS): $(SEGMENT_BUILD_DIR)/%.o: deepseek_v4.c deepseek_v4.h \
 $(SEGMENT_V4_REGISTRY_OBJ): expert_store_registry.c expert_store_registry.h \
 		expert_store.h | $(SEGMENT_BUILD_DIR)
 	$(CC) $(SEGMENT_CPU_CFLAGS) -c expert_store_registry.c -o $@
+
+$(SEGMENT_BUILD_DIR)/segment_runtime.o: segment_runtime.c segment_runtime.h | $(SEGMENT_BUILD_DIR)
+	$(CC) $(SEGMENT_CPU_CFLAGS) -c segment_runtime.c -o $@
+
+$(SEGMENT_BUILD_DIR)/edge_runtime.o: edge_runtime.c edge_runtime.h | $(SEGMENT_BUILD_DIR)
+	$(CC) $(SEGMENT_CPU_CFLAGS) -c edge_runtime.c -o $@
+
+$(SEGMENT_RUNTIME_LIB): $(SEGMENT_RUNTIME_OBJS) $(SEGMENT_ALL_OBJS)
+	$(AR) rcs $@ $^
+
+.PHONY: segment-edge-library
+segment-edge-library: $(SEGMENT_RUNTIME_LIB)
 
 tests/test_segment_adapters_registration$(EXE): \
 		tests/test_segment_adapters_registration.c segment_runtime.c \

--- a/c/Makefile
+++ b/c/Makefile
@@ -449,7 +449,8 @@ TEST_RULES  := $(shell sed -n 's|^tests/\(test_[a-z0-9_]*\)\$$(EXE):.*|\1|p' $(f
 # x86-64 Linux/Windows and aarch64 Linux hosts; the V4 infrastructure tests have
 # unconditional rules and therefore remain portable gates.
 TEST_EXCLUDE = test_uring test_deepseek_v4 test_v4_ownership test_v4_serve_framing \
-	test_segment_adapters_registration test_segment_adapters_real
+	test_segment_adapters_registration test_segment_adapters_real \
+	test_edge_adapters_registration test_edge_adapters_real
 TEST_BINS    = $(addprefix tests/,$(addsuffix $(EXE),$(filter-out $(TEST_EXCLUDE),$(TEST_RULES))))
 ifneq (,$(LINUX))
 TEST_BINS += tests/test_uring$(EXE)
@@ -458,7 +459,8 @@ ifeq ($(COLI_V4_SUPPORTED),1)
 TEST_BINS += tests/test_v4_hybrid_policy$(EXE) tests/test_k3_fill_budget$(EXE) tests/test_v4_bank_pair$(EXE)
 TEST_BINS += tests/test_deepseek_v4$(EXE) tests/test_v4_ownership$(EXE) \
 	tests/test_v4_serve_framing$(EXE) \
-	tests/test_segment_adapters_registration$(EXE)
+	tests/test_segment_adapters_registration$(EXE) \
+	tests/test_edge_adapters_registration$(EXE)
 endif
 
 # Windows CUDA/HIP DLL path: host links the loader, NOT cudart or amdhip64.
@@ -1280,6 +1282,9 @@ tests/test_expert_store_ops$(EXE): tests/test_expert_store_ops.c expert_store.h 
 tests/test_native_quant$(EXE): tests/test_native_quant.c deepseek_v4.c native_quant.h tensor.h quant.h
 	$(CC) $(CFLAGS) -DCOLI_V4_UNIT_NATIVE_QUANT deepseek_v4.c $< -o $@ $(LDFLAGS)
 
+tests/test_edge_runtime$(EXE): tests/test_edge_runtime.c edge_runtime.c edge_runtime.h
+	$(CC) $(CFLAGS) tests/test_edge_runtime.c edge_runtime.c -o $@ $(LDFLAGS)
+
 ifeq ($(COLI_V4_SUPPORTED),1)
 include Makefile.deepseek-v4.units
 
@@ -1289,7 +1294,7 @@ include Makefile.deepseek-v4.units
 SEGMENT_BUILD_DIR = build/segment
 SEGMENT_CPU_CFLAGS = $(filter-out -DCOLI_CUDA -DCOLI_ANS -DCOLI_METAL \
 	-DCOLI_VULKAN,$(CFLAGS)) -D_GNU_SOURCE -include pthread.h \
-	-DCOLI_SEGMENT_ADAPTER
+	-DCOLI_SEGMENT_ADAPTER -DCOLI_EDGE_ADAPTER
 SEGMENT_ENGINE_OBJS = \
 	$(SEGMENT_BUILD_DIR)/glm.o \
 	$(SEGMENT_BUILD_DIR)/inkling.o \
@@ -1306,29 +1311,35 @@ SEGMENT_ALL_OBJS = $(SEGMENT_ENGINE_OBJS) $(SEGMENT_V4_OBJS) \
 $(SEGMENT_BUILD_DIR):
 	mkdir -p $@
 
-$(SEGMENT_BUILD_DIR)/glm.o: colibri.c segment_runtime.h \
-		segment_adapters.h segment_adapter_internal.h st.h | $(SEGMENT_BUILD_DIR)
+$(SEGMENT_BUILD_DIR)/glm.o: colibri.c segment_runtime.h edge_runtime.h \
+		segment_adapters.h edge_adapters.h segment_adapter_internal.h \
+		edge_adapter_internal.h edge_tok_internal.h st.h | $(SEGMENT_BUILD_DIR)
 	$(CC) $(SEGMENT_CPU_CFLAGS) -DCOLIBRI_NO_MAIN -c colibri.c -o $@
 
-$(SEGMENT_BUILD_DIR)/inkling.o: inkling.c segment_runtime.h \
-		segment_adapters.h segment_adapter_internal.h st.h | $(SEGMENT_BUILD_DIR)
+$(SEGMENT_BUILD_DIR)/inkling.o: inkling.c segment_runtime.h edge_runtime.h \
+		segment_adapters.h edge_adapters.h segment_adapter_internal.h \
+		edge_adapter_internal.h edge_tok_internal.h st.h | $(SEGMENT_BUILD_DIR)
 	$(CC) $(SEGMENT_CPU_CFLAGS) -DINKLING_NO_MAIN -c inkling.c -o $@
 
-$(SEGMENT_BUILD_DIR)/kimi.o: kimi_k3.c segment_runtime.h \
-		segment_adapters.h segment_adapter_internal.h st.h | $(SEGMENT_BUILD_DIR)
+$(SEGMENT_BUILD_DIR)/kimi.o: kimi_k3.c segment_runtime.h edge_runtime.h \
+		segment_adapters.h edge_adapters.h segment_adapter_internal.h \
+		edge_adapter_internal.h edge_tok_internal.h st.h | $(SEGMENT_BUILD_DIR)
 	$(CC) $(SEGMENT_CPU_CFLAGS) -DKIMI_K3_NO_MAIN -c kimi_k3.c -o $@
 
-$(SEGMENT_BUILD_DIR)/olmoe.o: olmoe.c segment_runtime.h \
-		segment_adapters.h segment_adapter_internal.h st.h | $(SEGMENT_BUILD_DIR)
+$(SEGMENT_BUILD_DIR)/olmoe.o: olmoe.c segment_runtime.h edge_runtime.h \
+		segment_adapters.h edge_adapters.h segment_adapter_internal.h \
+		edge_adapter_internal.h edge_tok_internal.h st.h | $(SEGMENT_BUILD_DIR)
 	$(CC) $(SEGMENT_CPU_CFLAGS) -DOLMOE_NO_MAIN -c olmoe.c -o $@
 
-$(SEGMENT_BUILD_DIR)/qwen36.o: qwen36.c segment_runtime.h \
-		segment_adapters.h segment_adapter_internal.h st.h | $(SEGMENT_BUILD_DIR)
+$(SEGMENT_BUILD_DIR)/qwen36.o: qwen36.c segment_runtime.h edge_runtime.h \
+		segment_adapters.h edge_adapters.h segment_adapter_internal.h \
+		edge_adapter_internal.h st.h | $(SEGMENT_BUILD_DIR)
 	$(CC) $(SEGMENT_CPU_CFLAGS) -DQWEN36_NO_MAIN -c qwen36.c -o $@
 
 $(SEGMENT_V4_OBJS): $(SEGMENT_BUILD_DIR)/%.o: deepseek_v4.c deepseek_v4.h \
 		deepseek_v4_internal.h segment_runtime.h segment_adapters.h \
-		segment_adapter_internal.h st.h | $(SEGMENT_BUILD_DIR)
+		edge_runtime.h edge_adapters.h segment_adapter_internal.h \
+		edge_adapter_internal.h edge_tok_internal.h st.h | $(SEGMENT_BUILD_DIR)
 	$(CC) $(SEGMENT_CPU_CFLAGS) -D$* -c deepseek_v4.c -o $@
 
 $(SEGMENT_V4_REGISTRY_OBJ): expert_store_registry.c expert_store_registry.h \
@@ -1337,23 +1348,43 @@ $(SEGMENT_V4_REGISTRY_OBJ): expert_store_registry.c expert_store_registry.h \
 
 tests/test_segment_adapters_registration$(EXE): \
 		tests/test_segment_adapters_registration.c segment_runtime.c \
-		segment_runtime.h segment_adapters.h $(SEGMENT_ALL_OBJS)
+		edge_runtime.c segment_runtime.h edge_runtime.h segment_adapters.h \
+		edge_adapters.h $(SEGMENT_ALL_OBJS)
 	$(CC) $(SEGMENT_CPU_CFLAGS) tests/test_segment_adapters_registration.c \
-		segment_runtime.c $(SEGMENT_ALL_OBJS) -o $@ $(NOCUDA_LDFLAGS)
+		segment_runtime.c edge_runtime.c $(SEGMENT_ALL_OBJS) -o $@ $(NOCUDA_LDFLAGS)
 
 tests/test_segment_adapters_real$(EXE): tests/test_segment_adapters_real.c \
-		segment_runtime.c segment_runtime.h segment_adapters.h $(SEGMENT_ALL_OBJS)
+		segment_runtime.c edge_runtime.c segment_runtime.h edge_runtime.h \
+		segment_adapters.h edge_adapters.h $(SEGMENT_ALL_OBJS)
 	$(CC) $(SEGMENT_CPU_CFLAGS) tests/test_segment_adapters_real.c \
-		segment_runtime.c $(SEGMENT_ALL_OBJS) -o $@ $(NOCUDA_LDFLAGS)
+		segment_runtime.c edge_runtime.c $(SEGMENT_ALL_OBJS) -o $@ $(NOCUDA_LDFLAGS)
+
+tests/test_edge_adapters_registration$(EXE): \
+		tests/test_edge_adapters_registration.c edge_runtime.c segment_runtime.c \
+		edge_runtime.h segment_runtime.h edge_adapters.h $(SEGMENT_ALL_OBJS)
+	$(CC) $(SEGMENT_CPU_CFLAGS) tests/test_edge_adapters_registration.c \
+		edge_runtime.c segment_runtime.c $(SEGMENT_ALL_OBJS) -o $@ $(NOCUDA_LDFLAGS)
+
+tests/test_edge_adapters_real$(EXE): tests/test_edge_adapters_real.c \
+		edge_runtime.c segment_runtime.c edge_runtime.h segment_runtime.h \
+		edge_adapters.h segment_adapters.h json.h $(SEGMENT_ALL_OBJS)
+	$(CC) $(SEGMENT_CPU_CFLAGS) tests/test_edge_adapters_real.c \
+		edge_runtime.c segment_runtime.c $(SEGMENT_ALL_OBJS) -o $@ $(NOCUDA_LDFLAGS)
 
 .PHONY: segment-adapters segment-adapters-real
 segment-adapters: tests/test_segment_adapters_registration$(EXE)
 	./tests/test_segment_adapters_registration$(EXE)
 
+.PHONY: edge-adapters edge-adapters-real
+edge-adapters: tests/test_edge_adapters_registration$(EXE)
+	./tests/test_edge_adapters_registration$(EXE)
+
 # Maintainer/release gate. Paths point at generated/converted tiny Colibri
 # containers; see docs/segment-runtime.md for the exact generators.
 # OMP_NUM_THREADS defaults to a stable, non-single-threaded 2 for reproducible
 # reductions, but callers can override it to exercise a different schedule.
+# Kimi's generated fixture is safe at a few MB; overcommit there only prevents
+# its production-size reserve heuristic from making the test host-dependent.
 segment-adapters-real: tests/test_segment_adapters_real$(EXE)
 	@test -n "$(GLM_SEGMENT_MODEL)" || { echo "set GLM_SEGMENT_MODEL" >&2; exit 2; }
 	@test -n "$(INKLING_SEGMENT_MODEL)" || { echo "set INKLING_SEGMENT_MODEL" >&2; exit 2; }
@@ -1363,10 +1394,28 @@ segment-adapters-real: tests/test_segment_adapters_real$(EXE)
 	@test -n "$(DEEPSEEK_SEGMENT_MODEL)" || { echo "set DEEPSEEK_SEGMENT_MODEL" >&2; exit 2; }
 	OMP_NUM_THREADS=$${OMP_NUM_THREADS:-2} ./tests/test_segment_adapters_real$(EXE) glm "$(GLM_SEGMENT_MODEL)" 0 3 5 8
 	OMP_NUM_THREADS=$${OMP_NUM_THREADS:-2} ./tests/test_segment_adapters_real$(EXE) inkling "$(INKLING_SEGMENT_MODEL)" 0 4 8 8
-	OMP_NUM_THREADS=$${OMP_NUM_THREADS:-2} ./tests/test_segment_adapters_real$(EXE) kimi "$(KIMI_SEGMENT_MODEL)" 0 3 6 8
+	COLI_RAM_OVERCOMMIT=1 OMP_NUM_THREADS=$${OMP_NUM_THREADS:-2} ./tests/test_segment_adapters_real$(EXE) kimi "$(KIMI_SEGMENT_MODEL)" 0 3 6 8
 	OMP_NUM_THREADS=$${OMP_NUM_THREADS:-2} ./tests/test_segment_adapters_real$(EXE) olmoe "$(OLMOE_SEGMENT_MODEL)" 0 2 4 8
 	OMP_NUM_THREADS=$${OMP_NUM_THREADS:-2} ./tests/test_segment_adapters_real$(EXE) qwen36 "$(QWEN_SEGMENT_MODEL)" 0 4 8 8
 	OMP_NUM_THREADS=$${OMP_NUM_THREADS:-2} ./tests/test_segment_adapters_real$(EXE) deepseek_v4 "$(DEEPSEEK_SEGMENT_MODEL)" 0 1 3 8
+
+# End-to-end model-edge gate. Every run performs tokenizer round-trip, embeds
+# the independent oracle's prompt, executes the complete real Segment stack
+# and compares greedy decode tokens with that oracle. The fixture tokenizer
+# helper is only for existing math-only tiny checkpoints that omit one.
+edge-adapters-real: tests/test_edge_adapters_real$(EXE)
+	@test -n "$(GLM_EDGE_MODEL)" && test -n "$(GLM_EDGE_REF)" || { echo "set GLM_EDGE_MODEL and GLM_EDGE_REF" >&2; exit 2; }
+	@test -n "$(INKLING_EDGE_MODEL)" && test -n "$(INKLING_EDGE_REF)" || { echo "set INKLING_EDGE_MODEL and INKLING_EDGE_REF" >&2; exit 2; }
+	@test -n "$(KIMI_EDGE_MODEL)" && test -n "$(KIMI_EDGE_REF)" || { echo "set KIMI_EDGE_MODEL and KIMI_EDGE_REF" >&2; exit 2; }
+	@test -n "$(OLMOE_EDGE_MODEL)" && test -n "$(OLMOE_EDGE_REF)" || { echo "set OLMOE_EDGE_MODEL and OLMOE_EDGE_REF" >&2; exit 2; }
+	@test -n "$(QWEN_EDGE_MODEL)" && test -n "$(QWEN_EDGE_REF)" || { echo "set QWEN_EDGE_MODEL and QWEN_EDGE_REF" >&2; exit 2; }
+	@test -n "$(DEEPSEEK_EDGE_MODEL)" && test -n "$(DEEPSEEK_EDGE_REF)" || { echo "set DEEPSEEK_EDGE_MODEL and DEEPSEEK_EDGE_REF" >&2; exit 2; }
+	GLM_SEGMENT_EBITS=16 GLM_SEGMENT_DBITS=16 OMP_NUM_THREADS=$${OMP_NUM_THREADS:-2} ./tests/test_edge_adapters_real$(EXE) glm "$(GLM_EDGE_MODEL)" "$(GLM_EDGE_REF)" 3
+	INK_SEGMENT_BITS=0 OMP_NUM_THREADS=$${OMP_NUM_THREADS:-2} ./tests/test_edge_adapters_real$(EXE) inkling "$(INKLING_EDGE_MODEL)" "$(INKLING_EDGE_REF)" 3
+	COLI_RAM_OVERCOMMIT=1 K3_BITS=32 K3_MLA_BITS=32 K3_HEAD_BITS=32 K3_IDOT=0 OMP_NUM_THREADS=$${OMP_NUM_THREADS:-2} ./tests/test_edge_adapters_real$(EXE) kimi "$(KIMI_EDGE_MODEL)" "$(KIMI_EDGE_REF)" 3
+	OMP_NUM_THREADS=$${OMP_NUM_THREADS:-2} ./tests/test_edge_adapters_real$(EXE) olmoe "$(OLMOE_EDGE_MODEL)" "$(OLMOE_EDGE_REF)" 3
+	OMP_NUM_THREADS=$${OMP_NUM_THREADS:-2} ./tests/test_edge_adapters_real$(EXE) qwen36 "$(QWEN_EDGE_MODEL)" "$(QWEN_EDGE_REF)" 3
+	OMP_NUM_THREADS=$${OMP_NUM_THREADS:-2} ./tests/test_edge_adapters_real$(EXE) deepseek_v4 "$(DEEPSEEK_EDGE_MODEL)" "$(DEEPSEEK_EDGE_REF)" 3
 
 V4_HOT_TEST_OBJ = COLI_V4_UNIT_EXPERT_STORE_HOT_ROWS16_TEST.o
 V4_BATCH_TEST_OBJ = COLI_V4_UNIT_NATIVE_QUANT_BATCH_TEST.o

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -89,6 +89,11 @@ static inline void omp_set_num_threads(int n){ (void)n; }
 #include "segment_adapters.h"
 #include "segment_adapter_internal.h"
 #endif
+#ifdef COLI_EDGE_ADAPTER
+#include "edge_runtime.h"
+#include "edge_adapters.h"
+#include "edge_tok_internal.h"
+#endif
 #ifdef COLI_CUDA
 #include "backend_cuda.h"
 #endif
@@ -11767,3 +11772,200 @@ int coli_glm_segment_adapter_register(void) {
     return coli_segment_adapter_register(&glm_segment_adapter);
 }
 #endif /* COLI_SEGMENT_ADAPTER */
+
+#ifdef COLI_EDGE_ADAPTER
+/* ---------- engine-owned model Edge adapter --------------------------- */
+
+typedef struct {
+    Model model;
+    Tok tokenizer;
+} GlmEdgeEngine;
+
+static void glm_edge_qt_destroy(QT *tensor) {
+    if (!tensor) return;
+    free(tensor->qf); free(tensor->q8); free(tensor->q4); free(tensor->s);
+    memset(tensor, 0, sizeof(*tensor));
+}
+
+static void glm_edge_engine_destroy(void *engine_impl) {
+    GlmEdgeEngine *engine = (GlmEdgeEngine *)engine_impl;
+    if (!engine) return;
+    glm_edge_qt_destroy(&engine->model.embed);
+    glm_edge_qt_destroy(&engine->model.lm_head);
+    free(engine->model.final_norm);
+    st_destroy(&engine->model.S);
+    tok_free(&engine->tokenizer);
+    free(engine);
+}
+
+static int glm_edge_has_dsa(Model *model) {
+    Cfg *config = &model->c;
+    int enabled = config->index_topk > 0 && config->index_nh > 0 &&
+                  config->index_hd > 0 && config->index_hd <= 256;
+    char name[320];
+    for (int layer = 0; enabled && layer < config->n_layers; layer++) {
+        if (!config->idx_type[layer]) continue;
+        snprintf(name, sizeof(name),
+                 "model.layers.%d.self_attn.indexer.wq_b.weight", layer);
+        if (!st_has(&model->S, name)) enabled = 0;
+    }
+    if (getenv("DSA") && atoi(getenv("DSA")) == 0) enabled = 0;
+    return enabled;
+}
+
+static int glm_edge_engine_open(
+    void **engine_impl, ColiEdgeCapabilities *capabilities,
+    const ColiEdgeEngineOptions *options, char *error, size_t error_size) {
+    if (!engine_impl || !capabilities || !options)
+        return coli_edge_adapter_error(error, error_size,
+                                       "invalid GLM Edge open");
+    *engine_impl = NULL;
+    if (options->backend_mask &&
+        (options->backend_mask & ~COLI_EDGE_CAP_CPU))
+        return coli_edge_adapter_error(error, error_size,
+                                       "GLM Edge supports CPU only");
+    int ebits = getenv("GLM_SEGMENT_EBITS")
+        ? atoi(getenv("GLM_SEGMENT_EBITS")) : 8;
+    int dbits = getenv("GLM_SEGMENT_DBITS")
+        ? atoi(getenv("GLM_SEGMENT_DBITS")) : ebits;
+    if (ebits < 2 || ebits > 16 || dbits < 2 || dbits > 16)
+        return coli_edge_adapter_error(error, error_size,
+                                       "GLM Edge bit widths must be 2..16");
+    GlmEdgeEngine *engine = calloc(1, sizeof(*engine));
+    if (!engine)
+        return coli_edge_adapter_error(error, error_size,
+                                       "out of memory opening GLM Edge");
+    Model *model = &engine->model;
+    model->ebits = ebits; model->dbits = dbits;
+    load_cfg(&model->c, options->model_dir);
+    const char *model_dirs = getenv("COLI_MODEL_DIRS");
+    st_init_multi(&model->S, options->model_dir,
+                  model_dirs && *model_dirs ? model_dirs : NULL);
+    int io_bits = dbits >= 8 ? 16 : dbits;
+    model->embed = qt_load(model, "model.embed_tokens.weight",
+                           model->c.vocab, model->c.hidden, io_bits);
+    model->lm_head = qt_load(model, "lm_head.weight",
+                             model->c.vocab, model->c.hidden, io_bits);
+    model->final_norm = ld(model, "model.norm.weight");
+    char tokenizer_path[4096];
+    snprintf(tokenizer_path, sizeof(tokenizer_path), "%s/tokenizer.json",
+             options->model_dir);
+    tok_load(&engine->tokenizer, tokenizer_path);
+
+    int has_dsa = glm_edge_has_dsa(model);
+    uint64_t resident = (uint64_t)qt_bytes(&model->embed) +
+                        (uint64_t)qt_bytes(&model->lm_head) +
+                        (uint64_t)model->c.hidden * sizeof(float);
+    if (options->memory_limit_bytes && resident > options->memory_limit_bytes) {
+        glm_edge_engine_destroy(engine);
+        return coli_edge_adapter_error(error, error_size,
+                                       "GLM Edge exceeds memory limit");
+    }
+    memset(capabilities, 0, sizeof(*capabilities));
+    capabilities->struct_size = sizeof(*capabilities);
+    capabilities->abi_version = COLI_EDGE_ABI_VERSION;
+    capabilities->flags = COLI_EDGE_CAP_TOKENIZE |
+                          COLI_EDGE_CAP_DETOKENIZE |
+                          COLI_EDGE_CAP_GREEDY |
+                          COLI_EDGE_CAP_CPU;
+    coli_edge_capability_string(capabilities->engine_id,
+                                sizeof(capabilities->engine_id), "glm");
+    coli_edge_capability_string(capabilities->state_schema,
+                                sizeof(capabilities->state_schema),
+                                "glm/mla-rope-dsa-f32-v1");
+    snprintf(capabilities->numeric_class,
+             sizeof(capabilities->numeric_class),
+             "glm/e%d-d%d-dsa%d-kvf32/cpu-v1", ebits, dbits, has_dsa);
+    coli_edge_capability_string(capabilities->tokenizer_class,
+                                sizeof(capabilities->tokenizer_class),
+                                "glm/cl100k-byte-bpe-v1");
+    capabilities->state_dtype = COLI_EDGE_DTYPE_F32;
+    capabilities->state_width = (uint32_t)model->c.hidden;
+    capabilities->vocab_size = (uint32_t)model->c.vocab;
+    capabilities->max_batch_rows = 512;
+    capabilities->max_context_tokens = UINT32_MAX;
+    capabilities->num_layers = (uint32_t)model->c.n_layers;
+    capabilities->bos_token_id = -1;
+    capabilities->eos_token_id = -1;
+    capabilities->resident_bytes = resident;
+    *engine_impl = engine;
+    return 0;
+}
+
+static int glm_edge_tokenize(
+    void *engine_impl, const char *text, size_t text_bytes,
+    int32_t *token_ids, size_t token_capacity, size_t *token_count,
+    char *error, size_t error_size) {
+    GlmEdgeEngine *engine = (GlmEdgeEngine *)engine_impl;
+    return coli_edge_tok_tokenize(&engine->tokenizer, text, text_bytes,
+                                  token_ids, token_capacity, token_count,
+                                  error, error_size);
+}
+
+static int glm_edge_detokenize(
+    void *engine_impl, const int32_t *token_ids, size_t token_count,
+    char *text, size_t text_capacity, size_t *text_bytes,
+    char *error, size_t error_size) {
+    GlmEdgeEngine *engine = (GlmEdgeEngine *)engine_impl;
+    return coli_edge_tok_detokenize(&engine->tokenizer, token_ids, token_count,
+                                    text, text_capacity, text_bytes,
+                                    error, error_size);
+}
+
+static int glm_edge_embed(void *engine_impl,
+                          const ColiEdgeEmbedRequest *request,
+                          char *error, size_t error_size) {
+    GlmEdgeEngine *engine = (GlmEdgeEngine *)engine_impl;
+    int hidden = engine->model.c.hidden;
+    float *output = (float *)request->output;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        int token = request->token_ids[row];
+        if (token < 0 || token >= engine->model.c.vocab)
+            return coli_edge_adapter_error(error, error_size,
+                                           "GLM token ID is out of range");
+        embed_row(&engine->model, token, output + (size_t)row * hidden);
+    }
+    return 0;
+}
+
+static int glm_edge_select(void *engine_impl,
+                           const ColiEdgeSelectRequest *request,
+                           char *error, size_t error_size) {
+    GlmEdgeEngine *engine = (GlmEdgeEngine *)engine_impl;
+    Cfg *config = &engine->model.c;
+    float *normalized = falloc(config->hidden);
+    float *logits = falloc(config->vocab);
+    const float *input = (const float *)request->input;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        if (request->should_cancel &&
+            request->should_cancel(request->cancel_user_data)) {
+            free(logits); free(normalized);
+            return coli_edge_adapter_error(error, error_size,
+                                           "GLM Edge selection cancelled");
+        }
+        rmsnorm(normalized, input + (size_t)row * config->hidden,
+                engine->model.final_norm, config->hidden, config->eps);
+        matmul_qt(logits, normalized, &engine->model.lm_head, 1);
+        if (coli_edge_argmax(logits, (uint32_t)config->vocab,
+                            &request->token_ids[row],
+                            request->scores ? &request->scores[row] : NULL)) {
+            free(logits); free(normalized);
+            return coli_edge_adapter_error(error, error_size,
+                                           "GLM Edge head failed");
+        }
+    }
+    free(logits); free(normalized);
+    return 0;
+}
+
+static const ColiEdgeAdapter glm_edge_adapter = {
+    sizeof(ColiEdgeAdapter), COLI_EDGE_ABI_VERSION, "glm",
+    glm_edge_engine_open, glm_edge_engine_destroy,
+    glm_edge_tokenize, glm_edge_detokenize,
+    glm_edge_embed, glm_edge_select, {0}
+};
+
+int coli_glm_edge_adapter_register(void) {
+    return coli_edge_adapter_register(&glm_edge_adapter);
+}
+#endif /* COLI_EDGE_ADAPTER */

--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -17077,12 +17077,21 @@ int coli_fp4_dual_matvec_rows16_v10(float *output_a, float *output_b,
 #include "deepseek_v4_internal.h"
 #include "segment_adapter_internal.h"
 #include "segment_adapters.h"
+#include "edge_runtime.h"
+#include "edge_adapters.h"
+#include "tok.h"
+#include "edge_tok_internal.h"
 
+#include <float.h>
+#include <math.h>
 #include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef __AVX2__
+#include <immintrin.h>
+#endif
 
 typedef struct {
     ColiV4Engine *model;
@@ -17650,4 +17659,338 @@ static const ColiSegmentAdapter deepseek_v4_segment_adapter = {
 int coli_deepseek_v4_segment_adapter_register(void) {
     return coli_segment_adapter_register(&deepseek_v4_segment_adapter);
 }
+
+#ifdef COLI_EDGE_ADAPTER
+/* ######## DeepSeek V4 engine-owned model Edge adapter ################# */
+
+typedef struct {
+    ColiDeepSeekV4Config config;
+    ColiSafetensorsIndex *index;
+    ColiFloatTensor head_function, head_base, head_scale, final_norm;
+    Tok tokenizer;
+    uint32_t state_width;
+} DeepSeekV4EdgeEngine;
+
+static void deepseek_v4_edge_engine_destroy(void *engine_impl) {
+    DeepSeekV4EdgeEngine *engine = engine_impl;
+    if (!engine) return;
+    tok_free(&engine->tokenizer);
+    coli_float_tensor_free(&engine->final_norm);
+    coli_float_tensor_free(&engine->head_scale);
+    coli_float_tensor_free(&engine->head_base);
+    coli_float_tensor_free(&engine->head_function);
+    coli_st_index_close(engine->index);
+    free(engine);
+}
+
+static int deepseek_v4_edge_engine_open(
+    void **engine_impl, ColiEdgeCapabilities *capabilities,
+    const ColiEdgeEngineOptions *options, char *error, size_t error_size) {
+    if (!engine_impl || !capabilities || !options)
+        return coli_edge_adapter_error(error, error_size,
+                                       "invalid DeepSeek V4 Edge open");
+    *engine_impl = NULL;
+    if (options->backend_mask &&
+        (options->backend_mask & ~COLI_EDGE_CAP_CPU))
+        return coli_edge_adapter_error(error, error_size,
+                                       "DeepSeek V4 Edge supports CPU only");
+    DeepSeekV4EdgeEngine *engine = calloc(1, sizeof(*engine));
+    if (!engine)
+        return coli_edge_adapter_error(error, error_size,
+                                       "out of memory opening DeepSeek V4 Edge");
+    if (coli_v4_config_load(&engine->config, options->model_dir,
+                            error, error_size) ||
+        coli_st_index_open(&engine->index, options->model_dir,
+                           error, error_size)) {
+        deepseek_v4_edge_engine_destroy(engine);
+        return -1;
+    }
+    uint64_t width = (uint64_t)engine->config.hc_mult *
+                     (uint64_t)engine->config.hidden_size;
+    if (!width || width > UINT32_MAX) {
+        deepseek_v4_edge_engine_destroy(engine);
+        return coli_edge_adapter_error(error, error_size,
+                                       "DeepSeek V4 boundary state is too wide");
+    }
+    engine->state_width = (uint32_t)width;
+    if (coli_tensor_load_f32(&engine->head_function, engine->index,
+                             "hc_head_fn", error, error_size) ||
+        coli_tensor_load_f32(&engine->head_base, engine->index,
+                             "hc_head_base", error, error_size) ||
+        coli_tensor_load_f32(&engine->head_scale, engine->index,
+                             "hc_head_scale", error, error_size) ||
+        coli_tensor_load_f32(&engine->final_norm, engine->index,
+                             "norm.weight", error, error_size)) {
+        deepseek_v4_edge_engine_destroy(engine);
+        return -1;
+    }
+    int hidden = engine->config.hidden_size, hc = engine->config.hc_mult;
+    if (hc < 1 || hc > 16 ||
+        engine->head_function.count < (uint64_t)hc * hc * hidden ||
+        engine->head_base.count < (uint64_t)hc ||
+        engine->head_scale.count < 1 ||
+        engine->final_norm.count < (uint64_t)hidden) {
+        deepseek_v4_edge_engine_destroy(engine);
+        return coli_edge_adapter_error(error, error_size,
+                                       "DeepSeek V4 global tensor shape mismatch");
+    }
+    const ColiSafetensorsTensor *embedding =
+        coli_st_find(engine->index, "embed.weight");
+    const ColiSafetensorsTensor *head =
+        coli_st_find(engine->index, "head.weight");
+    uint64_t boundary_cells = (uint64_t)engine->config.vocab_size *
+                              (uint64_t)engine->config.hidden_size;
+    if (!embedding || embedding->dtype != COLI_ST_BF16 ||
+        embedding->numel != (int64_t)boundary_cells ||
+        !head || head->dtype != COLI_ST_BF16 ||
+        head->numel != (int64_t)boundary_cells) {
+        deepseek_v4_edge_engine_destroy(engine);
+        return coli_edge_adapter_error(error, error_size,
+                                       "DeepSeek V4 embedding/head shape or dtype mismatch");
+    }
+    char tokenizer_path[4096];
+    snprintf(tokenizer_path, sizeof(tokenizer_path), "%s/tokenizer.json",
+             options->model_dir);
+    tok_load(&engine->tokenizer, tokenizer_path);
+    uint64_t resident = (engine->head_function.count +
+                         engine->head_base.count +
+                         engine->head_scale.count +
+                         engine->final_norm.count) * sizeof(float);
+    if (options->memory_limit_bytes && resident > options->memory_limit_bytes) {
+        deepseek_v4_edge_engine_destroy(engine);
+        return coli_edge_adapter_error(error, error_size,
+                                       "DeepSeek V4 Edge exceeds memory limit");
+    }
+
+    memset(capabilities, 0, sizeof(*capabilities));
+    capabilities->struct_size = sizeof(*capabilities);
+    capabilities->abi_version = COLI_EDGE_ABI_VERSION;
+    capabilities->flags = COLI_EDGE_CAP_TOKENIZE |
+                          COLI_EDGE_CAP_DETOKENIZE |
+                          COLI_EDGE_CAP_GREEDY |
+                          COLI_EDGE_CAP_CPU;
+    coli_edge_capability_string(capabilities->engine_id,
+                                sizeof(capabilities->engine_id),
+                                "deepseek_v4");
+    coli_edge_capability_string(
+        capabilities->state_schema, sizeof(capabilities->state_schema),
+        "deepseek-v4/mhc-window-compressor-indexer-f32-v1");
+    coli_edge_capability_string(
+        capabilities->numeric_class, sizeof(capabilities->numeric_class),
+        "deepseek-v4/fp8-mxfp4-bf16/f32/cpu-v1");
+    coli_edge_capability_string(capabilities->tokenizer_class,
+                                sizeof(capabilities->tokenizer_class),
+                                "deepseek-v4/byte-bpe-v1");
+    capabilities->state_dtype = COLI_EDGE_DTYPE_F32;
+    capabilities->state_width = engine->state_width;
+    capabilities->vocab_size = (uint32_t)engine->config.vocab_size;
+    capabilities->max_batch_rows = 128;
+    capabilities->max_context_tokens =
+        (uint32_t)engine->config.max_position_embeddings;
+    capabilities->num_layers =
+        (uint32_t)engine->config.num_hidden_layers;
+    capabilities->bos_token_id = -1;
+    capabilities->eos_token_id = 1;
+    capabilities->resident_bytes = resident;
+    *engine_impl = engine;
+    return 0;
+}
+
+static int deepseek_v4_edge_tokenize(
+    void *engine_impl, const char *text, size_t text_bytes,
+    int32_t *token_ids, size_t token_capacity, size_t *token_count,
+    char *error, size_t error_size) {
+    DeepSeekV4EdgeEngine *engine = engine_impl;
+    return coli_edge_tok_tokenize(&engine->tokenizer, text, text_bytes,
+                                  token_ids, token_capacity, token_count,
+                                  error, error_size);
+}
+
+static int deepseek_v4_edge_detokenize(
+    void *engine_impl, const int32_t *token_ids, size_t token_count,
+    char *text, size_t text_capacity, size_t *text_bytes,
+    char *error, size_t error_size) {
+    DeepSeekV4EdgeEngine *engine = engine_impl;
+    return coli_edge_tok_detokenize(&engine->tokenizer, token_ids, token_count,
+                                    text, text_capacity, text_bytes,
+                                    error, error_size);
+}
+
+static int deepseek_v4_edge_embed(void *engine_impl,
+                                  const ColiEdgeEmbedRequest *request,
+                                  char *error, size_t error_size) {
+    DeepSeekV4EdgeEngine *engine = engine_impl;
+    const ColiSafetensorsTensor *embedding =
+        coli_st_find(engine->index, "embed.weight");
+    if (!embedding || embedding->dtype != COLI_ST_BF16)
+        return coli_edge_adapter_error(error, error_size,
+                                       "DeepSeek V4 embedding is unavailable");
+    int hidden = engine->config.hidden_size;
+    int copies = engine->config.hc_mult;
+    int shard = coli_st_tensor_shard(engine->index, embedding);
+    uint16_t *packed = malloc((size_t)hidden * sizeof(*packed));
+    if (!packed)
+        return coli_edge_adapter_error(error, error_size,
+                                       "out of memory reading DeepSeek V4 embedding");
+    float *output = request->output;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        int token = request->token_ids[row];
+        if (token < 0 || token >= engine->config.vocab_size ||
+            coli_st_read_at(
+                engine->index, shard,
+                (uint64_t)embedding->off +
+                    (uint64_t)token * hidden * sizeof(*packed),
+                (size_t)hidden * sizeof(*packed), packed)) {
+            free(packed);
+            return coli_edge_adapter_error(error, error_size,
+                                           "cannot read DeepSeek V4 embedding");
+        }
+        float *state = output + (size_t)row * engine->state_width;
+        for (int copy = 0; copy < copies; copy++)
+            for (int item = 0; item < hidden; item++)
+                state[(size_t)copy * hidden + item] =
+                    coli_bf16_decode(packed[item]);
+    }
+    free(packed);
+    return 0;
+}
+
+static void deepseek_v4_edge_final_hidden(
+    DeepSeekV4EdgeEngine *engine, float *output, const float *state) {
+    int hidden = engine->config.hidden_size;
+    int copies = engine->config.hc_mult;
+    int flattened = copies * hidden;
+    float square = 0.0f;
+    for (int item = 0; item < flattened; item++)
+        square += state[item] * state[item];
+    float inverse_rms = 1.0f / sqrtf(
+        square / flattened + engine->config.rms_norm_eps);
+    float pre[16];
+    for (int copy = 0; copy < copies; copy++) {
+        float mix = 0.0f;
+        for (int item = 0; item < flattened; item++)
+            mix += engine->head_function.data[
+                (size_t)copy * flattened + item] * state[item];
+        float z = mix * inverse_rms * engine->head_scale.data[0] +
+                  engine->head_base.data[copy];
+        float sigmoid = z >= 0.0f
+            ? 1.0f / (1.0f + expf(-z))
+            : expf(z) / (1.0f + expf(z));
+        pre[copy] = sigmoid + engine->config.hc_eps;
+    }
+    for (int item = 0; item < hidden; item++) {
+        float value = 0.0f;
+        for (int copy = 0; copy < copies; copy++)
+            value += pre[copy] * state[(size_t)copy * hidden + item];
+        output[item] = coli_bf16_round(value);
+    }
+    coli_v4_rmsnorm(output, output, engine->final_norm.data,
+                    hidden, engine->config.rms_norm_eps);
+    coli_bf16_round_array(output, (size_t)hidden);
+}
+
+static float deepseek_v4_edge_head_dot(
+    const uint16_t *weight, const float *hidden, int dimension) {
+    float sum = 0.0f;
+    int column = 0;
+#ifdef __AVX2__
+    for (; column + 8 <= dimension; column += 8) {
+        float products[8];
+        __m128i packed = _mm_loadu_si128((const __m128i *)(weight + column));
+        __m256i bits = _mm256_slli_epi32(
+            _mm256_cvtepu16_epi32(packed), 16);
+        _mm256_storeu_ps(products, _mm256_mul_ps(
+            _mm256_castsi256_ps(bits), _mm256_loadu_ps(hidden + column)));
+        for (int lane = 0; lane < 8; lane++) sum += products[lane];
+    }
+#endif
+    for (; column < dimension; column++)
+        sum += coli_bf16_decode(weight[column]) * hidden[column];
+    return sum;
+}
+
+static int deepseek_v4_edge_argmax(
+    DeepSeekV4EdgeEngine *engine, const float *hidden,
+    int32_t *best_token, float *best_logit,
+    ColiEdgeCancelFn should_cancel, void *cancel_user_data) {
+    const ColiSafetensorsTensor *head =
+        coli_st_find(engine->index, "head.weight");
+    if (!head || head->dtype != COLI_ST_BF16) return -1;
+    int dimension = engine->config.hidden_size;
+    int vocab = engine->config.vocab_size;
+    int shard = coli_st_tensor_shard(engine->index, head);
+    enum { TILE_ROWS = 64 };
+    uint16_t *raw = malloc((size_t)TILE_ROWS * dimension * sizeof(*raw));
+    float *scores = malloc((size_t)TILE_ROWS * sizeof(*scores));
+    if (!raw || !scores) { free(scores); free(raw); return -1; }
+    int winner = -1;
+    float maximum = -FLT_MAX;
+    for (int start = 0; start < vocab; start += TILE_ROWS) {
+        if (should_cancel && should_cancel(cancel_user_data)) {
+            free(scores); free(raw); return -2;
+        }
+        int rows = vocab - start < TILE_ROWS ? vocab - start : TILE_ROWS;
+        size_t bytes = (size_t)rows * dimension * sizeof(*raw);
+        if (coli_st_read_at(
+                engine->index, shard,
+                (uint64_t)head->off +
+                    (uint64_t)start * dimension * sizeof(*raw),
+                bytes, raw)) {
+            free(scores); free(raw); return -1;
+        }
+        #pragma omp parallel for schedule(static)
+        for (int row = 0; row < rows; row++)
+            scores[row] = deepseek_v4_edge_head_dot(
+                raw + (size_t)row * dimension, hidden, dimension);
+        for (int row = 0; row < rows; row++)
+            if (scores[row] > maximum) {
+                maximum = scores[row]; winner = start + row;
+            }
+    }
+    free(scores); free(raw);
+    *best_token = winner;
+    if (best_logit) *best_logit = maximum;
+    return winner < 0 ? -1 : 0;
+}
+
+static int deepseek_v4_edge_select(void *engine_impl,
+                                   const ColiEdgeSelectRequest *request,
+                                   char *error, size_t error_size) {
+    DeepSeekV4EdgeEngine *engine = engine_impl;
+    int hidden = engine->config.hidden_size;
+    float *final = malloc((size_t)hidden * sizeof(*final));
+    if (!final)
+        return coli_edge_adapter_error(error, error_size,
+                                       "out of memory running DeepSeek V4 head");
+    const float *input = request->input;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        deepseek_v4_edge_final_hidden(
+            engine, final, input + (size_t)row * engine->state_width);
+        int result = deepseek_v4_edge_argmax(
+            engine, final, &request->token_ids[row],
+            request->scores ? &request->scores[row] : NULL,
+            request->should_cancel, request->cancel_user_data);
+        if (result) {
+            free(final);
+            return coli_edge_adapter_error(
+                error, error_size, result == -2
+                    ? "DeepSeek V4 Edge selection cancelled"
+                    : "DeepSeek V4 Edge head failed");
+        }
+    }
+    free(final);
+    return 0;
+}
+
+static const ColiEdgeAdapter deepseek_v4_edge_adapter = {
+    sizeof(ColiEdgeAdapter), COLI_EDGE_ABI_VERSION, "deepseek_v4",
+    deepseek_v4_edge_engine_open, deepseek_v4_edge_engine_destroy,
+    deepseek_v4_edge_tokenize, deepseek_v4_edge_detokenize,
+    deepseek_v4_edge_embed, deepseek_v4_edge_select, {0}
+};
+
+int coli_deepseek_v4_edge_adapter_register(void) {
+    return coli_edge_adapter_register(&deepseek_v4_edge_adapter);
+}
+#endif /* COLI_EDGE_ADAPTER */
 #endif /* COLI_V4_UNIT_SEGMENT_ADAPTER && COLI_SEGMENT_ADAPTER */

--- a/c/edge_adapter_internal.h
+++ b/c/edge_adapter_internal.h
@@ -1,0 +1,33 @@
+#ifndef COLIBRI_EDGE_ADAPTER_INTERNAL_H
+#define COLIBRI_EDGE_ADAPTER_INTERNAL_H
+
+/* Engine-private helpers shared by the built-in adapters. */
+
+#include "edge_runtime.h"
+
+#include <stdio.h>
+
+static int coli_edge_adapter_error(char *error, size_t error_size,
+                                   const char *message) {
+    if (error && error_size) snprintf(error, error_size, "%s", message);
+    return -1;
+}
+
+static void coli_edge_capability_string(char *output, size_t output_size,
+                                        const char *value) {
+    if (!output || !output_size) return;
+    snprintf(output, output_size, "%s", value ? value : "");
+}
+
+static int coli_edge_argmax(const float *values, uint32_t count,
+                            int32_t *token, float *score) {
+    if (!values || !count || !token) return -1;
+    uint32_t best = 0;
+    for (uint32_t item = 1; item < count; item++)
+        if (values[item] > values[best]) best = item;
+    *token = (int32_t)best;
+    if (score) *score = values[best];
+    return 0;
+}
+
+#endif /* COLIBRI_EDGE_ADAPTER_INTERNAL_H */

--- a/c/edge_adapters.h
+++ b/c/edge_adapters.h
@@ -1,0 +1,22 @@
+#ifndef COLIBRI_EDGE_ADAPTERS_H
+#define COLIBRI_EDGE_ADAPTERS_H
+
+/* Explicit registration keeps the ordinary Colibri CLI initialization and
+ * Windows/MSVC builds independent from the distributed Edge runtime. */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int coli_glm_edge_adapter_register(void);
+int coli_inkling_edge_adapter_register(void);
+int coli_kimi_edge_adapter_register(void);
+int coli_olmoe_edge_adapter_register(void);
+int coli_qwen36_edge_adapter_register(void);
+int coli_deepseek_v4_edge_adapter_register(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* COLIBRI_EDGE_ADAPTERS_H */

--- a/c/edge_runtime.c
+++ b/c/edge_runtime.c
@@ -1,0 +1,232 @@
+#include "edge_runtime.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define COLI_EDGE_MAX_ADAPTERS 16
+
+struct ColiEdgeEngine {
+    const ColiEdgeAdapter *adapter;
+    void *impl;
+    ColiEdgeCapabilities capabilities;
+};
+
+static const ColiEdgeAdapter *g_adapters[COLI_EDGE_MAX_ADAPTERS];
+static int g_adapter_count;
+
+static int set_error(char *error, size_t error_size, const char *message) {
+    if (error && error_size) snprintf(error, error_size, "%s", message);
+    return -1;
+}
+
+static int id_valid(const char *id) {
+    if (!id || !*id) return 0;
+    size_t length = strlen(id);
+    if (length >= COLI_EDGE_ENGINE_ID_CAP) return 0;
+    for (size_t i = 0; i < length; i++) {
+        unsigned char c = (unsigned char)id[i];
+        if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+              c == '_' || c == '-')) return 0;
+    }
+    return 1;
+}
+
+static int fixed_string_valid(const char *value, size_t capacity) {
+    return value && value[0] && memchr(value, '\0', capacity) != NULL;
+}
+
+static size_t dtype_size(uint32_t dtype) {
+    switch (dtype) {
+        case COLI_EDGE_DTYPE_F32: return 4;
+        case COLI_EDGE_DTYPE_F16:
+        case COLI_EDGE_DTYPE_BF16: return 2;
+        default: return 0;
+    }
+}
+
+static int capabilities_valid(const ColiEdgeCapabilities *capabilities,
+                              const ColiEdgeAdapter *adapter) {
+    int tokenizer = adapter->tokenize && adapter->detokenize;
+    return capabilities->struct_size == sizeof(*capabilities) &&
+           capabilities->abi_version == COLI_EDGE_ABI_VERSION &&
+           fixed_string_valid(capabilities->engine_id,
+                              sizeof(capabilities->engine_id)) &&
+           strcmp(capabilities->engine_id, adapter->engine_id) == 0 &&
+           fixed_string_valid(capabilities->state_schema,
+                              sizeof(capabilities->state_schema)) &&
+           fixed_string_valid(capabilities->numeric_class,
+                              sizeof(capabilities->numeric_class)) &&
+           fixed_string_valid(capabilities->tokenizer_class,
+                              sizeof(capabilities->tokenizer_class)) &&
+           dtype_size(capabilities->state_dtype) != 0 &&
+           capabilities->state_width && capabilities->vocab_size &&
+           capabilities->num_layers &&
+           !!(capabilities->flags & COLI_EDGE_CAP_TOKENIZE) == tokenizer &&
+           !!(capabilities->flags & COLI_EDGE_CAP_DETOKENIZE) == tokenizer &&
+           !!(capabilities->flags & COLI_EDGE_CAP_GREEDY) ==
+               !!adapter->select;
+}
+
+int coli_edge_adapter_register(const ColiEdgeAdapter *adapter) {
+    if (!adapter || adapter->struct_size < sizeof(*adapter) ||
+        adapter->abi_version != COLI_EDGE_ABI_VERSION ||
+        !id_valid(adapter->engine_id) || !adapter->engine_open ||
+        !adapter->engine_destroy || !adapter->embed ||
+        !!adapter->tokenize != !!adapter->detokenize)
+        return -1;
+    for (int i = 0; i < g_adapter_count; i++)
+        if (strcmp(g_adapters[i]->engine_id, adapter->engine_id) == 0)
+            return -1;
+    if (g_adapter_count >= COLI_EDGE_MAX_ADAPTERS) return -1;
+    g_adapters[g_adapter_count++] = adapter;
+    return 0;
+}
+
+const ColiEdgeAdapter *coli_edge_adapter_lookup(const char *engine_id) {
+    if (!engine_id) return NULL;
+    for (int i = 0; i < g_adapter_count; i++)
+        if (strcmp(g_adapters[i]->engine_id, engine_id) == 0)
+            return g_adapters[i];
+    return NULL;
+}
+
+int coli_edge_adapter_count(void) { return g_adapter_count; }
+
+int coli_edge_engine_open(const char *engine_id,
+                          const ColiEdgeEngineOptions *options,
+                          ColiEdgeEngine **engine,
+                          char *error, size_t error_size) {
+    if (!engine) return set_error(error, error_size,
+                                  "missing edge engine output");
+    *engine = NULL;
+    if (!options || options->struct_size < sizeof(*options) ||
+        !options->model_dir || !*options->model_dir)
+        return set_error(error, error_size, "invalid edge engine options");
+    const ColiEdgeAdapter *adapter = coli_edge_adapter_lookup(engine_id);
+    if (!adapter)
+        return set_error(error, error_size, "edge engine is not registered");
+
+    ColiEdgeEngine *created = calloc(1, sizeof(*created));
+    if (!created)
+        return set_error(error, error_size, "out of memory opening edge engine");
+    created->adapter = adapter;
+    created->capabilities.struct_size = sizeof(created->capabilities);
+    created->capabilities.abi_version = COLI_EDGE_ABI_VERSION;
+    if (adapter->engine_open(&created->impl, &created->capabilities, options,
+                             error, error_size) || !created->impl) {
+        if (created->impl) adapter->engine_destroy(created->impl);
+        free(created);
+        return -1;
+    }
+    if (!capabilities_valid(&created->capabilities, adapter)) {
+        adapter->engine_destroy(created->impl);
+        free(created);
+        return set_error(error, error_size,
+                         "edge adapter returned incompatible capabilities");
+    }
+    *engine = created;
+    return 0;
+}
+
+int coli_edge_engine_capabilities(const ColiEdgeEngine *engine,
+                                  ColiEdgeCapabilities *capabilities,
+                                  char *error, size_t error_size) {
+    if (!engine || !capabilities ||
+        capabilities->struct_size < sizeof(*capabilities))
+        return set_error(error, error_size, "invalid edge capabilities buffer");
+    size_t caller_size = capabilities->struct_size;
+    memset(capabilities, 0, caller_size);
+    memcpy(capabilities, &engine->capabilities, sizeof(*capabilities));
+    return 0;
+}
+
+void coli_edge_engine_close(ColiEdgeEngine *engine) {
+    if (!engine) return;
+    engine->adapter->engine_destroy(engine->impl);
+    free(engine);
+}
+
+int coli_edge_tokenize(ColiEdgeEngine *engine,
+                       const char *text, size_t text_bytes,
+                       int32_t *token_ids, size_t token_capacity,
+                       size_t *token_count,
+                       char *error, size_t error_size) {
+    if (!engine || !text || !token_count ||
+        (!!token_ids != !!token_capacity))
+        return set_error(error, error_size, "invalid edge tokenize request");
+    if (!engine->adapter->tokenize)
+        return set_error(error, error_size, "edge tokenizer is not supported");
+    return engine->adapter->tokenize(engine->impl, text, text_bytes,
+                                     token_ids, token_capacity, token_count,
+                                     error, error_size);
+}
+
+int coli_edge_detokenize(ColiEdgeEngine *engine,
+                         const int32_t *token_ids, size_t token_count,
+                         char *text, size_t text_capacity, size_t *text_bytes,
+                         char *error, size_t error_size) {
+    if (!engine || !token_ids || !token_count || !text_bytes ||
+        (!!text != !!text_capacity))
+        return set_error(error, error_size, "invalid edge detokenize request");
+    if (!engine->adapter->detokenize)
+        return set_error(error, error_size,
+                         "edge detokenizer is not supported");
+    return engine->adapter->detokenize(engine->impl, token_ids, token_count,
+                                       text, text_capacity, text_bytes,
+                                       error, error_size);
+}
+
+static int activation_bytes(const ColiEdgeEngine *engine, uint32_t rows,
+                            size_t *bytes) {
+    size_t element_size = dtype_size(engine->capabilities.state_dtype);
+    if (!rows || !element_size ||
+        engine->capabilities.state_width > SIZE_MAX / rows ||
+        (size_t)rows * engine->capabilities.state_width >
+            SIZE_MAX / element_size)
+        return -1;
+    *bytes = (size_t)rows * engine->capabilities.state_width * element_size;
+    return 0;
+}
+
+int coli_edge_embed(ColiEdgeEngine *engine,
+                    const ColiEdgeEmbedRequest *request,
+                    char *error, size_t error_size) {
+    size_t expected = 0;
+    if (!engine || !request || request->struct_size < sizeof(*request) ||
+        !request->rows || !request->token_ids ||
+        request->token_count != request->rows || !request->output ||
+        activation_bytes(engine, request->rows, &expected) ||
+        request->output_bytes != expected)
+        return set_error(error, error_size, "invalid edge embed request");
+    if (engine->capabilities.max_batch_rows &&
+        request->rows > engine->capabilities.max_batch_rows)
+        return set_error(error, error_size, "edge batch exceeds capabilities");
+    if (request->should_cancel &&
+        request->should_cancel(request->cancel_user_data))
+        return set_error(error, error_size, "edge embedding cancelled");
+    return engine->adapter->embed(engine->impl, request, error, error_size);
+}
+
+int coli_edge_select(ColiEdgeEngine *engine,
+                     const ColiEdgeSelectRequest *request,
+                     char *error, size_t error_size) {
+    size_t expected = 0;
+    if (!engine || !request || request->struct_size < sizeof(*request) ||
+        !request->rows || !request->input ||
+        activation_bytes(engine, request->rows, &expected) ||
+        request->input_bytes != expected || !request->token_ids ||
+        request->token_capacity < request->rows ||
+        (!!request->scores != !!request->score_capacity) ||
+        (request->scores && request->score_capacity < request->rows))
+        return set_error(error, error_size, "invalid edge selection request");
+    if (!engine->adapter->select)
+        return set_error(error, error_size, "edge greedy head is not supported");
+    if (engine->capabilities.max_batch_rows &&
+        request->rows > engine->capabilities.max_batch_rows)
+        return set_error(error, error_size, "edge batch exceeds capabilities");
+    if (request->should_cancel &&
+        request->should_cancel(request->cancel_user_data))
+        return set_error(error, error_size, "edge selection cancelled");
+    return engine->adapter->select(engine->impl, request, error, error_size);
+}

--- a/c/edge_runtime.h
+++ b/c/edge_runtime.h
@@ -1,0 +1,177 @@
+#ifndef COLIBRI_EDGE_RUNTIME_H
+#define COLIBRI_EDGE_RUNTIME_H
+
+/*
+ * Public, engine-neutral model-edge runtime.
+ *
+ * A distributed inference client keeps only the input/output boundary of a
+ * model locally: tokenizer, token embedding, final normalization and output
+ * head. Layer ranges remain owned by the Segment runtime. Keeping this ABI
+ * separate prevents a network client from reaching into an engine's private
+ * Model structure or loading the complete transformer just to start a chat.
+ *
+ * Version 1 deliberately exposes deterministic greedy selection. Sampling
+ * policies can be added without changing the embedding/activation contract.
+ * Registration is explicit; ordinary Colibri executables do not use this API.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define COLI_EDGE_ABI_VERSION 1u
+#define COLI_EDGE_ENGINE_ID_CAP 64u
+#define COLI_EDGE_STATE_SCHEMA_CAP 128u
+#define COLI_EDGE_NUMERIC_CLASS_CAP 96u
+#define COLI_EDGE_TOKENIZER_CLASS_CAP 64u
+
+typedef struct ColiEdgeEngine ColiEdgeEngine;
+
+typedef enum {
+    COLI_EDGE_DTYPE_INVALID = 0,
+    COLI_EDGE_DTYPE_F32 = 1,
+    COLI_EDGE_DTYPE_F16 = 2,
+    COLI_EDGE_DTYPE_BF16 = 3,
+} ColiEdgeDType;
+
+enum {
+    COLI_EDGE_CAP_TOKENIZE = UINT64_C(1) << 0,
+    COLI_EDGE_CAP_DETOKENIZE = UINT64_C(1) << 1,
+    COLI_EDGE_CAP_GREEDY = UINT64_C(1) << 2,
+    COLI_EDGE_CAP_CPU = UINT64_C(1) << 8,
+    COLI_EDGE_CAP_CUDA = UINT64_C(1) << 9,
+    COLI_EDGE_CAP_HIP = UINT64_C(1) << 10,
+    COLI_EDGE_CAP_METAL = UINT64_C(1) << 11,
+    COLI_EDGE_CAP_VULKAN = UINT64_C(1) << 12,
+};
+
+#define COLI_EDGE_CAP_BACKEND_MASK                                      \
+    (COLI_EDGE_CAP_CPU | COLI_EDGE_CAP_CUDA | COLI_EDGE_CAP_HIP |       \
+     COLI_EDGE_CAP_METAL | COLI_EDGE_CAP_VULKAN)
+
+/* state_schema, numeric_class, dtype and width must match the first/last
+ * Segment peers selected by the distributed caller. */
+typedef struct {
+    uint32_t struct_size;
+    uint32_t abi_version;
+    uint64_t flags;
+    char engine_id[COLI_EDGE_ENGINE_ID_CAP];
+    char state_schema[COLI_EDGE_STATE_SCHEMA_CAP];
+    char numeric_class[COLI_EDGE_NUMERIC_CLASS_CAP];
+    char tokenizer_class[COLI_EDGE_TOKENIZER_CLASS_CAP];
+    uint32_t state_dtype;
+    uint32_t state_width;
+    uint32_t vocab_size;
+    uint32_t max_batch_rows;
+    uint32_t max_context_tokens;
+    uint32_t num_layers;
+    int32_t bos_token_id;
+    int32_t eos_token_id;
+    uint32_t reserved_u32[4];
+    uint64_t resident_bytes;
+    uint64_t reserved_u64[3];
+} ColiEdgeCapabilities;
+
+typedef struct {
+    uint32_t struct_size;
+    const char *model_dir;
+    uint64_t memory_limit_bytes;
+    uint64_t backend_mask;
+    const void *resource_plan;
+    size_t resource_plan_size;
+    uint64_t reserved_u64[3];
+} ColiEdgeEngineOptions;
+
+typedef int (*ColiEdgeCancelFn)(void *user_data);
+
+typedef struct {
+    uint32_t struct_size;
+    uint32_t rows;
+    const int32_t *token_ids;
+    size_t token_count;
+    void *output;
+    size_t output_bytes;
+    ColiEdgeCancelFn should_cancel;
+    void *cancel_user_data;
+    uint64_t reserved_u64[3];
+} ColiEdgeEmbedRequest;
+
+/* Greedy selection applies the engine's exact final-state transform and LM
+ * head to every input row. Scores may be NULL; token_ids must hold rows IDs. */
+typedef struct {
+    uint32_t struct_size;
+    uint32_t rows;
+    const void *input;
+    size_t input_bytes;
+    int32_t *token_ids;
+    size_t token_capacity;
+    float *scores;
+    size_t score_capacity;
+    ColiEdgeCancelFn should_cancel;
+    void *cancel_user_data;
+    uint64_t reserved_u64[3];
+} ColiEdgeSelectRequest;
+
+typedef struct {
+    uint32_t struct_size;
+    uint32_t abi_version;
+    const char *engine_id;
+
+    int (*engine_open)(void **engine_impl,
+                       ColiEdgeCapabilities *capabilities,
+                       const ColiEdgeEngineOptions *options,
+                       char *error, size_t error_size);
+    void (*engine_destroy)(void *engine_impl);
+    int (*tokenize)(void *engine_impl, const char *text, size_t text_bytes,
+                    int32_t *token_ids, size_t token_capacity,
+                    size_t *token_count, char *error, size_t error_size);
+    int (*detokenize)(void *engine_impl, const int32_t *token_ids,
+                      size_t token_count, char *text, size_t text_capacity,
+                      size_t *text_bytes, char *error, size_t error_size);
+    int (*embed)(void *engine_impl, const ColiEdgeEmbedRequest *request,
+                 char *error, size_t error_size);
+    int (*select)(void *engine_impl, const ColiEdgeSelectRequest *request,
+                  char *error, size_t error_size);
+
+    void (*reserved_fn[8])(void);
+} ColiEdgeAdapter;
+
+int coli_edge_adapter_register(const ColiEdgeAdapter *adapter);
+const ColiEdgeAdapter *coli_edge_adapter_lookup(const char *engine_id);
+int coli_edge_adapter_count(void);
+
+int coli_edge_engine_open(const char *engine_id,
+                          const ColiEdgeEngineOptions *options,
+                          ColiEdgeEngine **engine,
+                          char *error, size_t error_size);
+int coli_edge_engine_capabilities(const ColiEdgeEngine *engine,
+                                  ColiEdgeCapabilities *capabilities,
+                                  char *error, size_t error_size);
+void coli_edge_engine_close(ColiEdgeEngine *engine);
+
+/* Tokenizer calls support a sizing pass: output may be NULL only when its
+ * capacity is zero. The required count/size is always returned on success. */
+int coli_edge_tokenize(ColiEdgeEngine *engine,
+                       const char *text, size_t text_bytes,
+                       int32_t *token_ids, size_t token_capacity,
+                       size_t *token_count,
+                       char *error, size_t error_size);
+int coli_edge_detokenize(ColiEdgeEngine *engine,
+                         const int32_t *token_ids, size_t token_count,
+                         char *text, size_t text_capacity, size_t *text_bytes,
+                         char *error, size_t error_size);
+int coli_edge_embed(ColiEdgeEngine *engine,
+                    const ColiEdgeEmbedRequest *request,
+                    char *error, size_t error_size);
+int coli_edge_select(ColiEdgeEngine *engine,
+                     const ColiEdgeSelectRequest *request,
+                     char *error, size_t error_size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* COLIBRI_EDGE_RUNTIME_H */

--- a/c/edge_tok_internal.h
+++ b/c/edge_tok_internal.h
@@ -1,0 +1,105 @@
+#ifndef COLIBRI_EDGE_TOK_INTERNAL_H
+#define COLIBRI_EDGE_TOK_INTERNAL_H
+
+/* Include after tok.h. Kept separate because Qwen3.6 owns a different
+ * production tokenizer whose internal BPE symbol names intentionally overlap
+ * with tok.h. */
+
+#include "edge_adapter_internal.h"
+
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Byte-level BPE cannot emit more IDs than input bytes: every merge reduces
+ * the count and an added token replaces at least one byte. A private temporary
+ * makes the public two-pass API exact without depending on tok_encode's
+ * caller-capacity truncation semantics. */
+static int coli_edge_tok_tokenize(
+    Tok *tokenizer, const char *text, size_t text_bytes,
+    int32_t *token_ids, size_t token_capacity, size_t *token_count,
+    char *error, size_t error_size) {
+    if (!tokenizer || !text || !token_count || text_bytes > INT_MAX)
+        return coli_edge_adapter_error(error, error_size,
+                                       "tokenizer input is too large");
+    size_t capacity = text_bytes ? text_bytes : 1;
+    if (capacity > INT_MAX)
+        return coli_edge_adapter_error(error, error_size,
+                                       "tokenizer output is too large");
+    int *temporary = malloc(capacity * sizeof(*temporary));
+    if (!temporary)
+        return coli_edge_adapter_error(error, error_size,
+                                       "out of memory tokenizing text");
+    int count = tok_encode(tokenizer, text, (int)text_bytes,
+                           temporary, (int)capacity);
+    if (count < 0 || (size_t)count > capacity) {
+        free(temporary);
+        return coli_edge_adapter_error(error, error_size,
+                                       "tokenizer returned an invalid count");
+    }
+    *token_count = (size_t)count;
+    if (token_ids && token_capacity < (size_t)count) {
+        free(temporary);
+        return coli_edge_adapter_error(error, error_size,
+                                       "token output buffer is too small");
+    }
+    if (token_ids)
+        for (int item = 0; item < count; item++) token_ids[item] = temporary[item];
+    free(temporary);
+    return 0;
+}
+
+static int coli_edge_tok_detokenize(
+    Tok *tokenizer, const int32_t *token_ids, size_t token_count,
+    char *text, size_t text_capacity, size_t *text_bytes,
+    char *error, size_t error_size) {
+    if (!tokenizer || !token_ids || !token_count || !text_bytes ||
+        token_count > INT_MAX)
+        return coli_edge_adapter_error(error, error_size,
+                                       "invalid detokenizer input");
+    int *ids = malloc(token_count * sizeof(*ids));
+    if (!ids)
+        return coli_edge_adapter_error(error, error_size,
+                                       "out of memory detokenizing tokens");
+    for (size_t item = 0; item < token_count; item++) ids[item] = token_ids[item];
+
+    size_t capacity = token_count < 16 ? 256 :
+        (token_count > (size_t)INT_MAX / 16u ? (size_t)INT_MAX :
+         token_count * 16u);
+    char *temporary = NULL;
+    int count = 0;
+    for (;;) {
+        temporary = malloc(capacity + 1);
+        if (!temporary) {
+            free(ids);
+            return coli_edge_adapter_error(error, error_size,
+                                           "out of memory detokenizing tokens");
+        }
+        count = tok_decode(tokenizer, ids, (int)token_count,
+                           temporary, (int)capacity);
+        if (count < (int)capacity || capacity == INT_MAX) break;
+        free(temporary); temporary = NULL;
+        if (capacity > (size_t)INT_MAX / 2u) capacity = INT_MAX;
+        else capacity *= 2u;
+    }
+    free(ids);
+    if (count < 0 || count == INT_MAX) {
+        free(temporary);
+        return coli_edge_adapter_error(error, error_size,
+                                       "detokenized text is too large");
+    }
+    *text_bytes = (size_t)count;
+    if (text && text_capacity < (size_t)count + 1u) {
+        free(temporary);
+        return coli_edge_adapter_error(error, error_size,
+                                       "text output buffer is too small");
+    }
+    if (text) {
+        memcpy(text, temporary, (size_t)count);
+        text[count] = '\0';
+    }
+    free(temporary);
+    return 0;
+}
+
+#endif /* COLIBRI_EDGE_TOK_INTERNAL_H */

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -46,6 +46,11 @@
 #include "segment_adapters.h"
 #include "segment_adapter_internal.h"
 #endif
+#ifdef COLI_EDGE_ADAPTER
+#include "edge_runtime.h"
+#include "edge_adapters.h"
+#include "edge_tok_internal.h"
+#endif
 #ifdef COLI_CUDA
 #include "backend_cuda_ink.h"
 static int g_cuda = 0;
@@ -2979,3 +2984,211 @@ int coli_inkling_segment_adapter_register(void) {
     return coli_segment_adapter_register(&inkling_segment_adapter);
 }
 #endif /* COLI_SEGMENT_ADAPTER */
+
+#ifdef COLI_EDGE_ADAPTER
+/* ---------- engine-owned model Edge adapter --------------------------- */
+
+typedef struct {
+    Model model;
+    Tok tokenizer;
+} InklingEdgeEngine;
+
+static void inkling_edge_wt_destroy(Wt *weight) {
+    if (!weight) return;
+    free(weight->f); free(weight->h); free(weight->q4); free(weight->qs);
+    memset(weight, 0, sizeof(*weight));
+}
+
+static uint64_t inkling_edge_wt_bytes(const Wt *weight, uint64_t rows,
+                                      uint64_t columns) {
+    if (weight->f) return rows * columns * sizeof(float);
+    if (weight->h) return rows * columns * sizeof(uint16_t);
+    if (!weight->q4) return 0;
+    uint64_t scales = weight->qbits == 4 && weight->gs > 0
+        ? rows * ((columns + (uint64_t)weight->gs - 1u) /
+                  (uint64_t)weight->gs)
+        : rows;
+    return (uint64_t)weight->qn + scales * sizeof(float);
+}
+
+static void inkling_edge_engine_destroy(void *engine_impl) {
+    InklingEdgeEngine *engine = (InklingEdgeEngine *)engine_impl;
+    if (!engine) return;
+    inkling_edge_wt_destroy(&engine->model.embed);
+    inkling_edge_wt_destroy(&engine->model.lm_head);
+    free(engine->model.embed_norm); free(engine->model.final_norm);
+    st_destroy(&engine->model.Sq); st_destroy(&engine->model.S);
+    tok_free(&engine->tokenizer);
+    free(engine);
+}
+
+static int inkling_edge_engine_open(
+    void **engine_impl, ColiEdgeCapabilities *capabilities,
+    const ColiEdgeEngineOptions *options, char *error, size_t error_size) {
+    if (!engine_impl || !capabilities || !options)
+        return coli_edge_adapter_error(error, error_size,
+                                       "invalid Inkling Edge open");
+    *engine_impl = NULL;
+    if (options->backend_mask &&
+        (options->backend_mask & ~COLI_EDGE_CAP_CPU))
+        return coli_edge_adapter_error(error, error_size,
+                                       "Inkling Edge supports CPU only");
+    InklingEdgeEngine *engine = calloc(1, sizeof(*engine));
+    if (!engine)
+        return coli_edge_adapter_error(error, error_size,
+                                       "out of memory opening Inkling Edge");
+    Model *model = &engine->model;
+    load_cfg(&model->c, options->model_dir);
+    st_init(&model->S, options->model_dir);
+    char quantized_dir[4096];
+    snprintf(quantized_dir, sizeof(quantized_dir), "%s/dense-int4g64",
+             options->model_dir);
+    const char *disable_quantized = getenv("INK_DENSE_Q4");
+    struct stat quantized_stat;
+    if (!(disable_quantized && *disable_quantized == '0') &&
+        stat(quantized_dir, &quantized_stat) == 0 &&
+        S_ISDIR(quantized_stat.st_mode)) {
+        st_init(&model->Sq, quantized_dir);
+        model->has_q = model->Sq.n > 0;
+    }
+    model->embed = load_w(model, "model.embed_tokens.weight", 0);
+    model->embed_norm = st_has(&model->S, "model.embed_norm.weight")
+        ? load_t(model, "model.embed_norm.weight") : NULL;
+    model->final_norm = load_t(model, "model.norm.weight");
+    model->lm_head = load_w(model, "lm_head.weight", 1);
+    char tokenizer_path[4096];
+    snprintf(tokenizer_path, sizeof(tokenizer_path), "%s/tokenizer.json",
+             options->model_dir);
+    tok_load(&engine->tokenizer, tokenizer_path);
+
+    Cfg *config = &model->c;
+    uint64_t resident = inkling_edge_wt_bytes(
+        &model->embed, (uint64_t)config->vocab, (uint64_t)config->hidden);
+    resident += inkling_edge_wt_bytes(
+        &model->lm_head, (uint64_t)config->vocab, (uint64_t)config->hidden);
+    resident += (uint64_t)config->hidden * sizeof(float);
+    if (model->embed_norm)
+        resident += (uint64_t)config->hidden * sizeof(float);
+    if (options->memory_limit_bytes && resident > options->memory_limit_bytes) {
+        inkling_edge_engine_destroy(engine);
+        return coli_edge_adapter_error(error, error_size,
+                                       "Inkling Edge exceeds memory limit");
+    }
+    int bits = getenv("INK_SEGMENT_BITS")
+        ? atoi(getenv("INK_SEGMENT_BITS")) : 0;
+    memset(capabilities, 0, sizeof(*capabilities));
+    capabilities->struct_size = sizeof(*capabilities);
+    capabilities->abi_version = COLI_EDGE_ABI_VERSION;
+    capabilities->flags = COLI_EDGE_CAP_TOKENIZE |
+                          COLI_EDGE_CAP_DETOKENIZE |
+                          COLI_EDGE_CAP_GREEDY |
+                          COLI_EDGE_CAP_CPU;
+    coli_edge_capability_string(capabilities->engine_id,
+                                sizeof(capabilities->engine_id), "inkling");
+    coli_edge_capability_string(capabilities->state_schema,
+                                sizeof(capabilities->state_schema),
+                                "inkling/kv-ring-conv-f32-v1");
+    snprintf(capabilities->numeric_class,
+             sizeof(capabilities->numeric_class),
+             "inkling/expert-q%d/f32/cpu-v1", bits);
+    coli_edge_capability_string(capabilities->tokenizer_class,
+                                sizeof(capabilities->tokenizer_class),
+                                "inkling/o200k-byte-bpe-v1");
+    capabilities->state_dtype = COLI_EDGE_DTYPE_F32;
+    capabilities->state_width = (uint32_t)config->hidden;
+    capabilities->vocab_size = (uint32_t)config->unpad_vocab;
+    capabilities->max_batch_rows = 128;
+    capabilities->max_context_tokens = UINT32_MAX;
+    capabilities->num_layers = (uint32_t)config->n_layers;
+    capabilities->bos_token_id = -1;
+    capabilities->eos_token_id = config->eos;
+    capabilities->resident_bytes = resident;
+    *engine_impl = engine;
+    return 0;
+}
+
+static int inkling_edge_tokenize(
+    void *engine_impl, const char *text, size_t text_bytes,
+    int32_t *token_ids, size_t token_capacity, size_t *token_count,
+    char *error, size_t error_size) {
+    InklingEdgeEngine *engine = (InklingEdgeEngine *)engine_impl;
+    return coli_edge_tok_tokenize(&engine->tokenizer, text, text_bytes,
+                                  token_ids, token_capacity, token_count,
+                                  error, error_size);
+}
+
+static int inkling_edge_detokenize(
+    void *engine_impl, const int32_t *token_ids, size_t token_count,
+    char *text, size_t text_capacity, size_t *text_bytes,
+    char *error, size_t error_size) {
+    InklingEdgeEngine *engine = (InklingEdgeEngine *)engine_impl;
+    return coli_edge_tok_detokenize(&engine->tokenizer, token_ids, token_count,
+                                    text, text_capacity, text_bytes,
+                                    error, error_size);
+}
+
+static int inkling_edge_embed(void *engine_impl,
+                              const ColiEdgeEmbedRequest *request,
+                              char *error, size_t error_size) {
+    InklingEdgeEngine *engine = (InklingEdgeEngine *)engine_impl;
+    Cfg *config = &engine->model.c;
+    float *output = (float *)request->output;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        int token = request->token_ids[row];
+        if (token < 0 || token >= config->vocab)
+            return coli_edge_adapter_error(error, error_size,
+                                           "Inkling token ID is out of range");
+        float *state = output + (size_t)row * config->hidden;
+        wt_row_f32(engine->model.embed, (int64_t)token * config->hidden,
+                   state, config->hidden);
+        if (engine->model.embed_norm)
+            rmsnorm_row(state, state, engine->model.embed_norm,
+                        config->hidden, config->eps);
+    }
+    return 0;
+}
+
+static int inkling_edge_select(void *engine_impl,
+                               const ColiEdgeSelectRequest *request,
+                               char *error, size_t error_size) {
+    InklingEdgeEngine *engine = (InklingEdgeEngine *)engine_impl;
+    Cfg *config = &engine->model.c;
+    float *normalized = falloc(config->hidden);
+    float *logits = falloc(config->unpad_vocab);
+    const float *input = (const float *)request->input;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        if (request->should_cancel &&
+            request->should_cancel(request->cancel_user_data)) {
+            free(logits); free(normalized);
+            return coli_edge_adapter_error(error, error_size,
+                                           "Inkling Edge selection cancelled");
+        }
+        rmsnorm_row(normalized, input + (size_t)row * config->hidden,
+                    engine->model.final_norm, config->hidden, config->eps);
+        for (int item = 0; item < config->hidden; item++)
+            normalized[item] /= config->mup;
+        matmul_w(logits, normalized, engine->model.lm_head,
+                 1, config->hidden, config->unpad_vocab);
+        if (coli_edge_argmax(logits, (uint32_t)config->unpad_vocab,
+                            &request->token_ids[row],
+                            request->scores ? &request->scores[row] : NULL)) {
+            free(logits); free(normalized);
+            return coli_edge_adapter_error(error, error_size,
+                                           "Inkling Edge head failed");
+        }
+    }
+    free(logits); free(normalized);
+    return 0;
+}
+
+static const ColiEdgeAdapter inkling_edge_adapter = {
+    sizeof(ColiEdgeAdapter), COLI_EDGE_ABI_VERSION, "inkling",
+    inkling_edge_engine_open, inkling_edge_engine_destroy,
+    inkling_edge_tokenize, inkling_edge_detokenize,
+    inkling_edge_embed, inkling_edge_select, {0}
+};
+
+int coli_inkling_edge_adapter_register(void) {
+    return coli_edge_adapter_register(&inkling_edge_adapter);
+}
+#endif /* COLI_EDGE_ADAPTER */

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -120,6 +120,11 @@
 #include "segment_adapters.h"
 #include "segment_adapter_internal.h"
 #endif
+#ifdef COLI_EDGE_ADAPTER
+#include "edge_runtime.h"
+#include "edge_adapters.h"
+#include "edge_tok_internal.h"
+#endif
 
 /* ---------- config ---------- */
 typedef struct {
@@ -3726,3 +3731,230 @@ int coli_kimi_segment_adapter_register(void) {
     return coli_segment_adapter_register(&kimi_segment_adapter);
 }
 #endif /* COLI_SEGMENT_ADAPTER */
+
+#ifdef COLI_EDGE_ADAPTER
+/* ---------- engine-owned model Edge adapter --------------------------- */
+
+typedef struct {
+    Model model;
+    Tok tokenizer;
+    uint32_t state_width, nbmax;
+} KimiEdgeEngine;
+
+static uint64_t kimi_edge_w_bytes(const W *weight) {
+    uint64_t cells = (uint64_t)weight->O * weight->I;
+    if (weight->fmt == 0) return cells * sizeof(float);
+    if (weight->fmt == 1) return cells + (uint64_t)weight->O * sizeof(float);
+    if (weight->fmt == 2)
+        return (cells + 1u) / 2u + (uint64_t)weight->O * sizeof(float);
+    if (weight->fmt == 4) {
+        uint64_t groups = ((uint64_t)weight->I + weight->gs - 1u) /
+                          (uint64_t)weight->gs;
+        return (cells + 1u) / 2u +
+               (uint64_t)weight->O * groups * sizeof(float);
+    }
+    return 0;
+}
+
+static void kimi_edge_engine_destroy(void *engine_impl) {
+    KimiEdgeEngine *engine = (KimiEdgeEngine *)engine_impl;
+    if (!engine) return;
+    free(engine->model.final_norm); free(engine->model.out_sw);
+    w_release_host(&engine->model.lm_head);
+    st_destroy(&engine->model.S);
+    tok_free(&engine->tokenizer);
+    free(engine);
+}
+
+static int kimi_edge_engine_open(
+    void **engine_impl, ColiEdgeCapabilities *capabilities,
+    const ColiEdgeEngineOptions *options, char *error, size_t error_size) {
+    if (!engine_impl || !capabilities || !options)
+        return coli_edge_adapter_error(error, error_size,
+                                       "invalid Kimi K3 Edge open");
+    *engine_impl = NULL;
+    if (options->backend_mask &&
+        (options->backend_mask & ~COLI_EDGE_CAP_CPU))
+        return coli_edge_adapter_error(error, error_size,
+                                       "Kimi K3 Edge supports CPU only");
+    KimiEdgeEngine *engine = calloc(1, sizeof(*engine));
+    if (!engine)
+        return coli_edge_adapter_error(error, error_size,
+                                       "out of memory opening Kimi K3 Edge");
+    Model *model = &engine->model;
+    load_cfg(&model->c, options->model_dir);
+    st_init_multi(&model->S, options->model_dir, getenv("K3_DIRS"));
+    model->pfx[0] = '\0';
+    if (!st_has(&model->S, "model.layers.0.input_layernorm.weight") &&
+        st_has(&model->S,
+               "language_model.model.layers.0.input_layernorm.weight"))
+        snprintf(model->pfx, sizeof(model->pfx), "language_model.");
+    Cfg *config = &model->c;
+    uint64_t nbmax = ((uint64_t)config->n_layers + config->res_bs - 1u) /
+                     (uint64_t)config->res_bs;
+    uint64_t state_width = (1u + nbmax) * (uint64_t)config->hidden;
+    if (!nbmax || state_width > UINT32_MAX) {
+        kimi_edge_engine_destroy(engine);
+        return coli_edge_adapter_error(error, error_size,
+                                       "Kimi K3 boundary state is too wide");
+    }
+    engine->nbmax = (uint32_t)nbmax;
+    engine->state_width = (uint32_t)state_width;
+    g_bits_env = getenv("K3_BITS") != NULL;
+    g_k3_mmap = getenv("K3_MMAP") ? atoi(getenv("K3_MMAP")) : 0;
+    g_k3_idot = getenv("K3_IDOT") ? atoi(getenv("K3_IDOT")) : 1;
+    int head_bits = getenv("K3_HEAD_BITS")
+        ? atoi(getenv("K3_HEAD_BITS")) : 8;
+    char name[512];
+    snprintf(name, sizeof(name), "%smodel.norm.weight", model->pfx);
+    if (!st_has(&model->S, name)) {
+        kimi_edge_engine_destroy(engine);
+        return coli_edge_adapter_error(error, error_size,
+                                       "Kimi K3 final head is not present");
+    }
+    model->has_head = 1;
+    model->final_norm = f32_load(model, "model.norm.weight", config->hidden);
+    float *residual_norm = f32_load(
+        model, "model.output_attn_res_norm.weight", config->hidden);
+    float *residual_projection = f32_load(
+        model, "model.output_attn_res_proj.weight", config->hidden);
+    model->out_sw = falloc(config->hidden);
+    for (int item = 0; item < config->hidden; item++)
+        model->out_sw[item] = residual_norm[item] * residual_projection[item];
+    free(residual_norm); free(residual_projection);
+    w_load(model, &model->lm_head, "lm_head.weight",
+           config->vocab, config->hidden, head_bits);
+    char tokenizer_path[4096];
+    snprintf(tokenizer_path, sizeof(tokenizer_path), "%s/tokenizer.json",
+             options->model_dir);
+    tok_load(&engine->tokenizer, tokenizer_path);
+
+    uint64_t resident = kimi_edge_w_bytes(&model->lm_head) +
+                        2u * (uint64_t)config->hidden * sizeof(float);
+    if (options->memory_limit_bytes && resident > options->memory_limit_bytes) {
+        kimi_edge_engine_destroy(engine);
+        return coli_edge_adapter_error(error, error_size,
+                                       "Kimi K3 Edge exceeds memory limit");
+    }
+    int bits = getenv("K3_BITS") ? atoi(getenv("K3_BITS")) : 4;
+    int mla_bits = getenv("K3_MLA_BITS") ? atoi(getenv("K3_MLA_BITS")) : 8;
+    memset(capabilities, 0, sizeof(*capabilities));
+    capabilities->struct_size = sizeof(*capabilities);
+    capabilities->abi_version = COLI_EDGE_ABI_VERSION;
+    capabilities->flags = COLI_EDGE_CAP_TOKENIZE |
+                          COLI_EDGE_CAP_DETOKENIZE |
+                          COLI_EDGE_CAP_GREEDY |
+                          COLI_EDGE_CAP_CPU;
+    coli_edge_capability_string(capabilities->engine_id,
+                                sizeof(capabilities->engine_id), "kimi");
+    coli_edge_capability_string(capabilities->state_schema,
+                                sizeof(capabilities->state_schema),
+                                "kimi-k3/attnres-kda-mla-dsa-f32-v1");
+    snprintf(capabilities->numeric_class,
+             sizeof(capabilities->numeric_class),
+             "kimi-k3/q%d-mla%d-mxfp4-idot%d/f32/cpu-v1",
+             bits, mla_bits, g_k3_idot != 0);
+    coli_edge_capability_string(capabilities->tokenizer_class,
+                                sizeof(capabilities->tokenizer_class),
+                                "kimi-k3/rank-byte-bpe-v1");
+    capabilities->state_dtype = COLI_EDGE_DTYPE_F32;
+    capabilities->state_width = engine->state_width;
+    capabilities->vocab_size = (uint32_t)config->vocab;
+    capabilities->max_batch_rows = 128;
+    capabilities->max_context_tokens = UINT32_MAX;
+    capabilities->num_layers = (uint32_t)config->n_layers;
+    capabilities->bos_token_id = config->bos;
+    capabilities->eos_token_id = config->n_eos ? config->eos[0] : -1;
+    capabilities->resident_bytes = resident;
+    *engine_impl = engine;
+    return 0;
+}
+
+static int kimi_edge_tokenize(
+    void *engine_impl, const char *text, size_t text_bytes,
+    int32_t *token_ids, size_t token_capacity, size_t *token_count,
+    char *error, size_t error_size) {
+    KimiEdgeEngine *engine = (KimiEdgeEngine *)engine_impl;
+    return coli_edge_tok_tokenize(&engine->tokenizer, text, text_bytes,
+                                  token_ids, token_capacity, token_count,
+                                  error, error_size);
+}
+
+static int kimi_edge_detokenize(
+    void *engine_impl, const int32_t *token_ids, size_t token_count,
+    char *text, size_t text_capacity, size_t *text_bytes,
+    char *error, size_t error_size) {
+    KimiEdgeEngine *engine = (KimiEdgeEngine *)engine_impl;
+    return coli_edge_tok_detokenize(&engine->tokenizer, token_ids, token_count,
+                                    text, text_capacity, text_bytes,
+                                    error, error_size);
+}
+
+static int kimi_edge_embed(void *engine_impl,
+                           const ColiEdgeEmbedRequest *request,
+                           char *error, size_t error_size) {
+    KimiEdgeEngine *engine = (KimiEdgeEngine *)engine_impl;
+    Cfg *config = &engine->model.c;
+    float *output = (float *)request->output;
+    char name[512];
+    snprintf(name, sizeof(name), "%smodel.embed_tokens.weight",
+             engine->model.pfx);
+    for (uint32_t row = 0; row < request->rows; row++) {
+        int token = request->token_ids[row];
+        if (token < 0 || token >= config->vocab)
+            return coli_edge_adapter_error(error, error_size,
+                                           "Kimi K3 token ID is out of range");
+        float *state = output + (size_t)row * engine->state_width;
+        memset(state, 0, (size_t)engine->state_width * sizeof(float));
+        st_read_slice_f32(&engine->model.S, name,
+                          (int64_t)token * config->hidden,
+                          config->hidden, state, 0);
+    }
+    return 0;
+}
+
+static int kimi_edge_select(void *engine_impl,
+                            const ColiEdgeSelectRequest *request,
+                            char *error, size_t error_size) {
+    KimiEdgeEngine *engine = (KimiEdgeEngine *)engine_impl;
+    Cfg *config = &engine->model.c;
+    float *mixed = falloc(config->hidden);
+    float *logits = falloc(config->vocab);
+    const float *input = (const float *)request->input;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        if (request->should_cancel &&
+            request->should_cancel(request->cancel_user_data)) {
+            free(logits); free(mixed);
+            return coli_edge_adapter_error(error, error_size,
+                                           "Kimi K3 Edge selection cancelled");
+        }
+        const float *state = input + (size_t)row * engine->state_width;
+        res_mix(mixed, state, state + config->hidden,
+                (int)engine->nbmax, config->hidden,
+                engine->model.out_sw, config->eps);
+        rmsnorm_(mixed, mixed, engine->model.final_norm,
+                 config->hidden, config->eps);
+        w_matmul(logits, mixed, &engine->model.lm_head, 1);
+        if (coli_edge_argmax(logits, (uint32_t)config->vocab,
+                            &request->token_ids[row],
+                            request->scores ? &request->scores[row] : NULL)) {
+            free(logits); free(mixed);
+            return coli_edge_adapter_error(error, error_size,
+                                           "Kimi K3 Edge head failed");
+        }
+    }
+    free(logits); free(mixed);
+    return 0;
+}
+
+static const ColiEdgeAdapter kimi_edge_adapter = {
+    sizeof(ColiEdgeAdapter), COLI_EDGE_ABI_VERSION, "kimi",
+    kimi_edge_engine_open, kimi_edge_engine_destroy,
+    kimi_edge_tokenize, kimi_edge_detokenize,
+    kimi_edge_embed, kimi_edge_select, {0}
+};
+
+int coli_kimi_edge_adapter_register(void) {
+    return coli_edge_adapter_register(&kimi_edge_adapter);
+}
+#endif /* COLI_EDGE_ADAPTER */

--- a/c/olmoe.c
+++ b/c/olmoe.c
@@ -43,6 +43,12 @@
 #include "segment_adapters.h"
 #include "segment_adapter_internal.h"
 #endif
+#ifdef COLI_EDGE_ADAPTER
+#include "edge_runtime.h"
+#include "edge_adapters.h"
+#include "tok.h"
+#include "edge_tok_internal.h"
+#endif
 
 #ifdef _WIN32
 #include <windows.h>
@@ -1942,3 +1948,167 @@ int coli_olmoe_segment_adapter_register(void) {
     return coli_segment_adapter_register(&olmoe_segment_adapter);
 }
 #endif /* COLI_SEGMENT_ADAPTER */
+
+#ifdef COLI_EDGE_ADAPTER
+/* ---------- engine-owned model Edge adapter --------------------------- */
+
+typedef struct {
+    Model model;
+    Tok tokenizer;
+} OlmoeEdgeEngine;
+
+static void olmoe_edge_engine_destroy(void *engine_impl) {
+    OlmoeEdgeEngine *engine = (OlmoeEdgeEngine *)engine_impl;
+    if (!engine) return;
+    free(engine->model.embed);
+    free(engine->model.lm_head);
+    free(engine->model.final_norm);
+    st_destroy(&engine->model.S);
+    tok_free(&engine->tokenizer);
+    free(engine);
+}
+
+static int olmoe_edge_engine_open(
+    void **engine_impl, ColiEdgeCapabilities *capabilities,
+    const ColiEdgeEngineOptions *options, char *error, size_t error_size) {
+    if (!engine_impl || !capabilities || !options)
+        return coli_edge_adapter_error(error, error_size,
+                                       "invalid OLMoE Edge open");
+    *engine_impl = NULL;
+    if (options->backend_mask &&
+        (options->backend_mask & ~COLI_EDGE_CAP_CPU))
+        return coli_edge_adapter_error(error, error_size,
+                                       "OLMoE Edge supports CPU only");
+    OlmoeEdgeEngine *engine = calloc(1, sizeof(*engine));
+    if (!engine)
+        return coli_edge_adapter_error(error, error_size,
+                                       "out of memory opening OLMoE Edge");
+    load_cfg(&engine->model.c, options->model_dir);
+    st_init(&engine->model.S, options->model_dir);
+    engine->model.embed = load_t(&engine->model, "model.embed_tokens.weight");
+    engine->model.lm_head = load_t(&engine->model, "lm_head.weight");
+    engine->model.final_norm = load_t(&engine->model, "model.norm.weight");
+    char tokenizer_path[4096];
+    snprintf(tokenizer_path, sizeof(tokenizer_path), "%s/tokenizer.json",
+             options->model_dir);
+    tok_load(&engine->tokenizer, tokenizer_path);
+
+    Cfg *config = &engine->model.c;
+    uint64_t cells = (uint64_t)config->vocab * config->hidden;
+    uint64_t resident = (2u * cells + (uint64_t)config->hidden) * sizeof(float);
+    if (options->memory_limit_bytes && resident > options->memory_limit_bytes) {
+        olmoe_edge_engine_destroy(engine);
+        return coli_edge_adapter_error(error, error_size,
+                                       "OLMoE Edge exceeds memory limit");
+    }
+    memset(capabilities, 0, sizeof(*capabilities));
+    capabilities->struct_size = sizeof(*capabilities);
+    capabilities->abi_version = COLI_EDGE_ABI_VERSION;
+    capabilities->flags = COLI_EDGE_CAP_TOKENIZE |
+                          COLI_EDGE_CAP_DETOKENIZE |
+                          COLI_EDGE_CAP_GREEDY |
+                          COLI_EDGE_CAP_CPU;
+    coli_edge_capability_string(capabilities->engine_id,
+                                sizeof(capabilities->engine_id), "olmoe");
+    coli_edge_capability_string(capabilities->state_schema,
+                                sizeof(capabilities->state_schema),
+                                "olmoe/kv-f32-v1");
+    coli_edge_capability_string(capabilities->numeric_class,
+                                sizeof(capabilities->numeric_class),
+                                "olmoe/f32-int8/cpu-v1");
+    coli_edge_capability_string(capabilities->tokenizer_class,
+                                sizeof(capabilities->tokenizer_class),
+                                "olmoe/byte-bpe-v1");
+    capabilities->state_dtype = COLI_EDGE_DTYPE_F32;
+    capabilities->state_width = (uint32_t)config->hidden;
+    capabilities->vocab_size = (uint32_t)config->vocab;
+    capabilities->max_batch_rows = 128;
+    capabilities->max_context_tokens = 4096;
+    capabilities->num_layers = (uint32_t)config->n_layers;
+    capabilities->bos_token_id = -1;
+    capabilities->eos_token_id = -1;
+    capabilities->resident_bytes = resident;
+    *engine_impl = engine;
+    return 0;
+}
+
+static int olmoe_edge_tokenize(
+    void *engine_impl, const char *text, size_t text_bytes,
+    int32_t *token_ids, size_t token_capacity, size_t *token_count,
+    char *error, size_t error_size) {
+    OlmoeEdgeEngine *engine = (OlmoeEdgeEngine *)engine_impl;
+    return coli_edge_tok_tokenize(&engine->tokenizer, text, text_bytes,
+                                  token_ids, token_capacity, token_count,
+                                  error, error_size);
+}
+
+static int olmoe_edge_detokenize(
+    void *engine_impl, const int32_t *token_ids, size_t token_count,
+    char *text, size_t text_capacity, size_t *text_bytes,
+    char *error, size_t error_size) {
+    OlmoeEdgeEngine *engine = (OlmoeEdgeEngine *)engine_impl;
+    return coli_edge_tok_detokenize(&engine->tokenizer, token_ids, token_count,
+                                    text, text_capacity, text_bytes,
+                                    error, error_size);
+}
+
+static int olmoe_edge_embed(void *engine_impl,
+                            const ColiEdgeEmbedRequest *request,
+                            char *error, size_t error_size) {
+    OlmoeEdgeEngine *engine = (OlmoeEdgeEngine *)engine_impl;
+    Cfg *config = &engine->model.c;
+    float *output = (float *)request->output;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        int token = request->token_ids[row];
+        if (token < 0 || token >= config->vocab)
+            return coli_edge_adapter_error(error, error_size,
+                                           "OLMoE token ID is out of range");
+        memcpy(output + (size_t)row * config->hidden,
+               engine->model.embed + (size_t)token * config->hidden,
+               (size_t)config->hidden * sizeof(float));
+    }
+    return 0;
+}
+
+static int olmoe_edge_select(void *engine_impl,
+                             const ColiEdgeSelectRequest *request,
+                             char *error, size_t error_size) {
+    OlmoeEdgeEngine *engine = (OlmoeEdgeEngine *)engine_impl;
+    Cfg *config = &engine->model.c;
+    float *normalized = falloc(config->hidden);
+    float *logits = falloc(config->vocab);
+    const float *input = (const float *)request->input;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        if (request->should_cancel &&
+            request->should_cancel(request->cancel_user_data)) {
+            free(logits); free(normalized);
+            return coli_edge_adapter_error(error, error_size,
+                                           "OLMoE Edge selection cancelled");
+        }
+        rmsnorm_row(normalized, input + (size_t)row * config->hidden,
+                    engine->model.final_norm, config->hidden, config->eps);
+        matmul(logits, normalized, engine->model.lm_head,
+               1, config->hidden, config->vocab);
+        if (coli_edge_argmax(logits, (uint32_t)config->vocab,
+                            &request->token_ids[row],
+                            request->scores ? &request->scores[row] : NULL)) {
+            free(logits); free(normalized);
+            return coli_edge_adapter_error(error, error_size,
+                                           "OLMoE Edge head failed");
+        }
+    }
+    free(logits); free(normalized);
+    return 0;
+}
+
+static const ColiEdgeAdapter olmoe_edge_adapter = {
+    sizeof(ColiEdgeAdapter), COLI_EDGE_ABI_VERSION, "olmoe",
+    olmoe_edge_engine_open, olmoe_edge_engine_destroy,
+    olmoe_edge_tokenize, olmoe_edge_detokenize,
+    olmoe_edge_embed, olmoe_edge_select, {0}
+};
+
+int coli_olmoe_edge_adapter_register(void) {
+    return coli_edge_adapter_register(&olmoe_edge_adapter);
+}
+#endif /* COLI_EDGE_ADAPTER */

--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -65,6 +65,12 @@ static int qwen36_max_ctx(void) {
 #include "segment_adapters.h"
 #include "segment_adapter_internal.h"
 #endif
+#ifdef COLI_EDGE_ADAPTER
+#include "edge_runtime.h"
+#include "edge_adapters.h"
+#include "edge_adapter_internal.h"
+#include <limits.h>
+#endif
 
 #ifdef _WIN32
 #include <windows.h>
@@ -3158,3 +3164,242 @@ int coli_qwen36_segment_adapter_register(void) {
     return coli_segment_adapter_register(&qwen36_segment_adapter);
 }
 #endif /* COLI_SEGMENT_ADAPTER */
+
+#ifdef COLI_EDGE_ADAPTER
+/* ---------- engine-owned model Edge adapter --------------------------- */
+
+typedef struct {
+    Model model;
+} Qwen36EdgeEngine;
+
+static void qwen36_edge_tokenizer_destroy(void) {
+    for (int item = 0; item < g_tok_n; item++) free(g_tok[item]);
+    free(g_tok); g_tok = NULL; g_tok_n = 0;
+    for (int slot = 0; slot < g_merge.cap; slot++)
+        if (g_merge.used && g_merge.used[slot]) free(g_merge.keys[slot]);
+    free(g_rev.keys); free(g_rev.vals); free(g_rev.used);
+    free(g_merge.keys); free(g_merge.vals); free(g_merge.used);
+    memset(&g_rev, 0, sizeof(g_rev)); memset(&g_merge, 0, sizeof(g_merge));
+    for (int item = 0; item < g_nspecial; item++) free(g_sp_str[item]);
+    free(g_sp_str); free(g_sp_id); free(g_sp_len);
+    g_sp_str = NULL; g_sp_id = NULL; g_sp_len = NULL; g_nspecial = 0;
+}
+
+static void qwen36_edge_engine_destroy(void *engine_impl) {
+    Qwen36EdgeEngine *engine = (Qwen36EdgeEngine *)engine_impl;
+    if (!engine) return;
+    free(engine->model.embed);
+    free(engine->model.lm_head);
+    free(engine->model.final_norm);
+    free(engine->model.c.is_attn);
+    st_destroy(&engine->model.S);
+    qwen36_edge_tokenizer_destroy();
+    free(engine);
+}
+
+static int qwen36_edge_engine_open(
+    void **engine_impl, ColiEdgeCapabilities *capabilities,
+    const ColiEdgeEngineOptions *options, char *error, size_t error_size) {
+    if (!engine_impl || !capabilities || !options)
+        return coli_edge_adapter_error(error, error_size,
+                                       "invalid Qwen3.6 Edge open");
+    *engine_impl = NULL;
+    if (options->backend_mask &&
+        (options->backend_mask & ~COLI_EDGE_CAP_CPU))
+        return coli_edge_adapter_error(error, error_size,
+                                       "Qwen3.6 Edge supports CPU only");
+    /* qwen36.c's production tokenizer is process-global. The Edge runtime
+     * makes that limitation explicit instead of silently cross-wiring two
+     * model vocabularies in one process. Lumabri hosts one active model per
+     * chatter process; a future tokenizer refactor can lift this restriction. */
+    if (g_tok)
+        return coli_edge_adapter_error(error, error_size,
+                                       "a Qwen3.6 tokenizer is already active");
+    Qwen36EdgeEngine *engine = calloc(1, sizeof(*engine));
+    if (!engine)
+        return coli_edge_adapter_error(error, error_size,
+                                       "out of memory opening Qwen3.6 Edge");
+    load_cfg(&engine->model.c, options->model_dir);
+    int config_layers = engine->model.c.n_layers;
+    load_meta(&engine->model.c, options->model_dir);
+    validate_cfg(&engine->model.c, config_layers);
+    st_init(&engine->model.S, options->model_dir);
+    Cfg *config = &engine->model.c;
+    engine->model.embed = load_t_n(
+        &engine->model, "model.embed_tokens.weight",
+        (int64_t)config->vocab * config->hidden);
+    engine->model.lm_head = load_t_n(
+        &engine->model, "lm_head.weight",
+        (int64_t)config->vocab * config->hidden);
+    engine->model.final_norm = load_t_n(
+        &engine->model, "model.norm.weight", config->hidden);
+    engine->model.quant_bits = container_layer_is_int4(&engine->model, 0) ? 4 : 8;
+    char tokenizer_path[4096];
+    snprintf(tokenizer_path, sizeof(tokenizer_path), "%s/tokenizer.json",
+             options->model_dir);
+    load_tokenizer(tokenizer_path);
+    if (!g_tok) {
+        qwen36_edge_engine_destroy(engine);
+        return coli_edge_adapter_error(error, error_size,
+                                       "cannot load Qwen3.6 tokenizer");
+    }
+    uint64_t cells = (uint64_t)config->vocab * config->hidden;
+    uint64_t resident = (2u * cells + (uint64_t)config->hidden) * sizeof(float);
+    if (options->memory_limit_bytes && resident > options->memory_limit_bytes) {
+        qwen36_edge_engine_destroy(engine);
+        return coli_edge_adapter_error(error, error_size,
+                                       "Qwen3.6 Edge exceeds memory limit");
+    }
+
+    memset(capabilities, 0, sizeof(*capabilities));
+    capabilities->struct_size = sizeof(*capabilities);
+    capabilities->abi_version = COLI_EDGE_ABI_VERSION;
+    capabilities->flags = COLI_EDGE_CAP_TOKENIZE |
+                          COLI_EDGE_CAP_DETOKENIZE |
+                          COLI_EDGE_CAP_GREEDY |
+                          COLI_EDGE_CAP_CPU;
+    coli_edge_capability_string(capabilities->engine_id,
+                                sizeof(capabilities->engine_id), "qwen36");
+    coli_edge_capability_string(capabilities->state_schema,
+                                sizeof(capabilities->state_schema),
+                                "qwen36/kv-deltanet-conv-f32-v1");
+    snprintf(capabilities->numeric_class,
+             sizeof(capabilities->numeric_class),
+             "qwen36/f32-int%d/cpu-v1", engine->model.quant_bits);
+    coli_edge_capability_string(capabilities->tokenizer_class,
+                                sizeof(capabilities->tokenizer_class),
+                                "qwen36/hf-byte-bpe-v1");
+    capabilities->state_dtype = COLI_EDGE_DTYPE_F32;
+    capabilities->state_width = (uint32_t)config->hidden;
+    capabilities->vocab_size = (uint32_t)config->vocab;
+    capabilities->max_batch_rows = 128;
+    capabilities->max_context_tokens = QWEN36_ATTN_MAX_CTX;
+    capabilities->num_layers = (uint32_t)config->n_layers;
+    capabilities->bos_token_id = -1;
+    capabilities->eos_token_id = -1;
+    capabilities->resident_bytes = resident;
+    *engine_impl = engine;
+    return 0;
+}
+
+static int qwen36_edge_tokenize(
+    void *engine_impl, const char *text, size_t text_bytes,
+    int32_t *token_ids, size_t token_capacity, size_t *token_count,
+    char *error, size_t error_size) {
+    (void)engine_impl;
+    if (!text || !token_count || text_bytes > INT_MAX)
+        return coli_edge_adapter_error(error, error_size,
+                                       "invalid Qwen3.6 tokenizer input");
+    char *copy = malloc(text_bytes + 1u);
+    if (!copy)
+        return coli_edge_adapter_error(error, error_size,
+                                       "out of memory tokenizing Qwen3.6 text");
+    memcpy(copy, text, text_bytes); copy[text_bytes] = '\0';
+    int *ids = NULL, count = 0;
+    encode_text(copy, &ids, &count);
+    free(copy);
+    if (count < 0 || (token_ids && token_capacity < (size_t)count)) {
+        free(ids);
+        return coli_edge_adapter_error(error, error_size,
+                                       "Qwen3.6 token output buffer is too small");
+    }
+    *token_count = (size_t)count;
+    if (token_ids)
+        for (int item = 0; item < count; item++) token_ids[item] = ids[item];
+    free(ids);
+    return 0;
+}
+
+static int qwen36_edge_detokenize(
+    void *engine_impl, const int32_t *token_ids, size_t token_count,
+    char *text, size_t text_capacity, size_t *text_bytes,
+    char *error, size_t error_size) {
+    (void)engine_impl;
+    if (!token_ids || !token_count || !text_bytes || token_count > INT_MAX ||
+        token_count > (SIZE_MAX - 1u) / 255u ||
+        token_count > ((size_t)INT_MAX - 1u) / 255u)
+        return coli_edge_adapter_error(error, error_size,
+                                       "invalid Qwen3.6 detokenizer input");
+    int *ids = malloc(token_count * sizeof(*ids));
+    size_t capacity = token_count * 255u + 1u;
+    char *temporary = malloc(capacity);
+    if (!ids || !temporary) {
+        free(temporary); free(ids);
+        return coli_edge_adapter_error(error, error_size,
+                                       "out of memory detokenizing Qwen3.6 tokens");
+    }
+    for (size_t item = 0; item < token_count; item++) ids[item] = token_ids[item];
+    int count = decode_range(ids, 0, (int)token_count,
+                             temporary, (int)capacity);
+    free(ids);
+    *text_bytes = (size_t)count;
+    if (text && text_capacity < (size_t)count + 1u) {
+        free(temporary);
+        return coli_edge_adapter_error(error, error_size,
+                                       "Qwen3.6 text output buffer is too small");
+    }
+    if (text) memcpy(text, temporary, (size_t)count + 1u);
+    free(temporary);
+    return 0;
+}
+
+static int qwen36_edge_embed(void *engine_impl,
+                             const ColiEdgeEmbedRequest *request,
+                             char *error, size_t error_size) {
+    Qwen36EdgeEngine *engine = (Qwen36EdgeEngine *)engine_impl;
+    Cfg *config = &engine->model.c;
+    float *output = (float *)request->output;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        int token = request->token_ids[row];
+        if (token < 0 || token >= config->vocab)
+            return coli_edge_adapter_error(error, error_size,
+                                           "Qwen3.6 token ID is out of range");
+        memcpy(output + (size_t)row * config->hidden,
+               engine->model.embed + (size_t)token * config->hidden,
+               (size_t)config->hidden * sizeof(float));
+    }
+    return 0;
+}
+
+static int qwen36_edge_select(void *engine_impl,
+                              const ColiEdgeSelectRequest *request,
+                              char *error, size_t error_size) {
+    Qwen36EdgeEngine *engine = (Qwen36EdgeEngine *)engine_impl;
+    Cfg *config = &engine->model.c;
+    float *normalized = falloc(config->hidden);
+    float *logits = falloc(config->vocab);
+    const float *input = (const float *)request->input;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        if (request->should_cancel &&
+            request->should_cancel(request->cancel_user_data)) {
+            free(logits); free(normalized);
+            return coli_edge_adapter_error(error, error_size,
+                                           "Qwen3.6 Edge selection cancelled");
+        }
+        rmsnorm_row(normalized, input + (size_t)row * config->hidden,
+                    engine->model.final_norm, config->hidden, config->eps);
+        matmul_d(logits, normalized, engine->model.lm_head,
+                 1, config->hidden, config->vocab);
+        if (coli_edge_argmax(logits, (uint32_t)config->vocab,
+                            &request->token_ids[row],
+                            request->scores ? &request->scores[row] : NULL)) {
+            free(logits); free(normalized);
+            return coli_edge_adapter_error(error, error_size,
+                                           "Qwen3.6 Edge head failed");
+        }
+    }
+    free(logits); free(normalized);
+    return 0;
+}
+
+static const ColiEdgeAdapter qwen36_edge_adapter = {
+    sizeof(ColiEdgeAdapter), COLI_EDGE_ABI_VERSION, "qwen36",
+    qwen36_edge_engine_open, qwen36_edge_engine_destroy,
+    qwen36_edge_tokenize, qwen36_edge_detokenize,
+    qwen36_edge_embed, qwen36_edge_select, {0}
+};
+
+int coli_qwen36_edge_adapter_register(void) {
+    return coli_edge_adapter_register(&qwen36_edge_adapter);
+}
+#endif /* COLI_EDGE_ADAPTER */

--- a/c/tests/test_edge_adapters_real.c
+++ b/c/tests/test_edge_adapters_real.c
@@ -1,0 +1,244 @@
+#include "../edge_adapters.h"
+#include "../edge_runtime.h"
+#include "../json.h"
+#include "../segment_adapters.h"
+#include "../segment_runtime.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define REQUIRE(condition, message) do { \
+    if (!(condition)) { fprintf(stderr, "%s: %s\n", family, message); goto fail; } \
+} while (0)
+
+static char *read_file(const char *path) {
+    FILE *stream = fopen(path, "rb");
+    if (!stream) return NULL;
+    if (fseek(stream, 0, SEEK_END)) { fclose(stream); return NULL; }
+    long length = ftell(stream);
+    if (length < 0 || fseek(stream, 0, SEEK_SET)) { fclose(stream); return NULL; }
+    char *data = malloc((size_t)length + 1u);
+    if (!data || fread(data, 1, (size_t)length, stream) != (size_t)length) {
+        free(data); fclose(stream); return NULL;
+    }
+    data[length] = '\0'; fclose(stream);
+    return data;
+}
+
+static int32_t *read_ids(jval *object, const char *key, int *count) {
+    jval *array = json_get(object, key);
+    if (!array || array->t != J_ARR || array->len < 1) return NULL;
+    int32_t *ids = malloc((size_t)array->len * sizeof(*ids));
+    if (!ids) return NULL;
+    for (int item = 0; item < array->len; item++) {
+        if (!array->kids[item] || array->kids[item]->t != J_NUM ||
+            array->kids[item]->num < INT32_MIN ||
+            array->kids[item]->num > INT32_MAX ||
+            array->kids[item]->num !=
+                (double)(int32_t)array->kids[item]->num) {
+            free(ids); return NULL;
+        }
+        ids[item] = (int32_t)array->kids[item]->num;
+    }
+    *count = array->len;
+    return ids;
+}
+
+static int register_all(void) {
+    return coli_glm_segment_adapter_register() ||
+           coli_inkling_segment_adapter_register() ||
+           coli_kimi_segment_adapter_register() ||
+           coli_olmoe_segment_adapter_register() ||
+           coli_qwen36_segment_adapter_register() ||
+           coli_deepseek_v4_segment_adapter_register() ||
+           coli_glm_edge_adapter_register() ||
+           coli_inkling_edge_adapter_register() ||
+           coli_kimi_edge_adapter_register() ||
+           coli_olmoe_edge_adapter_register() ||
+           coli_qwen36_edge_adapter_register() ||
+           coli_deepseek_v4_edge_adapter_register();
+}
+
+int main(int argc, char **argv) {
+    if (argc < 4 || argc > 5) {
+        fprintf(stderr, "usage: %s FAMILY MODEL_DIR REF_JSON [MAX_NEW]\n", argv[0]);
+        return 2;
+    }
+    const char *family = argv[1], *model_dir = argv[2], *ref_path = argv[3];
+    int max_new = argc == 5 ? atoi(argv[4]) : 3;
+    if (max_new < 1) return 2;
+    char error[512] = {0};
+    char *json_text = NULL, *arena = NULL;
+    jval *root = NULL;
+    int32_t *prompt = NULL, *full = NULL;
+    int prompt_count = 0, full_count = 0;
+    ColiEdgeEngine *edge = NULL;
+    ColiSegmentEngine *segment = NULL;
+    ColiSegmentSession *session = NULL;
+    float *input = NULL, *output = NULL;
+    int32_t *probe_ids = NULL;
+    char *probe_text = NULL;
+    int status = 1;
+
+    REQUIRE(register_all() == 0, "cannot register all adapters");
+    json_text = read_file(ref_path);
+    REQUIRE(json_text != NULL, "cannot read reference JSON");
+    root = json_parse(json_text, &arena);
+    REQUIRE(root && root->t == J_OBJ, "invalid reference JSON");
+    jval *case_object = root;
+    const char *full_key = "full_ids";
+    if (!strcmp(family, "kimi") || !strcmp(family, "deepseek_v4")) {
+        jval *cases = json_get(root, "cases");
+        case_object = cases ? json_get(cases, "short") : NULL;
+        full_key = "greedy_full_ids";
+    }
+    REQUIRE(case_object && case_object->t == J_OBJ,
+            "reference has no selected case");
+    prompt = read_ids(case_object, "prompt_ids", &prompt_count);
+    full = read_ids(case_object, full_key, &full_count);
+    REQUIRE(prompt && full && full_count > prompt_count,
+            "reference token arrays are missing");
+    if (max_new > full_count - prompt_count) max_new = full_count - prompt_count;
+
+    ColiEdgeEngineOptions edge_options = {
+        .struct_size = sizeof(edge_options), .model_dir = model_dir,
+    };
+    REQUIRE(coli_edge_engine_open(family, &edge_options, &edge,
+                                  error, sizeof(error)) == 0, error);
+    ColiEdgeCapabilities edge_cap = {.struct_size = sizeof(edge_cap)};
+    REQUIRE(coli_edge_engine_capabilities(edge, &edge_cap,
+                                          error, sizeof(error)) == 0, error);
+    REQUIRE(edge_cap.flags & COLI_EDGE_CAP_TOKENIZE,
+            "real adapter does not expose tokenization");
+    REQUIRE(edge_cap.flags & COLI_EDGE_CAP_GREEDY,
+            "real adapter does not expose the model head");
+
+    static const char tokenizer_probe[] = "edge";
+    size_t probe_count = 0, probe_bytes = 0;
+    REQUIRE(coli_edge_tokenize(edge, tokenizer_probe,
+                               sizeof(tokenizer_probe) - 1u,
+                               NULL, 0, &probe_count,
+                               error, sizeof(error)) == 0 && probe_count,
+            "tokenizer sizing pass failed");
+    probe_ids = malloc(probe_count * sizeof(*probe_ids));
+    REQUIRE(probe_ids != NULL, "out of memory for tokenizer probe");
+    REQUIRE(coli_edge_tokenize(edge, tokenizer_probe,
+                               sizeof(tokenizer_probe) - 1u,
+                               probe_ids, probe_count, &probe_count,
+                               error, sizeof(error)) == 0,
+            "tokenizer encode failed");
+    REQUIRE(coli_edge_detokenize(edge, probe_ids, probe_count,
+                                 NULL, 0, &probe_bytes,
+                                 error, sizeof(error)) == 0,
+            "detokenizer sizing pass failed");
+    probe_text = malloc(probe_bytes + 1u);
+    REQUIRE(probe_text != NULL, "out of memory for detokenizer probe");
+    REQUIRE(coli_edge_detokenize(edge, probe_ids, probe_count,
+                                 probe_text, probe_bytes + 1u, &probe_bytes,
+                                 error, sizeof(error)) == 0,
+            "detokenizer decode failed");
+    REQUIRE(probe_bytes == sizeof(tokenizer_probe) - 1u &&
+            !memcmp(probe_text, tokenizer_probe, probe_bytes),
+            "tokenizer round-trip differs");
+    free(probe_text); probe_text = NULL;
+    free(probe_ids); probe_ids = NULL;
+
+    uint32_t context = (uint32_t)(prompt_count + max_new + 2);
+    ColiSegmentEngineOptions segment_options = {
+        .struct_size = sizeof(segment_options), .model_dir = model_dir,
+        .layer_begin = 0, .layer_end = edge_cap.num_layers,
+        .context_tokens = context,
+    };
+    REQUIRE(coli_segment_engine_open(family, &segment_options, &segment,
+                                     error, sizeof(error)) == 0, error);
+    ColiSegmentCapabilities segment_cap = {
+        .struct_size = sizeof(segment_cap)
+    };
+    REQUIRE(coli_segment_engine_capabilities(segment, &segment_cap,
+                                             error, sizeof(error)) == 0, error);
+    REQUIRE(segment_cap.state_dtype == edge_cap.state_dtype &&
+            segment_cap.state_width == edge_cap.state_width &&
+            !strcmp(segment_cap.state_schema, edge_cap.state_schema) &&
+            !strcmp(segment_cap.numeric_class, edge_cap.numeric_class),
+            "Edge/Segment activation identity differs");
+    ColiSegmentSessionOptions session_options = {
+        .struct_size = sizeof(session_options), .context_tokens = context,
+    };
+    REQUIRE(coli_segment_session_create(segment, &session_options, &session,
+                                        error, sizeof(error)) == 0, error);
+
+    size_t row_bytes = (size_t)edge_cap.state_width * sizeof(float);
+    REQUIRE((size_t)prompt_count <= SIZE_MAX / row_bytes,
+            "prompt activation size overflows");
+    input = malloc((size_t)prompt_count * row_bytes);
+    output = malloc((size_t)prompt_count * row_bytes);
+    REQUIRE(input && output, "out of memory for prompt activations");
+    ColiEdgeEmbedRequest embed = {
+        .struct_size = sizeof(embed), .rows = (uint32_t)prompt_count,
+        .token_ids = prompt,
+        .token_count = (size_t)prompt_count,
+        .output = input, .output_bytes = (size_t)prompt_count * row_bytes,
+    };
+    REQUIRE(coli_edge_embed(edge, &embed, error, sizeof(error)) == 0, error);
+    ColiSegmentRunRequest run = {
+        .struct_size = sizeof(run), .rows = (uint32_t)prompt_count,
+        .position = 0, .token_ids = prompt,
+        .token_count = (size_t)prompt_count,
+        .input = input, .input_bytes = (size_t)prompt_count * row_bytes,
+        .output = output, .output_bytes = (size_t)prompt_count * row_bytes,
+    };
+    REQUIRE(coli_segment_run(session, &run, error, sizeof(error)) == 0, error);
+
+    int32_t predicted = -1;
+    float score = 0.0f;
+    ColiEdgeSelectRequest select = {
+        .struct_size = sizeof(select), .rows = 1,
+        .input = output + (size_t)(prompt_count - 1) * edge_cap.state_width,
+        .input_bytes = row_bytes, .token_ids = &predicted,
+        .token_capacity = 1, .scores = &score, .score_capacity = 1,
+    };
+    REQUIRE(coli_edge_select(edge, &select, error, sizeof(error)) == 0, error);
+    REQUIRE(predicted == full[prompt_count],
+            "first generated token differs from the independent oracle");
+    size_t generated_bytes = 0;
+    REQUIRE(coli_edge_detokenize(edge, &predicted, 1, NULL, 0,
+                                 &generated_bytes, error, sizeof(error)) == 0 &&
+            generated_bytes > 0,
+            "generated token cannot be detokenized");
+
+    free(input); free(output);
+    input = malloc(row_bytes); output = malloc(row_bytes);
+    REQUIRE(input && output, "out of memory for decode activations");
+    for (int generated = 1; generated < max_new; generated++) {
+        int32_t token = predicted;
+        embed.rows = 1; embed.token_ids = &token; embed.token_count = 1;
+        embed.output = input; embed.output_bytes = row_bytes;
+        REQUIRE(coli_edge_embed(edge, &embed, error, sizeof(error)) == 0, error);
+        run.rows = 1;
+        run.position = (uint64_t)prompt_count + generated - 1u;
+        run.token_ids = &token; run.token_count = 1;
+        run.input = input; run.input_bytes = row_bytes;
+        run.output = output; run.output_bytes = row_bytes;
+        REQUIRE(coli_segment_run(session, &run, error, sizeof(error)) == 0, error);
+        select.input = output;
+        REQUIRE(coli_edge_select(edge, &select, error, sizeof(error)) == 0, error);
+        REQUIRE(predicted == full[prompt_count + generated],
+                "decode token differs from the independent oracle");
+    }
+    printf("%s Edge -> full Segment -> Edge: %d oracle tokens ok\n",
+           family, max_new);
+    status = 0;
+
+fail:
+    if (status && error[0]) fprintf(stderr, "%s: %s\n", family, error);
+    free(probe_text); free(probe_ids);
+    free(output); free(input);
+    coli_segment_session_destroy(session);
+    if (segment) (void)coli_segment_engine_close(segment, NULL, 0);
+    coli_edge_engine_close(edge);
+    free(full); free(prompt);
+    json_free(root); free(arena); free(json_text);
+    return status;
+}

--- a/c/tests/test_edge_adapters_registration.c
+++ b/c/tests/test_edge_adapters_registration.c
@@ -1,0 +1,23 @@
+#include "../edge_adapters.h"
+#include "../edge_runtime.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+int main(void) {
+    assert(coli_glm_edge_adapter_register() == 0);
+    assert(coli_inkling_edge_adapter_register() == 0);
+    assert(coli_kimi_edge_adapter_register() == 0);
+    assert(coli_olmoe_edge_adapter_register() == 0);
+    assert(coli_qwen36_edge_adapter_register() == 0);
+    assert(coli_deepseek_v4_edge_adapter_register() == 0);
+    assert(coli_edge_adapter_count() == 6);
+
+    static const char *expected[] = {
+        "glm", "inkling", "kimi", "olmoe", "qwen36", "deepseek_v4"
+    };
+    for (size_t item = 0; item < sizeof(expected) / sizeof(expected[0]); item++)
+        assert(coli_edge_adapter_lookup(expected[item]) != NULL);
+    puts("all six real Edge adapters register: ok");
+    return 0;
+}

--- a/c/tests/test_edge_runtime.c
+++ b/c/tests/test_edge_runtime.c
@@ -1,0 +1,202 @@
+#include "../edge_runtime.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct { int unused; } FakeEdge;
+
+static int fake_open(void **impl, ColiEdgeCapabilities *capabilities,
+                     const ColiEdgeEngineOptions *options,
+                     char *error, size_t error_size) {
+    (void)options; (void)error; (void)error_size;
+    FakeEdge *created = calloc(1, sizeof(*created));
+    if (!created) return -1;
+    capabilities->abi_version = COLI_EDGE_ABI_VERSION;
+    capabilities->flags = COLI_EDGE_CAP_TOKENIZE |
+                          COLI_EDGE_CAP_DETOKENIZE |
+                          COLI_EDGE_CAP_GREEDY | COLI_EDGE_CAP_CPU;
+    snprintf(capabilities->engine_id, sizeof(capabilities->engine_id), "fake");
+    snprintf(capabilities->state_schema, sizeof(capabilities->state_schema),
+             "fake/f32-v1");
+    snprintf(capabilities->numeric_class, sizeof(capabilities->numeric_class),
+             "fake/strict-v1");
+    snprintf(capabilities->tokenizer_class,
+             sizeof(capabilities->tokenizer_class), "fake/bytes-v1");
+    capabilities->state_dtype = COLI_EDGE_DTYPE_F32;
+    capabilities->state_width = 4;
+    capabilities->vocab_size = 256;
+    capabilities->max_batch_rows = 8;
+    capabilities->max_context_tokens = 32;
+    capabilities->num_layers = 6;
+    capabilities->bos_token_id = 2;
+    capabilities->eos_token_id = 3;
+    capabilities->resident_bytes = 64;
+    *impl = created;
+    return 0;
+}
+
+static void fake_destroy(void *impl) { free(impl); }
+
+static int fake_tokenize(void *impl, const char *text, size_t text_bytes,
+                         int32_t *ids, size_t capacity, size_t *count,
+                         char *error, size_t error_size) {
+    (void)impl;
+    *count = text_bytes;
+    if (ids && capacity < text_bytes) {
+        if (error && error_size) snprintf(error, error_size, "small token buffer");
+        return -1;
+    }
+    if (ids)
+        for (size_t item = 0; item < text_bytes; item++)
+            ids[item] = (unsigned char)text[item];
+    return 0;
+}
+
+static int fake_detokenize(void *impl, const int32_t *ids, size_t count,
+                           char *text, size_t capacity, size_t *bytes,
+                           char *error, size_t error_size) {
+    (void)impl;
+    *bytes = count;
+    if (text && capacity < count + 1) {
+        if (error && error_size) snprintf(error, error_size, "small text buffer");
+        return -1;
+    }
+    if (text) {
+        for (size_t item = 0; item < count; item++) text[item] = (char)ids[item];
+        text[count] = '\0';
+    }
+    return 0;
+}
+
+static int fake_embed(void *impl, const ColiEdgeEmbedRequest *request,
+                      char *error, size_t error_size) {
+    (void)impl; (void)error; (void)error_size;
+    float *output = request->output;
+    for (uint32_t row = 0; row < request->rows; row++)
+        for (uint32_t column = 0; column < 4; column++)
+            output[(size_t)row * 4 + column] =
+                (float)(request->token_ids[row] + (int32_t)column);
+    return 0;
+}
+
+static int fake_select(void *impl, const ColiEdgeSelectRequest *request,
+                       char *error, size_t error_size) {
+    (void)impl; (void)error; (void)error_size;
+    const float *input = request->input;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        float sum = 0.0f;
+        for (uint32_t column = 0; column < 4; column++)
+            sum += input[(size_t)row * 4 + column];
+        request->token_ids[row] = (int32_t)sum & 255;
+        if (request->scores) request->scores[row] = sum;
+    }
+    return 0;
+}
+
+static const ColiEdgeAdapter fake_adapter = {
+    sizeof(ColiEdgeAdapter), COLI_EDGE_ABI_VERSION, "fake",
+    fake_open, fake_destroy, fake_tokenize, fake_detokenize,
+    fake_embed, fake_select, {0}
+};
+
+static const ColiEdgeAdapter incomplete_tokenizer = {
+    .struct_size = sizeof(ColiEdgeAdapter),
+    .abi_version = COLI_EDGE_ABI_VERSION,
+    .engine_id = "bad-tokenizer",
+    .engine_open = fake_open,
+    .engine_destroy = fake_destroy,
+    .tokenize = fake_tokenize,
+    .embed = fake_embed,
+    .select = fake_select,
+};
+
+static int never_cancel(void *unused) { (void)unused; return 0; }
+static int always_cancel(void *unused) { (void)unused; return 1; }
+
+int main(void) {
+    char error[160] = {0};
+    assert(coli_edge_adapter_count() == 0);
+    assert(coli_edge_adapter_register(NULL) != 0);
+    assert(coli_edge_adapter_register(&incomplete_tokenizer) != 0);
+    assert(coli_edge_adapter_register(&fake_adapter) == 0);
+    assert(coli_edge_adapter_register(&fake_adapter) != 0);
+    assert(coli_edge_adapter_lookup("fake") == &fake_adapter);
+    assert(coli_edge_adapter_lookup("missing") == NULL);
+
+    ColiEdgeEngineOptions options = {
+        .struct_size = sizeof(options), .model_dir = "unused-fixture",
+    };
+    ColiEdgeEngine *engine = NULL;
+    assert(coli_edge_engine_open("fake", &options, &engine,
+                                 error, sizeof(error)) == 0);
+    assert(engine);
+
+    struct {
+        ColiEdgeCapabilities capabilities;
+        uint64_t future[2];
+    } capabilities;
+    memset(&capabilities, 0xa5, sizeof(capabilities));
+    capabilities.capabilities.struct_size = sizeof(capabilities);
+    assert(coli_edge_engine_capabilities(
+               engine, &capabilities.capabilities,
+               error, sizeof(error)) == 0);
+    assert(capabilities.capabilities.state_width == 4);
+    assert(capabilities.future[0] == 0 && capabilities.future[1] == 0);
+
+    size_t count = 0;
+    assert(coli_edge_tokenize(engine, "ab", 2, NULL, 0, &count,
+                              error, sizeof(error)) == 0 && count == 2);
+    int32_t ids[2] = {0};
+    assert(coli_edge_tokenize(engine, "ab", 2, ids, 1, &count,
+                              error, sizeof(error)) != 0);
+    assert(coli_edge_tokenize(engine, "ab", 2, ids, 2, &count,
+                              error, sizeof(error)) == 0);
+    assert(ids[0] == 'a' && ids[1] == 'b');
+
+    size_t bytes = 0;
+    assert(coli_edge_detokenize(engine, ids, 2, NULL, 0, &bytes,
+                                error, sizeof(error)) == 0 && bytes == 2);
+    char text[3];
+    assert(coli_edge_detokenize(engine, ids, 2, text, sizeof(text), &bytes,
+                                error, sizeof(error)) == 0);
+    assert(strcmp(text, "ab") == 0);
+
+    float states[8] = {0};
+    ColiEdgeEmbedRequest embed = {
+        .struct_size = sizeof(embed), .rows = 2,
+        .token_ids = ids, .token_count = 2,
+        .output = states, .output_bytes = sizeof(states),
+        .should_cancel = never_cancel,
+    };
+    assert(coli_edge_embed(engine, &embed, error, sizeof(error)) == 0);
+    assert(states[0] == 97.0f && states[7] == 101.0f);
+    embed.output_bytes--;
+    assert(coli_edge_embed(engine, &embed, error, sizeof(error)) != 0);
+    embed.output_bytes = sizeof(states);
+    embed.should_cancel = always_cancel;
+    assert(coli_edge_embed(engine, &embed, error, sizeof(error)) != 0);
+
+    int32_t selected[2] = {0};
+    float scores[2] = {0};
+    ColiEdgeSelectRequest select = {
+        .struct_size = sizeof(select), .rows = 2,
+        .input = states, .input_bytes = sizeof(states),
+        .token_ids = selected, .token_capacity = 2,
+        .scores = scores, .score_capacity = 2,
+        .should_cancel = never_cancel,
+    };
+    assert(coli_edge_select(engine, &select, error, sizeof(error)) == 0);
+    assert(selected[0] == ((97 + 98 + 99 + 100) & 255));
+    assert(scores[1] == 98.0f + 99.0f + 100.0f + 101.0f);
+    select.token_capacity = 1;
+    assert(coli_edge_select(engine, &select, error, sizeof(error)) != 0);
+    select.token_capacity = 2; select.should_cancel = always_cancel;
+    assert(coli_edge_select(engine, &select, error, sizeof(error)) != 0);
+
+    coli_edge_engine_close(engine);
+    puts("edge runtime tests: ok");
+    return 0;
+}

--- a/c/tools/make_edge_tiny_tokenizer.py
+++ b/c/tools/make_edge_tiny_tokenizer.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Write a deterministic byte-BPE tokenizer for generated Edge fixtures.
+
+The real adapters always load the checkpoint's production tokenizer. Several
+existing math-only tiny generators intentionally omit tokenizer.json; this
+small fixture supplies an identity byte vocabulary so the Edge release gate
+can exercise text sizing/round-trips without downloading a model tokenizer.
+It is test data, never a tokenizer substitute for a real checkpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def byte_symbols() -> list[str]:
+    direct = set(range(33, 127)) | set(range(161, 173)) | set(range(174, 256))
+    symbols: list[str] = []
+    extra = 0
+    for byte in range(256):
+        if byte in direct:
+            codepoint = byte
+        else:
+            codepoint = 256 + extra
+            extra += 1
+        symbols.append(chr(codepoint))
+    return symbols
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("model_dir", type=Path)
+    parser.add_argument("--vocab-size", type=int, required=True)
+    args = parser.parse_args()
+    if args.vocab_size < 128:
+        raise SystemExit("Edge fixture vocabulary must contain at least 128 IDs")
+    args.model_dir.mkdir(parents=True, exist_ok=True)
+    symbols = byte_symbols()
+    vocab = {symbols[token]: token for token in range(min(256, args.vocab_size))}
+    # Math-only fixtures can have vocabularies larger than the 256 byte IDs.
+    # Give every remaining row a unique decodable piece so a generated oracle
+    # token never falls outside the fixture tokenizer's id table.
+    for token in range(256, args.vocab_size):
+        vocab[f"<|edge_fixture_{token}|>"] = token
+    payload = {
+        "version": "1.0",
+        "truncation": None,
+        "padding": None,
+        "added_tokens": [],
+        "normalizer": None,
+        "pre_tokenizer": {
+            "type": "ByteLevel", "add_prefix_space": False,
+            "trim_offsets": True, "use_regex": True,
+        },
+        "post_processor": None,
+        "decoder": {
+            "type": "ByteLevel", "add_prefix_space": False,
+            "trim_offsets": True, "use_regex": True,
+        },
+        "model": {
+            "type": "BPE", "dropout": None, "unk_token": None,
+            "continuing_subword_prefix": "", "end_of_word_suffix": "",
+            "fuse_unk": False, "byte_fallback": False,
+            "ignore_merges": True, "vocab": vocab, "merges": [],
+        },
+    }
+    output = args.model_dir / "tokenizer.json"
+    output.write_text(json.dumps(payload, ensure_ascii=False) + "\n",
+                      encoding="utf-8")
+    print(f"wrote Edge fixture tokenizer: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/edge-runtime.md
+++ b/docs/edge-runtime.md
@@ -16,6 +16,13 @@ a real model without loading every transformer layer locally.
 The ABI is additive. Ordinary Colibri CLIs do not link or register Edge
 adapters and keep their existing initialization and inference paths.
 
+External consumers can build the complete CPU-baseline runtime with
+`make -C c segment-edge-library`. The resulting
+`c/build/segment/libcolibri_segment_edge.a` contains both public runtimes and
+all six built-in adapters. Consumers link it after their own objects and call
+the explicit registration functions below; ordinary Colibri executables do
+not link this archive.
+
 ## Lifecycle and compatibility
 
 1. Explicitly register the required adapters during process initialization.

--- a/docs/edge-runtime.md
+++ b/docs/edge-runtime.md
@@ -1,0 +1,134 @@
+# Model-edge runtime ABI
+
+`c/edge_runtime.h` is Colibri's engine-neutral local C boundary for the two
+ends of a distributed inference route:
+
+```text
+text -> tokenizer -> embedding -> one or more Segment engines -> final head
+```
+
+It is not a network protocol. Colibri owns tokenization, model boundary math,
+formats and kernels; a consumer such as Lumabri owns discovery, transport,
+placement, leases and session lifecycle. Together with
+[`segment_runtime.h`](../c/segment_runtime.h), this lets a chatter process run
+a real model without loading every transformer layer locally.
+
+The ABI is additive. Ordinary Colibri CLIs do not link or register Edge
+adapters and keep their existing initialization and inference paths.
+
+## Lifecycle and compatibility
+
+1. Explicitly register the required adapters during process initialization.
+   There are no link-time constructors, including on Windows.
+2. Open one model boundary with `coli_edge_engine_open`.
+3. Read its capabilities and require an exact match with the routed Segment
+   chain for `state_schema`, `numeric_class`, state dtype and state width.
+4. Tokenize and embed the prompt, run it through the complete Segment chain,
+   then call `coli_edge_select` on the last row.
+5. For decode, embed the selected token and repeat at the next position.
+6. Close the Edge engine after its sessions have drained.
+
+The caller initializes every public structure's `struct_size`. Capability
+queries zero the caller's complete allocation before copying fields known to
+the runtime, so an older runtime cannot leave future extension fields
+uninitialized.
+
+Version 1 deliberately exposes deterministic greedy selection. Sampling is a
+future additive operation; it is not emulated outside Colibri. Registration
+must finish before concurrent lookup. A consumer should currently host one
+active model per chatter process because some existing engine configuration is
+process-global; Qwen's production tokenizer makes that restriction explicit
+and rejects a second live Qwen Edge engine.
+
+## Real adapters
+
+`c/edge_adapters.h` exposes explicit registration functions for every current
+Colibri model family:
+
+| Adapter | Boundary state | Edge residency |
+| --- | --- | --- |
+| GLM-5.2 | hidden state | tokenizer, embedding, final norm and head |
+| Inkling | hidden state | tokenizer, optional embed norm, final norm and head |
+| Kimi K3 | hidden plus all AttnRes blocks | tokenizer, final transforms and head; embedding rows stream on demand |
+| OLMoE | hidden state | tokenizer, embedding, final norm and head |
+| Qwen3.6 | hidden state | tokenizer, embedding, final norm and head |
+| DeepSeek V4 | expanded mHC state | tokenizer and small final mHC tensors; BF16 embedding rows and head tiles stream on demand |
+
+Every adapter currently advertises CPU only. Accelerator flags will be added
+only when that adapter actually executes its Edge operations on the matching
+Colibri backend. `resident_bytes` reports the adapter-owned model tensors and
+can be bounded with `memory_limit_bytes`; model files and tokenizer metadata
+remain additional mapped/indexed resources.
+
+## API contract
+
+Tokenize and detokenize support a sizing pass by passing a null output with
+zero capacity. `coli_edge_embed` accepts exactly one token ID per row and emits
+`rows * state_width` values in the advertised dtype. `coli_edge_select`
+applies the model's exact final transform and output head to every input row,
+returning one greedy token and an optional score per row.
+
+The runtime validates structure sizes, activation geometry, batch limits,
+output capacities and cancellation before entering an adapter. Model adapters
+also validate token IDs and checkpoint boundary tensors. Errors are returned
+to the caller; the network layer decides whether to retry, migrate or fall back
+locally.
+
+## All-family release gate
+
+`make -C c edge-adapters` verifies that all six real adapters coexist in one
+runtime. `edge-adapters-real` is the stronger gate: for every family it loads
+the real Edge adapter and a full real Segment range, round-trips text, embeds
+an independent oracle prompt, performs prefill plus decode and compares three
+greedy tokens with that oracle. It also requires generated tokens to be
+detokenizable and requires exact Edge/Segment capability identity.
+
+Generate the existing tiny checkpoints from `c/` (they are test data and are
+not committed):
+
+```sh
+python3 tools/make_glm_oracle.py
+python3 tools/make_edge_tiny_tokenizer.py glm_tiny --vocab-size 256
+
+python3 tools/make_tiny_inkling.py tiny_inkling
+python3 tools/make_edge_tiny_tokenizer.py tiny_inkling --vocab-size 256
+
+python3 tools/make_kimi_k3_tiny.py --output kimi_k3_tiny --force
+python3 tools/make_edge_tiny_tokenizer.py kimi_k3_tiny --vocab-size 320
+
+python3 tools/make_olmoe_tiny.py --output olmoe_tiny_src --force
+python3 tools/make_edge_tiny_tokenizer.py olmoe_tiny_src --vocab-size 128
+python3 tools/convert_olmoe_merged.py --model olmoe_tiny_src \
+  --out olmoe_tiny_merged --min-free-gb 0
+
+python3 tools/make_qwen36_tiny.py --out qwen36_edge_src \
+  --emit-ref qwen36_edge_src/ref_qwen36.json --ref-mode full --max-new 8
+python3 tools/make_edge_tiny_tokenizer.py qwen36_edge_src --vocab-size 320
+python3 tools/convert_qwen36.py --model qwen36_edge_src \
+  --out qwen36_edge_i8 --ebits 8 --no-readme
+
+python3 tools/make_deepseek_v4_tiny.py --output deepseek_v4_edge_tiny --force
+python3 tools/make_edge_tiny_tokenizer.py deepseek_v4_edge_tiny --vocab-size 128
+```
+
+Inkling's generator requires `c/tools/oracle-requirements.txt`. Then run the
+single all-family gate:
+
+```sh
+make -C c edge-adapters-real \
+  GLM_EDGE_MODEL=glm_tiny GLM_EDGE_REF=ref_glm.json \
+  INKLING_EDGE_MODEL=tiny_inkling \
+  INKLING_EDGE_REF=tiny_inkling/ref_inkling.json \
+  KIMI_EDGE_MODEL=kimi_k3_tiny KIMI_EDGE_REF=kimi_k3_tiny/ref.json \
+  OLMOE_EDGE_MODEL=olmoe_tiny_merged \
+  OLMOE_EDGE_REF=olmoe_tiny_src/ref_olmoe.json \
+  QWEN_EDGE_MODEL=qwen36_edge_i8 \
+  QWEN_EDGE_REF=qwen36_edge_src/ref_qwen36.json \
+  DEEPSEEK_EDGE_MODEL=deepseek_v4_edge_tiny \
+  DEEPSEEK_EDGE_REF=deepseek_v4_edge_tiny/ref.json
+```
+
+The fixture tokenizer helper only fills the tokenizer deliberately omitted by
+math-only generators. Shipping checkpoints always use their production
+tokenizer. A family is not considered supported from registration or a
+synthetic adapter alone: this oracle gate must pass for all current families.

--- a/docs/segment-runtime.md
+++ b/docs/segment-runtime.md
@@ -4,6 +4,8 @@
 execute a contiguous, half-open layer range (`begin <= layer < end`). It is a
 local C ABI, not a network protocol. A distributed caller remains responsible
 for peer identity, transport, leases, request IDs, placement and retry policy.
+The companion [`edge_runtime.h`](../c/edge_runtime.h) supplies the model-owned
+tokenizer, embedding and final head needed to drive a complete Segment chain.
 
 The ABI is deliberately separate from every model's internal structs:
 


### PR DESCRIPTION
## Summary
- add an engine-neutral Edge ABI for tokenizer, embedding, exact final transform and greedy head
- add real CPU Edge adapters for GLM-5.2, Inkling, Kimi K3, OLMoE, Qwen3.6 and DeepSeek V4
- keep ordinary Colibri CLIs unchanged through explicit registration and dedicated build objects
- add ABI tests, all-six registration and a real Edge -> full Segment -> Edge oracle gate
- document the contract, resource residency and tiny-fixture release procedure

## Compatibility
- additive ABI; normal executables do not link or register Edge adapters
- capability structs zero the caller's full struct_size before copying known fields
- explicit initialization only; no link-time constructors
- Edge/Segment state schema, numeric class, dtype and width must match exactly
- v1 is deterministic greedy only; sampling remains a future additive API

## Validation
- make -C c test: 685 Python tests passed, 32 skipped; complete C suite passed
- make -C c edge-adapters-real: all six real model families matched 3 independent oracle tokens through full Segment execution
- make -C c segment-adapters: all six existing Segment adapters register
- ASan/UBSan focused Edge runtime test passed
- normal colibri, inkling, kimi_k3, olmoe, qwen36 and deepseek_v4 binaries all built successfully

No merge is requested as part of this work.