### PR TITLE
colibrì v1.9.0 — release build fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,10 @@ jobs:
       - name: Build engines
         run: |
           cd c
-          for t in colibri inkling kimi_k3 olmoe qwen36; do
+          for t in colibri glm53 inkling kimi_k3 olmoe qwen36; do
             make $t ${{ matrix.make_args }}
           done
-          ls -lh colibri${{ matrix.ext }} inkling${{ matrix.ext }} kimi_k3${{ matrix.ext }} olmoe${{ matrix.ext }} qwen36${{ matrix.ext }}
+          ls -lh colibri${{ matrix.ext }} glm53${{ matrix.ext }} inkling${{ matrix.ext }} kimi_k3${{ matrix.ext }} olmoe${{ matrix.ext }} qwen36${{ matrix.ext }}
 
       # DeepSeek V4 has its own Makefile and its own target name (`deepseek-v4`,
       # producing `deepseek_v4`), so it never joined the loop above -- and #858 is

--- a/README.it.md
+++ b/README.it.md
@@ -336,10 +336,10 @@ e per il gateway API opzionale.
   end-to-end, revisionati e sviluppati apertamente.
 - **Più modelli aperti.** L'algoritmo di tiering è indipendente dal modello:
   qualsiasi MoE con expert instradati può essere organizzato allo stesso modo.
-  Sei famiglie funzionano già (GLM-5.2, Inkling, Kimi K3, DeepSeek V4 Flash,
-  Qwen3.6, OLMoE); altre famiglie open-weight, **MiniMax** tra le candidate,
-  si guadagnano un engine come le prime sei: quando qualcuno le misura
-  end-to-end.
+  Sette famiglie funzionano già (GLM-5.2, GLM-5.3-Flash con la vision,
+  Inkling, Kimi K3, DeepSeek V4 Flash, Qwen3.6, OLMoE); altre famiglie
+  open-weight, **MiniMax** tra le candidate, si guadagnano un engine come le
+  prime sette: quando qualcuno le misura end-to-end.
 
 ## Sostenere il progetto
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,8 +10,9 @@
 **小巧引擎，庞大模型。**在消费级与异构硬件上运行**前沿 MoE 模型——从 744B 到
 2.8T 参数**——以引擎零依赖的纯 C 实现，将存储、RAM 与 VRAM 视为统一的推理层级。
 
