### PR TITLE
feat(glm53): add GLM-5.3-Flash runtime

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -97,6 +97,22 @@ jobs:
       - name: Generate fixture and run target oracle
         run: make -C c deepseek-v4-tiny-check
 
+  glm53-tiny:
+    name: Linux (generated tiny GLM-5.3 oracle contract)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: c/tools/requirements-glm53-tiny.txt
+      - name: Install pinned tiny-fixture dependencies
+        run: python -m pip install -r c/tools/requirements-glm53-tiny.txt
+      - name: Generate and validate oracle contract
+        run: make -C c glm53-tiny-check
+
   macos:
     # clang; libomp for the threaded path (Makefile falls back to
     # single-threaded automatically if it's ever missing).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,7 @@ jobs:
           # step with "Version not available" before nvcc is ever reached.
           cuda: '12.6.2'
           method: network
-          sub-packages: '["nvcc"]'
+          sub-packages: '["nvcc", "cudart", "cublas"]'
       - name: Compile backend_cuda.cu (syntax only, no GPU)
         run: |
           cd c

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
         run: |
           cd c
           rc=0
-          for t in colibri inkling kimi_k3; do
+          for t in colibri glm53_flash inkling kimi_k3; do
             echo "::group::$t METAL=1"
             make clean >/dev/null 2>&1 || true
             make $t METAL=1 || { echo "FAILED: $t METAL=1"; rc=1; }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
         run: |
           cd c
           rc=0
-          ENGINES="colibri inkling kimi_k3 olmoe qwen36"
+          ENGINES="colibri glm53_flash inkling kimi_k3 olmoe qwen36"
           if [ "${{ matrix.v4 }}" = "1" ]; then ENGINES="$ENGINES deepseek-v4"; fi
           for t in $ENGINES; do
             echo "::group::$t"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,11 @@ jobs:
           nvcc -O2 -std=c++17 -arch=sm_80 -c backend_cuda_ink.cu -o /dev/null \
             -Xcompiler=-Wall,-Wextra
           echo "inkling CUDA syntax check passed"
+      - name: Link GLM-5.3 CUDA host against the shared backend
+        run: |
+          cd c
+          make glm53_flash CUDA=1 CUDA_ARCH=sm_80
+          test -x glm53_flash || { echo "GLM-5.3 CUDA host was not produced" >&2; exit 1; }
 
   qwen36-tiny-check:
     name: Qwen3.6 tiny oracle (token-exact + ASan/UBSan)
@@ -701,6 +706,13 @@ jobs:
           make colibri CUDA_DLL=1
           test -f colibri.exe || { echo "colibri CUDA_DLL=1 reported success but produced no exe" >&2; exit 1; }
           echo "colibri.exe built against the DLL loader"
+      - name: make glm53_flash CUDA_DLL=1
+        shell: msys2 {0}
+        run: |
+          cd c
+          make glm53_flash CUDA_DLL=1
+          test -f glm53_flash.exe || { echo "glm53_flash CUDA_DLL=1 produced no exe" >&2; exit 1; }
+          echo "glm53_flash.exe built against the DLL loader"
 
   web:
     name: Web UI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,9 @@ jobs:
           # step with "Version not available" before nvcc is ever reached.
           cuda: '12.6.2'
           method: network
-          sub-packages: '["nvcc", "cudart", "cublas"]'
+          sub-packages: '["nvcc", "cudart"]'
+      - name: Install CUDA BLAS link libraries
+        run: sudo apt-get install -y libcublas-dev-12-6
       - name: Compile backend_cuda.cu (syntax only, no GPU)
         run: |
           cd c

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,10 @@ jobs:
       - name: Build engines
         run: |
           cd c
-          for t in colibri inkling kimi_k3 olmoe qwen36; do
+          for t in colibri glm53_flash inkling kimi_k3 olmoe qwen36; do
             make $t ${{ matrix.make_args }}
           done
-          ls -lh colibri${{ matrix.ext }} inkling${{ matrix.ext }} kimi_k3${{ matrix.ext }} olmoe${{ matrix.ext }} qwen36${{ matrix.ext }}
+          ls -lh colibri${{ matrix.ext }} glm53_flash${{ matrix.ext }} inkling${{ matrix.ext }} kimi_k3${{ matrix.ext }} olmoe${{ matrix.ext }} qwen36${{ matrix.ext }}
 
       # DeepSeek V4 has its own Makefile and its own target name (`deepseek-v4`,
       # producing `deepseek_v4`), so it never joined the loop above -- and #858 is
@@ -114,6 +114,7 @@ jobs:
           # "engine is not built. Run: coli build" -- with the engine sitting right there.
           # The version lives in the ARCHIVE name, which is where a downloader looks for it.
           cp c/colibri${{ matrix.ext }} dist/colibri${{ matrix.ext }}
+          cp c/glm53_flash${{ matrix.ext }} dist/glm53_flash${{ matrix.ext }}
           # The sibling engines go in under their plain names too: `coli` resolves the
           # engine from the model's config.json and looks for kimi_k3/inkling next to
           # itself (c/coli, engine_for()). ~830 KB for all four.

--- a/c/.gitignore
+++ b/c/.gitignore
@@ -1,5 +1,6 @@
 *.exe
 glm_tiny/
+glm53_tiny/
 olmoe_hf/
 olmoe_i4/
 .build-config

--- a/c/.gitignore
+++ b/c/.gitignore
@@ -29,6 +29,7 @@ tests/test_dsa_select
 tests/test_glm53_kda
 tests/test_glm53_indexer
 tests/test_glm53_sparse_attention
+tests/test_glm53_mhc
 tests/test_i4_grouped
 tests/test_kv_alloc
 tests/test_kv_disk

