### PR TITLE
fix(glm53): keep the prefix-reuse line out of a user's terminal

### DIFF
--- a/c/glm53.c
+++ b/c/glm53.c
@@ -2531,8 +2531,13 @@ static void serve_one(GModel *m, Tok *tokenizer, ServeReq *q) {
      * righe che non conosce, ma questo progetto ha scelto il contrario apposta
      * e lo mette per iscritto in un test: una riga sconosciuta uccide il
      * dispatcher, cosi' un motore non puo' parlare a un server che non lo
-     * capisce. La regola vera e' quella del test, non quella del documento. */
-    fprintf(stderr, "REUSE %llu %d %d\n", q->id, reused, prompt_tokens);
+     * capisce. La regola vera e' quella del test, non quella del documento.
+     *
+     * E dietro GLM53_VERBOSE, perche' `coli chat` eredita lo stderr del server:
+     * senza guardia questa riga compare a schermo dopo ogni risposta, sotto gli
+     * occhi di chi voleva solo la risposta. */
+    if (getenv("GLM53_VERBOSE"))
+        fprintf(stderr, "REUSE %llu %d %d\n", q->id, reused, prompt_tokens);
     serve_line("DONE %llu STAT %d %.2f %.1f %.1f %d %d\n", q->id, emitted,
                elapsed > 0 ? emitted / elapsed : 0.0,
                m->miss + m->hits ? 100.0 * m->hits / (double)(m->hits + m->miss) : 0.0,

--- a/c/tests/test_glm53_serve.py
+++ b/c/tests/test_glm53_serve.py
@@ -36,8 +36,11 @@ def reuse_reported():
 
 
 def engine(binary, fixture, extra=None):
+    # GLM53_VERBOSE: il riuso del prefisso si racconta solo su richiesta,
+    # perche' `coli chat` eredita lo stderr del server e quella riga finirebbe
+    # a schermo dopo ogni risposta.
     environment = {**os.environ, "SERVE": "1", "SERVE_BATCH": "1",
-                   "SNAP": str(fixture), "GLM53_BITS": "32"}
+                   "SNAP": str(fixture), "GLM53_BITS": "32", "GLM53_VERBOSE": "1"}
     environment.update(extra or {})
     # stderr in un file: il riuso del prefisso si racconta li', perche' nel
     # protocollo una riga in piu' farebbe cadere il gateway (di proposito).


### PR DESCRIPTION
`coli chat` inherits the server's stderr, so `REUSE <id> <reused> <prompt>` printed under the answer after every turn:

```
COLIBRI SUPPORTA VISION CON GLM 5.3REUSE 1 0 91
```

It is a diagnostic and now needs `GLM53_VERBOSE`, like the engine's other stderr output. The serve test asks for it explicitly, since it reads that line to check prefix reuse actually happens.

Verified both ways: no occurrences on stderr by default, one with `GLM53_VERBOSE=1`.

Found while recording a demo — the right place to find it. A line that means nothing to the person reading it is noise, and noise under an answer is worse on screen than in a log.