### PR TITLE
fix(qwen36): escape quotes in OpenAI JSON

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1016,6 +1016,9 @@ tests/test_qwen36_ctx$(EXE): tests/test_qwen36_ctx.c qwen36.c qwen36_tier.h st.h
 tests/test_qwen36_dense_batch$(EXE): tests/test_qwen36_dense_batch.c qwen36.c qwen36_tier.h st.h json.h compat.h $(QWEN36_TIER_SRC) $(CUDA_OBJ)
 	$(CC) $(QWEN36_CFLAGS) $< $(QWEN36_TIER_SRC) $(CUDA_OBJ) -o $@ $(QWEN36_LDFLAGS)
 
+tests/test_qwen36_json_escape$(EXE): tests/test_qwen36_json_escape.c qwen36.c qwen36_tier.h st.h json.h compat.h $(QWEN36_TIER_SRC) $(CUDA_OBJ)
+	$(CC) $(QWEN36_CFLAGS) $< $(QWEN36_TIER_SRC) $(CUDA_OBJ) -o $@ $(QWEN36_LDFLAGS)
+
 # Reproducible local timing evidence; intentionally not a noisy CI perf gate.
 tests/bench_qwen36_dense_batch$(EXE): tests/bench_qwen36_dense_batch.c qwen36.c qwen36_tier.h st.h json.h compat.h $(QWEN36_TIER_SRC) $(CUDA_OBJ)
 	$(CC) $(QWEN36_CFLAGS) $< $(QWEN36_TIER_SRC) $(CUDA_OBJ) -o $@ $(QWEN36_LDFLAGS)

--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -348,7 +348,7 @@ static int json_escape(const unsigned char *s, int n, char *out, int outsz){
     int o = 0;
     for (int i=0;i<n;i++){
         unsigned char c = s[i];
-        if (c == '"'){ if(o+2<outsz){ out[o++]='"'; out[o++]='"'; } }
+        if (c == '"'){ if(o+2<outsz){ out[o++]='\\'; out[o++]='"'; } }
         else if (c == '\\'){ if(o+2<outsz){ out[o++]='\\'; out[o++]='\\'; } }
         else if (c == '\n'){ if(o+2<outsz){ out[o++]='\\'; out[o++]='n'; } }
         else if (c == '\r'){ if(o+2<outsz){ out[o++]='\\'; out[o++]='r'; } }

--- a/c/tests/test_qwen36_json_escape.c
+++ b/c/tests/test_qwen36_json_escape.c
@@ -1,0 +1,44 @@
+/* Regression gate for qwen36 OpenAI JSON string escaping. */
+#define main qwen36_main_unused
+#include "../qwen36.c"
+#undef main
+
+static int failures;
+
+#define CHECK(cond, what) do { \
+    if (!(cond)) { fprintf(stderr, "FAIL: %s\n", (what)); failures++; } \
+    else printf("ok: %s\n", (what)); \
+} while (0)
+
+static void case_json_escapes(void) {
+    static const unsigned char input[] = {
+        'a', '"', 'b', '\\', 'c', '\n', '\r', '\t', '\b', '\f', 0x01
+    };
+    char out[128];
+    int n = json_escape(input, (int)sizeof input, out, (int)sizeof out);
+    const char *want = "a\\\"b\\\\c\\n\\r\\t\\b\\f\\u0001";
+
+    CHECK(strcmp(out, want) == 0, "quotes, backslashes and controls use JSON escapes");
+    CHECK(n == (int)strlen(want), "returned length matches escaped output");
+}
+
+static void case_plain_utf8_passes_through(void) {
+    static const unsigned char input[] = { 'x', 0xE2, 0x82, 0xAC, 'y' };
+    char out[32];
+    int n = json_escape(input, (int)sizeof input, out, (int)sizeof out);
+
+    CHECK(n == (int)sizeof input, "plain UTF-8 byte length is unchanged");
+    CHECK(memcmp(out, input, sizeof input) == 0 && out[sizeof input] == '\0',
+          "plain UTF-8 bytes pass through unchanged");
+}
+
+int main(void) {
+    case_json_escapes();
+    case_plain_utf8_passes_through();
+    if (failures) {
+        fprintf(stderr, "%d qwen36 JSON escape regression(s)\n", failures);
+        return 1;
+    }
+    puts("qwen36 JSON escape regression: PASS");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- escape literal double quotes as `\"` in Qwen3.6 OpenAI output
- add a checkpoint-free regression test for quotes, backslashes, control bytes, and UTF-8
- wire the regression test into the existing Makefile test discovery

## Verification

- `make tests/test_qwen36_json_escape`
- `./tests/test_qwen36_json_escape`
- `git diff --check`

Fixes the JSON escaping defect reported in #1253. The independent compiler-warning cleanup is already covered by #1232.