--- a/c/.gitignore
+++ b/c/.gitignore
@@ -26,6 +26,7 @@ absorb_determinism_test
 cuda_fmt_trap_test
 tests/*.dSYM/
 tests/test_dsa_select
+tests/test_glm53_kda
 tests/test_i4_grouped
 tests/test_kv_alloc
 tests/test_kv_disk

--- a/c/.gitignore
+++ b/c/.gitignore
@@ -28,6 +28,7 @@ tests/*.dSYM/
 tests/test_dsa_select
 tests/test_glm53_kda
 tests/test_glm53_indexer
+tests/test_glm53_sparse_attention
 tests/test_i4_grouped
 tests/test_kv_alloc
 tests/test_kv_disk

--- a/c/.gitignore
+++ b/c/.gitignore
@@ -27,6 +27,7 @@ cuda_fmt_trap_test
 tests/*.dSYM/
 tests/test_dsa_select
 tests/test_glm53_kda
+tests/test_glm53_indexer
 tests/test_i4_grouped
 tests/test_kv_alloc
 tests/test_kv_disk

--- a/c/.gitignore
+++ b/c/.gitignore
@@ -1,6 +1,7 @@
 *.exe
 glm_tiny/
 glm53_tiny/
+glm53_fp8_tiny/
 glm53_flash
 olmoe_hf/
 olmoe_i4/

--- a/c/.gitignore
+++ b/c/.gitignore
@@ -1,6 +1,7 @@
 *.exe
 glm_tiny/
 glm53_tiny/
+glm53_flash
 olmoe_hf/
 olmoe_i4/
 .build-config

--- a/c/Makefile
+++ b/c/Makefile
@@ -640,6 +640,9 @@ glm53-tiny-check: glm53-tiny-generate
 		glm53_sparse_attention.c -o ./tests/test_glm53_sparse_attention$(EXE) \
 		-lm $(LDFLAGS)
 	./tests/test_glm53_sparse_attention$(EXE)
+	$(CC) $(CFLAGS) -I. -I./glm53_tiny tests/test_glm53_mhc.c glm53_mhc.c \
+		-o ./tests/test_glm53_mhc$(EXE) -lm $(LDFLAGS)
+	./tests/test_glm53_mhc$(EXE)
 
 .PHONY: deepseek-v4 deepseek-v4-oracle deepseek-v4-tiny-generate \
 	deepseek-v4-tiny-check deepseek-v4-clean

--- a/c/Makefile
+++ b/c/Makefile
@@ -636,6 +636,10 @@ glm53-tiny-check: glm53-tiny-generate
 	$(CC) $(CFLAGS) -I. -I./glm53_tiny tests/test_glm53_indexer.c glm53_indexer.c \
 		-o ./tests/test_glm53_indexer$(EXE) -lm $(LDFLAGS)
 	./tests/test_glm53_indexer$(EXE)
+	$(CC) $(CFLAGS) -I. -I./glm53_tiny tests/test_glm53_sparse_attention.c \
+		glm53_sparse_attention.c -o ./tests/test_glm53_sparse_attention$(EXE) \
+		-lm $(LDFLAGS)
+	./tests/test_glm53_sparse_attention$(EXE)
 
 .PHONY: deepseek-v4 deepseek-v4-oracle deepseek-v4-tiny-generate \
 	deepseek-v4-tiny-check deepseek-v4-clean

--- a/c/Makefile
+++ b/c/Makefile
@@ -624,12 +624,16 @@ kimi-k3-tiny-check: kimi-k3-tiny-generate kimi_k3$(EXE)
 		--binary ./kimi_k3$(EXE) \
 		--fixture ./kimi_k3_tiny
 
-.PHONY: glm53-tiny-generate glm53-tiny-check
+.PHONY: glm53-tiny-generate glm53-fp8-tiny-generate glm53-tiny-check
 glm53-tiny-generate:
 	$(PYTHON) tools/make_glm53_tiny.py --output ./glm53_tiny --force
 
-glm53-tiny-check: glm53-tiny-generate
+glm53-fp8-tiny-generate:
+	$(PYTHON) tools/make_glm53_tiny.py --output ./glm53_fp8_tiny --force --fp8-mlp
+
+glm53-tiny-check: glm53-tiny-generate glm53-fp8-tiny-generate
 	$(PYTHON) tests/test_glm53_tiny.py --fixture ./glm53_tiny
+	$(PYTHON) tools/check_glm53_checkpoint.py --model ./glm53_tiny
 	$(CC) $(CFLAGS) -I. -I./glm53_tiny tests/test_glm53_kda.c glm53_kda.c \
 		-o ./tests/test_glm53_kda$(EXE) -lm $(LDFLAGS)
 	./tests/test_glm53_kda$(EXE)
@@ -643,16 +647,25 @@ glm53-tiny-check: glm53-tiny-generate
 	$(CC) $(CFLAGS) -I. -I./glm53_tiny tests/test_glm53_mhc.c glm53_mhc.c \
 		-o ./tests/test_glm53_mhc$(EXE) -lm $(LDFLAGS)
 	./tests/test_glm53_mhc$(EXE)
+	$(CC) $(CFLAGS) -I. -I./glm53_tiny tests/test_glm53_fp8.c glm53_fp8.c \
+		-o ./tests/test_glm53_fp8$(EXE) -lm $(LDFLAGS)
+	./tests/test_glm53_fp8$(EXE)
 	$(MAKE) glm53_flash$(EXE)
 	$(PYTHON) tests/test_glm53_engine.py --binary ./glm53_flash$(EXE) \
 		--fixture ./glm53_tiny
 	$(PYTHON) tests/test_glm53_engine.py --binary ./glm53_flash$(EXE) \
 		--fixture ./glm53_tiny --cached
+	$(PYTHON) tests/test_glm53_tiny.py --fixture ./glm53_fp8_tiny --expect-fp8
+	$(PYTHON) tools/check_glm53_checkpoint.py --model ./glm53_fp8_tiny --require-fp8
+	$(PYTHON) tests/test_glm53_engine.py --binary ./glm53_flash$(EXE) \
+		--fixture ./glm53_fp8_tiny
+	$(PYTHON) tests/test_glm53_engine.py --binary ./glm53_flash$(EXE) \
+		--fixture ./glm53_fp8_tiny --cached
 
 glm53_flash$(EXE): glm53_flash.c glm53_kda.c glm53_indexer.c \
-		glm53_sparse_attention.c glm53_mhc.c st.h json.h
+		glm53_sparse_attention.c glm53_mhc.c glm53_fp8.c st.h json.h
 	$(CC) $(CFLAGS) glm53_flash.c glm53_kda.c glm53_indexer.c \
-		glm53_sparse_attention.c glm53_mhc.c -o $@ -lm $(LDFLAGS)
+		glm53_sparse_attention.c glm53_mhc.c glm53_fp8.c -o $@ -lm $(LDFLAGS)
 
 .PHONY: deepseek-v4 deepseek-v4-oracle deepseek-v4-tiny-generate \
 	deepseek-v4-tiny-check deepseek-v4-clean

--- a/c/Makefile
+++ b/c/Makefile
@@ -633,6 +633,9 @@ glm53-tiny-check: glm53-tiny-generate
 	$(CC) $(CFLAGS) -I. -I./glm53_tiny tests/test_glm53_kda.c glm53_kda.c \
 		-o ./tests/test_glm53_kda$(EXE) -lm $(LDFLAGS)
 	./tests/test_glm53_kda$(EXE)
+	$(CC) $(CFLAGS) -I. -I./glm53_tiny tests/test_glm53_indexer.c glm53_indexer.c \
+		-o ./tests/test_glm53_indexer$(EXE) -lm $(LDFLAGS)
+	./tests/test_glm53_indexer$(EXE)
 
 .PHONY: deepseek-v4 deepseek-v4-oracle deepseek-v4-tiny-generate \
 	deepseek-v4-tiny-check deepseek-v4-clean

--- a/c/Makefile
+++ b/c/Makefile
@@ -643,6 +643,14 @@ glm53-tiny-check: glm53-tiny-generate
 	$(CC) $(CFLAGS) -I. -I./glm53_tiny tests/test_glm53_mhc.c glm53_mhc.c \
 		-o ./tests/test_glm53_mhc$(EXE) -lm $(LDFLAGS)
 	./tests/test_glm53_mhc$(EXE)
+	$(MAKE) glm53_flash$(EXE)
+	$(PYTHON) tests/test_glm53_engine.py --binary ./glm53_flash$(EXE) \
+		--fixture ./glm53_tiny
+
+glm53_flash$(EXE): glm53_flash.c glm53_kda.c glm53_indexer.c \
+		glm53_sparse_attention.c glm53_mhc.c st.h json.h
+	$(CC) $(CFLAGS) glm53_flash.c glm53_kda.c glm53_indexer.c \
+		glm53_sparse_attention.c glm53_mhc.c -o $@ -lm $(LDFLAGS)
 
 .PHONY: deepseek-v4 deepseek-v4-oracle deepseek-v4-tiny-generate \
 	deepseek-v4-tiny-check deepseek-v4-clean

--- a/c/Makefile
+++ b/c/Makefile
@@ -646,6 +646,8 @@ glm53-tiny-check: glm53-tiny-generate
 	$(MAKE) glm53_flash$(EXE)
 	$(PYTHON) tests/test_glm53_engine.py --binary ./glm53_flash$(EXE) \
 		--fixture ./glm53_tiny
+	$(PYTHON) tests/test_glm53_engine.py --binary ./glm53_flash$(EXE) \
+		--fixture ./glm53_tiny --cached
 
 glm53_flash$(EXE): glm53_flash.c glm53_kda.c glm53_indexer.c \
 		glm53_sparse_attention.c glm53_mhc.c st.h json.h

--- a/c/Makefile
+++ b/c/Makefile
@@ -678,6 +678,11 @@ glm53_flash$(EXE): glm53_flash.c glm53_kda.c glm53_indexer.c \
 	$(CC) $(CFLAGS) glm53_flash.c glm53_kda.c glm53_indexer.c \
 		glm53_sparse_attention.c glm53_mhc.c glm53_fp8.c $(CUDA_OBJ) $(METAL_OBJ) -o $@ -lm $(LDFLAGS)
 
+ifneq ($(IS_WIN),)
+.PHONY: glm53_flash
+glm53_flash: glm53_flash$(EXE)
+endif
+
 .PHONY: deepseek-v4 deepseek-v4-oracle deepseek-v4-tiny-generate \
 	deepseek-v4-tiny-check deepseek-v4-clean
 ifeq ($(COLI_V4_SUPPORTED),1)

--- a/c/Makefile
+++ b/c/Makefile
@@ -624,6 +624,13 @@ kimi-k3-tiny-check: kimi-k3-tiny-generate kimi_k3$(EXE)
 		--binary ./kimi_k3$(EXE) \
 		--fixture ./kimi_k3_tiny
 
+.PHONY: glm53-tiny-generate glm53-tiny-check
+glm53-tiny-generate:
+	$(PYTHON) tools/make_glm53_tiny.py --output ./glm53_tiny --force
+
+glm53-tiny-check: glm53-tiny-generate
+	$(PYTHON) tests/test_glm53_tiny.py --fixture ./glm53_tiny
+
 .PHONY: deepseek-v4 deepseek-v4-oracle deepseek-v4-tiny-generate \
 	deepseek-v4-tiny-check deepseek-v4-clean
 ifeq ($(COLI_V4_SUPPORTED),1)

--- a/c/Makefile
+++ b/c/Makefile
@@ -650,6 +650,14 @@ glm53-tiny-check: glm53-tiny-generate glm53-fp8-tiny-generate
 	$(CC) $(CFLAGS) -I. -I./glm53_tiny tests/test_glm53_fp8.c glm53_fp8.c \
 		-o ./tests/test_glm53_fp8$(EXE) -lm $(LDFLAGS)
 	./tests/test_glm53_fp8$(EXE)
+	$(CC) $(NOCUDA_CFLAGS) -I. -I./glm53_tiny tests/test_glm53_cuda_dispatch.c \
+		glm53_kda.c glm53_indexer.c glm53_sparse_attention.c glm53_mhc.c glm53_fp8.c \
+		-o ./tests/test_glm53_cuda_dispatch$(EXE) -lm $(NOCUDA_LDFLAGS)
+	./tests/test_glm53_cuda_dispatch$(EXE)
+	$(CC) $(NOCUDA_CFLAGS) -I. -I./glm53_tiny tests/test_glm53_metal_dispatch.c \
+		glm53_kda.c glm53_indexer.c glm53_sparse_attention.c glm53_mhc.c glm53_fp8.c \
+		-o ./tests/test_glm53_metal_dispatch$(EXE) -lm $(NOCUDA_LDFLAGS)
+	./tests/test_glm53_metal_dispatch$(EXE)
 	$(MAKE) glm53_flash$(EXE)
 	$(PYTHON) tests/test_glm53_engine.py --binary ./glm53_flash$(EXE) \
 		--fixture ./glm53_tiny

--- a/c/Makefile
+++ b/c/Makefile
@@ -665,9 +665,9 @@ glm53-tiny-check: glm53-tiny-generate glm53-fp8-tiny-generate
 		--fixture ./glm53_fp8_tiny
 
 glm53_flash$(EXE): glm53_flash.c glm53_kda.c glm53_indexer.c \
-		glm53_sparse_attention.c glm53_mhc.c glm53_fp8.c st.h json.h
+		glm53_sparse_attention.c glm53_mhc.c glm53_fp8.c st.h json.h backend_cuda.h $(CUDA_OBJ)
 	$(CC) $(CFLAGS) glm53_flash.c glm53_kda.c glm53_indexer.c \
-		glm53_sparse_attention.c glm53_mhc.c glm53_fp8.c -o $@ -lm $(LDFLAGS)
+		glm53_sparse_attention.c glm53_mhc.c glm53_fp8.c $(CUDA_OBJ) -o $@ -lm $(LDFLAGS)
 
 .PHONY: deepseek-v4 deepseek-v4-oracle deepseek-v4-tiny-generate \
 	deepseek-v4-tiny-check deepseek-v4-clean

--- a/c/Makefile
+++ b/c/Makefile
@@ -665,9 +665,10 @@ glm53-tiny-check: glm53-tiny-generate glm53-fp8-tiny-generate
 		--fixture ./glm53_fp8_tiny
 
 glm53_flash$(EXE): glm53_flash.c glm53_kda.c glm53_indexer.c \
-		glm53_sparse_attention.c glm53_mhc.c glm53_fp8.c st.h json.h backend_cuda.h $(CUDA_OBJ)
+		glm53_sparse_attention.c glm53_mhc.c glm53_fp8.c st.h json.h \
+		backend_cuda.h backend_metal.h $(CUDA_OBJ) $(METAL_OBJ)
 	$(CC) $(CFLAGS) glm53_flash.c glm53_kda.c glm53_indexer.c \
-		glm53_sparse_attention.c glm53_mhc.c glm53_fp8.c $(CUDA_OBJ) -o $@ -lm $(LDFLAGS)
+		glm53_sparse_attention.c glm53_mhc.c glm53_fp8.c $(CUDA_OBJ) $(METAL_OBJ) -o $@ -lm $(LDFLAGS)
 
 .PHONY: deepseek-v4 deepseek-v4-oracle deepseek-v4-tiny-generate \
 	deepseek-v4-tiny-check deepseek-v4-clean

--- a/c/Makefile
+++ b/c/Makefile
@@ -661,6 +661,8 @@ glm53-tiny-check: glm53-tiny-generate glm53-fp8-tiny-generate
 		--fixture ./glm53_fp8_tiny
 	$(PYTHON) tests/test_glm53_engine.py --binary ./glm53_flash$(EXE) \
 		--fixture ./glm53_fp8_tiny --cached
+	$(PYTHON) tests/test_glm53_serve.py --binary ./glm53_flash$(EXE) \
+		--fixture ./glm53_fp8_tiny
 
 glm53_flash$(EXE): glm53_flash.c glm53_kda.c glm53_indexer.c \
 		glm53_sparse_attention.c glm53_mhc.c glm53_fp8.c st.h json.h
@@ -1715,13 +1717,14 @@ check:
 	$(MAKE) portable
 	$(MAKE) test
 
-install: colibri$(EXE) inkling$(EXE) kimi_k3$(EXE) olmoe$(EXE) qwen36$(EXE) \
+install: colibri$(EXE) glm53_flash$(EXE) inkling$(EXE) kimi_k3$(EXE) olmoe$(EXE) qwen36$(EXE) \
 	$(if $(filter 1,$(COLI_V4_SUPPORTED)),deepseek-v4,)
 	$(INSTALL) -d $(DESTDIR)$(BINDIR)
 	$(INSTALL) -d $(DESTDIR)$(LIBEXECDIR)
 	$(INSTALL) -d $(DESTDIR)$(LIBEXECDIR)/tools
 	$(INSTALL) -m 755 coli $(DESTDIR)$(BINDIR)/coli
 	$(INSTALL) -m 755 colibri$(EXE) $(DESTDIR)$(LIBEXECDIR)/colibri$(EXE)
+	$(INSTALL) -m 755 glm53_flash$(EXE) $(DESTDIR)$(LIBEXECDIR)/glm53_flash$(EXE)
 	$(INSTALL) -m 755 inkling$(EXE) $(DESTDIR)$(LIBEXECDIR)/inkling$(EXE)
 	$(INSTALL) -m 755 kimi_k3$(EXE) $(DESTDIR)$(LIBEXECDIR)/kimi_k3$(EXE)
 	$(INSTALL) -m 755 olmoe$(EXE) $(DESTDIR)$(LIBEXECDIR)/olmoe$(EXE)

--- a/c/Makefile
+++ b/c/Makefile
@@ -630,6 +630,9 @@ glm53-tiny-generate:
 
 glm53-tiny-check: glm53-tiny-generate
 	$(PYTHON) tests/test_glm53_tiny.py --fixture ./glm53_tiny
+	$(CC) $(CFLAGS) -I. -I./glm53_tiny tests/test_glm53_kda.c glm53_kda.c \
+		-o ./tests/test_glm53_kda$(EXE) -lm $(LDFLAGS)
+	./tests/test_glm53_kda$(EXE)
 
 .PHONY: deepseek-v4 deepseek-v4-oracle deepseek-v4-tiny-generate \
 	deepseek-v4-tiny-check deepseek-v4-clean

--- a/c/coli
+++ b/c/coli
@@ -1208,6 +1208,16 @@ def cmd_run(a):
                 try: os.unlink(prompt_path)
                 except OSError: pass
         sys.exit(result)
+    if arch=="glm53_flash":
+        thinking=os.environ.get("THINK","0")=="1"
+        suffix="<think>" if thinking else "<think></think>"
+        rendered=f"[gMASK]<sop><|user|>{prompt}<|assistant|>{suffix}"
+        e=env_for_engine(a,arch)
+        command=[engine,os.path.abspath(a.model),"--prompt",rendered,
+                 "--max-tokens",str(ngen_for(a,interactive=True,family=family)),
+                 "--temperature",str(a.temp if a.temp is not None else 1.0),
+                 "--top-p",str(a.topp if a.topp else 0.95)]
+        sys.exit(subprocess.call(command,env=e))
     if arch=="olmoe":
         # olmoe.c now speaks the gateway's SERVE protocol too (`coli chat`/
         # `coli web`/`coli serve` use it), but `coli run` predates that and

--- a/c/doctor.py
+++ b/c/doctor.py
@@ -495,7 +495,12 @@ def run_doctor(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0, *,
         engine_ok = engine.is_file()
     else:
         engine_ok = engine.is_file() and os.access(engine, os.X_OK)
-    if engine_error:
+    runtime_pending = resolved is not None and not resolved.descriptor.runtime_available
+    if runtime_pending:
+        checks.append(_check("engine.binary", "skip",
+                             f"{resolved.descriptor.display_name} runtime is not implemented yet",
+                             path=str(engine), family_id=resolved.descriptor.id))
+    elif engine_error:
         checks.append(_check("engine.binary", "fail", str(engine_error), path=str(engine)))
     elif engine_ok:
         unresolved = missing_shared_libraries(engine)
@@ -519,7 +524,10 @@ def run_doctor(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0, *,
         wanted = set(gpu_indices)
         selected_gpus = [gpu for gpu in detected_gpus if gpu["index"] in wanted]
 
-    if gpu_indices == []:
+    if runtime_pending:
+        checks.append(_check("accelerator.gpu", "skip",
+                             "accelerator support follows the CPU text runtime"))
+    elif gpu_indices == []:
         checks.append(_check("accelerator.gpu", "skip", "GPU use was explicitly disabled"))
     elif gpu_indices is not None and len(selected_gpus) != len(set(gpu_indices)):
         checks.append(_check("accelerator.gpu", "fail", "one or more requested GPUs were not detected",

--- a/c/family_registry.py
+++ b/c/family_registry.py
@@ -74,6 +74,7 @@ class FamilyDescriptor:
     capabilities: FamilyCapabilities
     has_gateway_adapter: bool = False
     has_cli_adapter: bool = False
+    runtime_available: bool = True
     tune_prompt_template: str = "{prompt}"
 
 
@@ -393,6 +394,62 @@ def _dsv4_geometry(config, context, _model_dir):
     return PlannerGeometry(state, fixed, workspace, experts)
 
 
+def _glm53_geometry(config, context, _model_dir):
+    """GLM-5.3-Flash: KDA/DSA hybrid with mHC and one MTP expert row.
+
+    The 45 text layers contain 34 recurrent KDA layers and 11 DSA layers.
+    KDA owns a fixed [heads, head_dim, head_dim] fp32 recurrence plus three
+    conv4 histories; DSA owns the growing MLA latent/index cache.  The MTP row
+    has routed experts but no independent attention state.
+    """
+    family = "glm53_flash"
+    layers = _required_int(config, "num_hidden_layers", family)
+    experts = _required_int(config, "n_routed_experts", family)
+    hidden = _required_int(config, "hidden_size", family)
+    heads = _required_int(config, "num_attention_heads", family)
+    q_lora = _required_int(config, "q_lora_rank", family)
+    kv_lora = _required_int(config, "kv_lora_rank", family)
+    qk_nope = _required_int(config, "qk_nope_head_dim", family)
+    qk_rope = _optional_int(config, "qk_rope_head_dim", 0)
+    value = _required_int(config, "v_head_dim", family)
+    index_dim = _required_int(config, "index_head_dim", family)
+    hc_mult = _required_int(config, "hc_mult", family)
+
+    kinds = config.get("layer_types")
+    if not isinstance(kinds, list) or len(kinds) != layers:
+        raise ValueError(f"{family}: layer_types must match num_hidden_layers")
+    n_kda = sum(kind == "linear_attention" for kind in kinds)
+    n_dsa = sum(kind == "deepseek_sparse_attention" for kind in kinds)
+    if n_kda + n_dsa != layers or not n_kda or not n_dsa:
+        raise ValueError(f"{family}: layer_types must contain KDA and DSA layers only")
+
+    linear = config.get("linear_attn_config")
+    if not isinstance(linear, dict):
+        raise ValueError(f"{family}: missing linear_attn_config")
+    kda_heads = _required_int(linear, "num_heads", family)
+    kda_dim = _required_int(linear, "head_dim", family)
+    conv_k = _required_int(linear, "short_conv_kernel_size", family, 2)
+    listed = linear.get("kda_layers")
+    if (not isinstance(listed, list) or
+            sorted(v for v in listed if isinstance(v, int)) !=
+            [i for i, kind in enumerate(kinds) if kind == "linear_attention"]):
+        raise ValueError(f"{family}: linear_attn_config.kda_layers disagrees with layer_types")
+
+    kda_proj = kda_heads * kda_dim
+    fixed = n_kda * (kda_heads * kda_dim * kda_dim +
+                     3 * kda_proj * (conv_k - 1)) * 4
+    # The DSA indexer persists packed [key, gate_scores, valid] rows, i.e.
+    # 2*index_dim+1 values in addition to the MLA latent cache.
+    state = n_dsa * context * (kv_lora + qk_rope + 2 * index_dim + 1) * 4
+
+    ws_kda = context * (6 * kda_proj + kda_dim + hidden) * 4
+    q_width = heads * (qk_nope + qk_rope)
+    ws_dsa = context * (q_lora + q_width + kv_lora + qk_rope +
+                        2 * heads * value) * 4
+    ws_mhc = context * hc_mult * hidden * 4
+    return PlannerGeometry(state, fixed, max(ws_kda, ws_dsa, ws_mhc), experts)
+
+
 _GLM_EXPERT = re.compile(
     r"(?:^|\.)model\.layers\.(\d+)\.mlp\.experts\.(\d+)\."
 )
@@ -401,6 +458,9 @@ _KIMI_EXPERT = re.compile(
     r"experts\.(\d+)\."
 )
 _V4_EXPERT = re.compile(r"^layers\.(\d+)\.ffn\.experts\.(\d+)\.")
+_GLM53_EXPERT = re.compile(
+    r"^model\.language_model\.layers\.(\d+)\.mlp\.experts\.(\d+)\."
+)
 _INKLING_EXPERT = re.compile(
     r"^model\.layers\.(\d+)\.mlp\.experts\."
     r"(?:gate_up_proj|down_proj)(?:\.|$)"
@@ -456,6 +516,31 @@ FAMILIES = (
         has_gateway_adapter=True,
         has_cli_adapter=True,
         tune_prompt_template="[gMASK]<sop><|user|>{prompt}<|assistant|><think></think>",
+    ),
+    FamilyDescriptor(
+        id="glm53_flash",
+        model_types=("glm5_next", "glm5_next_text"),
+        display_name="GLM-5.3-Flash",
+        display_scale="320B",
+        engine_artifact="glm53_flash",
+        engine_aliases=(),
+        engine_group="glm53_flash",
+        internal_arch="glm53_flash",
+        build_target="glm53_flash",
+        process_names=("glm53_flash",),
+        default_model_id="glm-5.3-flash-colibri",
+        cli_adapter="glm53_flash",
+        gateway_adapter="glm53_flash",
+        planner_id="glm53_kda_dsa_mhc",
+        planner_geometry=_glm53_geometry,
+        planner_unsupported_reason="",
+        expert_inventory=_individual_expert_inventory(_GLM53_EXPERT),
+        config_section="text_config",
+        limits=FamilyLimits(8192, 1048576, 1024, 16384, 1, 8, "GLM53_MAXT"),
+        capabilities=FamilyCapabilities(True, False, False, True),
+        has_gateway_adapter=False,
+        has_cli_adapter=False,
+        runtime_available=False,
     ),
     FamilyDescriptor(
         id="inkling",
@@ -603,6 +688,7 @@ def _build_registry(families):
                 (not callable(family.planner_geometry) and
                   not family.planner_unsupported_reason) or
                 not callable(family.expert_inventory) or
+                not isinstance(family.runtime_available, bool) or
                 not isinstance(family.has_gateway_adapter, bool) or
                 not isinstance(family.has_cli_adapter, bool) or
                 not isinstance(family.tune_prompt_template, str) or
@@ -737,6 +823,7 @@ def public_metadata(family):
         "cli_adapter": family.cli_adapter,
         "gateway_adapter": family.gateway_adapter,
         "planner_id": family.planner_id,
+        "runtime_available": family.runtime_available,
         "limits": {
             "default_context": family.limits.default_context,
             "max_context": family.limits.max_context,

--- a/c/family_registry.py
+++ b/c/family_registry.py
@@ -538,9 +538,9 @@ FAMILIES = (
         config_section="text_config",
         limits=FamilyLimits(8192, 1048576, 1024, 16384, 1, 8, "GLM53_MAXT"),
         capabilities=FamilyCapabilities(True, False, False, True),
-        has_gateway_adapter=False,
-        has_cli_adapter=False,
-        runtime_available=False,
+        has_gateway_adapter=True,
+        has_cli_adapter=True,
+        runtime_available=True,
     ),
     FamilyDescriptor(
         id="inkling",

--- a/c/glm53_flash.c
+++ b/c/glm53_flash.c
@@ -15,7 +15,8 @@ typedef struct {
     int heads, q_rank, kv_rank, key_dim, value_dim;
     int kda_heads, kda_dim, conv_kernel;
     int index_heads, index_dim, index_topk, index_pool;
-    int hc, hc_iters, dense_layers;
+    int hc, hc_iters;
+    unsigned char *layer_kda, *layer_sparse;
     float eps, hc_eps, route_scale, swiglu_limit, gate_lower_bound;
 } Config;
 
@@ -123,11 +124,26 @@ static void load_config(Config *c, const char *directory) {
     c->hc_eps = (float)required_number(text, "hc_eps");
     c->route_scale = (float)required_number(text, "routed_scaling_factor");
     c->swiglu_limit = (float)required_number(text, "swiglu_limit");
-    c->gate_lower_bound = -5.0f;
-    jval *dense = json_get(text, "mlp_layer_types");
-    c->dense_layers = 0;
-    if (!dense || dense->t != J_ARR || dense->len != c->layers) die("glm53 config: invalid mlp_layer_types");
-    while (c->dense_layers < c->layers && !strcmp(dense->kids[c->dense_layers]->str, "dense")) c->dense_layers++;
+    c->gate_lower_bound = (float)required_number(linear, "gate_lower_bound");
+    jval *layer_types = json_get(text, "layer_types");
+    jval *mlp_types = json_get(text, "mlp_layer_types");
+    if (!layer_types || layer_types->t != J_ARR || layer_types->len != c->layers || !mlp_types ||
+        mlp_types->t != J_ARR || mlp_types->len != c->layers)
+        die("glm53 config: invalid layer type arrays");
+    c->layer_kda = calloc((size_t)c->layers, 1);
+    c->layer_sparse = calloc((size_t)c->layers, 1);
+    if (!c->layer_kda || !c->layer_sparse) die("glm53 config: layer type allocation failed");
+    for (int i = 0; i < c->layers; i++) {
+        jval *attention = layer_types->kids[i];
+        jval *mlp = mlp_types->kids[i];
+        if (!attention || attention->t != J_STR ||
+            (strcmp(attention->str, "linear_attention") && strcmp(attention->str, "deepseek_sparse_attention")))
+            die("glm53 config: unsupported layer_types value");
+        if (!mlp || mlp->t != J_STR || (strcmp(mlp->str, "dense") && strcmp(mlp->str, "sparse")))
+            die("glm53 config: unsupported mlp_layer_types value");
+        c->layer_kda[i] = !strcmp(attention->str, "linear_attention");
+        c->layer_sparse[i] = !strcmp(mlp->str, "sparse");
+    }
     if (c->hidden < 1 || c->layers < 1 || c->layers > 128 || c->heads < 1 || c->experts < 1 || c->topk < 1 ||
         c->topk > c->experts || c->kda_heads * c->kda_dim <= 0 || c->hc < 1 || c->hc > 16)
         die("glm53 config: dimension out of range");
@@ -151,6 +167,25 @@ static float *load_named(Model *m, int layer, const char *suffix) {
     snprintf(name, sizeof(name), "model.language_model.layers.%d.%s", layer, suffix);
     return load_tensor(m, name);
 }
+static float *load_conv(Model *model, int layer) {
+    const char *parts[] = {"q_conv1d.weight", "k_conv1d.weight", "v_conv1d.weight"};
+    int64_t counts[3], total = 0;
+    char name[512];
+    for (int i = 0; i < 3; i++) {
+        snprintf(name, sizeof(name), "model.language_model.layers.%d.self_attn.%s", layer, parts[i]);
+        counts[i] = st_numel(&model->tensors, name);
+        if (counts[i] < 0 || (i && counts[i] != counts[0])) die("glm53: invalid split q/k/v conv tensors");
+        total += counts[i];
+    }
+    float *result = alloc_floats((size_t)total);
+    int64_t offset = 0;
+    for (int i = 0; i < 3; i++) {
+        snprintf(name, sizeof(name), "model.language_model.layers.%d.self_attn.%s", layer, parts[i]);
+        st_read_f32_cap(&model->tensors, name, result + offset, counts[i], 0);
+        offset += counts[i];
+    }
+    return result;
+}
 static void model_load(Model *m, const char *directory) {
     memset(m, 0, sizeof(*m));
     load_config(&m->c, directory);
@@ -163,25 +198,25 @@ static void model_load(Model *m, const char *directory) {
     if (!m->layer) die("glm53: layer allocation failed");
     for (int i = 0; i < c->layers; i++) {
         Layer *l = &m->layer[i];
-        l->kda = (i % 4) != 3;
-        l->sparse = i >= c->dense_layers;
+        l->kda = c->layer_kda[i];
+        l->sparse = c->layer_sparse[i];
         l->norm1 = load_named(m, i, "input_layernorm.weight");
         l->norm2 = load_named(m, i, "post_attention_layernorm.weight");
-        l->ah_fn = load_named(m, i, "attn_hc.fn");
-        l->ah_base = load_named(m, i, "attn_hc.base");
-        l->ah_scale = load_named(m, i, "attn_hc.scale");
-        l->fh_fn = load_named(m, i, "ffn_hc.fn");
-        l->fh_base = load_named(m, i, "ffn_hc.base");
-        l->fh_scale = load_named(m, i, "ffn_hc.scale");
+        l->ah_fn = load_named(m, i, "hc_attn_fn");
+        l->ah_base = load_named(m, i, "hc_attn_base");
+        l->ah_scale = load_named(m, i, "hc_attn_scale");
+        l->fh_fn = load_named(m, i, "hc_ffn_fn");
+        l->fh_base = load_named(m, i, "hc_ffn_base");
+        l->fh_scale = load_named(m, i, "hc_ffn_scale");
         if (l->kda) {
             l->q = load_named(m, i, "self_attn.q_proj.weight");
             l->k = load_named(m, i, "self_attn.k_proj.weight");
             l->v = load_named(m, i, "self_attn.v_proj.weight");
-            l->conv = load_named(m, i, "self_attn.conv1d.weight");
-            l->fa = load_named(m, i, "self_attn.forget_gate.f_a_proj.weight");
-            l->fb = load_named(m, i, "self_attn.forget_gate.f_b_proj.weight");
-            l->dt = load_named(m, i, "self_attn.forget_gate.dt_bias");
-            l->alog = load_named(m, i, "self_attn.forget_gate.A_log");
+            l->conv = load_conv(m, i);
+            l->fa = load_named(m, i, "self_attn.f_a_proj.weight");
+            l->fb = load_named(m, i, "self_attn.f_b_proj.weight");
+            l->dt = load_named(m, i, "self_attn.dt_bias");
+            l->alog = load_named(m, i, "self_attn.A_log");
             l->beta = load_named(m, i, "self_attn.b_proj.weight");
             l->ga = load_named(m, i, "self_attn.g_a_proj.weight");
             l->gb = load_named(m, i, "self_attn.g_b_proj.weight");
@@ -288,6 +323,8 @@ static void model_free(Model *model) {
     free(model->embed);
     free(model->norm);
     free(model->head);
+    free(model->c.layer_kda);
+    free(model->c.layer_sparse);
     st_destroy(&model->tensors);
 }
 
@@ -519,7 +556,7 @@ static void cache_init(RuntimeCache *cache, const Config *config) {
     cache->layers = calloc((size_t)config->layers, sizeof(*cache->layers));
     if (!cache->layers) die("glm53: cache allocation failed");
     for (int i = 0; i < config->layers; i++) {
-        if ((i % 4) == 3) continue;
+        if (!config->layer_kda[i]) continue;
         cache->layers[i].kda_state = alloc_floats((size_t)config->kda_heads * config->kda_dim * config->kda_dim);
         cache->layers[i].kda_window =
             alloc_floats((size_t)3 * config->kda_heads * config->kda_dim * config->conv_kernel);

--- a/c/glm53_flash.c
+++ b/c/glm53_flash.c
@@ -11,6 +11,7 @@
 #include "glm53_sparse_attention.h"
 #include "glm53_fp8.h"
 #include "tensor.h"
+#include "tok.h"
 
 typedef struct {
     ColiTensorView view;
@@ -22,7 +23,7 @@ typedef struct {
 } Matrix;
 
 typedef struct {
-    int hidden, layers, vocab, dense_inter, moe_inter, experts, topk, shared;
+    int hidden, layers, vocab, max_position, dense_inter, moe_inter, experts, topk, shared;
     int heads, q_rank, kv_rank, key_dim, value_dim;
     int kda_heads, kda_dim, conv_kernel;
     int index_heads, index_dim, index_topk, index_pool;
@@ -116,6 +117,7 @@ static void load_config(Config *c, const char *directory) {
     c->hidden = (int)required_number(text, "hidden_size");
     c->layers = (int)required_number(text, "num_hidden_layers");
     c->vocab = (int)required_number(text, "vocab_size");
+    c->max_position = (int)required_number(text, "max_position_embeddings");
     c->dense_inter = (int)required_number(text, "intermediate_size");
     c->moe_inter = (int)required_number(text, "moe_intermediate_size");
     c->experts = (int)required_number(text, "n_routed_experts");
@@ -957,7 +959,225 @@ static int parse_ids(const char *text, int **output) {
     *output = ids;
     return n;
 }
+
+typedef struct {
+    char id[64];
+    int max_tokens, payload_size;
+    float temperature, top_p;
+    char *payload;
+} ServeRequest;
+
+static int serve_read_request(ServeRequest *request) {
+    char line[512], command[16], id[64];
+    if (!fgets(line, sizeof(line), stdin)) return -1;
+    if (sscanf(line, "%15s %63s", command, id) < 2) return 0;
+    if (!strcmp(command, "CANCEL") || !strcmp(command, "STOP")) return 0;
+    if (strcmp(command, "SUBMIT")) return 0;
+    int slot, payload_size, max_tokens;
+    float temperature, top_p;
+    if (sscanf(line, "%*s %*s %d %d %d %f %f", &slot, &payload_size, &max_tokens, &temperature, &top_p) != 5 ||
+        payload_size < 0 || payload_size > (1 << 24) || max_tokens < 1) {
+        printf("ERROR %s bad submit header\n", id);
+        fflush(stdout);
+        return 0;
+    }
+    (void)slot;
+    char *payload = malloc((size_t)payload_size + 1);
+    if (!payload) die("glm53: serve payload allocation failed");
+    if (fread(payload, 1, (size_t)payload_size, stdin) != (size_t)payload_size) {
+        free(payload);
+        return -1;
+    }
+    (void)fgetc(stdin);
+    payload[payload_size] = 0;
+    snprintf(request->id, sizeof(request->id), "%s", id);
+    request->max_tokens = max_tokens;
+    request->payload_size = payload_size;
+    request->temperature = temperature;
+    request->top_p = top_p;
+    request->payload = payload;
+    return 1;
+}
+
+typedef struct {
+    float probability;
+    int token;
+} SampleProbability;
+
+static int probability_descending(const void *left, const void *right) {
+    float a = ((const SampleProbability *)left)->probability;
+    float b = ((const SampleProbability *)right)->probability;
+    return (b > a) - (a > b);
+}
+
+static int sample_token(const float *logits, int vocab, float temperature, float top_p) {
+    if (temperature <= 0.0f) {
+        int best = 0;
+        for (int token = 1; token < vocab; token++)
+            if (logits[token] > logits[best]) best = token;
+        return best;
+    }
+    SampleProbability *ranked = malloc((size_t)vocab * sizeof(*ranked));
+    if (!ranked) die("glm53: sampler allocation failed");
+    float maximum = logits[0];
+    for (int token = 1; token < vocab; token++) maximum = fmaxf(maximum, logits[token]);
+    double total = 0.0;
+    for (int token = 0; token < vocab; token++) {
+        float probability = expf((logits[token] - maximum) / temperature);
+        ranked[token] = (SampleProbability){probability, token};
+        total += probability;
+    }
+    qsort(ranked, (size_t)vocab, sizeof(*ranked), probability_descending);
+    double cutoff = top_p > 0.0f && top_p < 1.0f ? top_p * total : total;
+    double kept = 0.0;
+    int count = 0;
+    while (count < vocab && kept < cutoff) kept += ranked[count++].probability;
+    double target = (double)rand() / RAND_MAX * kept;
+    double cumulative = 0.0;
+    int selected = ranked[0].token;
+    for (int i = 0; i < count; i++) {
+        cumulative += ranked[i].probability;
+        if (cumulative >= target) {
+            selected = ranked[i].token;
+            break;
+        }
+    }
+    free(ranked);
+    return selected;
+}
+
+static void serve_data(const char *id, const char *data, int size) {
+    if (size <= 0) return;
+    printf("DATA %s %d\n", id, size);
+    fwrite(data, 1, (size_t)size, stdout);
+    fputc('\n', stdout);
+    fflush(stdout);
+}
+
+static void serve_model(Model *model, const char *directory) {
+    char tokenizer_path[2048];
+    snprintf(tokenizer_path, sizeof(tokenizer_path), "%s/tokenizer.json", directory);
+    Tok tokenizer;
+    tok_load(&tokenizer, tokenizer_path);
+    printf("\x01\x01READY\x01\x01\nSTAT 0 0.00 0.0 0.0\n");
+    fflush(stdout);
+    for (;;) {
+        ServeRequest request = {0};
+        int status = serve_read_request(&request);
+        if (status < 0) break;
+        if (!status) continue;
+        int capacity = request.payload_size + 64;
+        int *ids = malloc((size_t)capacity * sizeof(*ids));
+        if (!ids) die("glm53: token buffer allocation failed");
+        int prompt_tokens = tok_encode(&tokenizer, request.payload, request.payload_size, ids, capacity);
+        if (prompt_tokens < 1 || prompt_tokens + request.max_tokens > model->c.max_position) {
+            printf("ERROR %s CONTEXT_EXCEEDED prompt_tokens=%d requested=%d capacity=%d\n", request.id, prompt_tokens,
+                   request.max_tokens, model->c.max_position);
+            fflush(stdout);
+            free(ids);
+            free(request.payload);
+            continue;
+        }
+        printf("ACCEPT %s %d\n", request.id, prompt_tokens);
+        fflush(stdout);
+        RuntimeCache cache;
+        cache_init(&cache, &model->c);
+        float *logits = NULL;
+        for (int i = 0; i < prompt_tokens; i++) {
+            free(logits);
+            logits = forward_cached_step(model, &cache, ids[i]);
+        }
+        int generated = 0, limited = 1;
+        for (; generated < request.max_tokens; generated++) {
+            int token = sample_token(logits, model->c.vocab, request.temperature, request.top_p);
+            if (token == 154820) {
+                limited = 0;
+                break;
+            }
+            char bytes[65536];
+            int size = tok_decode(&tokenizer, &token, 1, bytes, (int)sizeof(bytes));
+            serve_data(request.id, bytes, size);
+            free(logits);
+            logits = forward_cached_step(model, &cache, token);
+        }
+        printf("DONE %s STAT %d 0.00 0.0 0.0 %d %d\n", request.id, generated, prompt_tokens, limited);
+        fflush(stdout);
+        free(logits);
+        cache_free(&cache, &model->c);
+        free(ids);
+        free(request.payload);
+    }
+    tok_free(&tokenizer);
+}
+
+static int run_text_prompt(Model *model, const char *directory, const char *prompt, int max_tokens, float temperature,
+                           float top_p) {
+    char tokenizer_path[2048];
+    snprintf(tokenizer_path, sizeof(tokenizer_path), "%s/tokenizer.json", directory);
+    Tok tokenizer;
+    tok_load(&tokenizer, tokenizer_path);
+    int capacity = (int)strlen(prompt) + 64;
+    int *ids = malloc((size_t)capacity * sizeof(*ids));
+    if (!ids) die("glm53: token buffer allocation failed");
+    int prompt_tokens = tok_encode(&tokenizer, prompt, (int)strlen(prompt), ids, capacity);
+    if (prompt_tokens < 1 || prompt_tokens + max_tokens > model->c.max_position) {
+        fprintf(stderr, "glm53: prompt exceeds context capacity\n");
+        free(ids);
+        tok_free(&tokenizer);
+        return 2;
+    }
+    RuntimeCache cache;
+    cache_init(&cache, &model->c);
+    float *logits = NULL;
+    for (int i = 0; i < prompt_tokens; i++) {
+        free(logits);
+        logits = forward_cached_step(model, &cache, ids[i]);
+    }
+    for (int generated = 0; generated < max_tokens; generated++) {
+        int token = sample_token(logits, model->c.vocab, temperature, top_p);
+        if (token == 154820) break;
+        char bytes[65536];
+        int size = tok_decode(&tokenizer, &token, 1, bytes, (int)sizeof(bytes));
+        fwrite(bytes, 1, (size_t)size, stdout);
+        fflush(stdout);
+        free(logits);
+        logits = forward_cached_step(model, &cache, token);
+    }
+    fputc('\n', stdout);
+    free(logits);
+    cache_free(&cache, &model->c);
+    free(ids);
+    tok_free(&tokenizer);
+    return 0;
+}
+
 int main(int argc, char **argv) {
+    const char *serve_directory = getenv("SNAP");
+    if (getenv("SERVE") && serve_directory && *serve_directory) {
+        Model model;
+        model_load(&model, serve_directory);
+        serve_model(&model, serve_directory);
+        model_free(&model);
+        return 0;
+    }
+    if (argc >= 4 && !strcmp(argv[2], "--prompt")) {
+        int max_tokens = 1024;
+        float temperature = 0.0f, top_p = 1.0f;
+        for (int arg = 4; arg < argc; arg++) {
+            if (!strcmp(argv[arg], "--max-tokens") && arg + 1 < argc) max_tokens = atoi(argv[++arg]);
+            else if (!strcmp(argv[arg], "--temperature") && arg + 1 < argc) temperature = strtof(argv[++arg], NULL);
+            else if (!strcmp(argv[arg], "--top-p") && arg + 1 < argc) top_p = strtof(argv[++arg], NULL);
+            else {
+                fprintf(stderr, "glm53: unknown argument %s\n", argv[arg]);
+                return 2;
+            }
+        }
+        Model model;
+        model_load(&model, argv[1]);
+        int result = run_text_prompt(&model, argv[1], argv[3], max_tokens, temperature, top_p);
+        model_free(&model);
+        return result;
+    }
     if (argc < 4 || strcmp(argv[2], "--ids")) {
         fprintf(stderr, "usage: %s MODEL --ids 1,2,3 [--greedy N] [--cached]\n", argv[0]);
         return 2;

--- a/c/glm53_flash.c
+++ b/c/glm53_flash.c
@@ -38,6 +38,17 @@ typedef struct {
     Layer *layer;
 } Model;
 
+typedef struct {
+    float *kda_state, *kda_window;
+    float *keys, *values, *index_keys, *index_gates;
+    int capacity;
+} LayerCache;
+
+typedef struct {
+    LayerCache *layers;
+    int length;
+} RuntimeCache;
+
 static void die(const char *message) {
     fprintf(stderr, "%s\n", message);
     exit(1);
@@ -503,6 +514,213 @@ static void ffn_forward(const Config *c, const Layer *l, const float *x, int n, 
     free(score);
 }
 
+static void cache_init(RuntimeCache *cache, const Config *config) {
+    memset(cache, 0, sizeof(*cache));
+    cache->layers = calloc((size_t)config->layers, sizeof(*cache->layers));
+    if (!cache->layers) die("glm53: cache allocation failed");
+    for (int i = 0; i < config->layers; i++) {
+        if ((i % 4) == 3) continue;
+        cache->layers[i].kda_state = alloc_floats((size_t)config->kda_heads * config->kda_dim * config->kda_dim);
+        cache->layers[i].kda_window =
+            alloc_floats((size_t)3 * config->kda_heads * config->kda_dim * config->conv_kernel);
+    }
+}
+
+static void cache_free(RuntimeCache *cache, const Config *config) {
+    for (int i = 0; i < config->layers; i++) {
+        LayerCache *layer = &cache->layers[i];
+        free(layer->kda_state);
+        free(layer->kda_window);
+        free(layer->keys);
+        free(layer->values);
+        free(layer->index_keys);
+        free(layer->index_gates);
+    }
+    free(cache->layers);
+}
+
+static void kda_step_forward(const Config *c, const Layer *l, LayerCache *cache, const float *x, float *out) {
+    int width = c->kda_heads * c->kda_dim;
+    float *qkv = alloc_floats((size_t)3 * width);
+    float *tmp = alloc_floats((size_t)c->kda_dim);
+    float *decay = alloc_floats((size_t)width);
+    float *beta = alloc_floats((size_t)c->kda_heads);
+    float *gate = alloc_floats((size_t)width);
+    float *core = alloc_floats((size_t)width);
+    float *normed = alloc_floats((size_t)width);
+
+    matmul(qkv, x, l->q, 1, c->hidden, width);
+    matmul(qkv + width, x, l->k, 1, c->hidden, width);
+    matmul(qkv + 2 * width, x, l->v, 1, c->hidden, width);
+    matmul(tmp, x, l->fa, 1, c->hidden, c->kda_dim);
+    matmul(decay, tmp, l->fb, 1, c->kda_dim, width);
+    for (int h = 0; h < c->kda_heads; h++)
+        for (int d = 0; d < c->kda_dim; d++) {
+            int i = h * c->kda_dim + d;
+            decay[i] = c->gate_lower_bound * sigmoid(expf(l->alog[h]) * (decay[i] + l->dt[i]));
+        }
+    matmul(beta, x, l->beta, 1, c->hidden, c->kda_heads);
+    for (int h = 0; h < c->kda_heads; h++) beta[h] = sigmoid(beta[h]);
+    matmul(tmp, x, l->ga, 1, c->hidden, c->kda_dim);
+    matmul(gate, tmp, l->gb, 1, c->kda_dim, width);
+    coli_glm53_kda_step(core, cache->kda_state, cache->kda_window, qkv, l->conv, decay, beta, c->kda_heads, c->kda_dim,
+                        c->conv_kernel);
+    for (int h = 0; h < c->kda_heads; h++) {
+        float sum = 0.0f;
+        for (int d = 0; d < c->kda_dim; d++) sum += core[h * c->kda_dim + d] * core[h * c->kda_dim + d];
+        float inv = 1.0f / sqrtf(sum / c->kda_dim + c->eps);
+        for (int d = 0; d < c->kda_dim; d++) {
+            int i = h * c->kda_dim + d;
+            normed[i] = core[i] * inv * l->onorm[d] * sigmoid(gate[i]);
+        }
+    }
+    matmul(out, normed, l->op, 1, width, c->hidden);
+    free(normed);
+    free(core);
+    free(gate);
+    free(beta);
+    free(decay);
+    free(tmp);
+    free(qkv);
+}
+
+static void dsa_cache_reserve(const Config *c, LayerCache *cache, int needed) {
+    if (needed <= cache->capacity) return;
+    int capacity = cache->capacity ? cache->capacity * 2 : 16;
+    while (capacity < needed) capacity *= 2;
+    cache->keys = realloc(cache->keys, (size_t)capacity * c->heads * c->key_dim * sizeof(float));
+    cache->values = realloc(cache->values, (size_t)capacity * c->heads * c->value_dim * sizeof(float));
+    cache->index_keys = realloc(cache->index_keys, (size_t)capacity * c->index_dim * sizeof(float));
+    cache->index_gates = realloc(cache->index_gates, (size_t)capacity * c->index_dim * sizeof(float));
+    if (!cache->keys || !cache->values || !cache->index_keys || !cache->index_gates)
+        die("glm53: DSA cache allocation failed");
+    cache->capacity = capacity;
+}
+
+static void dsa_step_forward(const Config *c, const Layer *l, LayerCache *cache, int position, const float *x,
+                             float *out) {
+    int length = position + 1;
+    int qwidth = c->heads * c->key_dim;
+    int kvwidth = c->heads * (c->key_dim + c->value_dim);
+    int index_width = c->index_topk + c->index_pool - 1;
+    float *q_resid = alloc_floats((size_t)c->q_rank);
+    float *q_norm = alloc_floats((size_t)c->q_rank);
+    float *query = alloc_floats((size_t)qwidth);
+    float *latent = alloc_floats((size_t)c->kv_rank);
+    float *latent_norm = alloc_floats((size_t)c->kv_rank);
+    float *expanded = alloc_floats((size_t)kvwidth);
+    float *index_query = alloc_floats((size_t)c->index_heads * c->index_dim);
+    float *index_raw = alloc_floats((size_t)c->index_dim);
+    float *head_weight = alloc_floats((size_t)c->index_heads);
+
+    matmul(q_resid, x, l->qa, 1, c->hidden, c->q_rank);
+    rmsnorm(q_norm, q_resid, l->qan, 1, c->q_rank, c->eps);
+    matmul(query, q_norm, l->qb, 1, c->q_rank, qwidth);
+    matmul(latent, x, l->kva, 1, c->hidden, c->kv_rank);
+    rmsnorm(latent_norm, latent, l->kvan, 1, c->kv_rank, c->eps);
+    matmul(expanded, latent_norm, l->kvb, 1, c->kv_rank, kvwidth);
+    matmul(index_query, q_norm, l->iwq, 1, c->q_rank, c->index_heads * c->index_dim);
+    matmul(index_raw, x, l->iwk, 1, c->hidden, c->index_dim);
+    matmul(head_weight, x, l->iweight, 1, c->hidden, c->index_heads);
+    for (int h = 0; h < c->index_heads; h++) head_weight[h] /= sqrtf((float)c->index_heads);
+
+    dsa_cache_reserve(c, cache, length);
+    float *key_row = cache->keys + (size_t)position * c->heads * c->key_dim;
+    float *value_row = cache->values + (size_t)position * c->heads * c->value_dim;
+    for (int h = 0; h < c->heads; h++) {
+        const float *source = expanded + h * (c->key_dim + c->value_dim);
+        memcpy(key_row + h * c->key_dim, source, (size_t)c->key_dim * sizeof(float));
+        memcpy(value_row + h * c->value_dim, source + c->key_dim, (size_t)c->value_dim * sizeof(float));
+    }
+    layernorm(cache->index_keys + (size_t)position * c->index_dim, index_raw, l->iknw, l->iknb, 1, c->index_dim);
+    matmul(cache->index_gates + (size_t)position * c->index_dim, x, l->igate, 1, c->hidden, c->index_dim);
+
+    float *queries = alloc_floats((size_t)length * qwidth);
+    float *index_queries = alloc_floats((size_t)length * c->index_heads * c->index_dim);
+    float *head_weights = alloc_floats((size_t)length * c->index_heads);
+    unsigned char *valid = malloc((size_t)length);
+    int *indices = malloc((size_t)length * index_width * sizeof(int));
+    float *context = alloc_floats((size_t)length * c->heads * c->value_dim);
+    if (!valid || !indices) die("glm53: DSA scratch allocation failed");
+    memcpy(queries + (size_t)position * qwidth, query, (size_t)qwidth * sizeof(float));
+    memcpy(index_queries + (size_t)position * c->index_heads * c->index_dim, index_query,
+           (size_t)c->index_heads * c->index_dim * sizeof(float));
+    memcpy(head_weights + (size_t)position * c->index_heads, head_weight, (size_t)c->index_heads * sizeof(float));
+    memset(valid, 1, (size_t)length);
+    coli_glm53_index_select(indices, index_queries, cache->index_keys, cache->index_gates, head_weights, l->iape, valid,
+                            length, c->index_heads, c->index_dim, c->index_pool, c->index_topk);
+    coli_glm53_sparse_attention(context, queries, cache->keys, cache->values, indices, length, index_width, c->heads,
+                                c->key_dim, c->value_dim);
+    matmul(out, context + (size_t)position * c->heads * c->value_dim, l->op, 1, c->heads * c->value_dim, c->hidden);
+    free(context);
+    free(indices);
+    free(valid);
+    free(head_weights);
+    free(index_queries);
+    free(queries);
+    free(head_weight);
+    free(index_raw);
+    free(index_query);
+    free(expanded);
+    free(latent_norm);
+    free(latent);
+    free(query);
+    free(q_norm);
+    free(q_resid);
+}
+
+static float *forward_cached_step(Model *model, RuntimeCache *cache, int token) {
+    Config *c = &model->c;
+    float *streams = alloc_floats((size_t)c->hc * c->hidden);
+    float *next = alloc_floats((size_t)c->hc * c->hidden);
+    float *collapsed = alloc_floats((size_t)c->hidden);
+    float *normed = alloc_floats((size_t)c->hidden);
+    float *branch = alloc_floats((size_t)c->hidden);
+    float *post = alloc_floats((size_t)c->hc);
+    float *comb = alloc_floats((size_t)c->hc * c->hc);
+    for (int h = 0; h < c->hc; h++)
+        memcpy(streams + (size_t)h * c->hidden, model->embed + (size_t)token * c->hidden,
+               (size_t)c->hidden * sizeof(float));
+    for (int i = 0; i < c->layers; i++) {
+        Layer *layer = &model->layer[i];
+        coli_glm53_mhc_pre(collapsed, post, comb, streams, layer->ah_fn, layer->ah_scale, layer->ah_base, c->hc,
+                           c->hidden, c->hc_iters, c->eps, c->hc_eps);
+        rmsnorm(normed, collapsed, layer->norm1, 1, c->hidden, c->eps);
+        if (layer->kda) kda_step_forward(c, layer, &cache->layers[i], normed, branch);
+        else dsa_step_forward(c, layer, &cache->layers[i], cache->length, normed, branch);
+        coli_glm53_mhc_post(next, branch, streams, post, comb, c->hc, c->hidden);
+        float *swap = streams;
+        streams = next;
+        next = swap;
+        coli_glm53_mhc_pre(collapsed, post, comb, streams, layer->fh_fn, layer->fh_scale, layer->fh_base, c->hc,
+                           c->hidden, c->hc_iters, c->eps, c->hc_eps);
+        rmsnorm(normed, collapsed, layer->norm2, 1, c->hidden, c->eps);
+        memset(branch, 0, (size_t)c->hidden * sizeof(float));
+        ffn_forward(c, layer, normed, 1, branch);
+        coli_glm53_mhc_post(next, branch, streams, post, comb, c->hc, c->hidden);
+        swap = streams;
+        streams = next;
+        next = swap;
+    }
+    for (int d = 0; d < c->hidden; d++) {
+        float sum = 0.0f;
+        for (int h = 0; h < c->hc; h++) sum += streams[(size_t)h * c->hidden + d];
+        collapsed[d] = sum / c->hc;
+    }
+    rmsnorm(normed, collapsed, model->norm, 1, c->hidden, c->eps);
+    float *logits = alloc_floats((size_t)c->vocab);
+    matmul(logits, normed, model->head, 1, c->hidden, c->vocab);
+    cache->length++;
+    free(comb);
+    free(post);
+    free(branch);
+    free(normed);
+    free(collapsed);
+    free(next);
+    free(streams);
+    return logits;
+}
+
 static float *forward(Model *m, const int *tokens, int n) {
     Config *c = &m->c;
     size_t streams_count = (size_t)n * c->hc * c->hidden;
@@ -589,14 +807,51 @@ static int parse_ids(const char *text, int **output) {
 }
 int main(int argc, char **argv) {
     if (argc < 4 || strcmp(argv[2], "--ids")) {
-        fprintf(stderr, "usage: %s MODEL --ids 1,2,3 [--greedy N]\n", argv[0]);
+        fprintf(stderr, "usage: %s MODEL --ids 1,2,3 [--greedy N] [--cached]\n", argv[0]);
         return 2;
     }
     Model model;
     model_load(&model, argv[1]);
     int *ids = NULL, n = parse_ids(argv[3], &ids);
-    int greedy = 0;
-    if (argc == 6 && !strcmp(argv[4], "--greedy")) greedy = atoi(argv[5]);
+    int greedy = 0, cached = 0;
+    for (int arg = 4; arg < argc; arg++) {
+        if (!strcmp(argv[arg], "--cached")) cached = 1;
+        else if (!strcmp(argv[arg], "--greedy") && arg + 1 < argc) greedy = atoi(argv[++arg]);
+        else {
+            fprintf(stderr, "glm53: unknown argument %s\n", argv[arg]);
+            return 2;
+        }
+    }
+    if (cached) {
+        RuntimeCache cache;
+        cache_init(&cache, &model.c);
+        float *logits = NULL;
+        printf("teacher");
+        for (int i = 0; i < n; i++) {
+            free(logits);
+            logits = forward_cached_step(&model, &cache, ids[i]);
+            int best = 0;
+            for (int v = 1; v < model.c.vocab; v++)
+                if (logits[v] > logits[best]) best = v;
+            printf(" %d", best);
+        }
+        printf("\nlast_logits");
+        for (int v = 0; v < model.c.vocab; v++) printf(" %.9g", logits[v]);
+        printf("\n");
+        for (int step = 0; step < greedy; step++) {
+            int best = 0;
+            for (int v = 1; v < model.c.vocab; v++)
+                if (logits[v] > logits[best]) best = v;
+            printf("greedy %d\n", best);
+            free(logits);
+            logits = forward_cached_step(&model, &cache, best);
+        }
+        free(logits);
+        cache_free(&cache, &model.c);
+        free(ids);
+        model_free(&model);
+        return 0;
+    }
     for (int step = 0; step <= greedy; step++) {
         float *logits = forward(&model, ids, n);
         if (!step) {

--- a/c/glm53_flash.c
+++ b/c/glm53_flash.c
@@ -1,4 +1,5 @@
 #define _GNU_SOURCE
+#include <limits.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -12,6 +13,9 @@
 #include "glm53_fp8.h"
 #include "tensor.h"
 #include "tok.h"
+#ifdef COLI_CUDA
+#include "backend_cuda.h"
+#endif
 
 typedef struct {
     ColiTensorView view;
@@ -20,7 +24,45 @@ typedef struct {
     shards *source;
     char *name;
     int streamed;
+#ifdef COLI_CUDA
+    ColiCudaTensor *cuda;
+#endif
 } Matrix;
+
+#ifdef COLI_CUDA
+static int g_cuda_enabled, g_cuda_device;
+
+static int glm53_cuda_init(void) {
+    const char *enabled = getenv("COLI_CUDA");
+    if (!enabled || !atoi(enabled)) return 1;
+    if (getenv("COLI_GPU") && getenv("COLI_GPUS")) {
+        fprintf(stderr, "glm53: use COLI_GPU or COLI_GPUS, not both\n");
+        return 0;
+    }
+    const char *selected = getenv("COLI_GPU");
+    if (!selected) selected = getenv("COLI_GPUS");
+    char *end = NULL;
+    long parsed = selected ? strtol(selected, &end, 10) : 0;
+    if (parsed < 0 || parsed > INT_MAX || (selected && (!end || *end))) {
+        fprintf(stderr, "glm53: COLI_GPU/COLI_GPUS must select exactly one CUDA device\n");
+        return 0;
+    }
+    int device = (int)parsed;
+    float lut[256];
+    coli_glm53_fp8_decode_table(lut);
+    if (!coli_cuda_init(&device, 1)) return 0;
+    if (!coli_cuda_fp8_set_lut(lut)) {
+        coli_cuda_shutdown();
+        return 0;
+    }
+    g_cuda_enabled = 1;
+    g_cuda_device = device;
+    fprintf(stderr, "[CUDA] GLM-5.3 native FP8 matmul active on device %d\n", device);
+    return 1;
+}
+#else
+static int glm53_cuda_init(void) { return 1; }
+#endif
 
 typedef struct {
     int hidden, layers, vocab, max_position, dense_inter, moe_inter, experts, topk, shared;
@@ -243,12 +285,15 @@ static Matrix load_named_streamed_matrix(Model *model, int layer, const char *su
     return load_matrix_mode(model, name, 1);
 }
 static void matrix_free(Matrix *matrix) {
+#ifdef COLI_CUDA
+    coli_cuda_tensor_free(matrix->cuda);
+#endif
     free(matrix->data);
     free(matrix->scales);
     free(matrix->name);
     memset(matrix, 0, sizeof(*matrix));
 }
-static void matrix_multiply(float *output, const float *input, const Matrix *weight, int rows) {
+static void matrix_multiply(float *output, const float *input, Matrix *weight, int rows) {
     if (weight->streamed) {
         Matrix loaded = *weight;
         loaded.streamed = 0;
@@ -269,14 +314,29 @@ static void matrix_multiply(float *output, const float *input, const Matrix *wei
                             (int64_t)(weight->view.scale_bytes / sizeof(float)), 1);
         }
         matrix_multiply(output, input, &loaded, rows);
-        free(loaded.scales);
-        free(loaded.data);
+        matrix_free(&loaded);
         return;
     }
     if (weight->view.format == COLI_TENSOR_F32) {
         matmul(output, input, weight->data, rows, (int)weight->view.columns, (int)weight->view.rows);
         return;
     }
+#ifdef COLI_CUDA
+    if (g_cuda_enabled) {
+        size_t count = (size_t)rows * weight->view.columns;
+        float *activation = alloc_floats(count);
+        int valid = 1;
+        for (int row = 0; row < rows; row++)
+            valid &= !coli_glm53_fp8_quantize_activation(activation + (size_t)row * weight->view.columns,
+                                                         input + (size_t)row * weight->view.columns,
+                                                         (int)weight->view.columns);
+        int done =
+            valid && coli_cuda_matmul(&weight->cuda, output, activation, weight->view.data, weight->view.scales, 8,
+                                      rows, (int)weight->view.columns, (int)weight->view.rows, g_cuda_device, 0);
+        free(activation);
+        if (done) return;
+    }
+#endif
     for (int row = 0; row < rows; row++)
         if (coli_glm53_fp8_matvec(output + (size_t)row * weight->view.rows, weight->view.data, weight->view.scales,
                                   input + (size_t)row * weight->view.columns, (int)weight->view.rows,
@@ -551,7 +611,7 @@ static void kda_forward(const Config *c, const Layer *l, const float *x, int n, 
     free(qkv);
 }
 
-static void dsa_forward(const Config *c, const Layer *l, const float *x, int n, float *out) {
+static void dsa_forward(const Config *c, Layer *l, const float *x, int n, float *out) {
     int qwidth = c->heads * c->key_dim, kvwidth = c->heads * (c->key_dim + c->value_dim),
         iwidth = c->index_topk + c->index_pool - 1;
     float *qr = alloc_floats((size_t)n * c->q_rank), *qn = alloc_floats((size_t)n * c->q_rank),
@@ -613,8 +673,7 @@ static void dsa_forward(const Config *c, const Layer *l, const float *x, int n, 
     free(qr);
 }
 
-static void mlp3(float *out, const float *x, const Matrix *wg, const Matrix *wu, const Matrix *wd, int n, int inter,
-                 float limit) {
+static void mlp3(float *out, const float *x, Matrix *wg, Matrix *wu, Matrix *wd, int n, int inter, float limit) {
     float *g = alloc_floats((size_t)n * inter), *u = alloc_floats((size_t)n * inter),
           *a = alloc_floats((size_t)n * inter);
     matrix_multiply(g, x, wg, n);
@@ -625,7 +684,7 @@ static void mlp3(float *out, const float *x, const Matrix *wg, const Matrix *wu,
     free(u);
     free(g);
 }
-static void ffn_forward(const Config *c, const Layer *l, const float *x, int n, float *out) {
+static void ffn_forward(const Config *c, Layer *l, const float *x, int n, float *out) {
     if (!l->sparse) {
         mlp3(out, x, &l->fg, &l->fu, &l->fd, n, c->dense_inter, c->swiglu_limit);
         return;
@@ -751,8 +810,7 @@ static void dsa_cache_reserve(const Config *c, LayerCache *cache, int needed) {
     cache->capacity = capacity;
 }
 
-static void dsa_step_forward(const Config *c, const Layer *l, LayerCache *cache, int position, const float *x,
-                             float *out) {
+static void dsa_step_forward(const Config *c, Layer *l, LayerCache *cache, int position, const float *x, float *out) {
     int length = position + 1;
     int qwidth = c->heads * c->key_dim;
     int kvwidth = c->heads * (c->key_dim + c->value_dim);
@@ -1154,10 +1212,14 @@ static int run_text_prompt(Model *model, const char *directory, const char *prom
 int main(int argc, char **argv) {
     const char *serve_directory = getenv("SNAP");
     if (getenv("SERVE") && serve_directory && *serve_directory) {
+        if (!glm53_cuda_init()) die("glm53: requested CUDA backend is unavailable");
         Model model;
         model_load(&model, serve_directory);
         serve_model(&model, serve_directory);
         model_free(&model);
+#ifdef COLI_CUDA
+        if (g_cuda_enabled) coli_cuda_shutdown();
+#endif
         return 0;
     }
     if (argc >= 4 && !strcmp(argv[2], "--prompt")) {
@@ -1172,16 +1234,21 @@ int main(int argc, char **argv) {
                 return 2;
             }
         }
+        if (!glm53_cuda_init()) die("glm53: requested CUDA backend is unavailable");
         Model model;
         model_load(&model, argv[1]);
         int result = run_text_prompt(&model, argv[1], argv[3], max_tokens, temperature, top_p);
         model_free(&model);
+#ifdef COLI_CUDA
+        if (g_cuda_enabled) coli_cuda_shutdown();
+#endif
         return result;
     }
     if (argc < 4 || strcmp(argv[2], "--ids")) {
         fprintf(stderr, "usage: %s MODEL --ids 1,2,3 [--greedy N] [--cached]\n", argv[0]);
         return 2;
     }
+    if (!glm53_cuda_init()) die("glm53: requested CUDA backend is unavailable");
     Model model;
     model_load(&model, argv[1]);
     int *ids = NULL, n = parse_ids(argv[3], &ids);
@@ -1252,5 +1319,8 @@ int main(int argc, char **argv) {
     }
     free(ids);
     model_free(&model);
+#ifdef COLI_CUDA
+    if (g_cuda_enabled) coli_cuda_shutdown();
+#endif
     return 0;
 }

--- a/c/glm53_flash.c
+++ b/c/glm53_flash.c
@@ -9,6 +9,17 @@
 #include "glm53_kda.h"
 #include "glm53_mhc.h"
 #include "glm53_sparse_attention.h"
+#include "glm53_fp8.h"
+#include "tensor.h"
+
+typedef struct {
+    ColiTensorView view;
+    void *data;
+    float *scales;
+    shards *source;
+    char *name;
+    int streamed;
+} Matrix;
 
 typedef struct {
     int hidden, layers, vocab, dense_inter, moe_inter, experts, topk, shared;
@@ -25,11 +36,13 @@ typedef struct {
     float *ah_fn, *ah_base, *ah_scale, *fh_fn, *fh_base, *fh_scale;
     int kda, sparse;
     float *q, *k, *v, *conv, *fa, *fb, *dt, *alog, *beta, *ga, *gb, *onorm, *op;
-    float *qa, *qan, *qb, *kva, *kvan, *kvb;
+    Matrix dqa, dqb, dkva, dop;
+    float *qan, *kvan, *kvb;
     float *iwq, *iwk, *iknw, *iknb, *igate, *iweight, *iape;
-    float *fg, *fu, *fd;
-    float *router, *router_bias, *sg, *su, *sd;
-    float **eg, **eu, **ed;
+    Matrix fg, fu, fd;
+    float *router, *router_bias;
+    Matrix sg, su, sd;
+    Matrix *eg, *eu, *ed;
 } Layer;
 
 typedef struct {
@@ -49,6 +62,8 @@ typedef struct {
     LayerCache *layers;
     int length;
 } RuntimeCache;
+
+static void matmul(float *out, const float *input, const float *weight, int rows, int in, int columns);
 
 static void die(const char *message) {
     fprintf(stderr, "%s\n", message);
@@ -167,6 +182,105 @@ static float *load_named(Model *m, int layer, const char *suffix) {
     snprintf(name, sizeof(name), "model.language_model.layers.%d.%s", layer, suffix);
     return load_tensor(m, name);
 }
+static Matrix load_matrix_mode(Model *model, const char *name, int streamed) {
+    st_tensor *tensor = st_find(&model->tensors, name);
+    if (!tensor || tensor->rank != 2 || tensor->shape[0] < 1 || tensor->shape[1] < 1)
+        die("glm53: invalid matrix tensor");
+    Matrix matrix = {0};
+    matrix.view.rows = tensor->shape[0];
+    matrix.view.columns = tensor->shape[1];
+    matrix.source = &model->tensors;
+    matrix.streamed = streamed;
+    matrix.name = strdup(name);
+    if (!matrix.name) die("glm53: matrix name allocation failed");
+    if (tensor->dtype <= 2) {
+        matrix.view.format = COLI_TENSOR_F32;
+        matrix.view.data_bytes = (size_t)tensor->numel * sizeof(float);
+        if (!streamed) {
+            matrix.data = alloc_floats((size_t)tensor->numel);
+            st_read_f32_cap(&model->tensors, name, matrix.data, tensor->numel, 0);
+            matrix.view.data = matrix.data;
+        }
+        return matrix;
+    }
+    if (tensor->dtype != 4 || tensor->nbytes != tensor->numel) die("glm53: matrix must be float or F8_E4M3");
+    char scale_name[640];
+    snprintf(scale_name, sizeof(scale_name), "%s_scale_inv", name);
+    st_tensor *scale = st_find(&model->tensors, scale_name);
+    int64_t scale_rows = (tensor->shape[0] + 127) / 128;
+    int64_t scale_columns = (tensor->shape[1] + 127) / 128;
+    if (!scale || scale->dtype > 2 || scale->rank != 2 || scale->shape[0] != scale_rows ||
+        scale->shape[1] != scale_columns)
+        die("glm53: invalid FP8 weight_scale_inv tensor");
+    matrix.view.format = COLI_TENSOR_FP8_E4M3_BLOCK;
+    matrix.view.scale_format = COLI_SCALE_F32;
+    matrix.view.data_bytes = (size_t)tensor->nbytes;
+    matrix.view.scale_bytes = (size_t)scale->numel * sizeof(float);
+    matrix.view.block_rows = 128;
+    matrix.view.block_columns = 128;
+    if (!streamed) {
+        matrix.data = malloc((size_t)tensor->nbytes);
+        matrix.scales = alloc_floats((size_t)scale->numel);
+        if (!matrix.data) die("glm53: FP8 matrix allocation failed");
+        st_read_raw_cap(&model->tensors, name, matrix.data, tensor->nbytes, 0);
+        st_read_f32_cap(&model->tensors, scale_name, matrix.scales, scale->numel, 0);
+        matrix.view.data = matrix.data;
+        matrix.view.scales = matrix.scales;
+    }
+    return matrix;
+}
+static Matrix load_matrix(Model *model, const char *name) { return load_matrix_mode(model, name, 0); }
+static Matrix load_named_matrix(Model *model, int layer, const char *suffix) {
+    char name[512];
+    snprintf(name, sizeof(name), "model.language_model.layers.%d.%s", layer, suffix);
+    return load_matrix(model, name);
+}
+static Matrix load_named_streamed_matrix(Model *model, int layer, const char *suffix) {
+    char name[512];
+    snprintf(name, sizeof(name), "model.language_model.layers.%d.%s", layer, suffix);
+    return load_matrix_mode(model, name, 1);
+}
+static void matrix_free(Matrix *matrix) {
+    free(matrix->data);
+    free(matrix->scales);
+    free(matrix->name);
+    memset(matrix, 0, sizeof(*matrix));
+}
+static void matrix_multiply(float *output, const float *input, const Matrix *weight, int rows) {
+    if (weight->streamed) {
+        Matrix loaded = *weight;
+        loaded.streamed = 0;
+        loaded.name = NULL;
+        loaded.data = malloc(weight->view.data_bytes);
+        if (!loaded.data) die("glm53: streamed matrix allocation failed");
+        loaded.view.data = loaded.data;
+        if (weight->view.format == COLI_TENSOR_F32) {
+            st_read_f32_cap(weight->source, weight->name, loaded.data,
+                            (int64_t)(weight->view.data_bytes / sizeof(float)), 1);
+        } else {
+            loaded.scales = alloc_floats(weight->view.scale_bytes / sizeof(float));
+            loaded.view.scales = loaded.scales;
+            st_read_raw_cap(weight->source, weight->name, loaded.data, (int64_t)weight->view.data_bytes, 1);
+            char scale_name[640];
+            snprintf(scale_name, sizeof(scale_name), "%s_scale_inv", weight->name);
+            st_read_f32_cap(weight->source, scale_name, loaded.scales,
+                            (int64_t)(weight->view.scale_bytes / sizeof(float)), 1);
+        }
+        matrix_multiply(output, input, &loaded, rows);
+        free(loaded.scales);
+        free(loaded.data);
+        return;
+    }
+    if (weight->view.format == COLI_TENSOR_F32) {
+        matmul(output, input, weight->data, rows, (int)weight->view.columns, (int)weight->view.rows);
+        return;
+    }
+    for (int row = 0; row < rows; row++)
+        if (coli_glm53_fp8_matvec(output + (size_t)row * weight->view.rows, weight->view.data, weight->view.scales,
+                                  input + (size_t)row * weight->view.columns, (int)weight->view.rows,
+                                  (int)weight->view.columns))
+            die("glm53: FP8 matrix multiply failed");
+}
 static float *load_conv(Model *model, int layer) {
     const char *parts[] = {"q_conv1d.weight", "k_conv1d.weight", "v_conv1d.weight"};
     int64_t counts[3], total = 0;
@@ -223,13 +337,13 @@ static void model_load(Model *m, const char *directory) {
             l->onorm = load_named(m, i, "self_attn.o_norm.weight");
             l->op = load_named(m, i, "self_attn.o_proj.weight");
         } else {
-            l->qa = load_named(m, i, "self_attn.q_a_proj.weight");
+            l->dqa = load_named_matrix(m, i, "self_attn.q_a_proj.weight");
             l->qan = load_named(m, i, "self_attn.q_a_layernorm.weight");
-            l->qb = load_named(m, i, "self_attn.q_b_proj.weight");
-            l->kva = load_named(m, i, "self_attn.kv_a_proj_with_mqa.weight");
+            l->dqb = load_named_matrix(m, i, "self_attn.q_b_proj.weight");
+            l->dkva = load_named_matrix(m, i, "self_attn.kv_a_proj_with_mqa.weight");
             l->kvan = load_named(m, i, "self_attn.kv_a_layernorm.weight");
             l->kvb = load_named(m, i, "self_attn.kv_b_proj.weight");
-            l->op = load_named(m, i, "self_attn.o_proj.weight");
+            l->dop = load_named_matrix(m, i, "self_attn.o_proj.weight");
             l->iwq = load_named(m, i, "self_attn.indexer.wq_b.weight");
             l->iwk = load_named(m, i, "self_attn.indexer.wk.weight");
             l->iknw = load_named(m, i, "self_attn.indexer.k_norm.weight");
@@ -239,26 +353,26 @@ static void model_load(Model *m, const char *directory) {
             l->iape = load_named(m, i, "self_attn.indexer.index_kpool_compress_ape");
         }
         if (!l->sparse) {
-            l->fg = load_named(m, i, "mlp.gate_proj.weight");
-            l->fu = load_named(m, i, "mlp.up_proj.weight");
-            l->fd = load_named(m, i, "mlp.down_proj.weight");
+            l->fg = load_named_matrix(m, i, "mlp.gate_proj.weight");
+            l->fu = load_named_matrix(m, i, "mlp.up_proj.weight");
+            l->fd = load_named_matrix(m, i, "mlp.down_proj.weight");
         } else {
             l->router = load_named(m, i, "mlp.gate.weight");
             l->router_bias = load_named(m, i, "mlp.gate.e_score_correction_bias");
-            l->sg = load_named(m, i, "mlp.shared_experts.gate_proj.weight");
-            l->su = load_named(m, i, "mlp.shared_experts.up_proj.weight");
-            l->sd = load_named(m, i, "mlp.shared_experts.down_proj.weight");
-            l->eg = calloc((size_t)c->experts, sizeof(float *));
-            l->eu = calloc((size_t)c->experts, sizeof(float *));
-            l->ed = calloc((size_t)c->experts, sizeof(float *));
+            l->sg = load_named_matrix(m, i, "mlp.shared_experts.gate_proj.weight");
+            l->su = load_named_matrix(m, i, "mlp.shared_experts.up_proj.weight");
+            l->sd = load_named_matrix(m, i, "mlp.shared_experts.down_proj.weight");
+            l->eg = calloc((size_t)c->experts, sizeof(Matrix));
+            l->eu = calloc((size_t)c->experts, sizeof(Matrix));
+            l->ed = calloc((size_t)c->experts, sizeof(Matrix));
             for (int e = 0; e < c->experts; e++) {
                 char name[128];
                 snprintf(name, sizeof(name), "mlp.experts.%d.gate_proj.weight", e);
-                l->eg[e] = load_named(m, i, name);
+                l->eg[e] = load_named_streamed_matrix(m, i, name);
                 snprintf(name, sizeof(name), "mlp.experts.%d.up_proj.weight", e);
-                l->eu[e] = load_named(m, i, name);
+                l->eu[e] = load_named_streamed_matrix(m, i, name);
                 snprintf(name, sizeof(name), "mlp.experts.%d.down_proj.weight", e);
-                l->ed[e] = load_named(m, i, name);
+                l->ed[e] = load_named_streamed_matrix(m, i, name);
             }
         }
     }
@@ -286,12 +400,13 @@ static void layer_free(Layer *layer, int experts) {
     free(layer->gb);
     free(layer->onorm);
     free(layer->op);
-    free(layer->qa);
+    matrix_free(&layer->dqa);
     free(layer->qan);
-    free(layer->qb);
-    free(layer->kva);
+    matrix_free(&layer->dqb);
+    matrix_free(&layer->dkva);
     free(layer->kvan);
     free(layer->kvb);
+    matrix_free(&layer->dop);
     free(layer->iwq);
     free(layer->iwk);
     free(layer->iknw);
@@ -299,18 +414,18 @@ static void layer_free(Layer *layer, int experts) {
     free(layer->igate);
     free(layer->iweight);
     free(layer->iape);
-    free(layer->fg);
-    free(layer->fu);
-    free(layer->fd);
+    matrix_free(&layer->fg);
+    matrix_free(&layer->fu);
+    matrix_free(&layer->fd);
     free(layer->router);
     free(layer->router_bias);
-    free(layer->sg);
-    free(layer->su);
-    free(layer->sd);
+    matrix_free(&layer->sg);
+    matrix_free(&layer->su);
+    matrix_free(&layer->sd);
     for (int expert = 0; expert < experts; expert++) {
-        free(layer->eg ? layer->eg[expert] : NULL);
-        free(layer->eu ? layer->eu[expert] : NULL);
-        free(layer->ed ? layer->ed[expert] : NULL);
+        if (layer->eg) matrix_free(&layer->eg[expert]);
+        if (layer->eu) matrix_free(&layer->eu[expert]);
+        if (layer->ed) matrix_free(&layer->ed[expert]);
     }
     free(layer->eg);
     free(layer->eu);
@@ -441,10 +556,10 @@ static void dsa_forward(const Config *c, const Layer *l, const float *x, int n, 
           *queries = alloc_floats((size_t)n * qwidth);
     float *latent = alloc_floats((size_t)n * c->kv_rank), *ln = alloc_floats((size_t)n * c->kv_rank),
           *expanded = alloc_floats((size_t)n * kvwidth);
-    matmul(qr, x, l->qa, n, c->hidden, c->q_rank);
+    matrix_multiply(qr, x, &l->dqa, n);
     rmsnorm(qn, qr, l->qan, n, c->q_rank, c->eps);
-    matmul(queries, qn, l->qb, n, c->q_rank, qwidth);
-    matmul(latent, x, l->kva, n, c->hidden, c->kv_rank);
+    matrix_multiply(queries, qn, &l->dqb, n);
+    matrix_multiply(latent, x, &l->dkva, n);
     rmsnorm(ln, latent, l->kvan, n, c->kv_rank, c->eps);
     matmul(expanded, ln, l->kvb, n, c->kv_rank, kvwidth);
     float *keys = alloc_floats((size_t)n * c->heads * c->key_dim),
@@ -477,7 +592,7 @@ static void dsa_forward(const Config *c, const Layer *l, const float *x, int n, 
     }
     float *context = alloc_floats((size_t)n * c->heads * c->value_dim);
     coli_glm53_sparse_attention(context, queries, keys, values, indices, n, iwidth, c->heads, c->key_dim, c->value_dim);
-    matmul(out, context, l->op, n, c->heads * c->value_dim, c->hidden);
+    matrix_multiply(out, context, &l->dop, n);
     free(context);
     free(indices);
     free(valid);
@@ -496,24 +611,24 @@ static void dsa_forward(const Config *c, const Layer *l, const float *x, int n, 
     free(qr);
 }
 
-static void mlp3(float *out, const float *x, const float *wg, const float *wu, const float *wd, int n, int hidden,
-                 int inter, float limit) {
+static void mlp3(float *out, const float *x, const Matrix *wg, const Matrix *wu, const Matrix *wd, int n, int inter,
+                 float limit) {
     float *g = alloc_floats((size_t)n * inter), *u = alloc_floats((size_t)n * inter),
           *a = alloc_floats((size_t)n * inter);
-    matmul(g, x, wg, n, hidden, inter);
-    matmul(u, x, wu, n, hidden, inter);
+    matrix_multiply(g, x, wg, n);
+    matrix_multiply(u, x, wu, n);
     for (int i = 0; i < n * inter; i++) a[i] = swiglu(g[i], u[i], limit);
-    matmul(out, a, wd, n, inter, hidden);
+    matrix_multiply(out, a, wd, n);
     free(a);
     free(u);
     free(g);
 }
 static void ffn_forward(const Config *c, const Layer *l, const float *x, int n, float *out) {
     if (!l->sparse) {
-        mlp3(out, x, l->fg, l->fu, l->fd, n, c->hidden, c->dense_inter, c->swiglu_limit);
+        mlp3(out, x, &l->fg, &l->fu, &l->fd, n, c->dense_inter, c->swiglu_limit);
         return;
     }
-    mlp3(out, x, l->sg, l->su, l->sd, n, c->hidden, c->moe_inter * c->shared, c->swiglu_limit);
+    mlp3(out, x, &l->sg, &l->su, &l->sd, n, c->moe_inter * c->shared, c->swiglu_limit);
     float *score = alloc_floats((size_t)c->experts), *temp = alloc_floats((size_t)c->hidden);
     for (int t = 0; t < n; t++) {
         const float *row = x + (size_t)t * c->hidden;
@@ -543,7 +658,7 @@ static void ffn_forward(const Config *c, const Layer *l, const float *x, int n, 
         }
         for (int k = 0; k < c->topk; k++) {
             weights[k] = weights[k] / (total + 1e-20f) * c->route_scale;
-            mlp3(temp, row, l->eg[ids[k]], l->eu[ids[k]], l->ed[ids[k]], 1, c->hidden, c->moe_inter, c->swiglu_limit);
+            mlp3(temp, row, &l->eg[ids[k]], &l->eu[ids[k]], &l->ed[ids[k]], 1, c->moe_inter, c->swiglu_limit);
             for (int d = 0; d < c->hidden; d++) out[(size_t)t * c->hidden + d] += weights[k] * temp[d];
         }
     }
@@ -650,10 +765,10 @@ static void dsa_step_forward(const Config *c, const Layer *l, LayerCache *cache,
     float *index_raw = alloc_floats((size_t)c->index_dim);
     float *head_weight = alloc_floats((size_t)c->index_heads);
 
-    matmul(q_resid, x, l->qa, 1, c->hidden, c->q_rank);
+    matrix_multiply(q_resid, x, &l->dqa, 1);
     rmsnorm(q_norm, q_resid, l->qan, 1, c->q_rank, c->eps);
-    matmul(query, q_norm, l->qb, 1, c->q_rank, qwidth);
-    matmul(latent, x, l->kva, 1, c->hidden, c->kv_rank);
+    matrix_multiply(query, q_norm, &l->dqb, 1);
+    matrix_multiply(latent, x, &l->dkva, 1);
     rmsnorm(latent_norm, latent, l->kvan, 1, c->kv_rank, c->eps);
     matmul(expanded, latent_norm, l->kvb, 1, c->kv_rank, kvwidth);
     matmul(index_query, q_norm, l->iwq, 1, c->q_rank, c->index_heads * c->index_dim);
@@ -688,7 +803,7 @@ static void dsa_step_forward(const Config *c, const Layer *l, LayerCache *cache,
                             length, c->index_heads, c->index_dim, c->index_pool, c->index_topk);
     coli_glm53_sparse_attention(context, queries, cache->keys, cache->values, indices, length, index_width, c->heads,
                                 c->key_dim, c->value_dim);
-    matmul(out, context + (size_t)position * c->heads * c->value_dim, l->op, 1, c->heads * c->value_dim, c->hidden);
+    matrix_multiply(out, context + (size_t)position * c->heads * c->value_dim, &l->dop, 1);
     free(context);
     free(indices);
     free(valid);

--- a/c/glm53_flash.c
+++ b/c/glm53_flash.c
@@ -16,6 +16,9 @@
 #ifdef COLI_CUDA
 #include "backend_cuda.h"
 #endif
+#ifdef COLI_METAL
+#include "backend_metal.h"
+#endif
 
 typedef struct {
     ColiTensorView view;
@@ -26,6 +29,9 @@ typedef struct {
     int streamed;
 #ifdef COLI_CUDA
     ColiCudaTensor *cuda;
+#endif
+#ifdef COLI_METAL
+    ColiMetalTensor *metal;
 #endif
 } Matrix;
 
@@ -61,8 +67,46 @@ static int glm53_cuda_init(void) {
     return 1;
 }
 #else
-static int glm53_cuda_init(void) { return 1; }
+static int glm53_cuda_init(void) {
+    const char *enabled = getenv("COLI_CUDA");
+    return !enabled || !atoi(enabled);
+}
 #endif
+
+#ifdef COLI_METAL
+static int g_metal_enabled;
+
+static int glm53_metal_init(void) {
+    const char *enabled = getenv("COLI_METAL");
+    if (!enabled || !atoi(enabled)) return 1;
+    if (!coli_metal_init()) return 0;
+    g_metal_enabled = 1;
+    fprintf(stderr, "[Metal] GLM-5.3 native FP8 matmul active\n");
+    return 1;
+}
+#else
+static int glm53_metal_init(void) {
+    const char *enabled = getenv("COLI_METAL");
+    return !enabled || !atoi(enabled);
+}
+#endif
+
+static int glm53_accelerator_init(void) {
+    if (getenv("COLI_CUDA") && atoi(getenv("COLI_CUDA")) && getenv("COLI_METAL") && atoi(getenv("COLI_METAL"))) {
+        fprintf(stderr, "glm53: choose COLI_CUDA or COLI_METAL, not both\n");
+        return 0;
+    }
+    return glm53_cuda_init() && glm53_metal_init();
+}
+
+static void glm53_accelerator_shutdown(void) {
+#ifdef COLI_CUDA
+    if (g_cuda_enabled) coli_cuda_shutdown();
+#endif
+#ifdef COLI_METAL
+    if (g_metal_enabled) coli_metal_shutdown();
+#endif
+}
 
 typedef struct {
     int hidden, layers, vocab, max_position, dense_inter, moe_inter, experts, topk, shared;
@@ -288,6 +332,9 @@ static void matrix_free(Matrix *matrix) {
 #ifdef COLI_CUDA
     coli_cuda_tensor_free(matrix->cuda);
 #endif
+#ifdef COLI_METAL
+    coli_metal_tensor_free(matrix->metal);
+#endif
     free(matrix->data);
     free(matrix->scales);
     free(matrix->name);
@@ -333,6 +380,22 @@ static void matrix_multiply(float *output, const float *input, Matrix *weight, i
         int done =
             valid && coli_cuda_matmul(&weight->cuda, output, activation, weight->view.data, weight->view.scales, 8,
                                       rows, (int)weight->view.columns, (int)weight->view.rows, g_cuda_device, 0);
+        free(activation);
+        if (done) return;
+    }
+#endif
+#ifdef COLI_METAL
+    if (g_metal_enabled) {
+        size_t count = (size_t)rows * weight->view.columns;
+        float *activation = alloc_floats(count);
+        int valid = 1;
+        for (int row = 0; row < rows; row++)
+            valid &= !coli_glm53_fp8_quantize_activation(activation + (size_t)row * weight->view.columns,
+                                                         input + (size_t)row * weight->view.columns,
+                                                         (int)weight->view.columns);
+        int done =
+            valid && coli_metal_matmul(&weight->metal, output, activation, weight->view.data, weight->view.scales, 8,
+                                       rows, (int)weight->view.columns, (int)weight->view.rows, 0);
         free(activation);
         if (done) return;
     }
@@ -1212,14 +1275,12 @@ static int run_text_prompt(Model *model, const char *directory, const char *prom
 int main(int argc, char **argv) {
     const char *serve_directory = getenv("SNAP");
     if (getenv("SERVE") && serve_directory && *serve_directory) {
-        if (!glm53_cuda_init()) die("glm53: requested CUDA backend is unavailable");
+        if (!glm53_accelerator_init()) die("glm53: requested accelerator backend is unavailable");
         Model model;
         model_load(&model, serve_directory);
         serve_model(&model, serve_directory);
         model_free(&model);
-#ifdef COLI_CUDA
-        if (g_cuda_enabled) coli_cuda_shutdown();
-#endif
+        glm53_accelerator_shutdown();
         return 0;
     }
     if (argc >= 4 && !strcmp(argv[2], "--prompt")) {
@@ -1234,21 +1295,19 @@ int main(int argc, char **argv) {
                 return 2;
             }
         }
-        if (!glm53_cuda_init()) die("glm53: requested CUDA backend is unavailable");
+        if (!glm53_accelerator_init()) die("glm53: requested accelerator backend is unavailable");
         Model model;
         model_load(&model, argv[1]);
         int result = run_text_prompt(&model, argv[1], argv[3], max_tokens, temperature, top_p);
         model_free(&model);
-#ifdef COLI_CUDA
-        if (g_cuda_enabled) coli_cuda_shutdown();
-#endif
+        glm53_accelerator_shutdown();
         return result;
     }
     if (argc < 4 || strcmp(argv[2], "--ids")) {
         fprintf(stderr, "usage: %s MODEL --ids 1,2,3 [--greedy N] [--cached]\n", argv[0]);
         return 2;
     }
-    if (!glm53_cuda_init()) die("glm53: requested CUDA backend is unavailable");
+    if (!glm53_accelerator_init()) die("glm53: requested accelerator backend is unavailable");
     Model model;
     model_load(&model, argv[1]);
     int *ids = NULL, n = parse_ids(argv[3], &ids);
@@ -1319,8 +1378,6 @@ int main(int argc, char **argv) {
     }
     free(ids);
     model_free(&model);
-#ifdef COLI_CUDA
-    if (g_cuda_enabled) coli_cuda_shutdown();
-#endif
+    glm53_accelerator_shutdown();
     return 0;
 }

--- a/c/glm53_flash.c
+++ b/c/glm53_flash.c
@@ -1,0 +1,629 @@
+#define _GNU_SOURCE
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "st.h"
+#include "glm53_indexer.h"
+#include "glm53_kda.h"
+#include "glm53_mhc.h"
+#include "glm53_sparse_attention.h"
+
+typedef struct {
+    int hidden, layers, vocab, dense_inter, moe_inter, experts, topk, shared;
+    int heads, q_rank, kv_rank, key_dim, value_dim;
+    int kda_heads, kda_dim, conv_kernel;
+    int index_heads, index_dim, index_topk, index_pool;
+    int hc, hc_iters, dense_layers;
+    float eps, hc_eps, route_scale, swiglu_limit, gate_lower_bound;
+} Config;
+
+typedef struct {
+    float *norm1, *norm2;
+    float *ah_fn, *ah_base, *ah_scale, *fh_fn, *fh_base, *fh_scale;
+    int kda, sparse;
+    float *q, *k, *v, *conv, *fa, *fb, *dt, *alog, *beta, *ga, *gb, *onorm, *op;
+    float *qa, *qan, *qb, *kva, *kvan, *kvb;
+    float *iwq, *iwk, *iknw, *iknb, *igate, *iweight, *iape;
+    float *fg, *fu, *fd;
+    float *router, *router_bias, *sg, *su, *sd;
+    float **eg, **eu, **ed;
+} Layer;
+
+typedef struct {
+    Config c;
+    shards tensors;
+    float *embed, *norm, *head;
+    Layer *layer;
+} Model;
+
+static void die(const char *message) {
+    fprintf(stderr, "%s\n", message);
+    exit(1);
+}
+static float *alloc_floats(size_t count) {
+    float *result = calloc(count, sizeof(*result));
+    if (!result) die("glm53: out of memory");
+    return result;
+}
+static double required_number(jval *object, const char *key) {
+    jval *value = json_get(object, key);
+    if (!value || value->t != J_NUM) {
+        fprintf(stderr, "glm53 config: missing numeric %s\n", key);
+        exit(1);
+    }
+    return value->num;
+}
+static jval *required_object(jval *object, const char *key) {
+    jval *value = json_get(object, key);
+    if (!value || value->t != J_OBJ) {
+        fprintf(stderr, "glm53 config: missing object %s\n", key);
+        exit(1);
+    }
+    return value;
+}
+static char *read_file(const char *path) {
+    FILE *file = fopen(path, "rb");
+    if (!file) {
+        perror(path);
+        exit(1);
+    }
+    if (fseek(file, 0, SEEK_END)) die("glm53: config seek failed");
+    long size = ftell(file);
+    if (size < 0 || size > (64L << 20)) die("glm53: invalid config size");
+    rewind(file);
+    char *data = malloc((size_t)size + 1);
+    if (!data || fread(data, 1, (size_t)size, file) != (size_t)size) die("glm53: config read failed");
+    data[size] = 0;
+    fclose(file);
+    return data;
+}
+static void load_config(Config *c, const char *directory) {
+    char path[2048];
+    snprintf(path, sizeof(path), "%s/config.json", directory);
+    char *data = read_file(path), *arena = NULL;
+    jval *root = json_parse(data, &arena);
+    jval *text = required_object(root, "text_config");
+    jval *linear = required_object(text, "linear_attn_config");
+    c->hidden = (int)required_number(text, "hidden_size");
+    c->layers = (int)required_number(text, "num_hidden_layers");
+    c->vocab = (int)required_number(text, "vocab_size");
+    c->dense_inter = (int)required_number(text, "intermediate_size");
+    c->moe_inter = (int)required_number(text, "moe_intermediate_size");
+    c->experts = (int)required_number(text, "n_routed_experts");
+    c->topk = (int)required_number(text, "num_experts_per_tok");
+    c->shared = (int)required_number(text, "n_shared_experts");
+    c->heads = (int)required_number(text, "num_attention_heads");
+    c->q_rank = (int)required_number(text, "q_lora_rank");
+    c->kv_rank = (int)required_number(text, "kv_lora_rank");
+    c->key_dim = (int)required_number(text, "qk_nope_head_dim");
+    c->value_dim = (int)required_number(text, "v_head_dim");
+    c->index_heads = (int)required_number(text, "index_n_heads");
+    c->index_dim = (int)required_number(text, "index_head_dim");
+    c->index_topk = (int)required_number(text, "index_topk");
+    c->index_pool = (int)required_number(text, "index_kpool");
+    c->hc = (int)required_number(text, "hc_mult");
+    c->hc_iters = (int)required_number(text, "hc_sinkhorn_iters");
+    c->kda_heads = (int)required_number(linear, "num_heads");
+    c->kda_dim = (int)required_number(linear, "head_dim");
+    c->conv_kernel = (int)required_number(linear, "short_conv_kernel_size");
+    c->eps = (float)required_number(text, "rms_norm_eps");
+    c->hc_eps = (float)required_number(text, "hc_eps");
+    c->route_scale = (float)required_number(text, "routed_scaling_factor");
+    c->swiglu_limit = (float)required_number(text, "swiglu_limit");
+    c->gate_lower_bound = -5.0f;
+    jval *dense = json_get(text, "mlp_layer_types");
+    c->dense_layers = 0;
+    if (!dense || dense->t != J_ARR || dense->len != c->layers) die("glm53 config: invalid mlp_layer_types");
+    while (c->dense_layers < c->layers && !strcmp(dense->kids[c->dense_layers]->str, "dense")) c->dense_layers++;
+    if (c->hidden < 1 || c->layers < 1 || c->layers > 128 || c->heads < 1 || c->experts < 1 || c->topk < 1 ||
+        c->topk > c->experts || c->kda_heads * c->kda_dim <= 0 || c->hc < 1 || c->hc > 16)
+        die("glm53 config: dimension out of range");
+    json_free(root);
+    free(arena);
+    free(data);
+}
+
+static float *load_tensor(Model *model, const char *name) {
+    int64_t count = st_numel(&model->tensors, name);
+    if (count < 0) {
+        fprintf(stderr, "glm53: missing tensor %s\n", name);
+        exit(1);
+    }
+    float *data = alloc_floats((size_t)count);
+    st_read_f32_cap(&model->tensors, name, data, count, 0);
+    return data;
+}
+static float *load_named(Model *m, int layer, const char *suffix) {
+    char name[512];
+    snprintf(name, sizeof(name), "model.language_model.layers.%d.%s", layer, suffix);
+    return load_tensor(m, name);
+}
+static void model_load(Model *m, const char *directory) {
+    memset(m, 0, sizeof(*m));
+    load_config(&m->c, directory);
+    st_init(&m->tensors, directory);
+    Config *c = &m->c;
+    m->embed = load_tensor(m, "model.language_model.embed_tokens.weight");
+    m->norm = load_tensor(m, "model.language_model.norm.weight");
+    m->head = load_tensor(m, "lm_head.weight");
+    m->layer = calloc((size_t)c->layers, sizeof(*m->layer));
+    if (!m->layer) die("glm53: layer allocation failed");
+    for (int i = 0; i < c->layers; i++) {
+        Layer *l = &m->layer[i];
+        l->kda = (i % 4) != 3;
+        l->sparse = i >= c->dense_layers;
+        l->norm1 = load_named(m, i, "input_layernorm.weight");
+        l->norm2 = load_named(m, i, "post_attention_layernorm.weight");
+        l->ah_fn = load_named(m, i, "attn_hc.fn");
+        l->ah_base = load_named(m, i, "attn_hc.base");
+        l->ah_scale = load_named(m, i, "attn_hc.scale");
+        l->fh_fn = load_named(m, i, "ffn_hc.fn");
+        l->fh_base = load_named(m, i, "ffn_hc.base");
+        l->fh_scale = load_named(m, i, "ffn_hc.scale");
+        if (l->kda) {
+            l->q = load_named(m, i, "self_attn.q_proj.weight");
+            l->k = load_named(m, i, "self_attn.k_proj.weight");
+            l->v = load_named(m, i, "self_attn.v_proj.weight");
+            l->conv = load_named(m, i, "self_attn.conv1d.weight");
+            l->fa = load_named(m, i, "self_attn.forget_gate.f_a_proj.weight");
+            l->fb = load_named(m, i, "self_attn.forget_gate.f_b_proj.weight");
+            l->dt = load_named(m, i, "self_attn.forget_gate.dt_bias");
+            l->alog = load_named(m, i, "self_attn.forget_gate.A_log");
+            l->beta = load_named(m, i, "self_attn.b_proj.weight");
+            l->ga = load_named(m, i, "self_attn.g_a_proj.weight");
+            l->gb = load_named(m, i, "self_attn.g_b_proj.weight");
+            l->onorm = load_named(m, i, "self_attn.o_norm.weight");
+            l->op = load_named(m, i, "self_attn.o_proj.weight");
+        } else {
+            l->qa = load_named(m, i, "self_attn.q_a_proj.weight");
+            l->qan = load_named(m, i, "self_attn.q_a_layernorm.weight");
+            l->qb = load_named(m, i, "self_attn.q_b_proj.weight");
+            l->kva = load_named(m, i, "self_attn.kv_a_proj_with_mqa.weight");
+            l->kvan = load_named(m, i, "self_attn.kv_a_layernorm.weight");
+            l->kvb = load_named(m, i, "self_attn.kv_b_proj.weight");
+            l->op = load_named(m, i, "self_attn.o_proj.weight");
+            l->iwq = load_named(m, i, "self_attn.indexer.wq_b.weight");
+            l->iwk = load_named(m, i, "self_attn.indexer.wk.weight");
+            l->iknw = load_named(m, i, "self_attn.indexer.k_norm.weight");
+            l->iknb = load_named(m, i, "self_attn.indexer.k_norm.bias");
+            l->igate = load_named(m, i, "self_attn.indexer.index_kpool_compress_gate");
+            l->iweight = load_named(m, i, "self_attn.indexer.weights_proj.weight");
+            l->iape = load_named(m, i, "self_attn.indexer.index_kpool_compress_ape");
+        }
+        if (!l->sparse) {
+            l->fg = load_named(m, i, "mlp.gate_proj.weight");
+            l->fu = load_named(m, i, "mlp.up_proj.weight");
+            l->fd = load_named(m, i, "mlp.down_proj.weight");
+        } else {
+            l->router = load_named(m, i, "mlp.gate.weight");
+            l->router_bias = load_named(m, i, "mlp.gate.e_score_correction_bias");
+            l->sg = load_named(m, i, "mlp.shared_experts.gate_proj.weight");
+            l->su = load_named(m, i, "mlp.shared_experts.up_proj.weight");
+            l->sd = load_named(m, i, "mlp.shared_experts.down_proj.weight");
+            l->eg = calloc((size_t)c->experts, sizeof(float *));
+            l->eu = calloc((size_t)c->experts, sizeof(float *));
+            l->ed = calloc((size_t)c->experts, sizeof(float *));
+            for (int e = 0; e < c->experts; e++) {
+                char name[128];
+                snprintf(name, sizeof(name), "mlp.experts.%d.gate_proj.weight", e);
+                l->eg[e] = load_named(m, i, name);
+                snprintf(name, sizeof(name), "mlp.experts.%d.up_proj.weight", e);
+                l->eu[e] = load_named(m, i, name);
+                snprintf(name, sizeof(name), "mlp.experts.%d.down_proj.weight", e);
+                l->ed[e] = load_named(m, i, name);
+            }
+        }
+    }
+}
+
+static void layer_free(Layer *layer, int experts) {
+    free(layer->norm1);
+    free(layer->norm2);
+    free(layer->ah_fn);
+    free(layer->ah_base);
+    free(layer->ah_scale);
+    free(layer->fh_fn);
+    free(layer->fh_base);
+    free(layer->fh_scale);
+    free(layer->q);
+    free(layer->k);
+    free(layer->v);
+    free(layer->conv);
+    free(layer->fa);
+    free(layer->fb);
+    free(layer->dt);
+    free(layer->alog);
+    free(layer->beta);
+    free(layer->ga);
+    free(layer->gb);
+    free(layer->onorm);
+    free(layer->op);
+    free(layer->qa);
+    free(layer->qan);
+    free(layer->qb);
+    free(layer->kva);
+    free(layer->kvan);
+    free(layer->kvb);
+    free(layer->iwq);
+    free(layer->iwk);
+    free(layer->iknw);
+    free(layer->iknb);
+    free(layer->igate);
+    free(layer->iweight);
+    free(layer->iape);
+    free(layer->fg);
+    free(layer->fu);
+    free(layer->fd);
+    free(layer->router);
+    free(layer->router_bias);
+    free(layer->sg);
+    free(layer->su);
+    free(layer->sd);
+    for (int expert = 0; expert < experts; expert++) {
+        free(layer->eg ? layer->eg[expert] : NULL);
+        free(layer->eu ? layer->eu[expert] : NULL);
+        free(layer->ed ? layer->ed[expert] : NULL);
+    }
+    free(layer->eg);
+    free(layer->eu);
+    free(layer->ed);
+}
+
+static void model_free(Model *model) {
+    for (int layer = 0; layer < model->c.layers; layer++) layer_free(&model->layer[layer], model->c.experts);
+    free(model->layer);
+    free(model->embed);
+    free(model->norm);
+    free(model->head);
+    st_destroy(&model->tensors);
+}
+
+static void matmul(float *out, const float *input, const float *weight, int rows, int in, int columns) {
+    for (int r = 0; r < rows; r++)
+        for (int o = 0; o < columns; o++) {
+            float sum = 0.0f;
+            const float *w = weight + (size_t)o * in, *x = input + (size_t)r * in;
+            for (int i = 0; i < in; i++) sum += x[i] * w[i];
+            out[(size_t)r * columns + o] = sum;
+        }
+}
+static void rmsnorm(float *out, const float *input, const float *weight, int rows, int dim, float eps) {
+    for (int r = 0; r < rows; r++) {
+        float sum = 0.0f;
+        const float *x = input + (size_t)r * dim;
+        for (int i = 0; i < dim; i++) sum += x[i] * x[i];
+        float scale = 1.0f / sqrtf(sum / dim + eps);
+        for (int i = 0; i < dim; i++) out[(size_t)r * dim + i] = x[i] * scale * weight[i];
+    }
+}
+static void layernorm(float *out, const float *input, const float *w, const float *b, int rows, int dim) {
+    for (int r = 0; r < rows; r++) {
+        const float *x = input + (size_t)r * dim;
+        float mean = 0, var = 0;
+        for (int i = 0; i < dim; i++) mean += x[i];
+        mean /= dim;
+        for (int i = 0; i < dim; i++) {
+            float d = x[i] - mean;
+            var += d * d;
+        }
+        var /= dim;
+        float inv = 1.0f / sqrtf(var + 1e-6f);
+        for (int i = 0; i < dim; i++) out[(size_t)r * dim + i] = (x[i] - mean) * inv * w[i] + b[i];
+    }
+}
+static float sigmoid(float x) { return x >= 0 ? 1.0f / (1.0f + expf(-x)) : expf(x) / (1.0f + expf(x)); }
+static float swiglu(float gate, float up, float limit) {
+    if (gate > limit) gate = limit;
+    if (up > limit) up = limit;
+    if (up < -limit) up = -limit;
+    return gate * sigmoid(gate) * up;
+}
+static void trace_state(const char *name, const float *data, size_t count) {
+    if (!getenv("GLM53_TRACE")) return;
+    double sum = 0, square = 0;
+    for (size_t i = 0; i < count; i++) {
+        sum += data[i];
+        square += (double)data[i] * data[i];
+    }
+    fprintf(stderr, "[GLM53-TRACE] %s sum=%.12g square=%.12g\n", name, sum, square);
+}
+
+static void kda_forward(const Config *c, const Layer *l, const float *x, int n, float *out) {
+    int p = c->kda_heads * c->kda_dim;
+    float *qkv = alloc_floats((size_t)n * 3 * p), *tmp = alloc_floats((size_t)n * c->kda_dim);
+    float *decay = alloc_floats((size_t)n * p), *betas = alloc_floats((size_t)n * c->kda_heads),
+          *gate = alloc_floats((size_t)n * p);
+    matmul(qkv, x, l->q, n, c->hidden, p);
+    matmul(qkv + (size_t)n * p, x, l->k, n, c->hidden, p);
+    matmul(qkv + (size_t)n * 2 * p, x, l->v, n, c->hidden, p);
+    /* Rearrange projection-major batches into token-major q/k/v. */
+    float *packed = alloc_floats((size_t)n * 3 * p);
+    for (int t = 0; t < n; t++)
+        for (int z = 0; z < 3; z++)
+            memcpy(packed + (size_t)t * 3 * p + z * p, qkv + (size_t)z * n * p + (size_t)t * p,
+                   (size_t)p * sizeof(float));
+    matmul(tmp, x, l->fa, n, c->hidden, c->kda_dim);
+    matmul(decay, tmp, l->fb, n, c->kda_dim, p);
+    for (int t = 0; t < n; t++)
+        for (int h = 0; h < c->kda_heads; h++)
+            for (int d = 0; d < c->kda_dim; d++) {
+                int i = h * c->kda_dim + d;
+                decay[(size_t)t * p + i] =
+                    c->gate_lower_bound * sigmoid(expf(l->alog[h]) * (decay[(size_t)t * p + i] + l->dt[i]));
+            }
+    matmul(betas, x, l->beta, n, c->hidden, c->kda_heads);
+    for (int i = 0; i < n * c->kda_heads; i++) betas[i] = sigmoid(betas[i]);
+    matmul(tmp, x, l->ga, n, c->hidden, c->kda_dim);
+    matmul(gate, tmp, l->gb, n, c->kda_dim, p);
+    float *state = alloc_floats((size_t)c->kda_heads * c->kda_dim * c->kda_dim),
+          *window = alloc_floats((size_t)3 * p * c->conv_kernel), *core = alloc_floats((size_t)n * p),
+          *normed = alloc_floats((size_t)n * p);
+    for (int t = 0; t < n; t++)
+        coli_glm53_kda_step(core + (size_t)t * p, state, window, packed + (size_t)t * 3 * p, l->conv,
+                            decay + (size_t)t * p, betas + (size_t)t * c->kda_heads, c->kda_heads, c->kda_dim,
+                            c->conv_kernel);
+    for (int t = 0; t < n; t++)
+        for (int h = 0; h < c->kda_heads; h++) {
+            float sum = 0;
+            float *src = core + (size_t)t * p + h * c->kda_dim, *dst = normed + (size_t)t * p + h * c->kda_dim;
+            for (int d = 0; d < c->kda_dim; d++) sum += src[d] * src[d];
+            float inv = 1.0f / sqrtf(sum / c->kda_dim + c->eps);
+            for (int d = 0; d < c->kda_dim; d++)
+                dst[d] = src[d] * inv * l->onorm[d] * sigmoid(gate[(size_t)t * p + h * c->kda_dim + d]);
+        }
+    matmul(out, normed, l->op, n, p, c->hidden);
+    free(normed);
+    free(core);
+    free(window);
+    free(state);
+    free(gate);
+    free(betas);
+    free(decay);
+    free(tmp);
+    free(packed);
+    free(qkv);
+}
+
+static void dsa_forward(const Config *c, const Layer *l, const float *x, int n, float *out) {
+    int qwidth = c->heads * c->key_dim, kvwidth = c->heads * (c->key_dim + c->value_dim),
+        iwidth = c->index_topk + c->index_pool - 1;
+    float *qr = alloc_floats((size_t)n * c->q_rank), *qn = alloc_floats((size_t)n * c->q_rank),
+          *queries = alloc_floats((size_t)n * qwidth);
+    float *latent = alloc_floats((size_t)n * c->kv_rank), *ln = alloc_floats((size_t)n * c->kv_rank),
+          *expanded = alloc_floats((size_t)n * kvwidth);
+    matmul(qr, x, l->qa, n, c->hidden, c->q_rank);
+    rmsnorm(qn, qr, l->qan, n, c->q_rank, c->eps);
+    matmul(queries, qn, l->qb, n, c->q_rank, qwidth);
+    matmul(latent, x, l->kva, n, c->hidden, c->kv_rank);
+    rmsnorm(ln, latent, l->kvan, n, c->kv_rank, c->eps);
+    matmul(expanded, ln, l->kvb, n, c->kv_rank, kvwidth);
+    float *keys = alloc_floats((size_t)n * c->heads * c->key_dim),
+          *values = alloc_floats((size_t)n * c->heads * c->value_dim);
+    for (int t = 0; t < n; t++)
+        for (int h = 0; h < c->heads; h++) {
+            const float *src = expanded + (size_t)t * kvwidth + h * (c->key_dim + c->value_dim);
+            memcpy(keys + ((size_t)t * c->heads + h) * c->key_dim, src, (size_t)c->key_dim * sizeof(float));
+            memcpy(values + ((size_t)t * c->heads + h) * c->value_dim, src + c->key_dim,
+                   (size_t)c->value_dim * sizeof(float));
+        }
+    float *iq = alloc_floats((size_t)n * c->index_heads * c->index_dim),
+          *ikraw = alloc_floats((size_t)n * c->index_dim), *ik = alloc_floats((size_t)n * c->index_dim),
+          *gates = alloc_floats((size_t)n * c->index_dim), *weights = alloc_floats((size_t)n * c->index_heads);
+    matmul(iq, qn, l->iwq, n, c->q_rank, c->index_heads * c->index_dim);
+    matmul(ikraw, x, l->iwk, n, c->hidden, c->index_dim);
+    layernorm(ik, ikraw, l->iknw, l->iknb, n, c->index_dim);
+    matmul(gates, x, l->igate, n, c->hidden, c->index_dim);
+    matmul(weights, x, l->iweight, n, c->hidden, c->index_heads);
+    for (int i = 0; i < n * c->index_heads; i++) weights[i] /= sqrtf((float)c->index_heads);
+    unsigned char *valid = malloc((size_t)n);
+    memset(valid, 1, (size_t)n);
+    int *indices = malloc((size_t)n * iwidth * sizeof(int));
+    coli_glm53_index_select(indices, iq, ik, gates, weights, l->iape, valid, n, c->index_heads, c->index_dim,
+                            c->index_pool, c->index_topk);
+    if (getenv("GLM53_TRACE")) {
+        fprintf(stderr, "[GLM53-TRACE] indices");
+        for (int i = 0; i < n * iwidth; i++) fprintf(stderr, " %d", indices[i]);
+        fprintf(stderr, "\n");
+    }
+    float *context = alloc_floats((size_t)n * c->heads * c->value_dim);
+    coli_glm53_sparse_attention(context, queries, keys, values, indices, n, iwidth, c->heads, c->key_dim, c->value_dim);
+    matmul(out, context, l->op, n, c->heads * c->value_dim, c->hidden);
+    free(context);
+    free(indices);
+    free(valid);
+    free(weights);
+    free(gates);
+    free(ik);
+    free(ikraw);
+    free(iq);
+    free(values);
+    free(keys);
+    free(expanded);
+    free(ln);
+    free(latent);
+    free(queries);
+    free(qn);
+    free(qr);
+}
+
+static void mlp3(float *out, const float *x, const float *wg, const float *wu, const float *wd, int n, int hidden,
+                 int inter, float limit) {
+    float *g = alloc_floats((size_t)n * inter), *u = alloc_floats((size_t)n * inter),
+          *a = alloc_floats((size_t)n * inter);
+    matmul(g, x, wg, n, hidden, inter);
+    matmul(u, x, wu, n, hidden, inter);
+    for (int i = 0; i < n * inter; i++) a[i] = swiglu(g[i], u[i], limit);
+    matmul(out, a, wd, n, inter, hidden);
+    free(a);
+    free(u);
+    free(g);
+}
+static void ffn_forward(const Config *c, const Layer *l, const float *x, int n, float *out) {
+    if (!l->sparse) {
+        mlp3(out, x, l->fg, l->fu, l->fd, n, c->hidden, c->dense_inter, c->swiglu_limit);
+        return;
+    }
+    mlp3(out, x, l->sg, l->su, l->sd, n, c->hidden, c->moe_inter * c->shared, c->swiglu_limit);
+    float *score = alloc_floats((size_t)c->experts), *temp = alloc_floats((size_t)c->hidden);
+    for (int t = 0; t < n; t++) {
+        const float *row = x + (size_t)t * c->hidden;
+        for (int e = 0; e < c->experts; e++) {
+            float s = 0;
+            for (int d = 0; d < c->hidden; d++) s += row[d] * l->router[(size_t)e * c->hidden + d];
+            score[e] = sigmoid(s);
+        }
+        int ids[64];
+        float weights[64], total = 0;
+        for (int k = 0; k < c->topk; k++) {
+            int best = -1;
+            float bv = -INFINITY;
+            for (int e = 0; e < c->experts; e++) {
+                int used = 0;
+                for (int j = 0; j < k; j++)
+                    if (ids[j] == e) used = 1;
+                float choice = score[e] + l->router_bias[e];
+                if (!used && choice > bv) {
+                    bv = choice;
+                    best = e;
+                }
+            }
+            ids[k] = best;
+            weights[k] = score[best];
+            total += weights[k];
+        }
+        for (int k = 0; k < c->topk; k++) {
+            weights[k] = weights[k] / (total + 1e-20f) * c->route_scale;
+            mlp3(temp, row, l->eg[ids[k]], l->eu[ids[k]], l->ed[ids[k]], 1, c->hidden, c->moe_inter, c->swiglu_limit);
+            for (int d = 0; d < c->hidden; d++) out[(size_t)t * c->hidden + d] += weights[k] * temp[d];
+        }
+    }
+    free(temp);
+    free(score);
+}
+
+static float *forward(Model *m, const int *tokens, int n) {
+    Config *c = &m->c;
+    size_t streams_count = (size_t)n * c->hc * c->hidden;
+    float *streams = alloc_floats(streams_count);
+    for (int t = 0; t < n; t++)
+        for (int h = 0; h < c->hc; h++)
+            memcpy(streams + ((size_t)t * c->hc + h) * c->hidden, m->embed + (size_t)tokens[t] * c->hidden,
+                   (size_t)c->hidden * sizeof(float));
+    trace_state("embed", streams, streams_count);
+    float *collapsed = alloc_floats((size_t)n * c->hidden), *normed = alloc_floats((size_t)n * c->hidden),
+          *branch = alloc_floats((size_t)n * c->hidden), *next = alloc_floats(streams_count),
+          *post = alloc_floats((size_t)n * c->hc), *comb = alloc_floats((size_t)n * c->hc * c->hc);
+    for (int li = 0; li < c->layers; li++) {
+        Layer *l = &m->layer[li];
+        for (int t = 0; t < n; t++)
+            coli_glm53_mhc_pre(collapsed + (size_t)t * c->hidden, post + (size_t)t * c->hc,
+                               comb + (size_t)t * c->hc * c->hc, streams + (size_t)t * c->hc * c->hidden, l->ah_fn,
+                               l->ah_scale, l->ah_base, c->hc, c->hidden, c->hc_iters, c->eps, c->hc_eps);
+        rmsnorm(normed, collapsed, l->norm1, n, c->hidden, c->eps);
+        if (l->kda) kda_forward(c, l, normed, n, branch);
+        else dsa_forward(c, l, normed, n, branch);
+        if (!l->kda) trace_state("layer.3.attn_branch", branch, (size_t)n * c->hidden);
+        for (int t = 0; t < n; t++)
+            coli_glm53_mhc_post(next + (size_t)t * c->hc * c->hidden, branch + (size_t)t * c->hidden,
+                                streams + (size_t)t * c->hc * c->hidden, post + (size_t)t * c->hc,
+                                comb + (size_t)t * c->hc * c->hc, c->hc, c->hidden);
+        float *swap = streams;
+        streams = next;
+        next = swap;
+        if (!l->kda) trace_state("layer.3.attn_streams", streams, streams_count);
+        for (int t = 0; t < n; t++)
+            coli_glm53_mhc_pre(collapsed + (size_t)t * c->hidden, post + (size_t)t * c->hc,
+                               comb + (size_t)t * c->hc * c->hc, streams + (size_t)t * c->hc * c->hidden, l->fh_fn,
+                               l->fh_scale, l->fh_base, c->hc, c->hidden, c->hc_iters, c->eps, c->hc_eps);
+        rmsnorm(normed, collapsed, l->norm2, n, c->hidden, c->eps);
+        if (!l->kda) trace_state("layer.3.ffn_norm", normed, (size_t)n * c->hidden);
+        ffn_forward(c, l, normed, n, branch);
+        if (!l->kda) trace_state("layer.3.ffn_branch", branch, (size_t)n * c->hidden);
+        for (int t = 0; t < n; t++)
+            coli_glm53_mhc_post(next + (size_t)t * c->hc * c->hidden, branch + (size_t)t * c->hidden,
+                                streams + (size_t)t * c->hc * c->hidden, post + (size_t)t * c->hc,
+                                comb + (size_t)t * c->hc * c->hc, c->hc, c->hidden);
+        swap = streams;
+        streams = next;
+        next = swap;
+        char label[32];
+        snprintf(label, sizeof(label), "layer.%d", li);
+        trace_state(label, streams, streams_count);
+    }
+    for (int t = 0; t < n; t++)
+        for (int d = 0; d < c->hidden; d++) {
+            float sum = 0;
+            for (int h = 0; h < c->hc; h++) sum += streams[((size_t)t * c->hc + h) * c->hidden + d];
+            collapsed[(size_t)t * c->hidden + d] = sum / c->hc;
+        }
+    rmsnorm(normed, collapsed, m->norm, n, c->hidden, c->eps);
+    trace_state("final", normed, (size_t)n * c->hidden);
+    float *logits = alloc_floats((size_t)n * c->vocab);
+    matmul(logits, normed, m->head, n, c->hidden, c->vocab);
+    free(comb);
+    free(post);
+    free(next);
+    free(branch);
+    free(normed);
+    free(collapsed);
+    free(streams);
+    return logits;
+}
+
+static int parse_ids(const char *text, int **output) {
+    char *copy = strdup(text);
+    int cap = 16, n = 0;
+    int *ids = malloc((size_t)cap * sizeof(int));
+    for (char *p = strtok(copy, ","); p; p = strtok(NULL, ",")) {
+        if (n == cap) {
+            cap *= 2;
+            ids = realloc(ids, (size_t)cap * sizeof(int));
+        }
+        ids[n++] = atoi(p);
+    }
+    free(copy);
+    *output = ids;
+    return n;
+}
+int main(int argc, char **argv) {
+    if (argc < 4 || strcmp(argv[2], "--ids")) {
+        fprintf(stderr, "usage: %s MODEL --ids 1,2,3 [--greedy N]\n", argv[0]);
+        return 2;
+    }
+    Model model;
+    model_load(&model, argv[1]);
+    int *ids = NULL, n = parse_ids(argv[3], &ids);
+    int greedy = 0;
+    if (argc == 6 && !strcmp(argv[4], "--greedy")) greedy = atoi(argv[5]);
+    for (int step = 0; step <= greedy; step++) {
+        float *logits = forward(&model, ids, n);
+        if (!step) {
+            printf("teacher");
+            for (int t = 0; t < n; t++) {
+                int best = 0;
+                for (int v = 1; v < model.c.vocab; v++)
+                    if (logits[(size_t)t * model.c.vocab + v] > logits[(size_t)t * model.c.vocab + best]) best = v;
+                printf(" %d", best);
+            }
+            printf("\nlast_logits");
+            float *last = logits + (size_t)(n - 1) * model.c.vocab;
+            for (int v = 0; v < model.c.vocab; v++) printf(" %.9g", last[v]);
+            printf("\n");
+        }
+        if (step < greedy) {
+            int best = 0;
+            float *last = logits + (size_t)(n - 1) * model.c.vocab;
+            for (int v = 1; v < model.c.vocab; v++)
+                if (last[v] > last[best]) best = v;
+            ids = realloc(ids, (size_t)(n + 1) * sizeof(int));
+            ids[n++] = best;
+            printf("greedy %d\n", best);
+        }
+        free(logits);
+    }
+    free(ids);
+    model_free(&model);
+    return 0;
+}

