### PR TITLE
feat: expose universal Edge logits

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -11866,7 +11866,7 @@ static int glm_edge_engine_open(
     capabilities->abi_version = COLI_EDGE_ABI_VERSION;
     capabilities->flags = COLI_EDGE_CAP_TOKENIZE |
                           COLI_EDGE_CAP_DETOKENIZE |
-                          COLI_EDGE_CAP_GREEDY |
+                          COLI_EDGE_CAP_GREEDY | COLI_EDGE_CAP_LOGITS |
                           COLI_EDGE_CAP_CPU;
     coli_edge_capability_string(capabilities->engine_id,
                                 sizeof(capabilities->engine_id), "glm");
@@ -11958,11 +11958,34 @@ static int glm_edge_select(void *engine_impl,
     return 0;
 }
 
+static int glm_edge_logits(void *engine_impl,
+                           const ColiEdgeLogitsRequest *request,
+                           char *error, size_t error_size) {
+    GlmEdgeEngine *engine = (GlmEdgeEngine *)engine_impl;
+    Cfg *config = &engine->model.c;
+    float *normalized = falloc(config->hidden);
+    const float *input = (const float *)request->input;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        if (request->should_cancel &&
+            request->should_cancel(request->cancel_user_data)) {
+            free(normalized);
+            return coli_edge_adapter_error(error, error_size,
+                                           "GLM Edge logits cancelled");
+        }
+        rmsnorm(normalized, input + (size_t)row * config->hidden,
+                engine->model.final_norm, config->hidden, config->eps);
+        matmul_qt(request->logits + (size_t)row * config->vocab,
+                  normalized, &engine->model.lm_head, 1);
+    }
+    free(normalized);
+    return 0;
+}
+
 static const ColiEdgeAdapter glm_edge_adapter = {
     sizeof(ColiEdgeAdapter), COLI_EDGE_ABI_VERSION, "glm",
     glm_edge_engine_open, glm_edge_engine_destroy,
     glm_edge_tokenize, glm_edge_detokenize,
-    glm_edge_embed, glm_edge_select, {0}
+    glm_edge_embed, glm_edge_select, glm_edge_logits, {0}
 };
 
 int coli_glm_edge_adapter_register(void) {

--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -17767,7 +17767,7 @@ static int deepseek_v4_edge_engine_open(
     capabilities->abi_version = COLI_EDGE_ABI_VERSION;
     capabilities->flags = COLI_EDGE_CAP_TOKENIZE |
                           COLI_EDGE_CAP_DETOKENIZE |
-                          COLI_EDGE_CAP_GREEDY |
+                          COLI_EDGE_CAP_GREEDY | COLI_EDGE_CAP_LOGITS |
                           COLI_EDGE_CAP_CPU;
     coli_edge_capability_string(capabilities->engine_id,
                                 sizeof(capabilities->engine_id),
@@ -17982,11 +17982,65 @@ static int deepseek_v4_edge_select(void *engine_impl,
     return 0;
 }
 
+static int deepseek_v4_edge_logits(void *engine_impl,
+                                   const ColiEdgeLogitsRequest *request,
+                                   char *error, size_t error_size) {
+    DeepSeekV4EdgeEngine *engine = engine_impl;
+    const ColiSafetensorsTensor *head =
+        coli_st_find(engine->index, "head.weight");
+    if (!head || head->dtype != COLI_ST_BF16)
+        return coli_edge_adapter_error(error, error_size,
+                                       "DeepSeek V4 Edge head is unavailable");
+    int hidden = engine->config.hidden_size;
+    int vocab = engine->config.vocab_size;
+    int shard = coli_st_tensor_shard(engine->index, head);
+    enum { TILE_ROWS = 64 };
+    uint16_t *raw = malloc((size_t)TILE_ROWS * hidden * sizeof(*raw));
+    float *final = malloc((size_t)hidden * sizeof(*final));
+    if (!raw || !final) {
+        free(final); free(raw);
+        return coli_edge_adapter_error(error, error_size,
+                                       "out of memory running DeepSeek V4 logits");
+    }
+    const float *input = request->input;
+    for (uint32_t batch_row = 0; batch_row < request->rows; batch_row++) {
+        deepseek_v4_edge_final_hidden(
+            engine, final, input + (size_t)batch_row * engine->state_width);
+        float *logits = request->logits + (size_t)batch_row * vocab;
+        for (int start = 0; start < vocab; start += TILE_ROWS) {
+            if (request->should_cancel &&
+                request->should_cancel(request->cancel_user_data)) {
+                free(final); free(raw);
+                return coli_edge_adapter_error(
+                    error, error_size, "DeepSeek V4 Edge logits cancelled");
+            }
+            int rows = vocab - start < TILE_ROWS ? vocab - start : TILE_ROWS;
+            size_t bytes = (size_t)rows * hidden * sizeof(*raw);
+            if (coli_st_read_at(
+                    engine->index, shard,
+                    (uint64_t)head->off +
+                        (uint64_t)start * hidden * sizeof(*raw),
+                    bytes, raw)) {
+                free(final); free(raw);
+                return coli_edge_adapter_error(
+                    error, error_size, "DeepSeek V4 Edge head read failed");
+            }
+            #pragma omp parallel for schedule(static)
+            for (int row = 0; row < rows; row++)
+                logits[start + row] = deepseek_v4_edge_head_dot(
+                    raw + (size_t)row * hidden, final, hidden);
+        }
+    }
+    free(final); free(raw);
+    return 0;
+}
+
 static const ColiEdgeAdapter deepseek_v4_edge_adapter = {
     sizeof(ColiEdgeAdapter), COLI_EDGE_ABI_VERSION, "deepseek_v4",
     deepseek_v4_edge_engine_open, deepseek_v4_edge_engine_destroy,
     deepseek_v4_edge_tokenize, deepseek_v4_edge_detokenize,
-    deepseek_v4_edge_embed, deepseek_v4_edge_select, {0}
+    deepseek_v4_edge_embed, deepseek_v4_edge_select,
+    deepseek_v4_edge_logits, {0}
 };
 
 int coli_deepseek_v4_edge_adapter_register(void) {

--- a/c/edge_runtime.c
+++ b/c/edge_runtime.c
@@ -65,7 +65,9 @@ static int capabilities_valid(const ColiEdgeCapabilities *capabilities,
            !!(capabilities->flags & COLI_EDGE_CAP_TOKENIZE) == tokenizer &&
            !!(capabilities->flags & COLI_EDGE_CAP_DETOKENIZE) == tokenizer &&
            !!(capabilities->flags & COLI_EDGE_CAP_GREEDY) ==
-               !!adapter->select;
+               !!adapter->select &&
+           !!(capabilities->flags & COLI_EDGE_CAP_LOGITS) ==
+               !!adapter->logits;
 }
 
 int coli_edge_adapter_register(const ColiEdgeAdapter *adapter) {
@@ -229,4 +231,27 @@ int coli_edge_select(ColiEdgeEngine *engine,
         request->should_cancel(request->cancel_user_data))
         return set_error(error, error_size, "edge selection cancelled");
     return engine->adapter->select(engine->impl, request, error, error_size);
+}
+
+int coli_edge_logits(ColiEdgeEngine *engine,
+                     const ColiEdgeLogitsRequest *request,
+                     char *error, size_t error_size) {
+    size_t expected = 0;
+    if (!engine || !request || request->struct_size < sizeof(*request) ||
+        !request->rows || !request->input ||
+        activation_bytes(engine, request->rows, &expected) ||
+        request->input_bytes != expected || !request->logits ||
+        engine->capabilities.vocab_size > SIZE_MAX / request->rows ||
+        request->logits_capacity <
+            (size_t)request->rows * engine->capabilities.vocab_size)
+        return set_error(error, error_size, "invalid edge logits request");
+    if (!engine->adapter->logits)
+        return set_error(error, error_size, "edge logits are not supported");
+    if (engine->capabilities.max_batch_rows &&
+        request->rows > engine->capabilities.max_batch_rows)
+        return set_error(error, error_size, "edge batch exceeds capabilities");
+    if (request->should_cancel &&
+        request->should_cancel(request->cancel_user_data))
+        return set_error(error, error_size, "edge logits cancelled");
+    return engine->adapter->logits(engine->impl, request, error, error_size);
 }

--- a/c/edge_runtime.h
+++ b/c/edge_runtime.h
@@ -10,9 +10,10 @@
  * separate prevents a network client from reaching into an engine's private
  * Model structure or loading the complete transformer just to start a chat.
  *
- * Version 1 deliberately exposes deterministic greedy selection. Sampling
- * policies can be added without changing the embedding/activation contract.
- * Registration is explicit; ordinary Colibri executables do not use this API.
+ * Version 2 additionally exposes final-head logits. Sampling policy and RNG
+ * remain with the serving caller, while every model-specific final transform
+ * and output-head implementation stays owned by Colibri. Registration is
+ * explicit; ordinary Colibri executables do not use this API.
  */
 
 #include <stddef.h>
@@ -22,7 +23,7 @@
 extern "C" {
 #endif
 
-#define COLI_EDGE_ABI_VERSION 1u
+#define COLI_EDGE_ABI_VERSION 2u
 #define COLI_EDGE_ENGINE_ID_CAP 64u
 #define COLI_EDGE_STATE_SCHEMA_CAP 128u
 #define COLI_EDGE_NUMERIC_CLASS_CAP 96u
@@ -41,6 +42,7 @@ enum {
     COLI_EDGE_CAP_TOKENIZE = UINT64_C(1) << 0,
     COLI_EDGE_CAP_DETOKENIZE = UINT64_C(1) << 1,
     COLI_EDGE_CAP_GREEDY = UINT64_C(1) << 2,
+    COLI_EDGE_CAP_LOGITS = UINT64_C(1) << 3,
     COLI_EDGE_CAP_CPU = UINT64_C(1) << 8,
     COLI_EDGE_CAP_CUDA = UINT64_C(1) << 9,
     COLI_EDGE_CAP_HIP = UINT64_C(1) << 10,
@@ -115,6 +117,22 @@ typedef struct {
     uint64_t reserved_u64[3];
 } ColiEdgeSelectRequest;
 
+/* Applies the exact model-specific final transform and LM head, returning
+ * rows*vocab_size float logits in row-major order. This deliberately does
+ * not prescribe temperature, top-p or an RNG: those are serving policy, not
+ * model math. */
+typedef struct {
+    uint32_t struct_size;
+    uint32_t rows;
+    const void *input;
+    size_t input_bytes;
+    float *logits;
+    size_t logits_capacity;
+    ColiEdgeCancelFn should_cancel;
+    void *cancel_user_data;
+    uint64_t reserved_u64[3];
+} ColiEdgeLogitsRequest;
+
 typedef struct {
     uint32_t struct_size;
     uint32_t abi_version;
@@ -135,8 +153,10 @@ typedef struct {
                  char *error, size_t error_size);
     int (*select)(void *engine_impl, const ColiEdgeSelectRequest *request,
                   char *error, size_t error_size);
+    int (*logits)(void *engine_impl, const ColiEdgeLogitsRequest *request,
+                  char *error, size_t error_size);
 
-    void (*reserved_fn[8])(void);
+    void (*reserved_fn[7])(void);
 } ColiEdgeAdapter;
 
 int coli_edge_adapter_register(const ColiEdgeAdapter *adapter);
@@ -168,6 +188,9 @@ int coli_edge_embed(ColiEdgeEngine *engine,
                     char *error, size_t error_size);
 int coli_edge_select(ColiEdgeEngine *engine,
                      const ColiEdgeSelectRequest *request,
+                     char *error, size_t error_size);
+int coli_edge_logits(ColiEdgeEngine *engine,
+                     const ColiEdgeLogitsRequest *request,
                      char *error, size_t error_size);
 
 #ifdef __cplusplus

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -3081,7 +3081,7 @@ static int inkling_edge_engine_open(
     capabilities->abi_version = COLI_EDGE_ABI_VERSION;
     capabilities->flags = COLI_EDGE_CAP_TOKENIZE |
                           COLI_EDGE_CAP_DETOKENIZE |
-                          COLI_EDGE_CAP_GREEDY |
+                          COLI_EDGE_CAP_GREEDY | COLI_EDGE_CAP_LOGITS |
                           COLI_EDGE_CAP_CPU;
     coli_edge_capability_string(capabilities->engine_id,
                                 sizeof(capabilities->engine_id), "inkling");
@@ -3181,11 +3181,37 @@ static int inkling_edge_select(void *engine_impl,
     return 0;
 }
 
+static int inkling_edge_logits(void *engine_impl,
+                               const ColiEdgeLogitsRequest *request,
+                               char *error, size_t error_size) {
+    InklingEdgeEngine *engine = (InklingEdgeEngine *)engine_impl;
+    Cfg *config = &engine->model.c;
+    float *normalized = falloc(config->hidden);
+    const float *input = (const float *)request->input;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        if (request->should_cancel &&
+            request->should_cancel(request->cancel_user_data)) {
+            free(normalized);
+            return coli_edge_adapter_error(error, error_size,
+                                           "Inkling Edge logits cancelled");
+        }
+        rmsnorm_row(normalized, input + (size_t)row * config->hidden,
+                    engine->model.final_norm, config->hidden, config->eps);
+        for (int item = 0; item < config->hidden; item++)
+            normalized[item] /= config->mup;
+        matmul_w(request->logits + (size_t)row * config->unpad_vocab,
+                 normalized, engine->model.lm_head,
+                 1, config->hidden, config->unpad_vocab);
+    }
+    free(normalized);
+    return 0;
+}
+
 static const ColiEdgeAdapter inkling_edge_adapter = {
     sizeof(ColiEdgeAdapter), COLI_EDGE_ABI_VERSION, "inkling",
     inkling_edge_engine_open, inkling_edge_engine_destroy,
     inkling_edge_tokenize, inkling_edge_detokenize,
-    inkling_edge_embed, inkling_edge_select, {0}
+    inkling_edge_embed, inkling_edge_select, inkling_edge_logits, {0}
 };
 
 int coli_inkling_edge_adapter_register(void) {

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -3843,7 +3843,7 @@ static int kimi_edge_engine_open(
     capabilities->abi_version = COLI_EDGE_ABI_VERSION;
     capabilities->flags = COLI_EDGE_CAP_TOKENIZE |
                           COLI_EDGE_CAP_DETOKENIZE |
-                          COLI_EDGE_CAP_GREEDY |
+                          COLI_EDGE_CAP_GREEDY | COLI_EDGE_CAP_LOGITS |
                           COLI_EDGE_CAP_CPU;
     coli_edge_capability_string(capabilities->engine_id,
                                 sizeof(capabilities->engine_id), "kimi");
@@ -3947,11 +3947,38 @@ static int kimi_edge_select(void *engine_impl,
     return 0;
 }
 
+static int kimi_edge_logits(void *engine_impl,
+                            const ColiEdgeLogitsRequest *request,
+                            char *error, size_t error_size) {
+    KimiEdgeEngine *engine = (KimiEdgeEngine *)engine_impl;
+    Cfg *config = &engine->model.c;
+    float *mixed = falloc(config->hidden);
+    const float *input = (const float *)request->input;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        if (request->should_cancel &&
+            request->should_cancel(request->cancel_user_data)) {
+            free(mixed);
+            return coli_edge_adapter_error(error, error_size,
+                                           "Kimi K3 Edge logits cancelled");
+        }
+        const float *state = input + (size_t)row * engine->state_width;
+        res_mix(mixed, state, state + config->hidden,
+                (int)engine->nbmax, config->hidden,
+                engine->model.out_sw, config->eps);
+        rmsnorm_(mixed, mixed, engine->model.final_norm,
+                 config->hidden, config->eps);
+        w_matmul(request->logits + (size_t)row * config->vocab,
+                 mixed, &engine->model.lm_head, 1);
+    }
+    free(mixed);
+    return 0;
+}
+
 static const ColiEdgeAdapter kimi_edge_adapter = {
     sizeof(ColiEdgeAdapter), COLI_EDGE_ABI_VERSION, "kimi",
     kimi_edge_engine_open, kimi_edge_engine_destroy,
     kimi_edge_tokenize, kimi_edge_detokenize,
-    kimi_edge_embed, kimi_edge_select, {0}
+    kimi_edge_embed, kimi_edge_select, kimi_edge_logits, {0}
 };
 
 int coli_kimi_edge_adapter_register(void) {

--- a/c/olmoe.c
+++ b/c/olmoe.c
@@ -2006,7 +2006,7 @@ static int olmoe_edge_engine_open(
     capabilities->abi_version = COLI_EDGE_ABI_VERSION;
     capabilities->flags = COLI_EDGE_CAP_TOKENIZE |
                           COLI_EDGE_CAP_DETOKENIZE |
-                          COLI_EDGE_CAP_GREEDY |
+                          COLI_EDGE_CAP_GREEDY | COLI_EDGE_CAP_LOGITS |
                           COLI_EDGE_CAP_CPU;
     coli_edge_capability_string(capabilities->engine_id,
                                 sizeof(capabilities->engine_id), "olmoe");
@@ -2101,11 +2101,35 @@ static int olmoe_edge_select(void *engine_impl,
     return 0;
 }
 
+static int olmoe_edge_logits(void *engine_impl,
+                             const ColiEdgeLogitsRequest *request,
+                             char *error, size_t error_size) {
+    OlmoeEdgeEngine *engine = (OlmoeEdgeEngine *)engine_impl;
+    Cfg *config = &engine->model.c;
+    float *normalized = falloc(config->hidden);
+    const float *input = (const float *)request->input;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        if (request->should_cancel &&
+            request->should_cancel(request->cancel_user_data)) {
+            free(normalized);
+            return coli_edge_adapter_error(error, error_size,
+                                           "OLMoE Edge logits cancelled");
+        }
+        rmsnorm_row(normalized, input + (size_t)row * config->hidden,
+                    engine->model.final_norm, config->hidden, config->eps);
+        matmul(request->logits + (size_t)row * config->vocab,
+               normalized, engine->model.lm_head,
+               1, config->hidden, config->vocab);
+    }
+    free(normalized);
+    return 0;
+}
+
 static const ColiEdgeAdapter olmoe_edge_adapter = {
     sizeof(ColiEdgeAdapter), COLI_EDGE_ABI_VERSION, "olmoe",
     olmoe_edge_engine_open, olmoe_edge_engine_destroy,
     olmoe_edge_tokenize, olmoe_edge_detokenize,
-    olmoe_edge_embed, olmoe_edge_select, {0}
+    olmoe_edge_embed, olmoe_edge_select, olmoe_edge_logits, {0}
 };
 
 int coli_olmoe_edge_adapter_register(void) {

--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -3256,7 +3256,7 @@ static int qwen36_edge_engine_open(
     capabilities->abi_version = COLI_EDGE_ABI_VERSION;
     capabilities->flags = COLI_EDGE_CAP_TOKENIZE |
                           COLI_EDGE_CAP_DETOKENIZE |
-                          COLI_EDGE_CAP_GREEDY |
+                          COLI_EDGE_CAP_GREEDY | COLI_EDGE_CAP_LOGITS |
                           COLI_EDGE_CAP_CPU;
     coli_edge_capability_string(capabilities->engine_id,
                                 sizeof(capabilities->engine_id), "qwen36");
@@ -3392,11 +3392,35 @@ static int qwen36_edge_select(void *engine_impl,
     return 0;
 }
 
+static int qwen36_edge_logits(void *engine_impl,
+                              const ColiEdgeLogitsRequest *request,
+                              char *error, size_t error_size) {
+    Qwen36EdgeEngine *engine = (Qwen36EdgeEngine *)engine_impl;
+    Cfg *config = &engine->model.c;
+    float *normalized = falloc(config->hidden);
+    const float *input = (const float *)request->input;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        if (request->should_cancel &&
+            request->should_cancel(request->cancel_user_data)) {
+            free(normalized);
+            return coli_edge_adapter_error(error, error_size,
+                                           "Qwen3.6 Edge logits cancelled");
+        }
+        rmsnorm_row(normalized, input + (size_t)row * config->hidden,
+                    engine->model.final_norm, config->hidden, config->eps);
+        matmul_d(request->logits + (size_t)row * config->vocab,
+                 normalized, engine->model.lm_head,
+                 1, config->hidden, config->vocab);
+    }
+    free(normalized);
+    return 0;
+}
+
 static const ColiEdgeAdapter qwen36_edge_adapter = {
     sizeof(ColiEdgeAdapter), COLI_EDGE_ABI_VERSION, "qwen36",
     qwen36_edge_engine_open, qwen36_edge_engine_destroy,
     qwen36_edge_tokenize, qwen36_edge_detokenize,
-    qwen36_edge_embed, qwen36_edge_select, {0}
+    qwen36_edge_embed, qwen36_edge_select, qwen36_edge_logits, {0}
 };
 
 int coli_qwen36_edge_adapter_register(void) {

--- a/c/tests/test_edge_adapters_real.c
+++ b/c/tests/test_edge_adapters_real.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
     ColiEdgeEngine *edge = NULL;
     ColiSegmentEngine *segment = NULL;
     ColiSegmentSession *session = NULL;
-    float *input = NULL, *output = NULL;
+    float *input = NULL, *output = NULL, *logits = NULL;
     int32_t *probe_ids = NULL;
     char *probe_text = NULL;
     int status = 1;
@@ -114,6 +114,8 @@ int main(int argc, char **argv) {
             "real adapter does not expose tokenization");
     REQUIRE(edge_cap.flags & COLI_EDGE_CAP_GREEDY,
             "real adapter does not expose the model head");
+    REQUIRE(edge_cap.flags & COLI_EDGE_CAP_LOGITS,
+            "real adapter does not expose final-head logits");
 
     static const char tokenizer_probe[] = "edge";
     size_t probe_count = 0, probe_bytes = 0;
@@ -202,6 +204,22 @@ int main(int argc, char **argv) {
     REQUIRE(coli_edge_select(edge, &select, error, sizeof(error)) == 0, error);
     REQUIRE(predicted == full[prompt_count],
             "first generated token differs from the independent oracle");
+    logits = malloc((size_t)edge_cap.vocab_size * sizeof(*logits));
+    REQUIRE(logits != NULL, "out of memory for Edge logits");
+    ColiEdgeLogitsRequest logits_request = {
+        .struct_size = sizeof(logits_request), .rows = 1,
+        .input = select.input, .input_bytes = row_bytes,
+        .logits = logits, .logits_capacity = edge_cap.vocab_size,
+    };
+    REQUIRE(coli_edge_logits(edge, &logits_request,
+                             error, sizeof(error)) == 0, error);
+    int32_t logits_winner = 0;
+    for (uint32_t token = 1; token < edge_cap.vocab_size; token++)
+        if (logits[token] > logits[logits_winner])
+            logits_winner = (int32_t)token;
+    REQUIRE(logits_winner == predicted,
+            "argmax(logits) differs from deterministic Edge selection");
+    free(logits); logits = NULL;
     size_t generated_bytes = 0;
     REQUIRE(coli_edge_detokenize(edge, &predicted, 1, NULL, 0,
                                  &generated_bytes, error, sizeof(error)) == 0 &&
@@ -234,7 +252,7 @@ int main(int argc, char **argv) {
 fail:
     if (status && error[0]) fprintf(stderr, "%s: %s\n", family, error);
     free(probe_text); free(probe_ids);
-    free(output); free(input);
+    free(logits); free(output); free(input);
     coli_segment_session_destroy(session);
     if (segment) (void)coli_segment_engine_close(segment, NULL, 0);
     coli_edge_engine_close(edge);

--- a/c/tests/test_edge_runtime.c
+++ b/c/tests/test_edge_runtime.c
@@ -17,7 +17,8 @@ static int fake_open(void **impl, ColiEdgeCapabilities *capabilities,
     capabilities->abi_version = COLI_EDGE_ABI_VERSION;
     capabilities->flags = COLI_EDGE_CAP_TOKENIZE |
                           COLI_EDGE_CAP_DETOKENIZE |
-                          COLI_EDGE_CAP_GREEDY | COLI_EDGE_CAP_CPU;
+                          COLI_EDGE_CAP_GREEDY | COLI_EDGE_CAP_LOGITS |
+                          COLI_EDGE_CAP_CPU;
     snprintf(capabilities->engine_id, sizeof(capabilities->engine_id), "fake");
     snprintf(capabilities->state_schema, sizeof(capabilities->state_schema),
              "fake/f32-v1");
@@ -96,10 +97,25 @@ static int fake_select(void *impl, const ColiEdgeSelectRequest *request,
     return 0;
 }
 
+static int fake_logits(void *impl, const ColiEdgeLogitsRequest *request,
+                       char *error, size_t error_size) {
+    (void)impl; (void)error; (void)error_size;
+    const float *input = request->input;
+    for (uint32_t row = 0; row < request->rows; row++) {
+        float sum = 0.0f;
+        for (uint32_t column = 0; column < 4; column++)
+            sum += input[(size_t)row * 4 + column];
+        float *logits = request->logits + (size_t)row * 256;
+        for (uint32_t token = 0; token < 256; token++) logits[token] = -1.0f;
+        logits[(uint32_t)((int32_t)sum & 255)] = sum;
+    }
+    return 0;
+}
+
 static const ColiEdgeAdapter fake_adapter = {
     sizeof(ColiEdgeAdapter), COLI_EDGE_ABI_VERSION, "fake",
     fake_open, fake_destroy, fake_tokenize, fake_detokenize,
-    fake_embed, fake_select, {0}
+    fake_embed, fake_select, fake_logits, {0}
 };
 
 static const ColiEdgeAdapter incomplete_tokenizer = {
@@ -111,6 +127,7 @@ static const ColiEdgeAdapter incomplete_tokenizer = {
     .tokenize = fake_tokenize,
     .embed = fake_embed,
     .select = fake_select,
+    .logits = fake_logits,
 };
 
 static int never_cancel(void *unused) { (void)unused; return 0; }
@@ -195,6 +212,25 @@ int main(void) {
     assert(coli_edge_select(engine, &select, error, sizeof(error)) != 0);
     select.token_capacity = 2; select.should_cancel = always_cancel;
     assert(coli_edge_select(engine, &select, error, sizeof(error)) != 0);
+
+    float logits[2 * 256];
+    ColiEdgeLogitsRequest logits_request = {
+        .struct_size = sizeof(logits_request), .rows = 2,
+        .input = states, .input_bytes = sizeof(states),
+        .logits = logits, .logits_capacity = 2 * 256,
+        .should_cancel = never_cancel,
+    };
+    assert(coli_edge_logits(engine, &logits_request,
+                            error, sizeof(error)) == 0);
+    assert(logits[(97 + 98 + 99 + 100) & 255] ==
+           97.0f + 98.0f + 99.0f + 100.0f);
+    logits_request.logits_capacity--;
+    assert(coli_edge_logits(engine, &logits_request,
+                            error, sizeof(error)) != 0);
+    logits_request.logits_capacity = 2 * 256;
+    logits_request.should_cancel = always_cancel;
+    assert(coli_edge_logits(engine, &logits_request,
+                            error, sizeof(error)) != 0);
 
     coli_edge_engine_close(engine);
     puts("edge runtime tests: ok");

--- a/docs/edge-runtime.md
+++ b/docs/edge-runtime.md
@@ -73,7 +73,12 @@ Tokenize and detokenize support a sizing pass by passing a null output with
 zero capacity. `coli_edge_embed` accepts exactly one token ID per row and emits
 `rows * state_width` values in the advertised dtype. `coli_edge_select`
 applies the model's exact final transform and output head to every input row,
-returning one greedy token and an optional score per row.
+returning one greedy token and an optional score per row. Edge ABI v2 also
+exposes `coli_edge_logits`, which returns the complete row-major vocabulary
+logits after that same model-specific transform. Colibri therefore remains the
+owner of model math, while a serving caller can apply temperature, top-p and
+its own reproducible RNG policy without duplicating any of the six heads.
+`argmax(logits)` is release-gated against `coli_edge_select` for every family.
 
 The runtime validates structure sizes, activation geometry, batch limits,
 output capacities and cancellation before entering an adapter. Model adapters
@@ -89,6 +94,9 @@ the real Edge adapter and a full real Segment range, round-trips text, embeds
 an independent oracle prompt, performs prefill plus decode and compares three
 greedy tokens with that oracle. It also requires generated tokens to be
 detokenizable and requires exact Edge/Segment capability identity.
+For each family, the gate additionally computes the full logits for the first
+decode row and requires their argmax to equal the already oracle-checked
+greedy token.
 
 Generate the existing tiny checkpoints from `c/` (they are test data and are
 not committed):


### PR DESCRIPTION
## Summary
- bump the additive Edge ABI to v2 with full final-head logits
- implement logits for GLM, Inkling, Kimi K3, OLMoE, Qwen3.6 and DeepSeek V4
- preserve the exact greedy API and keep sampling policy outside model math
- gate argmax(logits) against the oracle-checked greedy path for every family

## Validation
- make tests/test_edge_runtime tests/test_edge_adapters_registration tests/test_edge_adapters_real
- ./tests/test_edge_runtime
- ./tests/test_edge_adapters_registration
- make edge-adapters-real with all six local tiny fixtures

No ordinary Colibri executable uses the Edge ABI unless explicitly linked by a consumer.