-目前可运行六个模型家族：**GLM-5.2**（744B）、**Inkling**（975B）、**Kimi K3**
-（2.8T）、**DeepSeek V4 Flash**（284B）、**Qwen3.6**（35B-A3B）与 **OLMoE**（7B）
+目前可运行七个模型家族：**GLM-5.2**（744B）、**GLM-5.3-Flash**（321B，含视觉）、
+**Inkling**（975B）、**Kimi K3**（2.8T）、**DeepSeek V4 Flash**（284B）、
+**Qwen3.6**（35B-A3B）与 **OLMoE**（7B）
 ——各自一个 C 文件，共用同一套 `coli chat` / `coli serve` / `coli web` 前端。[完整列表](README.md#other-supported-models)
 
 > **Colibrì 既是今天就能运行的推理引擎，也是一个开放的研究平台。**它的首要目标是在
@@ -310,7 +311,7 @@ oracle 说明，请参阅[中文版 DeepSeek V4 文档](docs/deepseek-v4.zh-CN.m
   放置、调度、I/O、CPU/GPU 内核、异构重叠、KV 状态与路由感知推测。目标是降低硬件要求
   和每个有效 token 的成本，所有成果都以端到端测量为准、经审查并公开开发。
 - **支持更多开放模型。**层级算法与模型无关，任何带路由专家的 MoE 都能用相同方式分层。
-  目前已有六个模型家族可用（GLM-5.2、Inkling、Kimi K3、DeepSeek V4 Flash、
+  目前已有七个模型家族可用（GLM-5.2、GLM-5.3-Flash、Inkling、Kimi K3、DeepSeek V4 Flash、
   Qwen3.6、OLMoE）；更多开放权重家族（候选包括 **MiniMax**）将沿用同样的
   规则获得引擎支持：有人完成端到端实测之后。
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -10,8 +10,9 @@
 **小巧引擎，龐大模型。**在消費級與異質硬體上執行**前沿 MoE 模型——從 744B 到
 2.8T 參數**——以引擎零相依套件的純 C 實作，將儲存、RAM 與 VRAM 視為統一的推論階層。
 
-目前可執行六個模型家族：**GLM-5.2**（744B）、**Inkling**（975B）、**Kimi K3**
-（2.8T）、**DeepSeek V4 Flash**（284B）、**Qwen3.6**（35B-A3B）與 **OLMoE**（7B）
+目前可執行七個模型家族：**GLM-5.2**（744B）、**GLM-5.3-Flash**（321B，含視覺）、
+**Inkling**（975B）、**Kimi K3**（2.8T）、**DeepSeek V4 Flash**（284B）、
+**Qwen3.6**（35B-A3B）與 **OLMoE**（7B）
 ——各自一個 C 檔案，共用同一套 `coli chat` / `coli serve` / `coli web` 前端。[完整清單](README.md#other-supported-models)
 
 > **Colibrì 既是今天就能執行的推論引擎，也是一個開放的研究平台。**它的首要目標是在
@@ -290,7 +291,7 @@ COLI_MODEL=/nvme/glm52_i4 ./coli doctor   # 唯讀就緒檢查
   配置、排程、I/O、CPU/GPU 核心、異質重疊、KV 狀態與路由感知推測。目標是降低硬體要求
   和每個有效 token 的成本，所有成果都以端到端測量為準、經審查並公開開發。
 - **支援更多開放模型。**階層演算法與模型無關，任何帶路由專家的 MoE 都能用相同方式分層。
-  目前已有六個模型家族可用（GLM-5.2、Inkling、Kimi K3、DeepSeek V4 Flash、
+  目前已有七個模型家族可用（GLM-5.2、GLM-5.3-Flash、Inkling、Kimi K3、DeepSeek V4 Flash、
   Qwen3.6、OLMoE）；更多開放權重家族（候選包括 **MiniMax**）將沿用同樣的
   規則獲得引擎支援：有人完成端到端實測之後。
 

--- a/c/tests/test_family_registry.py
+++ b/c/tests/test_family_registry.py
@@ -923,6 +923,19 @@ class FamilyRegistryTest(unittest.TestCase):
                     self.assertIn(family.build_target,
                                   re.search(r'ENGINES="([^"]+)"', ci).group(1).split())
                     self.assertIn(f"cp c/{family.engine_artifact}", release)
+                    # Copiarlo non basta: va anche COSTRUITO. Il contratto
+                    # verificava solo meta', e con quella meta' la v1.9.0 e'
+                    # uscita col nome di GLM-5.3-Flash e senza il suo binario,
+                    # esattamente come la v1.5.0 con DeepSeek V4 (#858). Un
+                    # `cp` di un file che nessuno ha compilato fallisce a
+                    # release gia' pubblicata, cioe' nel momento peggiore.
+                    build_step = re.search(r"for t in ([a-z0-9_ ]+); do",
+                                           release)
+                    self.assertIsNotNone(build_step,
+                                         "release.yml: build loop not found")
+                    self.assertIn(family.build_target, build_step.group(1).split(),
+                                  f"{family.id}: release.yml copies "
+                                  f"c/{family.engine_artifact} but never builds it")
                     self.assertIn(f"$(LIBEXECDIR)/{family.engine_artifact}", makefile)
                 else:
                     self.assertIn("deepseek-v4", ci)


### PR DESCRIPTION
v1.9.0 published without archives: the release build failed on `cp: cannot stat 'c/glm53'` because the engine was in the copy list and not in the build loop. The repository already carried a comment about the same failure from #858, where v1.5.0 was titled DeepSeek V4 Flash and shipped no `deepseek_v4.exe`.

**The contract test enforced half the contract** — copied, never built — which is how it reached a pushed tag. It now checks the build loop too, and restoring the bug makes it fail with `release.yml copies c/glm53 but never builds it`.

Also carries the translated READMEs, which never got the family: English said seven families in three places while Italian and both Chinese pages still said six and did not mention GLM-5.3 at all.

Reproduced the release's exact build sequence locally (`make glm53 ARCH=x86-64-v3`) before pushing this.

After merging, v1.9.0's tag needs to move to the new main commit so the release workflow reruns and produces the archives.