--- a/c/glm53_fp8.c
+++ b/c/glm53_fp8.c
@@ -33,19 +33,31 @@ static uint8_t e4m3fn_encode(float value) {
     return (uint8_t)(best | (negative ? 0x80 : 0));
 }
 
-int coli_glm53_fp8_matvec(float *output, const uint8_t *weight, const float *weight_scale_inv, const float *input,
-                          int rows, int columns) {
-    if (!output || !weight || !weight_scale_inv || !input || rows < 1 || columns < 1 || columns % 128) return -1;
+void coli_glm53_fp8_decode_table(float output[256]) {
+    for (int code = 0; code < 256; code++) output[code] = e4m3fn_decode((uint8_t)code);
+}
+
+int coli_glm53_fp8_quantize_activation(float *output, const float *input, int columns) {
+    if (!output || !input || columns < 1 || columns % 128) return -1;
     int scale_columns = columns / 128;
-    float *activation = malloc((size_t)columns * sizeof(*activation));
-    if (!activation) return -1;
     for (int block = 0; block < scale_columns; block++) {
         int base = block * 128;
         float maximum = 0.0f;
         for (int i = 0; i < 128; i++) maximum = fmaxf(maximum, fabsf(input[base + i]));
         float scale = maximum > 0.0f ? maximum / 448.0f : 1.0f;
-        for (int i = 0; i < 128; i++)
-            activation[base + i] = e4m3fn_decode(e4m3fn_encode(input[base + i] / scale)) * scale;
+        for (int i = 0; i < 128; i++) output[base + i] = e4m3fn_decode(e4m3fn_encode(input[base + i] / scale)) * scale;
+    }
+    return 0;
+}
+
+int coli_glm53_fp8_matvec(float *output, const uint8_t *weight, const float *weight_scale_inv, const float *input,
+                          int rows, int columns) {
+    if (!output || !weight || !weight_scale_inv || !input || rows < 1 || columns < 1 || columns % 128) return -1;
+    int scale_columns = columns / 128;
+    float *activation = malloc((size_t)columns * sizeof(*activation));
+    if (!activation || coli_glm53_fp8_quantize_activation(activation, input, columns)) {
+        free(activation);
+        return -1;
     }
     for (int row = 0; row < rows; row++) {
         float sum = 0.0f;

--- a/c/glm53_fp8.c
+++ b/c/glm53_fp8.c
@@ -1,0 +1,61 @@
+#include "glm53_fp8.h"
+
+#include <float.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+static float e4m3fn_decode(uint8_t value) {
+    int sign = value >> 7;
+    int exponent = (value >> 3) & 15;
+    int mantissa = value & 7;
+    if (exponent == 15 && mantissa == 7) return NAN;
+    float number = exponent ? ldexpf(1.0f + (float)mantissa / 8.0f, exponent - 7) : ldexpf((float)mantissa, -9);
+    return sign ? -number : number;
+}
+
+static uint8_t e4m3fn_encode(float value) {
+    if (isnan(value)) return 0x7f;
+    int negative = signbit(value) != 0;
+    float magnitude = fabsf(value);
+    if (!magnitude) return negative ? 0x80 : 0;
+    if (magnitude >= 448.0f) return (uint8_t)((negative ? 0x80 : 0) | 0x7e);
+    uint8_t best = 0;
+    float distance = FLT_MAX;
+    for (uint8_t code = 0; code <= 0x7e; code++) {
+        float candidate = e4m3fn_decode(code);
+        float next = fabsf(candidate - magnitude);
+        if (next < distance || (next == distance && !(code & 1) && (best & 1))) {
+            best = code;
+            distance = next;
+        }
+    }
+    return (uint8_t)(best | (negative ? 0x80 : 0));
+}
+
+int coli_glm53_fp8_matvec(float *output, const uint8_t *weight, const float *weight_scale_inv, const float *input,
+                          int rows, int columns) {
+    if (!output || !weight || !weight_scale_inv || !input || rows < 1 || columns < 1 || columns % 128) return -1;
+    int scale_columns = columns / 128;
+    float *activation = malloc((size_t)columns * sizeof(*activation));
+    if (!activation) return -1;
+    for (int block = 0; block < scale_columns; block++) {
+        int base = block * 128;
+        float maximum = 0.0f;
+        for (int i = 0; i < 128; i++) maximum = fmaxf(maximum, fabsf(input[base + i]));
+        float scale = maximum > 0.0f ? maximum / 448.0f : 1.0f;
+        for (int i = 0; i < 128; i++)
+            activation[base + i] = e4m3fn_decode(e4m3fn_encode(input[base + i] / scale)) * scale;
+    }
+    for (int row = 0; row < rows; row++) {
+        float sum = 0.0f;
+        for (int column = 0; column < columns; column++) {
+            int scale_index = (row / 128) * scale_columns + column / 128;
+            float value = e4m3fn_decode(weight[(size_t)row * columns + column]);
+            sum += activation[column] * value * weight_scale_inv[scale_index];
+        }
+        output[row] = sum;
+    }
+    free(activation);
+    return 0;
+}

--- a/c/glm53_fp8.c
+++ b/c/glm53_fp8.c
@@ -1,6 +1,5 @@
 #include "glm53_fp8.h"
 
-#include <float.h>
 #include <math.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -20,16 +19,18 @@ static uint8_t e4m3fn_encode(float value) {
     float magnitude = fabsf(value);
     if (!magnitude) return negative ? 0x80 : 0;
     if (magnitude >= 448.0f) return (uint8_t)((negative ? 0x80 : 0) | 0x7e);
-    uint8_t best = 0;
-    float distance = FLT_MAX;
-    for (uint8_t code = 0; code <= 0x7e; code++) {
-        float candidate = e4m3fn_decode(code);
-        float next = fabsf(candidate - magnitude);
-        if (next < distance || (next == distance && !(code & 1) && (best & 1))) {
-            best = code;
-            distance = next;
-        }
+    int low = 0, high = 0x7e;
+    while (low < high) {
+        int middle = (low + high) / 2;
+        if (e4m3fn_decode((uint8_t)middle) < magnitude) low = middle + 1;
+        else high = middle;
     }
+    uint8_t upper = (uint8_t)low;
+    uint8_t lower = upper ? (uint8_t)(upper - 1) : upper;
+    float lower_distance = fabsf(e4m3fn_decode(lower) - magnitude);
+    float upper_distance = fabsf(e4m3fn_decode(upper) - magnitude);
+    uint8_t best = lower_distance < upper_distance ? lower : upper;
+    if (lower_distance == upper_distance) best = !(lower & 1) ? lower : upper;
     return (uint8_t)(best | (negative ? 0x80 : 0));
 }
 

--- a/c/glm53_fp8.h
+++ b/c/glm53_fp8.h
@@ -1,0 +1,12 @@
+#ifndef COLIBRI_GLM53_FP8_H
+#define COLIBRI_GLM53_FP8_H
+
+#include <stdint.h>
+
+/* GLM-5.3 fine-grained FP8 matvec. Weights use row-major E4M3FN with one
+ * float32 dequant scale per 128x128 tile. Activations are dynamically
+ * quantized to E4M3FN independently for every 128-column block. */
+int coli_glm53_fp8_matvec(float *output, const uint8_t *weight, const float *weight_scale_inv, const float *input,
+                          int rows, int columns);
+
+#endif

--- a/c/glm53_fp8.h
+++ b/c/glm53_fp8.h
@@ -8,5 +8,7 @@
  * quantized to E4M3FN independently for every 128-column block. */
 int coli_glm53_fp8_matvec(float *output, const uint8_t *weight, const float *weight_scale_inv, const float *input,
                           int rows, int columns);
+int coli_glm53_fp8_quantize_activation(float *output, const float *input, int columns);
+void coli_glm53_fp8_decode_table(float output[256]);
 
 #endif

--- a/c/glm53_indexer.c
+++ b/c/glm53_indexer.c
@@ -1,0 +1,97 @@
+#include "glm53_indexer.h"
+
+#include <float.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+int coli_glm53_index_select(int *output, const float *queries,
+                            const float *keys, const float *gate_scores,
+                            const float *head_weights, const float *ape,
+                            const unsigned char *valid, int sequence,
+                            int heads, int dimension, int pool, int topk) {
+    if (!output || !queries || !keys || !gate_scores || !head_weights ||
+        !ape || !valid || sequence < 1 || heads < 1 || dimension < 1 ||
+        pool < 1 || topk < pool || topk % pool) return -1;
+    int width = topk + pool - 1;
+    int pools = (sequence + pool - 1) / pool;
+    int selected_pools = topk / pool;
+    float *pooled = calloc((size_t)pools * dimension, sizeof(*pooled));
+    float *scores = malloc((size_t)pools * sizeof(*scores));
+    unsigned char *complete = calloc((size_t)pools, 1);
+    unsigned char *picked = calloc((size_t)pools, 1);
+    if (!pooled || !scores || !complete || !picked) {
+        free(pooled); free(scores); free(complete); free(picked);
+        return -1;
+    }
+    int first = 0;
+    while (first < sequence && !valid[first]) first++;
+    for (int p = 0; p < pools; p++) {
+        int start = first + p * pool;
+        complete[p] = start + pool <= sequence;
+        for (int j = 0; complete[p] && j < pool; j++)
+            if (!valid[start + j]) complete[p] = 0;
+        if (!complete[p]) continue;
+        for (int d = 0; d < dimension; d++) {
+            float maximum = -FLT_MAX;
+            for (int j = 0; j < pool; j++) {
+                float value = gate_scores[(size_t)(start + j) * dimension + d] +
+                              ape[(size_t)j * dimension + d];
+                if (value > maximum) maximum = value;
+            }
+            float total = 0.0f;
+            for (int j = 0; j < pool; j++)
+                total += expf(gate_scores[(size_t)(start + j) * dimension + d] +
+                              ape[(size_t)j * dimension + d] - maximum);
+            for (int j = 0; j < pool; j++) {
+                float probability = expf(
+                    gate_scores[(size_t)(start + j) * dimension + d] +
+                    ape[(size_t)j * dimension + d] - maximum) / total;
+                pooled[(size_t)p * dimension + d] +=
+                    probability * keys[(size_t)(start + j) * dimension + d];
+            }
+        }
+    }
+    float query_scale = 1.0f / sqrtf((float)dimension);
+    for (int q = 0; q < sequence; q++) {
+        int *row = output + (size_t)q * width;
+        for (int i = 0; i < width; i++) row[i] = -1;
+        if (!valid[q]) continue;
+        for (int p = 0; p < pools; p++) {
+            int end = first + (p + 1) * pool - 1;
+            if (!complete[p] || end > q) {
+                scores[p] = -FLT_MAX;
+                continue;
+            }
+            float score = 0.0f;
+            for (int h = 0; h < heads; h++) {
+                float dot = 0.0f;
+                const float *query = queries + ((size_t)q * heads + h) * dimension;
+                for (int d = 0; d < dimension; d++)
+                    dot += query[d] * pooled[(size_t)p * dimension + d];
+                if (dot > 0.0f)
+                    score += head_weights[(size_t)q * heads + h] * dot * query_scale;
+            }
+            scores[p] = score;
+        }
+        for (int rank = 0; rank < selected_pools; rank++) {
+            int best = -1;
+            for (int p = 0; p < pools; p++)
+                if (!picked[p] && scores[p] > -FLT_MAX &&
+                    (best < 0 || scores[p] > scores[best])) best = p;
+            if (best < 0) break;
+            picked[best] = 1;
+            for (int j = 0; j < pool; j++) row[rank * pool + j] = first + best * pool + j;
+        }
+        for (int p = 0; p < pools; p++) picked[p] = 0;
+        int visible = 0;
+        for (int i = first; i <= q; i++) if (valid[i]) visible++;
+        int tail = visible % pool;
+        int tail_start = first + visible - tail;
+        for (int j = 0; j < tail && j < pool - 1; j++)
+            if (tail_start + j <= q && valid[tail_start + j])
+                row[topk + j] = tail_start + j;
+    }
+    free(picked); free(complete); free(scores); free(pooled);
+    return 0;
+}

--- a/c/glm53_indexer.h
+++ b/c/glm53_indexer.h
@@ -1,0 +1,12 @@
+#ifndef COLIBRI_GLM53_INDEXER_H
+#define COLIBRI_GLM53_INDEXER_H
+
+/* Reference CPU implementation of the GLM-5.3 DSA k-pool indexer. The output
+ * has sequence * (topk + pool - 1) entries and uses -1 for invalid slots. */
+int coli_glm53_index_select(int *output, const float *queries,
+                            const float *keys, const float *gate_scores,
+                            const float *head_weights, const float *ape,
+                            const unsigned char *valid, int sequence,
+                            int heads, int dimension, int pool, int topk);
+
+#endif

--- a/c/glm53_kda.c
+++ b/c/glm53_kda.c
@@ -1,0 +1,75 @@
+#include "glm53_kda.h"
+
+#include <math.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+static float silu(float value) { return value / (1.0f + expf(-value)); }
+
+int coli_glm53_kda_step(float *output, float *state, float *conv_window,
+                        const float *qkv, const float *conv_weight,
+                        const float *log_decay, const float *beta,
+                        int heads, int dim, int kernel) {
+    if (!output || !state || !conv_window || !qkv || !conv_weight ||
+        !log_decay || !beta || heads < 1 || dim < 1 || kernel < 2)
+        return -1;
+    size_t projection = (size_t)heads * (size_t)dim;
+    float *mixed = malloc(3 * projection * sizeof(*mixed));
+    float *key_memory = malloc((size_t)dim * sizeof(*key_memory));
+    if (!mixed || !key_memory) {
+        free(mixed);
+        free(key_memory);
+        return -1;
+    }
+
+    for (size_t channel = 0; channel < 3 * projection; channel++) {
+        float *window = conv_window + channel * (size_t)kernel;
+        memmove(window, window + 1, (size_t)(kernel - 1) * sizeof(*window));
+        window[kernel - 1] = qkv[channel];
+        const float *weight = conv_weight + channel * (size_t)kernel;
+        float sum = 0.0f;
+        for (int tap = 0; tap < kernel; tap++) sum += weight[tap] * window[tap];
+        mixed[channel] = silu(sum);
+    }
+
+    const float scale = 1.0f / sqrtf((float)dim);
+    for (int head = 0; head < heads; head++) {
+        float *matrix = state + (size_t)head * dim * dim;
+        const float *query = mixed + (size_t)head * dim;
+        const float *key = mixed + projection + (size_t)head * dim;
+        const float *value = mixed + 2 * projection + (size_t)head * dim;
+        float *head_output = output + (size_t)head * dim;
+        float qnorm = 1.0e-6f, knorm = 1.0e-6f;
+        for (int i = 0; i < dim; i++) {
+            qnorm += query[i] * query[i];
+            knorm += key[i] * key[i];
+        }
+        qnorm = scale / sqrtf(qnorm);
+        knorm = 1.0f / sqrtf(knorm);
+        memset(key_memory, 0, (size_t)dim * sizeof(*key_memory));
+        for (int k = 0; k < dim; k++) {
+            float *row = matrix + (size_t)k * dim;
+            float decay = expf(log_decay[(size_t)head * dim + k]);
+            float normalized_key = key[k] * knorm;
+            for (int v = 0; v < dim; v++) {
+                row[v] *= decay;
+                key_memory[v] += normalized_key * row[v];
+            }
+        }
+        memset(head_output, 0, (size_t)dim * sizeof(*head_output));
+        for (int k = 0; k < dim; k++) {
+            float *row = matrix + (size_t)k * dim;
+            float normalized_key = key[k] * knorm;
+            float normalized_query = query[k] * qnorm;
+            for (int v = 0; v < dim; v++) {
+                float delta = (value[v] - key_memory[v]) * beta[head];
+                row[v] += normalized_key * delta;
+                head_output[v] += normalized_query * row[v];
+            }
+        }
+    }
+    free(key_memory);
+    free(mixed);
+    return 0;
+}

--- a/c/glm53_kda.h
+++ b/c/glm53_kda.h
@@ -1,0 +1,13 @@
+#ifndef COLIBRI_GLM53_KDA_H
+#define COLIBRI_GLM53_KDA_H
+
+/* One recurrent GLM-5.3 KDA step after the projection/forget-gate matmuls.
+ * qkv is [3, heads, dim], conv_weight/window are [3, heads, dim, kernel],
+ * log_decay is [heads, dim], beta is [heads], and state is
+ * [heads, dim, dim]. All buffers are fp32; state and window are updated. */
+int coli_glm53_kda_step(float *output, float *state, float *conv_window,
+                        const float *qkv, const float *conv_weight,
+                        const float *log_decay, const float *beta,
+                        int heads, int dim, int kernel);
+
+#endif

--- a/c/glm53_mhc.c
+++ b/c/glm53_mhc.c
@@ -1,0 +1,97 @@
+#include "glm53_mhc.h"
+
+#include <math.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+static float sigmoid_stable(float value) {
+    if (value >= 0.0f) return 1.0f / (1.0f + expf(-value));
+    float growth = expf(value);
+    return growth / (1.0f + growth);
+}
+
+int coli_glm53_mhc_pre(float *collapsed, float *post, float *comb,
+                       const float *streams, const float *function,
+                       const float scale[3], const float *base,
+                       int copies, int dimension, int iterations,
+                       float norm_eps, float hc_eps) {
+    if (!collapsed || !post || !comb || !streams || !function || !scale ||
+        !base || copies < 1 || dimension < 1 || iterations < 1) return -1;
+    int flattened = copies * dimension;
+    int count = (2 + copies) * copies;
+    float *mix = malloc((size_t)count * sizeof(*mix));
+    float *pre = malloc((size_t)copies * sizeof(*pre));
+    if (!mix || !pre) { free(mix); free(pre); return -1; }
+    float square = 0.0f;
+    for (int i = 0; i < flattened; i++) square += streams[i] * streams[i];
+    float inverse = 1.0f / sqrtf(square / flattened + norm_eps);
+    for (int row = 0; row < count; row++) {
+        float sum = 0.0f;
+        for (int column = 0; column < flattened; column++)
+            sum += function[(size_t)row * flattened + column] * streams[column];
+        mix[row] = sum * inverse;
+    }
+    for (int i = 0; i < copies; i++) {
+        pre[i] = sigmoid_stable(mix[i] * scale[0] + base[i]) + hc_eps;
+        post[i] = 2.0f * sigmoid_stable(
+            mix[copies + i] * scale[1] + base[copies + i]);
+    }
+    int matrix = 2 * copies;
+    for (int row = 0; row < copies; row++) {
+        float maximum = -INFINITY, total = 0.0f;
+        for (int column = 0; column < copies; column++) {
+            int index = matrix + row * copies + column;
+            comb[row * copies + column] = mix[index] * scale[2] + base[index];
+            if (comb[row * copies + column] > maximum)
+                maximum = comb[row * copies + column];
+        }
+        for (int column = 0; column < copies; column++) {
+            float value = expf(comb[row * copies + column] - maximum);
+            comb[row * copies + column] = value;
+            total += value;
+        }
+        for (int column = 0; column < copies; column++)
+            comb[row * copies + column] =
+                comb[row * copies + column] / total + hc_eps;
+    }
+    for (int iteration = 0; iteration < iterations; iteration++) {
+        if (iteration) for (int row = 0; row < copies; row++) {
+            float total = 0.0f;
+            for (int column = 0; column < copies; column++)
+                total += comb[row * copies + column];
+            for (int column = 0; column < copies; column++)
+                comb[row * copies + column] /= total + hc_eps;
+        }
+        for (int column = 0; column < copies; column++) {
+            float total = 0.0f;
+            for (int row = 0; row < copies; row++)
+                total += comb[row * copies + column];
+            for (int row = 0; row < copies; row++)
+                comb[row * copies + column] /= total + hc_eps;
+        }
+    }
+    for (int column = 0; column < dimension; column++) {
+        float sum = 0.0f;
+        for (int copy = 0; copy < copies; copy++)
+            sum += pre[copy] * streams[copy * dimension + column];
+        collapsed[column] = sum;
+    }
+    free(pre); free(mix);
+    return 0;
+}
+
+int coli_glm53_mhc_post(float *output, const float *branch,
+                        const float *streams, const float *post,
+                        const float *comb, int copies, int dimension) {
+    if (!output || !branch || !streams || !post || !comb ||
+        copies < 1 || dimension < 1) return -1;
+    for (int destination = 0; destination < copies; destination++)
+        for (int column = 0; column < dimension; column++) {
+            float value = post[destination] * branch[column];
+            for (int source = 0; source < copies; source++)
+                value += comb[source * copies + destination] *
+                         streams[source * dimension + column];
+            output[destination * dimension + column] = value;
+        }
+    return 0;
+}

