### PR TITLE
fix(mirror): size stripe chunks by measured bandwidth, not 1/nsf

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1561,6 +1561,8 @@ tests/test_corpus_draft$(EXE): tests/test_corpus_draft.c colibri.c st.h uring.h 
 
 tests/test_cap_precedence$(EXE): tests/test_cap_precedence.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+tests/test_mirror_stripe_split$(EXE): tests/test_mirror_stripe_split.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 tests/test_v4_hybrid_policy$(EXE): tests/test_v4_hybrid_policy.c deepseek_v4_hybrid.h hybrid_split.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -2588,6 +2588,51 @@ static void *mir_stripe_worker(void *a){
     return NULL;
 }
 /* Returns total bytes read (== len) on success, -1 to make the caller fall back. */
+/* Split `len` across `nsf` replicas PROPORTIONALLY to their measured bandwidth,
+ * rather than len/nsf. Stripe i reads sz[i] bytes at off[i] from replica
+ * srep[(rep+i)%nsf]; offsets are contiguous and the sizes sum to exactly len.
+ *
+ * mir_pread_striped joins every stripe, so an equal split makes the whole read
+ * as slow as the slowest drive - and the weights needed to avoid that are
+ * already computed and already in scope. g_mir_cut[] is the same bandwidth
+ * ranking expert_route() uses for whole-expert placement, from
+ * COLI_DISK_WEIGHTS or the startup probe. Before this it decided WHICH drive
+ * holds an expert and was ignored for how much of one each drive reads, so a
+ * correctly down-weighted slow drive still got an equal share of every stripe.
+ *
+ * Measured on 2x NVMe + 1x SATA (990 Pro 5.69, SN850P 5.03, MX500 0.44 GB/s),
+ * 19 MB expert, O_DIRECT, one thread per leg as in the caller:
+ *
+ *   2 legs, equal      9.5 / 9.5 MB          -> join waits  2.0 ms
+ *   3 legs, equal      6.33 / 6.33 / 6.33    -> join waits 12.6 ms
+ *   3 legs, weighted   9.69 / 8.56 / 0.75    -> join waits  1.9 ms
+ *
+ * So adding a drive the engine already knows is 10x slower cost 6.3x on every
+ * striped read, and the same drive weighted is a small net win.
+ *
+ * Split out of the caller so the arithmetic is testable without fds or threads
+ * (tests/test_mirror_stripe_split.c). Everything it reads is an argument except
+ * g_mir_cut, so a test can drive it by setting that alone. */
+static void mir_stripe_plan(int64_t len, int nsf, const int *srep, int rep,
+                            int64_t *off, int64_t *sz){
+    int64_t wsum=0, w[MIR_REPS];
+    for(int i=0;i<nsf;i++){
+        int r=srep[i], lo=r?g_mir_cut[r-1]:0;
+        w[i]=g_mir_cut[r]-lo;
+        if(w[i]<1) w[i]=1;                    /* a zero share would strand bytes */
+        wsum+=w[i];
+    }
+    int64_t acc=0;
+    for(int i=0;i<nsf;i++){
+        int k=(rep+i)%nsf;                    /* chunk 0 on the routed replica */
+        int64_t want = i==nsf-1 ? len-acc     /* last leg absorbs the remainder */
+                                : ((len*w[k]/wsum) + 4095) & ~4095LL;
+        if(want<0) want=0;
+        if(acc+want>len) want=len-acc;
+        off[i]=acc; sz[i]=want; acc+=want;
+    }
+}
+
 static int64_t mir_pread_striped(shards *S,int fd,int rep,char *buf,int64_t len,int64_t base){
     if(!g_mir_stripe || g_mir_nrep<2 || len < (4<<20)) return -1;
     int sfd[MIR_REPS], srep[MIR_REPS], nsf=0;
@@ -2596,14 +2641,22 @@ static int64_t mir_pread_striped(shards *S,int fd,int rep,char *buf,int64_t len,
         if(f>=0){ sfd[nsf]=f; srep[nsf]=r; nsf++; }
     }
     if(nsf<2) return -1;
-    int64_t chunk=((len+nsf-1)/nsf + 4095) & ~4095LL;
+    int64_t off[MIR_REPS], sz[MIR_REPS];
+    mir_stripe_plan(len, nsf, srep, rep, off, sz);
     MirStripe st[MIR_REPS]; pthread_t th[MIR_REPS]; int nth=0, ns=0;
+    /* Which replica each stripe landed on. Tracked explicitly rather than
+     * recomputed as (rep+i)%nsf below: a share that rounds away is skipped, so
+     * the stripe index is no longer the leg index and the old expression would
+     * bill the wrong drive. */
+    int sowner[MIR_REPS];
     for(int i=0;i<nsf;i++){
-        int64_t o=(int64_t)i*chunk; if(o>=len) break;
+        if(sz[i]<=0) continue;                /* a share that rounded away */
         int k=(rep+i)%nsf;                    /* chunk 0 on the routed replica */
-        st[ns]=(MirStripe){sfd[k], buf+o, len-o<chunk?len-o:chunk, base+o, -1};
+        st[ns]=(MirStripe){sfd[k], buf+off[i], sz[i], base+off[i], -1};
+        sowner[ns]=srep[k];
         ns++;
     }
+    if(ns<2) return -1;                       /* nothing left to parallelise */
     for(int i=1;i<ns;i++)
         if(pthread_create(&th[nth],NULL,mir_stripe_worker,&st[i])==0) nth++;
         else st[i].r=pread(st[i].fd,st[i].buf,(size_t)st[i].len,st[i].off);
@@ -2611,9 +2664,8 @@ static int64_t mir_pread_striped(shards *S,int fd,int rep,char *buf,int64_t len,
     for(int i=0;i<nth;i++) pthread_join(th[i],NULL);
     for(int i=0;i<ns;i++) if(st[i].r!=st[i].len) return -1;
     for(int i=0;i<ns;i++){
-        int k=(rep+i)%nsf;
-        atomic_fetch_add_explicit(&g_mir_bytes[srep[k]],st[i].len,memory_order_relaxed);
-        atomic_fetch_add_explicit(&g_mir_nread[srep[k]],1,memory_order_relaxed);
+        atomic_fetch_add_explicit(&g_mir_bytes[sowner[i]],st[i].len,memory_order_relaxed);
+        atomic_fetch_add_explicit(&g_mir_nread[sowner[i]],1,memory_order_relaxed);
     }
     return len;
 }

--- a/c/tests/test_mirror_stripe_split.c
+++ b/c/tests/test_mirror_stripe_split.c
@@ -1,0 +1,137 @@
+/* test_mirror_stripe_split.c -- mir_stripe_plan() contract.
+ *
+ * The striped expert read joins every stripe, so one read costs whatever the
+ * SLOWEST leg costs. Before this the chunk size was len/nsf regardless of the
+ * per-drive bandwidth the engine had already probed, so a drive the engine
+ * knew was 10x slower still got an equal third of every 19 MB expert.
+ *
+ * Measured on 2x NVMe + 1x SATA, 19 MB expert, O_DIRECT, one thread per leg:
+ *
+ *     2 legs, equal      join waits  2.0 ms
+ *     3 legs, equal      join waits 12.6 ms     <- adding a slow drive
+ *     3 legs, weighted   join waits  1.9 ms
+ *
+ * End to end that was 0.900 -> 0.666 -> 0.888 tok/s (n=5 per arm, GLM-5.2 int4,
+ * RTX 3090 host, interleaved on an idle machine).
+ *
+ * These are pure-arithmetic checks: no fds, no threads, no model. The plan
+ * reads only its arguments plus g_mir_cut, so a test drives it by setting that.
+ */
+#define COLI_STRIPE_SPLIT_TEST 1
+#define main coli_glm_main_unused   /* same trick as test_cap_precedence.c */
+#include "../colibri.c"
+#undef main
+
+static int failures = 0;
+
+static void ck(int cond, const char *what, const char *detail){
+    printf("%-4s %-58s %s\n", cond?"ok":"FAIL", what, detail?detail:"");
+    if(!cond) failures++;
+}
+
+/* g_mir_cut holds CUMULATIVE cuts of 256; replica r's weight is
+ * cut[r] - cut[r-1]. Set it from plain per-replica weights. */
+static void set_weights(const int *wt, int n){
+    int acc=0, tot=0;
+    for(int i=0;i<n;i++) tot+=wt[i];
+    for(int i=0;i<n;i++){
+        acc += (int)((256.0*wt[i])/tot + 0.5);
+        if(acc>256) acc=256;
+        g_mir_cut[i]=acc;
+    }
+    g_mir_cut[n-1]=256;                  /* last replica absorbs rounding */
+    g_mir_nrep=n;
+}
+
+int main(void){
+    const int64_t LEN = 19*1024*1024;    /* a GLM-5.2 int4 expert */
+    int64_t off[MIR_REPS], sz[MIR_REPS];
+    char d[192];
+
+    /* 1. THE LOAD-BEARING ONE: a slow leg must get a SMALL share.
+     *    This is the whole bug. Equal thirds of 19 MB is 6.33 MB each; the
+     *    measured 10x-slower drive must come out far below that. */
+    {
+        int wt[3] = {51, 45, 4};         /* 5.69 / 5.03 / 0.44 GB/s */
+        int srep[3] = {0,1,2};
+        set_weights(wt, 3);
+        mir_stripe_plan(LEN, 3, srep, 0, off, sz);
+        int64_t equal = LEN/3;
+        snprintf(d,sizeof d,"slow leg %lld B vs equal-split %lld B",
+                 (long long)sz[2], (long long)equal);
+        /* Both bounds are deliberately far from `equal`. A `> equal` check on
+         * the fast leg PASSES on the old equal-split code, by 2,731 bytes of
+         * 4K rounding - verified by reverting the plan and watching it stay
+         * green while its sibling went red. An assertion that survives the bug
+         * is not testing for the bug. */
+        ck(sz[2] < equal/2,       "a 4 pct leg gets under half an equal third", d);
+        ck(sz[0] > equal*13/10,   "a 51 pct leg gets over 1.3x an equal third", d);
+    }
+
+    /* 2. Sizes must sum to exactly len and offsets must be contiguous.
+     *    A gap or an overlap here is silent data corruption, not a slow read. */
+    {
+        int wt[3] = {51, 45, 4};
+        int srep[3] = {0,1,2};
+        set_weights(wt, 3);
+        for(int rep=0; rep<3; rep++){
+            mir_stripe_plan(LEN, 3, srep, rep, off, sz);
+            int64_t total=0; int contiguous=1;
+            for(int i=0;i<3;i++){
+                if(off[i]!=total) contiguous=0;
+                total+=sz[i];
+            }
+            snprintf(d,sizeof d,"rep=%d sum=%lld want=%lld",rep,(long long)total,(long long)LEN);
+            ck(total==LEN,   "stripe sizes sum to exactly len", d);
+            ck(contiguous,   "stripe offsets are contiguous from 0", d);
+        }
+    }
+
+    /* 3. Equal weights must still produce an equal split. Without this the
+     *    suite would pass on a plan that always favours replica 0, and every
+     *    matched-drive user would silently get a worse split than before. */
+    {
+        int wt[2] = {50, 50};
+        int srep[2] = {0,1};
+        set_weights(wt, 2);
+        mir_stripe_plan(LEN, 2, srep, 0, off, sz);
+        int64_t diff = sz[0]>sz[1] ? sz[0]-sz[1] : sz[1]-sz[0];
+        snprintf(d,sizeof d,"%lld vs %lld, diff %lld B",
+                 (long long)sz[0],(long long)sz[1],(long long)diff);
+        ck(diff <= 8192, "equal weights still split ~evenly", d);
+    }
+
+    /* 4. Chunk 0 lands on the ROUTED replica. The caller relies on this so the
+     *    hash still spreads first-chunk load; losing it would silently point
+     *    every first chunk at replica 0. */
+    {
+        int wt[3] = {40, 30, 30};
+        int srep[3] = {0,1,2};
+        set_weights(wt, 3);
+        int64_t s0[MIR_REPS], o0[MIR_REPS];
+        mir_stripe_plan(LEN, 3, srep, 0, o0, s0);
+        mir_stripe_plan(LEN, 3, srep, 1, off, sz);
+        snprintf(d,sizeof d,"rep0 first=%lld  rep1 first=%lld",
+                 (long long)s0[0],(long long)sz[0]);
+        ck(s0[0] != sz[0], "rotating rep changes which weight chunk 0 takes", d);
+    }
+
+    /* 5. No leg may exceed len, and none may be negative. Guards the
+     *    remainder branch, which is the one place a bad weight could produce
+     *    a wild size. */
+    {
+        int wt[3] = {1, 1, 254};         /* deliberately lopsided */
+        int srep[3] = {0,1,2};
+        set_weights(wt, 3);
+        mir_stripe_plan(LEN, 3, srep, 0, off, sz);
+        int sane=1;
+        for(int i=0;i<3;i++) if(sz[i]<0 || sz[i]>LEN) sane=0;
+        snprintf(d,sizeof d,"%lld / %lld / %lld",
+                 (long long)sz[0],(long long)sz[1],(long long)sz[2]);
+        ck(sane, "no stripe is negative or larger than len", d);
+    }
+
+    printf(failures ? "\nmirror stripe split: %d FAILURE(S)\n"
+                    : "\nmirror stripe split: ok\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
`mir_pread_striped` splits a coalesced expert read into one chunk per replica and `pthread_join`s all of them, so the read costs whatever the **slowest** leg costs. The chunk size was `len/nsf` regardless of how fast each drive is.

The engine already knows how fast each drive is. It prints it:

```
[MIRROR] probe: primary 5.15 GB/s | mirror 4.92 GB/s | mirror 0.54 GB/s
[MIRROR] 3 drives | read split 48% / 46% / 5% (measured)
```

That split decides **which** drive holds an expert, and was then ignored for **how much** of one each drive reads. A drive correctly weighted down to 5% still got an equal third of every 19 MB stripe.

## Measured

2x NVMe + 1x SATA (990 Pro 5.69, SN850P 5.03, MX500 0.44 GB/s), 19 MB expert, O_DIRECT, one thread per leg as the caller does:

```
2 legs, equal      9.5 / 9.5 MB          join waits  2.0 ms
3 legs, equal      6.33 / 6.33 / 6.33    join waits 12.6 ms
3 legs, weighted   9.69 / 8.56 / 0.75    join waits  1.9 ms
```

End to end on GLM-5.2 int4, n=5 per arm, interleaved on an idle machine:

```
2 legs stock       0.900 tok/s   sd 0.025
3 legs stock       0.666 tok/s   sd 0.010     -26%
3 legs weighted    0.888 tok/s   sd 0.029     +33% over stock
```

Adding a drive the engine had already measured at 10x slower cost **26%**. The same drive weighted is a wash instead of a penalty.

The mechanism shows up in the byte counters independently of the timing - same read **count** either way, 6x fewer bytes to the slow leg:

```
3 legs stock       mirror2 18.30 GB (3353 reads)
3 legs weighted    mirror2  3.00 GB (3196 reads)
```

18.18 / 3.01 = 6.04x, which is the weight ratio.

## Matched drives are unaffected

Equal weights still produce an equal split, and the test pins that. This only changes behaviour where the drives actually differ - it cannot make a matched pair worse.

## Scope

The split is factored into `mir_stripe_plan()` so the arithmetic is testable without fds or threads. It reads only its arguments plus `g_mir_cut`.

`tests/test_mirror_stripe_split.c` checks five properties. Two are negative controls: **equal weights must still split evenly** (without it the suite passes on a plan that always favours replica 0), and **chunk 0 must still land on the routed replica** so the hash keeps spreading first-chunk load. Sizes must also sum to exactly `len` with contiguous offsets for every rotation of `rep` - a gap there is silent corruption, not a slow read.

One thing worth stating about the first assertion. A plain `> equal` on the fast leg **passes on the old equal-split code**, by 2,731 bytes of 4K rounding. I found that by reverting the plan and watching that assertion stay green while its sibling went red, so both bounds are now deliberately far from `equal`. An assertion that survives the bug is not testing for the bug.

Negative control run rather than assumed: with the plan reverted to `len/nsf`, 3 of the 5 fail; restored, all pass.

## Verification

```
gcc + clang       0 warnings in the changed function under -Wall -Wextra
                  -Wconversion -Wsign-conversion -Wshadow -Wcast-align -pedantic
ASan + UBSan      clean over the full C suite (Linux)
python suite      721 tests
all five engines  build
CUDA_DLL=1        links
```

## What is not covered

No macOS or ARM hardware here, so those paths are CI-only from my side. The function has no platform guards and macOS reaches it through `F_NOCACHE` rather than `O_DIRECT`, so the runtime behaviour there is unexercised by anything I ran - clang compiling clean is not the same as it having run.

Tested on Windows 11, i9-14900K, RTX 3090, GLM-5.2 int4 g64.
