### PR TITLE
ci(windows): raise the check timeout the suite has outgrown

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,7 +34,13 @@ jobs:
     # (MSYS2/UCRT64), the exact toolchain the README's Windows port targets.
     name: Windows UCRT64
     runs-on: windows-latest
-    timeout-minutes: 20
+    # Measured, not guessed: this job now runs 19-21 minutes, so a 20-minute
+    # limit decided the result by runner luck. Three consecutive runs on
+    # 2026-08-27 took 19m21s (passed), 20m18s and 20m32s (both cancelled at the
+    # limit and reported as failures), including one on dev itself. The suite
+    # has grown - segment conformance and adapters, the edge runtime, per-engine
+    # cache indices - and MinGW is the slowest toolchain we build on.
+    timeout-minutes: 35
     defaults:
       run:
         shell: msys2 {0}


### PR DESCRIPTION
## What is happening

The Windows UCRT64 job runs `make check` under MinGW - the slowest toolchain we
build on - against a 20-minute limit, and the suite has grown past it. Three
consecutive runs on 2026-08-27:

| run | duration | outcome |
|---|---:|---|
| 01:39:32 → 01:58:53 | 19m 21s | passed, by 39 seconds |
| 10:15:48 → 10:36:06 | 20m 18s | cancelled at the limit |
| 10:24:47 → 10:45:19 | 20m 32s | cancelled at the limit |

A cancelled job is reported by `gh pr checks` as a failure, so this has been
failing unrelated pull requests - #1245 and #1251 both hit it - and telling
their authors that their change broke Windows. One of the cancelled runs was
dev's own push, which is the clearest sign that it is not any single change.

## What this does

Raises the limit to 35 minutes. Nothing is hanging: the job runs to completion,
it simply needs longer than it did before segment conformance, the segment and
edge adapters, and five engines' cache-index tests joined the suite.

Making `make check` faster on Windows is the better fix, and it is separate
work worth doing. A timer that fails honest work is the part that has to stop
today.