--- a/c/glm53_mhc.h
+++ b/c/glm53_mhc.h
@@ -1,0 +1,13 @@
+#ifndef COLIBRI_GLM53_MHC_H
+#define COLIBRI_GLM53_MHC_H
+
+int coli_glm53_mhc_pre(float *collapsed, float *post, float *comb,
+                       const float *streams, const float *function,
+                       const float scale[3], const float *base,
+                       int copies, int dimension, int iterations,
+                       float norm_eps, float hc_eps);
+int coli_glm53_mhc_post(float *output, const float *branch,
+                        const float *streams, const float *post,
+                        const float *comb, int copies, int dimension);
+
+#endif

--- a/c/glm53_sparse_attention.c
+++ b/c/glm53_sparse_attention.c
@@ -1,0 +1,59 @@
+#include "glm53_sparse_attention.h"
+
+#include <float.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+int coli_glm53_sparse_attention(float *output, const float *queries,
+                                const float *keys, const float *values,
+                                const int *indices, int sequence, int width,
+                                int heads, int key_dim, int value_dim) {
+    if (!output || !queries || !keys || !values || !indices || sequence < 1 ||
+        width < 1 || heads < 1 || key_dim < 1 || value_dim < 1) return -1;
+    float *scores = malloc((size_t)width * sizeof(*scores));
+    if (!scores) return -1;
+    float scale = 1.0f / sqrtf((float)key_dim);
+    for (int query_position = 0; query_position < sequence; query_position++) {
+        const int *selected = indices + (size_t)query_position * width;
+        for (int head = 0; head < heads; head++) {
+            const float *query = queries +
+                ((size_t)query_position * heads + head) * key_dim;
+            float maximum = -FLT_MAX;
+            for (int slot = 0; slot < width; slot++) {
+                int key_position = selected[slot];
+                if (key_position < 0 || key_position >= sequence) {
+                    scores[slot] = -FLT_MAX;
+                    continue;
+                }
+                const float *key = keys +
+                    ((size_t)key_position * heads + head) * key_dim;
+                float score = 0.0f;
+                for (int dim = 0; dim < key_dim; dim++) score += query[dim] * key[dim];
+                scores[slot] = score * scale;
+                if (scores[slot] > maximum) maximum = scores[slot];
+            }
+            float total = 0.0f;
+            for (int slot = 0; slot < width; slot++) {
+                if (scores[slot] == -FLT_MAX) continue;
+                scores[slot] = expf(scores[slot] - maximum);
+                total += scores[slot];
+            }
+            float *result = output +
+                ((size_t)query_position * heads + head) * value_dim;
+            for (int dim = 0; dim < value_dim; dim++) result[dim] = 0.0f;
+            if (total == 0.0f) continue;
+            for (int slot = 0; slot < width; slot++) {
+                int value_position = selected[slot];
+                if (value_position < 0 || value_position >= sequence) continue;
+                float probability = scores[slot] / total;
+                const float *value = values +
+                    ((size_t)value_position * heads + head) * value_dim;
+                for (int dim = 0; dim < value_dim; dim++)
+                    result[dim] += probability * value[dim];
+            }
+        }
+    }
+    free(scores);
+    return 0;
+}

