### PR TITLE
chore: v1.9.0

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -32,7 +32,7 @@ ma non ridefinire il modello di nascosto.
 
 ```
 $ ./coli chat
-  🐦 colibri v1.8.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
+  🐦 colibri v1.9.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
   ✓ ready in 32s · resident 9.9 GB
   › ciao!
   ◆ Ciao! 😊 Come posso aiutarti oggi?

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ may reduce speed; it must not quietly redefine the model.
 
 ```
 $ ./coli chat
-  🐦 colibri v1.8.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
+  🐦 colibri v1.9.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
   ✓ ready in 32s · resident 9.9 GB
   › ciao!
   ◆ Ciao! 😊 Come posso aiutarti oggi?

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,7 +24,7 @@ Colibrì 刻意用于验证激进的系统思路——因此**对速度不作 SL
 
 ```
 $ ./coli chat
-  🐦 colibri v1.8.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
+  🐦 colibri v1.9.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
   ✓ ready in 32s · resident 9.9 GB
   › ciao!
   ◆ Ciao! 😊 Come posso aiutarti oggi?

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -24,7 +24,7 @@ Colibrì 刻意用於驗證激進的系統構想——因此**對速度不作 SL
 
 ```
 $ ./coli chat
-  🐦 colibri v1.8.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
+  🐦 colibri v1.9.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
   ✓ ready in 32s · resident 9.9 GB
   › ciao!
   ◆ Ciao! 😊 Come posso aiutarti oggi?

--- a/c/version.py
+++ b/c/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the colibri version number."""
 
-__version__ = "1.8.0"
+__version__ = "1.9.0"


### PR DESCRIPTION
Version bump ahead of the release: `c/version.py` and the banner line of the four READMEs, which move together or the binary and the page disagree about what someone is running.

A new model family with vision is a minor bump.