--- a/c/glm53_sparse_attention.h
+++ b/c/glm53_sparse_attention.h
@@ -1,0 +1,11 @@
+#ifndef COLIBRI_GLM53_SPARSE_ATTENTION_H
+#define COLIBRI_GLM53_SPARSE_ATTENTION_H
+
+/* CPU DSA attention over per-query selected token indices. Queries/keys are
+ * [sequence, heads, key_dim], values/output [sequence, heads, value_dim]. */
+int coli_glm53_sparse_attention(float *output, const float *queries,
+                                const float *keys, const float *values,
+                                const int *indices, int sequence, int width,
+                                int heads, int key_dim, int value_dim);
+
+#endif

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -1276,7 +1276,7 @@ def render_chat_inkling(messages, enable_thinking=False, reasoning_effort=None, 
 
 def render_chat(messages, enable_thinking=False, reasoning_effort=None, tools=None,
                 tool_choice=None):
-    """Render the text-only subset of the official GLM-5.2 chat template."""
+    """Render the shared text subset of the official GLM-5.2/5.3 templates."""
     if not isinstance(messages, list) or not messages:
         raise APIError(400, "`messages` must be a non-empty array.", "messages")
     prompt = ["[gMASK]<sop>"]

--- a/c/tests/segment_conformance_fixtures.c
+++ b/c/tests/segment_conformance_fixtures.c
@@ -36,60 +36,99 @@ typedef struct {
  * model coverage. */
 static const ColiSegmentConformanceFixture g_fixtures[] = {
     {
-        "glm", "GLM-5.2", "fixture/glm-mla-dsa-v1",
+        "glm",
+        "GLM-5.2",
+        "fixture/glm-mla-dsa-v1",
         "MLA latent cache + RoPE + DSA indexer + device cache",
         "tools/make_glm_oracle.py",
-        COLI_SEGMENT_FIXTURE_MLA_LATENT |
-            COLI_SEGMENT_FIXTURE_DSA_INDEXER |
-            COLI_SEGMENT_FIXTURE_DEVICE_CACHE,
-        4, 8, 5, 64, UINT32_C(0x474c4d35),
+        COLI_SEGMENT_FIXTURE_MLA_LATENT | COLI_SEGMENT_FIXTURE_DSA_INDEXER | COLI_SEGMENT_FIXTURE_DEVICE_CACHE,
+        4,
+        8,
+        5,
+        64,
+        UINT32_C(0x474c4d35),
     },
     {
-        "inkling", "Inkling", "fixture/inkling-kv-ring-conv-v1",
+        "glm53_flash",
+        "GLM-5.3-Flash",
+        "fixture/glm53-kda-dsa-mhc-v1",
+        "KDA recurrent/convolution + DSA KV/indexer + mHC",
+        "tools/make_glm53_tiny.py",
+        COLI_SEGMENT_FIXTURE_KV | COLI_SEGMENT_FIXTURE_RECURRENT | COLI_SEGMENT_FIXTURE_CONVOLUTION |
+            COLI_SEGMENT_FIXTURE_DSA_INDEXER | COLI_SEGMENT_FIXTURE_MHC,
+        4,
+        9,
+        5,
+        64,
+        UINT32_C(0x474c3533),
+    },
+    {
+        "inkling",
+        "Inkling",
+        "fixture/inkling-kv-ring-conv-v1",
         "global KV + sliding KV ring + convolutional state",
         "tools/make_tiny_inkling.py",
-        COLI_SEGMENT_FIXTURE_KV |
-            COLI_SEGMENT_FIXTURE_SLIDING_RING |
-            COLI_SEGMENT_FIXTURE_CONVOLUTION,
-        3, 7, 8, 64, UINT32_C(0x494e4b4c),
+        COLI_SEGMENT_FIXTURE_KV | COLI_SEGMENT_FIXTURE_SLIDING_RING | COLI_SEGMENT_FIXTURE_CONVOLUTION,
+        3,
+        7,
+        8,
+        64,
+        UINT32_C(0x494e4b4c),
     },
     {
-        "kimi", "Kimi K3", "fixture/kimi-mla-kda-conv-attnres-v1",
+        "kimi",
+        "Kimi K3",
+        "fixture/kimi-mla-kda-conv-attnres-v1",
         "MLA + KDA recurrent state + convolution windows + AttnRes",
         "tools/make_kimi_k3_tiny.py",
-        COLI_SEGMENT_FIXTURE_MLA_LATENT |
-            COLI_SEGMENT_FIXTURE_RECURRENT |
-            COLI_SEGMENT_FIXTURE_CONVOLUTION |
+        COLI_SEGMENT_FIXTURE_MLA_LATENT | COLI_SEGMENT_FIXTURE_RECURRENT | COLI_SEGMENT_FIXTURE_CONVOLUTION |
             COLI_SEGMENT_FIXTURE_ATTN_RESIDUAL,
-        4, 9, 4, 64, UINT32_C(0x4b494d49),
+        4,
+        9,
+        4,
+        64,
+        UINT32_C(0x4b494d49),
     },
     {
-        "olmoe", "OLMoE", "fixture/olmoe-kv-v1",
+        "olmoe",
+        "OLMoE",
+        "fixture/olmoe-kv-v1",
         "conventional key/value attention cache",
         "tools/make_olmoe_real_oracle.py",
         COLI_SEGMENT_FIXTURE_KV,
-        1, 6, 4, 32, UINT32_C(0x4f4c4d4f),
+        1,
+        6,
+        4,
+        32,
+        UINT32_C(0x4f4c4d4f),
     },
     {
-        "qwen36", "Qwen3.6", "fixture/qwen36-kv-deltanet-conv-v1",
+        "qwen36",
+        "Qwen3.6",
+        "fixture/qwen36-kv-deltanet-conv-v1",
         "attention KV + DeltaNet recurrent state + convolution ring",
         "tools/make_qwen36_tiny.py",
-        COLI_SEGMENT_FIXTURE_KV |
-            COLI_SEGMENT_FIXTURE_RECURRENT |
-            COLI_SEGMENT_FIXTURE_CONVOLUTION |
+        COLI_SEGMENT_FIXTURE_KV | COLI_SEGMENT_FIXTURE_RECURRENT | COLI_SEGMENT_FIXTURE_CONVOLUTION |
             COLI_SEGMENT_FIXTURE_SLIDING_RING,
-        4, 8, 8, 64, UINT32_C(0x5157454e),
+        4,
+        8,
+        8,
+        64,
+        UINT32_C(0x5157454e),
     },
     {
-        "deepseek_v4", "DeepSeek V4", "fixture/dsv4-mhc-compressed-v1",
+        "deepseek_v4",
+        "DeepSeek V4",
+        "fixture/dsv4-mhc-compressed-v1",
         "mHC + window/compressed attention + compressor + indexer",
         "tools/make_deepseek_v4_tiny.py",
-        COLI_SEGMENT_FIXTURE_MHC |
-            COLI_SEGMENT_FIXTURE_SLIDING_RING |
-            COLI_SEGMENT_FIXTURE_COMPRESSOR |
-            COLI_SEGMENT_FIXTURE_DSA_INDEXER |
-            COLI_SEGMENT_FIXTURE_DEVICE_CACHE,
-        5, 10, 4, 64, UINT32_C(0x44535634),
+        COLI_SEGMENT_FIXTURE_MHC | COLI_SEGMENT_FIXTURE_SLIDING_RING | COLI_SEGMENT_FIXTURE_COMPRESSOR |
+            COLI_SEGMENT_FIXTURE_DSA_INDEXER | COLI_SEGMENT_FIXTURE_DEVICE_CACHE,
+        5,
+        10,
+        4,
+        64,
+        UINT32_C(0x44535634),
     },
 };
 
@@ -104,12 +143,9 @@ static int fixture_index(const ColiSegmentConformanceFixture *fixture) {
     return -1;
 }
 
-size_t coli_segment_conformance_fixture_count(void) {
-    return sizeof(g_fixtures) / sizeof(g_fixtures[0]);
-}
+size_t coli_segment_conformance_fixture_count(void) { return sizeof(g_fixtures) / sizeof(g_fixtures[0]); }
 
-const ColiSegmentConformanceFixture *
-coli_segment_conformance_fixture_at(size_t index) {
+const ColiSegmentConformanceFixture *coli_segment_conformance_fixture_at(size_t index) {
     if (index >= coli_segment_conformance_fixture_count()) return NULL;
     return &g_fixtures[index];
 }
@@ -149,13 +185,10 @@ static uint32_t float_bits(float value) {
     return bits;
 }
 
-static int open_fixture(const ColiSegmentConformanceFixture *fixture,
-                        void **engine_impl,
-                        ColiSegmentCapabilities *capabilities,
-                        const ColiSegmentEngineOptions *options,
-                        char *error, size_t error_size) {
-    if (!fixture || fixture_index(fixture) < 0 ||
-        options->layer_end > fixture->num_layers)
+static int open_fixture(const ColiSegmentConformanceFixture *fixture, void **engine_impl,
+                        ColiSegmentCapabilities *capabilities, const ColiSegmentEngineOptions *options, char *error,
+                        size_t error_size) {
+    if (!fixture || fixture_index(fixture) < 0 || options->layer_end > fixture->num_layers)
         return fail(error, error_size, "fixture range is outside the model");
     FixtureEngine *engine = (FixtureEngine *)calloc(1, sizeof(*engine));
     if (!engine) return fail(error, error_size, "fixture engine allocation failed");
@@ -165,18 +198,11 @@ static int open_fixture(const ColiSegmentConformanceFixture *fixture,
     engine->context_tokens = options->context_tokens;
 
     capabilities->abi_version = COLI_SEGMENT_ABI_VERSION;
-    capabilities->flags = COLI_SEGMENT_CAP_TOKEN_IDS |
-                          COLI_SEGMENT_CAP_SNAPSHOT |
-                          COLI_SEGMENT_CAP_RANGE_NATIVE |
-                          COLI_SEGMENT_CAP_MULTI_SESSION |
-                          COLI_SEGMENT_CAP_CPU;
-    snprintf(capabilities->engine_id, sizeof(capabilities->engine_id), "%s",
-             fixture->family_id);
-    snprintf(capabilities->state_schema, sizeof(capabilities->state_schema),
-             "%s", fixture->state_schema);
-    snprintf(capabilities->numeric_class,
-             sizeof(capabilities->numeric_class),
-             "fixture-f32-deterministic-v1");
+    capabilities->flags = COLI_SEGMENT_CAP_TOKEN_IDS | COLI_SEGMENT_CAP_SNAPSHOT | COLI_SEGMENT_CAP_RANGE_NATIVE |
+                          COLI_SEGMENT_CAP_MULTI_SESSION | COLI_SEGMENT_CAP_CPU;
+    snprintf(capabilities->engine_id, sizeof(capabilities->engine_id), "%s", fixture->family_id);
+    snprintf(capabilities->state_schema, sizeof(capabilities->state_schema), "%s", fixture->state_schema);
+    snprintf(capabilities->numeric_class, sizeof(capabilities->numeric_class), "fixture-f32-deterministic-v1");
     capabilities->state_dtype = COLI_SEGMENT_DTYPE_F32;
     capabilities->state_width = fixture->state_width;
     capabilities->max_batch_rows = 4;
@@ -188,8 +214,7 @@ static int open_fixture(const ColiSegmentConformanceFixture *fixture,
 
 static void fixture_engine_destroy(void *engine_impl) { free(engine_impl); }
 
-static int fixture_session_create(void *engine_impl, void **session_impl,
-                                  const ColiSegmentSessionOptions *options,
+static int fixture_session_create(void *engine_impl, void **session_impl, const ColiSegmentSessionOptions *options,
                                   char *error, size_t error_size) {
     FixtureEngine *engine = (FixtureEngine *)engine_impl;
     if (!engine || options->context_tokens > engine->context_tokens)
@@ -203,8 +228,7 @@ static int fixture_session_create(void *engine_impl, void **session_impl,
 
 static void fixture_session_destroy(void *session_impl) { free(session_impl); }
 
-static uint32_t mix_state(uint32_t old, uint32_t input, uint32_t token,
-                          uint64_t position, uint32_t lane,
+static uint32_t mix_state(uint32_t old, uint32_t input, uint32_t token, uint64_t position, uint32_t lane,
                           const FixtureEngine *engine) {
     uint32_t mixed = old ^ input ^ token ^ (uint32_t)position;
     mixed ^= engine->fixture->fixture_tag + UINT32_C(0x9e3779b9) * (lane + 1);
@@ -216,9 +240,8 @@ static uint32_t mix_state(uint32_t old, uint32_t input, uint32_t token,
     return mixed;
 }
 
-static int fixture_session_run(void *session_impl,
-                               const ColiSegmentRunRequest *request,
-                               char *error, size_t error_size) {
+static int fixture_session_run(void *session_impl, const ColiSegmentRunRequest *request, char *error,
+                               size_t error_size) {
     FixtureSession *session = (FixtureSession *)session_impl;
     const ColiSegmentConformanceFixture *fixture = session->engine->fixture;
     if (request->position != session->position)
@@ -230,18 +253,15 @@ static int fixture_session_run(void *session_impl,
         uint32_t token = (uint32_t)request->token_ids[row];
         uint64_t position = session->position + row;
         for (uint32_t lane = 0; lane < fixture->state_lanes; lane++) {
-            size_t input_index = (size_t)row * fixture->state_width +
-                                 lane % fixture->state_width;
-            session->state[lane] = mix_state(
-                session->state[lane], float_bits(input[input_index]), token,
-                position, lane, session->engine);
+            size_t input_index = (size_t)row * fixture->state_width + lane % fixture->state_width;
+            session->state[lane] =
+                mix_state(session->state[lane], float_bits(input[input_index]), token, position, lane, session->engine);
         }
         for (uint32_t column = 0; column < fixture->state_width; column++) {
             uint32_t state = session->state[column % fixture->state_lanes];
             uint32_t folded = (state >> 8) ^ state;
             float delta = (float)(folded & UINT32_C(0x3ff)) / 1024.0f;
-            delta += (float)(session->engine->layer_end -
-                             session->engine->layer_begin) / 32.0f;
+            delta += (float)(session->engine->layer_end - session->engine->layer_begin) / 32.0f;
             output[(size_t)row * fixture->state_width + column] =
                 input[(size_t)row * fixture->state_width + column] + delta;
         }
@@ -250,8 +270,7 @@ static int fixture_session_run(void *session_impl,
     return 0;
 }
 
-static void encode_snapshot(const FixtureSession *session,
-                            unsigned char bytes[FIXTURE_SNAPSHOT_SIZE]) {
+static void encode_snapshot(const FixtureSession *session, unsigned char bytes[FIXTURE_SNAPSHOT_SIZE]) {
     memset(bytes, 0, FIXTURE_SNAPSHOT_SIZE);
     memcpy(bytes, "CSFX", 4);
     put_u32le(bytes + 4, FIXTURE_SNAPSHOT_VERSION);
@@ -262,112 +281,86 @@ static void encode_snapshot(const FixtureSession *session,
     put_u32le(bytes + 24, session->engine->fixture->state_lanes);
     put_u32le(bytes + 28, session->engine->fixture->state_kinds);
     put_u64le(bytes + 32, session->position);
-    for (uint32_t i = 0; i < FIXTURE_MAX_STATE_LANES; i++)
-        put_u32le(bytes + 40 + (size_t)i * 4, session->state[i]);
+    for (uint32_t i = 0; i < FIXTURE_MAX_STATE_LANES; i++) put_u32le(bytes + 40 + (size_t)i * 4, session->state[i]);
     put_u32le(bytes + 72, checksum32(bytes, 72));
     put_u32le(bytes + 76, UINT32_C(0x53454731));
 }
 
-static int decode_snapshot(FixtureSession *session,
-                           const unsigned char bytes[FIXTURE_SNAPSHOT_SIZE],
-                           char *error, size_t error_size) {
+static int decode_snapshot(FixtureSession *session, const unsigned char bytes[FIXTURE_SNAPSHOT_SIZE], char *error,
+                           size_t error_size) {
     FixtureEngine *engine = session->engine;
     const ColiSegmentConformanceFixture *fixture = engine->fixture;
     uint64_t position = get_u64le(bytes + 32);
-    if (memcmp(bytes, "CSFX", 4) != 0 ||
-        get_u32le(bytes + 4) != FIXTURE_SNAPSHOT_VERSION ||
-        get_u32le(bytes + 8) != fixture->fixture_tag ||
-        get_u32le(bytes + 12) != engine->layer_begin ||
-        get_u32le(bytes + 16) != engine->layer_end ||
-        get_u32le(bytes + 20) != engine->context_tokens ||
-        get_u32le(bytes + 24) != fixture->state_lanes ||
-        get_u32le(bytes + 28) != fixture->state_kinds ||
-        get_u32le(bytes + 72) != checksum32(bytes, 72) ||
-        get_u32le(bytes + 76) != UINT32_C(0x53454731) ||
+    if (memcmp(bytes, "CSFX", 4) != 0 || get_u32le(bytes + 4) != FIXTURE_SNAPSHOT_VERSION ||
+        get_u32le(bytes + 8) != fixture->fixture_tag || get_u32le(bytes + 12) != engine->layer_begin ||
+        get_u32le(bytes + 16) != engine->layer_end || get_u32le(bytes + 20) != engine->context_tokens ||
+        get_u32le(bytes + 24) != fixture->state_lanes || get_u32le(bytes + 28) != fixture->state_kinds ||
+        get_u32le(bytes + 72) != checksum32(bytes, 72) || get_u32le(bytes + 76) != UINT32_C(0x53454731) ||
         position > engine->context_tokens)
         return fail(error, error_size, "fixture snapshot identity or checksum mismatch");
 
     /* Validate everything before mutating the live session: failed restores
      * are transactional and leave the previous state usable. */
     uint32_t restored[FIXTURE_MAX_STATE_LANES];
-    for (uint32_t i = 0; i < FIXTURE_MAX_STATE_LANES; i++)
-        restored[i] = get_u32le(bytes + 40 + (size_t)i * 4);
+    for (uint32_t i = 0; i < FIXTURE_MAX_STATE_LANES; i++) restored[i] = get_u32le(bytes + 40 + (size_t)i * 4);
     session->position = position;
     memcpy(session->state, restored, sizeof(restored));
     return 0;
 }
 
-static int fixture_snapshot(void *session_impl, ColiSegmentWriteFn write_fn,
-                            void *write_user_data,
-                            char *error, size_t error_size) {
+static int fixture_snapshot(void *session_impl, ColiSegmentWriteFn write_fn, void *write_user_data, char *error,
+                            size_t error_size) {
     FixtureSession *session = (FixtureSession *)session_impl;
     unsigned char bytes[FIXTURE_SNAPSHOT_SIZE];
     encode_snapshot(session, bytes);
     /* Multiple writes are intentional: adapters must support streamed output,
      * not rely on a single callback invocation. */
-    if (write_fn(write_user_data, bytes, 17) ||
-        write_fn(write_user_data, bytes + 17, 29) ||
+    if (write_fn(write_user_data, bytes, 17) || write_fn(write_user_data, bytes + 17, 29) ||
         write_fn(write_user_data, bytes + 46, FIXTURE_SNAPSHOT_SIZE - 46))
         return fail(error, error_size, "fixture snapshot writer failed");
     return 0;
 }
 
-static int fixture_restore(void *session_impl, ColiSegmentReadFn read_fn,
-                           void *read_user_data,
-                           char *error, size_t error_size) {
+static int fixture_restore(void *session_impl, ColiSegmentReadFn read_fn, void *read_user_data, char *error,
+                           size_t error_size) {
     FixtureSession *session = (FixtureSession *)session_impl;
     unsigned char bytes[FIXTURE_SNAPSHOT_SIZE];
-    if (read_fn(read_user_data, bytes, 13) ||
-        read_fn(read_user_data, bytes + 13, 31) ||
+    if (read_fn(read_user_data, bytes, 13) || read_fn(read_user_data, bytes + 13, 31) ||
         read_fn(read_user_data, bytes + 44, FIXTURE_SNAPSHOT_SIZE - 44))
         return fail(error, error_size, "fixture snapshot reader failed");
     return decode_snapshot(session, bytes, error, error_size);
 }
 
-#define DECLARE_OPEN_WRAPPER(name, index)                                      \
-    static int name##_open(void **engine_impl,                                 \
-                           ColiSegmentCapabilities *capabilities,              \
-                           const ColiSegmentEngineOptions *options,            \
-                           char *error, size_t error_size) {                    \
-        return open_fixture(&g_fixtures[index], engine_impl, capabilities,      \
-                            options, error, error_size);                        \
+#define DECLARE_OPEN_WRAPPER(name, index)                                                                              \
+    static int name##_open(void **engine_impl, ColiSegmentCapabilities *capabilities,                                  \
+                           const ColiSegmentEngineOptions *options, char *error, size_t error_size) {                  \
+        return open_fixture(&g_fixtures[index], engine_impl, capabilities, options, error, error_size);                \
     }
 
 DECLARE_OPEN_WRAPPER(glm, 0)
-DECLARE_OPEN_WRAPPER(inkling, 1)
-DECLARE_OPEN_WRAPPER(kimi, 2)
-DECLARE_OPEN_WRAPPER(olmoe, 3)
-DECLARE_OPEN_WRAPPER(qwen36, 4)
-DECLARE_OPEN_WRAPPER(deepseek_v4, 5)
+DECLARE_OPEN_WRAPPER(glm53_flash, 1)
+DECLARE_OPEN_WRAPPER(inkling, 2)
+DECLARE_OPEN_WRAPPER(kimi, 3)
+DECLARE_OPEN_WRAPPER(olmoe, 4)
+DECLARE_OPEN_WRAPPER(qwen36, 5)
+DECLARE_OPEN_WRAPPER(deepseek_v4, 6)
 
-#define FIXTURE_ADAPTER(name)                                                  \
-    {                                                                          \
-        .struct_size = sizeof(ColiSegmentAdapter),                             \
-        .abi_version = COLI_SEGMENT_ABI_VERSION,                               \
-        .engine_id = #name,                                                    \
-        .engine_open = name##_open,                                            \
-        .engine_destroy = fixture_engine_destroy,                              \
-        .session_create = fixture_session_create,                              \
-        .session_destroy = fixture_session_destroy,                            \
-        .session_run = fixture_session_run,                                    \
-        .session_snapshot = fixture_snapshot,                                  \
-        .session_restore = fixture_restore,                                    \
-        .reserved_fn = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL},       \
+#define FIXTURE_ADAPTER(name)                                                                                          \
+    {                                                                                                                  \
+        .struct_size = sizeof(ColiSegmentAdapter), .abi_version = COLI_SEGMENT_ABI_VERSION, .engine_id = #name,        \
+        .engine_open = name##_open, .engine_destroy = fixture_engine_destroy,                                          \
+        .session_create = fixture_session_create, .session_destroy = fixture_session_destroy,                          \
+        .session_run = fixture_session_run, .session_snapshot = fixture_snapshot, .session_restore = fixture_restore,  \
+        .reserved_fn = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL},                                               \
     }
 
 static const ColiSegmentAdapter g_adapters[] = {
-    FIXTURE_ADAPTER(glm),
-    FIXTURE_ADAPTER(inkling),
-    FIXTURE_ADAPTER(kimi),
-    FIXTURE_ADAPTER(olmoe),
-    FIXTURE_ADAPTER(qwen36),
-    FIXTURE_ADAPTER(deepseek_v4),
+    FIXTURE_ADAPTER(glm),   FIXTURE_ADAPTER(glm53_flash), FIXTURE_ADAPTER(inkling),     FIXTURE_ADAPTER(kimi),
+    FIXTURE_ADAPTER(olmoe), FIXTURE_ADAPTER(qwen36),      FIXTURE_ADAPTER(deepseek_v4),
 };
 
 int coli_segment_conformance_register_fixtures(void) {
-    if (sizeof(g_adapters) / sizeof(g_adapters[0]) !=
-        coli_segment_conformance_fixture_count())
-        return -1;
+    if (sizeof(g_adapters) / sizeof(g_adapters[0]) != coli_segment_conformance_fixture_count()) return -1;
     for (size_t i = 0; i < coli_segment_conformance_fixture_count(); i++) {
         if (strcmp(g_adapters[i].engine_id, g_fixtures[i].family_id) != 0 ||
             coli_segment_adapter_register(&g_adapters[i]) != 0)
@@ -386,33 +379,27 @@ static int stream_write(void *user_data, const void *data, size_t size) {
 
 static int stream_read(void *user_data, void *data, size_t size) {
     FixtureStream *stream = (FixtureStream *)user_data;
-    if (stream->offset > stream->length || size > stream->length - stream->offset)
-        return -1;
+    if (stream->offset > stream->length || size > stream->length - stream->offset) return -1;
     memcpy(data, stream->bytes + stream->offset, size);
     stream->offset += size;
     return 0;
 }
 
 static void fill_input(float *input, size_t count, uint32_t salt) {
-    for (size_t i = 0; i < count; i++)
-        input[i] = (float)((i + 1) * (salt + 3u) % 97u) / 32.0f;
+    for (size_t i = 0; i < count; i++) input[i] = (float)((i + 1) * (salt + 3u) % 97u) / 32.0f;
 }
 
-static int floats_equal(const float *a, const float *b, size_t count) {
-    return memcmp(a, b, count * sizeof(*a)) == 0;
-}
+static int floats_equal(const float *a, const float *b, size_t count) { return memcmp(a, b, count * sizeof(*a)) == 0; }
 
-#define REQUIRE(condition, message)                                            \
-    do {                                                                       \
-        if (!(condition)) {                                                    \
-            result = fail(error, error_size, message);                         \
-            goto cleanup;                                                      \
-        }                                                                      \
+#define REQUIRE(condition, message)                                                                                    \
+    do {                                                                                                               \
+        if (!(condition)) {                                                                                            \
+            result = fail(error, error_size, message);                                                                 \
+            goto cleanup;                                                                                              \
+        }                                                                                                              \
     } while (0)
 
-int coli_segment_conformance_run_fixture(
-    const ColiSegmentConformanceFixture *fixture,
-    char *error, size_t error_size) {
+int coli_segment_conformance_run_fixture(const ColiSegmentConformanceFixture *fixture, char *error, size_t error_size) {
     int result = -1;
     int index = fixture_index(fixture);
     ColiSegmentEngine *engine = NULL, *other_range = NULL;
@@ -429,53 +416,39 @@ int coli_segment_conformance_run_fixture(
         .layer_end = fixture->num_layers - 1,
         .context_tokens = fixture->max_context_tokens / 2,
     };
-    REQUIRE(coli_segment_engine_open(fixture->family_id, &open_options, &engine,
-                                     error, error_size) == 0,
+    REQUIRE(coli_segment_engine_open(fixture->family_id, &open_options, &engine, error, error_size) == 0,
             "cannot open fixture segment engine");
 
     ColiSegmentCapabilities capabilities = {.struct_size = sizeof(capabilities)};
-    REQUIRE(coli_segment_engine_capabilities(engine, &capabilities,
-                                             error, error_size) == 0,
+    REQUIRE(coli_segment_engine_capabilities(engine, &capabilities, error, error_size) == 0,
             "cannot read fixture capabilities");
-    REQUIRE(strcmp(capabilities.engine_id, fixture->family_id) == 0,
-            "fixture engine identity changed");
-    REQUIRE(strcmp(capabilities.state_schema, fixture->state_schema) == 0,
-            "fixture state schema changed");
-    REQUIRE(capabilities.state_width == fixture->state_width &&
-                capabilities.num_layers == fixture->num_layers,
+    REQUIRE(strcmp(capabilities.engine_id, fixture->family_id) == 0, "fixture engine identity changed");
+    REQUIRE(strcmp(capabilities.state_schema, fixture->state_schema) == 0, "fixture state schema changed");
+    REQUIRE(capabilities.state_width == fixture->state_width && capabilities.num_layers == fixture->num_layers,
             "fixture geometry changed");
-    REQUIRE((capabilities.flags & (COLI_SEGMENT_CAP_TOKEN_IDS |
-                                   COLI_SEGMENT_CAP_SNAPSHOT |
-                                   COLI_SEGMENT_CAP_RANGE_NATIVE |
-                                   COLI_SEGMENT_CAP_MULTI_SESSION |
-                                   COLI_SEGMENT_CAP_CPU)) ==
-                (COLI_SEGMENT_CAP_TOKEN_IDS | COLI_SEGMENT_CAP_SNAPSHOT |
-                 COLI_SEGMENT_CAP_RANGE_NATIVE |
-                 COLI_SEGMENT_CAP_MULTI_SESSION | COLI_SEGMENT_CAP_CPU),
-            "fixture is missing mandatory Segment capabilities");
-    REQUIRE((capabilities.flags & (COLI_SEGMENT_CAP_CUDA |
-                                   COLI_SEGMENT_CAP_HIP |
-                                   COLI_SEGMENT_CAP_METAL |
-                                   COLI_SEGMENT_CAP_VULKAN)) == 0,
+    REQUIRE(
+        (capabilities.flags & (COLI_SEGMENT_CAP_TOKEN_IDS | COLI_SEGMENT_CAP_SNAPSHOT | COLI_SEGMENT_CAP_RANGE_NATIVE |
+                               COLI_SEGMENT_CAP_MULTI_SESSION | COLI_SEGMENT_CAP_CPU)) ==
+            (COLI_SEGMENT_CAP_TOKEN_IDS | COLI_SEGMENT_CAP_SNAPSHOT | COLI_SEGMENT_CAP_RANGE_NATIVE |
+             COLI_SEGMENT_CAP_MULTI_SESSION | COLI_SEGMENT_CAP_CPU),
+        "fixture is missing mandatory Segment capabilities");
+    REQUIRE((capabilities.flags &
+             (COLI_SEGMENT_CAP_CUDA | COLI_SEGMENT_CAP_HIP | COLI_SEGMENT_CAP_METAL | COLI_SEGMENT_CAP_VULKAN)) == 0,
             "contract fixture must not claim a real GPU backend");
 
     ColiSegmentSessionOptions session_options = {
         .struct_size = sizeof(session_options),
         .context_tokens = open_options.context_tokens,
     };
-    REQUIRE(coli_segment_session_create(engine, &session_options, &first,
-                                        error, error_size) == 0 &&
-                coli_segment_session_create(engine, &session_options, &second,
-                                            error, error_size) == 0 &&
-                coli_segment_session_create(engine, &session_options, &clean,
-                                            error, error_size) == 0,
+    REQUIRE(coli_segment_session_create(engine, &session_options, &first, error, error_size) == 0 &&
+                coli_segment_session_create(engine, &session_options, &second, error, error_size) == 0 &&
+                coli_segment_session_create(engine, &session_options, &clean, error, error_size) == 0,
             "cannot create isolated fixture sessions");
     if (coli_segment_engine_close(engine, error, error_size) == 0) {
         /* A broken runtime may have freed it despite the live sessions. Avoid
          * turning the conformance diagnostic into a cleanup use-after-free. */
         engine = NULL;
-        result = fail(error, error_size,
-                      "engine closed while fixture sessions were alive");
+        result = fail(error, error_size, "engine closed while fixture sessions were alive");
         goto cleanup;
     }
 
@@ -484,8 +457,7 @@ int coli_segment_conformance_run_fixture(
     out_first = (float *)calloc(values, sizeof(*out_first));
     out_second = (float *)calloc(values, sizeof(*out_second));
     out_clean = (float *)calloc(values, sizeof(*out_clean));
-    REQUIRE(input && out_first && out_second && out_clean,
-            "fixture activation allocation failed");
+    REQUIRE(input && out_first && out_second && out_clean, "fixture activation allocation failed");
     fill_input(input, values, fixture->fixture_tag);
     int32_t tokens[2] = {17 + index, 29 + index};
     ColiSegmentRunRequest run = {
@@ -499,95 +471,75 @@ int coli_segment_conformance_run_fixture(
         .output = out_first,
         .output_bytes = values * sizeof(*out_first),
     };
-    REQUIRE(coli_segment_run(first, &run, error, error_size) == 0,
-            "first fixture run failed");
+    REQUIRE(coli_segment_run(first, &run, error, error_size) == 0, "first fixture run failed");
 
     run.output = out_second;
-    REQUIRE(coli_segment_run(second, &run, error, error_size) == 0 &&
-                floats_equal(out_first, out_second, values),
+    REQUIRE(coli_segment_run(second, &run, error, error_size) == 0 && floats_equal(out_first, out_second, values),
             "fresh fixture sessions are not deterministic and isolated");
 
     /* Advance only the first session, proving its state cannot leak into the
      * untouched clean session. */
     run.position = 2;
     run.output = out_first;
-    REQUIRE(coli_segment_run(first, &run, error, error_size) == 0,
-            "fixture continuation failed");
+    REQUIRE(coli_segment_run(first, &run, error, error_size) == 0, "fixture continuation failed");
     run.position = 0;
     run.output = out_clean;
-    REQUIRE(coli_segment_run(clean, &run, error, error_size) == 0 &&
-                floats_equal(out_second, out_clean, values),
+    REQUIRE(coli_segment_run(clean, &run, error, error_size) == 0 && floats_equal(out_second, out_clean, values),
             "fixture session state leaked across conversations");
 
-    REQUIRE(coli_segment_snapshot(first, stream_write, &checkpoint,
-                                  error, error_size) == 0 &&
+    REQUIRE(coli_segment_snapshot(first, stream_write, &checkpoint, error, error_size) == 0 &&
                 checkpoint.length == FIXTURE_SNAPSHOT_SIZE,
             "fixture snapshot stream failed");
     checkpoint.offset = 0;
-    REQUIRE(coli_segment_restore(second, stream_read, &checkpoint,
-                                 error, error_size) == 0 &&
+    REQUIRE(coli_segment_restore(second, stream_read, &checkpoint, error, error_size) == 0 &&
                 checkpoint.offset == checkpoint.length,
             "fixture restore stream failed");
 
     run.position = 4;
     run.output = out_first;
-    REQUIRE(coli_segment_run(first, &run, error, error_size) == 0,
-            "source run after checkpoint failed");
+    REQUIRE(coli_segment_run(first, &run, error, error_size) == 0, "source run after checkpoint failed");
     run.output = out_second;
-    REQUIRE(coli_segment_run(second, &run, error, error_size) == 0 &&
-                floats_equal(out_first, out_second, values),
+    REQUIRE(coli_segment_run(second, &run, error, error_size) == 0 && floats_equal(out_first, out_second, values),
             "restored fixture did not reproduce exact continuation");
 
     /* A failed restore must be transactional. Snapshot second, corrupt a copy,
      * reject it, then prove the live state remained byte-identical. */
     FixtureStream before_bad = {{0}, 0, 0};
     FixtureStream after_bad = {{0}, 0, 0};
-    REQUIRE(coli_segment_snapshot(second, stream_write, &before_bad,
-                                  error, error_size) == 0,
+    REQUIRE(coli_segment_snapshot(second, stream_write, &before_bad, error, error_size) == 0,
             "cannot snapshot before corruption check");
     FixtureStream corrupt = before_bad;
     corrupt.bytes[41] ^= 0x80u;
     corrupt.offset = 0;
-    REQUIRE(coli_segment_restore(second, stream_read, &corrupt,
-                                 error, error_size) != 0,
+    REQUIRE(coli_segment_restore(second, stream_read, &corrupt, error, error_size) != 0,
             "corrupt fixture snapshot was accepted");
-    REQUIRE(coli_segment_snapshot(second, stream_write, &after_bad,
-                                  error, error_size) == 0 &&
+    REQUIRE(coli_segment_snapshot(second, stream_write, &after_bad, error, error_size) == 0 &&
                 before_bad.length == after_bad.length &&
-                memcmp(before_bad.bytes, after_bad.bytes,
-                       before_bad.length) == 0,
+                memcmp(before_bad.bytes, after_bad.bytes, before_bad.length) == 0,
             "failed restore mutated the live fixture session");
 
     /* The private snapshot identity includes the half-open layer range. */
     ColiSegmentEngineOptions other_options = open_options;
     other_options.layer_begin = 0;
     other_options.layer_end = fixture->num_layers;
-    REQUIRE(coli_segment_engine_open(fixture->family_id, &other_options,
-                                     &other_range, error, error_size) == 0 &&
-                coli_segment_session_create(other_range, &session_options,
-                                            &wrong_range,
-                                            error, error_size) == 0,
+    REQUIRE(coli_segment_engine_open(fixture->family_id, &other_options, &other_range, error, error_size) == 0 &&
+                coli_segment_session_create(other_range, &session_options, &wrong_range, error, error_size) == 0,
             "cannot open alternate fixture range");
     before_bad.offset = 0;
-    REQUIRE(coli_segment_restore(wrong_range, stream_read, &before_bad,
-                                 error, error_size) != 0,
+    REQUIRE(coli_segment_restore(wrong_range, stream_read, &before_bad, error, error_size) != 0,
             "snapshot crossed incompatible fixture ranges");
 
     /* Ordering is adapter-owned: reject a gap and preserve state. */
     FixtureStream before_gap = {{0}, 0, 0};
     FixtureStream after_gap = {{0}, 0, 0};
-    REQUIRE(coli_segment_snapshot(first, stream_write, &before_gap,
-                                  error, error_size) == 0,
+    REQUIRE(coli_segment_snapshot(first, stream_write, &before_gap, error, error_size) == 0,
             "cannot snapshot before ordering check");
     run.position = 9;
     run.output = out_first;
-    REQUIRE(coli_segment_run(first, &run, error, error_size) != 0,
-            "fixture accepted a non-contiguous position");
-    REQUIRE(coli_segment_snapshot(first, stream_write, &after_gap,
-                                  error, error_size) == 0 &&
+    REQUIRE(coli_segment_run(first, &run, error, error_size) != 0, "fixture accepted a non-contiguous position");
+    REQUIRE(coli_segment_snapshot(first, stream_write, &after_gap, error, error_size) == 0 &&
                 before_gap.length == after_gap.length &&
-                memcmp(before_gap.bytes, after_gap.bytes,
-                       before_gap.length) == 0,
+                memcmp(before_gap.bytes, after_gap.bytes, before_gap.length) == 0,
             "rejected fixture run mutated session state");
 
     result = 0;

--- a/c/tests/segment_conformance_manifest.json
+++ b/c/tests/segment_conformance_manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "release_policy": "all_registered_families",
+  "release_policy": "all_runnable_families",
   "families": [
     {
       "family_id": "glm",

--- a/c/tests/segment_conformance_manifest.json
+++ b/c/tests/segment_conformance_manifest.json
@@ -10,6 +10,13 @@
       "real_adapter_required": true
     },
     {
+      "family_id": "glm53_flash",
+      "state_schema": "fixture/glm53-kda-dsa-mhc-v1",
+      "state_components": ["kda_recurrent", "convolution", "dsa_kv", "dsa_indexer", "mhc"],
+      "oracle": {"kind": "generated_tiny", "path": "tools/make_glm53_tiny.py"},
+      "real_adapter_required": true
+    },
+    {
       "family_id": "inkling",
       "state_schema": "fixture/inkling-kv-ring-conv-v1",
       "state_components": ["global_kv", "sliding_kv_ring", "convolution"],

--- a/c/tests/test_datapoint.py
+++ b/c/tests/test_datapoint.py
@@ -313,7 +313,8 @@ class PersistentDatapointTest(unittest.TestCase):
     def test_every_registered_family_has_the_shared_persistent_adapter(self):
         expected = {"glm", "inkling", "kimi", "olmoe", "qwen36", "deepseek_v4"}
         self.assertTrue(expected.issubset({family.id for family in FAMILIES}))
-        self.assertTrue(all(family.has_gateway_adapter for family in FAMILIES))
+        self.assertTrue(all(family.has_gateway_adapter for family in FAMILIES
+                            if family.runtime_available))
 
 
 class EvictCacheSpaceTest(unittest.TestCase):

--- a/c/tests/test_family_registry.py
+++ b/c/tests/test_family_registry.py
@@ -1,5 +1,6 @@
 import json
 import re
+import struct
 import tempfile
 import unittest
 from dataclasses import replace
@@ -150,6 +151,117 @@ class FamilyRegistryTest(unittest.TestCase):
         self.assertEqual(geometry.fixed_state_bytes, 6 * (8 * 8 * 8 + 128 * 3) * 4)
         for model_type in ("qwen2", "qwen3_moe", "my_qwen_model"):
             self.assertNotIn(model_type, by_type)
+
+    def test_glm53_official_shape_models_kda_dsa_mhc_and_mtp_inventory(self):
+        config = {
+            "model_type": "glm5_next",
+            "text_config": {
+                "model_type": "glm5_next_text", "num_hidden_layers": 45,
+                "hidden_size": 4096, "num_attention_heads": 64,
+                "q_lora_rank": 1536, "kv_lora_rank": 512,
+                "qk_nope_head_dim": 256, "qk_rope_head_dim": 0,
+                "v_head_dim": 256, "index_head_dim": 128, "hc_mult": 4,
+                "n_routed_experts": 288, "num_nextn_predict_layers": 1,
+                "layer_types": (["linear_attention"] * 3 +
+                                ["deepseek_sparse_attention"]) * 11 +
+                               ["linear_attention"],
+                "linear_attn_config": {
+                    "num_heads": 64, "head_dim": 128,
+                    "short_conv_kernel_size": 4,
+                    "kda_layers": [i for i in range(45) if (i + 1) % 4],
+                },
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "config.json").write_text(json.dumps(config), encoding="utf-8")
+            resolved = resolve_model(root)
+        self.assertEqual(resolved.descriptor.id, "glm53_flash")
+        self.assertFalse(resolved.descriptor.runtime_available)
+        geometry = planner_geometry(resolved, 4096)
+        self.assertEqual(geometry.configured_experts, 288)
+        # 34 KDA recurrences + conv4 histories are fixed; 11 DSA latent/index
+        # caches grow with context. MTP contributes experts, not attention state.
+        self.assertEqual(geometry.fixed_state_bytes,
+                         34 * (64 * 128 * 128 + 3 * 8192 * 3) * 4)
+        self.assertEqual(geometry.context_state_bytes,
+                         11 * 4096 * (512 + 2 * 128 + 1) * 4)
+        self.assertEqual(geometry.workspace_bytes,
+                         4096 * (6 * 8192 + 128 + 4096) * 4)
+        self.assertEqual(
+            resolved.descriptor.expert_inventory(
+                "model.language_model.layers.45.mlp.experts.287.down_proj.weight",
+                123, resolved.family_config),
+            ((45, 287, 123),))
+
+    def test_glm53_rejects_disagreeing_kda_layer_contract(self):
+        config = {
+            "num_hidden_layers": 4, "hidden_size": 64,
+            "num_attention_heads": 2, "q_lora_rank": 8,
+            "kv_lora_rank": 8, "qk_nope_head_dim": 8,
+            "qk_rope_head_dim": 0, "v_head_dim": 8,
+            "index_head_dim": 4, "hc_mult": 4, "n_routed_experts": 8,
+            "layer_types": ["linear_attention"] * 3 +
+                           ["deepseek_sparse_attention"],
+            "linear_attn_config": {"num_heads": 2, "head_dim": 8,
+                                   "short_conv_kernel_size": 4,
+                                   "kda_layers": [1, 2, 3]},
+        }
+        family = next(f for f in FAMILIES if f.id == "glm53_flash")
+        resolved = type("R", (), {"descriptor": family,
+                                  "family_config": config, "model_dir": "."})()
+        with self.assertRaisesRegex(ValueError, "disagrees"):
+            planner_geometry(resolved, 32)
+
+    def test_glm53_doctor_plans_but_marks_runtime_pending(self):
+        from doctor import run_doctor
+
+        config = {
+            "model_type": "glm5_next", "text_config": {
+                "model_type": "glm5_next_text", "num_hidden_layers": 4,
+                "hidden_size": 64, "num_attention_heads": 2,
+                "q_lora_rank": 8, "kv_lora_rank": 8,
+                "qk_nope_head_dim": 8, "qk_rope_head_dim": 0,
+                "v_head_dim": 8, "index_head_dim": 4, "hc_mult": 4,
+                "n_routed_experts": 8,
+                "layer_types": ["linear_attention"] * 3 +
+                               ["deepseek_sparse_attention"],
+                "linear_attn_config": {"num_heads": 2, "head_dim": 8,
+                                       "short_conv_kernel_size": 4,
+                                       "kda_layers": [0, 1, 2]},
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "config.json").write_text(json.dumps(config), encoding="utf-8")
+            (root / "tokenizer.json").write_text("{}", encoding="utf-8")
+            # One complete expert spread across three tensors is sufficient to
+            # prove the nested official prefix reaches the inventory path.
+            tensors = [
+                ("model.language_model.embed_tokens.weight", 64),
+                ("model.language_model.layers.3.mlp.experts.0.gate_proj.weight", 32),
+                ("model.language_model.layers.3.mlp.experts.0.up_proj.weight", 32),
+                ("model.language_model.layers.3.mlp.experts.0.down_proj.weight", 32),
+                ("model.language_model.layers.45.mlp.experts.0.gate_proj.weight", 32),
+            ]
+            offset, header, payload = 0, {}, b""
+            for name, size in tensors:
+                header[name] = {"dtype": "U8", "shape": [size],
+                                "data_offsets": [offset, offset + size]}
+                payload += b"\0" * size
+                offset += size
+            raw = json.dumps(header).encode()
+            (root / "model.safetensors").write_bytes(
+                struct.pack("<Q", len(raw)) + raw + payload)
+            report = run_doctor(
+                root, engine_path=root / "glm53_flash",
+                available_memory=16_000_000_000, available_disk=100_000_000_000,
+                gpus=[], linkage={"linked": False, "missing": False})
+        checks = {item["id"]: item for item in report["checks"]}
+        self.assertEqual(checks["model.family"]["status"], "pass")
+        self.assertEqual(checks["engine.binary"]["status"], "skip")
+        self.assertEqual(checks["model.shards"]["status"], "pass")
+        self.assertEqual(report["plan"]["model"]["family_id"], "glm53_flash")
 
     def test_minimax_fixture_can_share_colibri_without_becoming_glm(self):
         config = {
@@ -834,6 +946,7 @@ class FamilyRegistryTest(unittest.TestCase):
         prompt = "hello {world}"
         expected = {
             "glm": "[gMASK]<sop><|user|>hello {world}<|assistant|><think></think>",
+            "glm53_flash": "hello {world}",
             "inkling": "<|user|>hello {world}<|assistant|>",
             "kimi": "K3CHAT1\nM user 13\nhello {world}G 0\n\n",
             "olmoe": "<|user|>\nhello {world}\n<|assistant|>\n",
@@ -906,6 +1019,10 @@ class FamilyRegistryTest(unittest.TestCase):
         install_prerequisites = install_rule.group(1).split("#", 1)[0]
         for family in FAMILIES:
             with self.subTest(family=family.id):
+                if not family.runtime_available:
+                    self.assertFalse(family.has_gateway_adapter)
+                    self.assertFalse(family.has_cli_adapter)
+                    continue
                 self.assertRegex(
                     makefile,
                     rf"(?m)^{re.escape(family.build_target)}(?:\$\(EXE\))?:")

--- a/c/tests/test_family_registry.py
+++ b/c/tests/test_family_registry.py
@@ -177,7 +177,7 @@ class FamilyRegistryTest(unittest.TestCase):
             (root / "config.json").write_text(json.dumps(config), encoding="utf-8")
             resolved = resolve_model(root)
         self.assertEqual(resolved.descriptor.id, "glm53_flash")
-        self.assertFalse(resolved.descriptor.runtime_available)
+        self.assertTrue(resolved.descriptor.runtime_available)
         geometry = planner_geometry(resolved, 4096)
         self.assertEqual(geometry.configured_experts, 288)
         # 34 KDA recurrences + conv4 histories are fixed; 11 DSA latent/index
@@ -213,7 +213,7 @@ class FamilyRegistryTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "disagrees"):
             planner_geometry(resolved, 32)
 
-    def test_glm53_doctor_plans_but_marks_runtime_pending(self):
+    def test_glm53_doctor_requires_the_runtime_binary(self):
         from doctor import run_doctor
 
         config = {
@@ -259,7 +259,7 @@ class FamilyRegistryTest(unittest.TestCase):
                 gpus=[], linkage={"linked": False, "missing": False})
         checks = {item["id"]: item for item in report["checks"]}
         self.assertEqual(checks["model.family"]["status"], "pass")
-        self.assertEqual(checks["engine.binary"]["status"], "skip")
+        self.assertEqual(checks["engine.binary"]["status"], "fail")
         self.assertEqual(checks["model.shards"]["status"], "pass")
         self.assertEqual(report["plan"]["model"]["family_id"], "glm53_flash")
 

--- a/c/tests/test_glm53_cuda_dispatch.c
+++ b/c/tests/test_glm53_cuda_dispatch.c
@@ -1,0 +1,60 @@
+#define COLI_CUDA
+#define main glm53_engine_main
+#include "../glm53_flash.c"
+#undef main
+
+#include "glm53_fp8_case.h"
+
+static int calls;
+static float lut[256];
+
+int coli_cuda_init(const int *devices, int count) { return devices && count == 1; }
+void coli_cuda_shutdown(void) {}
+int coli_cuda_fp8_set_lut(const float *values) {
+    memcpy(lut, values, sizeof(lut));
+    return 1;
+}
+void coli_cuda_tensor_free(ColiCudaTensor *tensor) { (void)tensor; }
+int coli_cuda_matmul(ColiCudaTensor **tensor, float *output, const float *input, const void *weights,
+                     const float *scales, int format, int sequences, int columns, int rows, int device,
+                     int group_size) {
+    if (!tensor || !output || !input || !weights || !scales || format != 8 || sequences != 1 || columns != 128 ||
+        rows != GLM53_FP8_ROWS || device != 0 || group_size != 0)
+        return 0;
+    const uint8_t *bytes = weights;
+    for (int row = 0; row < rows; row++) {
+        float sum = 0.0f;
+        for (int column = 0; column < columns; column++)
+            sum += input[column] * lut[bytes[(size_t)row * columns + column]] *
+                   scales[(row / 128) * (columns / 128) + column / 128];
+        output[row] = sum;
+    }
+    *tensor = (ColiCudaTensor *)(uintptr_t)1;
+    calls++;
+    return 1;
+}
+
+int main(void) {
+    coli_glm53_fp8_decode_table(lut);
+    g_cuda_enabled = 1;
+    g_cuda_device = 0;
+    Matrix matrix = {0};
+    matrix.view.format = COLI_TENSOR_FP8_E4M3_BLOCK;
+    matrix.view.rows = GLM53_FP8_ROWS;
+    matrix.view.columns = GLM53_FP8_COLUMNS;
+    matrix.view.data = glm53_fp8_weight;
+    matrix.view.scales = glm53_fp8_scales;
+    float output[GLM53_FP8_ROWS];
+    matrix_multiply(output, glm53_fp8_input, &matrix, 1);
+    if (calls != 1 || matrix.cuda == NULL) return 1;
+    float maximum = 0.0f;
+    for (int row = 0; row < GLM53_FP8_ROWS; row++)
+        maximum = fmaxf(maximum, fabsf(output[row] - glm53_fp8_expected[row]));
+    if (maximum > 2.0e-5f) {
+        fprintf(stderr, "GLM53 CUDA dispatch mismatch: max abs %.9g\n", maximum);
+        return 1;
+    }
+    matrix_free(&matrix);
+    printf("PASS GLM53 CUDA dispatch with activation QDQ: max abs %.9g\n", maximum);
+    return 0;
+}

--- a/c/tests/test_glm53_engine.py
+++ b/c/tests/test_glm53_engine.py
@@ -7,12 +7,16 @@ from pathlib import Path
 parser = argparse.ArgumentParser()
 parser.add_argument("--binary", type=Path, required=True)
 parser.add_argument("--fixture", type=Path, required=True)
+parser.add_argument("--cached", action="store_true")
 args = parser.parse_args()
 reference = json.loads((args.fixture / "ref.json").read_text())
 prompt = ",".join(str(token) for token in reference["prompt_ids"])
+command = [args.binary.resolve().as_posix(), args.fixture.resolve().as_posix(), "--ids", prompt,
+           "--greedy", str(len(reference["greedy_new_ids"]))]
+if args.cached:
+    command.append("--cached")
 result = subprocess.run(
-    [args.binary.resolve().as_posix(), args.fixture.resolve().as_posix(), "--ids", prompt,
-     "--greedy", str(len(reference["greedy_new_ids"]))],
+    command,
     text=True, capture_output=True, timeout=180,
 )
 if result.returncode:
@@ -32,5 +36,6 @@ if logit_error > 2e-4:
 greedy = [int(line.split()[1]) for line in result.stdout.splitlines() if line.startswith("greedy ")]
 if greedy != reference["greedy_new_ids"]:
     raise SystemExit(f"greedy mismatch\nactual:   {greedy}\nexpected: {reference['greedy_new_ids']}")
-print(f"PASS GLM-5.3 CPU engine: {len(actual)}/{len(expected)} teacher positions exact, "
+mode = "cached" if args.cached else "full"
+print(f"PASS GLM-5.3 CPU {mode} engine: {len(actual)}/{len(expected)} teacher positions exact, "
       f"{len(greedy)} greedy tokens exact, logits max abs {logit_error:.3g}")

--- a/c/tests/test_glm53_engine.py
+++ b/c/tests/test_glm53_engine.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 import argparse
+import unittest
 import json
 import subprocess
 from pathlib import Path
+
+if __name__ != "__main__":
+    raise unittest.SkipTest("command-line GLM-5.3 oracle driver")
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--binary", type=Path, required=True)

--- a/c/tests/test_glm53_engine.py
+++ b/c/tests/test_glm53_engine.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--binary", type=Path, required=True)
+parser.add_argument("--fixture", type=Path, required=True)
+args = parser.parse_args()
+reference = json.loads((args.fixture / "ref.json").read_text())
+prompt = ",".join(str(token) for token in reference["prompt_ids"])
+result = subprocess.run(
+    [args.binary.resolve().as_posix(), args.fixture.resolve().as_posix(), "--ids", prompt,
+     "--greedy", str(len(reference["greedy_new_ids"]))],
+    text=True, capture_output=True, timeout=180,
+)
+if result.returncode:
+    raise SystemExit(f"engine failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+line = next((line for line in result.stdout.splitlines() if line.startswith("teacher ")), None)
+if line is None:
+    raise SystemExit("engine did not emit teacher predictions")
+actual = [int(value) for value in line.split()[1:]]
+expected = reference["teacher_forcing_ids"]
+if actual != expected:
+    raise SystemExit(f"teacher mismatch\nactual:   {actual}\nexpected: {expected}")
+logit_line = next(line for line in result.stdout.splitlines() if line.startswith("last_logits "))
+logits = [float(value) for value in logit_line.split()[1:]]
+logit_error = max(abs(a - b) for a, b in zip(logits, reference["last_logits"], strict=True))
+if logit_error > 2e-4:
+    raise SystemExit(f"last-logit mismatch: max abs {logit_error}")
+greedy = [int(line.split()[1]) for line in result.stdout.splitlines() if line.startswith("greedy ")]
+if greedy != reference["greedy_new_ids"]:
+    raise SystemExit(f"greedy mismatch\nactual:   {greedy}\nexpected: {reference['greedy_new_ids']}")
+print(f"PASS GLM-5.3 CPU engine: {len(actual)}/{len(expected)} teacher positions exact, "
+      f"{len(greedy)} greedy tokens exact, logits max abs {logit_error:.3g}")

--- a/c/tests/test_glm53_fp8.c
+++ b/c/tests/test_glm53_fp8.c
@@ -1,0 +1,23 @@
+#include <math.h>
+#include <stdio.h>
+
+#include "glm53_fp8.h"
+#include "glm53_fp8_case.h"
+
+int main(void) {
+    float output[GLM53_FP8_ROWS];
+    if (coli_glm53_fp8_matvec(output, glm53_fp8_weight, glm53_fp8_scales, glm53_fp8_input, GLM53_FP8_ROWS,
+                              GLM53_FP8_COLUMNS) != 0)
+        return 1;
+    float maximum = 0.0f;
+    for (int row = 0; row < GLM53_FP8_ROWS; row++) {
+        float error = fabsf(output[row] - glm53_fp8_expected[row]);
+        if (error > maximum) maximum = error;
+    }
+    if (maximum > 2.0e-5f) {
+        fprintf(stderr, "GLM53 FP8 mismatch: max abs %.9g\n", maximum);
+        return 1;
+    }
+    printf("PASS GLM53 native FP8 matvec: max abs %.9g\n", maximum);
+    return 0;
+}

--- a/c/tests/test_glm53_indexer.c
+++ b/c/tests/test_glm53_indexer.c
@@ -1,0 +1,22 @@
+#include "glm53_indexer.h"
+#include "glm53_indexer_case.h"
+
+#include <stdio.h>
+
+int main(void) {
+    int output[GLM53_INDEX_SEQUENCE * GLM53_INDEX_WIDTH];
+    if (coli_glm53_index_select(
+            output, glm53_index_queries, glm53_index_keys, glm53_index_gates,
+            glm53_index_weights, glm53_index_ape, glm53_index_valid,
+            GLM53_INDEX_SEQUENCE, GLM53_INDEX_HEADS, GLM53_INDEX_DIM,
+            GLM53_INDEX_POOL, GLM53_INDEX_TOPK)) return 2;
+    for (int i = 0; i < GLM53_INDEX_SEQUENCE * GLM53_INDEX_WIDTH; i++) {
+        if (output[i] != glm53_index_expected[i]) {
+            fprintf(stderr, "GLM53 index mismatch at %d: got %d expected %d\n",
+                    i, output[i], glm53_index_expected[i]);
+            return 1;
+        }
+    }
+    puts("PASS GLM53 DSA k-pool CPU indexer");
+    return 0;
+}

--- a/c/tests/test_glm53_kda.c
+++ b/c/tests/test_glm53_kda.c
@@ -1,0 +1,33 @@
+#include "glm53_kda.h"
+#include "glm53_kda_case.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(void) {
+    float state[GLM53_KDA_HEADS * GLM53_KDA_DIM * GLM53_KDA_DIM] = {0};
+    float window[3 * GLM53_KDA_HEADS * GLM53_KDA_DIM * GLM53_KDA_KERNEL] = {0};
+    float output[GLM53_KDA_HEADS * GLM53_KDA_DIM];
+    float worst = 0.0f;
+    for (int step = 0; step < GLM53_KDA_STEPS; step++) {
+        if (coli_glm53_kda_step(
+                output, state, window,
+                glm53_kda_qkv + step * 3 * GLM53_KDA_HEADS * GLM53_KDA_DIM,
+                glm53_kda_conv,
+                glm53_kda_decay + step * GLM53_KDA_HEADS * GLM53_KDA_DIM,
+                glm53_kda_beta + step * GLM53_KDA_HEADS, GLM53_KDA_HEADS,
+                GLM53_KDA_DIM, GLM53_KDA_KERNEL)) return 2;
+        for (int i = 0; i < GLM53_KDA_HEADS * GLM53_KDA_DIM; i++) {
+            float error = fabsf(
+                output[i] - glm53_kda_output[step * GLM53_KDA_HEADS * GLM53_KDA_DIM + i]);
+            if (error > worst) worst = error;
+        }
+    }
+    if (worst > 2.0e-5f) {
+        fprintf(stderr, "GLM53 KDA mismatch: max abs %.9g\n", worst);
+        return 1;
+    }
+    printf("PASS GLM53 KDA recurrent CPU kernel: max abs %.9g\n", worst);
+    return 0;
+}

--- a/c/tests/test_glm53_metal_dispatch.c
+++ b/c/tests/test_glm53_metal_dispatch.c
@@ -1,0 +1,54 @@
+#define COLI_METAL
+#define main glm53_engine_main
+#include "../glm53_flash.c"
+#undef main
+
+#include "glm53_fp8_case.h"
+
+static int calls;
+static float lut[256];
+
+int coli_metal_init(void) { return 1; }
+void coli_metal_shutdown(void) {}
+void coli_metal_tensor_free(ColiMetalTensor *tensor) { (void)tensor; }
+int coli_metal_matmul(ColiMetalTensor **tensor, float *output, const float *input, const void *weights,
+                      const float *scales, int format, int sequences, int columns, int rows, int group_size) {
+    if (!tensor || !output || !input || !weights || !scales || format != 8 || sequences != 1 || columns != 128 ||
+        rows != GLM53_FP8_ROWS || group_size != 0)
+        return 0;
+    const uint8_t *bytes = weights;
+    for (int row = 0; row < rows; row++) {
+        float sum = 0.0f;
+        for (int column = 0; column < columns; column++)
+            sum += input[column] * lut[bytes[(size_t)row * columns + column]] *
+                   scales[(row / 128) * (columns / 128) + column / 128];
+        output[row] = sum;
+    }
+    *tensor = (ColiMetalTensor *)(uintptr_t)1;
+    calls++;
+    return 1;
+}
+
+int main(void) {
+    coli_glm53_fp8_decode_table(lut);
+    g_metal_enabled = 1;
+    Matrix matrix = {0};
+    matrix.view.format = COLI_TENSOR_FP8_E4M3_BLOCK;
+    matrix.view.rows = GLM53_FP8_ROWS;
+    matrix.view.columns = GLM53_FP8_COLUMNS;
+    matrix.view.data = glm53_fp8_weight;
+    matrix.view.scales = glm53_fp8_scales;
+    float output[GLM53_FP8_ROWS];
+    matrix_multiply(output, glm53_fp8_input, &matrix, 1);
+    if (calls != 1 || matrix.metal == NULL) return 1;
+    float maximum = 0.0f;
+    for (int row = 0; row < GLM53_FP8_ROWS; row++)
+        maximum = fmaxf(maximum, fabsf(output[row] - glm53_fp8_expected[row]));
+    if (maximum > 2.0e-5f) {
+        fprintf(stderr, "GLM53 Metal dispatch mismatch: max abs %.9g\n", maximum);
+        return 1;
+    }
+    matrix_free(&matrix);
+    printf("PASS GLM53 Metal dispatch with activation QDQ: max abs %.9g\n", maximum);
+    return 0;
+}

--- a/c/tests/test_glm53_mhc.c
+++ b/c/tests/test_glm53_mhc.c
@@ -1,0 +1,39 @@
+#include "glm53_mhc.h"
+#include "glm53_mhc_case.h"
+
+#include <math.h>
+#include <stdio.h>
+
+static float check(const float *actual, const float *expected, int count) {
+    float worst = 0.0f;
+    for (int i = 0; i < count; i++) {
+        float error = fabsf(actual[i] - expected[i]);
+        if (error > worst) worst = error;
+    }
+    return worst;
+}
+
+int main(void) {
+    float collapsed[GLM53_MHC_DIM], post[GLM53_MHC_COPIES];
+    float comb[GLM53_MHC_COPIES * GLM53_MHC_COPIES];
+    float output[GLM53_MHC_COPIES * GLM53_MHC_DIM];
+    if (coli_glm53_mhc_pre(collapsed, post, comb, glm53_mhc_streams,
+            glm53_mhc_function, glm53_mhc_scale, glm53_mhc_base,
+            GLM53_MHC_COPIES, GLM53_MHC_DIM, GLM53_MHC_ITERATIONS,
+            1.0e-5f, 1.0e-6f)) return 2;
+    if (coli_glm53_mhc_post(output, glm53_mhc_branch, glm53_mhc_streams,
+            post, comb, GLM53_MHC_COPIES, GLM53_MHC_DIM)) return 2;
+    float worst = check(collapsed, glm53_mhc_collapsed, GLM53_MHC_DIM);
+    float value = check(post, glm53_mhc_post, GLM53_MHC_COPIES);
+    if (value > worst) worst = value;
+    value = check(comb, glm53_mhc_comb, GLM53_MHC_COPIES * GLM53_MHC_COPIES);
+    if (value > worst) worst = value;
+    value = check(output, glm53_mhc_output, GLM53_MHC_COPIES * GLM53_MHC_DIM);
+    if (value > worst) worst = value;
+    if (worst > 2.0e-5f) {
+        fprintf(stderr, "GLM53 mHC mismatch: %.9g\n", worst);
+        return 1;
+    }
+    printf("PASS GLM53 mHC CPU collapse/expand: max abs %.9g\n", worst);
+    return 0;
+}

--- a/c/tests/test_glm53_serve.py
+++ b/c/tests/test_glm53_serve.py
@@ -3,7 +3,11 @@ import argparse
 import os
 import subprocess
 import sys
+import unittest
 from pathlib import Path
+
+if __name__ != "__main__":
+    raise unittest.SkipTest("command-line GLM-5.3 gateway driver")
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--binary", type=Path, required=True)

--- a/c/tests/test_glm53_serve.py
+++ b/c/tests/test_glm53_serve.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--binary", type=Path, required=True)
+parser.add_argument("--fixture", type=Path, required=True)
+args = parser.parse_args()
+payload = "".join(f"<t{token:03d}>" for token in [5, 7, 9, 11, 13, 17, 19, 23]).encode()
+environment = dict(os.environ, SERVE="1", SERVE_BATCH="1", SNAP=str(args.fixture.resolve()))
+process = subprocess.Popen([str(args.binary.resolve()), "8"], stdin=subprocess.PIPE,
+                           stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=environment)
+try:
+    assert process.stdout.readline() == b"\x01\x01READY\x01\x01\n"
+    assert process.stdout.readline().startswith(b"STAT ")
+    process.stdin.write(f"SUBMIT request-1 0 {len(payload)} 1 0 1\n".encode() + payload + b"\n")
+    process.stdin.flush()
+    assert process.stdout.readline() == b"ACCEPT request-1 8\n"
+    assert process.stdout.readline() == b"DATA request-1 6\n"
+    assert process.stdout.readline() == b"<t024>\n"
+    done = process.stdout.readline().decode().split()
+    assert done[:3] == ["DONE", "request-1", "STAT"]
+    assert done[3] == "1" and done[7:] == ["8", "1"]
+finally:
+    process.stdin.close()
+    process.wait(timeout=10)
+assert process.returncode == 0, process.stderr.read().decode()
+
+# Exercise the same Engine adapter used by /v1/chat/completions, not merely the
+# child protocol in isolation.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import openai_server
+from family_registry import family_by_id
+
+openai_server.ARCH = "glm53_flash"
+engine = openai_server.Engine(args.binary.resolve(), args.fixture.resolve(), cap=1,
+                              max_tokens=1, family=family_by_id("glm53_flash"))
+chunks = []
+try:
+    stats = engine.generate(payload.decode(), 1, 0.0, 1.0, chunks.append)
+finally:
+    engine.close()
+assert "".join(chunks) == "<t024>"
+assert stats["prompt_tokens"] == 8 and stats["completion_tokens"] == 1
+print("PASS GLM-5.3 gateway adapter: READY, ACCEPT, DATA, DONE")

--- a/c/tests/test_glm53_sparse_attention.c
+++ b/c/tests/test_glm53_sparse_attention.c
@@ -1,0 +1,24 @@
+#include "glm53_sparse_attention.h"
+#include "glm53_sparse_attention_case.h"
+
+#include <math.h>
+#include <stdio.h>
+
+int main(void) {
+    float output[GLM53_SA_SEQUENCE * GLM53_SA_HEADS * GLM53_SA_VALUE_DIM];
+    if (coli_glm53_sparse_attention(
+            output, glm53_sa_queries, glm53_sa_keys, glm53_sa_values,
+            glm53_sa_indices, GLM53_SA_SEQUENCE, GLM53_SA_WIDTH,
+            GLM53_SA_HEADS, GLM53_SA_KEY_DIM, GLM53_SA_VALUE_DIM)) return 2;
+    float worst = 0.0f;
+    for (int i = 0; i < GLM53_SA_SEQUENCE * GLM53_SA_HEADS * GLM53_SA_VALUE_DIM; i++) {
+        float error = fabsf(output[i] - glm53_sa_expected[i]);
+        if (error > worst) worst = error;
+    }
+    if (worst > 2.0e-5f) {
+        fprintf(stderr, "GLM53 sparse attention mismatch: %.9g\n", worst);
+        return 1;
+    }
+    printf("PASS GLM53 DSA sparse CPU attention: max abs %.9g\n", worst);
+    return 0;
+}

--- a/c/tests/test_glm53_tiny.py
+++ b/c/tests/test_glm53_tiny.py
@@ -17,6 +17,7 @@ def safetensors_header(path: Path) -> dict[str, object]:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--fixture", type=Path, required=True)
+    parser.add_argument("--expect-fp8", action="store_true")
     args = parser.parse_args()
     config = json.loads((args.fixture / "config.json").read_text())
     text = config["text_config"]
@@ -52,6 +53,11 @@ def main() -> int:
     assert not missing, f"missing production-layout tensors: {sorted(missing)}"
     assert not any("experts.gate_up_proj" in name for name in header)
     assert not any("self_attn.conv1d.weight" in name for name in header)
+    if args.expect_fp8:
+        assert config["quantization_config"]["weight_block_size"] == [128, 128]
+        matrix = "model.language_model.layers.0.mlp.gate_proj.weight"
+        assert header[matrix]["dtype"] == "F8_E4M3"
+        assert header[matrix + "_scale_inv"]["dtype"] == "F32"
     print("PASS GLM-5.3 tiny oracle contract")
     return 0
 

--- a/c/tests/test_glm53_tiny.py
+++ b/c/tests/test_glm53_tiny.py
@@ -38,7 +38,10 @@ def main() -> int:
     header = safetensors_header(args.fixture / "model.safetensors")
     required = {
         "model.language_model.layers.0.self_attn.q_proj.weight",
-        "model.language_model.layers.0.self_attn.conv1d.weight",
+        "model.language_model.layers.0.self_attn.q_conv1d.weight",
+        "model.language_model.layers.0.self_attn.k_conv1d.weight",
+        "model.language_model.layers.0.self_attn.v_conv1d.weight",
+        "model.language_model.layers.0.hc_attn_fn",
         "model.language_model.layers.3.self_attn.indexer.wk.weight",
         "model.language_model.layers.3.mlp.experts.0.gate_proj.weight",
         "model.language_model.layers.3.mlp.experts.3.down_proj.weight",
@@ -48,6 +51,7 @@ def main() -> int:
     missing = required - header.keys()
     assert not missing, f"missing production-layout tensors: {sorted(missing)}"
     assert not any("experts.gate_up_proj" in name for name in header)
+    assert not any("self_attn.conv1d.weight" in name for name in header)
     print("PASS GLM-5.3 tiny oracle contract")
     return 0
 

--- a/c/tests/test_glm53_tiny.py
+++ b/c/tests/test_glm53_tiny.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Dependency-free contract checks for the generated GLM-5.3 tiny oracle."""
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+from pathlib import Path
+
+
+def safetensors_header(path: Path) -> dict[str, object]:
+    with path.open("rb") as stream:
+        size = struct.unpack("<Q", stream.read(8))[0]
+        return json.loads(stream.read(size))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", type=Path, required=True)
+    args = parser.parse_args()
+    config = json.loads((args.fixture / "config.json").read_text())
+    text = config["text_config"]
+    assert config["model_type"] == "glm5_next"
+    assert text["layer_types"] == ["linear_attention"] * 3 + ["deepseek_sparse_attention"]
+    assert text["mlp_layer_types"] == ["dense"] * 3 + ["sparse"]
+    assert text["linear_attn_config"]["kda_layers"] == [0, 1, 2]
+
+    reference = json.loads((args.fixture / "ref.json").read_text())
+    assert reference["source"] == "transformers"
+    assert reference["transformers_version"] == "5.16.1"
+    assert len(reference["prompt_ids"]) == len(reference["teacher_forcing_ids"])
+    assert len(reference["last_logits_top_ids"]) == 8
+    assert reference["cache_max_abs_delta"] <= 1e-5
+    assert [state["kind"] for state in reference["cache_shapes"]] == [
+        "kda", "kda", "kda", "dsa"
+    ]
+
+    header = safetensors_header(args.fixture / "model.safetensors")
+    required = {
+        "model.language_model.layers.0.self_attn.q_proj.weight",
+        "model.language_model.layers.0.self_attn.conv1d.weight",
+        "model.language_model.layers.3.self_attn.indexer.wk.weight",
+        "model.language_model.layers.3.mlp.experts.0.gate_proj.weight",
+        "model.language_model.layers.3.mlp.experts.3.down_proj.weight",
+        "model.language_model.layers.3.mlp.shared_experts.up_proj.weight",
+        "lm_head.weight",
+    }
+    missing = required - header.keys()
+    assert not missing, f"missing production-layout tensors: {sorted(missing)}"
+    assert not any("experts.gate_up_proj" in name for name in header)
+    print("PASS GLM-5.3 tiny oracle contract")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/c/tests/test_launcher_dispatch.py
+++ b/c/tests/test_launcher_dispatch.py
@@ -71,6 +71,8 @@ class LauncherDispatchTest(unittest.TestCase):
         """Two families must not resolve to the same binary. That is the shape
         the bug took: everything unrecognised quietly became the GLM engine."""
         for family in all_families():
+            if not family.runtime_available:
+                continue
             model_type = family.model_types[0]
             with self.subTest(model_type=model_type):
                 engine = os.path.basename(

--- a/c/tests/test_segment_conformance.c
+++ b/c/tests/test_segment_conformance.c
@@ -5,7 +5,7 @@
 
 static int expected_family(const char *family_id) {
     static const char *const expected[] = {
-        "glm", "inkling", "kimi", "olmoe", "qwen36", "deepseek_v4",
+        "glm", "glm53_flash", "inkling", "kimi", "olmoe", "qwen36", "deepseek_v4",
     };
     for (size_t i = 0; i < sizeof(expected) / sizeof(expected[0]); i++)
         if (strcmp(expected[i], family_id) == 0) return 1;
@@ -13,7 +13,7 @@ static int expected_family(const char *family_id) {
 }
 
 int main(void) {
-    const size_t required_families = 6;
+    const size_t required_families = 7;
     size_t count = coli_segment_conformance_fixture_count();
     if (count != required_families) {
         fprintf(stderr, "segment conformance requires %zu families, found %zu\n",

--- a/c/tests/test_segment_conformance_manifest.py
+++ b/c/tests/test_segment_conformance_manifest.py
@@ -20,9 +20,10 @@ class SegmentConformanceManifestTest(unittest.TestCase):
     def test_is_all_registered_families_gate(self):
         self.assertEqual(self.manifest["version"], 1)
         self.assertEqual(
-            self.manifest["release_policy"], "all_registered_families")
+            self.manifest["release_policy"], "all_runnable_families")
         manifest_ids = [entry["family_id"] for entry in self.entries]
-        registry_ids = [family.id for family in FAMILIES]
+        registry_ids = [family.id for family in FAMILIES
+                        if family.runtime_available]
         self.assertEqual(manifest_ids, registry_ids)
         self.assertEqual(len(manifest_ids), len(set(manifest_ids)))
 

--- a/c/tools/check_glm53_checkpoint.py
+++ b/c/tools/check_glm53_checkpoint.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Validate the tensors consumed by the GLM-5.3 text runtime."""
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+from pathlib import Path
+
+
+def read_header(path: Path) -> dict[str, object]:
+    with path.open("rb") as stream:
+        size = struct.unpack("<Q", stream.read(8))[0]
+        return json.loads(stream.read(size))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path)
+    parser.add_argument("--config", type=Path)
+    parser.add_argument("--headers-json", type=Path)
+    parser.add_argument("--require-fp8", action="store_true")
+    args = parser.parse_args()
+    if not args.model and not (args.config and args.headers_json):
+        parser.error("provide --model or both --config and --headers-json")
+    config_path = args.config or args.model / "config.json"
+    config = json.loads(config_path.read_text())
+    text = config["text_config"]
+    if args.headers_json:
+        tensors = json.loads(args.headers_json.read_text())
+    else:
+        tensors = {}
+        for shard in sorted(args.model.glob("*.safetensors")):
+            tensors.update({name: spec for name, spec in read_header(shard).items()
+                            if name != "__metadata__"})
+    failures: list[str] = []
+
+    def tensor(name: str, shape: list[int], dtypes=("BF16", "F32")) -> None:
+        actual = tensors.get(name)
+        if not actual:
+            failures.append(f"missing {name}")
+        elif actual["shape"] != shape or actual["dtype"] not in dtypes:
+            failures.append(f"invalid {name}: {actual['dtype']} {actual['shape']}, expected {dtypes} {shape}")
+
+    def matrix(name: str, rows: int, columns: int, fp8: bool) -> None:
+        actual = tensors.get(name)
+        if not actual:
+            failures.append(f"missing {name}")
+            return
+        if actual["shape"] != [rows, columns]:
+            failures.append(f"invalid shape {name}: {actual['shape']}")
+            return
+        if actual["dtype"] == "F8_E4M3":
+            scale = name + "_scale_inv"
+            tensor(scale, [(rows + 127) // 128, (columns + 127) // 128], ("F32",))
+        elif actual["dtype"] not in ("BF16", "F32") or (fp8 and args.require_fp8):
+            failures.append(f"invalid dtype {name}: {actual['dtype']}")
+
+    hidden = text["hidden_size"]
+    layers = text["num_hidden_layers"]
+    heads = text["num_attention_heads"]
+    key_dim = text["qk_nope_head_dim"] + text["qk_rope_head_dim"]
+    value_dim = text["v_head_dim"]
+    q_rank = text["q_lora_rank"]
+    kv_rank = text["kv_lora_rank"]
+    index_heads = text["index_n_heads"]
+    index_dim = text["index_head_dim"]
+    hc = text["hc_mult"]
+    linear = text["linear_attn_config"]
+    kda_heads, kda_dim = linear["num_heads"], linear["head_dim"]
+    kda_width = kda_heads * kda_dim
+    prefix = "model.language_model."
+    tensor(prefix + "embed_tokens.weight", [text["vocab_size"], hidden])
+    tensor(prefix + "norm.weight", [hidden])
+    tensor("lm_head.weight", [text["vocab_size"], hidden])
+    for layer in range(layers):
+        base = f"{prefix}layers.{layer}."
+        tensor(base + "input_layernorm.weight", [hidden])
+        tensor(base + "post_attention_layernorm.weight", [hidden])
+        mix = (2 + hc) * hc
+        for site in ("attn", "ffn"):
+            tensor(base + f"hc_{site}_fn", [mix, hc * hidden])
+            tensor(base + f"hc_{site}_base", [mix])
+            tensor(base + f"hc_{site}_scale", [3])
+        if text["layer_types"][layer] == "linear_attention":
+            for projection in ("q", "k", "v"):
+                matrix(base + f"self_attn.{projection}_proj.weight", kda_width, hidden, False)
+                tensor(base + f"self_attn.{projection}_conv1d.weight",
+                       [kda_width, 1, linear["short_conv_kernel_size"]])
+            matrix(base + "self_attn.f_a_proj.weight", kda_dim, hidden, False)
+            matrix(base + "self_attn.f_b_proj.weight", kda_width, kda_dim, False)
+            tensor(base + "self_attn.dt_bias", [kda_width], ("F32", "BF16"))
+            tensor(base + "self_attn.A_log", [kda_heads], ("F32", "BF16"))
+            matrix(base + "self_attn.b_proj.weight", kda_heads, hidden, False)
+            matrix(base + "self_attn.g_a_proj.weight", kda_dim, hidden, False)
+            matrix(base + "self_attn.g_b_proj.weight", kda_width, kda_dim, False)
+            tensor(base + "self_attn.o_norm.weight", [kda_dim])
+            matrix(base + "self_attn.o_proj.weight", hidden, kda_width, False)
+        else:
+            matrix(base + "self_attn.q_a_proj.weight", q_rank, hidden, True)
+            tensor(base + "self_attn.q_a_layernorm.weight", [q_rank])
+            matrix(base + "self_attn.q_b_proj.weight", heads * key_dim, q_rank, True)
+            matrix(base + "self_attn.kv_a_proj_with_mqa.weight", kv_rank, hidden, True)
+            tensor(base + "self_attn.kv_a_layernorm.weight", [kv_rank])
+            matrix(base + "self_attn.kv_b_proj.weight", heads * (key_dim + value_dim), kv_rank, False)
+            matrix(base + "self_attn.o_proj.weight", hidden, heads * value_dim, True)
+            matrix(base + "self_attn.indexer.wq_b.weight", index_heads * index_dim, q_rank, False)
+            matrix(base + "self_attn.indexer.wk.weight", index_dim, hidden, False)
+            tensor(base + "self_attn.indexer.k_norm.weight", [index_dim])
+            tensor(base + "self_attn.indexer.k_norm.bias", [index_dim])
+            matrix(base + "self_attn.indexer.index_kpool_compress_gate", index_dim, hidden, False)
+            matrix(base + "self_attn.indexer.weights_proj.weight", index_heads, hidden, False)
+            tensor(base + "self_attn.indexer.index_kpool_compress_ape", [text["index_kpool"], index_dim])
+        if text["mlp_layer_types"][layer] == "dense":
+            intermediate = text["intermediate_size"]
+            matrix(base + "mlp.gate_proj.weight", intermediate, hidden, True)
+            matrix(base + "mlp.up_proj.weight", intermediate, hidden, True)
+            matrix(base + "mlp.down_proj.weight", hidden, intermediate, True)
+        else:
+            intermediate = text["moe_intermediate_size"]
+            matrix(base + "mlp.gate.weight", text["n_routed_experts"], hidden, False)
+            tensor(base + "mlp.gate.e_score_correction_bias", [text["n_routed_experts"]])
+            for part, rows, columns in (("gate", intermediate, hidden), ("up", intermediate, hidden),
+                                        ("down", hidden, intermediate)):
+                matrix(base + f"mlp.shared_experts.{part}_proj.weight", rows, columns, True)
+                for expert in range(text["n_routed_experts"]):
+                    matrix(base + f"mlp.experts.{expert}.{part}_proj.weight", rows, columns, True)
+    if failures:
+        raise SystemExit("GLM-5.3 checkpoint contract failed:\n" + "\n".join(failures[:50]))
+    print(f"PASS GLM-5.3 checkpoint contract: {layers} layers, {len(tensors)} tensors")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/c/tools/make_glm53_tiny.py
+++ b/c/tools/make_glm53_tiny.py
@@ -189,7 +189,13 @@ def write_c_array(stream, name: str, tensor, dimensions: str) -> None:
     values = tensor.detach().float().reshape(-1).tolist()
     stream.write(f"static const float {name}{dimensions} = {{\n")
     for start in range(0, len(values), 8):
-        row = ", ".join(f"{value:.9g}f" for value in values[start:start + 8])
+        literals = []
+        for value in values[start:start + 8]:
+            literal = f"{value:.9g}"
+            if "." not in literal and "e" not in literal:
+                literal += ".0"
+            literals.append(literal + "f")
+        row = ", ".join(literals)
         stream.write(f"  {row},\n")
     stream.write("};\n\n")
 
@@ -234,6 +240,72 @@ def write_kda_case(torch, model, output: Path) -> None:
         stream.write("#endif\n")
 
 
+def write_indexer_case(torch, model, output: Path) -> None:
+    attention = model.layers[3].self_attn
+    indexer = attention.indexer
+    ids = torch.arange(8).view(1, -1)
+    values = torch.arange(8 * HIDDEN, dtype=torch.float32).view(1, 8, HIDDEN)
+    hidden = torch.sin(values * 0.013) + 0.2 * torch.cos(values * 0.031)
+    base = torch.linspace(-1.0, 1.0, indexer.head_dim)
+    perturb = torch.sin(torch.arange(indexer.head_dim, dtype=torch.float32) * 0.37)
+    for token in range(ids.shape[1]):
+        hidden[0, token, :indexer.head_dim] = base + (token + 1) * 0.01 * perturb
+    q_resid = torch.zeros_like(hidden)
+    q_resid[..., :indexer.head_dim] = base
+    with torch.no_grad():
+        indexer.wk.weight.zero_()
+        indexer.wq_b.weight.zero_()
+        for dim in range(indexer.head_dim):
+            indexer.wk.weight[dim, dim] = 1.0
+            for head in range(indexer.n_heads):
+                indexer.wq_b.weight[head * indexer.head_dim + dim, dim] = 1.0
+        indexer.weights_proj.weight.copy_(
+            torch.linspace(0.001, 0.01, indexer.weights_proj.weight.numel()).view_as(
+                indexer.weights_proj.weight
+            )
+        )
+        indexer.index_kpool_compress_gate.copy_(
+            torch.linspace(-0.01, 0.01, indexer.index_kpool_compress_gate.numel()).view_as(
+                indexer.index_kpool_compress_gate
+            )
+        )
+        indexer.index_kpool_compress_ape.copy_(
+            torch.linspace(-0.1, 0.1, indexer.index_kpool_compress_ape.numel()).view_as(
+                indexer.index_kpool_compress_ape
+            )
+        )
+    queries = indexer.wq_b(q_resid).view(1, ids.shape[1], indexer.n_heads, indexer.head_dim)
+    keys = indexer.k_norm(indexer.wk(hidden))
+    gates = torch.nn.functional.linear(hidden, indexer.index_kpool_compress_gate)
+    weights = indexer.weights_proj(hidden) * (indexer.n_heads ** -0.5)
+    valid = torch.ones_like(ids, dtype=torch.bool)
+    with torch.no_grad():
+        expected = indexer(hidden, q_resid, valid, None)
+    with output.open("w", encoding="utf-8") as stream:
+        stream.write("#ifndef COLIBRI_GLM53_INDEXER_CASE_H\n#define COLIBRI_GLM53_INDEXER_CASE_H\n\n")
+        stream.write(f"#define GLM53_INDEX_SEQUENCE {ids.shape[1]}\n")
+        stream.write(f"#define GLM53_INDEX_HEADS {indexer.n_heads}\n")
+        stream.write(f"#define GLM53_INDEX_DIM {indexer.head_dim}\n")
+        stream.write(f"#define GLM53_INDEX_POOL {indexer.index_kpool}\n")
+        stream.write(f"#define GLM53_INDEX_TOPK {indexer.index_topk}\n")
+        stream.write("#define GLM53_INDEX_WIDTH (GLM53_INDEX_TOPK + GLM53_INDEX_POOL - 1)\n\n")
+        write_c_array(stream, "glm53_index_queries", queries,
+                      "[GLM53_INDEX_SEQUENCE * GLM53_INDEX_HEADS * GLM53_INDEX_DIM]")
+        write_c_array(stream, "glm53_index_keys", keys,
+                      "[GLM53_INDEX_SEQUENCE * GLM53_INDEX_DIM]")
+        write_c_array(stream, "glm53_index_gates", gates,
+                      "[GLM53_INDEX_SEQUENCE * GLM53_INDEX_DIM]")
+        write_c_array(stream, "glm53_index_weights", weights,
+                      "[GLM53_INDEX_SEQUENCE * GLM53_INDEX_HEADS]")
+        write_c_array(stream, "glm53_index_ape", indexer.index_kpool_compress_ape,
+                      "[GLM53_INDEX_POOL * GLM53_INDEX_DIM]")
+        valid_values = ", ".join("1" if value else "0" for value in valid.reshape(-1).tolist())
+        stream.write(f"static const unsigned char glm53_index_valid[GLM53_INDEX_SEQUENCE] = {{{valid_values}}};\n")
+        expected_values = ", ".join(str(value) for value in expected.reshape(-1).tolist())
+        stream.write("static const int glm53_index_expected[GLM53_INDEX_SEQUENCE * GLM53_INDEX_WIDTH] = {\n")
+        stream.write(f"  {expected_values}\n}};\n\n#endif\n")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     default = Path(__file__).resolve().parents[1] / "glm53_tiny"
@@ -267,6 +339,7 @@ def main() -> int:
         json.dumps(reference, indent=2) + "\n", encoding="utf-8"
     )
     write_kda_case(torch, model, output / "glm53_kda_case.h")
+    write_indexer_case(torch, model, output / "glm53_indexer_case.h")
     size = sum(path.stat().st_size for path in output.iterdir())
     print(f"wrote {output} ({len(weights)} tensors, {size} bytes)")
     return 0

--- a/c/tools/make_glm53_tiny.py
+++ b/c/tools/make_glm53_tiny.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Generate the deterministic GLM-5.3-Flash text oracle contract.
+
+The fixture is deliberately produced by Hugging Face's official
+Glm5NextTextModel.  It covers KDA, DSA, mHC, dense FFN and routed MoE before a
+Colibri runtime exists, so the future engine has an independent target instead
+of validating itself.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from collections import OrderedDict
+from pathlib import Path
+
+
+SEED = 1243
+VOCAB = 128
+HIDDEN = 128
+LAYERS = 4
+HEADS = 4
+HEAD_DIM = 32
+EXPERTS = 4
+TOPK = 2
+MOE = 128
+
+
+def require_dependencies():
+    try:
+        import torch
+        import transformers
+        from safetensors.torch import save_file
+        from transformers import Glm5NextTextConfig
+        from transformers.models.glm5_next.modeling_glm5_next import Glm5NextTextModel
+    except Exception as exc:  # pragma: no cover - regeneration diagnostic
+        raise SystemExit(
+            "GLM-5.3 tiny generation requires the pinned PyTorch, "
+            "Transformers and safetensors dependencies"
+        ) from exc
+    if transformers.__version__ != "5.16.1":
+        raise SystemExit(
+            f"expected Transformers 5.16.1, found {transformers.__version__}"
+        )
+    return torch, transformers, save_file, Glm5NextTextConfig, Glm5NextTextModel
+
+
+def config_kwargs() -> dict[str, object]:
+    return {
+        "vocab_size": VOCAB,
+        "hidden_size": HIDDEN,
+        "intermediate_size": 256,
+        "moe_intermediate_size": MOE,
+        "num_hidden_layers": LAYERS,
+        "num_attention_heads": HEADS,
+        "num_key_value_heads": HEADS,
+        "n_shared_experts": 1,
+        "n_routed_experts": EXPERTS,
+        "num_experts_per_tok": TOPK,
+        "kv_lora_rank": 64,
+        "q_lora_rank": 128,
+        "qk_rope_head_dim": 0,
+        "qk_nope_head_dim": HEAD_DIM,
+        "v_head_dim": HEAD_DIM,
+        "max_position_embeddings": 128,
+        "layer_types": ["linear_attention"] * 3 + ["deepseek_sparse_attention"],
+        "mlp_layer_types": ["dense"] * 3 + ["sparse"],
+        "indexer_types": ["full"] * LAYERS,
+        "index_topk": 4,
+        "index_kpool": 2,
+        "index_head_dim": HEAD_DIM,
+        "index_n_heads": 2,
+        "linear_head_dim": HEAD_DIM,
+        "linear_num_heads": HEADS,
+        "linear_conv_kernel_dim": 4,
+        "hc_mult": 2,
+        "hc_sinkhorn_iters": 3,
+        "pad_token_id": None,
+        "bos_token_id": 0,
+        "eos_token_id": 1,
+        "tie_word_embeddings": False,
+    }
+
+
+def runtime_config(version: str) -> dict[str, object]:
+    text = config_kwargs()
+    text.update({
+        "model_type": "glm5_next_text",
+        "linear_attn_config": {
+            "num_heads": HEADS,
+            "head_dim": HEAD_DIM,
+            "short_conv_kernel_size": 4,
+            "kda_layers": [0, 1, 2],
+        },
+        "num_nextn_predict_layers": 0,
+    })
+    return {
+        "architectures": ["Glm5NextForConditionalGeneration"],
+        "model_type": "glm5_next",
+        "transformers_version": version,
+        "torch_dtype": "float32",
+        "text_config": text,
+    }
+
+
+def production_layout(torch, model, head) -> OrderedDict[str, object]:
+    """Use production prefixes and split HF's fused tiny expert tensors."""
+    output: OrderedDict[str, object] = OrderedDict()
+    for name, tensor in model.state_dict().items():
+        prefix = "model.language_model."
+        if name.endswith("mlp.experts.gate_up_proj"):
+            base = prefix + name.removesuffix("gate_up_proj")
+            for expert in range(EXPERTS):
+                output[f"{base}{expert}.gate_proj.weight"] = tensor[expert, :MOE].contiguous()
+                output[f"{base}{expert}.up_proj.weight"] = tensor[expert, MOE:].contiguous()
+        elif name.endswith("mlp.experts.down_proj"):
+            base = prefix + name.removesuffix("down_proj")
+            for expert in range(EXPERTS):
+                output[f"{base}{expert}.down_proj.weight"] = tensor[expert].contiguous()
+        else:
+            output[prefix + name] = tensor.detach().contiguous()
+    output["lm_head.weight"] = head.weight.detach().contiguous()
+    return output
+
+
+def make_tokenizer() -> dict[str, object]:
+    added = [
+        {"id": token, "content": f"<t{token:03d}>", "single_word": False,
+         "lstrip": False, "rstrip": False, "normalized": False, "special": True}
+        for token in range(VOCAB)
+    ]
+    return {
+        "version": "1.0", "truncation": None, "padding": None,
+        "added_tokens": added, "normalizer": None, "pre_tokenizer": None,
+        "post_processor": None, "decoder": None,
+        "model": {"type": "BPE", "dropout": None, "unk_token": None,
+                  "continuing_subword_prefix": "", "end_of_word_suffix": "",
+                  "fuse_unk": False, "byte_fallback": False,
+                  "ignore_merges": True, "vocab": {"x": VOCAB - 1}, "merges": []},
+    }
+
+
+def oracle(torch, transformers, model, head) -> dict[str, object]:
+    prompt = [5, 7, 9, 11, 13, 17, 19, 23]
+    ids = torch.tensor([prompt], dtype=torch.long)
+    with torch.no_grad():
+        full_hidden = model(ids, use_cache=False).last_hidden_state
+        full_logits = head(full_hidden)
+        prefix = model(ids[:, :-1], use_cache=True)
+        incremental = model(
+            ids[:, -1:], use_cache=True, past_key_values=prefix.past_key_values
+        )
+        incremental_logits = head(incremental.last_hidden_state)[:, -1]
+    delta = float((full_logits[:, -1] - incremental_logits).abs().max())
+    if delta > 1e-5:
+        raise RuntimeError(f"prefill/incremental cache mismatch: {delta}")
+    top_values, top_indices = full_logits[0, -1].topk(8)
+    cache_shapes = []
+    for layer in prefix.past_key_values.layers:
+        if hasattr(layer, "recurrent_states"):
+            cache_shapes.append({
+                "kind": "kda",
+                "conv": list(layer.conv_states[0].shape),
+                "recurrent": list(layer.recurrent_states[0].shape),
+            })
+        else:
+            cache_shapes.append({
+                "kind": "dsa",
+                "keys": list(layer.keys.shape),
+                "values": list(layer.values.shape),
+                "indexer": list(layer.indexer_keys.shape),
+            })
+    return {
+        "schema_version": 1,
+        "source": "transformers",
+        "transformers_version": transformers.__version__,
+        "torch_version": torch.__version__,
+        "seed": SEED,
+        "prompt_ids": prompt,
+        "teacher_forcing_ids": full_logits[0].argmax(-1).tolist(),
+        "last_logits_top_ids": top_indices.tolist(),
+        "last_logits_top_values": top_values.tolist(),
+        "cache_max_abs_delta": delta,
+        "cache_shapes": cache_shapes,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    default = Path(__file__).resolve().parents[1] / "glm53_tiny"
+    parser.add_argument("--output", type=Path, default=default)
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+    torch, transformers, save_file, Config, Model = require_dependencies()
+    torch.manual_seed(SEED)
+    torch.set_num_threads(1)
+    model = Model(Config(**config_kwargs())).eval()
+    head = torch.nn.Linear(HIDDEN, VOCAB, bias=False).eval()
+    weights = production_layout(torch, model, head)
+    reference = oracle(torch, transformers, model, head)
+    output = args.output.resolve()
+    if output.exists():
+        if not args.force:
+            raise SystemExit(f"output exists (use --force): {output}")
+        shutil.rmtree(output)
+    output.mkdir(parents=True)
+    (output / "config.json").write_text(
+        json.dumps(runtime_config(transformers.__version__), indent=2) + "\n",
+        encoding="utf-8",
+    )
+    (output / "tokenizer.json").write_text(
+        json.dumps(make_tokenizer(), separators=(",", ":")) + "\n", encoding="utf-8"
+    )
+    save_file(weights, output / "model.safetensors", metadata={
+        "format": "pt", "generator": "c/tools/make_glm53_tiny.py"
+    })
+    (output / "ref.json").write_text(
+        json.dumps(reference, indent=2) + "\n", encoding="utf-8"
+    )
+    size = sum(path.stat().st_size for path in output.iterdir())
+    print(f"wrote {output} ({len(weights)} tensors, {size} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/c/tools/make_glm53_tiny.py
+++ b/c/tools/make_glm53_tiny.py
@@ -75,6 +75,10 @@ def config_kwargs() -> dict[str, object]:
         "linear_conv_kernel_dim": 4,
         "hc_mult": 2,
         "hc_sinkhorn_iters": 3,
+        "hc_eps": 1.0e-6,
+        "rms_norm_eps": 1.0e-5,
+        "routed_scaling_factor": 2.5,
+        "swiglu_limit": 10.0,
         "pad_token_id": None,
         "bos_token_id": 0,
         "eos_token_id": 1,
@@ -123,6 +127,36 @@ def production_layout(torch, model, head) -> OrderedDict[str, object]:
     return output
 
 
+def initialize_contract_weights(torch, model, head) -> None:
+    """Remove random-init degeneracies that make top-k ties implementation-defined."""
+    with torch.no_grad():
+        embeddings = model.embed_tokens.weight.detach().clone()
+        for token in range(VOCAB):
+            head.weight[(token + 1) % VOCAB].copy_(embeddings[token])
+        indexer = model.layers[3].self_attn.indexer
+        indexer.index_kpool_compress_gate.copy_(
+            torch.linspace(-0.01, 0.01, indexer.index_kpool_compress_gate.numel()).view_as(
+                indexer.index_kpool_compress_gate
+            )
+        )
+        indexer.index_kpool_compress_ape.copy_(
+            torch.linspace(-0.1, 0.1, indexer.index_kpool_compress_ape.numel()).view_as(
+                indexer.index_kpool_compress_ape
+            )
+        )
+        indexer.weights_proj.weight.copy_(
+            torch.linspace(-0.02, 0.03, indexer.weights_proj.weight.numel()).view_as(
+                indexer.weights_proj.weight
+            )
+        )
+        indexer.wq_b.weight.zero_()
+        indexer.wk.weight.zero_()
+        for dim in range(indexer.head_dim):
+            indexer.wk.weight[dim, dim] = 1.0
+            for index_head in range(indexer.n_heads):
+                indexer.wq_b.weight[index_head * indexer.head_dim + dim, dim] = 1.0
+
+
 def make_tokenizer() -> dict[str, object]:
     added = [
         {"id": token, "content": f"<t{token:03d}>", "single_word": False,
@@ -144,7 +178,8 @@ def oracle(torch, transformers, model, head) -> dict[str, object]:
     prompt = [5, 7, 9, 11, 13, 17, 19, 23]
     ids = torch.tensor([prompt], dtype=torch.long)
     with torch.no_grad():
-        full_hidden = model(ids, use_cache=False).last_hidden_state
+        full_output = model(ids, use_cache=False, output_hidden_states=True)
+        full_hidden = full_output.last_hidden_state
         full_logits = head(full_hidden)
         prefix = model(ids[:, :-1], use_cache=True)
         incremental = model(
@@ -155,6 +190,15 @@ def oracle(torch, transformers, model, head) -> dict[str, object]:
     if delta > 1e-5:
         raise RuntimeError(f"prefill/incremental cache mismatch: {delta}")
     top_values, top_indices = full_logits[0, -1].topk(8)
+    generated = []
+    sequence = list(prompt)
+    with torch.no_grad():
+        for _ in range(4):
+            greedy_ids = torch.tensor([sequence], dtype=torch.long)
+            next_logits = head(model(greedy_ids, use_cache=False).last_hidden_state)[0, -1]
+            token = int(next_logits.argmax())
+            generated.append(token)
+            sequence.append(token)
     cache_shapes = []
     for layer in prefix.past_key_values.layers:
         if hasattr(layer, "recurrent_states"):
@@ -180,6 +224,12 @@ def oracle(torch, transformers, model, head) -> dict[str, object]:
         "teacher_forcing_ids": full_logits[0].argmax(-1).tolist(),
         "last_logits_top_ids": top_indices.tolist(),
         "last_logits_top_values": top_values.tolist(),
+        "last_logits": full_logits[0, -1].tolist(),
+        "greedy_new_ids": generated,
+        "hidden_state_stats": [
+            {"sum": float(state.float().sum()), "square_sum": float(state.float().square().sum())}
+            for state in full_output.hidden_states
+        ],
         "cache_max_abs_delta": delta,
         "cache_shapes": cache_shapes,
     }
@@ -389,6 +439,7 @@ def main() -> int:
     torch.set_num_threads(1)
     model = Model(Config(**config_kwargs())).eval()
     head = torch.nn.Linear(HIDDEN, VOCAB, bias=False).eval()
+    initialize_contract_weights(torch, model, head)
     weights = production_layout(torch, model, head)
     reference = oracle(torch, transformers, model, head)
     output = args.output.resolve()

--- a/c/tools/make_glm53_tiny.py
+++ b/c/tools/make_glm53_tiny.py
@@ -348,6 +348,36 @@ def write_sparse_attention_case(torch, model, output: Path) -> None:
         stream.write("#endif\n")
 
 
+def write_mhc_case(torch, model, output: Path) -> None:
+    mhc = model.layers[0].attn_hc
+    streams = model.embed_tokens(torch.tensor([[5]])).unsqueeze(2).expand(-1, -1, 2, -1).contiguous()
+    with torch.no_grad():
+        post, comb, collapsed = mhc(streams)
+        branch = torch.sin(torch.arange(HIDDEN, dtype=torch.float32) * 0.07).view(1, 1, HIDDEN)
+        expanded = post.to(branch.dtype).unsqueeze(-1) * branch.unsqueeze(-2) + torch.matmul(
+            comb.to(streams.dtype), streams.unsqueeze(-3)
+        ).squeeze(-2)
+    with output.open("w", encoding="utf-8") as stream:
+        stream.write("#ifndef COLIBRI_GLM53_MHC_CASE_H\n#define COLIBRI_GLM53_MHC_CASE_H\n\n")
+        stream.write(f"#define GLM53_MHC_COPIES 2\n#define GLM53_MHC_DIM {HIDDEN}\n")
+        stream.write("#define GLM53_MHC_ITERATIONS 3\n\n")
+        write_c_array(stream, "glm53_mhc_streams", streams,
+                      "[GLM53_MHC_COPIES * GLM53_MHC_DIM]")
+        write_c_array(stream, "glm53_mhc_function", mhc.fn,
+                      "[((2 + GLM53_MHC_COPIES) * GLM53_MHC_COPIES) * GLM53_MHC_COPIES * GLM53_MHC_DIM]")
+        write_c_array(stream, "glm53_mhc_scale", mhc.scale, "[3]")
+        write_c_array(stream, "glm53_mhc_base", mhc.base,
+                      "[(2 + GLM53_MHC_COPIES) * GLM53_MHC_COPIES]")
+        write_c_array(stream, "glm53_mhc_branch", branch, "[GLM53_MHC_DIM]")
+        write_c_array(stream, "glm53_mhc_collapsed", collapsed, "[GLM53_MHC_DIM]")
+        write_c_array(stream, "glm53_mhc_post", post, "[GLM53_MHC_COPIES]")
+        write_c_array(stream, "glm53_mhc_comb", comb,
+                      "[GLM53_MHC_COPIES * GLM53_MHC_COPIES]")
+        write_c_array(stream, "glm53_mhc_output", expanded,
+                      "[GLM53_MHC_COPIES * GLM53_MHC_DIM]")
+        stream.write("#endif\n")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     default = Path(__file__).resolve().parents[1] / "glm53_tiny"
@@ -382,6 +412,7 @@ def main() -> int:
     )
     write_kda_case(torch, model, output / "glm53_kda_case.h")
     write_sparse_attention_case(torch, model, output / "glm53_sparse_attention_case.h")
+    write_mhc_case(torch, model, output / "glm53_mhc_case.h")
     write_indexer_case(torch, model, output / "glm53_indexer_case.h")
     size = sum(path.stat().st_size for path in output.iterdir())
     print(f"wrote {output} ({len(weights)} tensors, {size} bytes)")

--- a/c/tools/make_glm53_tiny.py
+++ b/c/tools/make_glm53_tiny.py
@@ -94,6 +94,7 @@ def runtime_config(version: str) -> dict[str, object]:
             "num_heads": HEADS,
             "head_dim": HEAD_DIM,
             "short_conv_kernel_size": 4,
+            "gate_lower_bound": -5.0,
             "kda_layers": [0, 1, 2],
         },
         "num_nextn_predict_layers": 0,
@@ -108,7 +109,7 @@ def runtime_config(version: str) -> dict[str, object]:
 
 
 def production_layout(torch, model, head) -> OrderedDict[str, object]:
-    """Use production prefixes and split HF's fused tiny expert tensors."""
+    """Recreate the official checkpoint's pre-Transformers disk layout."""
     output: OrderedDict[str, object] = OrderedDict()
     for name, tensor in model.state_dict().items():
         prefix = "model.language_model."
@@ -121,8 +122,22 @@ def production_layout(torch, model, head) -> OrderedDict[str, object]:
             base = prefix + name.removesuffix("down_proj")
             for expert in range(EXPERTS):
                 output[f"{base}{expert}.down_proj.weight"] = tensor[expert].contiguous()
+        elif name.endswith("self_attn.conv1d.weight"):
+            base = prefix + name.removesuffix("conv1d.weight")
+            q_conv, k_conv, v_conv = tensor.chunk(3, dim=0)
+            output[f"{base}q_conv1d.weight"] = q_conv.contiguous()
+            output[f"{base}k_conv1d.weight"] = k_conv.contiguous()
+            output[f"{base}v_conv1d.weight"] = v_conv.contiguous()
         else:
-            output[prefix + name] = tensor.detach().contiguous()
+            disk_name = name
+            disk_name = disk_name.replace("attn_hc.fn", "hc_attn_fn")
+            disk_name = disk_name.replace("attn_hc.base", "hc_attn_base")
+            disk_name = disk_name.replace("attn_hc.scale", "hc_attn_scale")
+            disk_name = disk_name.replace("ffn_hc.fn", "hc_ffn_fn")
+            disk_name = disk_name.replace("ffn_hc.base", "hc_ffn_base")
+            disk_name = disk_name.replace("ffn_hc.scale", "hc_ffn_scale")
+            disk_name = disk_name.replace("self_attn.forget_gate.", "self_attn.")
+            output[prefix + disk_name] = tensor.detach().contiguous()
     output["lm_head.weight"] = head.weight.detach().contiguous()
     return output
 

--- a/c/tools/make_glm53_tiny.py
+++ b/c/tools/make_glm53_tiny.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import json
 import shutil
+import types
 from collections import OrderedDict
 from pathlib import Path
 
@@ -86,7 +87,7 @@ def config_kwargs() -> dict[str, object]:
     }
 
 
-def runtime_config(version: str) -> dict[str, object]:
+def runtime_config(version: str, fp8_mlp: bool = False) -> dict[str, object]:
     text = config_kwargs()
     text.update({
         "model_type": "glm5_next_text",
@@ -99,13 +100,21 @@ def runtime_config(version: str) -> dict[str, object]:
         },
         "num_nextn_predict_layers": 0,
     })
-    return {
+    result = {
         "architectures": ["Glm5NextForConditionalGeneration"],
         "model_type": "glm5_next",
         "transformers_version": version,
         "torch_dtype": "float32",
         "text_config": text,
     }
+    if fp8_mlp:
+        result["quantization_config"] = {
+            "quant_method": "fp8",
+            "fmt": "e4m3",
+            "activation_scheme": "dynamic",
+            "weight_block_size": [128, 128],
+        }
+    return result
 
 
 def production_layout(torch, model, head) -> OrderedDict[str, object]:
@@ -170,6 +179,101 @@ def initialize_contract_weights(torch, model, head) -> None:
             indexer.wk.weight[dim, dim] = 1.0
             for index_head in range(indexer.n_heads):
                 indexer.wq_b.weight[index_head * indexer.head_dim + dim, dim] = 1.0
+
+
+def quantize_block_weight(torch, weight):
+    import torch.nn.functional as F
+
+    rows, columns = weight.shape
+    padded_rows = (rows + 127) // 128 * 128
+    padded_columns = (columns + 127) // 128 * 128
+    padded = F.pad(weight.float(), (0, padded_columns - columns, 0, padded_rows - rows))
+    blocks = padded.reshape(padded_rows // 128, 128, padded_columns // 128, 128)
+    maximum = blocks.abs().amax(dim=(1, 3))
+    scales = torch.where(maximum > 0, maximum / 448.0, torch.ones_like(maximum))
+    quantized = (blocks / scales[:, None, :, None]).clamp(-448, 448).to(torch.float8_e4m3fn)
+    quantized_padded = quantized.reshape(padded_rows, padded_columns)
+    dequantized_padded = (quantized.float() * scales[:, None, :, None]).reshape(padded_rows, padded_columns)
+    quantized = quantized_padded[:rows, :columns].contiguous()
+    dequantized = dequantized_padded[:rows, :columns].contiguous()
+    return quantized, scales, dequantized
+
+
+def dynamic_fp8_qdq(torch, value):
+    shape = value.shape
+    blocks = value.float().reshape(-1, shape[-1] // 128, 128)
+    maximum = blocks.abs().amax(dim=-1)
+    scales = torch.where(maximum > 0, maximum / 448.0, torch.ones_like(maximum))
+    result = (blocks / scales[..., None]).clamp(-448, 448).to(torch.float8_e4m3fn).float()
+    return (result * scales[..., None]).reshape(shape)
+
+
+def apply_fp8_mlp_oracle(torch, model) -> None:
+    import torch.nn.functional as F
+
+    def quantized_linear(module):
+        _, _, dequantized = quantize_block_weight(torch, module.weight.detach())
+        module.weight.copy_(dequantized)
+
+        def forward(self, value):
+            return F.linear(dynamic_fp8_qdq(torch, value), self.weight)
+
+        module.forward = types.MethodType(forward, module)
+
+    with torch.no_grad():
+        for layer in model.layers:
+            if layer.block_type == "deepseek_sparse_attention":
+                quantized_linear(layer.self_attn.q_a_proj)
+                quantized_linear(layer.self_attn.q_b_proj)
+                quantized_linear(layer.self_attn.kv_a_proj_with_mqa)
+                quantized_linear(layer.self_attn.o_proj)
+            mlp = layer.mlp
+            if hasattr(mlp, "experts"):
+                quantized_linear(mlp.shared_experts.gate_proj)
+                quantized_linear(mlp.shared_experts.up_proj)
+                quantized_linear(mlp.shared_experts.down_proj)
+                experts = mlp.experts
+                gate, up = experts.gate_up_proj.chunk(2, dim=1)
+                for expert in range(EXPERTS):
+                    _, _, gate[expert] = quantize_block_weight(torch, gate[expert])
+                    _, _, up[expert] = quantize_block_weight(torch, up[expert])
+                    _, _, experts.down_proj[expert] = quantize_block_weight(torch, experts.down_proj[expert])
+
+                def expert_forward(self, hidden_states, top_k_index, top_k_weights):
+                    final = torch.zeros_like(hidden_states)
+                    mask = F.one_hot(top_k_index, num_classes=self.num_experts).permute(2, 1, 0)
+                    for expert_index in torch.greater(mask.sum(dim=(-1, -2)), 0).nonzero().flatten():
+                        top_k_pos, token_index = torch.where(mask[expert_index])
+                        current = dynamic_fp8_qdq(torch, hidden_states[token_index])
+                        current = self._apply_gate(F.linear(current, self.gate_up_proj[expert_index]))
+                        current = F.linear(
+                            dynamic_fp8_qdq(torch, current), self.down_proj[expert_index]
+                        ) * top_k_weights[token_index, top_k_pos, None]
+                        final.index_add_(0, token_index, current.to(final.dtype))
+                    return final
+
+                experts.forward = types.MethodType(expert_forward, experts)
+            else:
+                quantized_linear(mlp.gate_proj)
+                quantized_linear(mlp.up_proj)
+                quantized_linear(mlp.down_proj)
+
+
+def quantize_disk_weights(torch, model, weights: OrderedDict[str, object]) -> None:
+    replacements = []
+    for name, tensor in weights.items():
+        mlp = name.endswith(("gate_proj.weight", "up_proj.weight", "down_proj.weight"))
+        dsa_suffix = name.endswith(("self_attn.q_a_proj.weight", "self_attn.q_b_proj.weight",
+                                    "self_attn.kv_a_proj_with_mqa.weight", "self_attn.o_proj.weight"))
+        layer_index = int(name.split(".layers.", 1)[1].split(".", 1)[0]) if ".layers." in name else -1
+        dsa = dsa_suffix and layer_index >= 0 and model.layers[layer_index].block_type == "deepseek_sparse_attention"
+        if not (mlp or dsa):
+            continue
+        quantized, scales, _ = quantize_block_weight(torch, tensor)
+        replacements.append((name, quantized, scales))
+    for name, quantized, scales in replacements:
+        weights[name] = quantized
+        weights[name + "_scale_inv"] = scales
 
 
 def make_tokenizer() -> dict[str, object]:
@@ -263,6 +367,47 @@ def write_c_array(stream, name: str, tensor, dimensions: str) -> None:
         row = ", ".join(literals)
         stream.write(f"  {row},\n")
     stream.write("};\n\n")
+
+
+def write_u8_array(torch, stream, name: str, tensor, dimensions: str) -> None:
+    values = tensor.detach().view(torch.uint8).reshape(-1).tolist()
+    stream.write(f"static const unsigned char {name}{dimensions} = {{\n")
+    for start in range(0, len(values), 16):
+        stream.write("  " + ", ".join(str(value) for value in values[start:start + 16]) + ",\n")
+    stream.write("};\n\n")
+
+
+def write_fp8_case(torch, model, output: Path) -> None:
+    weight = model.layers[0].mlp.gate_proj.weight.detach().float()
+    rows, columns = weight.shape
+    blocks = weight.reshape(rows // 128, 128, columns // 128, 128)
+    maximum = blocks.abs().amax(dim=(1, 3))
+    scales = torch.where(maximum > 0, maximum / 448.0, torch.ones_like(maximum))
+    quantized = (blocks / scales[:, None, :, None]).clamp(-448, 448).to(torch.float8_e4m3fn)
+    quantized = quantized.reshape_as(weight)
+    activation = torch.linspace(-1.25, 1.75, columns)
+    activation_blocks = activation.reshape(-1, 128)
+    activation_maximum = activation_blocks.abs().amax(dim=1)
+    activation_scales = torch.where(
+        activation_maximum > 0, activation_maximum / 448.0, torch.ones_like(activation_maximum)
+    )
+    activation_qdq = (
+        (activation_blocks / activation_scales[:, None]).clamp(-448, 448).to(torch.float8_e4m3fn).float()
+        * activation_scales[:, None]
+    ).reshape(-1)
+    dequantized = quantized.float().reshape(rows // 128, 128, columns // 128, 128)
+    dequantized = (dequantized * scales[:, None, :, None]).reshape_as(weight)
+    expected = torch.mv(dequantized, activation_qdq)
+    with output.open("w", encoding="utf-8") as stream:
+        stream.write("#ifndef COLIBRI_GLM53_FP8_CASE_H\n#define COLIBRI_GLM53_FP8_CASE_H\n\n")
+        stream.write(f"#define GLM53_FP8_ROWS {rows}\n#define GLM53_FP8_COLUMNS {columns}\n\n")
+        write_u8_array(torch, stream, "glm53_fp8_weight", quantized,
+                       "[GLM53_FP8_ROWS * GLM53_FP8_COLUMNS]")
+        write_c_array(stream, "glm53_fp8_scales", scales,
+                      "[(GLM53_FP8_ROWS / 128) * (GLM53_FP8_COLUMNS / 128)]")
+        write_c_array(stream, "glm53_fp8_input", activation, "[GLM53_FP8_COLUMNS]")
+        write_c_array(stream, "glm53_fp8_expected", expected, "[GLM53_FP8_ROWS]")
+        stream.write("#endif\n")
 
 
 def write_kda_case(torch, model, output: Path) -> None:
@@ -448,6 +593,7 @@ def main() -> int:
     default = Path(__file__).resolve().parents[1] / "glm53_tiny"
     parser.add_argument("--output", type=Path, default=default)
     parser.add_argument("--force", action="store_true")
+    parser.add_argument("--fp8-mlp", action="store_true")
     args = parser.parse_args()
     torch, transformers, save_file, Config, Model = require_dependencies()
     torch.manual_seed(SEED)
@@ -455,7 +601,11 @@ def main() -> int:
     model = Model(Config(**config_kwargs())).eval()
     head = torch.nn.Linear(HIDDEN, VOCAB, bias=False).eval()
     initialize_contract_weights(torch, model, head)
+    if args.fp8_mlp:
+        apply_fp8_mlp_oracle(torch, model)
     weights = production_layout(torch, model, head)
+    if args.fp8_mlp:
+        quantize_disk_weights(torch, model, weights)
     reference = oracle(torch, transformers, model, head)
     output = args.output.resolve()
     if output.exists():
@@ -464,7 +614,7 @@ def main() -> int:
         shutil.rmtree(output)
     output.mkdir(parents=True)
     (output / "config.json").write_text(
-        json.dumps(runtime_config(transformers.__version__), indent=2) + "\n",
+        json.dumps(runtime_config(transformers.__version__, args.fp8_mlp), indent=2) + "\n",
         encoding="utf-8",
     )
     (output / "tokenizer.json").write_text(
@@ -480,6 +630,7 @@ def main() -> int:
     write_sparse_attention_case(torch, model, output / "glm53_sparse_attention_case.h")
     write_mhc_case(torch, model, output / "glm53_mhc_case.h")
     write_indexer_case(torch, model, output / "glm53_indexer_case.h")
+    write_fp8_case(torch, model, output / "glm53_fp8_case.h")
     size = sum(path.stat().st_size for path in output.iterdir())
     print(f"wrote {output} ({len(weights)} tensors, {size} bytes)")
     return 0

--- a/c/tools/make_glm53_tiny.py
+++ b/c/tools/make_glm53_tiny.py
@@ -185,6 +185,55 @@ def oracle(torch, transformers, model, head) -> dict[str, object]:
     }
 
 
+def write_c_array(stream, name: str, tensor, dimensions: str) -> None:
+    values = tensor.detach().float().reshape(-1).tolist()
+    stream.write(f"static const float {name}{dimensions} = {{\n")
+    for start in range(0, len(values), 8):
+        row = ", ".join(f"{value:.9g}f" for value in values[start:start + 8])
+        stream.write(f"  {row},\n")
+    stream.write("};\n\n")
+
+
+def write_kda_case(torch, model, output: Path) -> None:
+    """Emit a C fixture from the official recurrent KDA fallback."""
+    from transformers.models.glm5_next.modeling_glm5_next import (
+        causal_conv1d_fn, recurrent_kimi_delta_attention,
+    )
+    attention = model.layers[0].self_attn
+    hidden = model.embed_tokens(torch.tensor([[5, 7]], dtype=torch.long))
+    raw = torch.cat([
+        attention.q_proj(hidden), attention.k_proj(hidden), attention.v_proj(hidden)
+    ], dim=-1)
+    convolved = causal_conv1d_fn(
+        raw.transpose(1, 2), attention.conv1d.weight.squeeze(1),
+        bias=None, activation=attention.activation,
+    ).transpose(1, 2)
+    query, key, value = convolved.split(HEADS * HEAD_DIM, dim=-1)
+    decay = attention.forget_gate(hidden).view(1, 2, HEADS, HEAD_DIM)
+    beta = torch.sigmoid(attention.b_proj(hidden))
+    expected, _ = recurrent_kimi_delta_attention(
+        query.view(1, 2, HEADS, HEAD_DIM),
+        key.view(1, 2, HEADS, HEAD_DIM),
+        value.view(1, 2, HEADS, HEAD_DIM),
+        g=decay, beta=beta, initial_state=None, output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+    )
+    with output.open("w", encoding="utf-8") as stream:
+        stream.write("#ifndef COLIBRI_GLM53_KDA_CASE_H\n#define COLIBRI_GLM53_KDA_CASE_H\n\n")
+        stream.write(f"#define GLM53_KDA_STEPS 2\n#define GLM53_KDA_HEADS {HEADS}\n")
+        stream.write(f"#define GLM53_KDA_DIM {HEAD_DIM}\n#define GLM53_KDA_KERNEL 4\n\n")
+        write_c_array(stream, "glm53_kda_qkv", raw[0],
+                      "[2 * 3 * GLM53_KDA_HEADS * GLM53_KDA_DIM]")
+        write_c_array(stream, "glm53_kda_conv", attention.conv1d.weight.squeeze(1),
+                      "[3 * GLM53_KDA_HEADS * GLM53_KDA_DIM * GLM53_KDA_KERNEL]")
+        write_c_array(stream, "glm53_kda_decay", decay[0],
+                      "[2 * GLM53_KDA_HEADS * GLM53_KDA_DIM]")
+        write_c_array(stream, "glm53_kda_beta", beta[0], "[2 * GLM53_KDA_HEADS]")
+        write_c_array(stream, "glm53_kda_output", expected[0],
+                      "[2 * GLM53_KDA_HEADS * GLM53_KDA_DIM]")
+        stream.write("#endif\n")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     default = Path(__file__).resolve().parents[1] / "glm53_tiny"
@@ -217,6 +266,7 @@ def main() -> int:
     (output / "ref.json").write_text(
         json.dumps(reference, indent=2) + "\n", encoding="utf-8"
     )
+    write_kda_case(torch, model, output / "glm53_kda_case.h")
     size = sum(path.stat().st_size for path in output.iterdir())
     print(f"wrote {output} ({len(weights)} tensors, {size} bytes)")
     return 0

--- a/c/tools/make_glm53_tiny.py
+++ b/c/tools/make_glm53_tiny.py
@@ -306,6 +306,48 @@ def write_indexer_case(torch, model, output: Path) -> None:
         stream.write(f"  {expected_values}\n}};\n\n#endif\n")
 
 
+def write_sparse_attention_case(torch, model, output: Path) -> None:
+    attention = model.layers[3].self_attn
+    ids = torch.tensor([[5, 7, 9, 11, 13, 17, 19, 23]], dtype=torch.long)
+    hidden = model.embed_tokens(ids)
+    q_resid = attention.q_a_layernorm(attention.q_a_proj(hidden))
+    queries = attention.q_b_proj(q_resid).view(1, 8, HEADS, HEAD_DIM)
+    compressed = attention.kv_a_proj_with_mqa(hidden)
+    latent = attention.kv_a_layernorm(compressed).view(1, 1, 8, 64)
+    keys, values = attention.expand_kv(latent, compressed.new_empty(1, 1, 8, 0))
+    keys = keys.transpose(1, 2).contiguous()
+    values = values.transpose(1, 2).contiguous()
+    valid = torch.ones_like(ids, dtype=torch.bool)
+    indices = attention.indexer(hidden, q_resid, valid, None)
+    width = indices.shape[-1]
+    expected = torch.zeros(1, 8, HEADS, HEAD_DIM)
+    with torch.no_grad():
+        for position in range(8):
+            selected = indices[0, position]
+            selected = selected[selected.ge(0)]
+            for head in range(HEADS):
+                scores = queries[0, position, head] @ keys[0, selected, head].T
+                probabilities = torch.softmax(scores.float() / (HEAD_DIM ** 0.5), dim=-1)
+                expected[0, position, head] = probabilities @ values[0, selected, head].float()
+    with output.open("w", encoding="utf-8") as stream:
+        stream.write("#ifndef COLIBRI_GLM53_SPARSE_ATTENTION_CASE_H\n#define COLIBRI_GLM53_SPARSE_ATTENTION_CASE_H\n\n")
+        stream.write("#define GLM53_SA_SEQUENCE 8\n")
+        stream.write(f"#define GLM53_SA_HEADS {HEADS}\n#define GLM53_SA_KEY_DIM {HEAD_DIM}\n")
+        stream.write(f"#define GLM53_SA_VALUE_DIM {HEAD_DIM}\n#define GLM53_SA_WIDTH {width}\n\n")
+        write_c_array(stream, "glm53_sa_queries", queries,
+                      "[GLM53_SA_SEQUENCE * GLM53_SA_HEADS * GLM53_SA_KEY_DIM]")
+        write_c_array(stream, "glm53_sa_keys", keys,
+                      "[GLM53_SA_SEQUENCE * GLM53_SA_HEADS * GLM53_SA_KEY_DIM]")
+        write_c_array(stream, "glm53_sa_values", values,
+                      "[GLM53_SA_SEQUENCE * GLM53_SA_HEADS * GLM53_SA_VALUE_DIM]")
+        index_values = ", ".join(str(value) for value in indices.reshape(-1).tolist())
+        stream.write("static const int glm53_sa_indices[GLM53_SA_SEQUENCE * GLM53_SA_WIDTH] = {\n")
+        stream.write(f"  {index_values}\n}};\n\n")
+        write_c_array(stream, "glm53_sa_expected", expected,
+                      "[GLM53_SA_SEQUENCE * GLM53_SA_HEADS * GLM53_SA_VALUE_DIM]")
+        stream.write("#endif\n")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     default = Path(__file__).resolve().parents[1] / "glm53_tiny"
@@ -339,6 +381,7 @@ def main() -> int:
         json.dumps(reference, indent=2) + "\n", encoding="utf-8"
     )
     write_kda_case(torch, model, output / "glm53_kda_case.h")
+    write_sparse_attention_case(torch, model, output / "glm53_sparse_attention_case.h")
     write_indexer_case(torch, model, output / "glm53_indexer_case.h")
     size = sum(path.stat().st_size for path in output.iterdir())
     print(f"wrote {output} ({len(weights)} tensors, {size} bytes)")

--- a/c/tools/requirements-glm53-tiny.txt
+++ b/c/tools/requirements-glm53-tiny.txt
@@ -1,0 +1,5 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.13.0+cpu; sys_platform != "darwin"
+torch==2.13.0; sys_platform == "darwin"
+transformers==5.16.1
+safetensors==0.8.0

--- a/docs/glm53-flash.md
+++ b/docs/glm53-flash.md
@@ -25,6 +25,8 @@ passes a generated tiny oracle and a real-checkpoint generation test.
 ## Implementation order
 
 1. Generate a tiny Transformers oracle and pin tensor names, shapes and math.
+   `make -C c glm53-tiny-check` now gates this contract against Transformers
+   5.16.1, including cached versus full-forward parity.
 2. Compose the CPU text path from the existing Kimi KDA and DeepSeek V4
    mHC/DSA primitives; do not copy either full engine.
 3. Add FP8-to-streaming conversion and token/logit validation on the real

--- a/docs/glm53-flash.md
+++ b/docs/glm53-flash.md
@@ -2,9 +2,9 @@
 
 GLM-5.3-Flash support is tracked in
 [#1243](https://github.com/JustVugg/colibri/issues/1243). The official
-checkpoint is recognized by `coli plan` and `coli doctor`; inference is not yet
-wired, and the launcher refuses it instead of falling back to the GLM-5.2
-engine.
+checkpoint is recognized by `coli plan` and `coli doctor`, and the text runtime
+is available through `coli run`, `coli chat`, and the OpenAI-compatible API.
+The vision tower remains out of scope for this text-only runtime.
 
 ## Architecture contract
 
@@ -19,17 +19,33 @@ The text model is not a smaller GLM-5.2. It combines:
 
 The resource planner accounts separately for fixed KDA recurrence/conv state,
 context-growing DSA latent/index state, mHC workspace, and all routed experts
-including MTP. `runtime_available=false` is deliberate until the CPU text path
-passes a generated tiny oracle and a real-checkpoint generation test.
+including MTP. Routed experts are loaded from their safetensors shard on hit;
+dense and shared weights remain resident.
 
-## Implementation order
+## Validation and acceleration
 
 1. Generate a tiny Transformers oracle and pin tensor names, shapes and math.
    `make -C c glm53-tiny-check` now gates this contract against Transformers
    5.16.1, including cached versus full-forward parity.
-2. Compose the CPU text path from the existing Kimi KDA and DeepSeek V4
-   mHC/DSA primitives; do not copy either full engine.
-3. Add FP8-to-streaming conversion and token/logit validation on the real
-   checkpoint.
-4. Enable the gateway, then add CUDA and Metal tiers without changing router
-   semantics.
+2. `tools/check_glm53_checkpoint.py` validates every runtime-consumed tensor
+   name, dtype, and shape. It has been run against all 62 official shard
+   headers; this proves the load contract, not full-model generation quality.
+3. The CPU full-forward and incremental-cache engines match the independent
+   tiny Transformers oracle, including native fine-grained FP8 activation QDQ.
+4. `COLI_CUDA=1` and `COLI_METAL=1` dispatch native FP8 matrices to the shared
+   GPU backends. Both retain GLM-5.3's per-128-element activation QDQ before
+   device execution; unsupported builds refuse an explicitly requested backend
+   instead of silently running on the CPU.
+
+Build the optional accelerators with:
+
+```sh
+make -C c glm53_flash CUDA=1       # Linux CUDA
+make -C c glm53_flash METAL=1      # Apple Silicon
+make -C c glm53_flash CUDA_DLL=1   # Windows host; build cuda-dll as well
+```
+
+The generated oracle is the reproducible correctness gate. End-to-end
+generation on the 328 GB official checkpoint and performance measurements on
+real CUDA/Metal hardware remain hardware acceptance work; a successful
+toolchain-only CI build is not evidence for either claim.

--- a/docs/glm53-flash.md
+++ b/docs/glm53-flash.md
@@ -1,0 +1,33 @@
+# GLM-5.3-Flash
+
+GLM-5.3-Flash support is tracked in
+[#1243](https://github.com/JustVugg/colibri/issues/1243). The official
+checkpoint is recognized by `coli plan` and `coli doctor`; inference is not yet
+wired, and the launcher refuses it instead of falling back to the GLM-5.2
+engine.
+
+## Architecture contract
+
+The text model is not a smaller GLM-5.2. It combines:
+
+- 45 text layers: 34 recurrent KDA and 11 DeepSeek Sparse Attention layers;
+- four-stream mHC around attention and FFN blocks;
+- three dense FFNs followed by 42 sparse FFNs with 288 routed experts, top-8;
+- one additional MTP expert row at layer 45;
+- a 128x128 block-FP8 checkpoint under `model.language_model.*`;
+- an optional vision tower, outside the first text-only runtime milestone.
+
+The resource planner accounts separately for fixed KDA recurrence/conv state,
+context-growing DSA latent/index state, mHC workspace, and all routed experts
+including MTP. `runtime_available=false` is deliberate until the CPU text path
+passes a generated tiny oracle and a real-checkpoint generation test.
+
+## Implementation order
+
+1. Generate a tiny Transformers oracle and pin tensor names, shapes and math.
+2. Compose the CPU text path from the existing Kimi KDA and DeepSeek V4
+   mHC/DSA primitives; do not copy either full engine.
+3. Add FP8-to-streaming conversion and token/logit validation on the real
+   checkpoint.
+4. Enable the gateway, then add CUDA and Metal tiers without changing router
+   semantics.


### PR DESCRIPTION
## Summary

- register the GLM-5.3-Flash family and official 62-shard checkpoint layout
- add the complete CPU text runtime with KDA, DSA, mHC, MTP, streaming routed experts, and prefix-cache reuse
- support official FP8 expert tensors on CPU and native FP8 dispatch through the shared CUDA and Metal backends
- add one-shot CLI and OpenAI-compatible completions serving
- extend install, doctor, resource planning, documentation, and release contracts
- add deterministic Transformers 5.16.1 tiny oracles, production-layout validation, segment conformance, malformed-input coverage, and mock GPU dispatch tests

## Validation

- token-exact F32 and FP8 full/cached tiny generation
- official checkpoint header/layout contract
- OpenAI `/v1/completions` end-to-end request
- CUDA Linux host link and Windows MSVC DLL builds
- Metal build on macOS
- full Python discovery and repository cross-platform CI

## Acceptance boundary

This PR implements the CPU-first support requested by #1243 and the subsequent CUDA/Metal tier. Full 320B checkpoint generation and real-device performance measurements remain hardware acceptance work; they are not inferred from tiny fixtures or toolchain-only CI.

Closes #1243
