### PR TITLE
feat(gemma4): add standalone Gemma 4 MoE runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
         run: |
           cd c
           rc=0
-          ENGINES="colibri glm53 inkling kimi_k3 olmoe qwen36 qwen38"
+          ENGINES="colibri glm53 inkling kimi_k3 olmoe qwen36 qwen38 gemma4"
           if [ "${{ matrix.v4 }}" = "1" ]; then ENGINES="$ENGINES deepseek-v4"; fi
           for t in $ENGINES; do
             echo "::group::$t"

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ c/kimi_k3.exe
 c/olmoe.exe
 c/qwen38
 c/qwen38.exe
+c/gemma4
+c/gemma4.exe
 # deepseek_v4 and the per-unit objects its amalgamated Makefile leaves behind.
 # The same omission as #858, one file over: every engine is listed here except
 # the one added last, so `make deepseek-v4` left 26 untracked .o files in

--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ Two things that differ per model, both documented in the per-model page:
 | CUDA backend, VRAM expert tier, full residency | [docs/cuda.md](docs/cuda.md) |
 | Vulkan backend (any GPU: AMD via RADV, incl. cards ROCm dropped) | [docs/vulkan.md](docs/vulkan.md) |
 | Apple Silicon Metal backend | [docs/metal.md](docs/metal.md) |
+| Experimental Gemma 4 runtime adaptation | [docs/gemma4.md](docs/gemma4.md) |
 | OpenAI-compatible API, KV slots, web dashboard | [docs/api.md](docs/api.md) |
 | Experimental layer-segment embedding ABI | [docs/segment-runtime.md](docs/segment-runtime.md) |
 | Experimental tokenizer/embedding/head Edge ABI | [docs/edge-runtime.md](docs/edge-runtime.md) |

--- a/c/Makefile
+++ b/c/Makefile
@@ -1081,6 +1081,25 @@ glm53$(EXE): glm53.c st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.
 kimi_k3$(EXE): kimi_k3.c st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h omp_tune.h route_trace.h kv_prefix.h serve_codec.h backend_cuda.h $(CUDA_OBJ) $(VK_OBJ) $(VK_SPV) $(METAL_OBJ)
 	$(CC) $(CFLAGS) kimi_k3.c $(CUDA_OBJ) $(VK_OBJ) $(METAL_OBJ) -o kimi_k3$(EXE) $(LDFLAGS)
 
+GEMMA4_SRCS = gemma4_backend.c gemma4_gguf.c gemma4_model.c gemma4_sampling.c gemma4_tokenizer.c gemma4_tools.c gemma4_vision.c gemma4_cuda_stub.c
+GEMMA4_HDRS = gemma4_backend.h gemma4_gguf.h gemma4_model.h gemma4_sampling.h gemma4_tokenizer.h gemma4_tools.h gemma4_vision.h gemma4_cuda.h model.h json.h
+GEMMA4_PNG_CFLAGS  := $(if $(IS_WIN),,$(shell pkg-config --cflags libpng 2>/dev/null))
+GEMMA4_PNG_LIBS    := $(if $(IS_WIN),,$(shell pkg-config --libs libpng 2>/dev/null))
+GEMMA4_JPEG_CFLAGS := $(if $(IS_WIN),,$(shell pkg-config --cflags libjpeg 2>/dev/null))
+GEMMA4_JPEG_LIBS   := $(if $(IS_WIN),,$(shell pkg-config --libs libjpeg 2>/dev/null))
+GEMMA4_CODEC_FLAGS := $(if $(GEMMA4_PNG_LIBS),-DCOLI_GEMMA4_LIBPNG=1 $(GEMMA4_PNG_CFLAGS),) \
+                      $(if $(GEMMA4_JPEG_LIBS),-DCOLI_GEMMA4_LIBJPEG=1 $(GEMMA4_JPEG_CFLAGS),)
+GEMMA4_CPPFLAGS = -I.
+GEMMA4_LIBS = $(if $(IS_WIN),-lwindowscodecs -lole32,$(GEMMA4_PNG_LIBS) $(GEMMA4_JPEG_LIBS))
+
+gemma4$(EXE): gemma4.c $(GEMMA4_SRCS) $(GEMMA4_HDRS)
+	$(CC) $(CFLAGS) $(GEMMA4_CPPFLAGS) $(GEMMA4_CODEC_FLAGS) gemma4.c $(GEMMA4_SRCS) -o gemma4$(EXE) $(LDFLAGS) $(GEMMA4_LIBS)
+
+ifneq ($(EXE),)
+.PHONY: gemma4
+gemma4: gemma4$(EXE)
+endif
+
 # Use a baseline that matches the compiler target. macOS already targets a
 # portable baseline when ARCH is empty; forcing the x86 value there breaks
 # Apple Silicon. Unknown targets use native rather than an invalid x86 flag.
@@ -1680,6 +1699,27 @@ tests/test_omp_tune$(EXE): tests/test_omp_tune.c omp_tune.h
 
 tests/test_kvb_notice$(EXE): tests/test_kvb_notice.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+tests/test_gemma4$(EXE): tests/test_gemma4.c $(GEMMA4_SRCS) $(GEMMA4_HDRS)
+	$(CC) $(CFLAGS) $(GEMMA4_CPPFLAGS) $(GEMMA4_CODEC_FLAGS) $< $(GEMMA4_SRCS) -o $@ $(LDFLAGS) $(GEMMA4_LIBS)
+
+tests/test_gemma4_model$(EXE): tests/test_gemma4_model.c $(GEMMA4_SRCS) $(GEMMA4_HDRS)
+	$(CC) $(CFLAGS) $(GEMMA4_CPPFLAGS) $(GEMMA4_CODEC_FLAGS) $< $(GEMMA4_SRCS) -o $@ $(LDFLAGS) $(GEMMA4_LIBS)
+
+tests/test_gemma4_attention$(EXE): tests/test_gemma4_attention.c $(GEMMA4_SRCS) $(GEMMA4_HDRS)
+	$(CC) $(CFLAGS) $(GEMMA4_CPPFLAGS) $(GEMMA4_CODEC_FLAGS) $< $(GEMMA4_SRCS) -o $@ $(LDFLAGS) $(GEMMA4_LIBS)
+
+tests/test_gemma4_tokenizer$(EXE): tests/test_gemma4_tokenizer.c $(GEMMA4_SRCS) $(GEMMA4_HDRS)
+	$(CC) $(CFLAGS) $(GEMMA4_CPPFLAGS) $(GEMMA4_CODEC_FLAGS) $< $(GEMMA4_SRCS) -o $@ $(LDFLAGS) $(GEMMA4_LIBS)
+
+tests/test_gemma4_tools$(EXE): tests/test_gemma4_tools.c $(GEMMA4_SRCS) $(GEMMA4_HDRS)
+	$(CC) $(CFLAGS) $(GEMMA4_CPPFLAGS) $(GEMMA4_CODEC_FLAGS) $< $(GEMMA4_SRCS) -o $@ $(LDFLAGS) $(GEMMA4_LIBS)
+
+tests/test_gemma4_sampling$(EXE): tests/test_gemma4_sampling.c $(GEMMA4_SRCS) $(GEMMA4_HDRS)
+	$(CC) $(CFLAGS) $(GEMMA4_CPPFLAGS) $(GEMMA4_CODEC_FLAGS) $< $(GEMMA4_SRCS) -o $@ $(LDFLAGS) $(GEMMA4_LIBS)
+
+tests/test_gemma4_vision$(EXE): tests/test_gemma4_vision.c $(GEMMA4_SRCS) $(GEMMA4_HDRS)
+	$(CC) $(CFLAGS) $(GEMMA4_CPPFLAGS) $(GEMMA4_CODEC_FLAGS) $< $(GEMMA4_SRCS) -o $@ $(LDFLAGS) $(GEMMA4_LIBS)
 
 test-c: $(TEST_BINS)
 	$(PYTHON) tools/run_tests.py $(TEST_BINS)

--- a/c/gemma4.c
+++ b/c/gemma4.c
@@ -1,0 +1,3102 @@
+#define _CRT_SECURE_NO_WARNINGS
+
+#include "gemma4_backend.h"
+#include "gemma4_model.h"
+#include "gemma4_sampling.h"
+#include "gemma4_tokenizer.h"
+#include "gemma4_tools.h"
+#include "gemma4_vision.h"
+#include "grammar.h"
+#include "schema_gbnf.h"
+
+#include <errno.h>
+#include <inttypes.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#include <windows.h>
+#else
+#include <sys/select.h>
+#include <unistd.h>
+#endif
+
+static void usage(const char *program) {
+    fprintf(stderr,
+        "Colibri Gemma 4 expert bridge\n\n"
+        "usage:\n"
+        "  %s --version\n"
+        "  %s model-info MODEL.gguf\n"
+        "  %s vision-info MMPROJ.gguf [SOURCE_WIDTH SOURCE_HEIGHT]\n"
+        "  %s vision-image-info MMPROJ.gguf IMAGE\n"
+        "  %s vision-patch-probe MMPROJ.gguf SOURCE_WIDTH SOURCE_HEIGHT\n"
+        "      [--output-f32 FILE]\n"
+        "  %s vision-encode-probe MMPROJ.gguf SOURCE_WIDTH SOURCE_HEIGHT\n"
+        "      [--layers N] [--start-layer N --input-f32 FILE]\n"
+        "      [--output-f32 FILE] [--prepared-f32 FILE]\n"
+        "      [--trace-layer N --trace-dir DIRECTORY]\n"
+        "  %s tokenize MODEL.gguf TEXT [--no-bos]\n"
+        "  %s tokenize-file MODEL.gguf UTF8_FILE [--no-bos]\n"
+        "  %s chat-user MODEL.gguf TEXT [--system TEXT|--system-file FILE]\n"
+        "      [--tools-file FILE]\n"
+        "  %s chat-user-file MODEL.gguf UTF8_FILE [--system TEXT|--system-file FILE]\n"
+        "      [--tools-file FILE]\n"
+        "  %s image-chat-user MODEL.gguf TEXT [--system TEXT|--system-file FILE]\n"
+        "      [--tools-file FILE]\n"
+        "  %s embed MODEL.gguf TOKEN [--output-f32 FILE]\n"
+        "  %s lm-head MODEL.gguf --input-f32 FILE [--top N]\n"
+        "      [--normalized-f32 FILE] [--logits-f32 FILE]\n"
+        "  %s next-token MODEL.gguf PACKED_DIR TEXT [--chat] [--top N]\n"
+        "      [--system TEXT|--system-file FILE]\n"
+        "      [--tools-file FILE]\n"
+        "      [--image IMAGE --mmproj MMPROJ.gguf]\n"
+        "      [--image-embeddings-f32 FILE]\n"
+        "      [--residual-f32 FILE] [--logits-f32 FILE] [--expert-cache N]\n"
+        "      [--expert-pins N] [--expert-prefetch] [--expert-lookahead]\n"
+        "      [--cuda-device N]\n"
+        "      [--expert-usage FILE]\n"
+        "  %s next-token-file MODEL.gguf PACKED_DIR UTF8_FILE [--chat] [--top N]\n"
+        "      [--system TEXT|--system-file FILE] [--tools-file FILE]\n"
+        "  %s generate MODEL.gguf PACKED_DIR TEXT [--chat] [--max-new N]\n"
+        "      [--system TEXT|--system-file FILE]\n"
+        "      [--tools-file FILE]\n"
+        "      [--image IMAGE --mmproj MMPROJ.gguf]\n"
+        "      [--temperature F] [--top-k N] [--top-p F] [--seed N]\n"
+        "      [--show-special] [--expert-cache N] [--expert-pins N]\n"
+        "      [--expert-prefetch] [--expert-lookahead]\n"
+        "      [--cuda-device N]\n"
+        "      [--expert-usage FILE]\n"
+        "  %s generate-file MODEL.gguf PACKED_DIR UTF8_FILE [--chat]\n"
+        "      [--system TEXT|--system-file FILE]\n"
+        "      [--tools-file FILE]\n"
+        "      [--max-new N] [--show-special] [--expert-cache N]\n"
+        "      [--expert-pins N] [--expert-prefetch]\n"
+        "      [--expert-usage FILE]\n"
+        "  %s chat MODEL.gguf PACKED_DIR [--max-context N] [--max-new N]\n"
+        "      [--system TEXT|--system-file FILE]\n"
+        "      [--tools-file FILE] [--show-special]\n"
+        "      [--temperature F] [--top-k N] [--top-p F] [--seed N]\n"
+        "      [--expert-cache N] [--expert-pins N] [--expert-prefetch]\n"
+        "      [--expert-lookahead]\n"
+        "      [--cuda-device N]\n"
+        "      [--expert-usage FILE]\n"
+        "  %s route MODEL.gguf --layer N [--input-f32 FILE] [--seed N]\n"
+        "      [--probabilities-f32 FILE]\n"
+        "  %s attention-proj MODEL.gguf --layer N [--position N] [--input-f32 FILE]\n"
+        "      [--query-f32 FILE] [--key-f32 FILE] [--value-f32 FILE] [--seed N]\n"
+        "  %s attention-seq MODEL.gguf --layer N [--tokens N] [--input-f32 FILE]\n"
+        "      [--output-f32 FILE] [--seed N]\n"
+        "  %s dense-mlp MODEL.gguf --layer N [--input-f32 FILE]\n"
+        "      [--output-f32 FILE] [--seed N]\n"
+        "  %s routed-mlp MODEL.gguf PACKED_DIR --layer N [--input-f32 FILE]\n"
+        "      [--output-f32 FILE] [--seed N]\n"
+        "  %s layer-seq MODEL.gguf PACKED_DIR --layer N [--tokens N]\n"
+        "      [--input-f32 FILE] [--output-f32 FILE] [--seed N]\n"
+        "  %s info PACKED_DIR\n"
+        "  %s expert PACKED_DIR --layer N --expert N [--input-f32 FILE]\n"
+        "      [--output-f32 FILE] [--seed N] [--repeat N] [--cuda-device N]\n\n"
+        "model-info and route operate directly on the GGUF. PACKED_DIR is\n"
+        "produced by g4lab pack and may fall back to that GGUF for unpacked\n"
+        "experts. Generation is still in progress.\n",
+        program, program, program, program, program, program, program, program,
+        program,
+        program,
+        program,
+        program,
+        program, program, program, program, program, program, program, program,
+        program,
+        program, program, program, program, program);
+}
+
+static int parse_u32(const char *text, uint32_t *result) {
+    char *end = NULL;
+    unsigned long value;
+    errno = 0;
+    value = strtoul(text, &end, 10);
+    if (errno || !end || *end || value > UINT32_MAX) return -1;
+    *result = (uint32_t)value;
+    return 0;
+}
+
+static int option_value(int argc, char **argv, const char *name,
+                        const char **result) {
+    int i;
+    for (i = 0; i < argc; ++i) {
+        if (strcmp(argv[i], name) == 0) {
+            if (i + 1 >= argc) return -1;
+            *result = argv[i + 1];
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int read_f32(const char *path, float *values, size_t count) {
+    FILE *file = fopen(path, "rb");
+    long extra;
+    if (!file) {
+        fprintf(stderr, "cannot open input %s: %s\n", path, strerror(errno));
+        return -1;
+    }
+    if (fread(values, sizeof(float), count, file) != count) {
+        fclose(file);
+        fprintf(stderr, "input must contain exactly %zu float32 values\n", count);
+        return -1;
+    }
+    extra = fgetc(file);
+    fclose(file);
+    if (extra != EOF) {
+        fprintf(stderr, "input must contain exactly %zu float32 values\n", count);
+        return -1;
+    }
+    return 0;
+}
+
+static int write_f32(const char *path, const float *values, size_t count) {
+    FILE *file = fopen(path, "wb");
+    if (!file) {
+        fprintf(stderr, "cannot create output %s: %s\n", path, strerror(errno));
+        return -1;
+    }
+    if (fwrite(values, sizeof(float), count, file) != count || fclose(file) != 0) {
+        fprintf(stderr, "failed writing output %s\n", path);
+        return -1;
+    }
+    return 0;
+}
+
+static uint64_t next_random(uint64_t *state) {
+    uint64_t x = *state;
+    x ^= x >> 12;
+    x ^= x << 25;
+    x ^= x >> 27;
+    *state = x;
+    return x * UINT64_C(2685821657736338717);
+}
+
+static void make_input(float *values, size_t count, uint32_t seed) {
+    uint64_t state = seed ? seed : UINT64_C(0x9e3779b97f4a7c15);
+    size_t i;
+    for (i = 0; i < count; ++i) {
+        uint32_t bits = (uint32_t)(next_random(&state) >> 40);
+        values[i] = ((float)bits / 16777215.0F - 0.5F) * 0.1F;
+    }
+}
+
+static int command_info(const char *directory) {
+    coli_gemma4_backend gemma;
+    uint32_t i;
+    if (coli_gemma4_open_packed(&gemma, directory) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        return 1;
+    }
+    printf("architecture:       gemma4\n");
+    printf("routed layers:      %u\n", gemma.config.n_layer);
+    printf("experts per layer:  %u\n", gemma.config.n_expert);
+    printf("experts selected:   %u\n", gemma.config.n_expert_used);
+    printf("expert shape:       %u -> %u -> %u\n",
+           gemma.config.n_embd, gemma.config.n_expert_ff, gemma.config.n_embd);
+    printf("source GGUF:        %s\n", gemma.source);
+    for (i = 0; i < gemma.layer_count; ++i) {
+        const coli_gemma4_layer *layer = &gemma.layers[i];
+        printf("layer %2u: %s, %" PRIu64 " bytes/record%s, %s\n",
+               layer->layer, layer->packed_file, layer->record_stride,
+               layer->has_scale ? ", learned scale" : ", unit scale",
+               coli_gemma4_has_packed_layer(&gemma, layer) ?
+                   "packed" : "direct GGUF fallback");
+    }
+    coli_gemma4_close(&gemma);
+    return 0;
+}
+
+static int parse_u64(const char *text, uint64_t *result) {
+    char *end = NULL;
+    unsigned long long value;
+    if (!text || text[0] == '-') return -1;
+    errno = 0;
+    value = strtoull(text, &end, 10);
+    if (errno || !end || *end) return -1;
+    *result = (uint64_t)value;
+    return 0;
+}
+
+static int read_utf8_text(const char *path, char **text, size_t *text_bytes) {
+    FILE *file = fopen(path, "rb");
+    char *storage;
+    long length;
+    if (!file || fseek(file, 0, SEEK_END) != 0 ||
+        (length = ftell(file)) < 0 || fseek(file, 0, SEEK_SET) != 0) {
+        if (file) fclose(file);
+        fprintf(stderr, "cannot read UTF-8 input %s\n", path);
+        return -1;
+    }
+    if ((uint64_t)length > SIZE_MAX - 1) {
+        fclose(file);
+        fprintf(stderr, "UTF-8 input is too large\n");
+        return -1;
+    }
+    storage = (char *)malloc((size_t)length + 1);
+    if (!storage) {
+        fclose(file);
+        fprintf(stderr, "out of memory reading UTF-8 input\n");
+        return -1;
+    }
+    {
+        int read_failed = length &&
+            fread(storage, 1, (size_t)length, file) != (size_t)length;
+        int close_failed = fclose(file) != 0;
+        if (read_failed || close_failed) {
+            free(storage);
+            fprintf(stderr, "cannot read UTF-8 input %s\n", path);
+            return -1;
+        }
+    }
+    storage[(size_t)length] = '\0';
+    *text = storage;
+    *text_bytes = (size_t)length;
+    return 0;
+}
+
+static int read_tool_declarations(const char *path, char **rendered,
+                                  size_t *rendered_bytes) {
+    char *json = NULL;
+    size_t json_bytes = 0;
+    char error[COLI_GEMMA4_TOOLS_ERROR_MAX];
+    int result;
+    if (read_utf8_text(path, &json, &json_bytes) != 0) return -1;
+    result = coli_gemma4_render_tools(
+        json, json_bytes, rendered, rendered_bytes, error, sizeof(error));
+    free(json);
+    if (result != 0) {
+        fprintf(stderr, "invalid tools file %s: %s\n", path, error);
+        return -1;
+    }
+    return 0;
+}
+
+static int parse_f32(const char *text, float *result) {
+    char *end = NULL;
+    float value;
+    errno = 0;
+    value = strtof(text, &end);
+    if (errno || !end || *end || !isfinite(value)) return -1;
+    *result = value;
+    return 0;
+}
+
+static int command_tokenize(int argc, char **argv, const char *model_path,
+                            const char *text, size_t text_bytes, int user_chat,
+                            int image_chat) {
+    coli_gemma4_gguf gguf;
+    coli_gemma4_tokenizer tokenizer;
+    const char *system_text = NULL, *system_path = NULL;
+    const char *tools_path = NULL;
+    char *system_storage = NULL, *rendered_tools = NULL;
+    uint32_t *tokens = NULL, *suffix_tokens = NULL;
+    size_t system_bytes = 0, rendered_tools_bytes = 0, total_bytes;
+    size_t capacity, count = 0, suffix_count = 0, index;
+    int add_bos = 1, status = 1, argument;
+    memset(&gguf, 0, sizeof(gguf));
+    memset(&tokenizer, 0, sizeof(tokenizer));
+    for (argument = 0; argument < argc; ++argument) {
+        if (!user_chat && strcmp(argv[argument], "--no-bos") == 0) add_bos = 0;
+        else if (user_chat &&
+                 (strcmp(argv[argument], "--system") == 0 ||
+                  strcmp(argv[argument], "--system-file") == 0 ||
+                  strcmp(argv[argument], "--tools-file") == 0)) {
+            if (++argument >= argc) {
+                fprintf(stderr, "missing chat option value\n");
+                return 2;
+            }
+        }
+        else {
+            fprintf(stderr, "unknown tokenize option: %s\n", argv[argument]);
+            return 2;
+        }
+    }
+    if (user_chat &&
+        (option_value(argc, argv, "--system", &system_text) < 0 ||
+         option_value(argc, argv, "--system-file", &system_path) < 0 ||
+         option_value(argc, argv, "--tools-file", &tools_path) < 0 ||
+         (system_text && system_path))) {
+        fprintf(stderr, "use exactly one of --system and --system-file\n");
+        return 2;
+    }
+    if (system_path) {
+        if (read_utf8_text(system_path, &system_storage, &system_bytes) != 0)
+            return 1;
+        system_text = system_storage;
+    } else if (system_text) {
+        system_bytes = strlen(system_text);
+    }
+    if (tools_path && read_tool_declarations(
+            tools_path, &rendered_tools, &rendered_tools_bytes) != 0) {
+        free(system_storage);
+        return 1;
+    }
+    if (system_bytes > SIZE_MAX - text_bytes ||
+        rendered_tools_bytes > SIZE_MAX - text_bytes - system_bytes) {
+        fprintf(stderr, "text is too large to tokenize\n");
+        free(system_storage);
+        free(rendered_tools);
+        return 1;
+    }
+    total_bytes = text_bytes + system_bytes + rendered_tools_bytes;
+    if (total_bytes > (SIZE_MAX - 256) / 3) {
+        fprintf(stderr, "text is too large to tokenize\n");
+        free(system_storage);
+        free(rendered_tools);
+        return 1;
+    }
+    capacity = total_bytes * 3 + 256;
+    if (capacity > SIZE_MAX / sizeof(*tokens)) {
+        fprintf(stderr, "text is too large to tokenize\n");
+        free(system_storage);
+        free(rendered_tools);
+        return 1;
+    }
+    tokens = (uint32_t *)malloc(capacity * sizeof(*tokens));
+    if (image_chat)
+        suffix_tokens = (uint32_t *)malloc(capacity * sizeof(*suffix_tokens));
+    if (!tokens || (image_chat && !suffix_tokens)) {
+        fprintf(stderr, "out of memory allocating token buffer\n");
+        free(system_storage);
+        free(rendered_tools);
+        free(tokens);
+        free(suffix_tokens);
+        return 1;
+    }
+    if (coli_gemma4_gguf_open(&gguf, model_path) != 0) {
+        fprintf(stderr, "%s\n", coli_gemma4_gguf_last_error(&gguf));
+        goto cleanup;
+    }
+    if (coli_gemma4_tokenizer_init(&tokenizer, &gguf) != 0) {
+        fprintf(stderr, "%s\n", coli_gemma4_tokenizer_last_error(&tokenizer));
+        goto cleanup;
+    }
+    if ((image_chat ?
+         coli_gemma4_tokenize_image_chat_turn_with_tools(
+             &tokenizer, system_text, system_bytes,
+             rendered_tools, rendered_tools_bytes,
+             text, text_bytes, 1, tokens, capacity, &count,
+             suffix_tokens, capacity, &suffix_count) : user_chat ?
+         coli_gemma4_tokenize_chat_turn_with_tools(
+             &tokenizer, system_text, system_bytes,
+             rendered_tools, rendered_tools_bytes,
+             text, text_bytes, 1, tokens, capacity, &count) :
+         coli_gemma4_tokenize(&tokenizer, text, text_bytes, add_bos,
+                              tokens, capacity, &count)) != 0) {
+        fprintf(stderr, "Gemma 4 tokenization failed\n");
+        goto cleanup;
+    }
+    if (image_chat) {
+        printf("prefix tokens: %zu\nprefix ids:", count);
+        for (index = 0; index < count; ++index) printf(" %u", tokens[index]);
+        printf("\nimage embeddings: insert N x 2816 float32 values here (non-causal chunk)\n");
+        printf("suffix tokens: %zu\nsuffix ids:", suffix_count);
+        for (index = 0; index < suffix_count; ++index)
+            printf(" %u", suffix_tokens[index]);
+        putchar('\n');
+    } else {
+        printf("tokens: %zu\nids:", count);
+        for (index = 0; index < count; ++index) printf(" %u", tokens[index]);
+        putchar('\n');
+    }
+    status = 0;
+cleanup:
+    coli_gemma4_tokenizer_close(&tokenizer);
+    coli_gemma4_gguf_close(&gguf);
+    free(system_storage);
+    free(rendered_tools);
+    free(tokens);
+    free(suffix_tokens);
+    return status;
+}
+
+static int command_tokenize_file(int argc, char **argv,
+                                 const char *model_path, const char *path,
+                                 int user_chat) {
+    FILE *file = fopen(path, "rb");
+    char *text = NULL;
+    long length;
+    int status;
+    if (!file || fseek(file, 0, SEEK_END) != 0 ||
+        (length = ftell(file)) < 0 || fseek(file, 0, SEEK_SET) != 0) {
+        if (file) fclose(file);
+        fprintf(stderr, "cannot read UTF-8 input %s\n", path);
+        return 1;
+    }
+    text = (char *)malloc((size_t)length + 1);
+    if (!text) {
+        fclose(file);
+        fprintf(stderr, "out of memory reading UTF-8 input %s\n", path);
+        return 1;
+    }
+    {
+        int read_failed = length &&
+            fread(text, 1, (size_t)length, file) != (size_t)length;
+        int close_failed = fclose(file) != 0;
+        if (read_failed || close_failed) {
+            free(text);
+            fprintf(stderr, "cannot read UTF-8 input %s\n", path);
+            return 1;
+        }
+    }
+    text[length] = '\0';
+    status = command_tokenize(argc, argv, model_path, text, (size_t)length,
+                              user_chat, 0);
+    free(text);
+    return status;
+}
+
+static int command_embedding(int argc, char **argv, const char *model_path,
+                             const char *token_text) {
+    coli_gemma4_gguf gguf;
+    coli_gemma4_model_io io;
+    const char *output_path = NULL;
+    uint32_t token;
+    float *embedding = NULL;
+    int status = 1;
+    memset(&gguf, 0, sizeof(gguf));
+    memset(&io, 0, sizeof(io));
+    if (parse_u32(token_text, &token) != 0 ||
+        option_value(argc, argv, "--output-f32", &output_path) < 0) {
+        fprintf(stderr, "invalid token or output option\n");
+        return 2;
+    }
+    if (coli_gemma4_gguf_open(&gguf, model_path) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_gguf_last_error(&gguf));
+        return 1;
+    }
+    if (coli_gemma4_model_io_open(&io, &gguf) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_model_io_last_error(&io));
+        goto cleanup;
+    }
+    embedding = (float *)malloc((size_t)io.model_width * sizeof(float));
+    if (!embedding || coli_gemma4_model_embed(&io, token, embedding) != 0) {
+        fprintf(stderr, "error: cannot decode embedding for token %u\n", token);
+        goto cleanup;
+    }
+    if (output_path && write_f32(output_path, embedding, io.model_width) != 0)
+        goto cleanup;
+    printf("token:             %u\n", token);
+    printf("embedding width:   %u\n", io.model_width);
+    printf("embedding scale:   %.9g\n", io.embedding_scale);
+    printf("embedding hash:    0x%016" PRIx64 "\n",
+           coli_gemma4_checksum_f32(embedding, io.model_width));
+    if (output_path) printf("wrote embedding:   %s\n", output_path);
+    status = 0;
+
+cleanup:
+    free(embedding);
+    coli_gemma4_model_io_close(&io);
+    coli_gemma4_gguf_close(&gguf);
+    return status;
+}
+
+static int command_lm_head(int argc, char **argv, const char *model_path) {
+    coli_gemma4_gguf gguf;
+    coli_gemma4_model_io io;
+    const char *input_path = NULL, *normalized_path = NULL;
+    const char *logits_path = NULL, *top_text = NULL;
+    uint32_t top_count = 5, rank;
+    float *input = NULL, *normalized = NULL, *logits = NULL;
+    uint8_t *selected = NULL;
+    int status = 1;
+    memset(&gguf, 0, sizeof(gguf));
+    memset(&io, 0, sizeof(io));
+    if (option_value(argc, argv, "--input-f32", &input_path) <= 0 ||
+        option_value(argc, argv, "--normalized-f32", &normalized_path) < 0 ||
+        option_value(argc, argv, "--logits-f32", &logits_path) < 0 ||
+        option_value(argc, argv, "--top", &top_text) < 0 ||
+        (top_text && parse_u32(top_text, &top_count) != 0) ||
+        !top_count || top_count > 100) {
+        fprintf(stderr, "lm-head requires --input-f32 and --top must be 1..100\n");
+        return 2;
+    }
+    if (coli_gemma4_gguf_open(&gguf, model_path) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_gguf_last_error(&gguf));
+        return 1;
+    }
+    if (coli_gemma4_model_io_open(&io, &gguf) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_model_io_last_error(&io));
+        goto cleanup;
+    }
+    input = (float *)malloc((size_t)io.model_width * sizeof(float));
+    normalized = (float *)malloc((size_t)io.model_width * sizeof(float));
+    logits = (float *)malloc((size_t)io.vocab_size * sizeof(float));
+    selected = (uint8_t *)calloc(io.vocab_size, 1);
+    if (!input || !normalized || !logits || !selected) {
+        fprintf(stderr, "error: out of memory allocating LM-head buffers\n");
+        goto cleanup;
+    }
+    if (read_f32(input_path, input, io.model_width) != 0 ||
+        coli_gemma4_model_logits(&io, input, normalized, logits) != 0) {
+        fprintf(stderr, "error: Gemma 4 LM head failed\n");
+        goto cleanup;
+    }
+    if ((normalized_path && write_f32(normalized_path, normalized,
+                                      io.model_width) != 0) ||
+        (logits_path && write_f32(logits_path, logits, io.vocab_size) != 0))
+        goto cleanup;
+    printf("vocabulary:        %u\n", io.vocab_size);
+    printf("logit softcap:     %.9g\n", io.logit_softcap);
+    printf("top tokens:\n");
+    for (rank = 0; rank < top_count; ++rank) {
+        uint32_t token, best = UINT32_MAX;
+        float best_value = -INFINITY;
+        for (token = 0; token < io.vocab_size; ++token) {
+            if (!selected[token] && isfinite(logits[token]) &&
+                (best == UINT32_MAX || logits[token] > best_value)) {
+                best = token;
+                best_value = logits[token];
+            }
+        }
+        if (best == UINT32_MAX) break;
+        selected[best] = 1;
+        printf("  %u: token=%u logit=%.9g\n", rank + 1, best, best_value);
+    }
+    if (normalized_path) printf("wrote normalized:  %s\n", normalized_path);
+    if (logits_path) printf("wrote logits:      %s\n", logits_path);
+    status = 0;
+
+cleanup:
+    free(input); free(normalized); free(logits); free(selected);
+    coli_gemma4_model_io_close(&io);
+    coli_gemma4_gguf_close(&gguf);
+    return status;
+}
+
+static int emit_token_piece(const coli_gemma4_tokenizer *tokenizer,
+                            uint32_t token, int show_special) {
+    size_t piece_bytes = 0;
+    char *piece;
+    if (coli_gemma4_decode_token(tokenizer, token, NULL, 0,
+                                 &piece_bytes) != 0 ||
+        piece_bytes == SIZE_MAX) return -1;
+    piece = (char *)malloc(piece_bytes + 1);
+    if (!piece || coli_gemma4_decode_token(
+            tokenizer, token, piece, piece_bytes + 1, &piece_bytes) != 0) {
+        free(piece);
+        return -1;
+    }
+    if (show_special || !coli_gemma4_token_is_control(tokenizer, token))
+        fwrite(piece, 1, piece_bytes, stdout);
+    free(piece);
+    return ferror(stdout) ? -1 : 0;
+}
+
+static int append_dynamic_text(char **buffer, size_t *length,
+                               size_t *capacity, const char *text,
+                               size_t text_bytes) {
+    size_t needed, grown_capacity;
+    char *grown;
+    if (text_bytes > SIZE_MAX - *length - 1) return -1;
+    needed = *length + text_bytes + 1;
+    if (needed > *capacity) {
+        grown_capacity = *capacity ? *capacity : 256;
+        while (grown_capacity < needed) {
+            if (grown_capacity > SIZE_MAX / 2) {
+                grown_capacity = needed;
+                break;
+            }
+            grown_capacity *= 2;
+        }
+        grown = (char *)realloc(*buffer, grown_capacity);
+        if (!grown) return -1;
+        *buffer = grown;
+        *capacity = grown_capacity;
+    }
+    if (text_bytes) memcpy(*buffer + *length, text, text_bytes);
+    *length += text_bytes;
+    (*buffer)[*length] = '\0';
+    return 0;
+}
+
+static int capture_token_piece(const coli_gemma4_tokenizer *tokenizer,
+                               uint32_t token, char **buffer,
+                               size_t *length, size_t *capacity) {
+    size_t piece_bytes = 0, needed;
+    char *grown;
+    if (coli_gemma4_decode_token(tokenizer, token, NULL, 0,
+                                 &piece_bytes) != 0 ||
+        piece_bytes > SIZE_MAX - *length - 1) return -1;
+    needed = *length + piece_bytes + 1;
+    if (needed > *capacity) {
+        size_t grown_capacity = *capacity ? *capacity : 256;
+        while (grown_capacity < needed) {
+            if (grown_capacity > SIZE_MAX / 2) {
+                grown_capacity = needed;
+                break;
+            }
+            grown_capacity *= 2;
+        }
+        grown = (char *)realloc(*buffer, grown_capacity);
+        if (!grown) return -1;
+        *buffer = grown;
+        *capacity = grown_capacity;
+    }
+    if (coli_gemma4_decode_token(
+            tokenizer, token, *buffer + *length, *capacity - *length,
+            &piece_bytes) != 0) return -1;
+    *length += piece_bytes;
+    (*buffer)[*length] = '\0';
+    return 0;
+}
+
+static void report_expert_cache(const coli_gemma4_backend *backend) {
+    coli_gemma4_cache_stats stats;
+    coli_gemma4_cache_get_stats(backend, &stats);
+    if (!stats.capacity) return;
+    fprintf(stderr,
+            "expert cache: slots=%u resident=%u pins=%u hits=%llu "
+            "pin-hits=%llu misses=%llu preloads=%llu prefetch=%llu/%llu "
+            "lookahead=%llu/%llu match=%llu/%llu "
+            "evictions=%llu promotions=%llu "
+            "loaded=%.1f MiB\n",
+            stats.capacity, stats.resident, stats.pinned_capacity,
+            (unsigned long long)stats.hits,
+            (unsigned long long)stats.pinned_hits,
+            (unsigned long long)stats.misses,
+            (unsigned long long)stats.preloads,
+            (unsigned long long)stats.prefetch_launches,
+            (unsigned long long)stats.prefetched_records,
+            (unsigned long long)stats.lookahead_launches,
+            (unsigned long long)stats.lookahead_records,
+            (unsigned long long)stats.lookahead_matches,
+            (unsigned long long)stats.lookahead_selected,
+            (unsigned long long)stats.evictions,
+            (unsigned long long)stats.promotions,
+            (double)stats.bytes_loaded / (1024.0 * 1024.0));
+}
+
+static int persist_expert_usage(coli_gemma4_backend *backend,
+                                const char *path, uint64_t *selections) {
+    if (coli_gemma4_usage_save(backend, path, selections) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(backend));
+        return -1;
+    }
+    return 0;
+}
+
+static int command_next_token(int argc, char **argv, const char *model_path,
+                              const char *packed_dir, const char *text,
+                              size_t text_bytes, int generate) {
+    coli_gemma4_gguf gguf;
+    coli_gemma4_tokenizer tokenizer;
+    coli_gemma4_backend gemma;
+    coli_expert_backend experts;
+    coli_gemma4_model model;
+    coli_gemma4_sampler sampler;
+    coli_gemma4_vision vision;
+    coli_gemma4_vision_image prepared_image;
+    const char *top_text = NULL, *max_new_text = NULL;
+    const char *temperature_text = NULL, *sample_top_k_text = NULL;
+    const char *sample_top_p_text = NULL, *seed_text = NULL;
+    const char *expert_cache_text = NULL, *expert_pins_text = NULL;
+    const char *expert_usage_path = NULL;
+    const char *cuda_device_text = NULL;
+    const char *system_text = NULL, *system_path = NULL;
+    const char *tools_path = NULL;
+    const char *image_path = NULL, *mmproj_path = NULL;
+    const char *image_embeddings_path = NULL;
+    const char *residual_path = NULL, *logits_path = NULL;
+    char *system_storage = NULL, *rendered_tools = NULL;
+    uint32_t *tokens = NULL, *suffix_tokens = NULL;
+    uint32_t top_count = 5, max_new = generate ? 16U : 0U;
+    uint32_t position, rank, maximum_tokens, sample_top_k = 0;
+    uint32_t image_token_count = 0, source_width = 0, source_height = 0;
+    uint32_t expert_cache = 0, expert_pins = 0;
+    uint32_t cuda_device = 0;
+    uint64_t seed = 1;
+    uint64_t usage_total = 0;
+    float temperature = 0.0F, sample_top_p = 1.0F;
+    uint8_t *selected = NULL, *source_rgb = NULL;
+    float *residual = NULL, *logits = NULL, *image_embeddings = NULL;
+    size_t capacity, count = 0, system_bytes = 0;
+    size_t suffix_count = 0, rendered_tools_bytes = 0, total_bytes;
+    uint32_t prompt_positions = 0;
+    char image_error[COLI_GEMMA4_VISION_ERROR_MAX];
+    int chat = 0, show_special = 0, expert_prefetch = 0;
+    int expert_lookahead = 0;
+    int argument, status = 1, usage_active = 0;
+    memset(&gguf, 0, sizeof(gguf));
+    memset(&tokenizer, 0, sizeof(tokenizer));
+    memset(&gemma, 0, sizeof(gemma));
+    memset(&model, 0, sizeof(model));
+    memset(&sampler, 0, sizeof(sampler));
+    memset(&vision, 0, sizeof(vision));
+    memset(&prepared_image, 0, sizeof(prepared_image));
+    for (argument = 0; argument < argc; ++argument)
+        if (strcmp(argv[argument], "--chat") == 0) chat = 1;
+        else if (strcmp(argv[argument], "--show-special") == 0) show_special = 1;
+        else if (strcmp(argv[argument], "--expert-prefetch") == 0)
+            expert_prefetch = 1;
+        else if (strcmp(argv[argument], "--expert-lookahead") == 0)
+            expert_lookahead = 1;
+    if (option_value(argc, argv, "--top", &top_text) < 0 ||
+        option_value(argc, argv, "--max-new", &max_new_text) < 0 ||
+        option_value(argc, argv, "--temperature", &temperature_text) < 0 ||
+        option_value(argc, argv, "--top-k", &sample_top_k_text) < 0 ||
+        option_value(argc, argv, "--top-p", &sample_top_p_text) < 0 ||
+        option_value(argc, argv, "--seed", &seed_text) < 0 ||
+        option_value(argc, argv, "--expert-cache", &expert_cache_text) < 0 ||
+        option_value(argc, argv, "--expert-pins", &expert_pins_text) < 0 ||
+        option_value(argc, argv, "--expert-usage", &expert_usage_path) < 0 ||
+        option_value(argc, argv, "--cuda-device", &cuda_device_text) < 0 ||
+        option_value(argc, argv, "--system", &system_text) < 0 ||
+        option_value(argc, argv, "--system-file", &system_path) < 0 ||
+        option_value(argc, argv, "--tools-file", &tools_path) < 0 ||
+        option_value(argc, argv, "--image", &image_path) < 0 ||
+        option_value(argc, argv, "--mmproj", &mmproj_path) < 0 ||
+        option_value(argc, argv, "--image-embeddings-f32",
+                     &image_embeddings_path) < 0 ||
+        option_value(argc, argv, "--residual-f32", &residual_path) < 0 ||
+        option_value(argc, argv, "--logits-f32", &logits_path) < 0 ||
+        (top_text && parse_u32(top_text, &top_count) != 0) ||
+        (max_new_text && parse_u32(max_new_text, &max_new) != 0) ||
+        (temperature_text && parse_f32(temperature_text, &temperature) != 0) ||
+        (sample_top_k_text && parse_u32(sample_top_k_text, &sample_top_k) != 0) ||
+        (sample_top_p_text && parse_f32(sample_top_p_text, &sample_top_p) != 0) ||
+        (seed_text && parse_u64(seed_text, &seed) != 0) ||
+        (expert_cache_text && parse_u32(expert_cache_text, &expert_cache) != 0) ||
+        (expert_pins_text && parse_u32(expert_pins_text, &expert_pins) != 0) ||
+        (cuda_device_text && parse_u32(cuda_device_text, &cuda_device) != 0) ||
+        (expert_usage_path && !expert_cache) ||
+        (expert_prefetch && !expert_cache) ||
+        (expert_lookahead && !expert_prefetch) ||
+        (expert_pins && expert_pins >= expert_cache) ||
+        ((system_text || system_path || tools_path) && !chat) ||
+        ((image_path || mmproj_path) && (!image_path || !mmproj_path || !chat)) ||
+        (image_embeddings_path && !image_path) ||
+        (system_text && system_path) ||
+        !top_count || top_count > 100 || (generate && !max_new) ||
+        (!generate && (max_new_text || temperature_text || sample_top_k_text ||
+                       sample_top_p_text || seed_text))) {
+        fprintf(stderr, "invalid generation or ranking option\n");
+        return 2;
+    }
+    if (system_path) {
+        if (read_utf8_text(system_path, &system_storage, &system_bytes) != 0)
+            return 1;
+        system_text = system_storage;
+    } else if (system_text) {
+        system_bytes = strlen(system_text);
+    }
+    if (tools_path && read_tool_declarations(
+            tools_path, &rendered_tools, &rendered_tools_bytes) != 0) {
+        free(system_storage);
+        return 1;
+    }
+    if (system_bytes > SIZE_MAX - text_bytes ||
+        rendered_tools_bytes > SIZE_MAX - text_bytes - system_bytes) {
+        fprintf(stderr, "prompt is too large to tokenize\n");
+        free(system_storage);
+        free(rendered_tools);
+        return 2;
+    }
+    total_bytes = text_bytes + system_bytes + rendered_tools_bytes;
+    if (total_bytes > (SIZE_MAX - 256) / 3) {
+        fprintf(stderr, "prompt is too large to tokenize\n");
+        free(system_storage);
+        free(rendered_tools);
+        return 2;
+    }
+    capacity = total_bytes * 3 + 256;
+    if (capacity > SIZE_MAX / sizeof(*tokens)) {
+        free(system_storage);
+        free(rendered_tools);
+        return 2;
+    }
+    tokens = (uint32_t *)malloc(capacity * sizeof(*tokens));
+    if (image_path)
+        suffix_tokens = (uint32_t *)malloc(capacity * sizeof(*suffix_tokens));
+    if (!tokens || (image_path && !suffix_tokens)) {
+        free(system_storage);
+        free(rendered_tools);
+        return 1;
+    }
+    if (coli_gemma4_gguf_open(&gguf, model_path) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_gguf_last_error(&gguf));
+        goto cleanup;
+    }
+    if (coli_gemma4_tokenizer_init(&tokenizer, &gguf) != 0) {
+        fprintf(stderr, "error: %s\n",
+                coli_gemma4_tokenizer_last_error(&tokenizer));
+        goto cleanup;
+    }
+    if (!sample_top_k_text) sample_top_k = gguf.sampling_top_k;
+    if (!sample_top_p_text) sample_top_p = gguf.sampling_top_p;
+    if (coli_gemma4_sampler_init(&sampler, temperature, sample_top_k,
+                                 sample_top_p, seed) != 0) {
+        fprintf(stderr, "error: invalid sampling configuration\n");
+        goto cleanup;
+    }
+    if ((image_path ? coli_gemma4_tokenize_image_chat_turn_with_tools(
+                    &tokenizer, system_text, system_bytes,
+                    rendered_tools, rendered_tools_bytes,
+                    text, text_bytes, 1, tokens, capacity, &count,
+                    suffix_tokens, capacity, &suffix_count) :
+                chat ? coli_gemma4_tokenize_chat_turn_with_tools(
+                    &tokenizer, system_text, system_bytes,
+                    rendered_tools, rendered_tools_bytes,
+                    text, text_bytes, 1, tokens, capacity, &count) :
+                coli_gemma4_tokenize(&tokenizer, text, text_bytes, 1,
+                                     tokens, capacity, &count)) != 0 ||
+        !count || count > UINT32_MAX) {
+        fprintf(stderr, "error: prompt tokenization failed\n");
+        goto cleanup;
+    }
+    if (image_path) {
+        if (coli_gemma4_vision_load_image(
+                image_path, &source_rgb, &source_width, &source_height,
+                image_error, sizeof(image_error)) != 0) {
+            fprintf(stderr, "error: %s\n", image_error);
+            goto cleanup;
+        }
+        if (coli_gemma4_vision_open(&vision, mmproj_path) != 0) {
+            fprintf(stderr, "error: %s\n",
+                    coli_gemma4_vision_last_error(&vision));
+            goto cleanup;
+        }
+        if (coli_gemma4_vision_prepare_rgb(
+                &vision, source_rgb, source_width, source_height,
+                &prepared_image) != 0 ||
+            coli_gemma4_vision_encode(
+                &vision, &prepared_image, &image_embeddings,
+                &image_token_count) != 0) {
+            fprintf(stderr, "error: %s\n",
+                    coli_gemma4_vision_last_error(&vision));
+            goto cleanup;
+        }
+        if (image_embeddings_path && read_f32(
+                image_embeddings_path, image_embeddings,
+                (size_t)image_token_count * gguf.config.n_embd) != 0)
+            goto cleanup;
+    }
+    if (count > UINT32_MAX - image_token_count ||
+        suffix_count > UINT32_MAX - count - image_token_count) {
+        fprintf(stderr, "error: image prompt is too large\n");
+        goto cleanup;
+    }
+    prompt_positions = (uint32_t)count + image_token_count +
+                       (uint32_t)suffix_count;
+    if (prompt_positions > UINT32_MAX - max_new) {
+        fprintf(stderr, "error: prompt plus generation length is too large\n");
+        goto cleanup;
+    }
+    maximum_tokens = prompt_positions + max_new;
+    if (coli_gemma4_open_packed(&gemma, packed_dir) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    if (strlen(gguf.path) + 1 > sizeof(gemma.source)) {
+        fprintf(stderr, "error: model path is too long for expert backend\n");
+        goto cleanup;
+    }
+    memcpy(gemma.source, gguf.path, strlen(gguf.path) + 1);
+    if (coli_gemma4_cache_configure(&gemma, expert_cache) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    if (expert_pins &&
+        coli_gemma4_cache_set_pinned(&gemma, expert_pins) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    if (expert_usage_path) {
+        if (coli_gemma4_usage_load(&gemma, expert_usage_path,
+                                   &usage_total) != 0) {
+            fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+            goto cleanup;
+        }
+        usage_active = 1;
+        fprintf(stderr, "expert usage: loaded=%llu path=%s\n",
+                (unsigned long long)usage_total, expert_usage_path);
+    }
+    if (expert_prefetch &&
+        coli_gemma4_prefetch_configure(&gemma, 1) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    if (expert_lookahead &&
+        coli_gemma4_lookahead_configure(&gemma, 1) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    if (cuda_device_text && coli_gemma4_cuda_configure(
+            &gemma, (int)cuda_device) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    if (gemma.config.n_layer != gguf.config.n_layer ||
+        gemma.config.n_embd != gguf.config.n_embd ||
+        gemma.config.n_expert != gguf.config.n_expert ||
+        gemma.config.n_expert_used != gguf.config.n_expert_used) {
+        fprintf(stderr, "error: packed manifest and GGUF configuration disagree\n");
+        goto cleanup;
+    }
+    residual = (float *)malloc((size_t)gguf.config.n_embd * sizeof(float));
+    logits = (float *)malloc((size_t)gguf.config.n_vocab * sizeof(float));
+    selected = (uint8_t *)calloc(gguf.config.n_vocab, 1);
+    if (!residual || !logits || !selected) {
+        fprintf(stderr, "error: out of memory allocating full-model output\n");
+        goto cleanup;
+    }
+    experts = coli_gemma4_expert_backend(&gemma);
+    if (coli_gemma4_model_open(&model, &gguf, &experts,
+                               maximum_tokens) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_model_last_error(&model));
+        goto cleanup;
+    }
+    printf("prompt tokens:     %zu\n", count + suffix_count);
+    if (image_path)
+        printf("image:             %ux%u -> %u embeddings\n",
+               source_width, source_height, image_token_count);
+    for (position = 0; position < (uint32_t)count; ++position) {
+        int last = !image_path && position + 1 == (uint32_t)count;
+        if (coli_gemma4_model_step(&model, tokens[position], position,
+                                   last ? residual : NULL,
+                                   last ? logits : NULL) != 0) {
+            fprintf(stderr, "error: %s\n", coli_gemma4_model_last_error(&model));
+            goto cleanup;
+        }
+        printf("evaluated:         %u/%u (token %u)\n",
+               position + 1, prompt_positions, tokens[position]);
+    }
+    if (image_path) {
+        size_t suffix_index;
+        if (coli_gemma4_model_image_embeddings(
+                &model, image_embeddings, image_token_count,
+                (uint64_t)count, NULL) != 0) {
+            fprintf(stderr, "error: %s\n", coli_gemma4_model_last_error(&model));
+            goto cleanup;
+        }
+        printf("evaluated:         %u/%u (image embeddings)\n",
+               (uint32_t)count + image_token_count, prompt_positions);
+        for (suffix_index = 0; suffix_index < suffix_count; ++suffix_index) {
+            uint32_t suffix_position = (uint32_t)count + image_token_count +
+                                       (uint32_t)suffix_index;
+            int last = suffix_index + 1 == suffix_count;
+            if (coli_gemma4_model_step(
+                    &model, suffix_tokens[suffix_index], suffix_position,
+                    last ? residual : NULL, last ? logits : NULL) != 0) {
+                fprintf(stderr, "error: %s\n",
+                        coli_gemma4_model_last_error(&model));
+                goto cleanup;
+            }
+            printf("evaluated:         %u/%u (token %u)\n",
+                   suffix_position + 1, prompt_positions,
+                   suffix_tokens[suffix_index]);
+        }
+    }
+    if ((residual_path && write_f32(residual_path, residual,
+                                    gguf.config.n_embd) != 0) ||
+        (logits_path && write_f32(logits_path, logits,
+                                  gguf.config.n_vocab) != 0)) goto cleanup;
+    if (generate) {
+        uint32_t generated;
+        printf("sampling:          temperature=%.7g top-k=%u top-p=%.7g seed=%llu\n",
+               temperature, sample_top_k, sample_top_p,
+               (unsigned long long)seed);
+        printf("generated:\n");
+        for (generated = 0; generated < max_new; ++generated) {
+            uint32_t best;
+            if (coli_gemma4_sample(&sampler, logits, gguf.config.n_vocab,
+                                   &best, NULL) != 0) {
+                fprintf(stderr, "error: sampling failed\n");
+                goto cleanup;
+            }
+            if (emit_token_piece(&tokenizer, best, show_special) != 0)
+                goto cleanup;
+            fflush(stdout);
+            if (coli_gemma4_token_is_eog(&tokenizer, best)) break;
+            if (generated + 1 < max_new &&
+                coli_gemma4_model_step(&model, best,
+                                       (uint64_t)prompt_positions + generated,
+                                       NULL, logits) != 0) {
+                fprintf(stderr, "error: %s\n",
+                        coli_gemma4_model_last_error(&model));
+                goto cleanup;
+            }
+        }
+        fputc('\n', stdout);
+    } else {
+        printf("top tokens:\n");
+        for (rank = 0; rank < top_count; ++rank) {
+            uint32_t token, best = UINT32_MAX;
+            float best_value = -INFINITY;
+            for (token = 0; token < gguf.config.n_vocab; ++token) {
+                if (!selected[token] && isfinite(logits[token]) &&
+                    (best == UINT32_MAX || logits[token] > best_value)) {
+                    best = token;
+                    best_value = logits[token];
+                }
+            }
+            if (best == UINT32_MAX) break;
+            selected[best] = 1;
+            printf("  %u: token=%u logit=%.9g\n", rank + 1, best, best_value);
+        }
+    }
+    if (residual_path) printf("wrote residual:    %s\n", residual_path);
+    if (logits_path) printf("wrote logits:      %s\n", logits_path);
+    status = 0;
+
+cleanup:
+    if (usage_active) {
+        if (persist_expert_usage(&gemma, expert_usage_path,
+                                 &usage_total) != 0) status = 1;
+        else fprintf(stderr, "expert usage: saved=%llu path=%s\n",
+                     (unsigned long long)usage_total, expert_usage_path);
+    }
+    report_expert_cache(&gemma);
+    free(system_storage);
+    free(rendered_tools);
+    free(tokens); free(suffix_tokens); free(residual); free(logits);
+    free(selected); free(source_rgb); free(image_embeddings);
+    coli_gemma4_vision_image_close(&prepared_image);
+    coli_gemma4_vision_close(&vision);
+    coli_gemma4_model_close(&model);
+    coli_gemma4_close(&gemma);
+    coli_gemma4_tokenizer_close(&tokenizer);
+    coli_gemma4_gguf_close(&gguf);
+    return status;
+}
+
+static int command_next_token_file(int argc, char **argv,
+                                   const char *model_path,
+                                   const char *packed_dir,
+                                   const char *path, int generate) {
+    FILE *file = fopen(path, "rb");
+    char *text = NULL;
+    long length;
+    int status;
+    if (!file || fseek(file, 0, SEEK_END) != 0 ||
+        (length = ftell(file)) < 0 || fseek(file, 0, SEEK_SET) != 0) {
+        if (file) fclose(file);
+        fprintf(stderr, "cannot read UTF-8 input %s\n", path);
+        return 1;
+    }
+    if ((uint64_t)length > SIZE_MAX - 1) {
+        fclose(file);
+        fprintf(stderr, "UTF-8 input is too large\n");
+        return 1;
+    }
+    text = (char *)malloc((size_t)length + 1);
+    if (!text) {
+        fclose(file);
+        return 1;
+    }
+    {
+        int read_failed = length &&
+            fread(text, 1, (size_t)length, file) != (size_t)length;
+        int close_failed = fclose(file) != 0;
+        if (read_failed || close_failed) {
+            free(text);
+            fprintf(stderr, "cannot read UTF-8 input %s\n", path);
+            return 1;
+        }
+    }
+    text[(size_t)length] = '\0';
+    status = command_next_token(argc, argv, model_path, packed_dir,
+                                text, (size_t)length, generate);
+    free(text);
+    return status;
+}
+
+static int inject_chat_tool_responses(
+    const coli_gemma4_tokenizer *tokenizer, coli_gemma4_model *model,
+    const char *generated, size_t generated_bytes,
+    uint32_t *tokens, uint32_t max_context, uint32_t *position,
+    float *logits, char *line, size_t line_capacity, int show_special,
+    int *exit_requested) {
+    enum { MAX_TOOL_CALLS = 16 };
+    coli_gemma4_tool_call calls[MAX_TOOL_CALLS];
+    char error[COLI_GEMMA4_TOOLS_ERROR_MAX];
+    char *response_prompt = NULL;
+    size_t response_bytes = 0, response_capacity = 0;
+    size_t call_count = 0, call_index, response_token_count = 0, token_index;
+    int result = -1;
+    *exit_requested = 0;
+    if (coli_gemma4_parse_tool_calls(
+            generated, generated_bytes, calls, MAX_TOOL_CALLS, &call_count,
+            error, sizeof(error)) != 0) {
+        fprintf(stderr, "error: cannot parse Gemma tool call: %s\n", error);
+        return -1;
+    }
+    for (call_index = 0; call_index < call_count; ++call_index) {
+        char *rendered = NULL;
+        size_t rendered_bytes = 0;
+        for (;;) {
+            size_t line_bytes;
+            printf("\ntool %s arguments: ", calls[call_index].name);
+            fwrite(generated + calls[call_index].arguments_offset, 1,
+                   calls[call_index].arguments_bytes, stdout);
+            fputs("\nresult JSON> ", stdout);
+            fflush(stdout);
+            if (!fgets(line, (int)line_capacity, stdin)) {
+                if (ferror(stdin)) fprintf(stderr, "error reading tool result\n");
+                else *exit_requested = 1;
+                goto cleanup;
+            }
+            line_bytes = strlen(line);
+            if (line_bytes && line[line_bytes - 1] != '\n' && !feof(stdin)) {
+                int character;
+                while ((character = fgetc(stdin)) != '\n' && character != EOF) {}
+                fprintf(stderr, "tool result exceeds %zu bytes\n",
+                        line_capacity - 1);
+                continue;
+            }
+            while (line_bytes &&
+                   (line[line_bytes - 1] == '\r' ||
+                    line[line_bytes - 1] == '\n'))
+                line[--line_bytes] = '\0';
+            if (!strcmp(line, "/exit")) {
+                *exit_requested = 1;
+                goto cleanup;
+            }
+            if (coli_gemma4_render_tool_response(
+                    calls[call_index].name, line, line_bytes,
+                    call_index != 0, &rendered, &rendered_bytes,
+                    error, sizeof(error)) != 0) {
+                fprintf(stderr, "invalid tool result: %s\n", error);
+                continue;
+            }
+            break;
+        }
+        if (append_dynamic_text(
+                &response_prompt, &response_bytes, &response_capacity,
+                rendered, rendered_bytes) != 0) {
+            free(rendered);
+            fprintf(stderr, "error: out of memory collecting tool results\n");
+            goto cleanup;
+        }
+        free(rendered);
+    }
+    if (!response_bytes || *position >= max_context ||
+        coli_gemma4_tokenize_ex(
+            tokenizer, response_prompt, response_bytes, 0, 1,
+            tokens, max_context - *position, &response_token_count) != 0 ||
+        !response_token_count ||
+        response_token_count >= max_context - *position) {
+        fprintf(stderr, "error: tool response exhausts the chat context\n");
+        goto cleanup;
+    }
+    if (show_special) fwrite(response_prompt, 1, response_bytes, stdout);
+    for (token_index = 0; token_index < response_token_count; ++token_index) {
+        int last = token_index + 1 == response_token_count;
+        if (coli_gemma4_model_step(
+                model, tokens[token_index], (*position)++, NULL,
+                last ? logits : NULL) != 0) {
+            fprintf(stderr, "error: %s\n", coli_gemma4_model_last_error(model));
+            goto cleanup;
+        }
+    }
+    fputs("\ngemma> ", stdout);
+    fflush(stdout);
+    result = 0;
+cleanup:
+    free(response_prompt);
+    return result;
+}
+
+static int command_chat(int argc, char **argv, const char *model_path,
+                        const char *packed_dir) {
+    coli_gemma4_gguf gguf;
+    coli_gemma4_tokenizer tokenizer;
+    coli_gemma4_backend gemma;
+    coli_expert_backend experts;
+    coli_gemma4_model model;
+    coli_gemma4_sampler sampler;
+    const char *max_context_text = NULL, *max_new_text = NULL;
+    const char *temperature_text = NULL, *top_k_text = NULL;
+    const char *top_p_text = NULL, *seed_text = NULL;
+    const char *expert_cache_text = NULL, *expert_pins_text = NULL;
+    const char *expert_usage_path = NULL;
+    const char *cuda_device_text = NULL;
+    const char *system_text = NULL, *system_path = NULL;
+    const char *tools_path = NULL;
+    char *system_storage = NULL, *rendered_tools = NULL;
+    size_t system_bytes = 0, rendered_tools_bytes = 0;
+    uint32_t max_context = 512, max_new = 64, top_k = 0;
+    uint32_t expert_cache = 0, expert_pins = 0;
+    uint32_t cuda_device = 0;
+    uint32_t *tokens = NULL, position = 0;
+    uint64_t seed = 1;
+    uint64_t usage_total = 0;
+    float temperature = 0.0F, top_p = 1.0F;
+    float *logits = NULL;
+    char *line = NULL, *generated_text = NULL;
+    size_t generated_text_bytes = 0, generated_text_capacity = 0;
+    int show_special = 0, expert_prefetch = 0, expert_lookahead = 0;
+    int argument, status = 1, usage_active = 0;
+    memset(&gguf, 0, sizeof(gguf));
+    memset(&tokenizer, 0, sizeof(tokenizer));
+    memset(&gemma, 0, sizeof(gemma));
+    memset(&model, 0, sizeof(model));
+    memset(&sampler, 0, sizeof(sampler));
+    for (argument = 0; argument < argc; ++argument)
+        if (strcmp(argv[argument], "--show-special") == 0) show_special = 1;
+        else if (strcmp(argv[argument], "--expert-prefetch") == 0)
+            expert_prefetch = 1;
+        else if (strcmp(argv[argument], "--expert-lookahead") == 0)
+            expert_lookahead = 1;
+    if (option_value(argc, argv, "--max-context", &max_context_text) < 0 ||
+        option_value(argc, argv, "--max-new", &max_new_text) < 0 ||
+        option_value(argc, argv, "--temperature", &temperature_text) < 0 ||
+        option_value(argc, argv, "--top-k", &top_k_text) < 0 ||
+        option_value(argc, argv, "--top-p", &top_p_text) < 0 ||
+        option_value(argc, argv, "--seed", &seed_text) < 0 ||
+        option_value(argc, argv, "--expert-cache", &expert_cache_text) < 0 ||
+        option_value(argc, argv, "--expert-pins", &expert_pins_text) < 0 ||
+        option_value(argc, argv, "--expert-usage", &expert_usage_path) < 0 ||
+        option_value(argc, argv, "--cuda-device", &cuda_device_text) < 0 ||
+        option_value(argc, argv, "--system", &system_text) < 0 ||
+        option_value(argc, argv, "--system-file", &system_path) < 0 ||
+        option_value(argc, argv, "--tools-file", &tools_path) < 0 ||
+        (max_context_text && parse_u32(max_context_text, &max_context) != 0) ||
+        (max_new_text && parse_u32(max_new_text, &max_new) != 0) ||
+        (temperature_text && parse_f32(temperature_text, &temperature) != 0) ||
+        (top_k_text && parse_u32(top_k_text, &top_k) != 0) ||
+        (top_p_text && parse_f32(top_p_text, &top_p) != 0) ||
+        (seed_text && parse_u64(seed_text, &seed) != 0) ||
+        (expert_cache_text && parse_u32(expert_cache_text, &expert_cache) != 0) ||
+        (expert_pins_text && parse_u32(expert_pins_text, &expert_pins) != 0) ||
+        (cuda_device_text && parse_u32(cuda_device_text, &cuda_device) != 0) ||
+        (expert_usage_path && !expert_cache) ||
+        (expert_prefetch && !expert_cache) ||
+        (expert_lookahead && !expert_prefetch) ||
+        (expert_pins && expert_pins >= expert_cache) ||
+        (system_text && system_path) ||
+        !max_context || !max_new || max_new >= max_context) {
+        fprintf(stderr, "invalid chat-session option\n");
+        return 2;
+    }
+    if (system_path) {
+        if (read_utf8_text(system_path, &system_storage, &system_bytes) != 0)
+            return 1;
+        system_text = system_storage;
+    } else if (system_text) {
+        system_bytes = strlen(system_text);
+    }
+    if (tools_path && read_tool_declarations(
+            tools_path, &rendered_tools, &rendered_tools_bytes) != 0) {
+        free(system_storage);
+        return 1;
+    }
+    if (coli_gemma4_gguf_open(&gguf, model_path) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_gguf_last_error(&gguf));
+        goto cleanup;
+    }
+    if (coli_gemma4_tokenizer_init(&tokenizer, &gguf) != 0) {
+        fprintf(stderr, "error: %s\n",
+                coli_gemma4_tokenizer_last_error(&tokenizer));
+        goto cleanup;
+    }
+    if (!top_k_text) top_k = gguf.sampling_top_k;
+    if (!top_p_text) top_p = gguf.sampling_top_p;
+    if (coli_gemma4_sampler_init(&sampler, temperature, top_k,
+                                 top_p, seed) != 0) {
+        fprintf(stderr, "error: invalid sampling configuration\n");
+        goto cleanup;
+    }
+    if (coli_gemma4_open_packed(&gemma, packed_dir) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    if (strlen(gguf.path) + 1 > sizeof(gemma.source)) {
+        fprintf(stderr, "error: model path is too long for expert backend\n");
+        goto cleanup;
+    }
+    memcpy(gemma.source, gguf.path, strlen(gguf.path) + 1);
+    if (coli_gemma4_cache_configure(&gemma, expert_cache) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    if (expert_pins &&
+        coli_gemma4_cache_set_pinned(&gemma, expert_pins) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    if (expert_usage_path) {
+        if (coli_gemma4_usage_load(&gemma, expert_usage_path,
+                                   &usage_total) != 0) {
+            fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+            goto cleanup;
+        }
+        usage_active = 1;
+        fprintf(stderr, "expert usage: loaded=%llu path=%s\n",
+                (unsigned long long)usage_total, expert_usage_path);
+    }
+    if (expert_prefetch &&
+        coli_gemma4_prefetch_configure(&gemma, 1) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    if (expert_lookahead &&
+        coli_gemma4_lookahead_configure(&gemma, 1) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    if (cuda_device_text && coli_gemma4_cuda_configure(
+            &gemma, (int)cuda_device) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    if (gemma.config.n_layer != gguf.config.n_layer ||
+        gemma.config.n_embd != gguf.config.n_embd ||
+        gemma.config.n_expert != gguf.config.n_expert ||
+        gemma.config.n_expert_used != gguf.config.n_expert_used) {
+        fprintf(stderr, "error: packed manifest and GGUF configuration disagree\n");
+        goto cleanup;
+    }
+#if SIZE_MAX < UINT32_MAX
+    if ((size_t)max_context > SIZE_MAX / sizeof(*tokens)) goto cleanup;
+#endif
+    tokens = (uint32_t *)malloc((size_t)max_context * sizeof(*tokens));
+    logits = (float *)malloc((size_t)gguf.config.n_vocab * sizeof(float));
+    line = (char *)malloc(65536);
+    if (!tokens || !logits || !line) {
+        fprintf(stderr, "error: out of memory allocating chat session\n");
+        goto cleanup;
+    }
+    experts = coli_gemma4_expert_backend(&gemma);
+    if (coli_gemma4_model_open(&model, &gguf, &experts, max_context) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_model_last_error(&model));
+        goto cleanup;
+    }
+    printf("Gemma 4 chat: context=%u max-new=%u temperature=%.7g "
+           "top-k=%u top-p=%.7g seed=%llu\n",
+           max_context, max_new, temperature, top_k, top_p,
+           (unsigned long long)seed);
+    puts("Enter /exit to quit.");
+    while (position < max_context) {
+        size_t line_bytes, token_count = 0, index;
+        int initial_turn = position == 0;
+        fputs("you> ", stdout);
+        fflush(stdout);
+        if (!fgets(line, 65536, stdin)) {
+            if (ferror(stdin)) fprintf(stderr, "error reading chat input\n");
+            else status = 0;
+            break;
+        }
+        line_bytes = strlen(line);
+        if (line_bytes && line[line_bytes - 1] != '\n' && !feof(stdin)) {
+            int character;
+            while ((character = fgetc(stdin)) != '\n' && character != EOF) {}
+            fprintf(stderr, "input line exceeds 65535 bytes\n");
+            continue;
+        }
+        while (line_bytes &&
+               (line[line_bytes - 1] == '\r' || line[line_bytes - 1] == '\n'))
+            line[--line_bytes] = '\0';
+        if (strcmp(line, "/exit") == 0) {
+            status = 0;
+            break;
+        }
+        if (!line_bytes) continue;
+        if (coli_gemma4_tokenize_chat_turn_with_tools(
+                &tokenizer, initial_turn ? system_text : NULL,
+                initial_turn ? system_bytes : 0,
+                initial_turn ? rendered_tools : NULL,
+                initial_turn ? rendered_tools_bytes : 0,
+                line, line_bytes, initial_turn, tokens,
+                max_context - position, &token_count) != 0 || !token_count) {
+            fprintf(stderr, "error: cannot tokenize user turn\n");
+            goto cleanup;
+        }
+        if (token_count > max_context - position ||
+            max_new + 1 > max_context - position - token_count) {
+            fprintf(stderr, "context capacity exhausted; start a new session\n");
+            status = 0;
+            break;
+        }
+        for (index = 0; index < token_count; ++index) {
+            int last = index + 1 == token_count;
+            if (coli_gemma4_model_step(&model, tokens[index], position++,
+                                       NULL, last ? logits : NULL) != 0) {
+                fprintf(stderr, "error: %s\n",
+                        coli_gemma4_model_last_error(&model));
+                goto cleanup;
+            }
+        }
+        generated_text_bytes = 0;
+        if (generated_text) generated_text[0] = '\0';
+        fputs("gemma> ", stdout);
+        fflush(stdout);
+        {
+            uint32_t generated;
+            int ended = 0;
+            for (generated = 0; generated < max_new; ++generated) {
+                uint32_t selected;
+                int eog, tool_handoff;
+                if (coli_gemma4_sample(&sampler, logits, gguf.config.n_vocab,
+                                       &selected, NULL) != 0 ||
+                    capture_token_piece(
+                        &tokenizer, selected, &generated_text,
+                        &generated_text_bytes, &generated_text_capacity) != 0 ||
+                    emit_token_piece(&tokenizer, selected, show_special) != 0) {
+                    fprintf(stderr, "error: chat sampling or decoding failed\n");
+                    goto cleanup;
+                }
+                eog = coli_gemma4_token_is_eog(&tokenizer, selected);
+                tool_handoff = coli_gemma4_token_is_tool_response(
+                    &tokenizer, selected);
+                if (position >= max_context ||
+                    coli_gemma4_model_step(
+                        &model, selected, position++, NULL,
+                        !eog && generated + 1 < max_new ? logits : NULL) != 0) {
+                    fprintf(stderr, "error: %s\n",
+                            coli_gemma4_model_last_error(&model));
+                    goto cleanup;
+                }
+                fflush(stdout);
+                if (tool_handoff && rendered_tools_bytes) {
+                    int exit_requested = 0;
+                    int inject_result = inject_chat_tool_responses(
+                        &tokenizer, &model,
+                        generated_text, generated_text_bytes,
+                        tokens, max_context, &position, logits,
+                        line, 65536, show_special, &exit_requested);
+                    if (exit_requested) {
+                        fputc('\n', stdout);
+                        status = 0;
+                        goto cleanup;
+                    }
+                    if (inject_result != 0) goto cleanup;
+                    generated_text_bytes = 0;
+                    generated_text[0] = '\0';
+                    continue;
+                }
+                if (eog) {
+                    ended = 1;
+                    break;
+                }
+            }
+            if (!ended) {
+                size_t close_count = 0;
+                static const char close_turn[] = "<turn|>";
+                if (position >= max_context ||
+                    coli_gemma4_tokenize_ex(
+                        &tokenizer, close_turn, sizeof(close_turn) - 1,
+                        0, 1, tokens, max_context - position,
+                        &close_count) != 0 || close_count != 1 ||
+                    coli_gemma4_model_step(&model, tokens[0], position++,
+                                           NULL, NULL) != 0) {
+                    fprintf(stderr, "error: cannot close truncated model turn\n");
+                    goto cleanup;
+                }
+                if (show_special) fputs("<turn|>", stdout);
+            }
+        }
+        fputc('\n', stdout);
+        if (usage_active && persist_expert_usage(
+                &gemma, expert_usage_path, &usage_total) != 0) {
+            usage_active = 0;
+            goto cleanup;
+        }
+    }
+    if (position >= max_context) status = 0;
+
+cleanup:
+    if (usage_active) {
+        if (persist_expert_usage(&gemma, expert_usage_path,
+                                 &usage_total) != 0) status = 1;
+        else fprintf(stderr, "expert usage: saved=%llu path=%s\n",
+                     (unsigned long long)usage_total, expert_usage_path);
+    }
+    report_expert_cache(&gemma);
+    free(system_storage);
+    free(rendered_tools);
+    free(tokens); free(logits); free(line); free(generated_text);
+    coli_gemma4_model_close(&model);
+    coli_gemma4_close(&gemma);
+    coli_gemma4_tokenizer_close(&tokenizer);
+    coli_gemma4_gguf_close(&gguf);
+    return status;
+}
+
+static int command_model_info(const char *path) {
+    coli_gemma4_gguf gguf;
+    uint32_t layer;
+    if (coli_gemma4_gguf_open(&gguf, path) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_gguf_last_error(&gguf));
+        return 1;
+    }
+    printf("architecture:       %s\n", gguf.architecture);
+    printf("GGUF version:       %u\n", gguf.version);
+    printf("tensor count:       %" PRIu64 "\n", gguf.tensor_count);
+    printf("tensor data offset: %" PRIu64 "\n", gguf.data_offset);
+    printf("layers/width/vocab: %u / %u / %u\n",
+           gguf.config.n_layer, gguf.config.n_embd, gguf.config.n_vocab);
+    printf("experts/top-k/ff:   %u / %u / %u\n",
+           gguf.config.n_expert, gguf.config.n_expert_used,
+           gguf.config.n_expert_ff);
+    printf("attention heads:    %u\n", gguf.attention_heads);
+    printf("sliding window:     %u\n", gguf.config.sliding_window);
+    printf("RMS epsilon:        %.9g\n", gguf.rms_epsilon);
+    printf("sampling defaults: temp=%.7g top-k=%u top-p=%.7g\n",
+           gguf.sampling_temperature, gguf.sampling_top_k,
+           gguf.sampling_top_p);
+    printf("attention schedule:\n");
+    for (layer = 0; layer < gguf.config.n_layer; ++layer) {
+        int sliding = gguf.sliding_window_pattern[layer] != 0;
+        printf("  layer %2u: %-7s kv-heads=%u head-dim=%u rope-base=%.7g\n",
+               layer, sliding ? "sliding" : "global",
+               gguf.head_count_kv[layer],
+               sliding ? gguf.key_length_swa : gguf.key_length,
+               sliding ? gguf.rope_freq_base_swa : gguf.rope_freq_base);
+    }
+    coli_gemma4_gguf_close(&gguf);
+    return 0;
+}
+
+static int command_vision_info(int argc, char **argv) {
+    coli_gemma4_vision vision;
+    uint32_t width = 0, height = 0, tokens = 0;
+    if (argc != 1 && argc != 3) {
+        fprintf(stderr, "vision-info expects MMPROJ.gguf and optional width height\n");
+        return 2;
+    }
+    if (argc == 3 &&
+        (parse_u32(argv[1], &width) != 0 || parse_u32(argv[2], &height) != 0 ||
+         !width || !height)) {
+        fprintf(stderr, "invalid source image dimensions\n");
+        return 2;
+    }
+    memset(&vision, 0, sizeof(vision));
+    if (coli_gemma4_vision_open(&vision, argv[0]) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_vision_last_error(&vision));
+        return 1;
+    }
+    printf("architecture:       %s/%s\n",
+           vision.gguf.architecture, vision.gguf.projector_type);
+    printf("GGUF/tensors:       v%u / %" PRIu64 "\n",
+           vision.gguf.version, vision.gguf.tensor_count);
+    printf("image/patch/merge:  %u / %u / %u\n",
+           vision.gguf.vision_image_size, vision.gguf.vision_patch_size,
+           vision.merge_size);
+    printf("layers/width/ff:    %u / %u / %u\n",
+           vision.gguf.vision_block_count,
+           vision.gguf.vision_embedding_length,
+           vision.gguf.vision_feed_forward_length);
+    printf("heads/epsilon:      %u / %.9g\n",
+           vision.gguf.vision_head_count, vision.gguf.vision_epsilon);
+    printf("decoder projection: %u\n", vision.gguf.vision_projection_dim);
+    printf("image token range:  %u..%u\n",
+           vision.minimum_tokens, vision.maximum_tokens);
+    printf("image mean:         %.7g %.7g %.7g\n",
+           vision.gguf.vision_image_mean[0],
+           vision.gguf.vision_image_mean[1],
+           vision.gguf.vision_image_mean[2]);
+    printf("image std:          %.7g %.7g %.7g\n",
+           vision.gguf.vision_image_std[0],
+           vision.gguf.vision_image_std[1],
+           vision.gguf.vision_image_std[2]);
+    if (argc == 3) {
+        uint32_t target_width, target_height;
+        if (coli_gemma4_vision_target_size(
+                &vision, width, height, &target_width, &target_height,
+                &tokens) != 0) {
+            fprintf(stderr, "cannot calculate target image dimensions\n");
+            coli_gemma4_vision_close(&vision);
+            return 1;
+        }
+        printf("source/target:      %ux%u -> %ux%u\n",
+               width, height, target_width, target_height);
+        printf("projected tokens:   %u (%ux%u)\n", tokens,
+               target_width / (vision.gguf.vision_patch_size * vision.merge_size),
+               target_height / (vision.gguf.vision_patch_size * vision.merge_size));
+    }
+    coli_gemma4_vision_close(&vision);
+    return 0;
+}
+
+static int command_vision_image_info(const char *mmproj_path,
+                                     const char *image_path) {
+    coli_gemma4_vision vision;
+    uint8_t *rgb = NULL;
+    uint32_t source_width = 0, source_height = 0;
+    uint32_t target_width = 0, target_height = 0, token_count = 0;
+    char error[COLI_GEMMA4_VISION_ERROR_MAX];
+    int status = 1;
+    memset(&vision, 0, sizeof(vision));
+    if (coli_gemma4_vision_load_image(
+            image_path, &rgb, &source_width, &source_height,
+            error, sizeof(error)) != 0) {
+        fprintf(stderr, "error: %s\n", error);
+        goto cleanup;
+    }
+    if (coli_gemma4_vision_open(&vision, mmproj_path) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_vision_last_error(&vision));
+        goto cleanup;
+    }
+    if (coli_gemma4_vision_target_size(
+            &vision, source_width, source_height,
+            &target_width, &target_height, &token_count) != 0) {
+        fprintf(stderr, "error: cannot calculate image geometry\n");
+        goto cleanup;
+    }
+    printf("image:              %s\n", image_path);
+    printf("source geometry:    %u x %u\n", source_width, source_height);
+    printf("prepared geometry:  %u x %u\n", target_width, target_height);
+    printf("projected tokens:   %u\n", token_count);
+    status = 0;
+cleanup:
+    free(rgb);
+    coli_gemma4_vision_close(&vision);
+    return status;
+}
+
+static int command_vision_patch_probe(const char *path,
+                                      const char *width_text,
+                                      const char *height_text,
+                                      const char *output_path) {
+    coli_gemma4_vision vision;
+    coli_gemma4_vision_image image;
+    uint8_t *rgb = NULL;
+    float *embeddings = NULL;
+    uint32_t source_width, source_height, patch_count = 0;
+    uint64_t pixel_values, index;
+    clock_t started, stopped;
+    int status = 1;
+    if (parse_u32(width_text, &source_width) != 0 ||
+        parse_u32(height_text, &source_height) != 0 ||
+        !source_width || !source_height ||
+        source_width > SIZE_MAX / 3U / source_height) {
+        fprintf(stderr, "invalid source image dimensions\n");
+        return 2;
+    }
+    memset(&vision, 0, sizeof(vision));
+    memset(&image, 0, sizeof(image));
+    pixel_values = (uint64_t)source_width * source_height * 3U;
+    if (pixel_values > SIZE_MAX) {
+        fprintf(stderr, "source image is too large\n");
+        return 2;
+    }
+    rgb = (uint8_t *)malloc((size_t)pixel_values);
+    if (!rgb) {
+        fprintf(stderr, "out of memory allocating probe image\n");
+        return 1;
+    }
+    for (index = 0; index < pixel_values; ++index)
+        rgb[index] = (uint8_t)((index * UINT64_C(37) + UINT64_C(11)) & 255U);
+    if (coli_gemma4_vision_open(&vision, path) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_vision_last_error(&vision));
+        goto cleanup;
+    }
+    started = clock();
+    if (coli_gemma4_vision_prepare_rgb(
+            &vision, rgb, source_width, source_height, &image) != 0 ||
+        coli_gemma4_vision_patch_embeddings(
+            &vision, &image, &embeddings, &patch_count) != 0) {
+        fprintf(stderr, "Gemma 4 patch embedding probe failed\n");
+        goto cleanup;
+    }
+    stopped = clock();
+    if (output_path && write_f32(
+            output_path, embeddings,
+            (size_t)patch_count * vision.gguf.vision_embedding_length) != 0)
+        goto cleanup;
+    printf("source/prepared:    %ux%u -> %ux%u\n",
+           source_width, source_height, image.width, image.height);
+    printf("patches/width:      %u / %u\n",
+           patch_count, vision.gguf.vision_embedding_length);
+    printf("embedding hash:    0x%016" PRIx64 "\n",
+           coli_gemma4_checksum_f32(
+               embeddings,
+               (size_t)patch_count * vision.gguf.vision_embedding_length));
+    printf("elapsed:           %.3f ms\n",
+           1000.0 * (double)(stopped - started) / (double)CLOCKS_PER_SEC);
+    if (output_path) printf("wrote embeddings:  %s\n", output_path);
+    status = 0;
+cleanup:
+    free(rgb);
+    free(embeddings);
+    coli_gemma4_vision_image_close(&image);
+    coli_gemma4_vision_close(&vision);
+    return status;
+}
+
+static int command_vision_encode_probe(int argc, char **argv) {
+    coli_gemma4_vision vision;
+    coli_gemma4_vision_image image;
+    uint8_t *rgb = NULL;
+    float *embeddings = NULL;
+    const char *input_path = NULL, *output_path = NULL, *layer_text = NULL;
+    const char *prepared_path = NULL;
+    const char *start_layer_text = NULL;
+    const char *trace_layer_text = NULL, *trace_directory = NULL;
+    uint32_t source_width, source_height, count = 0, layers = 0;
+    uint32_t start_layer = 0, trace_layer = 0;
+    uint32_t output_width = 0;
+    uint64_t pixel_values, index;
+    clock_t started, stopped;
+    int partial, status = 1;
+    if (argc < 3 ||
+        parse_u32(argv[1], &source_width) != 0 ||
+        parse_u32(argv[2], &source_height) != 0 ||
+        !source_width || !source_height ||
+        source_width > SIZE_MAX / 3U / source_height ||
+        option_value(argc - 3, argv + 3, "--input-f32", &input_path) < 0 ||
+        option_value(argc - 3, argv + 3, "--output-f32", &output_path) < 0 ||
+        option_value(argc - 3, argv + 3, "--prepared-f32", &prepared_path) < 0 ||
+        option_value(argc - 3, argv + 3, "--layers", &layer_text) < 0 ||
+        option_value(argc - 3, argv + 3, "--start-layer",
+                     &start_layer_text) < 0 ||
+        option_value(argc - 3, argv + 3, "--trace-layer",
+                     &trace_layer_text) < 0 ||
+        option_value(argc - 3, argv + 3, "--trace-dir",
+                     &trace_directory) < 0 ||
+        (layer_text && parse_u32(layer_text, &layers) != 0) ||
+        (start_layer_text && parse_u32(start_layer_text, &start_layer) != 0) ||
+        (trace_layer_text && parse_u32(trace_layer_text, &trace_layer) != 0) ||
+        ((trace_layer_text != NULL) != (trace_directory != NULL)) ||
+        (input_path && !layer_text) ||
+        (start_layer_text && !input_path)) {
+        fprintf(stderr, "invalid vision encode probe arguments\n");
+        return 2;
+    }
+    partial = layer_text != NULL;
+    memset(&vision, 0, sizeof(vision));
+    memset(&image, 0, sizeof(image));
+    pixel_values = (uint64_t)source_width * source_height * 3U;
+    if (pixel_values > SIZE_MAX) {
+        fprintf(stderr, "source image is too large\n");
+        return 2;
+    }
+    rgb = (uint8_t *)malloc((size_t)pixel_values);
+    if (!rgb) {
+        fprintf(stderr, "out of memory allocating probe image\n");
+        return 1;
+    }
+    for (index = 0; index < pixel_values; ++index)
+        rgb[index] = (uint8_t)((index * UINT64_C(37) + UINT64_C(11)) & 255U);
+    if (coli_gemma4_vision_open(&vision, argv[0]) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_vision_last_error(&vision));
+        goto cleanup;
+    }
+    if (partial && (layers > vision.gguf.vision_block_count ||
+                    start_layer > layers)) {
+        fprintf(stderr, "--layers exceeds the projector's %u blocks\n",
+                vision.gguf.vision_block_count);
+        status = 2;
+        goto cleanup;
+    }
+    if (trace_layer_text &&
+        (trace_layer >= vision.gguf.vision_block_count ||
+         (partial && (trace_layer < start_layer || trace_layer >= layers)))) {
+        fprintf(stderr, "--trace-layer is outside the evaluated block range\n");
+        status = 2;
+        goto cleanup;
+    }
+    if (trace_layer_text)
+        coli_gemma4_vision_trace_layer(&vision, trace_layer, trace_directory);
+    started = clock();
+    if (coli_gemma4_vision_prepare_rgb(
+            &vision, rgb, source_width, source_height, &image) != 0)
+        goto graph_failure;
+    if (prepared_path) {
+        size_t plane = (size_t)image.width * image.height;
+        float *prepared = (float *)malloc(image.value_count * sizeof(*prepared));
+        uint32_t py, px, channel;
+        if (!prepared) goto graph_failure;
+        for (channel = 0; channel < 3; ++channel)
+            for (py = 0; py < image.height; ++py)
+                for (px = 0; px < image.width; ++px)
+                    prepared[(size_t)channel * plane +
+                             (size_t)py * image.width + px] =
+                        2.0F * image.pixels[
+                            ((size_t)py * image.width + px) * 3U + channel] -
+                        1.0F;
+        if (write_f32(prepared_path, prepared, image.value_count) != 0) {
+            free(prepared);
+            goto cleanup;
+        }
+        free(prepared);
+    }
+    if (partial) {
+        if (coli_gemma4_vision_patch_embeddings(
+                &vision, &image, &embeddings, &count) != 0 ||
+            (input_path && read_f32(
+                input_path, embeddings,
+                (size_t)count * vision.gguf.vision_embedding_length) != 0) ||
+            coli_gemma4_vision_transform_range(
+                &vision, embeddings, count, image.patch_columns,
+                start_layer, layers) != 0)
+            goto graph_failure;
+        output_width = vision.gguf.vision_embedding_length;
+    } else {
+        if (coli_gemma4_vision_encode(
+                &vision, &image, &embeddings, &count) != 0)
+            goto graph_failure;
+        output_width = vision.gguf.vision_projection_dim;
+    }
+    stopped = clock();
+    if (output_path && write_f32(output_path, embeddings,
+            (size_t)count * output_width) != 0)
+        goto cleanup;
+    printf("source/prepared:    %ux%u -> %ux%u\n",
+           source_width, source_height, image.width, image.height);
+    if (partial)
+        printf("transform blocks:   %u..%u / %u\n", start_layer, layers,
+               vision.gguf.vision_block_count);
+    printf("vectors/width:      %u / %u\n", count, output_width);
+    printf("embedding hash:    0x%016" PRIx64 "\n",
+           coli_gemma4_checksum_f32(
+               embeddings, (size_t)count * output_width));
+    printf("elapsed:           %.3f ms\n",
+           1000.0 * (double)(stopped - started) / (double)CLOCKS_PER_SEC);
+    if (output_path) printf("wrote embeddings:  %s\n", output_path);
+    status = 0;
+    goto cleanup;
+graph_failure:
+    fprintf(stderr, "Gemma 4 vision encode probe failed: %s\n",
+            coli_gemma4_vision_last_error(&vision));
+cleanup:
+    free(rgb);
+    free(embeddings);
+    coli_gemma4_vision_image_close(&image);
+    coli_gemma4_vision_close(&vision);
+    return status;
+}
+
+static int command_route(int argc, char **argv, const char *path) {
+    coli_gemma4_gguf gguf;
+    coli_gemma4_router router;
+    const char *value = NULL, *input_path = NULL, *probability_path = NULL;
+    uint32_t layer = 0, seed = 1, i;
+    float *input = NULL, *probabilities = NULL, *weights = NULL, *effective = NULL;
+    uint32_t *ids = NULL;
+    int status = 1;
+    memset(&gguf, 0, sizeof(gguf));
+    memset(&router, 0, sizeof(router));
+    if (option_value(argc, argv, "--layer", &value) < 0 ||
+        (value && parse_u32(value, &layer) != 0)) {
+        fprintf(stderr, "invalid --layer value\n");
+        return 2;
+    }
+    value = NULL;
+    if (option_value(argc, argv, "--seed", &value) < 0 ||
+        (value && parse_u32(value, &seed) != 0) ||
+        option_value(argc, argv, "--input-f32", &input_path) < 0 ||
+        option_value(argc, argv, "--probabilities-f32", &probability_path) < 0) {
+        fprintf(stderr, "invalid or missing option value\n");
+        return 2;
+    }
+    if (coli_gemma4_gguf_open(&gguf, path) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_gguf_last_error(&gguf));
+        return 1;
+    }
+    if (coli_gemma4_router_open(&router, &gguf, layer) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_router_last_error(&router));
+        goto cleanup;
+    }
+    input = (float *)malloc((size_t)router.width * sizeof(float));
+    probabilities = (float *)malloc((size_t)router.expert_count * sizeof(float));
+    ids = (uint32_t *)malloc((size_t)router.selected_count * sizeof(uint32_t));
+    weights = (float *)malloc((size_t)router.selected_count * sizeof(float));
+    effective = (float *)malloc((size_t)router.selected_count * sizeof(float));
+    if (!input || !probabilities || !ids || !weights || !effective) {
+        fprintf(stderr, "error: out of memory allocating router buffers\n");
+        goto cleanup;
+    }
+    if (input_path) {
+        if (read_f32(input_path, input, router.width) != 0) goto cleanup;
+    } else {
+        make_input(input, router.width, seed);
+    }
+    if (coli_gemma4_router_route(&router, input, probabilities, ids,
+                                 weights, effective) != 0) {
+        fprintf(stderr, "error: router evaluation failed\n");
+        goto cleanup;
+    }
+    if (probability_path &&
+        write_f32(probability_path, probabilities, router.expert_count) != 0)
+        goto cleanup;
+    printf("layer:             %u\n", layer);
+    printf("input:             %s\n",
+           input_path ? input_path : "deterministic pseudorandom");
+    printf("probability hash:  0x%016" PRIx64 "\n",
+           coli_gemma4_checksum_f32(probabilities, router.expert_count));
+    printf("selected experts:\n");
+    for (i = 0; i < router.selected_count; ++i)
+        printf("  %2u: expert %3u  normalized=%.9g  effective=%.9g\n",
+               i, ids[i], weights[i], effective[i]);
+    if (probability_path) printf("wrote probabilities: %s\n", probability_path);
+    status = 0;
+
+cleanup:
+    free(input); free(probabilities); free(ids); free(weights); free(effective);
+    coli_gemma4_router_close(&router);
+    coli_gemma4_gguf_close(&gguf);
+    return status;
+}
+
+static int command_attention_projection(int argc, char **argv, const char *path) {
+    coli_gemma4_gguf gguf;
+    coli_gemma4_attention attention;
+    const char *option = NULL, *input_path = NULL;
+    const char *query_path = NULL, *key_path = NULL, *value_path = NULL;
+    uint32_t layer = 0, position = 0, seed = 1;
+    uint32_t query_width, kv_width;
+    float *input = NULL, *query = NULL, *key = NULL, *value = NULL;
+    int status = 1;
+    memset(&gguf, 0, sizeof(gguf));
+    memset(&attention, 0, sizeof(attention));
+    if (option_value(argc, argv, "--layer", &option) < 0 ||
+        (option && parse_u32(option, &layer) != 0)) {
+        fprintf(stderr, "invalid --layer value\n");
+        return 2;
+    }
+    option = NULL;
+    if (option_value(argc, argv, "--position", &option) < 0 ||
+        (option && parse_u32(option, &position) != 0)) {
+        fprintf(stderr, "invalid --position value\n");
+        return 2;
+    }
+    option = NULL;
+    if (option_value(argc, argv, "--seed", &option) < 0 ||
+        (option && parse_u32(option, &seed) != 0) ||
+        option_value(argc, argv, "--input-f32", &input_path) < 0 ||
+        option_value(argc, argv, "--query-f32", &query_path) < 0 ||
+        option_value(argc, argv, "--key-f32", &key_path) < 0 ||
+        option_value(argc, argv, "--value-f32", &value_path) < 0) {
+        fprintf(stderr, "invalid or missing option value\n");
+        return 2;
+    }
+    if (coli_gemma4_gguf_open(&gguf, path) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_gguf_last_error(&gguf));
+        return 1;
+    }
+    if (coli_gemma4_attention_open(&attention, &gguf, layer) != 0) {
+        fprintf(stderr, "error: %s\n",
+                coli_gemma4_attention_last_error(&attention));
+        goto cleanup;
+    }
+    query_width = attention.query_heads * attention.head_dim;
+    kv_width = attention.kv_heads * attention.head_dim;
+    input = (float *)malloc((size_t)attention.model_width * sizeof(float));
+    query = (float *)malloc((size_t)query_width * sizeof(float));
+    key = (float *)malloc((size_t)kv_width * sizeof(float));
+    value = (float *)malloc((size_t)kv_width * sizeof(float));
+    if (!input || !query || !key || !value) {
+        fprintf(stderr, "error: out of memory allocating attention vectors\n");
+        goto cleanup;
+    }
+    if (input_path) {
+        if (read_f32(input_path, input, attention.model_width) != 0) goto cleanup;
+    } else make_input(input, attention.model_width, seed);
+    if (coli_gemma4_attention_project(&attention, input, query, key, value) != 0 ||
+        coli_gemma4_attention_apply_rope(&attention, position, query, key) != 0) {
+        fprintf(stderr, "error: attention projection failed\n");
+        goto cleanup;
+    }
+    if ((query_path && write_f32(query_path, query, query_width) != 0) ||
+        (key_path && write_f32(key_path, key, kv_width) != 0) ||
+        (value_path && write_f32(value_path, value, kv_width) != 0))
+        goto cleanup;
+    printf("layer:             %u (%s)\n", layer,
+           attention.sliding ? "sliding" : "global");
+    printf("position:          %u\n", position);
+    printf("heads/dimension:   q=%u kv=%u dim=%u\n",
+           attention.query_heads, attention.kv_heads, attention.head_dim);
+    printf("value projection:  %s\n",
+           attention.key_equals_value ? "derived from key" : "independent");
+    printf("query hash:        0x%016" PRIx64 "\n",
+           coli_gemma4_checksum_f32(query, query_width));
+    printf("key hash:          0x%016" PRIx64 "\n",
+           coli_gemma4_checksum_f32(key, kv_width));
+    printf("value hash:        0x%016" PRIx64 "\n",
+           coli_gemma4_checksum_f32(value, kv_width));
+    status = 0;
+
+cleanup:
+    free(input); free(query); free(key); free(value);
+    coli_gemma4_attention_close(&attention);
+    coli_gemma4_gguf_close(&gguf);
+    return status;
+}
+
+static int command_attention_sequence(int argc, char **argv, const char *path) {
+    coli_gemma4_gguf gguf;
+    coli_gemma4_attention attention;
+    coli_gemma4_kv_cache cache;
+    const char *option = NULL, *input_path = NULL, *output_path = NULL;
+    uint32_t layer = 0, tokens = 1, seed = 1, token;
+    uint64_t value_count;
+    float *input = NULL, *output = NULL;
+    int status = 1;
+    memset(&gguf, 0, sizeof(gguf));
+    memset(&attention, 0, sizeof(attention));
+    memset(&cache, 0, sizeof(cache));
+    if (option_value(argc, argv, "--layer", &option) < 0 ||
+        (option && parse_u32(option, &layer) != 0)) {
+        fprintf(stderr, "invalid --layer value\n");
+        return 2;
+    }
+    option = NULL;
+    if (option_value(argc, argv, "--tokens", &option) < 0 ||
+        (option && parse_u32(option, &tokens) != 0) || !tokens) {
+        fprintf(stderr, "invalid --tokens value\n");
+        return 2;
+    }
+    option = NULL;
+    if (option_value(argc, argv, "--seed", &option) < 0 ||
+        (option && parse_u32(option, &seed) != 0) ||
+        option_value(argc, argv, "--input-f32", &input_path) < 0 ||
+        option_value(argc, argv, "--output-f32", &output_path) < 0) {
+        fprintf(stderr, "invalid or missing option value\n");
+        return 2;
+    }
+    if (coli_gemma4_gguf_open(&gguf, path) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_gguf_last_error(&gguf));
+        return 1;
+    }
+    if (coli_gemma4_attention_open(&attention, &gguf, layer) != 0) {
+        fprintf(stderr, "error: %s\n",
+                coli_gemma4_attention_last_error(&attention));
+        goto cleanup;
+    }
+    value_count = (uint64_t)tokens * attention.model_width;
+    if (value_count > SIZE_MAX / sizeof(float)) {
+        fprintf(stderr, "error: attention sequence is too large\n");
+        goto cleanup;
+    }
+    input = (float *)malloc((size_t)value_count * sizeof(float));
+    output = (float *)malloc((size_t)value_count * sizeof(float));
+    if (!input || !output ||
+        coli_gemma4_kv_cache_init(&cache, &attention, tokens) != 0) {
+        fprintf(stderr, "error: out of memory allocating attention sequence\n");
+        goto cleanup;
+    }
+    if (input_path) {
+        if (read_f32(input_path, input, (size_t)value_count) != 0) goto cleanup;
+    } else make_input(input, (size_t)value_count, seed);
+    for (token = 0; token < tokens; ++token) {
+        if (coli_gemma4_attention_step(
+                &attention, &cache, token,
+                input + (size_t)token * attention.model_width,
+                output + (size_t)token * attention.model_width) != 0) {
+            fprintf(stderr, "error: causal attention failed at token %u\n", token);
+            goto cleanup;
+        }
+    }
+    if (output_path && write_f32(output_path, output, (size_t)value_count) != 0)
+        goto cleanup;
+    printf("layer:             %u (%s)\n", layer,
+           attention.sliding ? "sliding" : "global");
+    printf("tokens:            %u\n", tokens);
+    printf("heads/dimension:   q=%u kv=%u dim=%u\n",
+           attention.query_heads, attention.kv_heads, attention.head_dim);
+    printf("cache:             %s, capacity=%u, retained=%u\n",
+           attention.sliding ? "sliding ring" : "global append-only",
+           cache.capacity, cache.count);
+    printf("output hash:       0x%016" PRIx64 "\n",
+           coli_gemma4_checksum_f32(output, (size_t)value_count));
+    if (output_path) printf("wrote output:      %s\n", output_path);
+    status = 0;
+
+cleanup:
+    free(input); free(output);
+    coli_gemma4_kv_cache_close(&cache);
+    coli_gemma4_attention_close(&attention);
+    coli_gemma4_gguf_close(&gguf);
+    return status;
+}
+
+static int command_dense_mlp(int argc, char **argv, const char *path) {
+    coli_gemma4_gguf gguf;
+    coli_gemma4_dense_mlp mlp;
+    const char *option = NULL, *input_path = NULL, *output_path = NULL;
+    uint32_t layer = 0, seed = 1;
+    float *input = NULL, *output = NULL;
+    int status = 1;
+    memset(&gguf, 0, sizeof(gguf));
+    memset(&mlp, 0, sizeof(mlp));
+    if (option_value(argc, argv, "--layer", &option) < 0 ||
+        (option && parse_u32(option, &layer) != 0)) {
+        fprintf(stderr, "invalid --layer value\n");
+        return 2;
+    }
+    option = NULL;
+    if (option_value(argc, argv, "--seed", &option) < 0 ||
+        (option && parse_u32(option, &seed) != 0) ||
+        option_value(argc, argv, "--input-f32", &input_path) < 0 ||
+        option_value(argc, argv, "--output-f32", &output_path) < 0) {
+        fprintf(stderr, "invalid or missing option value\n");
+        return 2;
+    }
+    if (coli_gemma4_gguf_open(&gguf, path) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_gguf_last_error(&gguf));
+        return 1;
+    }
+    if (coli_gemma4_dense_mlp_open(&mlp, &gguf, layer) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_dense_mlp_last_error(&mlp));
+        goto cleanup;
+    }
+    input = (float *)malloc((size_t)mlp.model_width * sizeof(float));
+    output = (float *)malloc((size_t)mlp.model_width * sizeof(float));
+    if (!input || !output) {
+        fprintf(stderr, "error: out of memory allocating dense MLP vectors\n");
+        goto cleanup;
+    }
+    if (input_path) {
+        if (read_f32(input_path, input, mlp.model_width) != 0) goto cleanup;
+    } else make_input(input, mlp.model_width, seed);
+    if (coli_gemma4_dense_mlp_run(&mlp, input, output) != 0) {
+        fprintf(stderr, "error: dense MLP evaluation failed\n");
+        goto cleanup;
+    }
+    if (output_path && write_f32(output_path, output, mlp.model_width) != 0)
+        goto cleanup;
+    printf("layer:             %u\n", layer);
+    printf("shape:             %u -> %u -> %u\n",
+           mlp.model_width, mlp.intermediate_width, mlp.model_width);
+    printf("output hash:       0x%016" PRIx64 "\n",
+           coli_gemma4_checksum_f32(output, mlp.model_width));
+    if (output_path) printf("wrote output:      %s\n", output_path);
+    status = 0;
+
+cleanup:
+    free(input); free(output);
+    coli_gemma4_dense_mlp_close(&mlp);
+    coli_gemma4_gguf_close(&gguf);
+    return status;
+}
+
+static int command_layer_sequence(int argc, char **argv,
+                                  const char *model_path,
+                                  const char *packed_dir) {
+    coli_gemma4_gguf gguf;
+    coli_gemma4_decoder_layer decoder;
+    coli_gemma4_kv_cache cache;
+    coli_gemma4_backend gemma;
+    coli_expert_backend experts;
+    const char *option = NULL, *input_path = NULL, *output_path = NULL;
+    uint32_t layer = 0, tokens = 1, seed = 1, token;
+    uint64_t value_count;
+    float *input = NULL, *output = NULL;
+    int status = 1;
+    memset(&gguf, 0, sizeof(gguf));
+    memset(&decoder, 0, sizeof(decoder));
+    memset(&cache, 0, sizeof(cache));
+    memset(&gemma, 0, sizeof(gemma));
+    if (option_value(argc, argv, "--layer", &option) < 0 ||
+        (option && parse_u32(option, &layer) != 0)) {
+        fprintf(stderr, "invalid --layer value\n");
+        return 2;
+    }
+    option = NULL;
+    if (option_value(argc, argv, "--tokens", &option) < 0 ||
+        (option && parse_u32(option, &tokens) != 0) || !tokens) {
+        fprintf(stderr, "invalid --tokens value\n");
+        return 2;
+    }
+    option = NULL;
+    if (option_value(argc, argv, "--seed", &option) < 0 ||
+        (option && parse_u32(option, &seed) != 0) ||
+        option_value(argc, argv, "--input-f32", &input_path) < 0 ||
+        option_value(argc, argv, "--output-f32", &output_path) < 0) {
+        fprintf(stderr, "invalid or missing option value\n");
+        return 2;
+    }
+    if (coli_gemma4_gguf_open(&gguf, model_path) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_gguf_last_error(&gguf));
+        return 1;
+    }
+    if (coli_gemma4_decoder_layer_open(&decoder, &gguf, layer) != 0) {
+        fprintf(stderr, "error: %s\n",
+                coli_gemma4_decoder_layer_last_error(&decoder));
+        goto cleanup;
+    }
+    if (coli_gemma4_open_packed(&gemma, packed_dir) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    if (strlen(gguf.path) + 1 > sizeof(gemma.source)) {
+        fprintf(stderr, "error: model path is too long for expert backend\n");
+        goto cleanup;
+    }
+    memcpy(gemma.source, gguf.path, strlen(gguf.path) + 1);
+    if (gemma.config.n_embd != gguf.config.n_embd ||
+        gemma.config.n_expert != gguf.config.n_expert ||
+        gemma.config.n_expert_used != gguf.config.n_expert_used ||
+        !coli_gemma4_find_layer(&gemma, layer)) {
+        fprintf(stderr, "error: packed manifest and GGUF configuration disagree\n");
+        goto cleanup;
+    }
+    value_count = (uint64_t)tokens * decoder.model_width;
+    if (value_count > SIZE_MAX / sizeof(float)) {
+        fprintf(stderr, "error: decoder sequence is too large\n");
+        goto cleanup;
+    }
+    input = (float *)malloc((size_t)value_count * sizeof(float));
+    output = (float *)malloc((size_t)value_count * sizeof(float));
+    if (!input || !output ||
+        coli_gemma4_kv_cache_init(&cache, &decoder.attention, tokens) != 0) {
+        fprintf(stderr, "error: out of memory allocating decoder sequence\n");
+        goto cleanup;
+    }
+    if (input_path) {
+        if (read_f32(input_path, input, (size_t)value_count) != 0) goto cleanup;
+    } else make_input(input, (size_t)value_count, seed);
+    experts = coli_gemma4_expert_backend(&gemma);
+    for (token = 0; token < tokens; ++token) {
+        if (coli_gemma4_decoder_layer_step(
+                &decoder, &cache, &experts, token,
+                input + (size_t)token * decoder.model_width,
+                output + (size_t)token * decoder.model_width) != 0) {
+            fprintf(stderr, "error: decoder layer failed at token %u: %s\n",
+                    token, coli_gemma4_last_error(&gemma));
+            goto cleanup;
+        }
+    }
+    if (output_path && write_f32(output_path, output, (size_t)value_count) != 0)
+        goto cleanup;
+    printf("layer:             %u (%s)\n", layer,
+           decoder.attention.sliding ? "sliding" : "global");
+    printf("tokens:            %u\n", tokens);
+    printf("dense MLP:         %u -> %u -> %u\n", decoder.model_width,
+           decoder.dense_mlp.intermediate_width, decoder.model_width);
+    printf("routed experts:    top-%u of %u\n",
+           decoder.router.selected_count, decoder.router.expert_count);
+    printf("cache:             %s, capacity=%u, retained=%u\n",
+           decoder.attention.sliding ? "sliding ring" : "global append-only",
+           cache.capacity, cache.count);
+    printf("output hash:       0x%016" PRIx64 "\n",
+           coli_gemma4_checksum_f32(output, (size_t)value_count));
+    if (output_path) printf("wrote output:      %s\n", output_path);
+    status = 0;
+
+cleanup:
+    free(input); free(output);
+    coli_gemma4_kv_cache_close(&cache);
+    coli_gemma4_close(&gemma);
+    coli_gemma4_decoder_layer_close(&decoder);
+    coli_gemma4_gguf_close(&gguf);
+    return status;
+}
+
+static int command_routed_mlp(int argc, char **argv,
+                              const char *model_path, const char *packed_dir) {
+    coli_gemma4_gguf gguf;
+    coli_gemma4_router router;
+    coli_gemma4_backend gemma;
+    coli_expert_backend experts;
+    const coli_gemma4_tensor *norm_tensor;
+    const char *value = NULL, *input_path = NULL, *output_path = NULL;
+    char norm_name[128];
+    uint32_t layer = 0, seed = 1, i;
+    uint32_t *ids = NULL;
+    float *input = NULL, *normalized = NULL, *norm_weight = NULL;
+    float *weights = NULL, *effective = NULL, *output = NULL;
+    int length, status = 1;
+    memset(&gguf, 0, sizeof(gguf));
+    memset(&router, 0, sizeof(router));
+    memset(&gemma, 0, sizeof(gemma));
+    if (option_value(argc, argv, "--layer", &value) < 0 ||
+        (value && parse_u32(value, &layer) != 0)) {
+        fprintf(stderr, "invalid --layer value\n");
+        return 2;
+    }
+    value = NULL;
+    if (option_value(argc, argv, "--seed", &value) < 0 ||
+        (value && parse_u32(value, &seed) != 0) ||
+        option_value(argc, argv, "--input-f32", &input_path) < 0 ||
+        option_value(argc, argv, "--output-f32", &output_path) < 0) {
+        fprintf(stderr, "invalid or missing option value\n");
+        return 2;
+    }
+    if (coli_gemma4_gguf_open(&gguf, model_path) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_gguf_last_error(&gguf));
+        return 1;
+    }
+    if (coli_gemma4_router_open(&router, &gguf, layer) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_router_last_error(&router));
+        goto cleanup;
+    }
+    if (coli_gemma4_open_packed(&gemma, packed_dir) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    if (strlen(gguf.path) + 1 > sizeof(gemma.source)) {
+        fprintf(stderr, "error: model path is too long for expert backend\n");
+        goto cleanup;
+    }
+    /* The explicit model argument is authoritative and also makes old
+       manifests with cwd-relative source paths portable. */
+    memcpy(gemma.source, gguf.path, strlen(gguf.path) + 1);
+    if (gemma.config.n_embd != gguf.config.n_embd ||
+        gemma.config.n_expert != gguf.config.n_expert ||
+        gemma.config.n_expert_used != gguf.config.n_expert_used ||
+        !coli_gemma4_find_layer(&gemma, layer)) {
+        fprintf(stderr, "error: packed manifest and GGUF configuration disagree\n");
+        goto cleanup;
+    }
+    length = snprintf(norm_name, sizeof(norm_name),
+                      "blk.%u.pre_ffw_norm_2.weight", layer);
+    norm_tensor = length >= 0 && (size_t)length < sizeof(norm_name) ?
+        coli_gemma4_gguf_find(&gguf, norm_name) : NULL;
+    if (!norm_tensor || norm_tensor->type != COLI_GGML_TYPE_F32 ||
+        norm_tensor->n_dims != 1 || norm_tensor->dims[0] != router.width ||
+        norm_tensor->nbytes != (uint64_t)router.width * sizeof(float)) {
+        fprintf(stderr, "error: invalid or missing %s\n", norm_name);
+        goto cleanup;
+    }
+    input = (float *)malloc((size_t)router.width * sizeof(float));
+    normalized = (float *)malloc((size_t)router.width * sizeof(float));
+    norm_weight = (float *)malloc((size_t)norm_tensor->nbytes);
+    output = (float *)malloc((size_t)router.width * sizeof(float));
+    ids = (uint32_t *)malloc((size_t)router.selected_count * sizeof(uint32_t));
+    weights = (float *)malloc((size_t)router.selected_count * sizeof(float));
+    effective = (float *)malloc((size_t)router.selected_count * sizeof(float));
+    if (!input || !normalized || !norm_weight || !output ||
+        !ids || !weights || !effective) {
+        fprintf(stderr, "error: out of memory allocating routed-MLP buffers\n");
+        goto cleanup;
+    }
+    if (input_path) {
+        if (read_f32(input_path, input, router.width) != 0) goto cleanup;
+    } else make_input(input, router.width, seed);
+    if (coli_gemma4_gguf_read(&gguf, norm_tensor, norm_weight,
+                              (size_t)norm_tensor->nbytes) != 0 ||
+        coli_gemma4_rmsnorm(input, norm_weight, router.width,
+                            gguf.rms_epsilon, normalized) != 0 ||
+        coli_gemma4_router_route(&router, input, NULL, ids,
+                                 weights, effective) != 0) {
+        fprintf(stderr, "error: routed-MLP normalization or routing failed\n");
+        goto cleanup;
+    }
+    experts = coli_gemma4_expert_backend(&gemma);
+    if (experts.prepare_layer(experts.ctx, layer, ids,
+                              router.selected_count) != 0 ||
+        experts.run_experts(experts.ctx, layer, ids, weights,
+                            router.selected_count, normalized, output) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    experts.release_layer(experts.ctx, layer);
+    if (output_path && write_f32(output_path, output, router.width) != 0)
+        goto cleanup;
+    printf("layer:             %u\n", layer);
+    printf("input:             %s\n",
+           input_path ? input_path : "deterministic pseudorandom");
+    printf("selected experts:  ");
+    for (i = 0; i < router.selected_count; ++i)
+        printf("%s%u", i ? "," : "", ids[i]);
+    printf("\n");
+    printf("output hash:       0x%016" PRIx64 "\n",
+           coli_gemma4_checksum_f32(output, router.width));
+    if (output_path) printf("wrote output:      %s\n", output_path);
+    status = 0;
+
+cleanup:
+    free(input); free(normalized); free(norm_weight); free(output);
+    free(ids); free(weights); free(effective);
+    coli_gemma4_close(&gemma);
+    coli_gemma4_router_close(&router);
+    coli_gemma4_gguf_close(&gguf);
+    return status;
+}
+
+static int command_expert(int argc, char **argv, const char *directory) {
+    coli_gemma4_backend gemma;
+    coli_expert_backend expert_backend;
+    const coli_gemma4_layer *layer;
+    const char *value = NULL;
+    const char *input_path = NULL;
+    const char *output_path = NULL;
+    const char *cuda_device_text = NULL;
+    const char *repeat_text = NULL;
+    uint32_t layer_number = 0, expert_number = 0, seed = 1, repeat = 1;
+    uint32_t cuda_device = 0;
+    uint32_t ids[1];
+    float weights[1] = {1.0F};
+    float *input = NULL, *output = NULL;
+    clock_t started, stopped;
+    int status = 1;
+    size_t preview, i;
+
+    if (option_value(argc, argv, "--layer", &value) < 0 ||
+        (value && parse_u32(value, &layer_number) != 0)) {
+        fprintf(stderr, "invalid --layer value\n");
+        return 2;
+    }
+    value = NULL;
+    if (option_value(argc, argv, "--expert", &value) < 0 ||
+        (value && parse_u32(value, &expert_number) != 0)) {
+        fprintf(stderr, "invalid --expert value\n");
+        return 2;
+    }
+    value = NULL;
+    if (option_value(argc, argv, "--seed", &value) < 0 ||
+        (value && parse_u32(value, &seed) != 0)) {
+        fprintf(stderr, "invalid --seed value\n");
+        return 2;
+    }
+    if (option_value(argc, argv, "--input-f32", &input_path) < 0 ||
+        option_value(argc, argv, "--output-f32", &output_path) < 0 ||
+        option_value(argc, argv, "--cuda-device", &cuda_device_text) < 0 ||
+        option_value(argc, argv, "--repeat", &repeat_text) < 0 ||
+        (cuda_device_text && parse_u32(cuda_device_text, &cuda_device) != 0) ||
+        (repeat_text && (parse_u32(repeat_text, &repeat) != 0 || !repeat))) {
+        fprintf(stderr, "missing option value\n");
+        return 2;
+    }
+
+    if (coli_gemma4_open_packed(&gemma, directory) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        return 1;
+    }
+    if (cuda_device_text && coli_gemma4_cuda_configure(
+            &gemma, (int)cuda_device) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    if (coli_gemma4_cache_configure(&gemma, 1) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    layer = coli_gemma4_find_layer(&gemma, layer_number);
+    if (!layer || expert_number >= layer->expert_count) {
+        fprintf(stderr, "error: layer or expert index is outside the model\n");
+        goto cleanup;
+    }
+    input = (float *)malloc((size_t)layer->model_width * sizeof(float));
+    output = (float *)malloc((size_t)layer->model_width * sizeof(float));
+    if (!input || !output) {
+        fprintf(stderr, "error: out of memory allocating expert vectors\n");
+        goto cleanup;
+    }
+    if (input_path) {
+        if (read_f32(input_path, input, layer->model_width) != 0) goto cleanup;
+    } else {
+        make_input(input, layer->model_width, seed);
+    }
+
+    ids[0] = expert_number;
+    expert_backend = coli_gemma4_expert_backend(&gemma);
+    if (expert_backend.prepare_layer(
+            expert_backend.ctx, layer_number, ids, 1) != 0) {
+        fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    started = clock();
+    for (i = 0; i < repeat; ++i)
+        if (expert_backend.run_experts(
+                expert_backend.ctx, layer_number, ids, weights,
+                1, input, output) != 0) {
+            fprintf(stderr, "error: %s\n", coli_gemma4_last_error(&gemma));
+            goto cleanup;
+        }
+    stopped = clock();
+    expert_backend.release_layer(expert_backend.ctx, layer_number);
+
+    if (output_path && write_f32(output_path, output, layer->model_width) != 0)
+        goto cleanup;
+    printf("layer/expert: %u/%u\n", layer_number, expert_number);
+    printf("shape:        %u -> %u -> %u\n",
+           layer->model_width, layer->expert_width, layer->model_width);
+    printf("input:        %s\n", input_path ? input_path : "deterministic pseudorandom");
+    printf("compute:      %s\n", cuda_device_text ? "CUDA" : "CPU");
+    printf("payload:      %" PRIu64 " bytes\n", layer->payload_bytes);
+    printf("elapsed:      %.3f ms\n",
+           1000.0 * (double)(stopped - started) / (double)CLOCKS_PER_SEC);
+    printf("average:      %.3f ms/expert (repeat %u)\n",
+           1000.0 * (double)(stopped - started) /
+               ((double)CLOCKS_PER_SEC * repeat), repeat);
+    printf("checksum:     0x%016" PRIx64 "\n",
+           coli_gemma4_checksum_f32(output, layer->model_width));
+    if (output_path) printf("wrote output: %s\n", output_path);
+    preview = layer->model_width < 8 ? layer->model_width : 8;
+    printf("first:        ");
+    for (i = 0; i < preview; ++i)
+        printf("%s%.7g", i ? ", " : "", output[i]);
+    printf("\n");
+    status = 0;
+
+cleanup:
+    free(input);
+    free(output);
+    coli_gemma4_close(&gemma);
+    return status;
+}
+
+static int serve_data(uint64_t request_id, const char *bytes, size_t count) {
+    if (!count) return 0;
+    if (printf("DATA %llu %zu\n", (unsigned long long)request_id, count) < 0 ||
+        fwrite(bytes, 1, count, stdout) != count || fputc('\n', stdout) == EOF ||
+        fflush(stdout) != 0) return -1;
+    return 0;
+}
+
+typedef struct {
+    coli_gemma4_model model;
+    uint32_t *tokens;
+    size_t token_count;
+    int opened;
+} gemma4_serve_slot;
+
+typedef struct {
+    Grammar grammar;
+    GrState state;
+    char *compiled;
+    int active;
+} gemma4_serve_grammar;
+
+static void serve_grammar_close(gemma4_serve_grammar *grammar) {
+    if (!grammar) return;
+    if (grammar->active) gr_free(&grammar->grammar);
+    free(grammar->compiled);
+    memset(grammar, 0, sizeof(*grammar));
+}
+
+static int serve_grammar_open(gemma4_serve_grammar *grammar,
+                              const char *source) {
+    const char *cursor = source;
+    char error[160];
+    if (!grammar || !source) return -1;
+    memset(grammar, 0, sizeof(*grammar));
+    while (*cursor == ' ' || *cursor == '\t' ||
+           *cursor == '\r' || *cursor == '\n') ++cursor;
+    if (*cursor == '{') {
+        grammar->compiled = schema_to_gbnf(source, error, sizeof(error));
+        if (!grammar->compiled) return -1;
+        source = grammar->compiled;
+    }
+    if (gr_parse(&grammar->grammar, source) != 0) {
+        serve_grammar_close(grammar);
+        return -1;
+    }
+    grammar->active = 1;
+    gr_state_init(&grammar->state, &grammar->grammar);
+    if (!grammar->state.alive) {
+        serve_grammar_close(grammar);
+        return -1;
+    }
+    return 0;
+}
+
+static int serve_grammar_filter(const coli_gemma4_tokenizer *tokenizer,
+                                gemma4_serve_grammar *grammar,
+                                float *logits, uint32_t vocabulary) {
+    unsigned char first_mask[32];
+    uint32_t token;
+    int can_end = 0, valid = 0;
+    if (!grammar || !grammar->active) return 0;
+    gr_admissible(&grammar->state, first_mask, &can_end);
+    for (token = 0; token < vocabulary; ++token) {
+        size_t bytes = 0, index;
+        char *piece = NULL;
+        GrState candidate;
+        if (!isfinite(logits[token])) continue;
+        if (coli_gemma4_token_is_control(tokenizer, token)) {
+            if (coli_gemma4_token_is_eog(tokenizer, token) && !can_end)
+                logits[token] = -INFINITY;
+            else
+                ++valid;
+            continue;
+        }
+        if (coli_gemma4_decode_token(
+                tokenizer, token, NULL, 0, &bytes) != 0 || !bytes) {
+            logits[token] = -INFINITY;
+            continue;
+        }
+        piece = (char *)malloc(bytes + 1);
+        if (!piece || coli_gemma4_decode_token(
+                tokenizer, token, piece, bytes + 1, &bytes) != 0) {
+            free(piece);
+            return -1;
+        }
+        if (!(first_mask[(unsigned char)piece[0] >> 3] &
+              (1U << ((unsigned char)piece[0] & 7)))) {
+            logits[token] = -INFINITY;
+            free(piece);
+            continue;
+        }
+        candidate = grammar->state;
+        for (index = 0; index < bytes; ++index)
+            if (gr_accept(&candidate, (unsigned char)piece[index]) != 1)
+                break;
+        if (index != bytes)
+            logits[token] = -INFINITY;
+        else
+            ++valid;
+        free(piece);
+    }
+    return valid ? 0 : -1;
+}
+
+static int serve_grammar_accept_token(
+    const coli_gemma4_tokenizer *tokenizer, gemma4_serve_grammar *grammar,
+    uint32_t token) {
+    size_t bytes = 0, index;
+    char *piece;
+    if (!grammar || !grammar->active ||
+        coli_gemma4_token_is_control(tokenizer, token)) return 0;
+    if (coli_gemma4_decode_token(
+            tokenizer, token, NULL, 0, &bytes) != 0 || !bytes) return -1;
+    piece = (char *)malloc(bytes + 1);
+    if (!piece || coli_gemma4_decode_token(
+            tokenizer, token, piece, bytes + 1, &bytes) != 0) {
+        free(piece);
+        return -1;
+    }
+    for (index = 0; index < bytes; ++index)
+        if (gr_accept(&grammar->state, (unsigned char)piece[index]) != 1)
+            break;
+    free(piece);
+    return index == bytes ? 0 : -1;
+}
+
+static size_t serve_prefix_length(const gemma4_serve_slot *slot,
+                                  const uint32_t *tokens, size_t count) {
+    size_t prefix = 0, available;
+    if (!slot || !slot->opened || !slot->tokens || !tokens) return 0;
+    available = slot->token_count < count ? slot->token_count : count;
+    while (prefix < available && slot->tokens[prefix] == tokens[prefix])
+        ++prefix;
+    if (prefix == count && prefix) --prefix;
+    return prefix;
+}
+
+typedef struct {
+    uint64_t request_id;
+    int action; /* 0 = run, 1 = graceful stop, 2 = client cancellation */
+} gemma4_serve_control;
+
+static int serve_stdin_ready(void) {
+#ifdef _WIN32
+    HANDLE input = (HANDLE)_get_osfhandle(_fileno(stdin));
+    DWORD available = 0;
+    return input != INVALID_HANDLE_VALUE &&
+           PeekNamedPipe(input, NULL, 0, NULL, &available, NULL) && available;
+#else
+    fd_set readers;
+    struct timeval timeout = {0, 0};
+    int descriptor = fileno(stdin);
+    FD_ZERO(&readers);
+    FD_SET(descriptor, &readers);
+    return select(descriptor + 1, &readers, NULL, NULL, &timeout) > 0;
+#endif
+}
+
+static int serve_discard_bytes(uint64_t count) {
+    unsigned char buffer[4096];
+    while (count) {
+        size_t chunk = count < sizeof(buffer) ? (size_t)count : sizeof(buffer);
+        if (fread(buffer, 1, chunk, stdin) != chunk) return -1;
+        count -= chunk;
+    }
+    return 0;
+}
+
+static int serve_control_poll(gemma4_serve_control *control) {
+    while (control && !control->action && serve_stdin_ready()) {
+        char header[512], kind[16];
+        unsigned long long request_id = 0, payload = 0, grammar = 0;
+        unsigned slot = 0, requested = 0;
+        float temperature = 0.0F, top_p = 1.0F;
+        int fields;
+        if (!fgets(header, sizeof(header), stdin)) return -1;
+        fields = sscanf(header, "%15s %llu %u %llu %u %f %f %llu",
+                        kind, &request_id, &slot, &payload, &requested,
+                        &temperature, &top_p, &grammar);
+        if (fields >= 2 && (!strcmp(kind, "STOP") ||
+                           !strcmp(kind, "CANCEL"))) {
+            if ((uint64_t)request_id == control->request_id)
+                control->action = !strcmp(kind, "CANCEL") ? 2 : 1;
+            else {
+                printf("ERROR %llu NOT_FOUND\n", request_id);
+                fflush(stdout);
+            }
+            continue;
+        }
+        /* The native engine is intentionally single-flight.  Drain a
+           pipelined submission so its payload cannot desynchronize framing. */
+        if (fields >= 7 && !strcmp(kind, "SUBMIT") &&
+            payload <= UINT64_MAX - grammar &&
+            serve_discard_bytes((uint64_t)payload + grammar) == 0 &&
+            fgetc(stdin) == '\n') {
+            printf("ERROR %llu BUSY\n", request_id);
+            fflush(stdout);
+            continue;
+        }
+        control->action = 3;
+        return -1;
+    }
+    return control && control->action ? 1 : 0;
+}
+
+static int serve_model_cancelled(void *opaque) {
+    return serve_control_poll((gemma4_serve_control *)opaque) != 0;
+}
+
+static int command_serve(const char *cap_text) {
+    coli_gemma4_gguf gguf;
+    coli_gemma4_tokenizer tokenizer;
+    coli_gemma4_backend gemma;
+    const char *model_path = getenv("SNAP");
+    const char *packed_dir = getenv("GEMMA4_PACKED");
+    const char *context_text = getenv("CTX");
+    const char *cuda_text = getenv("GEMMA4_CUDA_DEVICE");
+    const char *kv_slots_text = getenv("KV_SLOTS");
+    uint32_t cache_slots = 0, maximum_context = 4096, cuda_device = 0;
+    uint32_t kv_slot_count = 1, slot_index;
+    gemma4_serve_slot *slots = NULL;
+    int status = 1;
+    memset(&gguf, 0, sizeof(gguf));
+    memset(&tokenizer, 0, sizeof(tokenizer));
+    memset(&gemma, 0, sizeof(gemma));
+    if (!model_path || !packed_dir ||
+        parse_u32(cap_text, &cache_slots) != 0 ||
+        (context_text && (parse_u32(context_text, &maximum_context) != 0 ||
+                          !maximum_context || maximum_context == UINT32_MAX)) ||
+        (kv_slots_text && (parse_u32(kv_slots_text, &kv_slot_count) != 0 ||
+                           !kv_slot_count || kv_slot_count > 16)) ||
+        (cuda_text && parse_u32(cuda_text, &cuda_device) != 0)) {
+        fprintf(stderr, "Gemma serve requires SNAP, GEMMA4_PACKED, and valid settings\n");
+        return 2;
+    }
+    if (!cache_slots) cache_slots = 256;
+    slots = (gemma4_serve_slot *)calloc(kv_slot_count, sizeof(*slots));
+    if (!slots) {
+        fprintf(stderr, "cannot allocate Gemma KV slots\n");
+        return 1;
+    }
+    if (coli_gemma4_gguf_open(&gguf, model_path) != 0 ||
+        coli_gemma4_tokenizer_init(&tokenizer, &gguf) != 0 ||
+        coli_gemma4_open_packed(&gemma, packed_dir) != 0) {
+        fprintf(stderr, "cannot initialize Gemma serve boundary: %s\n",
+                gguf.last_error[0] ? gguf.last_error :
+                tokenizer.last_error[0] ? tokenizer.last_error :
+                coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    if (strlen(gguf.path) + 1 > sizeof(gemma.source)) {
+        fprintf(stderr, "Gemma model path is too long for serving\n");
+        goto cleanup;
+    }
+    memcpy(gemma.source, gguf.path, strlen(gguf.path) + 1);
+    if (coli_gemma4_cache_configure(&gemma, cache_slots) != 0 ||
+        (cuda_text && coli_gemma4_cuda_configure(
+             &gemma, (int)cuda_device) != 0)) {
+        fprintf(stderr, "cannot configure Gemma serve boundary: %s\n",
+                coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+#ifdef _WIN32
+    _setmode(_fileno(stdin), _O_BINARY);
+    _setmode(_fileno(stdout), _O_BINARY);
+#endif
+    setvbuf(stdin, NULL, _IONBF, 0);
+    setvbuf(stdout, NULL, _IONBF, 0);
+    printf("\x01\x01READY\x01\x01\nSTAT 0 0.00 0.0 0.00\n");
+    fflush(stdout);
+    for (;;) {
+        char header[512];
+        char kind[16];
+        unsigned long long request_id = 0, payload_bytes_ull = 0;
+        unsigned long long grammar_bytes_ull = 0;
+        unsigned slot = 0, requested = 0;
+        float temperature = 0.0F, top_p = 1.0F;
+        int fields;
+        char *prompt = NULL, *grammar = NULL;
+        uint32_t *tokens = NULL;
+        float *logits = NULL;
+        size_t token_count = 0;
+        coli_expert_backend experts;
+        gemma4_serve_slot *serve_slot = NULL;
+        coli_gemma4_model *model = NULL;
+        coli_gemma4_sampler sampler;
+        gemma4_serve_grammar request_grammar;
+        uint32_t position, emitted = 0, generation_limit;
+        size_t reused = 0;
+        int length_limited = 0, accepted = 0, channel_header = 0;
+        int step_status;
+        gemma4_serve_control control;
+        clock_t started;
+        memset(&sampler, 0, sizeof(sampler));
+        memset(&request_grammar, 0, sizeof(request_grammar));
+        memset(&control, 0, sizeof(control));
+        if (!fgets(header, sizeof(header), stdin)) {
+            status = feof(stdin) ? 0 : 1;
+            break;
+        }
+        fields = sscanf(header, "%15s %llu %u %llu %u %f %f %llu",
+                        kind, &request_id, &slot, &payload_bytes_ull,
+                        &requested, &temperature, &top_p, &grammar_bytes_ull);
+        if (fields >= 2 && (!strcmp(kind, "STOP") ||
+                           !strcmp(kind, "CANCEL"))) {
+            printf("ERROR %llu NOT_FOUND\n", request_id);
+            fflush(stdout);
+            continue;
+        }
+        if (fields < 7 || strcmp(kind, "SUBMIT") || slot >= kv_slot_count ||
+            !payload_bytes_ull || payload_bytes_ull > SIZE_MAX - 1 ||
+            grammar_bytes_ull > SIZE_MAX - 1) {
+            printf("ERROR %llu BAD_REQUEST\n", request_id);
+            fflush(stdout);
+            continue;
+        }
+        prompt = (char *)malloc((size_t)payload_bytes_ull + 1);
+        if (grammar_bytes_ull)
+            grammar = (char *)malloc((size_t)grammar_bytes_ull + 1);
+        if (!prompt || (grammar_bytes_ull && !grammar) ||
+            fread(prompt, 1, (size_t)payload_bytes_ull, stdin) !=
+                (size_t)payload_bytes_ull ||
+            (grammar_bytes_ull && fread(
+                grammar, 1, (size_t)grammar_bytes_ull, stdin) !=
+                (size_t)grammar_bytes_ull) || fgetc(stdin) != '\n') {
+            free(prompt); free(grammar);
+            status = 1;
+            break;
+        }
+        prompt[(size_t)payload_bytes_ull] = '\0';
+        if (grammar) grammar[(size_t)grammar_bytes_ull] = '\0';
+        if (memchr(prompt, 0, (size_t)payload_bytes_ull) ||
+            (grammar_bytes_ull && (memchr(grammar, 0,
+                 (size_t)grammar_bytes_ull) ||
+             serve_grammar_open(&request_grammar, grammar) != 0))) {
+            printf("ERROR %llu %s\n", request_id,
+                   grammar_bytes_ull ? "INVALID_GRAMMAR" : "BAD_REQUEST");
+            fflush(stdout);
+            goto request_cleanup;
+        }
+        tokens = (uint32_t *)malloc(
+            ((size_t)maximum_context + 1) * sizeof(*tokens));
+        logits = (float *)malloc((size_t)gguf.config.n_vocab * sizeof(*logits));
+        if (!tokens || !logits || coli_gemma4_tokenize_ex(
+                &tokenizer, prompt, (size_t)payload_bytes_ull, 0, 1,
+                tokens, maximum_context + 1, &token_count) != 0 ||
+            !token_count || token_count >= maximum_context) {
+            printf("ERROR %llu CONTEXT_EXCEEDED %zu %u\n", request_id,
+                   token_count, maximum_context - 1);
+            fflush(stdout);
+            goto request_cleanup;
+        }
+        generation_limit = requested;
+        if (generation_limit > maximum_context - (uint32_t)token_count) {
+            generation_limit = maximum_context - (uint32_t)token_count;
+            length_limited = 1;
+        }
+        experts = coli_gemma4_expert_backend(&gemma);
+        serve_slot = &slots[slot];
+        model = &serve_slot->model;
+        if (!serve_slot->opened) {
+            serve_slot->tokens = (uint32_t *)malloc(
+                (size_t)maximum_context * sizeof(*serve_slot->tokens));
+            if (!serve_slot->tokens || coli_gemma4_model_open(
+                    model, &gguf, &experts, maximum_context) != 0) {
+                printf("ERROR %llu ENGINE_INIT %s\n", request_id,
+                       coli_gemma4_model_last_error(model));
+                fflush(stdout);
+                goto request_cleanup;
+            }
+            serve_slot->opened = 1;
+        }
+        reused = serve_prefix_length(serve_slot, tokens, token_count);
+        model->next_position = reused;
+        serve_slot->token_count = reused;
+        if (coli_gemma4_sampler_init(
+                &sampler, temperature, gguf.sampling_top_k, top_p,
+                request_id ? request_id : 1) != 0) {
+            printf("ERROR %llu ENGINE_INIT %s\n", request_id,
+                   coli_gemma4_model_last_error(model));
+            fflush(stdout);
+            goto request_cleanup;
+        }
+        printf("ACCEPT %llu %zu\n", request_id, token_count);
+        fflush(stdout);
+        accepted = 1;
+        control.request_id = request_id;
+        started = clock();
+        for (position = (uint32_t)reused;
+             position < (uint32_t)token_count; ++position) {
+            int last = position + 1 == (uint32_t)token_count;
+            step_status = coli_gemma4_model_step_cancelable(
+                model, tokens[position], position, NULL,
+                last ? logits : NULL, serve_model_cancelled, &control);
+            if (step_status > 0 || control.action) goto request_interrupted;
+            if (step_status < 0) goto engine_error;
+            serve_slot->tokens[position] = tokens[position];
+            serve_slot->token_count = (size_t)position + 1;
+        }
+        while (emitted < generation_limit) {
+            uint32_t selected;
+            size_t piece_bytes = 0;
+            char *piece = NULL;
+            if (serve_control_poll(&control) != 0) goto request_interrupted;
+            if (serve_grammar_filter(
+                    &tokenizer, &request_grammar, logits,
+                    gguf.config.n_vocab) != 0 ||
+                coli_gemma4_sample(
+                    &sampler, logits, gguf.config.n_vocab,
+                    &selected, NULL) != 0) goto engine_error;
+            if (serve_grammar_accept_token(
+                    &tokenizer, &request_grammar, selected) != 0)
+                goto engine_error;
+            if (coli_gemma4_token_is_eog(&tokenizer, selected)) break;
+            if (coli_gemma4_decode_token(
+                    &tokenizer, selected, NULL, 0, &piece_bytes) != 0)
+                goto engine_error;
+            if (piece_bytes) {
+                piece = (char *)malloc(piece_bytes + 1);
+                if (!piece || coli_gemma4_decode_token(
+                        &tokenizer, selected, piece, piece_bytes + 1,
+                        &piece_bytes) != 0) {
+                    free(piece);
+                    goto engine_error;
+                }
+            }
+            if (piece && !strcmp(piece, "<|channel>"))
+                channel_header = 1;
+            else if (piece && !strcmp(piece, "<channel|>"))
+                channel_header = 0;
+            if (((!coli_gemma4_token_is_control(&tokenizer, selected) &&
+                  !channel_header) ||
+                 (piece && (!strcmp(piece, "<|tool_call>") ||
+                            !strcmp(piece, "<tool_call|>")))) &&
+                serve_data(request_id, piece, piece_bytes) != 0) {
+                free(piece);
+                goto engine_error;
+            }
+            free(piece);
+            ++emitted;
+            if (emitted < generation_limit) {
+                uint64_t generated_position =
+                    (uint64_t)token_count + emitted - 1;
+                step_status = coli_gemma4_model_step_cancelable(
+                    model, selected, generated_position, NULL, logits,
+                    serve_model_cancelled, &control);
+                if (step_status > 0 || control.action) goto request_interrupted;
+                if (step_status < 0) goto engine_error;
+                serve_slot->tokens[generated_position] = selected;
+                serve_slot->token_count = (size_t)generated_position + 1;
+            }
+        }
+        if (emitted == generation_limit && generation_limit == requested)
+            length_limited = 1;
+generation_done:
+        {
+            double seconds = (double)(clock() - started) / CLOCKS_PER_SEC;
+            double reuse_percent = token_count ?
+                100.0 * (double)reused / (double)token_count : 0.0;
+            if (seconds < 0.001) seconds = 0.001;
+            printf("DONE %llu STAT %u %.3f %.1f 0.00 %zu %d\n",
+                   request_id, emitted, emitted / seconds, reuse_percent,
+                   token_count, length_limited);
+            fflush(stdout);
+        }
+        goto request_cleanup;
+
+request_interrupted:
+        if (control.action == 3) goto engine_error;
+        if (control.action == 2) {
+            printf("ERROR %llu CANCELLED\n", request_id);
+            fflush(stdout);
+            goto request_cleanup;
+        }
+        length_limited = 0;
+        goto generation_done;
+
+engine_error:
+        if (accepted) {
+            printf("ERROR %llu ENGINE_ERROR %s\n", request_id,
+                   coli_gemma4_model_last_error(model));
+            fflush(stdout);
+        }
+        if (serve_slot) serve_slot->token_count = 0;
+request_cleanup:
+        free(prompt); free(grammar); free(tokens); free(logits);
+        serve_grammar_close(&request_grammar);
+    }
+cleanup:
+    if (slots) for (slot_index = 0; slot_index < kv_slot_count; ++slot_index) {
+        coli_gemma4_model_close(&slots[slot_index].model);
+        free(slots[slot_index].tokens);
+    }
+    free(slots);
+    coli_gemma4_close(&gemma);
+    coli_gemma4_tokenizer_close(&tokenizer);
+    coli_gemma4_gguf_close(&gguf);
+    return status;
+}
+
+int main(int argc, char **argv) {
+    if (argc == 2 && getenv("SERVE") && atoi(getenv("SERVE")) != 0)
+        return command_serve(argv[1]);
+    if (argc == 2 && strcmp(argv[1], "--version") == 0) {
+        puts("0.29.0-colibri-gemma4");
+        return 0;
+    }
+    if (argc >= 3 && strcmp(argv[1], "model-info") == 0)
+        return command_model_info(argv[2]);
+    if (argc >= 3 && strcmp(argv[1], "vision-info") == 0)
+        return command_vision_info(argc - 2, argv + 2);
+    if (argc == 4 && strcmp(argv[1], "vision-image-info") == 0)
+        return command_vision_image_info(argv[2], argv[3]);
+    if ((argc == 5 || argc == 7) &&
+        strcmp(argv[1], "vision-patch-probe") == 0 &&
+        (argc == 5 || strcmp(argv[5], "--output-f32") == 0))
+        return command_vision_patch_probe(
+            argv[2], argv[3], argv[4], argc == 7 ? argv[6] : NULL);
+    if (argc >= 5 && strcmp(argv[1], "vision-encode-probe") == 0)
+        return command_vision_encode_probe(argc - 2, argv + 2);
+    if (argc >= 4 && strcmp(argv[1], "tokenize") == 0)
+        return command_tokenize(argc - 4, argv + 4, argv[2], argv[3],
+                                strlen(argv[3]), 0, 0);
+    if (argc >= 4 && strcmp(argv[1], "tokenize-file") == 0)
+        return command_tokenize_file(argc - 4, argv + 4, argv[2], argv[3], 0);
+    if (argc >= 4 && strcmp(argv[1], "chat-user") == 0)
+        return command_tokenize(argc - 4, argv + 4, argv[2], argv[3],
+                                strlen(argv[3]), 1, 0);
+    if (argc >= 4 && strcmp(argv[1], "chat-user-file") == 0)
+        return command_tokenize_file(argc - 4, argv + 4,
+                                     argv[2], argv[3], 1);
+    if (argc >= 4 && strcmp(argv[1], "image-chat-user") == 0)
+        return command_tokenize(argc - 4, argv + 4, argv[2], argv[3],
+                                strlen(argv[3]), 1, 1);
+    if (argc >= 4 && strcmp(argv[1], "embed") == 0)
+        return command_embedding(argc - 4, argv + 4, argv[2], argv[3]);
+    if (argc >= 3 && strcmp(argv[1], "lm-head") == 0)
+        return command_lm_head(argc - 3, argv + 3, argv[2]);
+    if (argc >= 5 && strcmp(argv[1], "next-token") == 0)
+        return command_next_token(argc - 5, argv + 5, argv[2], argv[3],
+                                  argv[4], strlen(argv[4]), 0);
+    if (argc >= 5 && strcmp(argv[1], "next-token-file") == 0)
+        return command_next_token_file(argc - 5, argv + 5, argv[2], argv[3],
+                                       argv[4], 0);
+    if (argc >= 5 && strcmp(argv[1], "generate") == 0)
+        return command_next_token(argc - 5, argv + 5, argv[2], argv[3],
+                                  argv[4], strlen(argv[4]), 1);
+    if (argc >= 5 && strcmp(argv[1], "generate-file") == 0)
+        return command_next_token_file(argc - 5, argv + 5, argv[2], argv[3],
+                                       argv[4], 1);
+    if (argc >= 4 && strcmp(argv[1], "chat") == 0)
+        return command_chat(argc - 4, argv + 4, argv[2], argv[3]);
+    if (argc >= 3 && strcmp(argv[1], "route") == 0)
+        return command_route(argc - 3, argv + 3, argv[2]);
+    if (argc >= 3 && strcmp(argv[1], "attention-proj") == 0)
+        return command_attention_projection(argc - 3, argv + 3, argv[2]);
+    if (argc >= 3 && strcmp(argv[1], "attention-seq") == 0)
+        return command_attention_sequence(argc - 3, argv + 3, argv[2]);
+    if (argc >= 3 && strcmp(argv[1], "dense-mlp") == 0)
+        return command_dense_mlp(argc - 3, argv + 3, argv[2]);
+    if (argc >= 4 && strcmp(argv[1], "routed-mlp") == 0)
+        return command_routed_mlp(argc - 4, argv + 4, argv[2], argv[3]);
+    if (argc >= 4 && strcmp(argv[1], "layer-seq") == 0)
+        return command_layer_sequence(argc - 4, argv + 4, argv[2], argv[3]);
+    if (argc >= 3 && strcmp(argv[1], "info") == 0)
+        return command_info(argv[2]);
+    if (argc >= 3 && strcmp(argv[1], "expert") == 0)
+        return command_expert(argc - 3, argv + 3, argv[2]);
+    usage(argv[0]);
+    return 2;
+}

--- a/c/gemma4_backend.c
+++ b/c/gemma4_backend.c
@@ -1,0 +1,1712 @@
+#define _CRT_SECURE_NO_WARNINGS
+#define _FILE_OFFSET_BITS 64
+
+#include "gemma4_backend.h"
+#include "gemma4_cuda.h"
+
+#include <errno.h>
+#include <float.h>
+#include <limits.h>
+#include <math.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "json.h"
+#include "tier.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <process.h>
+#define g4_seek _fseeki64
+#define g4_tell _ftelli64
+typedef __int64 g4_off_t;
+#else
+#include <pthread.h>
+#include <sys/types.h>
+#define g4_seek fseeko
+#define g4_tell ftello
+typedef off_t g4_off_t;
+#endif
+
+enum {
+    G4_ROLE_GATE = 0,
+    G4_ROLE_UP = 1,
+    G4_ROLE_DOWN = 2
+};
+
+struct coli_gemma4_cache_slot {
+    uint32_t layer;
+    uint32_t expert;
+    uint8_t *payload;
+    size_t payload_capacity;
+    uint64_t last_used;
+    float scale;
+    int valid;
+};
+
+struct coli_gemma4_prefetch_state {
+    coli_gemma4_backend *backend;
+    const coli_gemma4_layer *descriptor;
+    uint32_t *expert_ids;
+    uint32_t count;
+    uint32_t capacity;
+    int result;
+    int active;
+    int lookahead;
+#ifdef _WIN32
+    HANDLE thread;
+#else
+    pthread_t thread;
+#endif
+};
+
+static void g4_prefetch_destroy(coli_gemma4_backend *backend);
+
+static void g4_set_error(coli_gemma4_backend *backend, const char *fmt, ...) {
+    va_list args;
+    if (!backend) return;
+    va_start(args, fmt);
+    vsnprintf(backend->last_error, sizeof(backend->last_error), fmt, args);
+    va_end(args);
+}
+
+static void g4_free_json(jval *value) {
+    int i;
+    if (!value) return;
+    if (value->t == J_OBJ) {
+        for (i = 0; i < value->len; ++i) {
+            free(value->keys[i]);
+            g4_free_json(value->kids[i]);
+        }
+        free(value->keys);
+        free(value->kids);
+    } else if (value->t == J_ARR) {
+        for (i = 0; i < value->len; ++i) g4_free_json(value->kids[i]);
+        free(value->kids);
+    } else if (value->t == J_STR) {
+        free(value->str);
+    }
+    free(value);
+}
+
+static int g4_copy_string(coli_gemma4_backend *backend, char *destination,
+                          size_t capacity, const char *value, const char *label) {
+    size_t length;
+    if (!value) {
+        g4_set_error(backend, "manifest field %s is missing", label);
+        return -1;
+    }
+    length = strlen(value);
+    if (length + 1 > capacity) {
+        g4_set_error(backend, "manifest field %s is too long", label);
+        return -1;
+    }
+    memcpy(destination, value, length + 1);
+    return 0;
+}
+
+static int g4_number_u64(coli_gemma4_backend *backend, jval *object,
+                         const char *key, uint64_t *result) {
+    jval *value = json_get(object, key);
+    double number;
+    uint64_t converted;
+    if (!value || value->t != J_NUM) {
+        g4_set_error(backend, "manifest field %s is missing or not numeric", key);
+        return -1;
+    }
+    number = value->num;
+    if (!isfinite(number) || number < 0.0 || number > 9007199254740991.0 ||
+        floor(number) != number) {
+        g4_set_error(backend, "manifest field %s is not an exact non-negative integer", key);
+        return -1;
+    }
+    converted = (uint64_t)number;
+    *result = converted;
+    return 0;
+}
+
+static int g4_number_u32(coli_gemma4_backend *backend, jval *object,
+                         const char *key, uint32_t *result) {
+    uint64_t value;
+    if (g4_number_u64(backend, object, key, &value) != 0) return -1;
+    if (value > UINT32_MAX) {
+        g4_set_error(backend, "manifest field %s exceeds uint32", key);
+        return -1;
+    }
+    *result = (uint32_t)value;
+    return 0;
+}
+
+static const char *g4_string(jval *object, const char *key) {
+    jval *value = json_get(object, key);
+    return value && value->t == J_STR ? value->str : NULL;
+}
+
+static int g4_is_absolute_path(const char *path) {
+    if (!path || !*path) return 0;
+    if (path[0] == '/' || path[0] == '\\') return 1;
+    return ((path[0] >= 'A' && path[0] <= 'Z') ||
+            (path[0] >= 'a' && path[0] <= 'z')) && path[1] == ':';
+}
+
+static int g4_join_path(coli_gemma4_backend *backend, char *destination,
+                        size_t capacity, const char *directory, const char *name) {
+    size_t directory_length;
+    const char *separator;
+    int written;
+    if (!directory || !name) {
+        g4_set_error(backend, "cannot join a null path");
+        return -1;
+    }
+    directory_length = strlen(directory);
+    separator = (directory_length && (directory[directory_length - 1] == '/' ||
+                                      directory[directory_length - 1] == '\\')) ? "" : "/";
+    written = snprintf(destination, capacity, "%s%s%s", directory, separator, name);
+    if (written < 0 || (size_t)written >= capacity) {
+        g4_set_error(backend, "path is too long: %s/%s", directory, name);
+        return -1;
+    }
+    return 0;
+}
+
+static int g4_safe_packed_name(const char *name) {
+    if (!name || !*name || strstr(name, "..")) return 0;
+    return !strchr(name, '/') && !strchr(name, '\\') && !strchr(name, ':');
+}
+
+static char *g4_read_text(coli_gemma4_backend *backend, const char *path) {
+    FILE *file;
+    g4_off_t length;
+    char *text;
+    file = fopen(path, "rb");
+    if (!file) {
+        g4_set_error(backend, "cannot open manifest %s: %s", path, strerror(errno));
+        return NULL;
+    }
+    if (g4_seek(file, 0, SEEK_END) != 0 || (length = g4_tell(file)) < 0 ||
+        length > (64LL << 20) || g4_seek(file, 0, SEEK_SET) != 0) {
+        fclose(file);
+        g4_set_error(backend, "manifest is unreadable or larger than 64 MiB: %s", path);
+        return NULL;
+    }
+    text = (char *)malloc((size_t)length + 1);
+    if (!text) {
+        fclose(file);
+        g4_set_error(backend, "out of memory reading manifest");
+        return NULL;
+    }
+    if (fread(text, 1, (size_t)length, file) != (size_t)length) {
+        free(text);
+        fclose(file);
+        g4_set_error(backend, "short read from manifest %s", path);
+        return NULL;
+    }
+    text[length] = 0;
+    fclose(file);
+    return text;
+}
+
+static uint32_t g4_load_u32(const uint8_t *bytes) {
+    return (uint32_t)bytes[0] |
+           ((uint32_t)bytes[1] << 8) |
+           ((uint32_t)bytes[2] << 16) |
+           ((uint32_t)bytes[3] << 24);
+}
+
+static uint64_t g4_load_u64(const uint8_t *bytes) {
+    return (uint64_t)g4_load_u32(bytes) |
+           ((uint64_t)g4_load_u32(bytes + 4) << 32);
+}
+
+static int g4_parse_component(coli_gemma4_backend *backend,
+                              coli_gemma4_layer *layer, jval *component) {
+    const char *role = g4_string(component, "role");
+    const char *type_name = g4_string(component, "type_name");
+    uint32_t ggml_type;
+    uint64_t slice_bytes;
+    uint64_t source_offset;
+    uint64_t source_expert_stride;
+    uint64_t source_within_expert_offset;
+    int role_index;
+    if (!role || !type_name ||
+        g4_number_u32(backend, component, "ggml_type", &ggml_type) != 0 ||
+        g4_number_u64(backend, component, "slice_bytes", &slice_bytes) != 0 ||
+        g4_number_u64(backend, component, "source_offset", &source_offset) != 0 ||
+        g4_number_u64(backend, component, "source_expert_stride",
+                      &source_expert_stride) != 0 ||
+        g4_number_u64(backend, component, "source_within_expert_offset",
+                      &source_within_expert_offset) != 0) {
+        return -1;
+    }
+    if (strcmp(role, "gate") == 0) role_index = G4_ROLE_GATE;
+    else if (strcmp(role, "up") == 0) role_index = G4_ROLE_UP;
+    else if (strcmp(role, "down") == 0) role_index = G4_ROLE_DOWN;
+    else {
+        g4_set_error(backend, "unsupported expert component role: %s", role);
+        return -1;
+    }
+    if (ggml_type != 2 || strcmp(type_name, "Q4_0") != 0) {
+        g4_set_error(backend, "Gemma packed experts must use Q4_0");
+        return -1;
+    }
+    if (layer->component_bytes[role_index] != 0) {
+        g4_set_error(backend, "duplicate %s component in layer %u", role, layer->layer);
+        return -1;
+    }
+    layer->component_bytes[role_index] = slice_bytes;
+    layer->source_offset[role_index] = source_offset;
+    layer->source_expert_stride[role_index] = source_expert_stride;
+    layer->source_within_expert_offset[role_index] = source_within_expert_offset;
+    return 0;
+}
+
+static void g4_cache_clear(coli_gemma4_backend *backend) {
+    uint32_t i;
+    if (!backend) return;
+    for (i = 0; i < backend->cache_capacity; ++i)
+        free(backend->cache_slots[i].payload);
+    free(backend->cache_slots);
+    free(backend->cache_usage);
+    free(backend->cache_heat);
+    free(backend->cache_last);
+    backend->cache_slots = NULL;
+    backend->cache_usage = NULL;
+    backend->cache_heat = NULL;
+    backend->cache_last = NULL;
+    backend->cache_capacity = 0;
+    backend->cache_resident = 0;
+    backend->cache_pinned_capacity = 0;
+    backend->cache_access_clock = 0;
+    backend->cache_clock = 0;
+    backend->cache_hits = 0;
+    backend->cache_pinned_hits = 0;
+    backend->cache_misses = 0;
+    backend->cache_preloads = 0;
+    backend->cache_prefetch_launches = 0;
+    backend->cache_prefetched_records = 0;
+    backend->cache_lookahead_launches = 0;
+    backend->cache_lookahead_records = 0;
+    backend->cache_lookahead_matches = 0;
+    backend->cache_lookahead_selected = 0;
+    backend->cache_evictions = 0;
+    backend->cache_promotions = 0;
+    backend->cache_bytes_loaded = 0;
+}
+
+static int g4_validate_layer(coli_gemma4_backend *backend,
+                             const coli_gemma4_layer *layer) {
+    uint64_t gate_expected, down_expected, sum;
+    if (!layer->expert_count || !layer->model_width || !layer->expert_width ||
+        layer->model_width % 32 != 0 || layer->expert_width % 32 != 0) {
+        g4_set_error(backend, "layer %u has invalid expert dimensions", layer->layer);
+        return -1;
+    }
+    gate_expected = (uint64_t)layer->expert_width *
+                    ((uint64_t)layer->model_width / 32) * 18;
+    down_expected = (uint64_t)layer->model_width *
+                    ((uint64_t)layer->expert_width / 32) * 18;
+    if (layer->component_bytes[G4_ROLE_GATE] != gate_expected ||
+        layer->component_bytes[G4_ROLE_UP] != gate_expected ||
+        layer->component_bytes[G4_ROLE_DOWN] != down_expected) {
+        g4_set_error(backend, "layer %u Q4_0 component sizes do not match %u -> %u -> %u",
+                     layer->layer, layer->model_width, layer->expert_width,
+                     layer->model_width);
+        return -1;
+    }
+    if (layer->source_within_expert_offset[G4_ROLE_GATE] > UINT64_MAX - gate_expected ||
+        layer->source_within_expert_offset[G4_ROLE_UP] > UINT64_MAX - gate_expected ||
+        layer->source_within_expert_offset[G4_ROLE_DOWN] > UINT64_MAX - down_expected ||
+        layer->source_expert_stride[G4_ROLE_GATE] <
+            layer->source_within_expert_offset[G4_ROLE_GATE] + gate_expected ||
+        layer->source_expert_stride[G4_ROLE_UP] <
+            layer->source_within_expert_offset[G4_ROLE_UP] + gate_expected ||
+        layer->source_expert_stride[G4_ROLE_DOWN] <
+            layer->source_within_expert_offset[G4_ROLE_DOWN] + down_expected) {
+        g4_set_error(backend, "layer %u has invalid GGUF component strides",
+                     layer->layer);
+        return -1;
+    }
+    sum = layer->component_bytes[0] + layer->component_bytes[1] +
+          layer->component_bytes[2];
+    if (sum != layer->payload_bytes || layer->record_stride < layer->payload_bytes ||
+        layer->record_stride % 4096 != 0) {
+        g4_set_error(backend, "layer %u has inconsistent payload/record sizes", layer->layer);
+        return -1;
+    }
+    if (!g4_safe_packed_name(layer->packed_file)) {
+        g4_set_error(backend, "layer %u has an unsafe packed filename", layer->layer);
+        return -1;
+    }
+    return 0;
+}
+
+static int g4_parse_layer(coli_gemma4_backend *backend,
+                          coli_gemma4_layer *layer, jval *value) {
+    jval *components;
+    jval *scale;
+    const char *layout;
+    const char *packed_file;
+    uint32_t i;
+    memset(layer, 0, sizeof(*layer));
+    if (!value || value->t != J_OBJ ||
+        g4_number_u32(backend, value, "layer", &layer->layer) != 0 ||
+        g4_number_u32(backend, value, "expert_count", &layer->expert_count) != 0 ||
+        g4_number_u32(backend, value, "model_width", &layer->model_width) != 0 ||
+        g4_number_u32(backend, value, "expert_width", &layer->expert_width) != 0 ||
+        g4_number_u64(backend, value, "payload_bytes", &layer->payload_bytes) != 0 ||
+        g4_number_u64(backend, value, "record_stride", &layer->record_stride) != 0) {
+        return -1;
+    }
+    layout = g4_string(value, "source_layout");
+    packed_file = g4_string(value, "packed_file");
+    if (!layout || strcmp(layout, "fused_gate_up") != 0) {
+        g4_set_error(backend, "layer %u is not fused_gate_up", layer->layer);
+        return -1;
+    }
+    if (g4_copy_string(backend, layer->packed_file, sizeof(layer->packed_file),
+                       packed_file, "packed_file") != 0) return -1;
+
+    scale = json_get(value, "expert_scale");
+    if (scale && scale->t == J_OBJ) {
+        uint32_t scale_type;
+        if (g4_number_u32(backend, scale, "ggml_type", &scale_type) != 0 ||
+            g4_number_u64(backend, scale, "source_offset", &layer->scale_offset) != 0 ||
+            g4_number_u32(backend, scale, "scalar_bytes", &layer->scale_scalar_bytes) != 0) {
+            return -1;
+        }
+        if (scale_type != 0 || layer->scale_scalar_bytes != 4) {
+            g4_set_error(backend, "layer %u expert scale must be F32", layer->layer);
+            return -1;
+        }
+        layer->has_scale = 1;
+    } else if (scale && scale->t != J_NULL) {
+        g4_set_error(backend, "layer %u expert_scale is malformed", layer->layer);
+        return -1;
+    }
+
+    components = json_get(value, "components");
+    if (!components || components->t != J_ARR || components->len != 3) {
+        g4_set_error(backend, "layer %u must contain gate, up, and down components", layer->layer);
+        return -1;
+    }
+    for (i = 0; i < 3; ++i) {
+        if (g4_parse_component(backend, layer, components->kids[i]) != 0) return -1;
+    }
+    return g4_validate_layer(backend, layer);
+}
+
+static int g4_validate_unique_layers(coli_gemma4_backend *backend) {
+    uint32_t i, j, expected;
+    for (i = 0; i < backend->layer_count; ++i) {
+        for (j = i + 1; j < backend->layer_count; ++j) {
+            if (backend->layers[i].layer == backend->layers[j].layer) {
+                g4_set_error(backend, "manifest contains duplicate layer %u",
+                             backend->layers[i].layer);
+                return -1;
+            }
+        }
+    }
+    for (expected = 0; expected < backend->layer_count; ++expected) {
+        int found = 0;
+        for (i = 0; i < backend->layer_count; ++i)
+            if (backend->layers[i].layer == expected) found = 1;
+        if (!found) {
+            g4_set_error(backend, "manifest is missing routed layer %u", expected);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+int coli_gemma4_open_packed(coli_gemma4_backend *backend, const char *packed_dir) {
+    char manifest_path[COLI_GEMMA4_PATH_MAX];
+    char *text = NULL;
+    char *arena = NULL;
+    jval *root = NULL;
+    jval *layers;
+    const char *format;
+    const char *architecture;
+    const char *source;
+    uint32_t expert_count, expert_used_count;
+    uint32_t i;
+
+    if (!backend || !packed_dir || !*packed_dir) return -1;
+    memset(backend, 0, sizeof(*backend));
+    if (g4_copy_string(backend, backend->packed_dir, sizeof(backend->packed_dir),
+                       packed_dir, "packed directory") != 0 ||
+        g4_join_path(backend, manifest_path, sizeof(manifest_path),
+                     packed_dir, "manifest.json") != 0) {
+        return -1;
+    }
+    text = g4_read_text(backend, manifest_path);
+    if (!text) return -1;
+    root = json_parse(text, &arena);
+    if (!root || root->t != J_OBJ) {
+        g4_set_error(backend, "manifest root is not a JSON object");
+        goto fail;
+    }
+    format = g4_string(root, "format");
+    architecture = g4_string(root, "architecture");
+    source = g4_string(root, "source");
+    if (!format || strcmp(format, "g4lab-expert-manifest-v2") != 0) {
+        g4_set_error(backend, "unsupported packed manifest format");
+        goto fail;
+    }
+    if (!architecture || strcmp(architecture, "gemma4") != 0) {
+        g4_set_error(backend, "packed manifest architecture is not gemma4");
+        goto fail;
+    }
+    if (g4_number_u32(backend, root, "expert_count", &expert_count) != 0 ||
+        g4_number_u32(backend, root, "expert_used_count", &expert_used_count) != 0 ||
+        !expert_count || !expert_used_count || expert_used_count > expert_count) {
+        if (!backend->last_error[0])
+            g4_set_error(backend, "invalid expert count in manifest");
+        goto fail;
+    }
+    if (g4_copy_string(backend, backend->source, sizeof(backend->source),
+                       source, "source") != 0) goto fail;
+    layers = json_get(root, "layers");
+    if (!layers || layers->t != J_ARR || layers->len < 1 || layers->len > 4096) {
+        g4_set_error(backend, "manifest layers array is missing or invalid");
+        goto fail;
+    }
+    backend->layers = (coli_gemma4_layer *)calloc((size_t)layers->len,
+                                                  sizeof(*backend->layers));
+    if (!backend->layers) {
+        g4_set_error(backend, "out of memory allocating Gemma layer descriptors");
+        goto fail;
+    }
+    backend->layer_count = (uint32_t)layers->len;
+    for (i = 0; i < backend->layer_count; ++i) {
+        if (g4_parse_layer(backend, &backend->layers[i], layers->kids[i]) != 0)
+            goto fail;
+        if (backend->layers[i].expert_count != expert_count) {
+            g4_set_error(backend, "layer %u expert count disagrees with manifest",
+                         backend->layers[i].layer);
+            goto fail;
+        }
+    }
+    if (g4_validate_unique_layers(backend) != 0) goto fail;
+
+    backend->config.n_layer = backend->layer_count;
+    backend->config.n_embd = backend->layers[0].model_width;
+    backend->config.n_expert = expert_count;
+    backend->config.n_expert_used = expert_used_count;
+    backend->config.n_expert_ff = backend->layers[0].expert_width;
+    for (i = 1; i < backend->layer_count; ++i) {
+        if (backend->layers[i].model_width != backend->config.n_embd ||
+            backend->layers[i].expert_width != backend->config.n_expert_ff) {
+            g4_set_error(backend, "Gemma expert dimensions vary across layers");
+            goto fail;
+        }
+    }
+    free(arena);
+    g4_free_json(root);
+    free(text);
+    return 0;
+
+fail:
+    free(arena);
+    g4_free_json(root);
+    free(text);
+    free(backend->layers);
+    backend->layers = NULL;
+    backend->layer_count = 0;
+    return -1;
+}
+
+void coli_gemma4_close(coli_gemma4_backend *backend) {
+    if (!backend) return;
+    coli_gemma4_cuda_destroy(backend->cuda);
+    g4_prefetch_destroy(backend);
+    g4_cache_clear(backend);
+    free(backend->layers);
+    memset(backend, 0, sizeof(*backend));
+}
+
+int coli_gemma4_cache_configure(coli_gemma4_backend *backend, uint32_t slots) {
+    coli_gemma4_cache_slot *cache = NULL;
+    uint32_t *usage = NULL;
+    size_t records = 0;
+    if (!backend || !backend->layers) return -1;
+#if SIZE_MAX <= UINT32_MAX
+    if (slots > SIZE_MAX / sizeof(*cache)) {
+        g4_set_error(backend, "expert cache slot count does not fit in memory");
+        return -1;
+    }
+#endif
+    if (slots) {
+        if (backend->config.n_expert &&
+            backend->layer_count > SIZE_MAX / backend->config.n_expert) {
+            g4_set_error(backend, "expert usage-map dimensions overflow");
+            return -1;
+        }
+        records = (size_t)backend->layer_count * backend->config.n_expert;
+        cache = (coli_gemma4_cache_slot *)calloc((size_t)slots, sizeof(*cache));
+        usage = (uint32_t *)calloc(records, sizeof(*usage));
+        if (!cache || !usage) {
+            free(cache); free(usage);
+            g4_set_error(backend, "out of memory allocating expert cache metadata");
+            return -1;
+        }
+    }
+    g4_prefetch_destroy(backend);
+    g4_cache_clear(backend);
+    backend->cache_slots = cache;
+    backend->cache_usage = usage;
+    backend->cache_capacity = slots;
+    return 0;
+}
+
+int coli_gemma4_cache_set_pinned(coli_gemma4_backend *backend, uint32_t slots) {
+    uint32_t *heat = NULL, *last = NULL;
+    size_t records;
+    if (!backend || !backend->layers || slots >= backend->cache_capacity) {
+        if (backend)
+            g4_set_error(backend,
+                         "pinned expert slots must be fewer than cache slots");
+        return -1;
+    }
+    if (slots) {
+        if (backend->config.n_expert &&
+            backend->layer_count > SIZE_MAX / backend->config.n_expert) {
+            g4_set_error(backend, "expert heat-map dimensions overflow");
+            return -1;
+        }
+        records = (size_t)backend->layer_count * backend->config.n_expert;
+        if (records > INT_MAX) {
+            g4_set_error(backend, "expert heat map exceeds LFRU policy limits");
+            return -1;
+        }
+        heat = (uint32_t *)calloc(records, sizeof(*heat));
+        last = (uint32_t *)calloc(records, sizeof(*last));
+        if (!heat || !last) {
+            free(heat); free(last);
+            g4_set_error(backend, "out of memory allocating expert heat map");
+            return -1;
+        }
+    }
+    free(backend->cache_heat);
+    free(backend->cache_last);
+    backend->cache_heat = heat;
+    backend->cache_last = last;
+    backend->cache_pinned_capacity = slots;
+    backend->cache_access_clock = 0;
+    backend->cache_pinned_hits = 0;
+    backend->cache_promotions = 0;
+    return 0;
+}
+
+void coli_gemma4_cache_get_stats(const coli_gemma4_backend *backend,
+                                 coli_gemma4_cache_stats *stats) {
+    if (!stats) return;
+    memset(stats, 0, sizeof(*stats));
+    if (!backend) return;
+    stats->capacity = backend->cache_capacity;
+    stats->resident = backend->cache_resident;
+    stats->pinned_capacity = backend->cache_pinned_capacity;
+    stats->hits = backend->cache_hits;
+    stats->pinned_hits = backend->cache_pinned_hits;
+    stats->misses = backend->cache_misses;
+    stats->preloads = backend->cache_preloads;
+    stats->prefetch_launches = backend->cache_prefetch_launches;
+    stats->prefetched_records = backend->cache_prefetched_records;
+    stats->lookahead_launches = backend->cache_lookahead_launches;
+    stats->lookahead_records = backend->cache_lookahead_records;
+    stats->lookahead_matches = backend->cache_lookahead_matches;
+    stats->lookahead_selected = backend->cache_lookahead_selected;
+    stats->evictions = backend->cache_evictions;
+    stats->promotions = backend->cache_promotions;
+    stats->bytes_loaded = backend->cache_bytes_loaded;
+}
+
+const char *coli_gemma4_last_error(const coli_gemma4_backend *backend) {
+    return backend && backend->last_error[0] ? backend->last_error : "unknown Gemma backend error";
+}
+
+const coli_gemma4_layer *coli_gemma4_find_layer(
+    const coli_gemma4_backend *backend, uint32_t layer) {
+    uint32_t i;
+    if (!backend) return NULL;
+    for (i = 0; i < backend->layer_count; ++i)
+        if (backend->layers[i].layer == layer) return &backend->layers[i];
+    return NULL;
+}
+
+int coli_gemma4_has_packed_layer(
+    const coli_gemma4_backend *backend, const coli_gemma4_layer *layer) {
+    char path[COLI_GEMMA4_PATH_MAX];
+    FILE *file;
+    size_t directory_length;
+    const char *separator;
+    int written;
+    if (!backend || !layer) return 0;
+    directory_length = strlen(backend->packed_dir);
+    separator = (directory_length &&
+                 (backend->packed_dir[directory_length - 1] == '/' ||
+                  backend->packed_dir[directory_length - 1] == '\\')) ? "" : "/";
+    written = snprintf(path, sizeof(path), "%s%s%s", backend->packed_dir,
+                       separator, layer->packed_file);
+    if (written < 0 || (size_t)written >= sizeof(path)) return 0;
+    file = fopen(path, "rb");
+    if (!file) return 0;
+    fclose(file);
+    return 1;
+}
+
+float coli_gemma4_fp16_to_fp32(uint16_t value) {
+    uint32_t sign = (uint32_t)(value & 0x8000U) << 16U;
+    uint32_t exponent = (value >> 10U) & 0x1FU;
+    uint32_t mantissa = value & 0x03FFU;
+    uint32_t bits;
+    float result;
+    if (exponent == 0) {
+        if (mantissa == 0) bits = sign;
+        else {
+            int unbiased = -14;
+            while ((mantissa & 0x0400U) == 0) {
+                mantissa <<= 1U;
+                --unbiased;
+            }
+            mantissa &= 0x03FFU;
+            bits = sign | ((uint32_t)(unbiased + 127) << 23U) | (mantissa << 13U);
+        }
+    } else if (exponent == 0x1FU) {
+        bits = sign | 0x7F800000U | (mantissa << 13U);
+    } else {
+        bits = sign | ((exponent + 112U) << 23U) | (mantissa << 13U);
+    }
+    memcpy(&result, &bits, sizeof(result));
+    return result;
+}
+
+float coli_gemma4_gelu_tanh(float value) {
+    const float coefficient = 0.7978845608028654F;
+    const float cubic = 0.044715F;
+    return 0.5F * value *
+           (1.0F + tanhf(coefficient * (value + cubic * value * value * value)));
+}
+
+int coli_gemma4_q4_0_matvec(const uint8_t *weights, size_t rows, size_t columns,
+                            const float *input, float *output) {
+    size_t blocks_per_row, row_bytes;
+    long long row_signed;
+    if (!weights || !input || !output || !rows || !columns || columns % 32 != 0)
+        return -1;
+    blocks_per_row = columns / 32;
+    row_bytes = blocks_per_row * 18;
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (row_signed = 0; row_signed < (long long)rows; ++row_signed) {
+        size_t row = (size_t)row_signed;
+        const uint8_t *row_data = weights + row * row_bytes;
+        float sum = 0.0F;
+        size_t block;
+        for (block = 0; block < blocks_per_row; ++block) {
+            const uint8_t *encoded = row_data + block * 18;
+            uint16_t scale_bits = (uint16_t)encoded[0] |
+                                  ((uint16_t)encoded[1] << 8);
+            float scale = coli_gemma4_fp16_to_fp32(scale_bits);
+            const uint8_t *quants = encoded + 2;
+            const float *x = input + block * 32;
+            float integer_dot = 0.0F;
+            size_t index;
+            for (index = 0; index < 16; ++index) {
+                uint8_t packed = quants[index];
+                int low = (int)(packed & 0x0FU) - 8;
+                int high = (int)(packed >> 4U) - 8;
+                integer_dot += (float)low * x[index];
+                integer_dot += (float)high * x[index + 16];
+            }
+            sum += scale * integer_dot;
+        }
+        output[row] = sum;
+    }
+    return 0;
+}
+
+static int q6_k_value(const uint8_t *block, size_t half, size_t lane,
+                      size_t quarter) {
+    const uint8_t *ql = block + half * 64;
+    const uint8_t *qh = block + 128 + half * 32;
+    uint8_t low;
+    uint8_t high;
+    if (quarter == 0) {
+        low = ql[lane] & 0x0FU;
+        high = (qh[lane] >> 0U) & 3U;
+    } else if (quarter == 1) {
+        low = ql[lane + 32] & 0x0FU;
+        high = (qh[lane] >> 2U) & 3U;
+    } else if (quarter == 2) {
+        low = ql[lane] >> 4U;
+        high = (qh[lane] >> 4U) & 3U;
+    } else {
+        low = ql[lane + 32] >> 4U;
+        high = (qh[lane] >> 6U) & 3U;
+    }
+    return (int)(low | (uint8_t)(high << 4U)) - 32;
+}
+
+static int q6_k_scale(const uint8_t *block, size_t index) {
+    uint8_t encoded = block[192 + index];
+    return encoded < 128U ? (int)encoded : (int)encoded - 256;
+}
+
+int coli_gemma4_q6_k_row(const uint8_t *weights, size_t rows, size_t columns,
+                         size_t row, float *output) {
+    size_t blocks_per_row, block_index;
+    if (!weights || !output || !rows || !columns || row >= rows ||
+        columns % 256 != 0) return -1;
+    blocks_per_row = columns / 256;
+    weights += row * blocks_per_row * 210;
+    for (block_index = 0; block_index < blocks_per_row; ++block_index) {
+        const uint8_t *block = weights + block_index * 210;
+        uint16_t scale_bits = (uint16_t)block[208] |
+                              ((uint16_t)block[209] << 8U);
+        float super_scale = coli_gemma4_fp16_to_fp32(scale_bits);
+        size_t half, lane, quarter;
+        for (half = 0; half < 2; ++half) {
+            for (lane = 0; lane < 32; ++lane) {
+                for (quarter = 0; quarter < 4; ++quarter) {
+                    size_t within = half * 128 + quarter * 32 + lane;
+                    size_t scale_index = half * 8 + quarter * 2 + lane / 16;
+                    output[block_index * 256 + within] =
+                        super_scale * (float)q6_k_scale(block, scale_index) *
+                        (float)q6_k_value(block, half, lane, quarter);
+                }
+            }
+        }
+    }
+    return 0;
+}
+
+int coli_gemma4_q6_k_matvec(const uint8_t *weights, size_t rows, size_t columns,
+                            const float *input, float *output) {
+    size_t blocks_per_row, row_bytes;
+    long long row_signed;
+    if (!weights || !input || !output || !rows || !columns ||
+        columns % 256 != 0) return -1;
+    blocks_per_row = columns / 256;
+    row_bytes = blocks_per_row * 210;
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (row_signed = 0; row_signed < (long long)rows; ++row_signed) {
+        const uint8_t *row_data = weights + (size_t)row_signed * row_bytes;
+        float sum = 0.0F;
+        size_t block_index;
+        for (block_index = 0; block_index < blocks_per_row; ++block_index) {
+            const uint8_t *block = row_data + block_index * 210;
+            const float *x = input + block_index * 256;
+            uint16_t scale_bits = (uint16_t)block[208] |
+                                  ((uint16_t)block[209] << 8U);
+            float super_scale = coli_gemma4_fp16_to_fp32(scale_bits);
+            size_t half, lane, quarter;
+            for (half = 0; half < 2; ++half) {
+                for (lane = 0; lane < 32; ++lane) {
+                    for (quarter = 0; quarter < 4; ++quarter) {
+                        size_t within = half * 128 + quarter * 32 + lane;
+                        size_t scale_index =
+                            half * 8 + quarter * 2 + lane / 16;
+                        sum += super_scale *
+                               (float)q6_k_scale(block, scale_index) *
+                               (float)q6_k_value(block, half, lane, quarter) *
+                               x[within];
+                    }
+                }
+            }
+        }
+        output[(size_t)row_signed] = sum;
+    }
+    return 0;
+}
+
+static int g4_run_payload(coli_gemma4_backend *backend,
+                          const coli_gemma4_layer *layer, const uint8_t *payload,
+                          const float *input, float scale, float *output) {
+    float *gate, *up, *hidden;
+    long long index_signed;
+    const uint8_t *gate_weights = payload;
+    const uint8_t *up_weights = gate_weights + layer->component_bytes[G4_ROLE_GATE];
+    const uint8_t *down_weights = up_weights + layer->component_bytes[G4_ROLE_UP];
+    if (backend->cuda) {
+        if (coli_gemma4_cuda_run(
+                backend->cuda, payload, (size_t)layer->payload_bytes,
+                (size_t)layer->component_bytes[G4_ROLE_GATE],
+                (size_t)layer->component_bytes[G4_ROLE_UP],
+                layer->model_width, layer->expert_width, input, scale, output,
+                backend->last_error, sizeof(backend->last_error)) != 0)
+            return -1;
+        return 0;
+    }
+    gate = (float *)malloc((size_t)layer->expert_width * sizeof(float));
+    up = (float *)malloc((size_t)layer->expert_width * sizeof(float));
+    hidden = (float *)malloc((size_t)layer->expert_width * sizeof(float));
+    if (!gate || !up || !hidden) {
+        free(gate); free(up); free(hidden);
+        g4_set_error(backend, "out of memory running Gemma expert");
+        return -1;
+    }
+    if (coli_gemma4_q4_0_matvec(gate_weights, layer->expert_width,
+                                layer->model_width, input, gate) != 0 ||
+        coli_gemma4_q4_0_matvec(up_weights, layer->expert_width,
+                                layer->model_width, input, up) != 0) {
+        g4_set_error(backend, "invalid Q4_0 gate/up matrix");
+        free(gate); free(up); free(hidden);
+        return -1;
+    }
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (index_signed = 0; index_signed < (long long)layer->expert_width; ++index_signed) {
+        size_t index = (size_t)index_signed;
+        hidden[index] = coli_gemma4_gelu_tanh(gate[index]) * up[index];
+    }
+    if (coli_gemma4_q4_0_matvec(down_weights, layer->model_width,
+                                layer->expert_width, hidden, output) != 0) {
+        g4_set_error(backend, "invalid Q4_0 down matrix");
+        free(gate); free(up); free(hidden);
+        return -1;
+    }
+    if (scale != 1.0F) {
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+        for (index_signed = 0; index_signed < (long long)layer->model_width; ++index_signed)
+            output[(size_t)index_signed] *= scale;
+    }
+    free(gate); free(up); free(hidden);
+    return 0;
+}
+
+static int g4_read_header_and_payload(coli_gemma4_backend *backend,
+                                      const coli_gemma4_layer *layer,
+                                      uint32_t expert, uint8_t *payload) {
+    char path[COLI_GEMMA4_PATH_MAX];
+    uint8_t header[80];
+    FILE *file;
+    uint64_t header_bytes, payload_bytes, record_stride, offset, required;
+    uint64_t component_sum;
+    g4_off_t file_size;
+    int i;
+    if (g4_join_path(backend, path, sizeof(path), backend->packed_dir,
+                     layer->packed_file) != 0) return -1;
+    file = fopen(path, "rb");
+    if (!file) {
+        g4_set_error(backend, "cannot open packed layer %s: %s", path, strerror(errno));
+        return -1;
+    }
+    if (fread(header, 1, sizeof(header), file) != sizeof(header) ||
+        memcmp(header, "G4EXPK01", 8) != 0) {
+        fclose(file);
+        g4_set_error(backend, "packed layer header is missing or corrupt: %s", path);
+        return -1;
+    }
+    header_bytes = g4_load_u64(header + 32);
+    payload_bytes = g4_load_u64(header + 40);
+    record_stride = g4_load_u64(header + 48);
+    component_sum = g4_load_u64(header + 56) + g4_load_u64(header + 64) +
+                    g4_load_u64(header + 72);
+    if (g4_load_u32(header + 8) != 1 ||
+        g4_load_u32(header + 12) != layer->layer ||
+        g4_load_u32(header + 16) != layer->expert_count ||
+        g4_load_u32(header + 20) != 2 ||
+        g4_load_u32(header + 24) != 4096 ||
+        header_bytes != 4096 ||
+        payload_bytes != layer->payload_bytes ||
+        record_stride != layer->record_stride ||
+        component_sum != payload_bytes) {
+        fclose(file);
+        g4_set_error(backend, "packed layer header disagrees with manifest: %s", path);
+        return -1;
+    }
+    for (i = 0; i < 3; ++i) {
+        if (g4_load_u64(header + 56 + i * 8) != layer->component_bytes[i]) {
+            fclose(file);
+            g4_set_error(backend, "packed layer component sizes disagree with manifest");
+            return -1;
+        }
+    }
+    if (expert >= layer->expert_count ||
+        (record_stride &&
+         expert > (UINT64_MAX - header_bytes) / record_stride)) {
+        fclose(file);
+        g4_set_error(backend, "expert %u is outside layer %u", expert, layer->layer);
+        return -1;
+    }
+    offset = header_bytes + (uint64_t)expert * record_stride;
+    required = offset + payload_bytes;
+    if (required < offset || required > (uint64_t)LLONG_MAX ||
+        g4_seek(file, 0, SEEK_END) != 0 || (file_size = g4_tell(file)) < 0 ||
+        required > (uint64_t)file_size ||
+        g4_seek(file, (g4_off_t)offset, SEEK_SET) != 0 ||
+        fread(payload, 1, (size_t)payload_bytes, file) != (size_t)payload_bytes) {
+        fclose(file);
+        g4_set_error(backend, "packed expert record is truncated: %s", path);
+        return -1;
+    }
+    fclose(file);
+    return 0;
+}
+
+int coli_gemma4_cuda_configure(coli_gemma4_backend *backend, int device) {
+    void *context = NULL;
+    if (!backend || !backend->layers || device < 0) return -1;
+    if (coli_gemma4_cuda_create(
+            &context, device, backend->last_error,
+            sizeof(backend->last_error)) != 0) return -1;
+    coli_gemma4_cuda_destroy(backend->cuda);
+    backend->cuda = context;
+    return 0;
+}
+
+static int g4_source_path(coli_gemma4_backend *backend, char *destination,
+                          size_t capacity) {
+    if (g4_is_absolute_path(backend->source))
+        return g4_copy_string(backend, destination, capacity,
+                              backend->source, "source");
+    return g4_join_path(backend, destination, capacity,
+                        backend->packed_dir, backend->source);
+}
+
+static int g4_read_source_payload(coli_gemma4_backend *backend,
+                                  const coli_gemma4_layer *layer,
+                                  uint32_t expert, uint8_t *payload) {
+    char source_path[COLI_GEMMA4_PATH_MAX];
+    FILE *file;
+    uint64_t destination_offset = 0;
+    int role;
+    if (expert >= layer->expert_count) {
+        g4_set_error(backend, "expert %u is outside layer %u", expert, layer->layer);
+        return -1;
+    }
+    if (g4_source_path(backend, source_path, sizeof(source_path)) != 0) return -1;
+    file = fopen(source_path, "rb");
+    if (!file) {
+        g4_set_error(backend, "cannot open source GGUF %s: %s",
+                     source_path, strerror(errno));
+        return -1;
+    }
+    for (role = 0; role < 3; ++role) {
+        uint64_t source;
+        uint64_t expert_offset;
+        uint64_t bytes = layer->component_bytes[role];
+        if (layer->source_expert_stride[role] != 0 &&
+            expert > (UINT64_MAX - layer->source_offset[role]) /
+                         layer->source_expert_stride[role]) {
+            fclose(file);
+            g4_set_error(backend, "GGUF expert source offset overflows");
+            return -1;
+        }
+        expert_offset = layer->source_offset[role] +
+                        (uint64_t)expert * layer->source_expert_stride[role];
+        if (expert_offset > UINT64_MAX - layer->source_within_expert_offset[role]) {
+            fclose(file);
+            g4_set_error(backend, "GGUF expert component offset overflows");
+            return -1;
+        }
+        source = expert_offset + layer->source_within_expert_offset[role];
+        if (source > (uint64_t)LLONG_MAX || bytes > SIZE_MAX ||
+            g4_seek(file, (g4_off_t)source, SEEK_SET) != 0 ||
+            fread(payload + (size_t)destination_offset, 1, (size_t)bytes, file) !=
+                (size_t)bytes) {
+            fclose(file);
+            g4_set_error(backend,
+                         "cannot read layer %u expert %u component %d from %s",
+                         layer->layer, expert, role, source_path);
+            return -1;
+        }
+        destination_offset += bytes;
+    }
+    fclose(file);
+    if (destination_offset != layer->payload_bytes) {
+        g4_set_error(backend, "GGUF expert components do not fill the payload");
+        return -1;
+    }
+    return 0;
+}
+
+static int g4_read_scale(coli_gemma4_backend *backend,
+                         const coli_gemma4_layer *layer,
+                         uint32_t expert, float *scale) {
+    char source_path[COLI_GEMMA4_PATH_MAX];
+    uint8_t bytes[4];
+    uint64_t offset;
+    uint32_t bits;
+    FILE *file;
+    if (!layer->has_scale) {
+        *scale = 1.0F;
+        return 0;
+    }
+    if (expert >= layer->expert_count ||
+        expert > (UINT64_MAX - layer->scale_offset) / layer->scale_scalar_bytes) {
+        g4_set_error(backend, "expert scale offset overflows");
+        return -1;
+    }
+    if (g4_source_path(backend, source_path, sizeof(source_path)) != 0) return -1;
+    offset = layer->scale_offset + (uint64_t)expert * layer->scale_scalar_bytes;
+    if (offset > (uint64_t)LLONG_MAX) {
+        g4_set_error(backend, "expert scale offset is too large");
+        return -1;
+    }
+    file = fopen(source_path, "rb");
+    if (!file || g4_seek(file, (g4_off_t)offset, SEEK_SET) != 0 ||
+        fread(bytes, 1, sizeof(bytes), file) != sizeof(bytes)) {
+        if (file) fclose(file);
+        g4_set_error(backend, "cannot read expert scale from %s", source_path);
+        return -1;
+    }
+    fclose(file);
+    bits = g4_load_u32(bytes);
+    memcpy(scale, &bits, sizeof(*scale));
+    if (!isfinite(*scale)) {
+        g4_set_error(backend, "expert scale is not finite");
+        return -1;
+    }
+    return 0;
+}
+
+static coli_gemma4_cache_slot *g4_cache_find(coli_gemma4_backend *backend,
+                                              uint32_t layer,
+                                              uint32_t expert,
+                                              uint32_t *slot_index) {
+    uint32_t i;
+    for (i = 0; i < backend->cache_capacity; ++i) {
+        coli_gemma4_cache_slot *slot = backend->cache_slots + i;
+        if (slot->valid && slot->layer == layer && slot->expert == expert) {
+            if (slot_index) *slot_index = i;
+            return slot;
+        }
+    }
+    return NULL;
+}
+
+static size_t g4_cache_heat_index(const coli_gemma4_backend *backend,
+                                  uint32_t layer, uint32_t expert) {
+    return (size_t)layer * backend->config.n_expert + expert;
+}
+
+static void g4_cache_record_access(coli_gemma4_backend *backend,
+                                   uint32_t layer, uint32_t expert) {
+    size_t records, index;
+    index = g4_cache_heat_index(backend, layer, expert);
+    if (backend->cache_usage && backend->cache_usage[index] != UINT32_MAX)
+        ++backend->cache_usage[index];
+    if (!backend->cache_pinned_capacity) return;
+    records = (size_t)backend->layer_count * backend->config.n_expert;
+    if (backend->cache_access_clock == UINT32_MAX) {
+        tier_decay(backend->cache_heat, (int)records);
+        memset(backend->cache_last, 0, records * sizeof(*backend->cache_last));
+        backend->cache_access_clock = 0;
+    }
+    ++backend->cache_access_clock;
+    if (backend->cache_heat[index] != UINT32_MAX)
+        ++backend->cache_heat[index];
+    backend->cache_last[index] = backend->cache_access_clock;
+}
+
+static int g4_cache_pick_pin(const coli_gemma4_backend *backend,
+                             uint32_t layer, uint32_t expert,
+                             uint32_t *pin_index) {
+    uint32_t cold = 0, i;
+    uint64_t hot_score, cold_score;
+    size_t hot_index, candidate_index;
+    if (!backend->cache_pinned_capacity) return 0;
+    for (i = 1; i < backend->cache_pinned_capacity; ++i) {
+        size_t cold_index;
+        if (!backend->cache_slots[i].valid) {
+            cold = i;
+            break;
+        }
+        candidate_index = g4_cache_heat_index(
+            backend, backend->cache_slots[i].layer,
+            backend->cache_slots[i].expert);
+        cold_index = g4_cache_heat_index(
+            backend, backend->cache_slots[cold].layer,
+            backend->cache_slots[cold].expert);
+        if (tier_lfru_score(backend->cache_heat[candidate_index],
+                            backend->cache_last[candidate_index],
+                            backend->cache_access_clock) <
+            tier_lfru_score(backend->cache_heat[cold_index],
+                            backend->cache_last[cold_index],
+                            backend->cache_access_clock)) cold = i;
+    }
+    if (!backend->cache_slots[cold].valid) {
+        *pin_index = cold;
+        return 1;
+    }
+    hot_index = g4_cache_heat_index(backend, layer, expert);
+    candidate_index = g4_cache_heat_index(
+        backend, backend->cache_slots[cold].layer,
+        backend->cache_slots[cold].expert);
+    hot_score = tier_lfru_score(backend->cache_heat[hot_index],
+                                backend->cache_last[hot_index],
+                                backend->cache_access_clock);
+    cold_score = tier_lfru_score(backend->cache_heat[candidate_index],
+                                 backend->cache_last[candidate_index],
+                                 backend->cache_access_clock);
+    if (hot_score <= cold_score + (cold_score >> 2) + (4U << 8)) return 0;
+    *pin_index = cold;
+    return 1;
+}
+
+static coli_gemma4_cache_slot *g4_cache_promote_hit(
+    coli_gemma4_backend *backend, coli_gemma4_cache_slot *slot,
+    uint32_t slot_index) {
+    uint32_t pin_index;
+    coli_gemma4_cache_slot temporary;
+    if (!backend->cache_pinned_capacity) return slot;
+    if (slot_index < backend->cache_pinned_capacity) {
+        ++backend->cache_pinned_hits;
+        return slot;
+    }
+    if (!g4_cache_pick_pin(backend, slot->layer, slot->expert,
+                           &pin_index)) return slot;
+    temporary = backend->cache_slots[pin_index];
+    backend->cache_slots[pin_index] = *slot;
+    *slot = temporary;
+    ++backend->cache_promotions;
+    return backend->cache_slots + pin_index;
+}
+
+static int g4_load_record(coli_gemma4_backend *backend,
+                          const coli_gemma4_layer *descriptor,
+                          uint32_t expert, uint8_t *payload, float *scale) {
+    int read_status;
+    if (coli_gemma4_has_packed_layer(backend, descriptor))
+        read_status = g4_read_header_and_payload(backend, descriptor,
+                                                 expert, payload);
+    else
+        read_status = g4_read_source_payload(backend, descriptor,
+                                             expert, payload);
+    if (read_status != 0) return -1;
+    return g4_read_scale(backend, descriptor, expert, scale);
+}
+
+static coli_gemma4_cache_slot *g4_cache_load(
+    coli_gemma4_backend *backend, const coli_gemma4_layer *descriptor,
+    uint32_t expert, int access_mode) {
+    coli_gemma4_cache_slot *slot;
+    uint32_t i, slot_index = 0, pin_index = 0;
+    int evicting = 0, promoting = 0;
+    slot = g4_cache_find(backend, descriptor->layer, expert, &slot_index);
+    if (slot) {
+        slot->last_used = ++backend->cache_clock;
+        if (access_mode > 0) ++backend->cache_hits;
+        return access_mode > 0 ? g4_cache_promote_hit(
+                               backend, slot, slot_index) : slot;
+    }
+    if (access_mode < 0) ++backend->cache_preloads;
+    else ++backend->cache_misses;
+    if (g4_cache_pick_pin(backend, descriptor->layer, expert, &pin_index)) {
+        slot = backend->cache_slots + pin_index;
+        promoting = slot->valid;
+    } else {
+        slot = backend->cache_slots + backend->cache_pinned_capacity;
+        for (i = backend->cache_pinned_capacity; i < backend->cache_capacity; ++i) {
+            coli_gemma4_cache_slot *candidate = backend->cache_slots + i;
+            if (!candidate->valid) {
+                slot = candidate;
+                break;
+            }
+            if (candidate->last_used < slot->last_used) slot = candidate;
+        }
+    }
+    evicting = slot->valid;
+    slot->valid = 0;
+    if (descriptor->payload_bytes > SIZE_MAX) {
+        g4_set_error(backend, "expert payload does not fit in memory");
+        return NULL;
+    }
+    if (slot->payload_capacity < (size_t)descriptor->payload_bytes) {
+        uint8_t *payload = (uint8_t *)realloc(
+            slot->payload, (size_t)descriptor->payload_bytes);
+        if (!payload) {
+            g4_set_error(backend, "out of memory allocating cached expert record");
+            return NULL;
+        }
+        slot->payload = payload;
+        slot->payload_capacity = (size_t)descriptor->payload_bytes;
+    }
+    if (g4_load_record(backend, descriptor, expert, slot->payload,
+                       &slot->scale) != 0) return NULL;
+    slot->layer = descriptor->layer;
+    slot->expert = expert;
+    slot->last_used = ++backend->cache_clock;
+    slot->valid = 1;
+    if (promoting) ++backend->cache_promotions;
+    if (evicting) ++backend->cache_evictions;
+    else ++backend->cache_resident;
+    backend->cache_bytes_loaded += descriptor->payload_bytes;
+    if (descriptor->has_scale)
+        backend->cache_bytes_loaded += descriptor->scale_scalar_bytes;
+    return slot;
+}
+
+#ifdef _WIN32
+static unsigned __stdcall g4_prefetch_worker(void *opaque)
+#else
+static void *g4_prefetch_worker(void *opaque)
+#endif
+{
+    coli_gemma4_prefetch_state *state =
+        (coli_gemma4_prefetch_state *)opaque;
+    uint32_t i;
+    state->result = 0;
+    for (i = 0; i < state->count; ++i) {
+        if (!g4_cache_load(state->backend, state->descriptor,
+                           state->expert_ids[i], state->lookahead ? 0 : 1)) {
+            state->result = -1;
+            break;
+        }
+    }
+#ifdef _WIN32
+    return 0;
+#else
+    return NULL;
+#endif
+}
+
+static int g4_prefetch_wait(coli_gemma4_backend *backend) {
+    coli_gemma4_prefetch_state *state = backend ? backend->prefetch : NULL;
+    if (!state || !state->active) return 0;
+#ifdef _WIN32
+    if (WaitForSingleObject(state->thread, INFINITE) != WAIT_OBJECT_0) {
+        CloseHandle(state->thread);
+        state->thread = NULL;
+        state->active = 0;
+        g4_set_error(backend, "cannot join Gemma expert prefetch worker");
+        return -1;
+    }
+    CloseHandle(state->thread);
+    state->thread = NULL;
+#else
+    if (pthread_join(state->thread, NULL) != 0) {
+        state->active = 0;
+        g4_set_error(backend, "cannot join Gemma expert prefetch worker");
+        return -1;
+    }
+#endif
+    state->active = 0;
+    return state->result;
+}
+
+static void g4_prefetch_destroy(coli_gemma4_backend *backend) {
+    coli_gemma4_prefetch_state *state;
+    if (!backend) return;
+    state = backend->prefetch;
+    backend->lookahead_enabled = 0;
+    if (!state) return;
+    (void)g4_prefetch_wait(backend);
+    free(state->expert_ids);
+    free(state);
+    backend->prefetch = NULL;
+}
+
+int coli_gemma4_prefetch_configure(coli_gemma4_backend *backend, int enabled) {
+    coli_gemma4_prefetch_state *state;
+    if (!backend || !backend->layers) return -1;
+    g4_prefetch_destroy(backend);
+    if (!enabled) return 0;
+    if (!backend->cache_capacity) {
+        g4_set_error(backend, "asynchronous expert prefetch requires a cache");
+        return -1;
+    }
+    state = (coli_gemma4_prefetch_state *)calloc(1, sizeof(*state));
+    if (!state) {
+        g4_set_error(backend, "out of memory allocating expert prefetch state");
+        return -1;
+    }
+    state->expert_ids = (uint32_t *)malloc(
+        (size_t)backend->config.n_expert_used * sizeof(*state->expert_ids));
+    if (!state->expert_ids) {
+        free(state);
+        g4_set_error(backend, "out of memory allocating expert prefetch request");
+        return -1;
+    }
+    state->capacity = backend->config.n_expert_used;
+    state->backend = backend;
+    backend->prefetch = state;
+    return 0;
+}
+
+int coli_gemma4_lookahead_configure(coli_gemma4_backend *backend, int enabled) {
+    if (!backend) return -1;
+    if (enabled && (!backend->prefetch || !backend->cache_capacity)) {
+        g4_set_error(backend,
+                     "next-layer lookahead requires asynchronous prefetch and a cache");
+        return -1;
+    }
+    backend->lookahead_enabled = enabled != 0;
+    return 0;
+}
+
+static int g4_prefetch_start(coli_gemma4_backend *backend,
+                             const coli_gemma4_layer *descriptor,
+                             uint32_t count, int lookahead) {
+    coli_gemma4_prefetch_state *state = backend->prefetch;
+    if (!state) return 0;
+    state->descriptor = descriptor;
+    state->count = count;
+    state->result = 0;
+    state->lookahead = lookahead;
+    if (!count) return 0;
+#ifdef _WIN32
+    state->thread = (HANDLE)_beginthreadex(
+        NULL, 0, g4_prefetch_worker, state, 0, NULL);
+    if (!state->thread) {
+        g4_set_error(backend, "cannot create Gemma expert prefetch worker");
+        return -1;
+    }
+#else
+    if (pthread_create(&state->thread, NULL, g4_prefetch_worker, state) != 0) {
+        g4_set_error(backend, "cannot create Gemma expert prefetch worker");
+        return -1;
+    }
+#endif
+    state->active = 1;
+    ++backend->cache_prefetch_launches;
+    backend->cache_prefetched_records += count;
+    if (lookahead) {
+        ++backend->cache_lookahead_launches;
+        backend->cache_lookahead_records += count;
+    }
+    return 0;
+}
+
+static void g4_usage_add_total(uint64_t *total, uint32_t value) {
+    if (UINT64_MAX - *total < value) *total = UINT64_MAX;
+    else *total += value;
+}
+
+int coli_gemma4_usage_load(coli_gemma4_backend *backend, const char *path,
+                           uint64_t *selections) {
+    FILE *file;
+    size_t records;
+    uint64_t total = 0;
+    unsigned layer, expert, count;
+    int fields;
+    uint32_t pin;
+    uint8_t *chosen = NULL;
+    if (selections) *selections = 0;
+    if (!backend || !backend->cache_usage || !path || !*path) {
+        if (backend) g4_set_error(backend, "usage profile requires an active expert cache");
+        return -1;
+    }
+    records = (size_t)backend->layer_count * backend->config.n_expert;
+    file = fopen(path, "r");
+    if (!file) {
+        if (errno == ENOENT) return 0;
+        g4_set_error(backend, "cannot open expert usage profile %s: %s",
+                     path, strerror(errno));
+        return -1;
+    }
+    memset(backend->cache_usage, 0, records * sizeof(*backend->cache_usage));
+    while ((fields = fscanf(file, "%u %u %u", &layer, &expert, &count)) == 3) {
+        if (layer < backend->layer_count && expert < backend->config.n_expert) {
+            size_t index = g4_cache_heat_index(backend, layer, expert);
+            uint32_t old = backend->cache_usage[index];
+            backend->cache_usage[index] = UINT32_MAX - old < count ?
+                                          UINT32_MAX : old + count;
+        }
+    }
+    if (fields != EOF || ferror(file)) {
+        fclose(file);
+        g4_set_error(backend, "expert usage profile is malformed: %s", path);
+        return -1;
+    }
+    fclose(file);
+    for (size_t index = 0; index < records; ++index)
+        g4_usage_add_total(&total, backend->cache_usage[index]);
+    if (backend->cache_pinned_capacity && total) {
+        chosen = (uint8_t *)calloc(records, 1);
+        if (!chosen) {
+            g4_set_error(backend, "out of memory ranking expert usage profile");
+            return -1;
+        }
+        for (pin = 0; pin < backend->cache_pinned_capacity; ++pin) {
+            size_t best = SIZE_MAX, index;
+            uint32_t best_count = 0;
+            for (index = 0; index < records; ++index) {
+                if (!chosen[index] && backend->cache_usage[index] > best_count) {
+                    best = index;
+                    best_count = backend->cache_usage[index];
+                }
+            }
+            if (best == SIZE_MAX || !best_count) break;
+            chosen[best] = 1;
+            layer = (unsigned)(best / backend->config.n_expert);
+            expert = (unsigned)(best % backend->config.n_expert);
+            {
+                const coli_gemma4_layer *descriptor =
+                    coli_gemma4_find_layer(backend, layer);
+                if (!descriptor || !g4_cache_load(
+                        backend, descriptor, expert, -1)) {
+                    free(chosen);
+                    return -1;
+                }
+            }
+        }
+        free(chosen);
+    }
+    if (selections) *selections = total;
+    return 0;
+}
+
+int coli_gemma4_usage_save(coli_gemma4_backend *backend, const char *path,
+                           uint64_t *selections) {
+    char temporary[COLI_GEMMA4_PATH_MAX + 8];
+    FILE *file;
+    uint64_t total = 0;
+    uint32_t layer, expert;
+    int written;
+    if (selections) *selections = 0;
+    if (!backend || !backend->cache_usage || !path || !*path) {
+        if (backend) g4_set_error(backend, "usage profile requires an active expert cache");
+        return -1;
+    }
+    written = snprintf(temporary, sizeof(temporary), "%s.tmp", path);
+    if (written < 0 || (size_t)written >= sizeof(temporary)) {
+        g4_set_error(backend, "expert usage profile path is too long");
+        return -1;
+    }
+    file = fopen(temporary, "w");
+    if (!file) {
+        g4_set_error(backend, "cannot create expert usage profile %s: %s",
+                     temporary, strerror(errno));
+        return -1;
+    }
+    for (layer = 0; layer < backend->layer_count; ++layer) {
+        for (expert = 0; expert < backend->config.n_expert; ++expert) {
+            uint32_t count = backend->cache_usage[
+                g4_cache_heat_index(backend, layer, expert)];
+            if (count && fprintf(file, "%u %u %u\n", layer, expert, count) < 0) {
+                fclose(file); remove(temporary);
+                g4_set_error(backend, "cannot write expert usage profile %s", temporary);
+                return -1;
+            }
+            g4_usage_add_total(&total, count);
+        }
+    }
+    if (fflush(file) != 0 || fclose(file) != 0) {
+        remove(temporary);
+        g4_set_error(backend, "cannot flush expert usage profile %s", temporary);
+        return -1;
+    }
+#ifdef _WIN32
+    if (!MoveFileExA(temporary, path,
+                     MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        DWORD code = GetLastError();
+        remove(temporary);
+        g4_set_error(backend, "cannot replace expert usage profile %s (Windows error %lu)",
+                     path, (unsigned long)code);
+        return -1;
+    }
+#else
+    if (rename(temporary, path) != 0) {
+        remove(temporary);
+        g4_set_error(backend, "cannot replace expert usage profile %s: %s",
+                     path, strerror(errno));
+        return -1;
+    }
+#endif
+    if (selections) *selections = total;
+    return 0;
+}
+
+static int g4_validate_expert_ids(coli_gemma4_backend *backend,
+                                  const coli_gemma4_layer *descriptor,
+                                  uint32_t layer,
+                                  const uint32_t *expert_ids,
+                                  uint32_t count) {
+    uint32_t i;
+    if (!backend || !descriptor || (count && !expert_ids)) {
+        if (backend) g4_set_error(backend, "invalid Gemma prepare_layer request");
+        return -1;
+    }
+    for (i = 0; i < count; ++i) {
+        if (expert_ids[i] >= descriptor->expert_count) {
+            g4_set_error(backend, "expert %u is outside layer %u", expert_ids[i], layer);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int g4_prepare_layer(void *opaque, uint32_t layer,
+                            const uint32_t *expert_ids, uint32_t count) {
+    coli_gemma4_backend *backend = (coli_gemma4_backend *)opaque;
+    const coli_gemma4_layer *descriptor = coli_gemma4_find_layer(backend, layer);
+    uint32_t i;
+    if (g4_validate_expert_ids(backend, descriptor, layer,
+                               expert_ids, count) != 0) return -1;
+    if (backend->prefetch && backend->cache_capacity) {
+        uint32_t missing = 0;
+        if (backend->prefetch->lookahead &&
+            backend->prefetch->descriptor == descriptor) {
+            uint32_t selected, predicted;
+            backend->cache_lookahead_selected += count;
+            for (selected = 0; selected < count; ++selected)
+                for (predicted = 0; predicted < backend->prefetch->count;
+                     ++predicted)
+                    if (expert_ids[selected] ==
+                        backend->prefetch->expert_ids[predicted]) {
+                        ++backend->cache_lookahead_matches;
+                        break;
+                    }
+        }
+        if (g4_prefetch_wait(backend) != 0) return -1;
+        if (count > backend->prefetch->capacity) {
+            uint32_t *ids = (uint32_t *)realloc(
+                backend->prefetch->expert_ids,
+                (size_t)count * sizeof(*backend->prefetch->expert_ids));
+            if (!ids) {
+                g4_set_error(backend,
+                             "out of memory growing expert prefetch request");
+                return -1;
+            }
+            backend->prefetch->expert_ids = ids;
+            backend->prefetch->capacity = count;
+        }
+        for (i = 0; i < count; ++i) {
+            g4_cache_record_access(backend, layer, expert_ids[i]);
+            if (g4_cache_find(backend, layer, expert_ids[i], NULL)) {
+                if (!g4_cache_load(backend, descriptor, expert_ids[i], 1))
+                    return -1;
+            } else {
+                backend->prefetch->expert_ids[missing++] = expert_ids[i];
+            }
+        }
+        return g4_prefetch_start(backend, descriptor, missing, 0);
+    }
+    for (i = 0; i < count; ++i) {
+        g4_cache_record_access(backend, layer, expert_ids[i]);
+        if (backend->cache_capacity &&
+            !g4_cache_load(backend, descriptor, expert_ids[i], 1)) return -1;
+    }
+    return 0;
+}
+
+static int g4_run_experts(void *opaque, uint32_t layer,
+                          const uint32_t *expert_ids, const float *weights,
+                          uint32_t count, const float *input, float *output) {
+    coli_gemma4_backend *backend = (coli_gemma4_backend *)opaque;
+    const coli_gemma4_layer *descriptor = coli_gemma4_find_layer(backend, layer);
+    uint8_t *payload = NULL;
+    float *expert_output = NULL;
+    uint32_t selected, i;
+    if (!backend || !descriptor || !count || !expert_ids || !weights ||
+        !input || !output) {
+        if (backend) g4_set_error(backend, "invalid Gemma run_experts request");
+        return -1;
+    }
+    if (g4_validate_expert_ids(backend, descriptor, layer,
+                               expert_ids, count) != 0) return -1;
+    if (g4_prefetch_wait(backend) != 0) return -1;
+    if (descriptor->payload_bytes > SIZE_MAX) {
+        g4_set_error(backend, "expert payload does not fit in memory");
+        return -1;
+    }
+    if (!backend->cache_capacity)
+        payload = (uint8_t *)malloc((size_t)descriptor->payload_bytes);
+    expert_output = (float *)malloc((size_t)descriptor->model_width * sizeof(float));
+    if ((!backend->cache_capacity && !payload) || !expert_output) {
+        free(payload); free(expert_output);
+        g4_set_error(backend, "out of memory allocating expert buffers");
+        return -1;
+    }
+    memset(output, 0, (size_t)descriptor->model_width * sizeof(float));
+    for (selected = 0; selected < count; ++selected) {
+        float scale;
+        const uint8_t *record = payload;
+        if (backend->cache_capacity) {
+            coli_gemma4_cache_slot *slot = g4_cache_find(
+                backend, descriptor->layer, expert_ids[selected], NULL);
+            if (!slot) slot = g4_cache_load(
+                backend, descriptor, expert_ids[selected], 0);
+            if (!slot) {
+                free(payload); free(expert_output);
+                return -1;
+            }
+            record = slot->payload;
+            scale = slot->scale;
+        } else if (g4_load_record(backend, descriptor, expert_ids[selected],
+                                  payload, &scale) != 0) {
+            free(payload); free(expert_output);
+            return -1;
+        }
+        if (!isfinite(weights[selected]) ||
+            g4_run_payload(backend, descriptor, record, input, scale,
+                           expert_output) != 0) {
+            free(payload); free(expert_output);
+            return -1;
+        }
+        for (i = 0; i < descriptor->model_width; ++i)
+            output[i] += weights[selected] * expert_output[i];
+    }
+    free(payload);
+    free(expert_output);
+    return 0;
+}
+
+static void g4_release_layer(void *opaque, uint32_t layer) {
+    coli_gemma4_backend *backend = (coli_gemma4_backend *)opaque;
+    (void)layer;
+    if (backend) (void)g4_prefetch_wait(backend);
+}
+
+static int g4_prefetch_layer(void *opaque, uint32_t layer,
+                             const uint32_t *expert_ids, uint32_t count) {
+    coli_gemma4_backend *backend = (coli_gemma4_backend *)opaque;
+    const coli_gemma4_layer *descriptor = coli_gemma4_find_layer(backend, layer);
+    uint32_t i, missing = 0;
+    if (!backend || !backend->lookahead_enabled) return 0;
+    if (g4_validate_expert_ids(backend, descriptor, layer,
+                               expert_ids, count) != 0 ||
+        g4_prefetch_wait(backend) != 0) return -1;
+    if (count > backend->prefetch->capacity) {
+        uint32_t *ids = (uint32_t *)realloc(
+            backend->prefetch->expert_ids,
+            (size_t)count * sizeof(*backend->prefetch->expert_ids));
+        if (!ids) {
+            g4_set_error(backend, "out of memory growing lookahead request");
+            return -1;
+        }
+        backend->prefetch->expert_ids = ids;
+        backend->prefetch->capacity = count;
+    }
+    for (i = 0; i < count; ++i)
+        if (!g4_cache_find(backend, layer, expert_ids[i], NULL))
+            backend->prefetch->expert_ids[missing++] = expert_ids[i];
+    return g4_prefetch_start(backend, descriptor, missing, 1);
+}
+
+coli_expert_backend coli_gemma4_expert_backend(coli_gemma4_backend *backend) {
+    coli_expert_backend result;
+    result.ctx = backend;
+    result.prepare_layer = g4_prepare_layer;
+    result.run_experts = g4_run_experts;
+    result.release_layer = g4_release_layer;
+    result.prefetch_layer = backend && backend->lookahead_enabled ?
+                            g4_prefetch_layer : NULL;
+    return result;
+}
+
+uint64_t coli_gemma4_checksum_f32(const float *values, size_t count) {
+    uint64_t hash = UINT64_C(1469598103934665603);
+    size_t i;
+    if (!values) return 0;
+    for (i = 0; i < count; ++i) {
+        uint32_t bits;
+        unsigned shift;
+        memcpy(&bits, values + i, sizeof(bits));
+        for (shift = 0; shift < 32; shift += 8) {
+            hash ^= (uint8_t)((bits >> shift) & 0xFFU);
+            hash *= UINT64_C(1099511628211);
+        }
+    }
+    return hash;
+}

--- a/c/gemma4_backend.h
+++ b/c/gemma4_backend.h
@@ -1,0 +1,124 @@
+#ifndef COLI_GEMMA4_BACKEND_H
+#define COLI_GEMMA4_BACKEND_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "model.h"
+
+#define COLI_GEMMA4_PATH_MAX 2048
+#define COLI_GEMMA4_ERROR_MAX 512
+
+typedef struct {
+    uint32_t layer;
+    uint32_t expert_count;
+    uint32_t model_width;
+    uint32_t expert_width;
+    uint64_t payload_bytes;
+    uint64_t record_stride;
+    uint64_t component_bytes[3];
+    uint64_t source_offset[3];
+    uint64_t source_expert_stride[3];
+    uint64_t source_within_expert_offset[3];
+    uint64_t scale_offset;
+    uint32_t scale_scalar_bytes;
+    int has_scale;
+    char packed_file[128];
+} coli_gemma4_layer;
+
+typedef struct coli_gemma4_cache_slot coli_gemma4_cache_slot;
+typedef struct coli_gemma4_prefetch_state coli_gemma4_prefetch_state;
+
+typedef struct {
+    uint32_t capacity;
+    uint32_t resident;
+    uint32_t pinned_capacity;
+    uint64_t hits;
+    uint64_t pinned_hits;
+    uint64_t misses;
+    uint64_t preloads;
+    uint64_t prefetch_launches;
+    uint64_t prefetched_records;
+    uint64_t lookahead_launches;
+    uint64_t lookahead_records;
+    uint64_t lookahead_matches;
+    uint64_t lookahead_selected;
+    uint64_t evictions;
+    uint64_t promotions;
+    uint64_t bytes_loaded;
+} coli_gemma4_cache_stats;
+
+typedef struct {
+    coli_model_config config;
+    coli_gemma4_layer *layers;
+    uint32_t layer_count;
+    coli_gemma4_cache_slot *cache_slots;
+    uint32_t cache_capacity;
+    uint32_t cache_resident;
+    uint32_t cache_pinned_capacity;
+    uint32_t *cache_usage;
+    uint32_t *cache_heat;
+    uint32_t *cache_last;
+    uint32_t cache_access_clock;
+    uint64_t cache_clock;
+    uint64_t cache_hits;
+    uint64_t cache_pinned_hits;
+    uint64_t cache_misses;
+    uint64_t cache_preloads;
+    uint64_t cache_prefetch_launches;
+    uint64_t cache_prefetched_records;
+    uint64_t cache_lookahead_launches;
+    uint64_t cache_lookahead_records;
+    uint64_t cache_lookahead_matches;
+    uint64_t cache_lookahead_selected;
+    uint64_t cache_evictions;
+    uint64_t cache_promotions;
+    uint64_t cache_bytes_loaded;
+    coli_gemma4_prefetch_state *prefetch;
+    int lookahead_enabled;
+    void *cuda;
+    char source[COLI_GEMMA4_PATH_MAX];
+    char packed_dir[COLI_GEMMA4_PATH_MAX];
+    char last_error[COLI_GEMMA4_ERROR_MAX];
+} coli_gemma4_backend;
+
+/* Open a g4lab packed-expert directory and validate its manifest. */
+int coli_gemma4_open_packed(coli_gemma4_backend *backend, const char *packed_dir);
+void coli_gemma4_close(coli_gemma4_backend *backend);
+const char *coli_gemma4_last_error(const coli_gemma4_backend *backend);
+const coli_gemma4_layer *coli_gemma4_find_layer(
+    const coli_gemma4_backend *backend, uint32_t layer);
+int coli_gemma4_has_packed_layer(
+    const coli_gemma4_backend *backend, const coli_gemma4_layer *layer);
+
+/* Retain exact encoded expert records in a bounded global LRU. Zero disables it. */
+int coli_gemma4_cache_configure(coli_gemma4_backend *backend, uint32_t slots);
+/* Protect this many slots with Colibri's live LFRU learning policy. */
+int coli_gemma4_cache_set_pinned(coli_gemma4_backend *backend, uint32_t slots);
+/* Overlap missing-record loads with the model's resident dense branch. */
+int coli_gemma4_prefetch_configure(coli_gemma4_backend *backend, int enabled);
+int coli_gemma4_lookahead_configure(coli_gemma4_backend *backend, int enabled);
+int coli_gemma4_cuda_configure(coli_gemma4_backend *backend, int device);
+void coli_gemma4_cache_get_stats(const coli_gemma4_backend *backend,
+                                 coli_gemma4_cache_stats *stats);
+/* Load/save Colibri-compatible "layer expert count" cumulative usage. */
+int coli_gemma4_usage_load(coli_gemma4_backend *backend, const char *path,
+                           uint64_t *selections);
+int coli_gemma4_usage_save(coli_gemma4_backend *backend, const char *path,
+                           uint64_t *selections);
+
+/* Adapt the concrete packed backend to Colibri's placement-independent ABI. */
+coli_expert_backend coli_gemma4_expert_backend(coli_gemma4_backend *backend);
+
+/* Public numerical helpers are kept small so unit tests can validate kernels. */
+float coli_gemma4_fp16_to_fp32(uint16_t value);
+float coli_gemma4_gelu_tanh(float value);
+int coli_gemma4_q4_0_matvec(const uint8_t *weights, size_t rows, size_t columns,
+                            const float *input, float *output);
+int coli_gemma4_q6_k_row(const uint8_t *weights, size_t rows, size_t columns,
+                         size_t row, float *output);
+int coli_gemma4_q6_k_matvec(const uint8_t *weights, size_t rows, size_t columns,
+                            const float *input, float *output);
+uint64_t coli_gemma4_checksum_f32(const float *values, size_t count);
+
+#endif

--- a/c/gemma4_cuda.cu
+++ b/c/gemma4_cuda.cu
@@ -1,0 +1,196 @@
+#include "gemma4_cuda.h"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+struct gemma4_cuda_context {
+    int device;
+    uint8_t *payload;
+    float *input;
+    float *gate;
+    float *up;
+    float *hidden;
+    float *output;
+    size_t payload_capacity;
+    uint32_t model_capacity;
+    uint32_t expert_capacity;
+};
+
+static void cuda_error(char *error, size_t capacity, const char *operation,
+                       cudaError_t result) {
+    if (error && capacity)
+        std::snprintf(error, capacity, "%s: %s", operation,
+                      cudaGetErrorString(result));
+}
+
+__device__ static float fp16_value(const uint8_t *bytes) {
+    __half_raw raw;
+    raw.x = static_cast<unsigned short>(bytes[0]) |
+            static_cast<unsigned short>(bytes[1] << 8U);
+    return __half2float(raw);
+}
+
+__global__ static void q4_0_matvec(const uint8_t *weights,
+                                   uint32_t rows, uint32_t columns,
+                                   const float *input, float multiplier,
+                                   float *output) {
+    const uint32_t row = blockIdx.x * blockDim.x + threadIdx.x;
+    if (row >= rows) return;
+    const uint32_t blocks = columns / 32U;
+    const uint8_t *row_data = weights + static_cast<size_t>(row) * blocks * 18U;
+    float sum = 0.0F;
+    for (uint32_t block = 0; block < blocks; ++block) {
+        const uint8_t *encoded = row_data + static_cast<size_t>(block) * 18U;
+        const float scale = fp16_value(encoded);
+        const float *x = input + static_cast<size_t>(block) * 32U;
+        float dot = 0.0F;
+        for (uint32_t lane = 0; lane < 16U; ++lane) {
+            const uint8_t packed = encoded[2U + lane];
+            dot += static_cast<float>(static_cast<int>(packed & 15U) - 8) *
+                   x[lane];
+            dot += static_cast<float>(static_cast<int>(packed >> 4U) - 8) *
+                   x[lane + 16U];
+        }
+        sum += scale * dot;
+    }
+    output[row] = multiplier * sum;
+}
+
+__global__ static void gated_gelu(const float *gate, const float *up,
+                                  uint32_t count, float *hidden) {
+    const uint32_t index = blockIdx.x * blockDim.x + threadIdx.x;
+    if (index >= count) return;
+    const float value = gate[index];
+    const float activated = 0.5F * value *
+        (1.0F + tanhf(0.7978845608028654F *
+                      (value + 0.044715F * value * value * value)));
+    hidden[index] = activated * up[index];
+}
+
+static void release_buffers(gemma4_cuda_context *context) {
+    if (!context) return;
+    cudaFree(context->payload); cudaFree(context->input);
+    cudaFree(context->gate); cudaFree(context->up);
+    cudaFree(context->hidden); cudaFree(context->output);
+    context->payload = nullptr; context->input = nullptr;
+    context->gate = nullptr; context->up = nullptr;
+    context->hidden = nullptr; context->output = nullptr;
+    context->payload_capacity = 0;
+    context->model_capacity = 0;
+    context->expert_capacity = 0;
+}
+
+static cudaError_t reserve(gemma4_cuda_context *context,
+                           size_t payload_bytes, uint32_t model_width,
+                           uint32_t expert_width) {
+    if (context->payload_capacity >= payload_bytes &&
+        context->model_capacity >= model_width &&
+        context->expert_capacity >= expert_width) return cudaSuccess;
+    release_buffers(context);
+    cudaError_t result = cudaMalloc(&context->payload, payload_bytes);
+    if (result == cudaSuccess)
+        result = cudaMalloc(&context->input,
+                            static_cast<size_t>(model_width) * sizeof(float));
+    if (result == cudaSuccess)
+        result = cudaMalloc(&context->gate,
+                            static_cast<size_t>(expert_width) * sizeof(float));
+    if (result == cudaSuccess)
+        result = cudaMalloc(&context->up,
+                            static_cast<size_t>(expert_width) * sizeof(float));
+    if (result == cudaSuccess)
+        result = cudaMalloc(&context->hidden,
+                            static_cast<size_t>(expert_width) * sizeof(float));
+    if (result == cudaSuccess)
+        result = cudaMalloc(&context->output,
+                            static_cast<size_t>(model_width) * sizeof(float));
+    if (result != cudaSuccess) {
+        release_buffers(context);
+        return result;
+    }
+    context->payload_capacity = payload_bytes;
+    context->model_capacity = model_width;
+    context->expert_capacity = expert_width;
+    return cudaSuccess;
+}
+
+extern "C" int coli_gemma4_cuda_create(void **opaque, int device,
+                                        char *error, size_t error_capacity) {
+    if (!opaque || device < 0) return -1;
+    *opaque = nullptr;
+    int count = 0;
+    cudaError_t result = cudaGetDeviceCount(&count);
+    if (result != cudaSuccess || device >= count) {
+        cuda_error(error, error_capacity, "cannot select CUDA device", result);
+        return -1;
+    }
+    result = cudaSetDevice(device);
+    if (result != cudaSuccess) {
+        cuda_error(error, error_capacity, "cannot activate CUDA device", result);
+        return -1;
+    }
+    gemma4_cuda_context *context =
+        static_cast<gemma4_cuda_context *>(std::calloc(1, sizeof(*context)));
+    if (!context) return -1;
+    context->device = device;
+    *opaque = context;
+    return 0;
+}
+
+extern "C" void coli_gemma4_cuda_destroy(void *opaque) {
+    gemma4_cuda_context *context = static_cast<gemma4_cuda_context *>(opaque);
+    if (!context) return;
+    cudaSetDevice(context->device);
+    release_buffers(context);
+    std::free(context);
+}
+
+extern "C" int coli_gemma4_cuda_run(
+    void *opaque, const uint8_t *payload, size_t payload_bytes,
+    size_t gate_bytes, size_t up_bytes, uint32_t model_width,
+    uint32_t expert_width, const float *input, float scale, float *output,
+    char *error, size_t error_capacity) {
+    gemma4_cuda_context *context = static_cast<gemma4_cuda_context *>(opaque);
+    if (!context || !payload || !input || !output || !model_width ||
+        !expert_width || model_width % 32U || expert_width % 32U ||
+        gate_bytes + up_bytes > payload_bytes) return -1;
+    cudaError_t result = cudaSetDevice(context->device);
+    if (result == cudaSuccess)
+        result = reserve(context, payload_bytes, model_width, expert_width);
+    if (result == cudaSuccess)
+        result = cudaMemcpy(context->payload, payload, payload_bytes,
+                            cudaMemcpyHostToDevice);
+    if (result == cudaSuccess)
+        result = cudaMemcpy(context->input, input,
+                            static_cast<size_t>(model_width) * sizeof(float),
+                            cudaMemcpyHostToDevice);
+    if (result != cudaSuccess) {
+        cuda_error(error, error_capacity, "CUDA expert upload failed", result);
+        return -1;
+    }
+    const uint32_t threads = 128;
+    q4_0_matvec<<<(expert_width + threads - 1U) / threads, threads>>>(
+        context->payload, expert_width, model_width, context->input, 1.0F,
+        context->gate);
+    q4_0_matvec<<<(expert_width + threads - 1U) / threads, threads>>>(
+        context->payload + gate_bytes, expert_width, model_width,
+        context->input, 1.0F, context->up);
+    gated_gelu<<<(expert_width + threads - 1U) / threads, threads>>>(
+        context->gate, context->up, expert_width, context->hidden);
+    q4_0_matvec<<<(model_width + threads - 1U) / threads, threads>>>(
+        context->payload + gate_bytes + up_bytes, model_width, expert_width,
+        context->hidden, scale, context->output);
+    result = cudaGetLastError();
+    if (result == cudaSuccess)
+        result = cudaMemcpy(output, context->output,
+                            static_cast<size_t>(model_width) * sizeof(float),
+                            cudaMemcpyDeviceToHost);
+    if (result != cudaSuccess) {
+        cuda_error(error, error_capacity, "CUDA expert execution failed", result);
+        return -1;
+    }
+    return 0;
+}

--- a/c/gemma4_cuda.h
+++ b/c/gemma4_cuda.h
@@ -1,0 +1,25 @@
+#ifndef COLI_GEMMA4_CUDA_H
+#define COLI_GEMMA4_CUDA_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int coli_gemma4_cuda_create(void **context, int device,
+                            char *error, size_t error_capacity);
+void coli_gemma4_cuda_destroy(void *context);
+int coli_gemma4_cuda_run(void *context, const uint8_t *payload,
+                         size_t payload_bytes, size_t gate_bytes,
+                         size_t up_bytes, uint32_t model_width,
+                         uint32_t expert_width, const float *input,
+                         float scale, float *output,
+                         char *error, size_t error_capacity);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/c/gemma4_cuda_stub.c
+++ b/c/gemma4_cuda_stub.c
@@ -1,0 +1,28 @@
+#include "gemma4_cuda.h"
+
+#include <stdio.h>
+
+int coli_gemma4_cuda_create(void **context, int device,
+                            char *error, size_t error_capacity) {
+    (void)device;
+    if (context) *context = NULL;
+    if (error && error_capacity)
+        snprintf(error, error_capacity, "Gemma CUDA backend was not built");
+    return -1;
+}
+
+void coli_gemma4_cuda_destroy(void *context) { (void)context; }
+
+int coli_gemma4_cuda_run(void *context, const uint8_t *payload,
+                         size_t payload_bytes, size_t gate_bytes,
+                         size_t up_bytes, uint32_t model_width,
+                         uint32_t expert_width, const float *input,
+                         float scale, float *output,
+                         char *error, size_t error_capacity) {
+    (void)context; (void)payload; (void)payload_bytes; (void)gate_bytes;
+    (void)up_bytes; (void)model_width; (void)expert_width; (void)input;
+    (void)scale; (void)output;
+    if (error && error_capacity)
+        snprintf(error, error_capacity, "Gemma CUDA backend was not built");
+    return -1;
+}

--- a/c/gemma4_gguf.c
+++ b/c/gemma4_gguf.c
@@ -1,0 +1,647 @@
+#define _CRT_SECURE_NO_WARNINGS
+#define _FILE_OFFSET_BITS 64
+
+#include "gemma4_gguf.h"
+
+#include <errno.h>
+#include <limits.h>
+#include <math.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#define g4_seek _fseeki64
+#define g4_tell _ftelli64
+typedef __int64 g4_off_t;
+#else
+#include <sys/types.h>
+#define g4_seek fseeko
+#define g4_tell ftello
+typedef off_t g4_off_t;
+#endif
+
+enum {
+    GGUF_META_UINT8 = 0,
+    GGUF_META_INT8 = 1,
+    GGUF_META_UINT16 = 2,
+    GGUF_META_INT16 = 3,
+    GGUF_META_UINT32 = 4,
+    GGUF_META_INT32 = 5,
+    GGUF_META_FLOAT32 = 6,
+    GGUF_META_BOOL = 7,
+    GGUF_META_STRING = 8,
+    GGUF_META_ARRAY = 9,
+    GGUF_META_UINT64 = 10,
+    GGUF_META_INT64 = 11,
+    GGUF_META_FLOAT64 = 12
+};
+
+static void gguf_error(coli_gemma4_gguf *gguf, const char *format, ...) {
+    va_list arguments;
+    if (!gguf) return;
+    va_start(arguments, format);
+    vsnprintf(gguf->last_error, sizeof(gguf->last_error), format, arguments);
+    va_end(arguments);
+}
+
+static uint32_t load_u32(const uint8_t bytes[4]) {
+    return (uint32_t)bytes[0] | ((uint32_t)bytes[1] << 8) |
+           ((uint32_t)bytes[2] << 16) | ((uint32_t)bytes[3] << 24);
+}
+
+static uint64_t load_u64(const uint8_t bytes[8]) {
+    return (uint64_t)load_u32(bytes) | ((uint64_t)load_u32(bytes + 4) << 32);
+}
+
+static int read_bytes(coli_gemma4_gguf *gguf, FILE *file,
+                      void *destination, size_t bytes) {
+    if (bytes && fread(destination, 1, bytes, file) != bytes) {
+        gguf_error(gguf, "unexpected end of GGUF file");
+        return -1;
+    }
+    return 0;
+}
+
+static int read_u8(coli_gemma4_gguf *gguf, FILE *file, uint8_t *value) {
+    return read_bytes(gguf, file, value, 1);
+}
+
+static int read_u16(coli_gemma4_gguf *gguf, FILE *file, uint16_t *value) {
+    uint8_t bytes[2];
+    if (read_bytes(gguf, file, bytes, sizeof(bytes)) != 0) return -1;
+    *value = (uint16_t)((uint16_t)bytes[0] | ((uint16_t)bytes[1] << 8));
+    return 0;
+}
+
+static int read_u32(coli_gemma4_gguf *gguf, FILE *file, uint32_t *value) {
+    uint8_t bytes[4];
+    if (read_bytes(gguf, file, bytes, sizeof(bytes)) != 0) return -1;
+    *value = load_u32(bytes);
+    return 0;
+}
+
+static int read_u64(coli_gemma4_gguf *gguf, FILE *file, uint64_t *value) {
+    uint8_t bytes[8];
+    if (read_bytes(gguf, file, bytes, sizeof(bytes)) != 0) return -1;
+    *value = load_u64(bytes);
+    return 0;
+}
+
+static int read_f32(coli_gemma4_gguf *gguf, FILE *file, float *value) {
+    uint32_t bits;
+    if (read_u32(gguf, file, &bits) != 0) return -1;
+    memcpy(value, &bits, sizeof(*value));
+    return 0;
+}
+
+static int read_f64(coli_gemma4_gguf *gguf, FILE *file, double *value) {
+    uint64_t bits;
+    if (read_u64(gguf, file, &bits) != 0) return -1;
+    memcpy(value, &bits, sizeof(*value));
+    return 0;
+}
+
+static int skip_bytes(coli_gemma4_gguf *gguf, FILE *file, uint64_t bytes) {
+    if (bytes > (uint64_t)LLONG_MAX ||
+        g4_seek(file, (g4_off_t)bytes, SEEK_CUR) != 0) {
+        gguf_error(gguf, "GGUF metadata skip is outside the file");
+        return -1;
+    }
+    return 0;
+}
+
+static int read_string(coli_gemma4_gguf *gguf, FILE *file, char **result) {
+    uint64_t length;
+    char *value;
+    if (read_u64(gguf, file, &length) != 0) return -1;
+    if (length > SIZE_MAX - 1 || length > UINT64_C(268435456)) {
+        gguf_error(gguf, "GGUF string is unreasonably large");
+        return -1;
+    }
+    value = (char *)malloc((size_t)length + 1);
+    if (!value) {
+        gguf_error(gguf, "out of memory reading GGUF string");
+        return -1;
+    }
+    if (read_bytes(gguf, file, value, (size_t)length) != 0) {
+        free(value);
+        return -1;
+    }
+    value[length] = '\0';
+    *result = value;
+    return 0;
+}
+
+static int copy_string(coli_gemma4_gguf *gguf, char *destination,
+                       size_t capacity, const char *source, const char *label) {
+    size_t length = strlen(source);
+    if (length + 1 > capacity) {
+        gguf_error(gguf, "%s is too long", label);
+        return -1;
+    }
+    memcpy(destination, source, length + 1);
+    return 0;
+}
+
+static int key_is(const char *key, const char *expected) {
+    return strcmp(key, expected) == 0;
+}
+
+static int store_u64(coli_gemma4_gguf *gguf, const char *key, uint64_t value) {
+    if (value > UINT32_MAX) {
+        gguf_error(gguf, "metadata %s exceeds uint32", key);
+        return -1;
+    }
+    if (key_is(key, "general.alignment")) gguf->alignment = value;
+    else if (key_is(key, "general.sampling.top_k")) gguf->sampling_top_k = (uint32_t)value;
+    else if (key_is(key, "gemma4.block_count")) gguf->config.n_layer = (uint32_t)value;
+    else if (key_is(key, "gemma4.embedding_length")) gguf->config.n_embd = (uint32_t)value;
+    else if (key_is(key, "gemma4.expert_count")) gguf->config.n_expert = (uint32_t)value;
+    else if (key_is(key, "gemma4.expert_used_count")) gguf->config.n_expert_used = (uint32_t)value;
+    else if (key_is(key, "gemma4.expert_feed_forward_length")) gguf->config.n_expert_ff = (uint32_t)value;
+    else if (key_is(key, "gemma4.attention.sliding_window")) gguf->config.sliding_window = (uint32_t)value;
+    else if (key_is(key, "gemma4.attention.head_count")) gguf->attention_heads = (uint32_t)value;
+    else if (key_is(key, "gemma4.attention.key_length")) gguf->key_length = (uint32_t)value;
+    else if (key_is(key, "gemma4.attention.key_length_swa")) gguf->key_length_swa = (uint32_t)value;
+    else if (key_is(key, "gemma4.attention.value_length")) gguf->value_length = (uint32_t)value;
+    else if (key_is(key, "gemma4.attention.value_length_swa")) gguf->value_length_swa = (uint32_t)value;
+    else if (key_is(key, "gemma4.rope.dimension_count")) gguf->rope_dimensions = (uint32_t)value;
+    else if (key_is(key, "gemma4.rope.dimension_count_swa")) gguf->rope_dimensions_swa = (uint32_t)value;
+    else if (key_is(key, "tokenizer.ggml.bos_token_id")) gguf->tokenizer_bos_id = (uint32_t)value;
+    else if (key_is(key, "tokenizer.ggml.eos_token_id")) gguf->tokenizer_eos_id = (uint32_t)value;
+    else if (key_is(key, "tokenizer.ggml.unknown_token_id")) gguf->tokenizer_unknown_id = (uint32_t)value;
+    else if (key_is(key, "tokenizer.ggml.padding_token_id")) gguf->tokenizer_padding_id = (uint32_t)value;
+    else if (key_is(key, "tokenizer.ggml.add_bos_token")) gguf->tokenizer_add_bos = value != 0;
+    else if (key_is(key, "clip.has_vision_encoder")) gguf->vision_has_encoder = value != 0;
+    else if (key_is(key, "clip.vision.projection_dim")) gguf->vision_projection_dim = (uint32_t)value;
+    else if (key_is(key, "clip.vision.image_size")) gguf->vision_image_size = (uint32_t)value;
+    else if (key_is(key, "clip.vision.patch_size")) gguf->vision_patch_size = (uint32_t)value;
+    else if (key_is(key, "clip.vision.embedding_length")) gguf->vision_embedding_length = (uint32_t)value;
+    else if (key_is(key, "clip.vision.feed_forward_length")) gguf->vision_feed_forward_length = (uint32_t)value;
+    else if (key_is(key, "clip.vision.block_count")) gguf->vision_block_count = (uint32_t)value;
+    else if (key_is(key, "clip.vision.attention.head_count")) gguf->vision_head_count = (uint32_t)value;
+    return 0;
+}
+
+static void store_f64(coli_gemma4_gguf *gguf, const char *key, double value) {
+    if (key_is(key, "gemma4.attention.layer_norm_rms_epsilon")) gguf->rms_epsilon = (float)value;
+    else if (key_is(key, "gemma4.rope.freq_base")) gguf->rope_freq_base = (float)value;
+    else if (key_is(key, "gemma4.rope.freq_base_swa")) gguf->rope_freq_base_swa = (float)value;
+    else if (key_is(key, "gemma4.final_logit_softcapping")) gguf->final_logit_softcap = (float)value;
+    else if (key_is(key, "general.sampling.temp")) gguf->sampling_temperature = (float)value;
+    else if (key_is(key, "general.sampling.top_p")) gguf->sampling_top_p = (float)value;
+    else if (key_is(key, "clip.vision.attention.layer_norm_epsilon")) gguf->vision_epsilon = (float)value;
+}
+
+static size_t metadata_scalar_bytes(uint32_t type) {
+    switch (type) {
+        case GGUF_META_UINT8:
+        case GGUF_META_INT8:
+        case GGUF_META_BOOL: return 1;
+        case GGUF_META_UINT16:
+        case GGUF_META_INT16: return 2;
+        case GGUF_META_UINT32:
+        case GGUF_META_INT32:
+        case GGUF_META_FLOAT32: return 4;
+        case GGUF_META_UINT64:
+        case GGUF_META_INT64:
+        case GGUF_META_FLOAT64: return 8;
+        default: return 0;
+    }
+}
+
+static int read_metadata_value(coli_gemma4_gguf *gguf, FILE *file,
+                               const char *key, uint32_t type, unsigned depth) {
+    uint8_t u8;
+    uint16_t u16;
+    uint32_t u32;
+    uint64_t u64;
+    float f32;
+    double f64;
+    char *text = NULL;
+    if (depth > 16) {
+        gguf_error(gguf, "GGUF metadata nesting is too deep");
+        return -1;
+    }
+    switch (type) {
+        case GGUF_META_UINT8:
+        case GGUF_META_INT8:
+        case GGUF_META_BOOL:
+            if (read_u8(gguf, file, &u8) != 0) return -1;
+            return store_u64(gguf, key, u8);
+        case GGUF_META_UINT16:
+        case GGUF_META_INT16:
+            if (read_u16(gguf, file, &u16) != 0) return -1;
+            return store_u64(gguf, key, u16);
+        case GGUF_META_UINT32:
+        case GGUF_META_INT32:
+            if (read_u32(gguf, file, &u32) != 0) return -1;
+            return store_u64(gguf, key, u32);
+        case GGUF_META_FLOAT32:
+            if (read_f32(gguf, file, &f32) != 0) return -1;
+            store_f64(gguf, key, f32);
+            return 0;
+        case GGUF_META_UINT64:
+        case GGUF_META_INT64:
+            if (read_u64(gguf, file, &u64) != 0) return -1;
+            return store_u64(gguf, key, u64);
+        case GGUF_META_FLOAT64:
+            if (read_f64(gguf, file, &f64) != 0) return -1;
+            store_f64(gguf, key, f64);
+            return 0;
+        case GGUF_META_STRING:
+            if (read_string(gguf, file, &text) != 0) return -1;
+            if ((key_is(key, "general.architecture") &&
+                 copy_string(gguf, gguf->architecture, sizeof(gguf->architecture),
+                             text, "GGUF architecture") != 0) ||
+                (key_is(key, "tokenizer.ggml.model") &&
+                 copy_string(gguf, gguf->tokenizer_model,
+                             sizeof(gguf->tokenizer_model), text,
+                             "GGUF tokenizer model") != 0) ||
+                ((key_is(key, "clip.projector_type") ||
+                  key_is(key, "clip.vision.projector_type")) &&
+                 copy_string(gguf, gguf->projector_type,
+                             sizeof(gguf->projector_type), text,
+                             "projector type") != 0)) {
+                free(text);
+                return -1;
+            }
+            free(text);
+            return 0;
+        case GGUF_META_ARRAY: {
+            uint32_t element_type;
+            uint64_t count, index;
+            size_t scalar_bytes;
+            int capture_kv = key_is(key, "gemma4.attention.head_count_kv");
+            int capture_swa = key_is(key, "gemma4.attention.sliding_window_pattern");
+            int capture_tokens = key_is(key, "tokenizer.ggml.tokens");
+            int capture_merges = key_is(key, "tokenizer.ggml.merges");
+            int capture_types = key_is(key, "tokenizer.ggml.token_type");
+            int capture_mean = key_is(key, "clip.vision.image_mean");
+            int capture_std = key_is(key, "clip.vision.image_std");
+            if (read_u32(gguf, file, &element_type) != 0 ||
+                read_u64(gguf, file, &count) != 0) return -1;
+            if (element_type > GGUF_META_FLOAT64 || count > UINT64_C(1000000000)) {
+                gguf_error(gguf, "invalid GGUF metadata array");
+                return -1;
+            }
+            if (capture_kv || capture_swa) {
+                if (count > 256 ||
+                    (capture_kv && element_type != GGUF_META_INT32) ||
+                    (capture_swa && element_type != GGUF_META_BOOL)) {
+                    gguf_error(gguf, "invalid Gemma attention metadata array %s", key);
+                    return -1;
+                }
+                for (index = 0; index < count; ++index) {
+                    if (capture_kv) {
+                        if (read_u32(gguf, file, &u32) != 0) return -1;
+                        gguf->head_count_kv[index] = u32;
+                    } else {
+                        if (read_u8(gguf, file, &u8) != 0 || u8 > 1) return -1;
+                        gguf->sliding_window_pattern[index] = u8;
+                    }
+                }
+                return 0;
+            }
+            if (capture_tokens || capture_merges) {
+                char ***strings = capture_tokens ? &gguf->tokenizer_tokens :
+                                                   &gguf->tokenizer_merges;
+                uint64_t *stored_count = capture_tokens ?
+                    &gguf->tokenizer_token_count : &gguf->tokenizer_merge_count;
+                if (element_type != GGUF_META_STRING || count > UINT64_C(10000000) ||
+                    count > SIZE_MAX / sizeof(**strings)) {
+                    gguf_error(gguf, "invalid tokenizer string array %s", key);
+                    return -1;
+                }
+                *strings = (char **)calloc((size_t)count, sizeof(**strings));
+                if (count && !*strings) {
+                    gguf_error(gguf, "out of memory reading %s", key);
+                    return -1;
+                }
+                *stored_count = count;
+                for (index = 0; index < count; ++index)
+                    if (read_string(gguf, file, &(*strings)[index]) != 0) return -1;
+                return 0;
+            }
+            if (capture_types) {
+                if (element_type != GGUF_META_INT32 || count > UINT64_C(10000000) ||
+                    count > SIZE_MAX / sizeof(*gguf->tokenizer_token_types)) {
+                    gguf_error(gguf, "invalid tokenizer token-type array");
+                    return -1;
+                }
+                gguf->tokenizer_token_types = (uint32_t *)calloc(
+                    (size_t)count, sizeof(*gguf->tokenizer_token_types));
+                if (count && !gguf->tokenizer_token_types) {
+                    gguf_error(gguf, "out of memory reading tokenizer token types");
+                    return -1;
+                }
+                gguf->tokenizer_token_type_count = count;
+                for (index = 0; index < count; ++index)
+                    if (read_u32(gguf, file,
+                                 &gguf->tokenizer_token_types[index]) != 0) return -1;
+                return 0;
+            }
+            if (capture_mean || capture_std) {
+                float *values = capture_mean ? gguf->vision_image_mean :
+                                               gguf->vision_image_std;
+                if (element_type != GGUF_META_FLOAT32 || count != 3) {
+                    gguf_error(gguf, "invalid vision normalization array %s", key);
+                    return -1;
+                }
+                for (index = 0; index < count; ++index)
+                    if (read_f32(gguf, file, &values[index]) != 0) return -1;
+                return 0;
+            }
+            scalar_bytes = metadata_scalar_bytes(element_type);
+            if (scalar_bytes) {
+                if (count > UINT64_MAX / scalar_bytes)
+                    return (gguf_error(gguf, "GGUF metadata array overflows"), -1);
+                return skip_bytes(gguf, file, count * scalar_bytes);
+            }
+            for (index = 0; index < count; ++index) {
+                if (read_metadata_value(gguf, file, "", element_type, depth + 1) != 0)
+                    return -1;
+            }
+            return 0;
+        }
+        default:
+            gguf_error(gguf, "unknown GGUF metadata type %u", type);
+            return -1;
+    }
+}
+
+static int tensor_nbytes(coli_gemma4_gguf *gguf, coli_gemma4_tensor *tensor) {
+    uint64_t elements = 1;
+    uint64_t block_elements, block_bytes;
+    uint32_t dimension;
+    switch (tensor->type) {
+        case COLI_GGML_TYPE_F32: block_elements = 1; block_bytes = 4; break;
+        case COLI_GGML_TYPE_Q4_0: block_elements = 32; block_bytes = 18; break;
+        case COLI_GGML_TYPE_Q6_K: block_elements = 256; block_bytes = 210; break;
+        case COLI_GGML_TYPE_BF16: block_elements = 1; block_bytes = 2; break;
+        default:
+            gguf_error(gguf, "unsupported tensor type %u for %s",
+                       tensor->type, tensor->name);
+            return -1;
+    }
+    for (dimension = 0; dimension < tensor->n_dims; ++dimension) {
+        if (!tensor->dims[dimension] || elements > UINT64_MAX / tensor->dims[dimension]) {
+            gguf_error(gguf, "invalid dimensions for tensor %s", tensor->name);
+            return -1;
+        }
+        elements *= tensor->dims[dimension];
+    }
+    if (elements % block_elements ||
+        elements / block_elements > UINT64_MAX / block_bytes) {
+        gguf_error(gguf, "tensor %s does not align to its quantization block", tensor->name);
+        return -1;
+    }
+    tensor->nbytes = elements / block_elements * block_bytes;
+    return 0;
+}
+
+static int validate_config(coli_gemma4_gguf *gguf) {
+    uint32_t layer;
+    if (strcmp(gguf->architecture, "clip") == 0) {
+        uint32_t channel;
+        if (!gguf->vision_has_encoder ||
+            strcmp(gguf->projector_type, "gemma4v") != 0 ||
+            !gguf->vision_projection_dim || !gguf->vision_image_size ||
+            !gguf->vision_patch_size || !gguf->vision_embedding_length ||
+            !gguf->vision_feed_forward_length || !gguf->vision_block_count ||
+            !gguf->vision_head_count || !isfinite(gguf->vision_epsilon) ||
+            gguf->vision_epsilon <= 0.0F) {
+            gguf_error(gguf,
+                       "missing Gemma 4 vision configuration: encoder=%u projector=%s projection=%u image=%u patch=%u width=%u ff=%u blocks=%u heads=%u epsilon=%.9g",
+                       gguf->vision_has_encoder, gguf->projector_type,
+                       gguf->vision_projection_dim, gguf->vision_image_size,
+                       gguf->vision_patch_size, gguf->vision_embedding_length,
+                       gguf->vision_feed_forward_length,
+                       gguf->vision_block_count, gguf->vision_head_count,
+                       gguf->vision_epsilon);
+            return -1;
+        }
+        for (channel = 0; channel < 3; ++channel)
+            if (!isfinite(gguf->vision_image_mean[channel]) ||
+                !isfinite(gguf->vision_image_std[channel]) ||
+                gguf->vision_image_std[channel] <= 0.0F) {
+                gguf_error(gguf, "invalid Gemma 4 vision normalization metadata");
+                return -1;
+            }
+        return 0;
+    }
+    if (strcmp(gguf->architecture, "gemma4") != 0 ||
+        !gguf->config.n_layer || gguf->config.n_layer > 256 ||
+        !gguf->config.n_embd || !gguf->config.n_expert ||
+        !gguf->config.n_expert_used ||
+        gguf->config.n_expert_used > gguf->config.n_expert ||
+        !gguf->config.n_expert_ff || !gguf->attention_heads ||
+        !isfinite(gguf->rms_epsilon) || gguf->rms_epsilon <= 0.0F) {
+        gguf_error(gguf, "GGUF is missing required Gemma 4 configuration");
+        return -1;
+    }
+    for (layer = 0; layer < gguf->config.n_layer; ++layer) {
+        if (!gguf->head_count_kv[layer]) {
+            gguf_error(gguf, "Gemma layer %u has no KV-head count", layer);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+int coli_gemma4_gguf_open(coli_gemma4_gguf *gguf, const char *path) {
+    FILE *file = NULL;
+    char resolved[sizeof(gguf->path)];
+    uint8_t magic[4];
+    uint64_t metadata_count, index;
+    g4_off_t position, size;
+    int result = -1;
+    if (!gguf || !path) return -1;
+    memset(gguf, 0, sizeof(*gguf));
+    gguf->alignment = 32;
+    gguf->sampling_temperature = 1.0F;
+    gguf->sampling_top_p = 1.0F;
+    gguf->tokenizer_bos_id = UINT32_MAX;
+    gguf->tokenizer_eos_id = UINT32_MAX;
+    gguf->tokenizer_unknown_id = UINT32_MAX;
+    gguf->tokenizer_padding_id = UINT32_MAX;
+#ifdef _WIN32
+    if (!_fullpath(resolved, path, sizeof(resolved))) {
+#else
+    if (!realpath(path, resolved)) {
+#endif
+        gguf_error(gguf, "cannot resolve GGUF path %s: %s", path, strerror(errno));
+        return -1;
+    }
+    if (copy_string(gguf, gguf->path, sizeof(gguf->path), resolved, "GGUF path") != 0)
+        return -1;
+    file = fopen(gguf->path, "rb");
+    if (!file) {
+        gguf_error(gguf, "cannot open GGUF %s: %s", path, strerror(errno));
+        return -1;
+    }
+    if (g4_seek(file, 0, SEEK_END) != 0 || (size = g4_tell(file)) < 0 ||
+        g4_seek(file, 0, SEEK_SET) != 0) {
+        gguf_error(gguf, "cannot determine GGUF size");
+        goto cleanup;
+    }
+    gguf->file_size = (uint64_t)size;
+    if (read_bytes(gguf, file, magic, sizeof(magic)) != 0 ||
+        memcmp(magic, "GGUF", 4) != 0 ||
+        read_u32(gguf, file, &gguf->version) != 0 ||
+        read_u64(gguf, file, &gguf->tensor_count) != 0 ||
+        read_u64(gguf, file, &metadata_count) != 0) goto cleanup;
+    if (gguf->version < 2 || gguf->version > 3 ||
+        gguf->tensor_count > UINT64_C(10000000) ||
+        metadata_count > UINT64_C(10000000) ||
+        gguf->tensor_count > SIZE_MAX / sizeof(*gguf->tensors)) {
+        gguf_error(gguf, "unsupported or unreasonable GGUF header");
+        goto cleanup;
+    }
+    for (index = 0; index < metadata_count; ++index) {
+        char *key = NULL;
+        uint32_t type;
+        if (read_string(gguf, file, &key) != 0 ||
+            read_u32(gguf, file, &type) != 0 ||
+            read_metadata_value(gguf, file, key ? key : "", type, 0) != 0) {
+            free(key);
+            goto cleanup;
+        }
+        free(key);
+    }
+    gguf->tensors = (coli_gemma4_tensor *)calloc(
+        (size_t)gguf->tensor_count, sizeof(*gguf->tensors));
+    if (!gguf->tensors) {
+        gguf_error(gguf, "out of memory allocating GGUF tensor index");
+        goto cleanup;
+    }
+    for (index = 0; index < gguf->tensor_count; ++index) {
+        coli_gemma4_tensor *tensor = &gguf->tensors[index];
+        uint32_t dimension;
+        if (read_string(gguf, file, &tensor->name) != 0 ||
+            read_u32(gguf, file, &tensor->n_dims) != 0 ||
+            !tensor->n_dims || tensor->n_dims > COLI_GEMMA4_GGUF_MAX_DIMS) {
+            gguf_error(gguf, "invalid GGUF tensor directory entry");
+            goto cleanup;
+        }
+        for (dimension = 0; dimension < tensor->n_dims; ++dimension)
+            if (read_u64(gguf, file, &tensor->dims[dimension]) != 0) goto cleanup;
+        if (read_u32(gguf, file, &tensor->type) != 0 ||
+            read_u64(gguf, file, &tensor->offset) != 0 ||
+            tensor_nbytes(gguf, tensor) != 0) goto cleanup;
+    }
+    position = g4_tell(file);
+    if (position < 0 || !gguf->alignment || gguf->alignment % 8 ||
+        (uint64_t)position > UINT64_MAX - (gguf->alignment - 1)) {
+        gguf_error(gguf, "invalid GGUF alignment or directory size");
+        goto cleanup;
+    }
+    gguf->data_offset = ((uint64_t)position + gguf->alignment - 1) /
+                        gguf->alignment * gguf->alignment;
+    for (index = 0; index < gguf->tensor_count; ++index) {
+        coli_gemma4_tensor *tensor = &gguf->tensors[index];
+        if (tensor->offset > UINT64_MAX - gguf->data_offset) {
+            gguf_error(gguf, "tensor offset overflows for %s", tensor->name);
+            goto cleanup;
+        }
+        tensor->offset += gguf->data_offset;
+        if (tensor->offset > gguf->file_size ||
+            tensor->nbytes > gguf->file_size - tensor->offset) {
+            gguf_error(gguf, "tensor %s is outside the GGUF", tensor->name);
+            goto cleanup;
+        }
+    }
+    if (validate_config(gguf) != 0) goto cleanup;
+    if (strcmp(gguf->architecture, "gemma4") == 0) {
+        const coli_gemma4_tensor *embedding = coli_gemma4_gguf_find(gguf, "token_embd.weight");
+        if (!embedding || embedding->n_dims != 2 ||
+            embedding->dims[0] != gguf->config.n_embd ||
+            embedding->dims[1] > UINT32_MAX) {
+            gguf_error(gguf, "invalid or missing token embedding tensor");
+            goto cleanup;
+        }
+        gguf->config.n_vocab = (uint32_t)embedding->dims[1];
+    }
+    result = 0;
+
+cleanup:
+    fclose(file);
+    if (result != 0) {
+        char saved[COLI_GEMMA4_GGUF_ERROR_MAX];
+        memcpy(saved, gguf->last_error, sizeof(saved));
+        coli_gemma4_gguf_close(gguf);
+        memcpy(gguf->last_error, saved, sizeof(saved));
+    }
+    return result;
+}
+
+void coli_gemma4_gguf_close(coli_gemma4_gguf *gguf) {
+    uint64_t index;
+    if (!gguf) return;
+    for (index = 0; index < gguf->tensor_count; ++index)
+        free(gguf->tensors ? gguf->tensors[index].name : NULL);
+    for (index = 0; index < gguf->tokenizer_token_count; ++index)
+        free(gguf->tokenizer_tokens ? gguf->tokenizer_tokens[index] : NULL);
+    for (index = 0; index < gguf->tokenizer_merge_count; ++index)
+        free(gguf->tokenizer_merges ? gguf->tokenizer_merges[index] : NULL);
+    free(gguf->tensors);
+    free(gguf->tokenizer_tokens);
+    free(gguf->tokenizer_merges);
+    free(gguf->tokenizer_token_types);
+    memset(gguf, 0, sizeof(*gguf));
+}
+
+const char *coli_gemma4_gguf_last_error(const coli_gemma4_gguf *gguf) {
+    return gguf ? gguf->last_error : "invalid GGUF handle";
+}
+
+const coli_gemma4_tensor *coli_gemma4_gguf_find(
+    const coli_gemma4_gguf *gguf, const char *name) {
+    uint64_t index;
+    if (!gguf || !name) return NULL;
+    for (index = 0; index < gguf->tensor_count; ++index)
+        if (strcmp(gguf->tensors[index].name, name) == 0)
+            return &gguf->tensors[index];
+    return NULL;
+}
+
+int coli_gemma4_gguf_read(const coli_gemma4_gguf *gguf,
+                          const coli_gemma4_tensor *tensor,
+                          void *destination, size_t bytes) {
+    if (!tensor || bytes != tensor->nbytes) return -1;
+    return coli_gemma4_gguf_read_slice(
+        gguf, tensor, 0, destination, bytes);
+}
+
+int coli_gemma4_gguf_read_slice(const coli_gemma4_gguf *gguf,
+                                const coli_gemma4_tensor *tensor,
+                                uint64_t byte_offset, void *destination,
+                                size_t bytes) {
+    FILE *file;
+    uint64_t offset;
+    if (!gguf || !tensor || !destination ||
+        byte_offset > tensor->nbytes || bytes > tensor->nbytes - byte_offset ||
+        tensor->offset > UINT64_MAX - byte_offset) return -1;
+    offset = tensor->offset + byte_offset;
+    if (offset > (uint64_t)LLONG_MAX) return -1;
+    file = fopen(gguf->path, "rb");
+    if (!file) return -1;
+    if (g4_seek(file, (g4_off_t)offset, SEEK_SET) != 0 ||
+        fread(destination, 1, bytes, file) != bytes) {
+        fclose(file);
+        return -1;
+    }
+    return fclose(file) == 0 ? 0 : -1;
+}
+
+const char *coli_gemma4_ggml_type_name(uint32_t type) {
+    switch (type) {
+        case COLI_GGML_TYPE_F32: return "F32";
+        case COLI_GGML_TYPE_Q4_0: return "Q4_0";
+        case COLI_GGML_TYPE_Q6_K: return "Q6_K";
+        case COLI_GGML_TYPE_BF16: return "BF16";
+        default: return "UNKNOWN";
+    }
+}

--- a/c/gemma4_gguf.h
+++ b/c/gemma4_gguf.h
@@ -1,0 +1,95 @@
+#ifndef COLI_GEMMA4_GGUF_H
+#define COLI_GEMMA4_GGUF_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "model.h"
+
+#define COLI_GEMMA4_GGUF_MAX_DIMS 8
+#define COLI_GEMMA4_GGUF_ERROR_MAX 512
+
+enum {
+    COLI_GGML_TYPE_F32 = 0,
+    COLI_GGML_TYPE_Q4_0 = 2,
+    COLI_GGML_TYPE_Q6_K = 14,
+    COLI_GGML_TYPE_BF16 = 30
+};
+
+typedef struct {
+    char *name;
+    uint32_t type;
+    uint32_t n_dims;
+    uint64_t dims[COLI_GEMMA4_GGUF_MAX_DIMS];
+    uint64_t offset;
+    uint64_t nbytes;
+} coli_gemma4_tensor;
+
+typedef struct {
+    coli_model_config config;
+    uint32_t version;
+    uint64_t alignment;
+    uint64_t data_offset;
+    uint64_t file_size;
+    uint32_t attention_heads;
+    uint32_t key_length;
+    uint32_t key_length_swa;
+    uint32_t value_length;
+    uint32_t value_length_swa;
+    uint32_t rope_dimensions;
+    uint32_t rope_dimensions_swa;
+    uint32_t head_count_kv[256];
+    uint8_t sliding_window_pattern[256];
+    float rms_epsilon;
+    float rope_freq_base;
+    float rope_freq_base_swa;
+    float final_logit_softcap;
+    float sampling_temperature;
+    float sampling_top_p;
+    uint32_t sampling_top_k;
+    uint32_t vision_projection_dim;
+    uint32_t vision_image_size;
+    uint32_t vision_patch_size;
+    uint32_t vision_embedding_length;
+    uint32_t vision_feed_forward_length;
+    uint32_t vision_block_count;
+    uint32_t vision_head_count;
+    float vision_epsilon;
+    float vision_image_mean[3];
+    float vision_image_std[3];
+    uint8_t vision_has_encoder;
+    char **tokenizer_tokens;
+    char **tokenizer_merges;
+    uint32_t *tokenizer_token_types;
+    uint64_t tokenizer_token_count;
+    uint64_t tokenizer_merge_count;
+    uint64_t tokenizer_token_type_count;
+    uint32_t tokenizer_bos_id;
+    uint32_t tokenizer_eos_id;
+    uint32_t tokenizer_unknown_id;
+    uint32_t tokenizer_padding_id;
+    uint8_t tokenizer_add_bos;
+    coli_gemma4_tensor *tensors;
+    uint64_t tensor_count;
+    char path[2048];
+    char architecture[32];
+    char tokenizer_model[32];
+    char projector_type[32];
+    char last_error[COLI_GEMMA4_GGUF_ERROR_MAX];
+} coli_gemma4_gguf;
+
+int coli_gemma4_gguf_open(coli_gemma4_gguf *gguf, const char *path);
+void coli_gemma4_gguf_close(coli_gemma4_gguf *gguf);
+const char *coli_gemma4_gguf_last_error(const coli_gemma4_gguf *gguf);
+const coli_gemma4_tensor *coli_gemma4_gguf_find(
+    const coli_gemma4_gguf *gguf, const char *name);
+int coli_gemma4_gguf_read(const coli_gemma4_gguf *gguf,
+                          const coli_gemma4_tensor *tensor,
+                          void *destination, size_t bytes);
+int coli_gemma4_gguf_read_slice(const coli_gemma4_gguf *gguf,
+                                const coli_gemma4_tensor *tensor,
+                                uint64_t byte_offset, void *destination,
+                                size_t bytes);
+const char *coli_gemma4_ggml_type_name(uint32_t type);
+
+#endif

--- a/c/gemma4_model.c
+++ b/c/gemma4_model.c
@@ -1,0 +1,1473 @@
+#define _CRT_SECURE_NO_WARNINGS
+
+#include "gemma4_model.h"
+#include "gemma4_backend.h"
+
+#include <float.h>
+#include <math.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void router_error(coli_gemma4_router *router, const char *format, ...) {
+    va_list arguments;
+    if (!router) return;
+    va_start(arguments, format);
+    vsnprintf(router->last_error, sizeof(router->last_error), format, arguments);
+    va_end(arguments);
+}
+
+static int tensor_is(const coli_gemma4_tensor *tensor, uint32_t type,
+                     uint32_t n_dims, uint64_t dim0, uint64_t dim1) {
+    return tensor && tensor->type == type && tensor->n_dims == n_dims &&
+           tensor->dims[0] == dim0 && (n_dims < 2 || tensor->dims[1] == dim1);
+}
+
+static int read_f32_tensor(coli_gemma4_router *router,
+                           const coli_gemma4_tensor *tensor, float **result) {
+    float *values;
+    if (!tensor || tensor->nbytes > SIZE_MAX) {
+        router_error(router, "router tensor is missing or too large");
+        return -1;
+    }
+    values = (float *)malloc((size_t)tensor->nbytes);
+    if (!values) {
+        router_error(router, "out of memory loading router tensor");
+        return -1;
+    }
+    if (coli_gemma4_gguf_read(router->gguf, tensor, values,
+                              (size_t)tensor->nbytes) != 0) {
+        free(values);
+        router_error(router, "failed reading router tensor %s", tensor->name);
+        return -1;
+    }
+    *result = values;
+    return 0;
+}
+
+int coli_gemma4_matrix_open(coli_gemma4_matrix *matrix,
+                            const coli_gemma4_gguf *gguf, const char *name) {
+    const coli_gemma4_tensor *tensor;
+    if (!matrix || !gguf || !name) return -1;
+    memset(matrix, 0, sizeof(*matrix));
+    tensor = coli_gemma4_gguf_find(gguf, name);
+    if (!tensor || (tensor->type != COLI_GGML_TYPE_Q4_0 &&
+                    tensor->type != COLI_GGML_TYPE_Q6_K) ||
+        tensor->n_dims != 2 || !tensor->dims[0] || !tensor->dims[1] ||
+        (tensor->type == COLI_GGML_TYPE_Q4_0 && tensor->dims[0] % 32 != 0) ||
+        (tensor->type == COLI_GGML_TYPE_Q6_K && tensor->dims[0] % 256 != 0) ||
+        tensor->dims[0] > UINT32_MAX || tensor->dims[1] > UINT32_MAX ||
+        tensor->nbytes > SIZE_MAX) return -1;
+    matrix->data = (uint8_t *)malloc((size_t)tensor->nbytes);
+    if (!matrix->data) return -1;
+    if (coli_gemma4_gguf_read(gguf, tensor, matrix->data,
+                              (size_t)tensor->nbytes) != 0) {
+        free(matrix->data);
+        memset(matrix, 0, sizeof(*matrix));
+        return -1;
+    }
+    matrix->gguf = gguf;
+    matrix->tensor = tensor;
+    matrix->input_width = (uint32_t)tensor->dims[0];
+    matrix->output_width = (uint32_t)tensor->dims[1];
+    return 0;
+}
+
+void coli_gemma4_matrix_close(coli_gemma4_matrix *matrix) {
+    if (!matrix) return;
+    free(matrix->data);
+    memset(matrix, 0, sizeof(*matrix));
+}
+
+int coli_gemma4_matrix_matvec(const coli_gemma4_matrix *matrix,
+                              const float *input, float *output) {
+    if (!matrix || !matrix->data || !input || !output) return -1;
+    if (matrix->tensor->type == COLI_GGML_TYPE_Q4_0)
+        return coli_gemma4_q4_0_matvec(matrix->data, matrix->output_width,
+                                       matrix->input_width, input, output);
+    if (matrix->tensor->type == COLI_GGML_TYPE_Q6_K)
+        return coli_gemma4_q6_k_matvec(matrix->data, matrix->output_width,
+                                       matrix->input_width, input, output);
+    return -1;
+}
+
+int coli_gemma4_matrix_row(const coli_gemma4_matrix *matrix, uint32_t row,
+                           float *output) {
+    if (!matrix || !matrix->data || !output ||
+        matrix->tensor->type != COLI_GGML_TYPE_Q6_K) return -1;
+    return coli_gemma4_q6_k_row(matrix->data, matrix->output_width,
+                                matrix->input_width, row, output);
+}
+
+static void model_io_error(coli_gemma4_model_io *io,
+                           const char *format, ...) {
+    va_list arguments;
+    if (!io) return;
+    va_start(arguments, format);
+    vsnprintf(io->last_error, sizeof(io->last_error), format, arguments);
+    va_end(arguments);
+}
+
+int coli_gemma4_model_io_open(coli_gemma4_model_io *io,
+                              const coli_gemma4_gguf *gguf) {
+    const coli_gemma4_tensor *norm;
+    if (!io || !gguf) return -1;
+    memset(io, 0, sizeof(*io));
+    io->gguf = gguf;
+    io->model_width = gguf->config.n_embd;
+    io->vocab_size = gguf->config.n_vocab;
+    io->embedding_scale = sqrtf((float)io->model_width);
+    io->logit_softcap = gguf->final_logit_softcap;
+    if (!io->model_width || !io->vocab_size ||
+        !isfinite(io->embedding_scale) ||
+        !isfinite(io->logit_softcap) || io->logit_softcap < 0.0F) {
+        model_io_error(io, "invalid Gemma 4 model I/O configuration");
+        return -1;
+    }
+    if (coli_gemma4_matrix_open(&io->embedding, gguf,
+                                "token_embd.weight") != 0 ||
+        io->embedding.input_width != io->model_width ||
+        io->embedding.output_width != io->vocab_size) {
+        model_io_error(io, "invalid token_embd.weight tensor");
+        goto fail;
+    }
+    if (coli_gemma4_gguf_find(gguf, "output.weight")) {
+        if (coli_gemma4_matrix_open(&io->output, gguf, "output.weight") != 0 ||
+            io->output.input_width != io->model_width ||
+            io->output.output_width != io->vocab_size) {
+            model_io_error(io, "invalid output.weight tensor");
+            goto fail;
+        }
+    } else {
+        io->tied_output = 1;
+    }
+    norm = coli_gemma4_gguf_find(gguf, "output_norm.weight");
+    if (!tensor_is(norm, COLI_GGML_TYPE_F32, 1, io->model_width, 0) ||
+        norm->nbytes != (uint64_t)io->model_width * sizeof(float) ||
+        norm->nbytes > SIZE_MAX) {
+        model_io_error(io, "invalid output_norm.weight tensor");
+        goto fail;
+    }
+    io->output_norm = (float *)malloc((size_t)norm->nbytes);
+    if (!io->output_norm ||
+        coli_gemma4_gguf_read(gguf, norm, io->output_norm,
+                              (size_t)norm->nbytes) != 0) {
+        model_io_error(io, "cannot read output_norm.weight tensor");
+        goto fail;
+    }
+    return 0;
+
+fail:
+    {
+        char saved[COLI_GEMMA4_GGUF_ERROR_MAX];
+        memcpy(saved, io->last_error, sizeof(saved));
+        coli_gemma4_model_io_close(io);
+        memcpy(io->last_error, saved, sizeof(saved));
+    }
+    return -1;
+}
+
+void coli_gemma4_model_io_close(coli_gemma4_model_io *io) {
+    if (!io) return;
+    coli_gemma4_matrix_close(&io->embedding);
+    coli_gemma4_matrix_close(&io->output);
+    free(io->output_norm);
+    memset(io, 0, sizeof(*io));
+}
+
+const char *coli_gemma4_model_io_last_error(const coli_gemma4_model_io *io) {
+    return io ? io->last_error : "invalid Gemma 4 model I/O";
+}
+
+int coli_gemma4_model_embed(const coli_gemma4_model_io *io, uint32_t token,
+                            float *embedding) {
+    uint32_t index;
+    if (!io || !embedding || token >= io->vocab_size ||
+        coli_gemma4_matrix_row(&io->embedding, token, embedding) != 0)
+        return -1;
+    for (index = 0; index < io->model_width; ++index)
+        embedding[index] *= io->embedding_scale;
+    return 0;
+}
+
+int coli_gemma4_model_logits(const coli_gemma4_model_io *io,
+                             const float *residual, float *normalized,
+                             float *logits) {
+    const coli_gemma4_matrix *output;
+    uint32_t token;
+    if (!io || !residual || !normalized || !logits || !io->output_norm)
+        return -1;
+    output = io->tied_output ? &io->embedding : &io->output;
+    if (coli_gemma4_rmsnorm(residual, io->output_norm, io->model_width,
+                            io->gguf->rms_epsilon, normalized) != 0 ||
+        coli_gemma4_matrix_matvec(output, normalized, logits) != 0)
+        return -1;
+    if (io->logit_softcap > 0.0F) {
+        for (token = 0; token < io->vocab_size; ++token)
+            logits[token] = io->logit_softcap *
+                tanhf(logits[token] / io->logit_softcap);
+    }
+    return 0;
+}
+
+static void model_error(coli_gemma4_model *model, const char *format, ...) {
+    va_list arguments;
+    if (!model) return;
+    va_start(arguments, format);
+    vsnprintf(model->last_error, sizeof(model->last_error), format, arguments);
+    va_end(arguments);
+}
+
+int coli_gemma4_model_open(coli_gemma4_model *model,
+                           const coli_gemma4_gguf *gguf,
+                           const coli_expert_backend *experts,
+                           uint32_t maximum_tokens) {
+    uint32_t layer;
+    if (!model || !gguf || !experts || !maximum_tokens) return -1;
+    memset(model, 0, sizeof(*model));
+    model->gguf = gguf;
+    model->experts = *experts;
+    model->layer_count = gguf->config.n_layer;
+    model->maximum_tokens = maximum_tokens;
+    if (!model->layer_count || !experts->prepare_layer ||
+        !experts->run_experts || !experts->release_layer) {
+        model_error(model, "invalid Gemma 4 model runner configuration");
+        return -1;
+    }
+    if (coli_gemma4_model_io_open(&model->io, gguf) != 0) {
+        model_error(model, "%s", coli_gemma4_model_io_last_error(&model->io));
+        goto fail;
+    }
+    model->layers = (coli_gemma4_decoder_layer *)calloc(
+        model->layer_count, sizeof(*model->layers));
+    model->caches = (coli_gemma4_kv_cache *)calloc(
+        model->layer_count, sizeof(*model->caches));
+    if (!model->layers || !model->caches) {
+        model_error(model, "out of memory allocating Gemma 4 layers");
+        goto fail;
+    }
+    for (layer = 0; layer < model->layer_count; ++layer) {
+        if (coli_gemma4_decoder_layer_open(&model->layers[layer], gguf,
+                                           layer) != 0) {
+            model_error(model, "layer %u: %s", layer,
+                        coli_gemma4_decoder_layer_last_error(
+                            &model->layers[layer]));
+            goto fail;
+        }
+        if (coli_gemma4_kv_cache_init(&model->caches[layer],
+                                      &model->layers[layer].attention,
+                                      maximum_tokens) != 0) {
+            model_error(model, "layer %u: cannot allocate KV cache", layer);
+            goto fail;
+        }
+    }
+    return 0;
+
+fail:
+    {
+        char saved[COLI_GEMMA4_GGUF_ERROR_MAX];
+        memcpy(saved, model->last_error, sizeof(saved));
+        coli_gemma4_model_close(model);
+        memcpy(model->last_error, saved, sizeof(saved));
+    }
+    return -1;
+}
+
+void coli_gemma4_model_close(coli_gemma4_model *model) {
+    uint32_t layer;
+    if (!model) return;
+    for (layer = 0; layer < model->layer_count; ++layer) {
+        if (model->caches) coli_gemma4_kv_cache_close(&model->caches[layer]);
+        if (model->layers)
+            coli_gemma4_decoder_layer_close(&model->layers[layer]);
+    }
+    free(model->caches);
+    free(model->layers);
+    coli_gemma4_model_io_close(&model->io);
+    memset(model, 0, sizeof(*model));
+}
+
+const char *coli_gemma4_model_last_error(const coli_gemma4_model *model) {
+    return model ? model->last_error : "invalid Gemma 4 model runner";
+}
+
+int coli_gemma4_model_step_cancelable(coli_gemma4_model *model,
+                                      uint32_t token, uint64_t position,
+                                      float *final_residual, float *logits,
+                                      int (*cancelled)(void *), void *opaque) {
+    float *current = NULL, *next = NULL, *normalized = NULL;
+    float *lookahead_weights = NULL;
+    uint32_t *lookahead_ids = NULL;
+    uint32_t layer;
+    size_t vector_bytes;
+    int status = -1;
+    if (!model || !model->layers || !model->caches ||
+        position != model->next_position || position >= model->maximum_tokens)
+        return -1;
+    vector_bytes = (size_t)model->io.model_width * sizeof(float);
+    current = (float *)malloc(vector_bytes);
+    next = (float *)malloc(vector_bytes);
+    if (logits) normalized = (float *)malloc(vector_bytes);
+    if (model->experts.prefetch_layer) {
+        lookahead_ids = (uint32_t *)malloc(
+            (size_t)model->gguf->config.n_expert_used * sizeof(*lookahead_ids));
+        lookahead_weights = (float *)malloc(
+            (size_t)model->gguf->config.n_expert_used *
+            sizeof(*lookahead_weights));
+    }
+    if (!current || !next || (logits && !normalized) ||
+        (model->experts.prefetch_layer &&
+         (!lookahead_ids || !lookahead_weights))) {
+        model_error(model, "out of memory allocating token workspace");
+        goto cleanup;
+    }
+    if (coli_gemma4_model_embed(&model->io, token, current) != 0) {
+        model_error(model, "cannot decode embedding for token %u", token);
+        goto cleanup;
+    }
+    for (layer = 0; layer < model->layer_count; ++layer) {
+        float *swap;
+        if (cancelled && cancelled(opaque)) {
+            status = 1;
+            goto cleanup;
+        }
+        if (coli_gemma4_decoder_layer_step(
+                &model->layers[layer], &model->caches[layer], &model->experts,
+                position, current, next) != 0) {
+            model_error(model, "decoder layer %u failed at position %llu",
+                        layer, (unsigned long long)position);
+            goto cleanup;
+        }
+        swap = current;
+        current = next;
+        next = swap;
+        if (layer + 1 < model->layer_count &&
+            model->experts.prefetch_layer &&
+            (coli_gemma4_router_route(
+                 &model->layers[layer + 1].router, current, NULL,
+                 lookahead_ids, lookahead_weights, NULL) != 0 ||
+             model->experts.prefetch_layer(
+                 model->experts.ctx, layer + 1, lookahead_ids,
+                 model->layers[layer + 1].router.selected_count) != 0)) {
+            model_error(model,
+                        "next-layer expert lookahead failed after layer %u",
+                        layer);
+            goto cleanup;
+        }
+    }
+    if (final_residual) memcpy(final_residual, current, vector_bytes);
+    if (logits && coli_gemma4_model_logits(&model->io, current, normalized,
+                                           logits) != 0) {
+        model_error(model, "LM head failed at position %llu",
+                    (unsigned long long)position);
+        goto cleanup;
+    }
+    ++model->next_position;
+    status = 0;
+
+cleanup:
+    free(current);
+    free(next);
+    free(normalized);
+    free(lookahead_ids);
+    free(lookahead_weights);
+    return status;
+}
+
+int coli_gemma4_model_step(coli_gemma4_model *model, uint32_t token,
+                           uint64_t position, float *final_residual,
+                           float *logits) {
+    return coli_gemma4_model_step_cancelable(
+        model, token, position, final_residual, logits, NULL, NULL);
+}
+
+int coli_gemma4_model_image_embeddings(coli_gemma4_model *model,
+                                       const float *embeddings,
+                                       uint32_t token_count,
+                                       uint64_t start_position,
+                                       float *final_residuals) {
+    float *current = NULL, *next = NULL;
+    uint32_t layer;
+    uint64_t value_count;
+    size_t buffer_bytes;
+    int status = -1;
+    if (!model || !model->layers || !model->caches || !embeddings ||
+        !token_count || start_position != model->next_position ||
+        start_position >= model->maximum_tokens ||
+        token_count > model->maximum_tokens - start_position)
+        return -1;
+    value_count = (uint64_t)token_count * model->io.model_width;
+    if (value_count > SIZE_MAX / sizeof(float)) return -1;
+    buffer_bytes = (size_t)value_count * sizeof(float);
+    current = (float *)malloc(buffer_bytes);
+    next = (float *)malloc(buffer_bytes);
+    if (!current || !next) {
+        model_error(model, "out of memory allocating image-token workspace");
+        goto cleanup;
+    }
+    memcpy(current, embeddings, buffer_bytes);
+    for (layer = 0; layer < model->layer_count; ++layer) {
+        float *swap;
+        if (coli_gemma4_decoder_layer_noncausal(
+                &model->layers[layer], &model->caches[layer], &model->experts,
+                start_position, current, token_count, next) != 0) {
+            model_error(model,
+                        "decoder layer %u failed for %u image tokens at position %llu",
+                        layer, token_count, (unsigned long long)start_position);
+            goto cleanup;
+        }
+        swap = current;
+        current = next;
+        next = swap;
+    }
+    if (final_residuals) memcpy(final_residuals, current, buffer_bytes);
+    model->next_position += token_count;
+    status = 0;
+cleanup:
+    free(current);
+    free(next);
+    return status;
+}
+
+static void attention_error(coli_gemma4_attention *attention,
+                            const char *format, ...) {
+    va_list arguments;
+    if (!attention) return;
+    va_start(arguments, format);
+    vsnprintf(attention->last_error, sizeof(attention->last_error),
+              format, arguments);
+    va_end(arguments);
+}
+
+static int attention_name(char *name, size_t capacity, uint32_t layer,
+                          const char *suffix) {
+    int length = snprintf(name, capacity, "blk.%u.%s", layer, suffix);
+    return length >= 0 && (size_t)length < capacity ? 0 : -1;
+}
+
+static int attention_read_norm(coli_gemma4_attention *attention,
+                               const char *suffix, uint32_t width,
+                               float **result) {
+    char name[128];
+    const coli_gemma4_tensor *tensor;
+    float *values;
+    if (attention_name(name, sizeof(name), attention->layer, suffix) != 0)
+        return -1;
+    tensor = coli_gemma4_gguf_find(attention->gguf, name);
+    if (!tensor_is(tensor, COLI_GGML_TYPE_F32, 1, width, 0) ||
+        tensor->nbytes != (uint64_t)width * sizeof(float) ||
+        tensor->nbytes > SIZE_MAX) {
+        attention_error(attention, "invalid attention norm tensor %s", name);
+        return -1;
+    }
+    values = (float *)malloc((size_t)tensor->nbytes);
+    if (!values || coli_gemma4_gguf_read(attention->gguf, tensor, values,
+                                         (size_t)tensor->nbytes) != 0) {
+        free(values);
+        attention_error(attention, "cannot read attention norm tensor %s", name);
+        return -1;
+    }
+    *result = values;
+    return 0;
+}
+
+static int attention_open_matrix(coli_gemma4_attention *attention,
+                                 const char *suffix,
+                                 coli_gemma4_matrix *matrix,
+                                 uint32_t input_width,
+                                 uint32_t output_width) {
+    char name[128];
+    if (attention_name(name, sizeof(name), attention->layer, suffix) != 0 ||
+        coli_gemma4_matrix_open(matrix, attention->gguf, name) != 0 ||
+        matrix->input_width != input_width ||
+        matrix->output_width != output_width) {
+        coli_gemma4_matrix_close(matrix);
+        attention_error(attention, "invalid attention projection %s", name);
+        return -1;
+    }
+    return 0;
+}
+
+int coli_gemma4_attention_open(coli_gemma4_attention *attention,
+                               const coli_gemma4_gguf *gguf, uint32_t layer) {
+    uint32_t query_width, kv_width;
+    if (!attention || !gguf) return -1;
+    memset(attention, 0, sizeof(*attention));
+    attention->gguf = gguf;
+    attention->layer = layer;
+    if (layer >= gguf->config.n_layer) {
+        attention_error(attention, "attention layer %u is outside the model", layer);
+        return -1;
+    }
+    attention->model_width = gguf->config.n_embd;
+    attention->query_heads = gguf->attention_heads;
+    attention->kv_heads = gguf->head_count_kv[layer];
+    attention->sliding = gguf->sliding_window_pattern[layer] != 0;
+    attention->head_dim = attention->sliding ?
+        gguf->key_length_swa : gguf->key_length;
+    if (!attention->model_width || !attention->query_heads ||
+        !attention->kv_heads || !attention->head_dim ||
+        attention->query_heads > UINT32_MAX / attention->head_dim ||
+        attention->kv_heads > UINT32_MAX / attention->head_dim) {
+        attention_error(attention, "invalid attention geometry for layer %u", layer);
+        return -1;
+    }
+    query_width = attention->query_heads * attention->head_dim;
+    kv_width = attention->kv_heads * attention->head_dim;
+    if (attention_open_matrix(attention, "attn_q.weight", &attention->query,
+                              attention->model_width, query_width) != 0 ||
+        attention_open_matrix(attention, "attn_k.weight", &attention->key,
+                              attention->model_width, kv_width) != 0 ||
+        attention_open_matrix(attention, "attn_output.weight", &attention->output,
+                              query_width, attention->model_width) != 0)
+        goto fail;
+    {
+        char value_name[128];
+        const coli_gemma4_tensor *value_tensor;
+        if (attention_name(value_name, sizeof(value_name), layer,
+                           "attn_v.weight") != 0) goto fail;
+        value_tensor = coli_gemma4_gguf_find(gguf, value_name);
+        if (value_tensor) {
+            if (attention_open_matrix(attention, "attn_v.weight", &attention->value,
+                                      attention->model_width, kv_width) != 0)
+                goto fail;
+        } else {
+            attention->key_equals_value = 1;
+        }
+    }
+    if (attention_read_norm(attention, "attn_norm.weight",
+                            attention->model_width, &attention->input_norm) != 0 ||
+        attention_read_norm(attention, "attn_q_norm.weight",
+                            attention->head_dim, &attention->query_norm) != 0 ||
+        attention_read_norm(attention, "attn_k_norm.weight",
+                            attention->head_dim, &attention->key_norm) != 0)
+        goto fail;
+    if (!attention->sliding) {
+        const coli_gemma4_tensor *factors =
+            coli_gemma4_gguf_find(gguf, "rope_freqs.weight");
+        uint32_t factor_count = attention->head_dim / 2;
+        if (!tensor_is(factors, COLI_GGML_TYPE_F32, 1, factor_count, 0) ||
+            factors->nbytes != (uint64_t)factor_count * sizeof(float) ||
+            factors->nbytes > SIZE_MAX) {
+            attention_error(attention, "invalid global RoPE frequency factors");
+            goto fail;
+        }
+        attention->rope_factors = (float *)malloc((size_t)factors->nbytes);
+        if (!attention->rope_factors ||
+            coli_gemma4_gguf_read(gguf, factors, attention->rope_factors,
+                                  (size_t)factors->nbytes) != 0) {
+            attention_error(attention, "cannot read global RoPE frequency factors");
+            goto fail;
+        }
+        attention->rope_factor_count = factor_count;
+    }
+    return 0;
+
+fail:
+    {
+        char saved[COLI_GEMMA4_GGUF_ERROR_MAX];
+        memcpy(saved, attention->last_error, sizeof(saved));
+        coli_gemma4_attention_close(attention);
+        memcpy(attention->last_error, saved, sizeof(saved));
+    }
+    return -1;
+}
+
+void coli_gemma4_attention_close(coli_gemma4_attention *attention) {
+    if (!attention) return;
+    coli_gemma4_matrix_close(&attention->query);
+    coli_gemma4_matrix_close(&attention->key);
+    coli_gemma4_matrix_close(&attention->value);
+    coli_gemma4_matrix_close(&attention->output);
+    free(attention->input_norm);
+    free(attention->query_norm);
+    free(attention->key_norm);
+    free(attention->rope_factors);
+    memset(attention, 0, sizeof(*attention));
+}
+
+const char *coli_gemma4_attention_last_error(
+    const coli_gemma4_attention *attention) {
+    return attention ? attention->last_error : "invalid Gemma attention";
+}
+
+static int rmsnorm_heads(float *values, uint32_t heads, uint32_t head_dim,
+                         const float *weight, float epsilon) {
+    uint32_t head;
+    for (head = 0; head < heads; ++head) {
+        float *row = values + (size_t)head * head_dim;
+        float sum_squares = 0.0F, inverse_rms;
+        uint32_t i;
+        for (i = 0; i < head_dim; ++i) {
+            if (!isfinite(row[i]) || (weight && !isfinite(weight[i]))) return -1;
+            sum_squares += row[i] * row[i];
+        }
+        inverse_rms = 1.0F / sqrtf(sum_squares / (float)head_dim + epsilon);
+        for (i = 0; i < head_dim; ++i)
+            row[i] *= inverse_rms * (weight ? weight[i] : 1.0F);
+    }
+    return 0;
+}
+
+int coli_gemma4_attention_project(const coli_gemma4_attention *attention,
+                                  const float *residual,
+                                  float *query, float *key, float *value) {
+    float *normalized;
+    uint32_t kv_width;
+    if (!attention || !residual || !query || !key || !value ||
+        !attention->input_norm || !attention->query_norm || !attention->key_norm)
+        return -1;
+    normalized = (float *)malloc((size_t)attention->model_width * sizeof(float));
+    if (!normalized) return -1;
+    if (coli_gemma4_rmsnorm(residual, attention->input_norm,
+                            attention->model_width, attention->gguf->rms_epsilon,
+                            normalized) != 0 ||
+        coli_gemma4_matrix_matvec(&attention->query, normalized, query) != 0 ||
+        coli_gemma4_matrix_matvec(&attention->key, normalized, key) != 0) {
+        free(normalized);
+        return -1;
+    }
+    kv_width = attention->kv_heads * attention->head_dim;
+    if (attention->key_equals_value) memcpy(value, key, (size_t)kv_width * sizeof(float));
+    else if (coli_gemma4_matrix_matvec(&attention->value, normalized, value) != 0) {
+        free(normalized);
+        return -1;
+    }
+    free(normalized);
+    if (rmsnorm_heads(query, attention->query_heads, attention->head_dim,
+                      attention->query_norm, attention->gguf->rms_epsilon) != 0 ||
+        rmsnorm_heads(key, attention->kv_heads, attention->head_dim,
+                      attention->key_norm, attention->gguf->rms_epsilon) != 0 ||
+        rmsnorm_heads(value, attention->kv_heads, attention->head_dim,
+                      NULL, attention->gguf->rms_epsilon) != 0)
+        return -1;
+    return 0;
+}
+
+static int apply_rope_heads(float *values, uint32_t heads, uint32_t head_dim,
+                            uint64_t position, float base,
+                            const float *factors, uint32_t factor_count) {
+    uint32_t head, index, half = head_dim / 2;
+    float position_f = (float)position;
+    if (!values || !heads || !head_dim || head_dim % 2 ||
+        !isfinite(base) || base <= 0.0F ||
+        (factors && factor_count != half)) return -1;
+    for (index = 0; index < half; ++index) {
+        float factor = factors ? factors[index] : 1.0F;
+        float frequency, angle, cosine, sine;
+        if (!isfinite(factor) || factor <= 0.0F) return -1;
+        frequency = powf(base, -2.0F * (float)index / (float)head_dim) / factor;
+        angle = position_f * frequency;
+        cosine = cosf(angle);
+        sine = sinf(angle);
+        for (head = 0; head < heads; ++head) {
+            float *row = values + (size_t)head * head_dim;
+            float first = row[index], second = row[index + half];
+            row[index] = first * cosine - second * sine;
+            row[index + half] = second * cosine + first * sine;
+        }
+    }
+    return 0;
+}
+
+int coli_gemma4_attention_apply_rope(const coli_gemma4_attention *attention,
+                                     uint64_t position, float *query, float *key) {
+    float base;
+    if (!attention || !attention->gguf || !query || !key) return -1;
+    base = attention->sliding ? attention->gguf->rope_freq_base_swa :
+                                attention->gguf->rope_freq_base;
+    if (apply_rope_heads(query, attention->query_heads, attention->head_dim,
+                         position, base, attention->rope_factors,
+                         attention->rope_factor_count) != 0 ||
+        apply_rope_heads(key, attention->kv_heads, attention->head_dim,
+                         position, base, attention->rope_factors,
+                         attention->rope_factor_count) != 0)
+        return -1;
+    return 0;
+}
+
+int coli_gemma4_kv_cache_init(coli_gemma4_kv_cache *cache,
+                              const coli_gemma4_attention *attention,
+                              uint32_t maximum_tokens) {
+    uint32_t capacity, i;
+    uint64_t value_count;
+    if (!cache || !attention || !maximum_tokens) return -1;
+    memset(cache, 0, sizeof(*cache));
+    capacity = maximum_tokens;
+    if (attention->sliding && attention->gguf->config.sliding_window < capacity)
+        capacity = attention->gguf->config.sliding_window;
+    if (!capacity || attention->kv_heads > UINT32_MAX / attention->head_dim)
+        return -1;
+    cache->kv_width = attention->kv_heads * attention->head_dim;
+    value_count = (uint64_t)capacity * cache->kv_width;
+    if (value_count > SIZE_MAX / sizeof(float)) return -1;
+    cache->positions = (uint64_t *)malloc((size_t)capacity * sizeof(uint64_t));
+    cache->keys = (float *)malloc((size_t)value_count * sizeof(float));
+    cache->values = (float *)malloc((size_t)value_count * sizeof(float));
+    if (!cache->positions || !cache->keys || !cache->values) {
+        coli_gemma4_kv_cache_close(cache);
+        return -1;
+    }
+    cache->capacity = capacity;
+    cache->sliding = attention->sliding;
+    for (i = 0; i < capacity; ++i) cache->positions[i] = UINT64_MAX;
+    return 0;
+}
+
+void coli_gemma4_kv_cache_close(coli_gemma4_kv_cache *cache) {
+    if (!cache) return;
+    free(cache->positions);
+    free(cache->keys);
+    free(cache->values);
+    memset(cache, 0, sizeof(*cache));
+}
+
+int coli_gemma4_kv_cache_store(coli_gemma4_kv_cache *cache, uint64_t position,
+                               const float *key, const float *value) {
+    uint64_t slot;
+    if (!cache || !cache->capacity || !key || !value) return -1;
+    if (cache->sliding) slot = position % cache->capacity;
+    else {
+        if (position >= cache->capacity) return -1;
+        slot = position;
+    }
+    memcpy(cache->keys + (size_t)slot * cache->kv_width, key,
+           (size_t)cache->kv_width * sizeof(float));
+    memcpy(cache->values + (size_t)slot * cache->kv_width, value,
+           (size_t)cache->kv_width * sizeof(float));
+    if (cache->positions[slot] == UINT64_MAX && cache->count < cache->capacity)
+        ++cache->count;
+    cache->positions[slot] = position;
+    return 0;
+}
+
+int coli_gemma4_kv_cache_find(const coli_gemma4_kv_cache *cache,
+                              uint64_t position,
+                              const float **key, const float **value) {
+    uint64_t slot;
+    if (!cache || !cache->capacity || !key || !value) return -1;
+    if (cache->sliding) slot = position % cache->capacity;
+    else {
+        if (position >= cache->capacity) return -1;
+        slot = position;
+    }
+    if (cache->positions[slot] != position) return -1;
+    *key = cache->keys + (size_t)slot * cache->kv_width;
+    *value = cache->values + (size_t)slot * cache->kv_width;
+    return 0;
+}
+
+int coli_gemma4_attention_step(const coli_gemma4_attention *attention,
+                               coli_gemma4_kv_cache *cache,
+                               uint64_t position, const float *residual,
+                               float *output) {
+    float *query = NULL, *key = NULL, *value = NULL;
+    float *context = NULL, *scores = NULL;
+    uint32_t query_width, kv_width, queries_per_kv, head;
+    uint64_t first_position, history_count, history_index;
+    int status = -1;
+    if (!attention || !cache || !residual || !output ||
+        !cache->capacity || cache->sliding != attention->sliding ||
+        attention->query_heads % attention->kv_heads != 0 ||
+        attention->query_heads > UINT32_MAX / attention->head_dim ||
+        attention->kv_heads > UINT32_MAX / attention->head_dim)
+        return -1;
+    query_width = attention->query_heads * attention->head_dim;
+    kv_width = attention->kv_heads * attention->head_dim;
+    if (cache->kv_width != kv_width) return -1;
+    query = (float *)malloc((size_t)query_width * sizeof(float));
+    key = (float *)malloc((size_t)kv_width * sizeof(float));
+    value = (float *)malloc((size_t)kv_width * sizeof(float));
+    context = (float *)calloc(query_width, sizeof(float));
+    scores = (float *)malloc((size_t)cache->capacity * sizeof(float));
+    if (!query || !key || !value || !context || !scores) goto cleanup;
+    if (coli_gemma4_attention_project(attention, residual, query, key, value) != 0 ||
+        coli_gemma4_attention_apply_rope(attention, position, query, key) != 0 ||
+        coli_gemma4_kv_cache_store(cache, position, key, value) != 0)
+        goto cleanup;
+
+    first_position = 0;
+    if (cache->sliding && position >= cache->capacity)
+        first_position = position - cache->capacity + 1;
+    history_count = position - first_position + 1;
+    if (!history_count || history_count > cache->capacity) goto cleanup;
+    queries_per_kv = attention->query_heads / attention->kv_heads;
+    for (head = 0; head < attention->query_heads; ++head) {
+        const float *query_head = query + (size_t)head * attention->head_dim;
+        float *context_head = context + (size_t)head * attention->head_dim;
+        uint32_t kv_head = head / queries_per_kv;
+        float maximum = -FLT_MAX, denominator = 0.0F;
+        for (history_index = 0; history_index < history_count; ++history_index) {
+            const float *cached_key, *cached_value;
+            const float *key_head;
+            float score = 0.0F;
+            uint32_t dimension;
+            uint64_t cached_position = first_position + history_index;
+            if (coli_gemma4_kv_cache_find(cache, cached_position,
+                                          &cached_key, &cached_value) != 0)
+                goto cleanup;
+            (void)cached_value;
+            key_head = cached_key + (size_t)kv_head * attention->head_dim;
+            for (dimension = 0; dimension < attention->head_dim; ++dimension)
+                score += query_head[dimension] * key_head[dimension];
+            if (!isfinite(score)) goto cleanup;
+            scores[history_index] = score;
+            if (score > maximum) maximum = score;
+        }
+        for (history_index = 0; history_index < history_count; ++history_index) {
+            scores[history_index] = expf(scores[history_index] - maximum);
+            denominator += scores[history_index];
+        }
+        if (!isfinite(denominator) || denominator <= 0.0F) goto cleanup;
+        for (history_index = 0; history_index < history_count; ++history_index) {
+            const float *cached_key, *cached_value;
+            const float *value_head;
+            float probability = scores[history_index] / denominator;
+            uint32_t dimension;
+            uint64_t cached_position = first_position + history_index;
+            if (coli_gemma4_kv_cache_find(cache, cached_position,
+                                          &cached_key, &cached_value) != 0)
+                goto cleanup;
+            (void)cached_key;
+            value_head = cached_value + (size_t)kv_head * attention->head_dim;
+            for (dimension = 0; dimension < attention->head_dim; ++dimension)
+                context_head[dimension] += probability * value_head[dimension];
+        }
+    }
+    if (coli_gemma4_matrix_matvec(&attention->output, context, output) != 0)
+        goto cleanup;
+    status = 0;
+
+cleanup:
+    free(query); free(key); free(value); free(context); free(scores);
+    return status;
+}
+
+int coli_gemma4_attention_noncausal(
+    const coli_gemma4_attention *attention, coli_gemma4_kv_cache *cache,
+    uint64_t start_position, const float *residuals, uint32_t token_count,
+    float *outputs) {
+    float *queries = NULL, *keys = NULL, *values = NULL;
+    float *context = NULL, *scores = NULL;
+    uint32_t query_width, kv_width, queries_per_kv, token, head;
+    uint64_t end_position, first_position, history_count, history_index;
+    uint64_t query_values, kv_values;
+    int status = -1;
+    if (!attention || !cache || !residuals || !outputs || !token_count ||
+        !cache->capacity || cache->sliding != attention->sliding ||
+        attention->query_heads % attention->kv_heads != 0 ||
+        attention->query_heads > UINT32_MAX / attention->head_dim ||
+        attention->kv_heads > UINT32_MAX / attention->head_dim ||
+        start_position > UINT64_MAX - token_count)
+        return -1;
+    query_width = attention->query_heads * attention->head_dim;
+    kv_width = attention->kv_heads * attention->head_dim;
+    if (cache->kv_width != kv_width || token_count > cache->capacity)
+        return -1;
+    query_values = (uint64_t)token_count * query_width;
+    kv_values = (uint64_t)token_count * kv_width;
+    if (query_values > SIZE_MAX / sizeof(float) ||
+        kv_values > SIZE_MAX / sizeof(float)) return -1;
+    queries = (float *)malloc((size_t)query_values * sizeof(float));
+    keys = (float *)malloc((size_t)kv_values * sizeof(float));
+    values = (float *)malloc((size_t)kv_values * sizeof(float));
+    context = (float *)malloc((size_t)query_width * sizeof(float));
+    scores = (float *)malloc((size_t)cache->capacity * sizeof(float));
+    if (!queries || !keys || !values || !context || !scores) goto cleanup;
+    for (token = 0; token < token_count; ++token) {
+        uint64_t position = start_position + token;
+        const float *residual = residuals +
+            (size_t)token * attention->model_width;
+        float *query = queries + (size_t)token * query_width;
+        float *key = keys + (size_t)token * kv_width;
+        float *value = values + (size_t)token * kv_width;
+        if (coli_gemma4_attention_project(
+                attention, residual, query, key, value) != 0 ||
+            coli_gemma4_attention_apply_rope(
+                attention, position, query, key) != 0 ||
+            coli_gemma4_kv_cache_store(cache, position, key, value) != 0)
+            goto cleanup;
+    }
+    end_position = start_position + token_count - 1;
+    first_position = 0;
+    if (cache->sliding && end_position >= cache->capacity)
+        first_position = end_position - cache->capacity + 1;
+    history_count = end_position - first_position + 1;
+    if (!history_count || history_count > cache->capacity) goto cleanup;
+    queries_per_kv = attention->query_heads / attention->kv_heads;
+    for (token = 0; token < token_count; ++token) {
+        const float *query = queries + (size_t)token * query_width;
+        float *output = outputs + (size_t)token * attention->model_width;
+        memset(context, 0, (size_t)query_width * sizeof(float));
+        for (head = 0; head < attention->query_heads; ++head) {
+            const float *query_head = query + (size_t)head * attention->head_dim;
+            float *context_head = context + (size_t)head * attention->head_dim;
+            uint32_t kv_head = head / queries_per_kv;
+            float maximum = -FLT_MAX, denominator = 0.0F;
+            for (history_index = 0; history_index < history_count;
+                 ++history_index) {
+                const float *cached_key, *cached_value, *key_head;
+                float score = 0.0F;
+                uint32_t dimension;
+                uint64_t cached_position = first_position + history_index;
+                if (coli_gemma4_kv_cache_find(
+                        cache, cached_position,
+                        &cached_key, &cached_value) != 0)
+                    goto cleanup;
+                (void)cached_value;
+                key_head = cached_key + (size_t)kv_head * attention->head_dim;
+                for (dimension = 0; dimension < attention->head_dim; ++dimension)
+                    score += query_head[dimension] * key_head[dimension];
+                if (!isfinite(score)) goto cleanup;
+                scores[history_index] = score;
+                if (score > maximum) maximum = score;
+            }
+            for (history_index = 0; history_index < history_count;
+                 ++history_index) {
+                scores[history_index] = expf(scores[history_index] - maximum);
+                denominator += scores[history_index];
+            }
+            if (!isfinite(denominator) || denominator <= 0.0F) goto cleanup;
+            for (history_index = 0; history_index < history_count;
+                 ++history_index) {
+                const float *cached_key, *cached_value, *value_head;
+                float probability = scores[history_index] / denominator;
+                uint32_t dimension;
+                uint64_t cached_position = first_position + history_index;
+                if (coli_gemma4_kv_cache_find(
+                        cache, cached_position,
+                        &cached_key, &cached_value) != 0)
+                    goto cleanup;
+                (void)cached_key;
+                value_head = cached_value +
+                    (size_t)kv_head * attention->head_dim;
+                for (dimension = 0; dimension < attention->head_dim; ++dimension)
+                    context_head[dimension] +=
+                        probability * value_head[dimension];
+            }
+        }
+        if (coli_gemma4_matrix_matvec(
+                &attention->output, context, output) != 0)
+            goto cleanup;
+    }
+    status = 0;
+cleanup:
+    free(queries); free(keys); free(values); free(context); free(scores);
+    return status;
+}
+
+static void dense_mlp_error(coli_gemma4_dense_mlp *mlp,
+                            const char *format, ...) {
+    va_list arguments;
+    if (!mlp) return;
+    va_start(arguments, format);
+    vsnprintf(mlp->last_error, sizeof(mlp->last_error), format, arguments);
+    va_end(arguments);
+}
+
+int coli_gemma4_dense_mlp_open(coli_gemma4_dense_mlp *mlp,
+                               const coli_gemma4_gguf *gguf, uint32_t layer) {
+    char name[128];
+    if (!mlp || !gguf) return -1;
+    memset(mlp, 0, sizeof(*mlp));
+    mlp->gguf = gguf;
+    mlp->layer = layer;
+    mlp->model_width = gguf->config.n_embd;
+    if (layer >= gguf->config.n_layer || !mlp->model_width) {
+        dense_mlp_error(mlp, "dense MLP layer %u is outside the model", layer);
+        return -1;
+    }
+    if (attention_name(name, sizeof(name), layer, "ffn_gate.weight") != 0 ||
+        coli_gemma4_matrix_open(&mlp->gate, gguf, name) != 0 ||
+        mlp->gate.input_width != mlp->model_width ||
+        !mlp->gate.output_width) {
+        dense_mlp_error(mlp, "invalid dense MLP gate projection");
+        goto fail;
+    }
+    mlp->intermediate_width = mlp->gate.output_width;
+    if (attention_name(name, sizeof(name), layer, "ffn_up.weight") != 0 ||
+        coli_gemma4_matrix_open(&mlp->up, gguf, name) != 0 ||
+        mlp->up.input_width != mlp->model_width ||
+        mlp->up.output_width != mlp->intermediate_width) {
+        dense_mlp_error(mlp, "invalid dense MLP up projection");
+        goto fail;
+    }
+    if (attention_name(name, sizeof(name), layer, "ffn_down.weight") != 0 ||
+        coli_gemma4_matrix_open(&mlp->down, gguf, name) != 0 ||
+        mlp->down.input_width != mlp->intermediate_width ||
+        mlp->down.output_width != mlp->model_width) {
+        dense_mlp_error(mlp, "invalid dense MLP down projection");
+        goto fail;
+    }
+    return 0;
+
+fail:
+    {
+        char saved[COLI_GEMMA4_GGUF_ERROR_MAX];
+        memcpy(saved, mlp->last_error, sizeof(saved));
+        coli_gemma4_dense_mlp_close(mlp);
+        memcpy(mlp->last_error, saved, sizeof(saved));
+    }
+    return -1;
+}
+
+void coli_gemma4_dense_mlp_close(coli_gemma4_dense_mlp *mlp) {
+    if (!mlp) return;
+    coli_gemma4_matrix_close(&mlp->gate);
+    coli_gemma4_matrix_close(&mlp->up);
+    coli_gemma4_matrix_close(&mlp->down);
+    memset(mlp, 0, sizeof(*mlp));
+}
+
+const char *coli_gemma4_dense_mlp_last_error(
+    const coli_gemma4_dense_mlp *mlp) {
+    return mlp ? mlp->last_error : "invalid Gemma dense MLP";
+}
+
+int coli_gemma4_dense_mlp_run(const coli_gemma4_dense_mlp *mlp,
+                              const float *input, float *output) {
+    float *gate = NULL, *up = NULL;
+    uint32_t index;
+    int status = -1;
+    if (!mlp || !input || !output || !mlp->intermediate_width) return -1;
+    gate = (float *)malloc((size_t)mlp->intermediate_width * sizeof(float));
+    up = (float *)malloc((size_t)mlp->intermediate_width * sizeof(float));
+    if (!gate || !up) goto cleanup;
+    if (coli_gemma4_matrix_matvec(&mlp->gate, input, gate) != 0 ||
+        coli_gemma4_matrix_matvec(&mlp->up, input, up) != 0)
+        goto cleanup;
+    for (index = 0; index < mlp->intermediate_width; ++index)
+        gate[index] = coli_gemma4_gelu_tanh(gate[index]) * up[index];
+    if (coli_gemma4_matrix_matvec(&mlp->down, gate, output) != 0) goto cleanup;
+    status = 0;
+
+cleanup:
+    free(gate); free(up);
+    return status;
+}
+
+static void decoder_error(coli_gemma4_decoder_layer *decoder,
+                          const char *format, ...) {
+    va_list arguments;
+    if (!decoder) return;
+    va_start(arguments, format);
+    vsnprintf(decoder->last_error, sizeof(decoder->last_error),
+              format, arguments);
+    va_end(arguments);
+}
+
+static int decoder_read_norm(coli_gemma4_decoder_layer *decoder,
+                             const char *suffix, float **result) {
+    char name[128];
+    const coli_gemma4_tensor *tensor;
+    float *values;
+    if (attention_name(name, sizeof(name), decoder->layer, suffix) != 0)
+        return -1;
+    tensor = coli_gemma4_gguf_find(decoder->gguf, name);
+    if (!tensor_is(tensor, COLI_GGML_TYPE_F32, 1,
+                   decoder->model_width, 0) ||
+        tensor->nbytes != (uint64_t)decoder->model_width * sizeof(float) ||
+        tensor->nbytes > SIZE_MAX) {
+        decoder_error(decoder, "invalid decoder norm tensor %s", name);
+        return -1;
+    }
+    values = (float *)malloc((size_t)tensor->nbytes);
+    if (!values || coli_gemma4_gguf_read(decoder->gguf, tensor, values,
+                                         (size_t)tensor->nbytes) != 0) {
+        free(values);
+        decoder_error(decoder, "cannot read decoder norm tensor %s", name);
+        return -1;
+    }
+    *result = values;
+    return 0;
+}
+
+int coli_gemma4_decoder_layer_open(coli_gemma4_decoder_layer *decoder,
+                                   const coli_gemma4_gguf *gguf,
+                                   uint32_t layer) {
+    char name[128];
+    const coli_gemma4_tensor *scale;
+    if (!decoder || !gguf) return -1;
+    memset(decoder, 0, sizeof(*decoder));
+    decoder->gguf = gguf;
+    decoder->layer = layer;
+    decoder->model_width = gguf->config.n_embd;
+    if (layer >= gguf->config.n_layer || !decoder->model_width) {
+        decoder_error(decoder, "decoder layer %u is outside the model", layer);
+        return -1;
+    }
+    if (coli_gemma4_attention_open(&decoder->attention, gguf, layer) != 0) {
+        decoder_error(decoder, "%s",
+                      coli_gemma4_attention_last_error(&decoder->attention));
+        goto fail;
+    }
+    if (coli_gemma4_router_open(&decoder->router, gguf, layer) != 0) {
+        decoder_error(decoder, "%s",
+                      coli_gemma4_router_last_error(&decoder->router));
+        goto fail;
+    }
+    if (coli_gemma4_dense_mlp_open(&decoder->dense_mlp, gguf, layer) != 0) {
+        decoder_error(decoder, "%s",
+                      coli_gemma4_dense_mlp_last_error(&decoder->dense_mlp));
+        goto fail;
+    }
+    if (decoder_read_norm(decoder, "post_attention_norm.weight",
+                          &decoder->post_attention_norm) != 0 ||
+        decoder_read_norm(decoder, "ffn_norm.weight", &decoder->ffn_norm) != 0 ||
+        decoder_read_norm(decoder, "post_ffw_norm_1.weight",
+                          &decoder->post_ffw_norm_1) != 0 ||
+        decoder_read_norm(decoder, "pre_ffw_norm_2.weight",
+                          &decoder->pre_ffw_norm_2) != 0 ||
+        decoder_read_norm(decoder, "post_ffw_norm_2.weight",
+                          &decoder->post_ffw_norm_2) != 0 ||
+        decoder_read_norm(decoder, "post_ffw_norm.weight",
+                          &decoder->post_ffw_norm) != 0)
+        goto fail;
+    if (attention_name(name, sizeof(name), layer,
+                       "layer_output_scale.weight") != 0)
+        goto fail;
+    scale = coli_gemma4_gguf_find(gguf, name);
+    if (!tensor_is(scale, COLI_GGML_TYPE_F32, 1, 1, 0) ||
+        scale->nbytes != sizeof(float) ||
+        coli_gemma4_gguf_read(gguf, scale, &decoder->layer_output_scale,
+                              sizeof(float)) != 0 ||
+        !isfinite(decoder->layer_output_scale)) {
+        decoder_error(decoder, "invalid decoder layer output scale %s", name);
+        goto fail;
+    }
+    return 0;
+
+fail:
+    {
+        char saved[COLI_GEMMA4_GGUF_ERROR_MAX];
+        memcpy(saved, decoder->last_error, sizeof(saved));
+        coli_gemma4_decoder_layer_close(decoder);
+        memcpy(decoder->last_error, saved, sizeof(saved));
+    }
+    return -1;
+}
+
+void coli_gemma4_decoder_layer_close(coli_gemma4_decoder_layer *decoder) {
+    if (!decoder) return;
+    coli_gemma4_attention_close(&decoder->attention);
+    coli_gemma4_router_close(&decoder->router);
+    coli_gemma4_dense_mlp_close(&decoder->dense_mlp);
+    free(decoder->post_attention_norm);
+    free(decoder->ffn_norm);
+    free(decoder->post_ffw_norm_1);
+    free(decoder->pre_ffw_norm_2);
+    free(decoder->post_ffw_norm_2);
+    free(decoder->post_ffw_norm);
+    memset(decoder, 0, sizeof(*decoder));
+}
+
+const char *coli_gemma4_decoder_layer_last_error(
+    const coli_gemma4_decoder_layer *decoder) {
+    return decoder ? decoder->last_error : "invalid Gemma decoder layer";
+}
+
+static int decoder_layer_complete(
+    const coli_gemma4_decoder_layer *decoder,
+    const coli_expert_backend *experts, const float *residual,
+    const float *attention_output, float *output) {
+    float *after_attention = NULL;
+    float *dense_input = NULL, *dense_output = NULL, *dense_normalized = NULL;
+    float *expert_input = NULL, *expert_output = NULL, *expert_normalized = NULL;
+    float *combined = NULL;
+    uint32_t *ids = NULL, index;
+    float *weights = NULL;
+    size_t vector_bytes;
+    int prepared = 0, status = -1;
+    if (!decoder || !experts || !residual || !attention_output || !output ||
+        !experts->prepare_layer || !experts->run_experts ||
+        !experts->release_layer || !decoder->model_width)
+        return -1;
+    vector_bytes = (size_t)decoder->model_width * sizeof(float);
+    after_attention = (float *)malloc(vector_bytes);
+    dense_input = (float *)malloc(vector_bytes);
+    dense_output = (float *)malloc(vector_bytes);
+    dense_normalized = (float *)malloc(vector_bytes);
+    expert_input = (float *)malloc(vector_bytes);
+    expert_output = (float *)malloc(vector_bytes);
+    expert_normalized = (float *)malloc(vector_bytes);
+    combined = (float *)calloc((size_t)decoder->model_width, sizeof(*combined));
+    ids = (uint32_t *)malloc((size_t)decoder->router.selected_count * sizeof(uint32_t));
+    weights = (float *)malloc((size_t)decoder->router.selected_count * sizeof(float));
+    if (!after_attention || !dense_input || !dense_output ||
+        !dense_normalized || !expert_input || !expert_output ||
+        !expert_normalized || !combined || !ids || !weights)
+        goto cleanup;
+    if (coli_gemma4_rmsnorm(attention_output, decoder->post_attention_norm,
+                            decoder->model_width, decoder->gguf->rms_epsilon,
+                            after_attention) != 0)
+        goto cleanup;
+    for (index = 0; index < decoder->model_width; ++index)
+        after_attention[index] += residual[index];
+    if (coli_gemma4_rmsnorm(after_attention, decoder->ffn_norm,
+                            decoder->model_width, decoder->gguf->rms_epsilon,
+                            dense_input) != 0 ||
+        coli_gemma4_router_route(&decoder->router, after_attention, NULL,
+                                 ids, weights, NULL) != 0 ||
+        coli_gemma4_rmsnorm(after_attention, decoder->pre_ffw_norm_2,
+                            decoder->model_width, decoder->gguf->rms_epsilon,
+                            expert_input) != 0)
+        goto cleanup;
+    if (experts->prepare_layer(experts->ctx, decoder->layer, ids,
+                               decoder->router.selected_count) != 0)
+        goto cleanup;
+    prepared = 1;
+    if (coli_gemma4_dense_mlp_run(&decoder->dense_mlp, dense_input,
+                                  dense_output) != 0 ||
+        coli_gemma4_rmsnorm(dense_output, decoder->post_ffw_norm_1,
+                            decoder->model_width, decoder->gguf->rms_epsilon,
+                            dense_normalized) != 0)
+        goto cleanup;
+    if (experts->run_experts(experts->ctx, decoder->layer, ids, weights,
+                             decoder->router.selected_count, expert_input,
+                             expert_output) != 0)
+        goto cleanup;
+    experts->release_layer(experts->ctx, decoder->layer);
+    prepared = 0;
+    if (coli_gemma4_rmsnorm(expert_output, decoder->post_ffw_norm_2,
+                            decoder->model_width, decoder->gguf->rms_epsilon,
+                            expert_normalized) != 0)
+        goto cleanup;
+    for (index = 0; index < decoder->model_width; ++index)
+        combined[index] = dense_normalized[index] + expert_normalized[index];
+    if (coli_gemma4_rmsnorm(combined, decoder->post_ffw_norm,
+                            decoder->model_width, decoder->gguf->rms_epsilon,
+                            output) != 0)
+        goto cleanup;
+    for (index = 0; index < decoder->model_width; ++index)
+        output[index] = (after_attention[index] + output[index]) *
+                        decoder->layer_output_scale;
+    status = 0;
+
+cleanup:
+    if (prepared) experts->release_layer(experts->ctx, decoder->layer);
+    free(after_attention);
+    free(dense_input); free(dense_output); free(dense_normalized);
+    free(expert_input); free(expert_output); free(expert_normalized);
+    free(combined); free(ids); free(weights);
+    return status;
+}
+
+int coli_gemma4_decoder_layer_step(
+    const coli_gemma4_decoder_layer *decoder, coli_gemma4_kv_cache *cache,
+    const coli_expert_backend *experts, uint64_t position,
+    const float *residual, float *output) {
+    float *attention_output;
+    size_t vector_bytes;
+    int status;
+    if (!decoder || !cache || !experts || !residual || !output ||
+        !decoder->model_width) return -1;
+    vector_bytes = (size_t)decoder->model_width * sizeof(float);
+    attention_output = (float *)malloc(vector_bytes);
+    if (!attention_output) return -1;
+    status = coli_gemma4_attention_step(
+        &decoder->attention, cache, position, residual, attention_output);
+    if (status == 0)
+        status = decoder_layer_complete(
+            decoder, experts, residual, attention_output, output);
+    free(attention_output);
+    return status;
+}
+
+int coli_gemma4_decoder_layer_noncausal(
+    const coli_gemma4_decoder_layer *decoder, coli_gemma4_kv_cache *cache,
+    const coli_expert_backend *experts, uint64_t start_position,
+    const float *residuals, uint32_t token_count, float *outputs) {
+    float *attention_outputs = NULL;
+    uint64_t value_count;
+    uint32_t token;
+    int status = -1;
+    if (!decoder || !cache || !experts || !residuals || !outputs ||
+        !decoder->model_width || !token_count) return -1;
+    value_count = (uint64_t)token_count * decoder->model_width;
+    if (value_count > SIZE_MAX / sizeof(float)) return -1;
+    attention_outputs = (float *)malloc(
+        (size_t)value_count * sizeof(float));
+    if (!attention_outputs) return -1;
+    if (coli_gemma4_attention_noncausal(
+            &decoder->attention, cache, start_position, residuals,
+            token_count, attention_outputs) != 0)
+        goto cleanup;
+    for (token = 0; token < token_count; ++token) {
+        size_t offset = (size_t)token * decoder->model_width;
+        if (decoder_layer_complete(
+                decoder, experts, residuals + offset,
+                attention_outputs + offset, outputs + offset) != 0)
+            goto cleanup;
+    }
+    status = 0;
+cleanup:
+    free(attention_outputs);
+    return status;
+}
+
+int coli_gemma4_router_open(coli_gemma4_router *router,
+                            const coli_gemma4_gguf *gguf, uint32_t layer) {
+    const coli_gemma4_tensor *input_scale, *projection, *expert_scale;
+    char name[128];
+    int length;
+    if (!router || !gguf) return -1;
+    memset(router, 0, sizeof(*router));
+    router->gguf = gguf;
+    router->layer = layer;
+    router->width = gguf->config.n_embd;
+    router->expert_count = gguf->config.n_expert;
+    router->selected_count = gguf->config.n_expert_used;
+    if (layer >= gguf->config.n_layer) {
+        router_error(router, "router layer %u is outside the model", layer);
+        return -1;
+    }
+    length = snprintf(name, sizeof(name), "blk.%u.ffn_gate_inp.scale", layer);
+    if (length < 0 || (size_t)length >= sizeof(name)) return -1;
+    input_scale = coli_gemma4_gguf_find(gguf, name);
+    length = snprintf(name, sizeof(name), "blk.%u.ffn_gate_inp.weight", layer);
+    if (length < 0 || (size_t)length >= sizeof(name)) return -1;
+    projection = coli_gemma4_gguf_find(gguf, name);
+    length = snprintf(name, sizeof(name), "blk.%u.ffn_down_exps.scale", layer);
+    if (length < 0 || (size_t)length >= sizeof(name)) return -1;
+    expert_scale = coli_gemma4_gguf_find(gguf, name);
+    if (!tensor_is(input_scale, COLI_GGML_TYPE_F32, 1, router->width, 0) ||
+        !tensor_is(projection, COLI_GGML_TYPE_F32, 2,
+                   router->width, router->expert_count) ||
+        !tensor_is(expert_scale, COLI_GGML_TYPE_F32, 1,
+                   router->expert_count, 0)) {
+        router_error(router, "layer %u router tensor types or dimensions disagree with metadata",
+                     layer);
+        return -1;
+    }
+    if (read_f32_tensor(router, input_scale, &router->input_scale) != 0 ||
+        read_f32_tensor(router, projection, &router->projection) != 0 ||
+        read_f32_tensor(router, expert_scale, &router->expert_scale) != 0) {
+        char saved[COLI_GEMMA4_GGUF_ERROR_MAX];
+        memcpy(saved, router->last_error, sizeof(saved));
+        coli_gemma4_router_close(router);
+        memcpy(router->last_error, saved, sizeof(saved));
+        return -1;
+    }
+    return 0;
+}
+
+void coli_gemma4_router_close(coli_gemma4_router *router) {
+    if (!router) return;
+    free(router->input_scale);
+    free(router->projection);
+    free(router->expert_scale);
+    memset(router, 0, sizeof(*router));
+}
+
+const char *coli_gemma4_router_last_error(const coli_gemma4_router *router) {
+    return router ? router->last_error : "invalid Gemma router";
+}
+
+int coli_gemma4_rmsnorm(const float *input, const float *weight,
+                        uint32_t width, float epsilon, float *output) {
+    float sum_squares = 0.0F, inverse_rms;
+    uint32_t i;
+    if (!input || !weight || !output || !width ||
+        !isfinite(epsilon) || epsilon <= 0.0F) return -1;
+    for (i = 0; i < width; ++i) {
+        if (!isfinite(input[i]) || !isfinite(weight[i])) return -1;
+        sum_squares += input[i] * input[i];
+    }
+    inverse_rms = 1.0F / sqrtf(sum_squares / (float)width + epsilon);
+    for (i = 0; i < width; ++i) output[i] = input[i] * inverse_rms * weight[i];
+    return 0;
+}
+
+int coli_gemma4_router_route(const coli_gemma4_router *router,
+                             const float *hidden_state,
+                             float *probabilities,
+                             uint32_t *selected_ids,
+                             float *selected_weights,
+                             float *effective_weights) {
+    float *normalized = NULL, *scores = NULL;
+    float sum_squares = 0.0F, inverse_rms, root_scale, maximum, probability_sum;
+    float selected_sum = 0.0F;
+    uint32_t width, experts, selected, i, e;
+    if (!router || !hidden_state || !selected_ids || !selected_weights ||
+        !router->input_scale || !router->projection || !router->expert_scale)
+        return -1;
+    width = router->width;
+    experts = router->expert_count;
+    selected = router->selected_count;
+    normalized = (float *)malloc((size_t)width * sizeof(float));
+    scores = (float *)malloc((size_t)experts * sizeof(float));
+    if (!normalized || !scores) {
+        free(normalized); free(scores);
+        return -1;
+    }
+    for (i = 0; i < width; ++i) {
+        if (!isfinite(hidden_state[i]) || !isfinite(router->input_scale[i])) {
+            free(normalized); free(scores);
+            return -1;
+        }
+        sum_squares += hidden_state[i] * hidden_state[i];
+    }
+    inverse_rms = 1.0F / sqrtf(sum_squares / (float)width + router->gguf->rms_epsilon);
+    root_scale = 1.0F / sqrtf((float)width);
+    for (i = 0; i < width; ++i)
+        normalized[i] = hidden_state[i] * inverse_rms *
+                        router->input_scale[i] * root_scale;
+    for (e = 0; e < experts; ++e) {
+        const float *row = router->projection + (size_t)e * width;
+        float score = 0.0F;
+        for (i = 0; i < width; ++i) score += row[i] * normalized[i];
+        scores[e] = score;
+    }
+    maximum = scores[0];
+    for (e = 1; e < experts; ++e) if (scores[e] > maximum) maximum = scores[e];
+    probability_sum = 0.0F;
+    for (e = 0; e < experts; ++e) {
+        scores[e] = expf(scores[e] - maximum);
+        probability_sum += scores[e];
+    }
+    if (!isfinite(probability_sum) || probability_sum <= 0.0F) {
+        free(normalized); free(scores);
+        return -1;
+    }
+    for (e = 0; e < experts; ++e) {
+        scores[e] /= probability_sum;
+        if (probabilities) probabilities[e] = scores[e];
+    }
+    for (i = 0; i < selected; ++i) {
+        uint32_t best = UINT32_MAX;
+        float best_value = -FLT_MAX;
+        for (e = 0; e < experts; ++e) {
+            uint32_t prior;
+            int already_selected = 0;
+            for (prior = 0; prior < i; ++prior)
+                if (selected_ids[prior] == e) already_selected = 1;
+            if (!already_selected &&
+                (scores[e] > best_value ||
+                 (scores[e] == best_value && (best == UINT32_MAX || e < best)))) {
+                best = e;
+                best_value = scores[e];
+            }
+        }
+        if (best == UINT32_MAX) {
+            free(normalized); free(scores);
+            return -1;
+        }
+        selected_ids[i] = best;
+        selected_weights[i] = best_value;
+        selected_sum += best_value;
+    }
+    if (!isfinite(selected_sum) || selected_sum <= 0.0F) {
+        free(normalized); free(scores);
+        return -1;
+    }
+    for (i = 0; i < selected; ++i) {
+        selected_weights[i] /= selected_sum;
+        if (effective_weights)
+            effective_weights[i] = selected_weights[i] *
+                                   router->expert_scale[selected_ids[i]];
+    }
+    free(normalized);
+    free(scores);
+    return 0;
+}

--- a/c/gemma4_model.h
+++ b/c/gemma4_model.h
@@ -1,0 +1,222 @@
+#ifndef COLI_GEMMA4_MODEL_H
+#define COLI_GEMMA4_MODEL_H
+
+#include <stdint.h>
+
+#include "gemma4_gguf.h"
+
+typedef struct {
+    const coli_gemma4_gguf *gguf;
+    uint32_t layer;
+    uint32_t width;
+    uint32_t expert_count;
+    uint32_t selected_count;
+    float *input_scale;
+    float *projection;
+    float *expert_scale;
+    char last_error[COLI_GEMMA4_GGUF_ERROR_MAX];
+} coli_gemma4_router;
+
+typedef struct {
+    const coli_gemma4_gguf *gguf;
+    const coli_gemma4_tensor *tensor;
+    uint8_t *data;
+    uint32_t input_width;
+    uint32_t output_width;
+} coli_gemma4_matrix;
+
+typedef struct {
+    const coli_gemma4_gguf *gguf;
+    uint32_t layer;
+    uint32_t model_width;
+    uint32_t query_heads;
+    uint32_t kv_heads;
+    uint32_t head_dim;
+    int sliding;
+    int key_equals_value;
+    coli_gemma4_matrix query;
+    coli_gemma4_matrix key;
+    coli_gemma4_matrix value;
+    coli_gemma4_matrix output;
+    float *input_norm;
+    float *query_norm;
+    float *key_norm;
+    float *rope_factors;
+    uint32_t rope_factor_count;
+    char last_error[COLI_GEMMA4_GGUF_ERROR_MAX];
+} coli_gemma4_attention;
+
+typedef struct {
+    uint32_t capacity;
+    uint32_t count;
+    uint32_t kv_width;
+    int sliding;
+    uint64_t *positions;
+    float *keys;
+    float *values;
+} coli_gemma4_kv_cache;
+
+typedef struct {
+    const coli_gemma4_gguf *gguf;
+    uint32_t layer;
+    uint32_t model_width;
+    uint32_t intermediate_width;
+    coli_gemma4_matrix gate;
+    coli_gemma4_matrix up;
+    coli_gemma4_matrix down;
+    char last_error[COLI_GEMMA4_GGUF_ERROR_MAX];
+} coli_gemma4_dense_mlp;
+
+typedef struct {
+    const coli_gemma4_gguf *gguf;
+    uint32_t layer;
+    uint32_t model_width;
+    coli_gemma4_attention attention;
+    coli_gemma4_router router;
+    coli_gemma4_dense_mlp dense_mlp;
+    float *post_attention_norm;
+    float *ffn_norm;
+    float *post_ffw_norm_1;
+    float *pre_ffw_norm_2;
+    float *post_ffw_norm_2;
+    float *post_ffw_norm;
+    float layer_output_scale;
+    char last_error[COLI_GEMMA4_GGUF_ERROR_MAX];
+} coli_gemma4_decoder_layer;
+
+typedef struct {
+    const coli_gemma4_gguf *gguf;
+    uint32_t model_width;
+    uint32_t vocab_size;
+    coli_gemma4_matrix embedding;
+    coli_gemma4_matrix output;
+    int tied_output;
+    float *output_norm;
+    float embedding_scale;
+    float logit_softcap;
+    char last_error[COLI_GEMMA4_GGUF_ERROR_MAX];
+} coli_gemma4_model_io;
+
+typedef struct {
+    const coli_gemma4_gguf *gguf;
+    coli_gemma4_model_io io;
+    coli_gemma4_decoder_layer *layers;
+    coli_gemma4_kv_cache *caches;
+    coli_expert_backend experts;
+    uint32_t layer_count;
+    uint32_t maximum_tokens;
+    uint64_t next_position;
+    char last_error[COLI_GEMMA4_GGUF_ERROR_MAX];
+} coli_gemma4_model;
+
+int coli_gemma4_matrix_open(coli_gemma4_matrix *matrix,
+                            const coli_gemma4_gguf *gguf, const char *name);
+void coli_gemma4_matrix_close(coli_gemma4_matrix *matrix);
+int coli_gemma4_matrix_matvec(const coli_gemma4_matrix *matrix,
+                              const float *input, float *output);
+int coli_gemma4_matrix_row(const coli_gemma4_matrix *matrix, uint32_t row,
+                           float *output);
+
+int coli_gemma4_model_io_open(coli_gemma4_model_io *io,
+                              const coli_gemma4_gguf *gguf);
+void coli_gemma4_model_io_close(coli_gemma4_model_io *io);
+const char *coli_gemma4_model_io_last_error(const coli_gemma4_model_io *io);
+int coli_gemma4_model_embed(const coli_gemma4_model_io *io, uint32_t token,
+                            float *embedding);
+int coli_gemma4_model_logits(const coli_gemma4_model_io *io,
+                             const float *residual, float *normalized,
+                             float *logits);
+int coli_gemma4_model_open(coli_gemma4_model *model,
+                           const coli_gemma4_gguf *gguf,
+                           const coli_expert_backend *experts,
+                           uint32_t maximum_tokens);
+void coli_gemma4_model_close(coli_gemma4_model *model);
+const char *coli_gemma4_model_last_error(const coli_gemma4_model *model);
+int coli_gemma4_model_step(coli_gemma4_model *model, uint32_t token,
+                           uint64_t position, float *final_residual,
+                           float *logits);
+int coli_gemma4_model_step_cancelable(coli_gemma4_model *model,
+                                      uint32_t token, uint64_t position,
+                                      float *final_residual, float *logits,
+                                      int (*cancelled)(void *), void *opaque);
+int coli_gemma4_model_image_embeddings(coli_gemma4_model *model,
+                                       const float *embeddings,
+                                       uint32_t token_count,
+                                       uint64_t start_position,
+                                       float *final_residuals);
+
+int coli_gemma4_attention_open(coli_gemma4_attention *attention,
+                               const coli_gemma4_gguf *gguf, uint32_t layer);
+void coli_gemma4_attention_close(coli_gemma4_attention *attention);
+const char *coli_gemma4_attention_last_error(
+    const coli_gemma4_attention *attention);
+int coli_gemma4_attention_project(const coli_gemma4_attention *attention,
+                                  const float *residual,
+                                  float *query, float *key, float *value);
+int coli_gemma4_attention_apply_rope(const coli_gemma4_attention *attention,
+                                     uint64_t position, float *query, float *key);
+int coli_gemma4_attention_step(const coli_gemma4_attention *attention,
+                               coli_gemma4_kv_cache *cache,
+                               uint64_t position, const float *residual,
+                               float *output);
+int coli_gemma4_attention_noncausal(
+    const coli_gemma4_attention *attention, coli_gemma4_kv_cache *cache,
+    uint64_t start_position, const float *residuals, uint32_t token_count,
+    float *outputs);
+
+int coli_gemma4_kv_cache_init(coli_gemma4_kv_cache *cache,
+                              const coli_gemma4_attention *attention,
+                              uint32_t maximum_tokens);
+void coli_gemma4_kv_cache_close(coli_gemma4_kv_cache *cache);
+int coli_gemma4_kv_cache_store(coli_gemma4_kv_cache *cache, uint64_t position,
+                               const float *key, const float *value);
+int coli_gemma4_kv_cache_find(const coli_gemma4_kv_cache *cache,
+                              uint64_t position,
+                              const float **key, const float **value);
+
+int coli_gemma4_dense_mlp_open(coli_gemma4_dense_mlp *mlp,
+                               const coli_gemma4_gguf *gguf, uint32_t layer);
+void coli_gemma4_dense_mlp_close(coli_gemma4_dense_mlp *mlp);
+const char *coli_gemma4_dense_mlp_last_error(
+    const coli_gemma4_dense_mlp *mlp);
+int coli_gemma4_dense_mlp_run(const coli_gemma4_dense_mlp *mlp,
+                              const float *input, float *output);
+
+int coli_gemma4_decoder_layer_open(coli_gemma4_decoder_layer *decoder,
+                                   const coli_gemma4_gguf *gguf,
+                                   uint32_t layer);
+void coli_gemma4_decoder_layer_close(coli_gemma4_decoder_layer *decoder);
+const char *coli_gemma4_decoder_layer_last_error(
+    const coli_gemma4_decoder_layer *decoder);
+int coli_gemma4_decoder_layer_step(
+    const coli_gemma4_decoder_layer *decoder, coli_gemma4_kv_cache *cache,
+    const coli_expert_backend *experts, uint64_t position,
+    const float *residual, float *output);
+int coli_gemma4_decoder_layer_noncausal(
+    const coli_gemma4_decoder_layer *decoder, coli_gemma4_kv_cache *cache,
+    const coli_expert_backend *experts, uint64_t start_position,
+    const float *residuals, uint32_t token_count, float *outputs);
+
+int coli_gemma4_router_open(coli_gemma4_router *router,
+                            const coli_gemma4_gguf *gguf, uint32_t layer);
+void coli_gemma4_router_close(coli_gemma4_router *router);
+const char *coli_gemma4_router_last_error(const coli_gemma4_router *router);
+
+/*
+ * probabilities receives the full softmax when non-NULL. selected_weights are
+ * normalized top-k probabilities before per-expert scaling, which is the form
+ * expected by coli_gemma4_backend (that backend applies the expert scale while
+ * executing each record). effective_weights optionally receives the equivalent
+ * reference-graph weights after per-expert scaling.
+ */
+int coli_gemma4_router_route(const coli_gemma4_router *router,
+                             const float *hidden_state,
+                             float *probabilities,
+                             uint32_t *selected_ids,
+                             float *selected_weights,
+                             float *effective_weights);
+
+int coli_gemma4_rmsnorm(const float *input, const float *weight,
+                        uint32_t width, float epsilon, float *output);
+
+#endif

--- a/c/gemma4_sampling.c
+++ b/c/gemma4_sampling.c
@@ -1,0 +1,125 @@
+#include "gemma4_sampling.h"
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    uint32_t token;
+    float logit;
+    double weight;
+} sampling_candidate;
+
+static int compare_candidates(const void *left, const void *right) {
+    const sampling_candidate *a = (const sampling_candidate *)left;
+    const sampling_candidate *b = (const sampling_candidate *)right;
+    if (a->logit < b->logit) return 1;
+    if (a->logit > b->logit) return -1;
+    if (a->token > b->token) return 1;
+    if (a->token < b->token) return -1;
+    return 0;
+}
+
+static uint64_t sampler_random(coli_gemma4_sampler *sampler) {
+    uint64_t value = sampler->state;
+    value ^= value >> 12;
+    value ^= value << 25;
+    value ^= value >> 27;
+    sampler->state = value;
+    return value * UINT64_C(2685821657736338717);
+}
+
+static double sampler_uniform(coli_gemma4_sampler *sampler) {
+    return (double)(sampler_random(sampler) >> 11) *
+           (1.0 / 9007199254740992.0);
+}
+
+int coli_gemma4_sampler_init(coli_gemma4_sampler *sampler,
+                             float temperature, uint32_t top_k,
+                             float top_p, uint64_t seed) {
+    if (!sampler || !isfinite(temperature) || temperature < 0.0F ||
+        !isfinite(top_p) || top_p <= 0.0F || top_p > 1.0F) return -1;
+    memset(sampler, 0, sizeof(*sampler));
+    sampler->temperature = temperature;
+    sampler->top_k = top_k;
+    sampler->top_p = top_p;
+    sampler->state = seed ? seed : UINT64_C(0x9e3779b97f4a7c15);
+    return 0;
+}
+
+int coli_gemma4_sample(coli_gemma4_sampler *sampler, const float *logits,
+                       size_t count, uint32_t *token, float *probability) {
+    sampling_candidate *candidates;
+    size_t index, candidate_count = 0, retained;
+    double total = 0.0, threshold, cumulative = 0.0;
+    if (!sampler || !logits || !token || !count || count > UINT32_MAX)
+        return -1;
+    if (sampler->temperature == 0.0F) {
+        uint32_t best = UINT32_MAX;
+        float best_logit = 0.0F;
+        for (index = 0; index < count; ++index) {
+            if (isfinite(logits[index]) &&
+                (best == UINT32_MAX || logits[index] > best_logit)) {
+                best = (uint32_t)index;
+                best_logit = logits[index];
+            }
+        }
+        if (best == UINT32_MAX) return -1;
+        *token = best;
+        if (probability) *probability = 1.0F;
+        return 0;
+    }
+    if (count > SIZE_MAX / sizeof(*candidates)) return -1;
+    candidates = (sampling_candidate *)malloc(count * sizeof(*candidates));
+    if (!candidates) return -1;
+    for (index = 0; index < count; ++index) {
+        if (isfinite(logits[index])) {
+            candidates[candidate_count].token = (uint32_t)index;
+            candidates[candidate_count].logit = logits[index];
+            candidates[candidate_count].weight = 0.0;
+            ++candidate_count;
+        }
+    }
+    if (!candidate_count) {
+        free(candidates);
+        return -1;
+    }
+    qsort(candidates, candidate_count, sizeof(*candidates), compare_candidates);
+    retained = sampler->top_k && sampler->top_k < candidate_count ?
+        sampler->top_k : candidate_count;
+    for (index = 0; index < retained; ++index) {
+        candidates[index].weight = exp(
+            ((double)candidates[index].logit - candidates[0].logit) /
+            sampler->temperature);
+        total += candidates[index].weight;
+    }
+    if (!isfinite(total) || total <= 0.0) {
+        free(candidates);
+        return -1;
+    }
+    cumulative = 0.0;
+    for (index = 0; index < retained; ++index) {
+        cumulative += candidates[index].weight / total;
+        if (cumulative >= sampler->top_p) {
+            retained = index + 1;
+            break;
+        }
+    }
+    total = 0.0;
+    for (index = 0; index < retained; ++index)
+        total += candidates[index].weight;
+    threshold = sampler_uniform(sampler) * total;
+    cumulative = 0.0;
+    for (index = 0; index < retained; ++index) {
+        cumulative += candidates[index].weight;
+        if (threshold < cumulative || index + 1 == retained) {
+            *token = candidates[index].token;
+            if (probability)
+                *probability = (float)(candidates[index].weight / total);
+            free(candidates);
+            return 0;
+        }
+    }
+    free(candidates);
+    return -1;
+}

--- a/c/gemma4_sampling.h
+++ b/c/gemma4_sampling.h
@@ -1,0 +1,20 @@
+#ifndef COLI_GEMMA4_SAMPLING_H
+#define COLI_GEMMA4_SAMPLING_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+    float temperature;
+    float top_p;
+    uint32_t top_k;
+    uint64_t state;
+} coli_gemma4_sampler;
+
+int coli_gemma4_sampler_init(coli_gemma4_sampler *sampler,
+                             float temperature, uint32_t top_k,
+                             float top_p, uint64_t seed);
+int coli_gemma4_sample(coli_gemma4_sampler *sampler, const float *logits,
+                       size_t count, uint32_t *token, float *probability);
+
+#endif

--- a/c/gemma4_tokenizer.c
+++ b/c/gemma4_tokenizer.c
@@ -1,0 +1,678 @@
+#include "gemma4_tokenizer.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct coli_gemma4_vocab_entry {
+    const char *text;
+    size_t length;
+    uint32_t token;
+    uint8_t used;
+};
+
+struct coli_gemma4_merge_entry {
+    const char *left;
+    const char *right;
+    size_t left_length;
+    size_t right_length;
+    uint32_t rank;
+    uint8_t used;
+};
+
+struct coli_gemma4_special_entry {
+    const char *text;
+    size_t length;
+    uint32_t token;
+};
+
+static void tokenizer_error(coli_gemma4_tokenizer *tokenizer,
+                            const char *format, ...) {
+    va_list arguments;
+    va_start(arguments, format);
+    vsnprintf(tokenizer->last_error, sizeof(tokenizer->last_error),
+              format, arguments);
+    va_end(arguments);
+}
+
+static uint64_t hash_bytes(uint64_t hash, const char *text, size_t length) {
+    size_t index;
+    for (index = 0; index < length; ++index) {
+        hash ^= (uint8_t)text[index];
+        hash *= UINT64_C(1099511628211);
+    }
+    return hash;
+}
+
+static uint64_t vocab_hash(const char *text, size_t length) {
+    return hash_bytes(UINT64_C(1469598103934665603), text, length);
+}
+
+static uint64_t merge_hash(const char *left, size_t left_length,
+                           const char *right, size_t right_length) {
+    uint64_t hash = vocab_hash(left, left_length);
+    const char separator = '\0';
+    hash = hash_bytes(hash, &separator, 1);
+    return hash_bytes(hash, right, right_length);
+}
+
+static size_t map_capacity(uint64_t count) {
+    size_t capacity = 1;
+    if (count > SIZE_MAX / 2) return 0;
+    while (capacity < (size_t)count * 2) {
+        if (capacity > SIZE_MAX / 2) return 0;
+        capacity *= 2;
+    }
+    return capacity;
+}
+
+static void vocab_insert(coli_gemma4_tokenizer *tokenizer,
+                         const char *text, size_t length, uint32_t token) {
+    size_t slot = (size_t)(vocab_hash(text, length) &
+                           (tokenizer->vocab_capacity - 1));
+    while (tokenizer->vocab[slot].used)
+        slot = (slot + 1) & (tokenizer->vocab_capacity - 1);
+    tokenizer->vocab[slot].text = text;
+    tokenizer->vocab[slot].length = length;
+    tokenizer->vocab[slot].token = token;
+    tokenizer->vocab[slot].used = 1;
+}
+
+static int vocab_find(const coli_gemma4_tokenizer *tokenizer,
+                      const char *text, size_t length, uint32_t *token) {
+    size_t slot = (size_t)(vocab_hash(text, length) &
+                           (tokenizer->vocab_capacity - 1));
+    while (tokenizer->vocab[slot].used) {
+        const coli_gemma4_vocab_entry *entry = &tokenizer->vocab[slot];
+        if (entry->length == length && !memcmp(entry->text, text, length)) {
+            if (token) *token = entry->token;
+            return 1;
+        }
+        slot = (slot + 1) & (tokenizer->vocab_capacity - 1);
+    }
+    return 0;
+}
+
+static void merge_insert(coli_gemma4_tokenizer *tokenizer,
+                         const char *left, size_t left_length,
+                         const char *right, size_t right_length, uint32_t rank) {
+    size_t slot = (size_t)(merge_hash(left, left_length, right, right_length) &
+                           (tokenizer->merge_capacity - 1));
+    while (tokenizer->merges[slot].used)
+        slot = (slot + 1) & (tokenizer->merge_capacity - 1);
+    tokenizer->merges[slot].left = left;
+    tokenizer->merges[slot].right = right;
+    tokenizer->merges[slot].left_length = left_length;
+    tokenizer->merges[slot].right_length = right_length;
+    tokenizer->merges[slot].rank = rank;
+    tokenizer->merges[slot].used = 1;
+}
+
+static int merge_find(const coli_gemma4_tokenizer *tokenizer,
+                      const char *left, size_t left_length,
+                      const char *right, size_t right_length, uint32_t *rank) {
+    size_t slot = (size_t)(merge_hash(left, left_length, right, right_length) &
+                           (tokenizer->merge_capacity - 1));
+    while (tokenizer->merges[slot].used) {
+        const coli_gemma4_merge_entry *entry = &tokenizer->merges[slot];
+        if (entry->left_length == left_length &&
+            entry->right_length == right_length &&
+            !memcmp(entry->left, left, left_length) &&
+            !memcmp(entry->right, right, right_length)) {
+            *rank = entry->rank;
+            return 1;
+        }
+        slot = (slot + 1) & (tokenizer->merge_capacity - 1);
+    }
+    return 0;
+}
+
+static int compare_specials(const void *left, const void *right) {
+    const coli_gemma4_special_entry *a =
+        (const coli_gemma4_special_entry *)left;
+    const coli_gemma4_special_entry *b =
+        (const coli_gemma4_special_entry *)right;
+    if (a->length < b->length) return 1;
+    if (a->length > b->length) return -1;
+    return 0;
+}
+
+int coli_gemma4_tokenizer_init(coli_gemma4_tokenizer *tokenizer,
+                               const coli_gemma4_gguf *gguf) {
+    uint64_t index;
+    if (!tokenizer || !gguf) return -1;
+    memset(tokenizer, 0, sizeof(*tokenizer));
+    tokenizer->gguf = gguf;
+    if (strcmp(gguf->tokenizer_model, "gemma4") != 0 ||
+        !gguf->tokenizer_tokens || !gguf->tokenizer_merges ||
+        gguf->tokenizer_token_count != gguf->config.n_vocab ||
+        gguf->tokenizer_bos_id >= gguf->tokenizer_token_count) {
+        tokenizer_error(tokenizer, "GGUF is missing a valid Gemma 4 tokenizer");
+        return -1;
+    }
+    tokenizer->vocab_capacity = map_capacity(gguf->tokenizer_token_count);
+    tokenizer->merge_capacity = map_capacity(gguf->tokenizer_merge_count);
+    if (!tokenizer->vocab_capacity || !tokenizer->merge_capacity) {
+        tokenizer_error(tokenizer, "tokenizer tables are too large");
+        return -1;
+    }
+    tokenizer->vocab = (coli_gemma4_vocab_entry *)calloc(
+        tokenizer->vocab_capacity, sizeof(*tokenizer->vocab));
+    tokenizer->merges = (coli_gemma4_merge_entry *)calloc(
+        tokenizer->merge_capacity, sizeof(*tokenizer->merges));
+    if (!tokenizer->vocab || !tokenizer->merges) {
+        tokenizer_error(tokenizer, "out of memory building tokenizer tables");
+        coli_gemma4_tokenizer_close(tokenizer);
+        return -1;
+    }
+    for (index = 0; index < gguf->tokenizer_token_count; ++index) {
+        const char *text = gguf->tokenizer_tokens[index];
+        vocab_insert(tokenizer, text, strlen(text), (uint32_t)index);
+    }
+    for (index = 0; index < gguf->tokenizer_merge_count; ++index) {
+        const char *merge = gguf->tokenizer_merges[index];
+        const char *separator = strchr(merge + (merge[0] ? 1 : 0), ' ');
+        if (!separator || !separator[1]) {
+            tokenizer_error(tokenizer, "invalid tokenizer merge at index %llu",
+                            (unsigned long long)index);
+            coli_gemma4_tokenizer_close(tokenizer);
+            return -1;
+        }
+        merge_insert(tokenizer, merge, (size_t)(separator - merge),
+                     separator + 1, strlen(separator + 1), (uint32_t)index);
+    }
+    if (gguf->tokenizer_token_types &&
+        gguf->tokenizer_token_type_count == gguf->tokenizer_token_count) {
+        for (index = 0; index < gguf->tokenizer_token_type_count; ++index)
+            if (gguf->tokenizer_token_types[index] == 3 ||
+                gguf->tokenizer_token_types[index] == 4)
+                ++tokenizer->special_count;
+        tokenizer->specials = (coli_gemma4_special_entry *)calloc(
+            tokenizer->special_count, sizeof(*tokenizer->specials));
+        if (tokenizer->special_count && !tokenizer->specials) {
+            tokenizer_error(tokenizer, "out of memory building special-token table");
+            coli_gemma4_tokenizer_close(tokenizer);
+            return -1;
+        }
+        tokenizer->special_count = 0;
+        for (index = 0; index < gguf->tokenizer_token_type_count; ++index) {
+            if (gguf->tokenizer_token_types[index] == 3 ||
+                gguf->tokenizer_token_types[index] == 4) {
+                coli_gemma4_special_entry *entry =
+                    &tokenizer->specials[tokenizer->special_count++];
+                entry->text = gguf->tokenizer_tokens[index];
+                entry->length = strlen(entry->text);
+                entry->token = (uint32_t)index;
+            }
+        }
+        qsort(tokenizer->specials, tokenizer->special_count,
+              sizeof(*tokenizer->specials), compare_specials);
+    }
+    return 0;
+}
+
+void coli_gemma4_tokenizer_close(coli_gemma4_tokenizer *tokenizer) {
+    char error[COLI_GEMMA4_GGUF_ERROR_MAX];
+    if (!tokenizer) return;
+    memcpy(error, tokenizer->last_error, sizeof(error));
+    free(tokenizer->vocab);
+    free(tokenizer->merges);
+    free(tokenizer->specials);
+    memset(tokenizer, 0, sizeof(*tokenizer));
+    memcpy(tokenizer->last_error, error, sizeof(error));
+}
+
+const char *coli_gemma4_tokenizer_last_error(
+    const coli_gemma4_tokenizer *tokenizer) {
+    return tokenizer ? tokenizer->last_error : "invalid tokenizer";
+}
+
+static size_t utf8_character_bytes(const char *text, size_t remaining) {
+    uint8_t first = (uint8_t)text[0];
+    if (first < 0x80) return 1;
+    if ((first & 0xe0) == 0xc0 && remaining >= 2) return 2;
+    if ((first & 0xf0) == 0xe0 && remaining >= 3) return 3;
+    if ((first & 0xf8) == 0xf0 && remaining >= 4) return 4;
+    return 1;
+}
+
+static int append_token(uint32_t token, uint32_t *tokens, size_t capacity,
+                        size_t *count) {
+    if (*count >= capacity) return -1;
+    tokens[(*count)++] = token;
+    return 0;
+}
+
+static int tokenize_segment(const coli_gemma4_tokenizer *tokenizer,
+                            const char *text, size_t length, int newline_only,
+                            uint32_t *tokens, size_t capacity, size_t *count) {
+    size_t *offsets = NULL, *lengths = NULL;
+    size_t symbols = 0, offset, index;
+    uint32_t token;
+    int result = -1;
+    if (newline_only && vocab_find(tokenizer, text, length, &token))
+        return append_token(token, tokens, capacity, count);
+    offsets = (size_t *)malloc((length + 1) * sizeof(*offsets));
+    lengths = (size_t *)malloc((length + 1) * sizeof(*lengths));
+    if (!offsets || !lengths) goto cleanup;
+    for (offset = 0; offset < length;) {
+        size_t bytes = utf8_character_bytes(text + offset, length - offset);
+        offsets[symbols] = offset;
+        lengths[symbols++] = bytes;
+        offset += bytes;
+    }
+    for (;;) {
+        uint32_t best_rank = UINT32_MAX;
+        size_t best = SIZE_MAX;
+        for (index = 0; index + 1 < symbols; ++index) {
+            uint32_t rank;
+            if (merge_find(tokenizer, text + offsets[index], lengths[index],
+                           text + offsets[index + 1], lengths[index + 1], &rank) &&
+                rank < best_rank) {
+                best_rank = rank;
+                best = index;
+            }
+        }
+        if (best == SIZE_MAX) break;
+        lengths[best] += lengths[best + 1];
+        for (index = best + 1; index + 1 < symbols; ++index) {
+            offsets[index] = offsets[index + 1];
+            lengths[index] = lengths[index + 1];
+        }
+        --symbols;
+    }
+    for (index = 0; index < symbols; ++index) {
+        if (vocab_find(tokenizer, text + offsets[index], lengths[index], &token)) {
+            if (append_token(token, tokens, capacity, count) != 0) goto cleanup;
+        } else {
+            size_t byte;
+            static const char hex[] = "0123456789ABCDEF";
+            for (byte = 0; byte < lengths[index]; ++byte) {
+                uint8_t value = (uint8_t)text[offsets[index] + byte];
+                char fallback[6] = {'<', '0', 'x', hex[value >> 4],
+                                    hex[value & 15], '>'};
+                if (!vocab_find(tokenizer, fallback, sizeof(fallback), &token) ||
+                    append_token(token, tokens, capacity, count) != 0) goto cleanup;
+            }
+        }
+    }
+    result = 0;
+cleanup:
+    free(offsets);
+    free(lengths);
+    return result;
+}
+
+static int tokenize_text(const coli_gemma4_tokenizer *tokenizer,
+                         const char *text, size_t text_bytes,
+                         uint32_t *tokens, size_t capacity, size_t *count) {
+    char *normalized;
+    size_t input, output = 0, start;
+    int result = -1;
+    static const char escaped_space[] = "\xe2\x96\x81";
+    if (text_bytes > (SIZE_MAX - 1) / 3) return -1;
+    normalized = (char *)malloc(text_bytes * 3 + 1);
+    if (!normalized) return -1;
+    for (input = 0; input < text_bytes; ++input) {
+        if (text[input] == ' ') {
+            memcpy(normalized + output, escaped_space, 3);
+            output += 3;
+        } else {
+            normalized[output++] = text[input];
+        }
+    }
+    normalized[output] = '\0';
+    for (start = 0; start < output;) {
+        size_t end = start;
+        int newline_only = normalized[start] == '\n';
+        if (newline_only) {
+            while (end < output && normalized[end] == '\n') ++end;
+        } else {
+            while (end < output && normalized[end] != '\n') ++end;
+        }
+        if (tokenize_segment(tokenizer, normalized + start, end - start,
+                             newline_only, tokens, capacity, count) != 0)
+            goto cleanup;
+        start = end;
+    }
+    result = 0;
+cleanup:
+    free(normalized);
+    return result;
+}
+
+int coli_gemma4_tokenize_ex(const coli_gemma4_tokenizer *tokenizer,
+                            const char *text, size_t text_bytes, int add_bos,
+                            int parse_special, uint32_t *tokens,
+                            size_t capacity, size_t *count) {
+    size_t position = 0, raw_start = 0;
+    if (!tokenizer || !tokenizer->gguf || (!text && text_bytes) ||
+        !tokens || !count) return -1;
+    *count = 0;
+    if (add_bos && tokenizer->gguf->tokenizer_add_bos &&
+        append_token(tokenizer->gguf->tokenizer_bos_id,
+                     tokens, capacity, count) != 0) return -1;
+    if (!parse_special || !tokenizer->special_count)
+        return tokenize_text(tokenizer, text, text_bytes,
+                             tokens, capacity, count);
+    while (position < text_bytes) {
+        size_t special_index;
+        const coli_gemma4_special_entry *match = NULL;
+        for (special_index = 0; special_index < tokenizer->special_count;
+             ++special_index) {
+            const coli_gemma4_special_entry *candidate =
+                &tokenizer->specials[special_index];
+            if (candidate->length <= text_bytes - position &&
+                !memcmp(text + position, candidate->text, candidate->length)) {
+                match = candidate;
+                break;
+            }
+        }
+        if (!match) {
+            ++position;
+            continue;
+        }
+        if (position > raw_start &&
+            tokenize_text(tokenizer, text + raw_start, position - raw_start,
+                          tokens, capacity, count) != 0) return -1;
+        if (append_token(match->token, tokens, capacity, count) != 0) return -1;
+        position += match->length;
+        raw_start = position;
+    }
+    return raw_start < text_bytes ?
+        tokenize_text(tokenizer, text + raw_start, text_bytes - raw_start,
+                      tokens, capacity, count) : 0;
+}
+
+int coli_gemma4_tokenize(const coli_gemma4_tokenizer *tokenizer,
+                         const char *text, size_t text_bytes, int add_bos,
+                         uint32_t *tokens, size_t capacity, size_t *count) {
+    return coli_gemma4_tokenize_ex(tokenizer, text, text_bytes, add_bos, 0,
+                                   tokens, capacity, count);
+}
+
+static void trim_chat_text(const char *text, size_t text_bytes,
+                           size_t *begin, size_t *end) {
+    *begin = 0;
+    *end = text_bytes;
+    while (*begin < *end &&
+           (text[*begin] == ' ' || text[*begin] == '\t' ||
+            text[*begin] == '\r' || text[*begin] == '\n'))
+        ++*begin;
+    while (*end > *begin &&
+           (text[*end - 1] == ' ' || text[*end - 1] == '\t' ||
+            text[*end - 1] == '\r' || text[*end - 1] == '\n'))
+        --*end;
+}
+
+int coli_gemma4_tokenize_chat_turn_with_tools(
+    const coli_gemma4_tokenizer *tokenizer,
+    const char *system_text, size_t system_bytes,
+    const char *rendered_tools, size_t rendered_tools_bytes,
+    const char *user_text, size_t text_bytes, int initial_turn,
+    uint32_t *tokens, size_t capacity, size_t *count) {
+    static const char initial_prefix[] = "<bos><|turn>user\n";
+    static const char system_prefix[] = "<bos><|turn>system\n";
+    static const char user_after_system[] = "<turn|>\n<|turn>user\n";
+    static const char continuation_prefix[] = "\n<|turn>user\n";
+    static const char suffix[] =
+        "<turn|>\n<|turn>model\n<|channel>thought\n<channel|>";
+    const int has_system = system_text != NULL;
+    const int has_tools = rendered_tools_bytes != 0;
+    const char *prefix;
+    size_t prefix_bytes;
+    char *rendered;
+    size_t begin, end, system_begin = 0, system_end = 0;
+    size_t rendered_bytes, offset = 0, overhead;
+    if (!tokenizer || !tokenizer->gguf || !tokens || !count) return -1;
+    if (!user_text) {
+        if (text_bytes) return -1;
+        user_text = "";
+    }
+    if ((has_system || has_tools) && !initial_turn) return -1;
+    if (!system_text && system_bytes) return -1;
+    if (!rendered_tools && rendered_tools_bytes) return -1;
+    trim_chat_text(user_text, text_bytes, &begin, &end);
+    if (has_system || has_tools) {
+        if (has_system)
+            trim_chat_text(system_text, system_bytes,
+                           &system_begin, &system_end);
+        prefix = system_prefix;
+        prefix_bytes = sizeof(system_prefix) - 1;
+        overhead = prefix_bytes + (sizeof(user_after_system) - 1) +
+                   (sizeof(suffix) - 1);
+        if (system_end - system_begin > SIZE_MAX - overhead) return -1;
+        overhead += system_end - system_begin;
+        if (rendered_tools_bytes > SIZE_MAX - overhead) return -1;
+        overhead += rendered_tools_bytes;
+    } else {
+        prefix = initial_turn ? initial_prefix : continuation_prefix;
+        prefix_bytes = initial_turn ? sizeof(initial_prefix) - 1 :
+                                     sizeof(continuation_prefix) - 1;
+        overhead = prefix_bytes + (sizeof(suffix) - 1);
+    }
+    if (overhead >= SIZE_MAX ||
+        end - begin > SIZE_MAX - overhead - 1) return -1;
+    rendered_bytes = overhead + (end - begin);
+    rendered = (char *)malloc(rendered_bytes + 1);
+    if (!rendered) return -1;
+    memcpy(rendered + offset, prefix, prefix_bytes);
+    offset += prefix_bytes;
+    if (has_system || has_tools) {
+        if (has_system) {
+            memcpy(rendered + offset, system_text + system_begin,
+                   system_end - system_begin);
+            offset += system_end - system_begin;
+        }
+        if (has_tools) {
+            memcpy(rendered + offset, rendered_tools, rendered_tools_bytes);
+            offset += rendered_tools_bytes;
+        }
+        memcpy(rendered + offset, user_after_system,
+               sizeof(user_after_system) - 1);
+        offset += sizeof(user_after_system) - 1;
+    }
+    memcpy(rendered + offset, user_text + begin, end - begin);
+    offset += end - begin;
+    memcpy(rendered + offset, suffix, sizeof(suffix) - 1);
+    rendered[rendered_bytes] = '\0';
+    {
+        int result = coli_gemma4_tokenize_ex(
+            tokenizer, rendered, rendered_bytes, 0, 1,
+            tokens, capacity, count);
+        free(rendered);
+        return result;
+    }
+}
+
+int coli_gemma4_tokenize_chat_turn(const coli_gemma4_tokenizer *tokenizer,
+                                   const char *system_text,
+                                   size_t system_bytes,
+                                   const char *user_text, size_t text_bytes,
+                                   int initial_turn, uint32_t *tokens,
+                                   size_t capacity, size_t *count) {
+    return coli_gemma4_tokenize_chat_turn_with_tools(
+        tokenizer, system_text, system_bytes, NULL, 0,
+        user_text, text_bytes, initial_turn, tokens, capacity, count);
+}
+
+int coli_gemma4_tokenize_image_chat_turn_with_tools(
+    const coli_gemma4_tokenizer *tokenizer,
+    const char *system_text, size_t system_bytes,
+    const char *rendered_tools, size_t rendered_tools_bytes,
+    const char *user_text, size_t text_bytes, int initial_turn,
+    uint32_t *prefix_tokens, size_t prefix_capacity, size_t *prefix_count,
+    uint32_t *suffix_tokens, size_t suffix_capacity, size_t *suffix_count) {
+    static const char image_open[] = "<|image>";
+    static const char image_close[] = "<image|>";
+    char *image_user = NULL;
+    uint32_t marker_tokens[2], *all_tokens = NULL;
+    size_t marker_count = 0, all_count = 0, capacity, index;
+    size_t image_user_bytes;
+    const size_t marker_bytes = sizeof(image_open) + sizeof(image_close) - 2;
+    int result = -1;
+    if (!tokenizer || !prefix_tokens || !prefix_count ||
+        !suffix_tokens || !suffix_count ||
+        (!user_text && text_bytes) ||
+        prefix_capacity > SIZE_MAX - suffix_capacity ||
+        text_bytes > SIZE_MAX - marker_bytes - 1)
+        return -1;
+    *prefix_count = 0;
+    *suffix_count = 0;
+    if (!user_text) user_text = "";
+    image_user_bytes = marker_bytes + text_bytes;
+    image_user = (char *)malloc(image_user_bytes + 1);
+    if (!image_user) goto cleanup;
+    memcpy(image_user, image_open, sizeof(image_open) - 1);
+    memcpy(image_user + sizeof(image_open) - 1,
+           image_close, sizeof(image_close) - 1);
+    memcpy(image_user + sizeof(image_open) + sizeof(image_close) - 2,
+           user_text, text_bytes);
+    image_user[image_user_bytes] = '\0';
+    if (coli_gemma4_tokenize_ex(
+            tokenizer, image_open, sizeof(image_open) - 1, 0, 1,
+            marker_tokens, 2, &marker_count) != 0 || marker_count != 1 ||
+        coli_gemma4_tokenize_ex(
+            tokenizer, image_close, sizeof(image_close) - 1, 0, 1,
+            marker_tokens + 1, 1, &marker_count) != 0 || marker_count != 1)
+        goto cleanup;
+    capacity = prefix_capacity + suffix_capacity;
+    if (!capacity || capacity > SIZE_MAX / sizeof(*all_tokens)) goto cleanup;
+    all_tokens = (uint32_t *)malloc(capacity * sizeof(*all_tokens));
+    if (!all_tokens) goto cleanup;
+    if (coli_gemma4_tokenize_chat_turn_with_tools(
+            tokenizer, system_text, system_bytes,
+            rendered_tools, rendered_tools_bytes,
+            image_user, image_user_bytes, initial_turn,
+            all_tokens, capacity, &all_count) != 0)
+        goto cleanup;
+    for (index = 0; index + 1 < all_count; ++index) {
+        size_t before_count, after_count;
+        if (all_tokens[index] != marker_tokens[0] ||
+            all_tokens[index + 1] != marker_tokens[1]) continue;
+        before_count = index + 1;
+        after_count = all_count - before_count;
+        if (before_count > prefix_capacity || after_count > suffix_capacity)
+            goto cleanup;
+        memcpy(prefix_tokens, all_tokens,
+               before_count * sizeof(*prefix_tokens));
+        memcpy(suffix_tokens, all_tokens + before_count,
+               after_count * sizeof(*suffix_tokens));
+        *prefix_count = before_count;
+        *suffix_count = after_count;
+        result = 0;
+        break;
+    }
+cleanup:
+    free(all_tokens);
+    free(image_user);
+    return result;
+}
+
+int coli_gemma4_tokenize_user_turn(const coli_gemma4_tokenizer *tokenizer,
+                                   const char *user_text, size_t text_bytes,
+                                   int initial_turn, uint32_t *tokens,
+                                   size_t capacity, size_t *count) {
+    return coli_gemma4_tokenize_chat_turn(
+        tokenizer, NULL, 0, user_text, text_bytes, initial_turn,
+        tokens, capacity, count);
+}
+
+int coli_gemma4_tokenize_user_chat(const coli_gemma4_tokenizer *tokenizer,
+                                   const char *user_text, size_t text_bytes,
+                                   uint32_t *tokens, size_t capacity,
+                                   size_t *count) {
+    return coli_gemma4_tokenize_user_turn(
+        tokenizer, user_text, text_bytes, 1, tokens, capacity, count);
+}
+
+static int hex_digit(unsigned char value) {
+    if (value >= '0' && value <= '9') return (int)(value - '0');
+    if (value >= 'A' && value <= 'F') return (int)(value - 'A') + 10;
+    if (value >= 'a' && value <= 'f') return (int)(value - 'a') + 10;
+    return -1;
+}
+
+int coli_gemma4_decode_token(const coli_gemma4_tokenizer *tokenizer,
+                             uint32_t token, char *text, size_t capacity,
+                             size_t *text_bytes) {
+    const char *piece;
+    size_t input = 0, output = 0;
+    if (!tokenizer || !tokenizer->gguf || !text_bytes ||
+        token >= tokenizer->gguf->tokenizer_token_count) return -1;
+    piece = tokenizer->gguf->tokenizer_tokens[token];
+    if (!piece) return -1;
+    if (strlen(piece) == 6 && !memcmp(piece, "<0x", 3) && piece[5] == '>') {
+        int high = hex_digit((unsigned char)piece[3]);
+        int low = hex_digit((unsigned char)piece[4]);
+        if (high >= 0 && low >= 0) {
+            *text_bytes = 1;
+            if (!text) return 0;
+            if (capacity < 2) return -1;
+            text[0] = (char)((high << 4) | low);
+            text[1] = '\0';
+            return 0;
+        }
+    }
+    while (piece[input]) {
+        if (piece[input + 1] && piece[input + 2] &&
+            (unsigned char)piece[input] == 0xe2U &&
+            (unsigned char)piece[input + 1] == 0x96U &&
+            (unsigned char)piece[input + 2] == 0x81U) {
+            ++output;
+            input += 3;
+        } else {
+            ++output;
+            ++input;
+        }
+    }
+    *text_bytes = output;
+    if (!text) return 0;
+    if (capacity <= output) return -1;
+    input = 0;
+    output = 0;
+    while (piece[input]) {
+        if (piece[input + 1] && piece[input + 2] &&
+            (unsigned char)piece[input] == 0xe2U &&
+            (unsigned char)piece[input + 1] == 0x96U &&
+            (unsigned char)piece[input + 2] == 0x81U) {
+            text[output++] = ' ';
+            input += 3;
+        } else {
+            text[output++] = piece[input++];
+        }
+    }
+    text[output] = '\0';
+    return 0;
+}
+
+int coli_gemma4_token_is_control(const coli_gemma4_tokenizer *tokenizer,
+                                 uint32_t token) {
+    uint32_t type;
+    if (!tokenizer || !tokenizer->gguf ||
+        token >= tokenizer->gguf->tokenizer_token_type_count ||
+        !tokenizer->gguf->tokenizer_token_types) return 0;
+    type = tokenizer->gguf->tokenizer_token_types[token];
+    return type == 3 || type == 4;
+}
+
+int coli_gemma4_token_is_eog(const coli_gemma4_tokenizer *tokenizer,
+                             uint32_t token) {
+    const char *piece;
+    if (!tokenizer || !tokenizer->gguf ||
+        token >= tokenizer->gguf->tokenizer_token_count) return 0;
+    if (token == tokenizer->gguf->tokenizer_eos_id) return 1;
+    piece = tokenizer->gguf->tokenizer_tokens[token];
+    return piece && (!strcmp(piece, "<turn|>") ||
+                     !strcmp(piece, "<|tool_response>"));
+}
+
+int coli_gemma4_token_is_tool_response(const coli_gemma4_tokenizer *tokenizer,
+                                       uint32_t token) {
+    const char *piece;
+    if (!tokenizer || !tokenizer->gguf ||
+        token >= tokenizer->gguf->tokenizer_token_count) return 0;
+    piece = tokenizer->gguf->tokenizer_tokens[token];
+    return piece && !strcmp(piece, "<|tool_response>");
+}

--- a/c/gemma4_tokenizer.h
+++ b/c/gemma4_tokenizer.h
@@ -1,0 +1,73 @@
+#ifndef COLI_GEMMA4_TOKENIZER_H
+#define COLI_GEMMA4_TOKENIZER_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "gemma4_gguf.h"
+
+typedef struct coli_gemma4_vocab_entry coli_gemma4_vocab_entry;
+typedef struct coli_gemma4_merge_entry coli_gemma4_merge_entry;
+typedef struct coli_gemma4_special_entry coli_gemma4_special_entry;
+
+typedef struct {
+    const coli_gemma4_gguf *gguf;
+    coli_gemma4_vocab_entry *vocab;
+    coli_gemma4_merge_entry *merges;
+    coli_gemma4_special_entry *specials;
+    size_t vocab_capacity;
+    size_t merge_capacity;
+    size_t special_count;
+    char last_error[COLI_GEMMA4_GGUF_ERROR_MAX];
+} coli_gemma4_tokenizer;
+
+int coli_gemma4_tokenizer_init(coli_gemma4_tokenizer *tokenizer,
+                               const coli_gemma4_gguf *gguf);
+void coli_gemma4_tokenizer_close(coli_gemma4_tokenizer *tokenizer);
+const char *coli_gemma4_tokenizer_last_error(
+    const coli_gemma4_tokenizer *tokenizer);
+int coli_gemma4_tokenize(const coli_gemma4_tokenizer *tokenizer,
+                         const char *text, size_t text_bytes, int add_bos,
+                         uint32_t *tokens, size_t capacity, size_t *count);
+int coli_gemma4_tokenize_ex(const coli_gemma4_tokenizer *tokenizer,
+                            const char *text, size_t text_bytes, int add_bos,
+                            int parse_special, uint32_t *tokens,
+                            size_t capacity, size_t *count);
+int coli_gemma4_tokenize_user_chat(const coli_gemma4_tokenizer *tokenizer,
+                                   const char *user_text, size_t text_bytes,
+                                   uint32_t *tokens, size_t capacity,
+                                   size_t *count);
+int coli_gemma4_tokenize_user_turn(const coli_gemma4_tokenizer *tokenizer,
+                                   const char *user_text, size_t text_bytes,
+                                   int initial_turn, uint32_t *tokens,
+                                   size_t capacity, size_t *count);
+int coli_gemma4_tokenize_chat_turn(const coli_gemma4_tokenizer *tokenizer,
+                                   const char *system_text,
+                                   size_t system_bytes,
+                                   const char *user_text, size_t text_bytes,
+                                   int initial_turn, uint32_t *tokens,
+                                   size_t capacity, size_t *count);
+int coli_gemma4_tokenize_chat_turn_with_tools(
+    const coli_gemma4_tokenizer *tokenizer,
+    const char *system_text, size_t system_bytes,
+    const char *rendered_tools, size_t rendered_tools_bytes,
+    const char *user_text, size_t text_bytes, int initial_turn,
+    uint32_t *tokens, size_t capacity, size_t *count);
+int coli_gemma4_tokenize_image_chat_turn_with_tools(
+    const coli_gemma4_tokenizer *tokenizer,
+    const char *system_text, size_t system_bytes,
+    const char *rendered_tools, size_t rendered_tools_bytes,
+    const char *user_text, size_t text_bytes, int initial_turn,
+    uint32_t *prefix_tokens, size_t prefix_capacity, size_t *prefix_count,
+    uint32_t *suffix_tokens, size_t suffix_capacity, size_t *suffix_count);
+int coli_gemma4_decode_token(const coli_gemma4_tokenizer *tokenizer,
+                             uint32_t token, char *text, size_t capacity,
+                             size_t *text_bytes);
+int coli_gemma4_token_is_control(const coli_gemma4_tokenizer *tokenizer,
+                                 uint32_t token);
+int coli_gemma4_token_is_eog(const coli_gemma4_tokenizer *tokenizer,
+                             uint32_t token);
+int coli_gemma4_token_is_tool_response(const coli_gemma4_tokenizer *tokenizer,
+                                       uint32_t token);
+
+#endif

--- a/c/gemma4_tools.c
+++ b/c/gemma4_tools.c
@@ -1,0 +1,820 @@
+#include "gemma4_tools.h"
+
+#include "json.h"
+
+#include <ctype.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    char *data;
+    size_t length;
+    size_t capacity;
+    char *error;
+    size_t error_capacity;
+} tool_buffer;
+
+typedef struct {
+    const char *key;
+    jval *value;
+    int original_index;
+} tool_field;
+
+static void tool_set_error(tool_buffer *buffer, const char *format, ...) {
+    va_list arguments;
+    if (!buffer || !buffer->error || !buffer->error_capacity ||
+        buffer->error[0]) return;
+    va_start(arguments, format);
+    vsnprintf(buffer->error, buffer->error_capacity, format, arguments);
+    va_end(arguments);
+}
+
+static void tool_free_json(jval *value) {
+    int index;
+    if (!value) return;
+    if (value->t == J_OBJ) {
+        for (index = 0; index < value->len; ++index) {
+            free(value->keys[index]);
+            tool_free_json(value->kids[index]);
+        }
+        free(value->keys);
+        free(value->kids);
+    } else if (value->t == J_ARR) {
+        for (index = 0; index < value->len; ++index)
+            tool_free_json(value->kids[index]);
+        free(value->kids);
+    } else if (value->t == J_STR) {
+        free(value->str);
+    }
+    free(value);
+}
+
+typedef struct {
+    const unsigned char *cursor;
+    const unsigned char *end;
+    unsigned depth;
+} tool_json_scanner;
+
+static void tool_json_skip_space(tool_json_scanner *scanner) {
+    while (scanner->cursor < scanner->end &&
+           isspace(*scanner->cursor)) ++scanner->cursor;
+}
+
+static int tool_json_scan_value(tool_json_scanner *scanner);
+
+static int tool_json_scan_string(tool_json_scanner *scanner) {
+    if (scanner->cursor >= scanner->end || *scanner->cursor++ != '"')
+        return 0;
+    while (scanner->cursor < scanner->end) {
+        unsigned char character = *scanner->cursor++;
+        if (character == '"') return 1;
+        if (character < 0x20U) return 0;
+        if (character == '\\') {
+            unsigned escape_index;
+            if (scanner->cursor >= scanner->end) return 0;
+            character = *scanner->cursor++;
+            if (character == 'u') {
+                for (escape_index = 0; escape_index < 4; ++escape_index) {
+                    if (scanner->cursor >= scanner->end ||
+                        !isxdigit(*scanner->cursor++)) return 0;
+                }
+            } else if (!strchr("\"\\/bfnrt", character)) {
+                return 0;
+            }
+        }
+    }
+    return 0;
+}
+
+static int tool_json_scan_number(tool_json_scanner *scanner) {
+    const unsigned char *start = scanner->cursor;
+    if (scanner->cursor < scanner->end && *scanner->cursor == '-')
+        ++scanner->cursor;
+    if (scanner->cursor >= scanner->end) return 0;
+    if (*scanner->cursor == '0') {
+        ++scanner->cursor;
+        if (scanner->cursor < scanner->end &&
+            isdigit(*scanner->cursor)) return 0;
+    } else {
+        if (*scanner->cursor < '1' || *scanner->cursor > '9') return 0;
+        while (scanner->cursor < scanner->end &&
+               isdigit(*scanner->cursor)) ++scanner->cursor;
+    }
+    if (scanner->cursor < scanner->end && *scanner->cursor == '.') {
+        ++scanner->cursor;
+        if (scanner->cursor >= scanner->end ||
+            !isdigit(*scanner->cursor)) return 0;
+        while (scanner->cursor < scanner->end &&
+               isdigit(*scanner->cursor)) ++scanner->cursor;
+    }
+    if (scanner->cursor < scanner->end &&
+        (*scanner->cursor == 'e' || *scanner->cursor == 'E')) {
+        ++scanner->cursor;
+        if (scanner->cursor < scanner->end &&
+            (*scanner->cursor == '+' || *scanner->cursor == '-'))
+            ++scanner->cursor;
+        if (scanner->cursor >= scanner->end ||
+            !isdigit(*scanner->cursor)) return 0;
+        while (scanner->cursor < scanner->end &&
+               isdigit(*scanner->cursor)) ++scanner->cursor;
+    }
+    return scanner->cursor > start;
+}
+
+static int tool_json_scan_compound(tool_json_scanner *scanner, int object) {
+    unsigned char close = object ? '}' : ']';
+    ++scanner->cursor;
+    if (++scanner->depth > 128) return 0;
+    tool_json_skip_space(scanner);
+    if (scanner->cursor < scanner->end && *scanner->cursor == close) {
+        ++scanner->cursor;
+        --scanner->depth;
+        return 1;
+    }
+    for (;;) {
+        if (object) {
+            if (!tool_json_scan_string(scanner)) return 0;
+            tool_json_skip_space(scanner);
+            if (scanner->cursor >= scanner->end ||
+                *scanner->cursor++ != ':') return 0;
+        }
+        if (!tool_json_scan_value(scanner)) return 0;
+        tool_json_skip_space(scanner);
+        if (scanner->cursor >= scanner->end) return 0;
+        if (*scanner->cursor == close) {
+            ++scanner->cursor;
+            --scanner->depth;
+            return 1;
+        }
+        if (*scanner->cursor++ != ',') return 0;
+        tool_json_skip_space(scanner);
+    }
+}
+
+static int tool_json_scan_value(tool_json_scanner *scanner) {
+    size_t remaining;
+    tool_json_skip_space(scanner);
+    if (scanner->cursor >= scanner->end) return 0;
+    remaining = (size_t)(scanner->end - scanner->cursor);
+    if (*scanner->cursor == '"') return tool_json_scan_string(scanner);
+    if (*scanner->cursor == '{') return tool_json_scan_compound(scanner, 1);
+    if (*scanner->cursor == '[') return tool_json_scan_compound(scanner, 0);
+    if (remaining >= 4 && !memcmp(scanner->cursor, "true", 4)) {
+        scanner->cursor += 4;
+        return 1;
+    }
+    if (remaining >= 5 && !memcmp(scanner->cursor, "false", 5)) {
+        scanner->cursor += 5;
+        return 1;
+    }
+    if (remaining >= 4 && !memcmp(scanner->cursor, "null", 4)) {
+        scanner->cursor += 4;
+        return 1;
+    }
+    return tool_json_scan_number(scanner);
+}
+
+static int tool_json_is_complete(const char *input, size_t input_bytes) {
+    tool_json_scanner scanner;
+    scanner.cursor = (const unsigned char *)input;
+    scanner.end = scanner.cursor + input_bytes;
+    scanner.depth = 0;
+    if (!tool_json_scan_value(&scanner)) return 0;
+    tool_json_skip_space(&scanner);
+    return scanner.cursor == scanner.end && scanner.depth == 0;
+}
+
+static int tool_reserve(tool_buffer *buffer, size_t additional) {
+    size_t needed, capacity;
+    char *grown;
+    if (additional > SIZE_MAX - buffer->length - 1) {
+        tool_set_error(buffer, "rendered tool declarations are too large");
+        return -1;
+    }
+    needed = buffer->length + additional + 1;
+    if (needed <= buffer->capacity) return 0;
+    capacity = buffer->capacity ? buffer->capacity : 256;
+    while (capacity < needed) {
+        if (capacity > SIZE_MAX / 2) {
+            capacity = needed;
+            break;
+        }
+        capacity *= 2;
+    }
+    grown = (char *)realloc(buffer->data, capacity);
+    if (!grown) {
+        tool_set_error(buffer, "out of memory rendering tool declarations");
+        return -1;
+    }
+    buffer->data = grown;
+    buffer->capacity = capacity;
+    return 0;
+}
+
+static int tool_append_bytes(tool_buffer *buffer, const char *text,
+                             size_t bytes) {
+    if (tool_reserve(buffer, bytes) != 0) return -1;
+    if (bytes) memcpy(buffer->data + buffer->length, text, bytes);
+    buffer->length += bytes;
+    buffer->data[buffer->length] = '\0';
+    return 0;
+}
+
+static int tool_append(tool_buffer *buffer, const char *text) {
+    return tool_append_bytes(buffer, text, strlen(text));
+}
+
+static int tool_field_compare(const void *left_pointer,
+                              const void *right_pointer) {
+    const tool_field *left = (const tool_field *)left_pointer;
+    const tool_field *right = (const tool_field *)right_pointer;
+    const unsigned char *a = (const unsigned char *)left->key;
+    const unsigned char *b = (const unsigned char *)right->key;
+    while (*a && *b) {
+        int lower_a = tolower(*a), lower_b = tolower(*b);
+        if (lower_a != lower_b) return lower_a < lower_b ? -1 : 1;
+        ++a;
+        ++b;
+    }
+    if (*a != *b) return *a ? 1 : -1;
+    return left->original_index < right->original_index ? -1 :
+           left->original_index > right->original_index ? 1 : 0;
+}
+
+static int tool_ascii_equal(const char *left, const char *right) {
+    while (*left && *right) {
+        if (tolower((unsigned char)*left) !=
+            tolower((unsigned char)*right)) return 0;
+        ++left;
+        ++right;
+    }
+    return *left == *right;
+}
+
+static tool_field *tool_sorted_fields(jval *object) {
+    tool_field *fields;
+    int index;
+    if (!object || object->t != J_OBJ || object->len <= 0) return NULL;
+    fields = (tool_field *)malloc((size_t)object->len * sizeof(*fields));
+    if (!fields) return NULL;
+    for (index = 0; index < object->len; ++index) {
+        fields[index].key = object->keys[index];
+        fields[index].value = object->kids[index];
+        fields[index].original_index = index;
+    }
+    qsort(fields, (size_t)object->len, sizeof(*fields), tool_field_compare);
+    return fields;
+}
+
+static int tool_append_quoted(tool_buffer *buffer, const char *text) {
+    return tool_append(buffer, "<|\"|>") == 0 &&
+           tool_append(buffer, text ? text : "") == 0 &&
+           tool_append(buffer, "<|\"|>") == 0 ? 0 : -1;
+}
+
+static int tool_append_upper_quoted(tool_buffer *buffer, const char *text) {
+    size_t index;
+    if (tool_append(buffer, "<|\"|>") != 0) return -1;
+    for (index = 0; text && text[index]; ++index) {
+        char character = (char)toupper((unsigned char)text[index]);
+        if (tool_append_bytes(buffer, &character, 1) != 0) return -1;
+    }
+    return tool_append(buffer, "<|\"|>");
+}
+
+static int tool_format_argument(tool_buffer *buffer, jval *value,
+                                int quote_keys, unsigned depth);
+
+static int tool_format_sequence_upper(tool_buffer *buffer, jval *value,
+                                      unsigned depth) {
+    int index;
+    if (!value || value->t != J_ARR) return -1;
+    if (tool_append(buffer, "[") != 0) return -1;
+    for (index = 0; index < value->len; ++index) {
+        if (index && tool_append(buffer, ",") != 0) return -1;
+        if (value->kids[index]->t == J_STR) {
+            if (tool_append_upper_quoted(buffer, value->kids[index]->str) != 0)
+                return -1;
+        } else if (tool_format_argument(buffer, value->kids[index], 1,
+                                        depth + 1) != 0) return -1;
+    }
+    return tool_append(buffer, "]");
+}
+
+static int tool_format_argument(tool_buffer *buffer, jval *value,
+                                int quote_keys, unsigned depth) {
+    int index;
+    char number[64];
+    tool_field *fields;
+    if (!value || depth > 128) {
+        tool_set_error(buffer, "tool schema nesting exceeds 128 levels");
+        return -1;
+    }
+    switch (value->t) {
+        case J_NULL:
+            return tool_append(buffer, "null");
+        case J_BOOL:
+            return tool_append(buffer, value->boolean ? "true" : "false");
+        case J_NUM:
+            snprintf(number, sizeof(number), "%.17g", value->num);
+            return tool_append(buffer, number);
+        case J_STR:
+            return tool_append_quoted(buffer, value->str);
+        case J_ARR:
+            if (tool_append(buffer, "[") != 0) return -1;
+            for (index = 0; index < value->len; ++index) {
+                if (index && tool_append(buffer, ",") != 0) return -1;
+                if (tool_format_argument(buffer, value->kids[index], quote_keys,
+                                         depth + 1) != 0) return -1;
+            }
+            return tool_append(buffer, "]");
+        case J_OBJ:
+            fields = tool_sorted_fields(value);
+            if (value->len && !fields) {
+                tool_set_error(buffer, "out of memory sorting tool schema");
+                return -1;
+            }
+            if (tool_append(buffer, "{") != 0) {
+                free(fields);
+                return -1;
+            }
+            for (index = 0; index < value->len; ++index) {
+                if ((index && tool_append(buffer, ",") != 0) ||
+                    (quote_keys ? tool_append_quoted(buffer, fields[index].key) :
+                                  tool_append(buffer, fields[index].key)) != 0 ||
+                    tool_append(buffer, ":") != 0 ||
+                    tool_format_argument(buffer, fields[index].value,
+                                         quote_keys, depth + 1) != 0) {
+                    free(fields);
+                    return -1;
+                }
+            }
+            free(fields);
+            return tool_append(buffer, "}");
+    }
+    return -1;
+}
+
+static int tool_append_required(tool_buffer *buffer, jval *required) {
+    int index;
+    if (!required || required->t != J_ARR) return -1;
+    if (tool_append(buffer, "required:[") != 0) return -1;
+    for (index = 0; index < required->len; ++index) {
+        if (required->kids[index]->t != J_STR) {
+            tool_set_error(buffer, "required entries must be strings");
+            return -1;
+        }
+        if ((index && tool_append(buffer, ",") != 0) ||
+            tool_append_quoted(buffer, required->kids[index]->str) != 0)
+            return -1;
+    }
+    return tool_append(buffer, "]");
+}
+
+static int tool_is_standard_key(const char *key) {
+    return !strcmp(key, "description") || !strcmp(key, "type") ||
+           !strcmp(key, "properties") || !strcmp(key, "required") ||
+           !strcmp(key, "nullable");
+}
+
+static int tool_format_parameters(tool_buffer *buffer, jval *properties,
+                                  int filter_keys, unsigned depth);
+
+static int tool_format_array_items(tool_buffer *buffer, jval *items,
+                                   unsigned depth) {
+    tool_field *fields;
+    int index, emitted = 0;
+    if (!items || items->t != J_OBJ || items->len == 0) return 0;
+    fields = tool_sorted_fields(items);
+    if (!fields) {
+        tool_set_error(buffer, "out of memory sorting array item schema");
+        return -1;
+    }
+    if (tool_append(buffer, "items:{") != 0) goto failure;
+    for (index = 0; index < items->len; ++index) {
+        jval *value = fields[index].value;
+        if (!value || value->t == J_NULL) continue;
+        if (emitted++ && tool_append(buffer, ",") != 0) goto failure;
+        if (!strcmp(fields[index].key, "properties")) {
+            if (value->t != J_OBJ || tool_append(buffer, "properties:{") != 0 ||
+                tool_format_parameters(buffer, value, 0, depth + 1) != 0 ||
+                tool_append(buffer, "}") != 0) goto failure;
+        } else if (!strcmp(fields[index].key, "required")) {
+            if (tool_append_required(buffer, value) != 0) goto failure;
+        } else if (!strcmp(fields[index].key, "type")) {
+            if (tool_append(buffer, "type:") != 0) goto failure;
+            if (value->t == J_STR) {
+                if (tool_append_upper_quoted(buffer, value->str) != 0)
+                    goto failure;
+            } else if (value->t == J_ARR) {
+                if (tool_format_sequence_upper(buffer, value, depth + 1) != 0)
+                    goto failure;
+            } else {
+                tool_set_error(buffer, "array item type must be a string or array");
+                goto failure;
+            }
+        } else {
+            if (tool_append(buffer, fields[index].key) != 0 ||
+                tool_append(buffer, ":") != 0 ||
+                tool_format_argument(buffer, value, 1, depth + 1) != 0)
+                goto failure;
+        }
+    }
+    free(fields);
+    return tool_append(buffer, "}");
+failure:
+    free(fields);
+    return -1;
+}
+
+static int tool_format_property(tool_buffer *buffer, jval *value,
+                                unsigned depth) {
+    jval *type, *description, *enumeration, *items, *nullable;
+    jval *properties, *required;
+    int has_field = 0;
+    if (!value || value->t != J_OBJ) {
+        tool_set_error(buffer, "each tool property must be a JSON object");
+        return -1;
+    }
+    type = json_get(value, "type");
+    if (!type || type->t != J_STR || !type->str[0]) {
+        tool_set_error(buffer, "each tool property needs a string type");
+        return -1;
+    }
+    description = json_get(value, "description");
+    enumeration = json_get(value, "enum");
+    items = json_get(value, "items");
+    nullable = json_get(value, "nullable");
+    properties = json_get(value, "properties");
+    required = json_get(value, "required");
+    if (description && description->t != J_NULL &&
+        (description->t != J_STR || description->str[0])) {
+        if (description->t != J_STR ||
+            tool_append(buffer, "description:") != 0 ||
+            tool_append_quoted(buffer, description->str) != 0) {
+            tool_set_error(buffer, "tool property description must be a string");
+            return -1;
+        }
+        has_field = 1;
+    }
+    if (tool_ascii_equal(type->str, "string")) {
+        if (enumeration && enumeration->t != J_NULL &&
+            (enumeration->t != J_ARR || enumeration->len)) {
+            if (enumeration->t != J_ARR ||
+                (has_field && tool_append(buffer, ",") != 0) ||
+                tool_append(buffer, "enum:") != 0 ||
+                tool_format_argument(buffer, enumeration, 1, depth + 1) != 0)
+                return -1;
+            has_field = 1;
+        }
+    } else if (tool_ascii_equal(type->str, "array")) {
+        if (items && items->t == J_OBJ && items->len) {
+            if ((has_field && tool_append(buffer, ",") != 0) ||
+                tool_format_array_items(buffer, items, depth + 1) != 0)
+                return -1;
+            has_field = 1;
+        }
+    }
+    if (nullable && nullable->t == J_BOOL && nullable->boolean) {
+        if ((has_field && tool_append(buffer, ",") != 0) ||
+            tool_append(buffer, "nullable:true") != 0) return -1;
+        has_field = 1;
+    }
+    if (tool_ascii_equal(type->str, "object")) {
+        if (properties && properties->t == J_OBJ) {
+            if ((has_field && tool_append(buffer, ",") != 0) ||
+                tool_append(buffer, "properties:{") != 0 ||
+                tool_format_parameters(buffer, properties, 0, depth + 1) != 0 ||
+                tool_append(buffer, "}") != 0) return -1;
+            has_field = 1;
+        } else {
+            if ((has_field && tool_append(buffer, ",") != 0) ||
+                tool_append(buffer, "properties:{") != 0 ||
+                tool_format_parameters(buffer, value, 1, depth + 1) != 0 ||
+                tool_append(buffer, "}") != 0) return -1;
+            has_field = 1;
+        }
+        if (required && required->t == J_ARR && required->len) {
+            if ((has_field && tool_append(buffer, ",") != 0) ||
+                tool_append_required(buffer, required) != 0) return -1;
+            has_field = 1;
+        }
+    }
+    if (has_field && tool_append(buffer, ",") != 0) return -1;
+    if (tool_append(buffer, "type:") != 0 ||
+        tool_append_upper_quoted(buffer, type->str) != 0 ||
+        tool_append(buffer, "}") != 0) return -1;
+    return 0;
+}
+
+static int tool_format_parameters(tool_buffer *buffer, jval *properties,
+                                  int filter_keys, unsigned depth) {
+    tool_field *fields;
+    int index, emitted = 0;
+    if (!properties || properties->t != J_OBJ || depth > 128) return -1;
+    fields = tool_sorted_fields(properties);
+    if (properties->len && !fields) {
+        tool_set_error(buffer, "out of memory sorting tool properties");
+        return -1;
+    }
+    for (index = 0; index < properties->len; ++index) {
+        if (filter_keys && tool_is_standard_key(fields[index].key)) continue;
+        if (emitted++ && tool_append(buffer, ",") != 0) goto failure;
+        if (tool_append(buffer, fields[index].key) != 0 ||
+            tool_append(buffer, ":{") != 0 ||
+            tool_format_property(buffer, fields[index].value, depth + 1) != 0)
+            goto failure;
+    }
+    free(fields);
+    return 0;
+failure:
+    free(fields);
+    return -1;
+}
+
+static int tool_format_function(tool_buffer *buffer, jval *tool,
+                                int tool_index) {
+    jval *kind, *function, *name, *description, *parameters, *response;
+    jval *properties, *required, *type;
+    if (!tool || tool->t != J_OBJ) goto invalid;
+    kind = json_get(tool, "type");
+    function = json_get(tool, "function");
+    if (!kind || kind->t != J_STR || strcmp(kind->str, "function") ||
+        !function || function->t != J_OBJ) goto invalid;
+    name = json_get(function, "name");
+    description = json_get(function, "description");
+    parameters = json_get(function, "parameters");
+    if (!name || name->t != J_STR || !name->str[0] ||
+        (description && description->t != J_STR) ||
+        (parameters && parameters->t != J_OBJ)) goto invalid;
+    if (tool_append(buffer, "<|tool>declaration:") != 0 ||
+        tool_append(buffer, name->str) != 0 ||
+        tool_append(buffer, "{description:") != 0 ||
+        tool_append_quoted(buffer, description ? description->str : "") != 0)
+        return -1;
+    if (parameters && parameters->len) {
+        properties = json_get(parameters, "properties");
+        required = json_get(parameters, "required");
+        type = json_get(parameters, "type");
+        if ((properties && properties->t != J_OBJ) ||
+            (required && required->t != J_ARR) ||
+            !type || type->t != J_STR || !type->str[0]) goto invalid;
+        if (tool_append(buffer, ",parameters:{") != 0) return -1;
+        if (properties && properties->len) {
+            if (tool_append(buffer, "properties:{") != 0 ||
+                tool_format_parameters(buffer, properties, 0, 0) != 0 ||
+                tool_append(buffer, "},") != 0) return -1;
+        }
+        if (required && required->len) {
+            if (tool_append_required(buffer, required) != 0 ||
+                tool_append(buffer, ",") != 0) return -1;
+        }
+        if (type && type->str[0]) {
+            if (tool_append(buffer, "type:") != 0 ||
+                tool_append_upper_quoted(buffer, type->str) != 0 ||
+                tool_append(buffer, "}") != 0) return -1;
+        }
+    }
+    response = json_get(function, "response");
+    if (response) {
+        jval *response_description, *response_type;
+        if (response->t != J_OBJ) goto invalid;
+        response_description = json_get(response, "description");
+        response_type = json_get(response, "type");
+        if ((response_description && response_description->t != J_STR) ||
+            !response_type || response_type->t != J_STR ||
+            !tool_ascii_equal(response_type->str, "object")) goto invalid;
+        if (tool_append(buffer, ",response:{") != 0) return -1;
+        if (response_description && response_description->str[0]) {
+            if (tool_append(buffer, "description:") != 0 ||
+                tool_append_quoted(buffer, response_description->str) != 0 ||
+                tool_append(buffer, ",") != 0) return -1;
+        }
+        if (tool_append(buffer, "type:") != 0 ||
+            tool_append_upper_quoted(buffer, response_type->str) != 0 ||
+            tool_append(buffer, "}") != 0) return -1;
+    }
+    return tool_append(buffer, "}<tool|>");
+invalid:
+    tool_set_error(buffer, "tool %d is not a valid function declaration",
+                   tool_index);
+    return -1;
+}
+
+int coli_gemma4_render_tools(const char *json, size_t json_bytes,
+                             char **rendered, size_t *rendered_bytes,
+                             char *error, size_t error_capacity) {
+    tool_buffer buffer;
+    char *input = NULL, *arena = NULL;
+    jval *root = NULL;
+    int index, result = -1;
+    if (error && error_capacity) error[0] = '\0';
+    if (!json || !rendered || !rendered_bytes ||
+        (json_bytes == SIZE_MAX)) return -1;
+    *rendered = NULL;
+    *rendered_bytes = 0;
+    memset(&buffer, 0, sizeof(buffer));
+    buffer.error = error;
+    buffer.error_capacity = error_capacity;
+    input = (char *)malloc(json_bytes + 1);
+    if (!input) {
+        tool_set_error(&buffer, "out of memory reading tool declarations");
+        goto cleanup;
+    }
+    memcpy(input, json, json_bytes);
+    input[json_bytes] = '\0';
+    if (!tool_json_is_complete(input, json_bytes)) {
+        tool_set_error(&buffer, "tools file is not complete JSON");
+        goto cleanup;
+    }
+    root = json_parse(input, &arena);
+    if (!root || root->t != J_ARR) {
+        tool_set_error(&buffer, "tools file must contain a JSON array");
+        goto cleanup;
+    }
+    for (index = 0; index < root->len; ++index)
+        if (tool_format_function(&buffer, root->kids[index], index) != 0)
+            goto cleanup;
+    if (!buffer.data) {
+        buffer.data = (char *)malloc(1);
+        if (!buffer.data) {
+            tool_set_error(&buffer, "out of memory rendering tool declarations");
+            goto cleanup;
+        }
+        buffer.data[0] = '\0';
+    }
+    *rendered = buffer.data;
+    *rendered_bytes = buffer.length;
+    buffer.data = NULL;
+    result = 0;
+cleanup:
+    if (result != 0 && error && error_capacity && !error[0])
+        snprintf(error, error_capacity, "cannot render tool declarations");
+    free(buffer.data);
+    tool_free_json(root);
+    free(arena);
+    free(input);
+    return result;
+}
+
+static size_t tool_find_bytes(const char *text, size_t text_bytes,
+                              size_t start, const char *needle,
+                              size_t needle_bytes) {
+    size_t position;
+    if (!needle_bytes || start > text_bytes ||
+        needle_bytes > text_bytes - start) return SIZE_MAX;
+    for (position = start; position <= text_bytes - needle_bytes; ++position)
+        if (!memcmp(text + position, needle, needle_bytes)) return position;
+    return SIZE_MAX;
+}
+
+static int tool_valid_name(const char *name, size_t name_bytes) {
+    size_t index;
+    if (!name_bytes || name_bytes >= COLI_GEMMA4_TOOL_NAME_MAX) return 0;
+    for (index = 0; index < name_bytes; ++index) {
+        unsigned char character = (unsigned char)name[index];
+        if (!isalnum(character) && character != '_' && character != '-' &&
+            character != '.') return 0;
+    }
+    return 1;
+}
+
+int coli_gemma4_parse_tool_calls(const char *generated,
+                                 size_t generated_bytes,
+                                 coli_gemma4_tool_call *calls,
+                                 size_t capacity, size_t *count,
+                                 char *error, size_t error_capacity) {
+    static const char prefix[] = "<|tool_call>call:";
+    static const char close[] = "<tool_call|>";
+    size_t cursor = 0, found = 0;
+    if (error && error_capacity) error[0] = '\0';
+    if (!generated || !calls || !count) return -1;
+    *count = 0;
+    while (cursor < generated_bytes) {
+        size_t begin = tool_find_bytes(
+            generated, generated_bytes, cursor, prefix, sizeof(prefix) - 1);
+        size_t name_begin, arguments_begin, close_begin, name_bytes;
+        if (begin == SIZE_MAX) break;
+        name_begin = begin + sizeof(prefix) - 1;
+        arguments_begin = tool_find_bytes(
+            generated, generated_bytes, name_begin, "{", 1);
+        close_begin = tool_find_bytes(
+            generated, generated_bytes, name_begin, close, sizeof(close) - 1);
+        if (arguments_begin == SIZE_MAX || close_begin == SIZE_MAX ||
+            arguments_begin >= close_begin) {
+            if (error && error_capacity)
+                snprintf(error, error_capacity,
+                         "generated tool call is missing arguments or closure");
+            return -1;
+        }
+        name_bytes = arguments_begin - name_begin;
+        if (!tool_valid_name(generated + name_begin, name_bytes)) {
+            if (error && error_capacity)
+                snprintf(error, error_capacity,
+                         "generated tool call has an invalid function name");
+            return -1;
+        }
+        if (found >= capacity) {
+            if (error && error_capacity)
+                snprintf(error, error_capacity,
+                         "generated more than %zu tool calls", capacity);
+            return -1;
+        }
+        memcpy(calls[found].name, generated + name_begin, name_bytes);
+        calls[found].name[name_bytes] = '\0';
+        calls[found].arguments_offset = arguments_begin;
+        calls[found].arguments_bytes = close_begin - arguments_begin;
+        ++found;
+        cursor = close_begin + sizeof(close) - 1;
+    }
+    if (!found) {
+        if (error && error_capacity)
+            snprintf(error, error_capacity,
+                     "tool-response handoff contained no complete tool call");
+        return -1;
+    }
+    *count = found;
+    return 0;
+}
+
+int coli_gemma4_render_tool_response(const char *tool_name,
+                                     const char *json, size_t json_bytes,
+                                     int include_open_token,
+                                     char **rendered,
+                                     size_t *rendered_bytes,
+                                     char *error, size_t error_capacity) {
+    tool_buffer buffer;
+    char *input = NULL, *arena = NULL;
+    jval *root = NULL;
+    tool_field *fields = NULL;
+    size_t name_bytes;
+    int index, result = -1;
+    if (error && error_capacity) error[0] = '\0';
+    if (!tool_name || !json || !rendered || !rendered_bytes ||
+        json_bytes == SIZE_MAX) return -1;
+    *rendered = NULL;
+    *rendered_bytes = 0;
+    memset(&buffer, 0, sizeof(buffer));
+    buffer.error = error;
+    buffer.error_capacity = error_capacity;
+    name_bytes = strlen(tool_name);
+    if (!tool_valid_name(tool_name, name_bytes)) {
+        tool_set_error(&buffer, "invalid tool response function name");
+        goto cleanup;
+    }
+    input = (char *)malloc(json_bytes + 1);
+    if (!input) {
+        tool_set_error(&buffer, "out of memory reading tool response");
+        goto cleanup;
+    }
+    memcpy(input, json, json_bytes);
+    input[json_bytes] = '\0';
+    if (!tool_json_is_complete(input, json_bytes)) {
+        tool_set_error(&buffer, "tool response must be one complete JSON value");
+        goto cleanup;
+    }
+    root = json_parse(input, &arena);
+    if (!root) {
+        tool_set_error(&buffer, "tool response must be a JSON value");
+        goto cleanup;
+    }
+    if ((include_open_token &&
+         tool_append(&buffer, "<|tool_response>") != 0) ||
+        tool_append(&buffer, "response:") != 0 ||
+        tool_append(&buffer, tool_name) != 0 ||
+        tool_append(&buffer, "{") != 0) goto cleanup;
+    if (root->t == J_OBJ) {
+        fields = tool_sorted_fields(root);
+        if (root->len && !fields) {
+            tool_set_error(&buffer, "out of memory sorting tool response");
+            goto cleanup;
+        }
+        for (index = 0; index < root->len; ++index) {
+            if ((index && tool_append(&buffer, ",") != 0) ||
+                tool_append(&buffer, fields[index].key) != 0 ||
+                tool_append(&buffer, ":") != 0 ||
+                tool_format_argument(&buffer, fields[index].value, 0, 0) != 0)
+                goto cleanup;
+        }
+    } else {
+        if (tool_append(&buffer, "value:") != 0 ||
+            tool_format_argument(&buffer, root, 0, 0) != 0) goto cleanup;
+    }
+    if (tool_append(&buffer, "}<tool_response|>") != 0) goto cleanup;
+    *rendered = buffer.data;
+    *rendered_bytes = buffer.length;
+    buffer.data = NULL;
+    result = 0;
+cleanup:
+    if (result != 0 && error && error_capacity && !error[0])
+        snprintf(error, error_capacity, "cannot render tool response");
+    free(fields);
+    free(buffer.data);
+    tool_free_json(root);
+    free(arena);
+    free(input);
+    return result;
+}

--- a/c/gemma4_tools.h
+++ b/c/gemma4_tools.h
@@ -1,0 +1,30 @@
+#ifndef COLI_GEMMA4_TOOLS_H
+#define COLI_GEMMA4_TOOLS_H
+
+#include <stddef.h>
+
+#define COLI_GEMMA4_TOOLS_ERROR_MAX 256
+#define COLI_GEMMA4_TOOL_NAME_MAX 128
+
+typedef struct {
+    char name[COLI_GEMMA4_TOOL_NAME_MAX];
+    size_t arguments_offset;
+    size_t arguments_bytes;
+} coli_gemma4_tool_call;
+
+int coli_gemma4_render_tools(const char *json, size_t json_bytes,
+                             char **rendered, size_t *rendered_bytes,
+                             char *error, size_t error_capacity);
+int coli_gemma4_parse_tool_calls(const char *generated,
+                                 size_t generated_bytes,
+                                 coli_gemma4_tool_call *calls,
+                                 size_t capacity, size_t *count,
+                                 char *error, size_t error_capacity);
+int coli_gemma4_render_tool_response(const char *tool_name,
+                                     const char *json, size_t json_bytes,
+                                     int include_open_token,
+                                     char **rendered,
+                                     size_t *rendered_bytes,
+                                     char *error, size_t error_capacity);
+
+#endif

--- a/c/gemma4_vision.c
+++ b/c/gemma4_vision.c
@@ -1,0 +1,1931 @@
+#define _CRT_SECURE_NO_WARNINGS
+
+#include "gemma4_vision.h"
+
+#include <math.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(COLI_GEMMA4_VISION_AVX2) || defined(__AVX2__)
+#include <immintrin.h>
+#define COLI_VISION_HAS_AVX2 1
+#endif
+
+#ifdef COLI_GEMMA4_LIBPNG
+#include <png.h>
+#endif
+#ifdef COLI_GEMMA4_LIBJPEG
+#include <setjmp.h>
+#include <jpeglib.h>
+#endif
+
+#ifdef _WIN32
+#define COBJMACROS
+#include <windows.h>
+#include <wincodec.h>
+#endif
+
+static void ppm_error(char *error, size_t capacity, const char *format, ...) {
+    va_list arguments;
+    if (!error || !capacity) return;
+    va_start(arguments, format);
+    vsnprintf(error, capacity, format, arguments);
+    va_end(arguments);
+}
+
+static int ppm_token(FILE *file, char *token, size_t capacity) {
+    int character;
+    size_t length = 0;
+    do {
+        character = fgetc(file);
+        if (character == '#')
+            while ((character = fgetc(file)) != '\n' && character != EOF) {}
+    } while (character == ' ' || character == '\t' ||
+             character == '\r' || character == '\n');
+    if (character == EOF) return -1;
+    do {
+        if (length + 1 >= capacity) return -1;
+        token[length++] = (char)character;
+        character = fgetc(file);
+    } while (character != EOF && character != ' ' && character != '\t' &&
+             character != '\r' && character != '\n');
+    if (character == '\r') {
+        character = fgetc(file);
+        if (character != '\n' && character != EOF) ungetc(character, file);
+    }
+    token[length] = '\0';
+    return 0;
+}
+
+int coli_gemma4_vision_load_ppm(const char *path, uint8_t **rgb,
+                                uint32_t *width, uint32_t *height,
+                                char *error, size_t error_capacity) {
+    FILE *file = NULL;
+    uint8_t *pixels = NULL;
+    char token[64], *end = NULL;
+    unsigned long parsed_width, parsed_height, maximum;
+    size_t pixel_bytes;
+    int status = -1;
+    if (error && error_capacity) error[0] = '\0';
+    if (!path || !rgb || !width || !height) return -1;
+    *rgb = NULL;
+    *width = 0;
+    *height = 0;
+    file = fopen(path, "rb");
+    if (!file) {
+        ppm_error(error, error_capacity, "cannot open %s: %s", path,
+                  strerror(errno));
+        return -1;
+    }
+    if (ppm_token(file, token, sizeof(token)) != 0 || strcmp(token, "P6") != 0) {
+        ppm_error(error, error_capacity,
+                  "%s is not a binary PPM (expected P6)", path);
+        goto cleanup;
+    }
+    if (ppm_token(file, token, sizeof(token)) != 0) goto invalid_header;
+    errno = 0;
+    parsed_width = strtoul(token, &end, 10);
+    if (errno || !end || *end || !parsed_width || parsed_width > UINT32_MAX)
+        goto invalid_header;
+    if (ppm_token(file, token, sizeof(token)) != 0) goto invalid_header;
+    errno = 0;
+    parsed_height = strtoul(token, &end, 10);
+    if (errno || !end || *end || !parsed_height || parsed_height > UINT32_MAX)
+        goto invalid_header;
+    if (ppm_token(file, token, sizeof(token)) != 0) goto invalid_header;
+    errno = 0;
+    maximum = strtoul(token, &end, 10);
+    if (errno || !end || *end || maximum != 255) {
+        ppm_error(error, error_capacity,
+                  "%s must use 8-bit PPM samples (maxval 255)", path);
+        goto cleanup;
+    }
+    if ((uint64_t)parsed_width * (uint64_t)parsed_height > SIZE_MAX / 3) {
+        ppm_error(error, error_capacity, "%s dimensions are too large", path);
+        goto cleanup;
+    }
+    pixel_bytes = (size_t)parsed_width * (size_t)parsed_height * 3;
+    pixels = (uint8_t *)malloc(pixel_bytes);
+    if (!pixels) {
+        ppm_error(error, error_capacity, "out of memory reading %s", path);
+        goto cleanup;
+    }
+    if (fread(pixels, 1, pixel_bytes, file) != pixel_bytes) {
+        ppm_error(error, error_capacity, "%s has a truncated pixel payload", path);
+        goto cleanup;
+    }
+    *rgb = pixels;
+    *width = (uint32_t)parsed_width;
+    *height = (uint32_t)parsed_height;
+    pixels = NULL;
+    status = 0;
+    goto cleanup;
+
+invalid_header:
+    ppm_error(error, error_capacity, "%s has an invalid PPM header", path);
+cleanup:
+    free(pixels);
+    fclose(file);
+    return status;
+}
+
+#ifdef COLI_GEMMA4_LIBPNG
+static int load_png_image(const char *path, uint8_t **rgb,
+                          uint32_t *width, uint32_t *height,
+                          char *error, size_t error_capacity) {
+    png_image image;
+    uint8_t *pixels = NULL;
+    size_t pixel_bytes;
+    memset(&image, 0, sizeof(image));
+    image.version = PNG_IMAGE_VERSION;
+    if (!png_image_begin_read_from_file(&image, path)) {
+        ppm_error(error, error_capacity, "cannot decode PNG %s: %s", path,
+                  image.message);
+        return -1;
+    }
+    image.format = PNG_FORMAT_RGB;
+    if (!image.width || !image.height || image.width > SIZE_MAX / 3U ||
+        image.height > SIZE_MAX / ((size_t)image.width * 3U)) {
+        ppm_error(error, error_capacity, "%s dimensions are too large", path);
+        png_image_free(&image);
+        return -1;
+    }
+    pixel_bytes = PNG_IMAGE_SIZE(image);
+    pixels = (uint8_t *)malloc(pixel_bytes);
+    if (!pixels || !png_image_finish_read(&image, NULL, pixels, 0, NULL)) {
+        ppm_error(error, error_capacity, "cannot decode PNG %s: %s", path,
+                  pixels ? image.message : "out of memory");
+        free(pixels);
+        png_image_free(&image);
+        return -1;
+    }
+    *rgb = pixels;
+    *width = (uint32_t)image.width;
+    *height = (uint32_t)image.height;
+    png_image_free(&image);
+    return 0;
+}
+#endif
+
+#ifdef COLI_GEMMA4_LIBJPEG
+typedef struct {
+    struct jpeg_error_mgr base;
+    jmp_buf jump;
+    char message[JMSG_LENGTH_MAX];
+} coli_jpeg_error;
+
+static void jpeg_failure(j_common_ptr common) {
+    coli_jpeg_error *failure = (coli_jpeg_error *)common->err;
+    (*common->err->format_message)(common, failure->message);
+    longjmp(failure->jump, 1);
+}
+
+static int load_jpeg_image(const char *path, uint8_t **rgb,
+                           uint32_t *width, uint32_t *height,
+                           char *error, size_t error_capacity) {
+    struct jpeg_decompress_struct decoder;
+    coli_jpeg_error failure;
+    FILE * volatile file = NULL;
+    uint8_t * volatile pixels = NULL;
+    size_t stride, pixel_bytes;
+    volatile int created = 0;
+    int status = -1;
+    memset(&decoder, 0, sizeof(decoder));
+    memset(&failure, 0, sizeof(failure));
+    decoder.err = jpeg_std_error(&failure.base);
+    failure.base.error_exit = jpeg_failure;
+    if (setjmp(failure.jump)) {
+        ppm_error(error, error_capacity, "cannot decode JPEG %s: %s", path,
+                  failure.message[0] ? failure.message : "invalid image");
+        goto cleanup;
+    }
+    file = fopen(path, "rb");
+    if (!file) {
+        ppm_error(error, error_capacity, "cannot open %s: %s", path,
+                  strerror(errno));
+        goto cleanup;
+    }
+    jpeg_create_decompress(&decoder);
+    created = 1;
+    jpeg_stdio_src(&decoder, (FILE *)file);
+    if (jpeg_read_header(&decoder, TRUE) != JPEG_HEADER_OK) goto cleanup;
+    decoder.out_color_space = JCS_RGB;
+    if (!jpeg_start_decompress(&decoder) || !decoder.output_width ||
+        !decoder.output_height || decoder.output_components != 3 ||
+        decoder.output_width > SIZE_MAX / 3U ||
+        decoder.output_height >
+            SIZE_MAX / ((size_t)decoder.output_width * 3U)) {
+        ppm_error(error, error_capacity, "%s has unsupported dimensions", path);
+        goto cleanup;
+    }
+    stride = (size_t)decoder.output_width * 3U;
+    pixel_bytes = stride * (size_t)decoder.output_height;
+    pixels = (uint8_t *)malloc(pixel_bytes);
+    if (!pixels) {
+        ppm_error(error, error_capacity, "out of memory reading %s", path);
+        goto cleanup;
+    }
+    while (decoder.output_scanline < decoder.output_height) {
+        JSAMPROW row = (uint8_t *)pixels +
+                       (size_t)decoder.output_scanline * stride;
+        if (jpeg_read_scanlines(&decoder, &row, 1) != 1) goto cleanup;
+    }
+    if (!jpeg_finish_decompress(&decoder)) goto cleanup;
+    *rgb = (uint8_t *)pixels;
+    *width = (uint32_t)decoder.output_width;
+    *height = (uint32_t)decoder.output_height;
+    pixels = NULL;
+    status = 0;
+cleanup:
+    free((uint8_t *)pixels);
+    if (created) jpeg_destroy_decompress(&decoder);
+    if (file) fclose((FILE *)file);
+    return status;
+}
+#endif
+
+#ifdef _WIN32
+static int load_wic_image(const char *path, uint8_t **rgb,
+                          uint32_t *width, uint32_t *height,
+                          char *error, size_t error_capacity) {
+    IWICImagingFactory *factory = NULL;
+    IWICBitmapDecoder *decoder = NULL;
+    IWICBitmapFrameDecode *frame = NULL;
+    IWICFormatConverter *converter = NULL;
+    wchar_t *wide_path = NULL;
+    uint8_t *pixels = NULL;
+    UINT image_width = 0, image_height = 0, stride = 0, pixel_bytes = 0;
+    HRESULT initialized, result;
+    int wide_length, status = -1;
+    initialized = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+    if (FAILED(initialized) && initialized != RPC_E_CHANGED_MODE) {
+        ppm_error(error, error_capacity, "cannot initialize image decoder (0x%08lx)",
+                  (unsigned long)initialized);
+        return -1;
+    }
+    wide_length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                                      path, -1, NULL, 0);
+    if (!wide_length ||
+        (size_t)wide_length > SIZE_MAX / sizeof(*wide_path)) {
+        ppm_error(error, error_capacity, "image path is not valid UTF-8");
+        goto cleanup;
+    }
+    wide_path = (wchar_t *)malloc((size_t)wide_length * sizeof(*wide_path));
+    if (!wide_path || !MultiByteToWideChar(
+            CP_UTF8, MB_ERR_INVALID_CHARS, path, -1,
+            wide_path, wide_length)) {
+        ppm_error(error, error_capacity, "image path is not valid UTF-8");
+        goto cleanup;
+    }
+    result = CoCreateInstance(&CLSID_WICImagingFactory, NULL,
+                              CLSCTX_INPROC_SERVER, &IID_IWICImagingFactory,
+                              (void **)&factory);
+    if (SUCCEEDED(result))
+        result = IWICImagingFactory_CreateDecoderFromFilename(
+            factory, wide_path, NULL, GENERIC_READ,
+            WICDecodeMetadataCacheOnLoad, &decoder);
+    if (SUCCEEDED(result))
+        result = IWICBitmapDecoder_GetFrame(decoder, 0, &frame);
+    if (SUCCEEDED(result))
+        result = IWICBitmapFrameDecode_GetSize(frame, &image_width,
+                                                &image_height);
+    if (SUCCEEDED(result) && (!image_width || !image_height ||
+        image_width > UINT32_MAX || image_height > UINT32_MAX ||
+        image_width > UINT_MAX / 3U ||
+        image_height > UINT_MAX / (image_width * 3U)))
+        result = E_INVALIDARG;
+    if (SUCCEEDED(result))
+        result = IWICImagingFactory_CreateFormatConverter(factory, &converter);
+    if (SUCCEEDED(result))
+        result = IWICFormatConverter_Initialize(
+            converter, (IWICBitmapSource *)frame, &GUID_WICPixelFormat24bppRGB,
+            WICBitmapDitherTypeNone, NULL, 0.0, WICBitmapPaletteTypeCustom);
+    if (SUCCEEDED(result)) {
+        stride = image_width * 3U;
+        pixel_bytes = stride * image_height;
+        pixels = (uint8_t *)malloc(pixel_bytes);
+        if (!pixels) result = E_OUTOFMEMORY;
+    }
+    if (SUCCEEDED(result))
+        result = IWICFormatConverter_CopyPixels(
+            converter, NULL, stride, pixel_bytes, pixels);
+    if (FAILED(result)) {
+        ppm_error(error, error_capacity,
+                  "cannot decode image %s (WIC error 0x%08lx)", path,
+                  (unsigned long)result);
+        goto cleanup;
+    }
+    *rgb = pixels;
+    *width = (uint32_t)image_width;
+    *height = (uint32_t)image_height;
+    pixels = NULL;
+    status = 0;
+cleanup:
+    free(pixels);
+    free(wide_path);
+    if (converter) IWICFormatConverter_Release(converter);
+    if (frame) IWICBitmapFrameDecode_Release(frame);
+    if (decoder) IWICBitmapDecoder_Release(decoder);
+    if (factory) IWICImagingFactory_Release(factory);
+    if (SUCCEEDED(initialized)) CoUninitialize();
+    return status;
+}
+#endif
+
+int coli_gemma4_vision_load_image(const char *path, uint8_t **rgb,
+                                  uint32_t *width, uint32_t *height,
+                                  char *error, size_t error_capacity) {
+    FILE *file;
+    unsigned char signature[8] = {0};
+    if (!path || !rgb || !width || !height) return -1;
+    file = fopen(path, "rb");
+    if (!file) {
+        ppm_error(error, error_capacity, "cannot open %s: %s", path,
+                  strerror(errno));
+        return -1;
+    }
+    (void)fread(signature, 1, sizeof(signature), file);
+    fclose(file);
+    if (signature[0] == 'P' && signature[1] == '6')
+        return coli_gemma4_vision_load_ppm(
+            path, rgb, width, height, error, error_capacity);
+#ifdef _WIN32
+    return load_wic_image(path, rgb, width, height, error, error_capacity);
+#else
+#ifdef COLI_GEMMA4_LIBPNG
+    if (png_sig_cmp(signature, 0, sizeof(signature)) == 0)
+        return load_png_image(path, rgb, width, height,
+                              error, error_capacity);
+#endif
+#ifdef COLI_GEMMA4_LIBJPEG
+    if (signature[0] == 0xffU && signature[1] == 0xd8U)
+        return load_jpeg_image(path, rgb, width, height,
+                               error, error_capacity);
+#endif
+    ppm_error(error, error_capacity,
+              "%s is not a supported PPM/PNG/JPEG image", path);
+    return -1;
+#endif
+}
+
+typedef struct {
+    uint16_t *q;
+    uint16_t *k;
+    uint16_t *v;
+    uint16_t *output;
+    uint16_t *ff_up;
+    uint16_t *ff_gate;
+    uint16_t *ff_down;
+    float *ln1;
+    float *ln2;
+    float *q_norm;
+    float *k_norm;
+    float *attention_post_norm;
+    float *ffn_post_norm;
+} vision_block;
+
+static void vision_error(coli_gemma4_vision *vision, const char *format, ...) {
+    va_list arguments;
+    if (!vision) return;
+    va_start(arguments, format);
+    vsnprintf(vision->last_error, sizeof(vision->last_error), format, arguments);
+    va_end(arguments);
+}
+
+static int vision_trace_f32(coli_gemma4_vision *vision, uint32_t layer,
+                            const char *name, const float *values,
+                            size_t count) {
+    char path[1024];
+    FILE *file;
+    int path_length;
+    int close_status;
+    if (!vision->trace_directory || vision->trace_layer != layer) return 0;
+    path_length = snprintf(path, sizeof(path),
+                           "%s/native-vision-layer%u-%s.f32",
+                           vision->trace_directory, layer, name);
+    if (path_length < 0 || (size_t)path_length >= sizeof(path)) {
+        vision_error(vision, "vision trace path is too long");
+        return -1;
+    }
+    file = fopen(path, "wb");
+    if (!file) {
+        vision_error(vision, "cannot write vision trace %s", path);
+        return -1;
+    }
+    if (fwrite(values, sizeof(*values), count, file) != count) {
+        fclose(file);
+        vision_error(vision, "cannot write vision trace %s", path);
+        return -1;
+    }
+    close_status = fclose(file);
+    if (close_status != 0) {
+        vision_error(vision, "cannot write vision trace %s", path);
+        return -1;
+    }
+    return 0;
+}
+
+static int tensor_shape(const coli_gemma4_tensor *tensor, uint32_t type,
+                        uint32_t dimensions, const uint64_t *shape) {
+    uint32_t dimension;
+    if (!tensor || tensor->type != type || tensor->n_dims != dimensions)
+        return 0;
+    for (dimension = 0; dimension < dimensions; ++dimension)
+        if (tensor->dims[dimension] != shape[dimension]) return 0;
+    return 1;
+}
+
+static float bf16_value(uint16_t value) {
+    union { uint32_t bits; float value; } converted;
+    converted.bits = (uint32_t)value << 16;
+    return converted.value;
+}
+
+static uint16_t bf16_rounded_bits(float value) {
+    union { uint32_t bits; float value; } converted;
+    uint16_t rounded;
+    converted.value = value;
+    if ((converted.bits & UINT32_C(0x7fffffff)) > UINT32_C(0x7f800000))
+        rounded = (uint16_t)((converted.bits >> 16) | UINT32_C(64));
+    else
+        rounded = (uint16_t)((converted.bits + UINT32_C(0x7fff) +
+                              ((converted.bits >> 16) & UINT32_C(1))) >> 16);
+    return rounded;
+}
+
+static const char *vision_compat_mode(void) {
+    const char *mode = getenv("COLI_GEMMA4_VISION_COMPAT");
+    return mode ? mode : "";
+}
+
+static int vision_compat_has(const char *feature) {
+    const char *mode = vision_compat_mode();
+    if (strcmp(mode, "llama-avx2") == 0)
+        return strcmp(feature, "rms64") == 0 ||
+               strcmp(feature, "ropeiter") == 0 ||
+               strcmp(feature, "fma8") == 0 ||
+               strcmp(feature, "patchvecdot") == 0 ||
+               strcmp(feature, "flashtiled") == 0 ||
+               strcmp(feature, "gelu16") == 0;
+    return strstr(mode, feature) != NULL;
+}
+
+static float bf16_dot_fma8(const uint16_t *left, const uint16_t *right,
+                           uint32_t count) {
+    float sums[8] = { 0.0F, 0.0F, 0.0F, 0.0F,
+                      0.0F, 0.0F, 0.0F, 0.0F };
+    uint32_t index = 0;
+    for (; index + 8U <= count; index += 8U) {
+        uint32_t lane;
+        for (lane = 0; lane < 8U; ++lane)
+            sums[lane] = fmaf(bf16_value(left[index + lane]),
+                              bf16_value(right[index + lane]), sums[lane]);
+    }
+    {
+        float pair0 = sums[0] + sums[4];
+        float pair1 = sums[1] + sums[5];
+        float pair2 = sums[2] + sums[6];
+        float pair3 = sums[3] + sums[7];
+        float total = (pair0 + pair2) + (pair1 + pair3);
+        for (; index < count; ++index)
+            total += bf16_value(left[index]) * bf16_value(right[index]);
+        return total;
+    }
+}
+
+static float bf16_dot_vecdot(const uint16_t *left, const uint16_t *right,
+                             uint32_t count) {
+    float sums[4][8] = { { 0.0F } };
+    uint32_t index = 0;
+    for (; index + 32U <= count; index += 32U) {
+        uint32_t vector, lane;
+        for (vector = 0; vector < 4U; ++vector)
+            for (lane = 0; lane < 8U; ++lane) {
+                uint32_t position = index + vector * 8U + lane;
+                float product = bf16_value(left[position]) *
+                                bf16_value(right[position]);
+                sums[vector][lane] += product;
+            }
+    }
+    {
+        float lanes[8];
+        float pair0, pair1, pair2, pair3, total;
+        uint32_t lane;
+        for (lane = 0; lane < 8U; ++lane)
+            lanes[lane] = (sums[0][lane] + sums[2][lane]) +
+                          (sums[1][lane] + sums[3][lane]);
+        pair0 = lanes[0] + lanes[4];
+        pair1 = lanes[1] + lanes[5];
+        pair2 = lanes[2] + lanes[6];
+        pair3 = lanes[3] + lanes[7];
+        total = (pair0 + pair2) + (pair1 + pair3);
+        for (; index < count; ++index)
+            total += bf16_value(left[index]) * bf16_value(right[index]);
+        return total;
+    }
+}
+
+static float f32_from_bits(uint32_t bits) {
+    union { uint32_t bits; float value; } converted;
+    converted.bits = bits;
+    return converted.value;
+}
+
+/* Scalar transcription of ggml_v_expf's AVX2/FMA polynomial. The vision
+   softmax only evaluates non-positive values close enough to zero to use the
+   fast path; extreme inputs retain libm's range handling. */
+static float vision_fast_expf(float x) {
+    const float r = f32_from_bits(UINT32_C(0x4b400000));
+    float z = fmaf(x, f32_from_bits(UINT32_C(0x3fb8aa3b)), r);
+    float n = z - r;
+    float b, u, polynomial, tail;
+    uint32_t exponent;
+    if (!isfinite(x)) return x < 0.0F ? 0.0F : expf(x);
+    if (fabsf(n) > 126.0F) return expf(x);
+    b = fmaf(-n, f32_from_bits(UINT32_C(0x35bfbe8e)),
+             fmaf(-n, f32_from_bits(UINT32_C(0x3f317200)), x));
+    {
+        union { uint32_t bits; float value; } converted;
+        converted.value = z;
+        exponent = converted.bits << 23;
+    }
+    u = b * b;
+    polynomial = fmaf(f32_from_bits(UINT32_C(0x3c072010)), b,
+                      f32_from_bits(UINT32_C(0x3d2b9f17)));
+    tail = fmaf(f32_from_bits(UINT32_C(0x3e2aaf33)), b,
+                f32_from_bits(UINT32_C(0x3efffedb)));
+    polynomial = fmaf(polynomial, u, tail);
+    polynomial = fmaf(polynomial, u,
+                      f32_from_bits(UINT32_C(0x3f7ffff6)) * b);
+    {
+        float scale = f32_from_bits(exponent + UINT32_C(0x3f800000));
+        return fmaf(polynomial, scale, scale);
+    }
+}
+
+#ifdef COLI_VISION_HAS_AVX2
+/* Match ggml's AVX2 ggml_v_expf fast path lane-for-lane.  Keeping this as an
+   intrinsic implementation matters here: a scalar transcription changes the
+   fused-operation and horizontal-reduction boundaries used by flash attention. */
+static __m256 vision_fast_exp8(__m256 x) {
+    const __m256 r = _mm256_set1_ps(12582912.0F);
+    const __m256 z = _mm256_fmadd_ps(
+        x, _mm256_set1_ps(f32_from_bits(UINT32_C(0x3fb8aa3b))), r);
+    const __m256 n = _mm256_sub_ps(z, r);
+    const __m256 b = _mm256_fnmadd_ps(
+        n, _mm256_set1_ps(f32_from_bits(UINT32_C(0x35bfbe8e))),
+        _mm256_fnmadd_ps(
+            n, _mm256_set1_ps(f32_from_bits(UINT32_C(0x3f317200))), x));
+    const __m256i exponent = _mm256_slli_epi32(_mm256_castps_si256(z), 23);
+    const __m256 scale = _mm256_castsi256_ps(_mm256_add_epi32(
+        exponent, _mm256_castps_si256(_mm256_set1_ps(1.0F))));
+    const __m256 square = _mm256_mul_ps(b, b);
+    const __m256 polynomial = _mm256_fmadd_ps(
+        _mm256_fmadd_ps(
+            _mm256_fmadd_ps(
+                _mm256_set1_ps(f32_from_bits(UINT32_C(0x3c072010))), b,
+                _mm256_set1_ps(f32_from_bits(UINT32_C(0x3d2b9f17)))),
+            square,
+            _mm256_fmadd_ps(
+                _mm256_set1_ps(f32_from_bits(UINT32_C(0x3e2aaf33))), b,
+                _mm256_set1_ps(f32_from_bits(UINT32_C(0x3efffedb))))),
+        square,
+        _mm256_mul_ps(
+            _mm256_set1_ps(f32_from_bits(UINT32_C(0x3f7ffff6))), b));
+    return _mm256_fmadd_ps(polynomial, scale, scale);
+}
+
+#endif
+
+static float f32_dot_vecdot(const float *left, const float *right,
+                            uint32_t count) {
+#ifdef COLI_VISION_HAS_AVX2
+    __m256 sums[4] = {
+        _mm256_setzero_ps(), _mm256_setzero_ps(),
+        _mm256_setzero_ps(), _mm256_setzero_ps()
+    };
+    uint32_t index = 0;
+    float total;
+    for (; index + 32U <= count; index += 32U) {
+        uint32_t vector;
+        for (vector = 0; vector < 4U; ++vector) {
+            uint32_t offset = index + vector * 8U;
+            sums[vector] = _mm256_fmadd_ps(
+                _mm256_loadu_ps(left + offset),
+                _mm256_loadu_ps(right + offset), sums[vector]);
+        }
+    }
+    sums[0] = _mm256_add_ps(sums[0], sums[2]);
+    sums[1] = _mm256_add_ps(sums[1], sums[3]);
+    sums[0] = _mm256_add_ps(sums[0], sums[1]);
+    {
+        __m128 reduced = _mm_add_ps(
+            _mm256_castps256_ps128(sums[0]),
+            _mm256_extractf128_ps(sums[0], 1));
+        reduced = _mm_hadd_ps(reduced, reduced);
+        reduced = _mm_hadd_ps(reduced, reduced);
+        total = _mm_cvtss_f32(reduced);
+    }
+    for (; index < count; ++index)
+        total += left[index] * right[index];
+    return total;
+#else
+    float sums[4][8] = { { 0.0F } };
+    uint32_t index = 0;
+    for (; index + 32U <= count; index += 32U) {
+        uint32_t vector, lane;
+        for (vector = 0; vector < 4U; ++vector)
+            for (lane = 0; lane < 8U; ++lane) {
+                uint32_t position = index + vector * 8U + lane;
+                sums[vector][lane] = fmaf(
+                    left[position], right[position], sums[vector][lane]);
+            }
+    }
+    {
+        float lanes[8];
+        float low0, low1, high0, high1, total;
+        uint32_t lane;
+        for (lane = 0; lane < 8U; ++lane)
+            lanes[lane] = (sums[0][lane] + sums[2][lane]) +
+                          (sums[1][lane] + sums[3][lane]);
+        low0 = (lanes[0] + lanes[4]) + (lanes[1] + lanes[5]);
+        low1 = (lanes[2] + lanes[6]) + (lanes[3] + lanes[7]);
+        high0 = low0;
+        high1 = low1;
+        total = high0 + high1;
+        for (; index < count; ++index)
+            total += left[index] * right[index];
+        return total;
+    }
+#endif
+}
+
+/* llamafile's AVX2 tinyBLAS F32 kernel accumulates consecutive groups into a
+   single eight-lane register, then performs the same low/high horizontal sum
+   used by hsum(__m256). */
+static float f32_dot_fma8(const float *left, const float *right,
+                          uint32_t count) {
+    float sums[8] = { 0.0F, 0.0F, 0.0F, 0.0F,
+                      0.0F, 0.0F, 0.0F, 0.0F };
+    uint32_t index = 0;
+    for (; index + 8U <= count; index += 8U) {
+        uint32_t lane;
+        for (lane = 0; lane < 8U; ++lane)
+            sums[lane] = fmaf(left[index + lane], right[index + lane],
+                              sums[lane]);
+    }
+    {
+        float pair0 = sums[0] + sums[4];
+        float pair1 = sums[1] + sums[5];
+        float pair2 = sums[2] + sums[6];
+        float pair3 = sums[3] + sums[7];
+        float total = (pair0 + pair2) + (pair1 + pair3);
+        for (; index < count; ++index)
+            total += left[index] * right[index];
+        return total;
+    }
+}
+
+static uint16_t vision_fp16_bits(float value) {
+    union { float value; uint32_t bits; } converted;
+    const float scale_to_inf = f32_from_bits(UINT32_C(0x77800000));
+    const float scale_to_zero = f32_from_bits(UINT32_C(0x08800000));
+    float base = (fabsf(value) * scale_to_inf) * scale_to_zero;
+    uint32_t shifted, sign, bias, bits, exponent, mantissa, nonsign;
+    converted.value = value;
+    shifted = converted.bits + converted.bits;
+    sign = converted.bits & UINT32_C(0x80000000);
+    bias = shifted & UINT32_C(0xff000000);
+    if (bias < UINT32_C(0x71000000)) bias = UINT32_C(0x71000000);
+    base = f32_from_bits((bias >> 1) + UINT32_C(0x07800000)) + base;
+    converted.value = base;
+    bits = converted.bits;
+    exponent = (bits >> 13) & UINT32_C(0x00007c00);
+    mantissa = bits & UINT32_C(0x00000fff);
+    nonsign = exponent + mantissa;
+    return (uint16_t)((sign >> 16) |
+        (shifted > UINT32_C(0xff000000) ? UINT32_C(0x7e00) : nonsign));
+}
+
+static float vision_fp16_value(uint16_t value) {
+    uint32_t word = (uint32_t)value << 16;
+    uint32_t sign = word & UINT32_C(0x80000000);
+    uint32_t twice = word + word;
+    float normalized = f32_from_bits(
+        (twice >> 4) + UINT32_C(0x70000000)) *
+        f32_from_bits(UINT32_C(0x07800000));
+    float denormalized = f32_from_bits(
+        (twice >> 17) | UINT32_C(0x3f000000)) - 0.5F;
+    uint32_t magnitude;
+    union { float value; uint32_t bits; } converted;
+    converted.value = twice < UINT32_C(0x08000000) ?
+        denormalized : normalized;
+    magnitude = converted.bits;
+    return f32_from_bits(sign | magnitude);
+}
+
+static float fp16_dot_vecdot(const uint16_t *left, const uint16_t *right,
+                             uint32_t count) {
+    float sums[4][8] = { { 0.0F } };
+    uint32_t index = 0;
+    for (; index + 32U <= count; index += 32U) {
+        uint32_t vector, lane;
+        for (vector = 0; vector < 4U; ++vector)
+            for (lane = 0; lane < 8U; ++lane) {
+                uint32_t position = index + vector * 8U + lane;
+                sums[vector][lane] = fmaf(
+                    vision_fp16_value(left[position]),
+                    vision_fp16_value(right[position]), sums[vector][lane]);
+            }
+    }
+    {
+        float lanes[8];
+        float low0, low1;
+        double total;
+        uint32_t lane;
+        for (lane = 0; lane < 8U; ++lane)
+            lanes[lane] = (sums[0][lane] + sums[2][lane]) +
+                          (sums[1][lane] + sums[3][lane]);
+        low0 = (lanes[0] + lanes[4]) + (lanes[1] + lanes[5]);
+        low1 = (lanes[2] + lanes[6]) + (lanes[3] + lanes[7]);
+        total = (double)(low0 + low1);
+        for (; index < count; ++index)
+            total += (double)(vision_fp16_value(left[index]) *
+                              vision_fp16_value(right[index]));
+        return (float)total;
+    }
+}
+
+static int vision_flash_attention_f16(float *output, const float *q,
+                                      const float *k, const float *v,
+                                      uint32_t patch_count,
+                                      uint32_t head_count,
+                                      uint32_t head_dim) {
+    int64_t item;
+    int failed = 0;
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static) reduction(|:failed)
+#endif
+    for (item = 0; item < (int64_t)patch_count * head_count; ++item) {
+        uint32_t query_index = (uint32_t)item / head_count;
+        uint32_t head_index = (uint32_t)item % head_count;
+        const float *query = q +
+            ((size_t)query_index * head_count + head_index) * head_dim;
+        uint16_t *query16 = (uint16_t *)malloc(
+            (size_t)head_dim * sizeof(*query16));
+        uint16_t *key16 = (uint16_t *)malloc(
+            (size_t)head_dim * sizeof(*key16));
+        uint16_t *accumulator16 = (uint16_t *)calloc(
+            head_dim, sizeof(*accumulator16));
+        float maximum = -INFINITY;
+        float sum = 0.0F;
+        uint32_t dimension, key_index;
+        if (!query16 || !key16 || !accumulator16) {
+            free(query16); free(key16); free(accumulator16);
+            failed = 1;
+            continue;
+        }
+        for (dimension = 0; dimension < head_dim; ++dimension)
+            query16[dimension] = vision_fp16_bits(query[dimension]);
+        for (key_index = 0; key_index < patch_count; ++key_index) {
+            const float *key = k +
+                ((size_t)key_index * head_count + head_index) * head_dim;
+            float score, old_maximum, maximum_scale = 1.0F;
+            float value_scale = 1.0F;
+            for (dimension = 0; dimension < head_dim; ++dimension)
+                key16[dimension] = vision_fp16_bits(key[dimension]);
+            score = fp16_dot_vecdot(key16, query16, head_dim);
+            old_maximum = maximum;
+            if (score > maximum) {
+                maximum = score;
+                maximum_scale = expf(old_maximum - maximum);
+                for (dimension = 0; dimension < head_dim; ++dimension)
+                    accumulator16[dimension] = vision_fp16_bits(
+                        vision_fp16_value(accumulator16[dimension]) *
+                        maximum_scale);
+            } else {
+                value_scale = expf(score - maximum);
+            }
+            for (dimension = 0; dimension < head_dim; ++dimension) {
+                float value = vision_fp16_value(vision_fp16_bits(v[
+                    ((size_t)key_index * head_count + head_index) *
+                    head_dim + dimension]));
+                accumulator16[dimension] = vision_fp16_bits(fmaf(
+                    value, value_scale,
+                    vision_fp16_value(accumulator16[dimension])));
+            }
+            sum = sum * maximum_scale + value_scale;
+        }
+        {
+            float inverse = sum == 0.0F ? 0.0F : 1.0F / sum;
+            for (dimension = 0; dimension < head_dim; ++dimension)
+                output[((size_t)query_index * head_count + head_index) *
+                       head_dim + dimension] =
+                    vision_fp16_value(accumulator16[dimension]) * inverse;
+        }
+        free(query16); free(key16); free(accumulator16);
+    }
+    return failed ? -1 : 0;
+}
+
+static double vision_softmax_tile64(float scores[64], float maximum) {
+    double sum = 0.0;
+    uint32_t index;
+    for (index = 0; index < 64U; index += 8U) {
+#ifdef COLI_VISION_HAS_AVX2
+        __m256 input = _mm256_loadu_ps(scores + index);
+        __m256 padded = _mm256_cmp_ps(
+            input, _mm256_set1_ps(-INFINITY), _CMP_EQ_OQ);
+        __m256 lanes = vision_fast_exp8(_mm256_sub_ps(
+            input, _mm256_set1_ps(maximum)));
+        __m128 reduced;
+        lanes = _mm256_andnot_ps(padded, lanes);
+        _mm256_storeu_ps(scores + index, lanes);
+        reduced = _mm_add_ps(
+            _mm256_extractf128_ps(lanes, 1), _mm256_castps256_ps128(lanes));
+        reduced = _mm_add_ps(reduced, _mm_movehl_ps(reduced, reduced));
+        reduced = _mm_add_ss(reduced, _mm_movehdup_ps(reduced));
+        sum += (double)_mm_cvtss_f32(reduced);
+#else
+        float lanes[8];
+        float pair0, pair1, pair2, pair3;
+        uint32_t lane;
+        for (lane = 0; lane < 8U; ++lane) {
+            lanes[lane] = vision_fast_expf(scores[index + lane] - maximum);
+            scores[index + lane] = lanes[lane];
+        }
+        pair0 = lanes[0] + lanes[4];
+        pair1 = lanes[1] + lanes[5];
+        pair2 = lanes[2] + lanes[6];
+        pair3 = lanes[3] + lanes[7];
+        sum += (double)((pair0 + pair2) + (pair1 + pair3));
+#endif
+    }
+    return sum;
+}
+
+static int vision_flash_attention_tiled(float *output, const float *q,
+                                        const float *k, const float *v,
+                                        uint32_t patch_count,
+                                        uint32_t head_count,
+                                        uint32_t head_dim) {
+    int64_t item;
+    int failed = 0;
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static) reduction(|:failed)
+#endif
+    for (item = 0; item < (int64_t)patch_count * head_count; ++item) {
+        uint32_t query_index = (uint32_t)item / head_count;
+        uint32_t head_index = (uint32_t)item % head_count;
+        const float *query = q +
+            ((size_t)query_index * head_count + head_index) * head_dim;
+        float *accumulator = (float *)calloc(head_dim, sizeof(*accumulator));
+        float maximum = -INFINITY;
+        float sum = 0.0F;
+        uint32_t tile_start, dimension;
+        if (!accumulator) {
+            failed = 1;
+            continue;
+        }
+        for (tile_start = 0; tile_start < patch_count; tile_start += 64U) {
+            uint32_t tile_count = patch_count - tile_start;
+            float scores[64];
+            float tile_maximum = -INFINITY;
+            float new_maximum, maximum_scale = 1.0F;
+            uint32_t tile_index;
+            if (tile_count > 64U) tile_count = 64U;
+#ifdef COLI_VISION_HAS_AVX2
+            for (tile_index = 0; tile_index < 64U; tile_index += 8U) {
+                __m256 score8 = _mm256_setzero_ps();
+                for (dimension = 0; dimension < head_dim; ++dimension) {
+                    float key_lanes[8];
+                    uint32_t lane;
+                    for (lane = 0; lane < 8U; ++lane) {
+                        uint32_t key_in_tile = tile_index + lane;
+                        if (key_in_tile < tile_count) {
+                            const float *key = k +
+                                ((size_t)(tile_start + key_in_tile) *
+                                 head_count + head_index) * head_dim;
+                            key_lanes[lane] = vision_fp16_value(
+                                vision_fp16_bits(key[dimension]));
+                        } else {
+                            key_lanes[lane] = 0.0F;
+                        }
+                    }
+                    score8 = _mm256_fmadd_ps(
+                        _mm256_set1_ps(query[dimension]),
+                        _mm256_loadu_ps(key_lanes), score8);
+                }
+                _mm256_storeu_ps(scores + tile_index, score8);
+            }
+            for (tile_index = 0; tile_index < tile_count; ++tile_index)
+                if (scores[tile_index] > tile_maximum)
+                    tile_maximum = scores[tile_index];
+#else
+            for (tile_index = 0; tile_index < tile_count; ++tile_index) {
+                const float *key = k +
+                    ((size_t)(tile_start + tile_index) * head_count +
+                     head_index) * head_dim;
+                float score = 0.0F;
+                for (dimension = 0; dimension < head_dim; ++dimension)
+                    score = fmaf(query[dimension],
+                                 vision_fp16_value(
+                                     vision_fp16_bits(key[dimension])),
+                                 score);
+                scores[tile_index] = score;
+                if (score > tile_maximum) tile_maximum = score;
+            }
+#endif
+            for (tile_index = tile_count; tile_index < 64U; ++tile_index)
+                scores[tile_index] = -INFINITY;
+            new_maximum = fmaxf(maximum, tile_maximum);
+            if (new_maximum > maximum) {
+                maximum_scale = expf(maximum - new_maximum);
+                for (dimension = 0; dimension < head_dim; ++dimension)
+                    accumulator[dimension] *= maximum_scale;
+                sum *= maximum_scale;
+            }
+            maximum = new_maximum;
+            sum = (float)((double)sum +
+                          vision_softmax_tile64(scores, maximum));
+#ifdef COLI_VISION_HAS_AVX2
+            for (dimension = 0; dimension + 8U <= head_dim;
+                 dimension += 8U) {
+                __m256 accumulated = _mm256_loadu_ps(
+                    accumulator + dimension);
+                for (tile_index = 0; tile_index < 64U; ++tile_index) {
+                    __m256 value8 = _mm256_setzero_ps();
+                    if (tile_index < tile_count) {
+                        const float *value = v +
+                            ((size_t)(tile_start + tile_index) * head_count +
+                             head_index) * head_dim + dimension;
+                        value8 = _mm256_cvtph_ps(_mm256_cvtps_ph(
+                            _mm256_loadu_ps(value), _MM_FROUND_TO_NEAREST_INT));
+                    }
+                    accumulated = _mm256_fmadd_ps(
+                        _mm256_set1_ps(scores[tile_index]), value8,
+                        accumulated);
+                }
+                _mm256_storeu_ps(accumulator + dimension, accumulated);
+            }
+            for (; dimension < head_dim; ++dimension)
+                for (tile_index = 0; tile_index < 64U; ++tile_index) {
+                    float value = 0.0F;
+                    if (tile_index < tile_count)
+                        value = vision_fp16_value(vision_fp16_bits(v[
+                            ((size_t)(tile_start + tile_index) * head_count +
+                             head_index) * head_dim + dimension]));
+                    accumulator[dimension] = fmaf(
+                        scores[tile_index], value, accumulator[dimension]);
+                }
+#else
+            for (dimension = 0; dimension < head_dim; ++dimension)
+                for (tile_index = 0; tile_index < 64U; ++tile_index) {
+                    float value = 0.0F;
+                    if (tile_index < tile_count)
+                        value = vision_fp16_value(vision_fp16_bits(v[
+                            ((size_t)(tile_start + tile_index) * head_count +
+                             head_index) * head_dim + dimension]));
+                    accumulator[dimension] = fmaf(
+                        scores[tile_index], value, accumulator[dimension]);
+                }
+#endif
+        }
+        {
+            float inverse = sum == 0.0F ? 0.0F : 1.0F / sum;
+            for (dimension = 0; dimension < head_dim; ++dimension)
+                output[((size_t)query_index * head_count + head_index) *
+                       head_dim + dimension] =
+                    accumulator[dimension] * inverse;
+        }
+        free(accumulator);
+    }
+    return failed ? -1 : 0;
+}
+
+static int read_named(const coli_gemma4_vision *vision, const char *name,
+                      uint32_t type, uint32_t dimensions,
+                      const uint64_t *shape, void **storage) {
+    const coli_gemma4_tensor *tensor =
+        coli_gemma4_gguf_find(&vision->gguf, name);
+    void *values;
+    if (!tensor_shape(tensor, type, dimensions, shape) ||
+        tensor->nbytes > SIZE_MAX) return -1;
+    values = malloc((size_t)tensor->nbytes);
+    if (!values || coli_gemma4_gguf_read(
+            &vision->gguf, tensor, values, (size_t)tensor->nbytes) != 0) {
+        free(values);
+        return -1;
+    }
+    *storage = values;
+    return 0;
+}
+
+static void vision_block_close(vision_block *block) {
+    if (!block) return;
+    free(block->q); free(block->k); free(block->v); free(block->output);
+    free(block->ff_up); free(block->ff_gate); free(block->ff_down);
+    free(block->ln1); free(block->ln2); free(block->q_norm); free(block->k_norm);
+    free(block->attention_post_norm); free(block->ffn_post_norm);
+    memset(block, 0, sizeof(*block));
+}
+
+static int vision_block_open(const coli_gemma4_vision *vision,
+                             uint32_t layer, vision_block *block) {
+    char name[128];
+    uint64_t square[2], up[2], down[2], vector[1], head[1];
+    uint32_t width = vision->gguf.vision_embedding_length;
+    uint32_t ff = vision->gguf.vision_feed_forward_length;
+    uint32_t head_dim;
+#define READ_BLOCK(field, suffix, type, dims, shape) do { \
+    if (snprintf(name, sizeof(name), "v.blk.%u.%s", layer, suffix) < 0 || \
+        read_named(vision, name, type, dims, shape, (void **)&block->field) != 0) \
+        goto failure; \
+} while (0)
+    if (!block || !width || !ff || !vision->gguf.vision_head_count ||
+        width % vision->gguf.vision_head_count) return -1;
+    head_dim = width / vision->gguf.vision_head_count;
+    memset(block, 0, sizeof(*block));
+    square[0] = width; square[1] = width;
+    up[0] = width; up[1] = ff;
+    down[0] = ff; down[1] = width;
+    vector[0] = width; head[0] = head_dim;
+    READ_BLOCK(ln1, "ln1.weight", COLI_GGML_TYPE_F32, 1, vector);
+    READ_BLOCK(ln2, "ln2.weight", COLI_GGML_TYPE_F32, 1, vector);
+    READ_BLOCK(q_norm, "attn_q_norm.weight", COLI_GGML_TYPE_F32, 1, head);
+    READ_BLOCK(k_norm, "attn_k_norm.weight", COLI_GGML_TYPE_F32, 1, head);
+    READ_BLOCK(attention_post_norm, "attn_post_norm.weight",
+               COLI_GGML_TYPE_F32, 1, vector);
+    READ_BLOCK(ffn_post_norm, "ffn_post_norm.weight",
+               COLI_GGML_TYPE_F32, 1, vector);
+    READ_BLOCK(q, "attn_q.weight", COLI_GGML_TYPE_BF16, 2, square);
+    READ_BLOCK(k, "attn_k.weight", COLI_GGML_TYPE_BF16, 2, square);
+    READ_BLOCK(v, "attn_v.weight", COLI_GGML_TYPE_BF16, 2, square);
+    READ_BLOCK(output, "attn_out.weight", COLI_GGML_TYPE_BF16, 2, square);
+    READ_BLOCK(ff_up, "ffn_up.weight", COLI_GGML_TYPE_BF16, 2, up);
+    READ_BLOCK(ff_gate, "ffn_gate.weight", COLI_GGML_TYPE_BF16, 2, up);
+    READ_BLOCK(ff_down, "ffn_down.weight", COLI_GGML_TYPE_BF16, 2, down);
+#undef READ_BLOCK
+    return 0;
+failure:
+#undef READ_BLOCK
+    vision_block_close(block);
+    return -1;
+}
+
+static void bf16_matmul(float *outputs, const float *inputs,
+                        const uint16_t *weights,
+                        uint32_t rows, uint32_t input_width,
+                        uint32_t output_width) {
+    uint16_t *rounded_inputs = NULL;
+    const char *compat_mode = vision_compat_mode();
+    int compat_fma8 = strcmp(compat_mode, "llama-avx2") == 0 ||
+                      strstr(compat_mode, "fma8") != NULL;
+    int compat_vecdot = strstr(compat_mode, "vecdot") != NULL;
+    size_t input_values = (size_t)rows * input_width;
+    int64_t output_row;
+    if (input_values <= SIZE_MAX / sizeof(*rounded_inputs))
+        rounded_inputs = (uint16_t *)malloc(input_values * sizeof(*rounded_inputs));
+    if (rounded_inputs) {
+        int64_t index;
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+        for (index = 0; index < (int64_t)input_values; ++index)
+            rounded_inputs[index] = bf16_rounded_bits(inputs[index]);
+    }
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (output_row = 0; output_row < (int64_t)output_width; ++output_row) {
+        const uint16_t *weight = weights + output_row * input_width;
+        uint32_t row;
+        for (row = 0; row < rows; ++row) {
+            const float *input = inputs + (size_t)row * input_width;
+            const uint16_t *rounded = rounded_inputs ?
+                rounded_inputs + (size_t)row * input_width : NULL;
+            /* ggml's BF16 mul_mat converts the F32 activation row to the
+               weight's BF16 vec-dot type before evaluating the product. */
+            float sum;
+            if (rounded && compat_fma8) {
+                sum = bf16_dot_fma8(rounded, weight, input_width);
+            } else if (rounded && compat_vecdot) {
+                sum = bf16_dot_vecdot(rounded, weight, input_width);
+            } else {
+                uint32_t column;
+                sum = 0.0F;
+                for (column = 0; column < input_width; ++column)
+                    sum += bf16_value(rounded ? rounded[column] :
+                                      bf16_rounded_bits(input[column])) *
+                           bf16_value(weight[column]);
+            }
+            outputs[(size_t)row * output_width + (size_t)output_row] = sum;
+        }
+    }
+    free(rounded_inputs);
+}
+
+static void vision_rmsnorm(float *outputs, const float *inputs,
+                           const float *weights, uint32_t rows,
+                           uint32_t width, float epsilon) {
+    int64_t row;
+    int compat_rms64 = vision_compat_has("rms64");
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (row = 0; row < (int64_t)rows; ++row) {
+        const float *input = inputs + row * width;
+        float *output = outputs + row * width;
+        double square_sum64 = 0.0;
+        float square_sum = 0.0F;
+        uint32_t column;
+        if (compat_rms64) {
+            for (column = 0; column < width; ++column)
+                square_sum64 += (double)(input[column] * input[column]);
+        } else {
+            for (column = 0; column < width; ++column)
+                square_sum += input[column] * input[column];
+        }
+        {
+            float mean = compat_rms64 ?
+                (float)(square_sum64 / (double)width) :
+                square_sum / (float)width;
+            float scale = 1.0F / sqrtf(mean + epsilon);
+            for (column = 0; column < width; ++column)
+                output[column] = input[column] * scale *
+                                 (weights ? weights[column] : 1.0F);
+        }
+    }
+}
+
+static void vision_rope_2d(float *values, uint32_t patch_count,
+                           uint32_t patch_columns, uint32_t head_count,
+                           uint32_t head_dim, float theta) {
+    int64_t item;
+    uint32_t half = head_dim / 2U;
+    uint32_t pairs = half / 2U;
+    int compat_rope_iter = vision_compat_has("ropeiter");
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (item = 0; item < (int64_t)patch_count * head_count; ++item) {
+        uint32_t patch = (uint32_t)item / head_count;
+        uint32_t position[2] = {
+            patch % patch_columns,
+            patch / patch_columns
+        };
+        float *head = values + (size_t)item * head_dim;
+        uint32_t section;
+        for (section = 0; section < 2U; ++section) {
+            float *part = head + section * half;
+            float theta_scale = powf(theta, -2.0F / (float)half);
+            float iterated_angle = (float)position[section];
+            uint32_t pair;
+            for (pair = 0; pair < pairs; ++pair) {
+                float angle;
+                if (compat_rope_iter) {
+                    angle = iterated_angle;
+                    iterated_angle *= theta_scale;
+                } else {
+                    float frequency = powf(theta,
+                        -2.0F * (float)pair / (float)half);
+                    angle = (float)position[section] * frequency;
+                }
+                float cosine = cosf(angle);
+                float sine = sinf(angle);
+                float first = part[pair];
+                float second = part[pair + pairs];
+                part[pair] = first * cosine - second * sine;
+                part[pair + pairs] = first * sine + second * cosine;
+            }
+        }
+    }
+}
+
+static int vision_attention(float *output, const float *q, const float *k,
+                            const float *v, uint32_t patch_count,
+                            uint32_t head_count, uint32_t head_dim) {
+    int64_t item;
+    int failed = 0;
+    if (vision_compat_has("flashtiled"))
+        return vision_flash_attention_tiled(
+            output, q, k, v, patch_count, head_count, head_dim);
+    if (strstr(vision_compat_mode(), "flash16"))
+        return vision_flash_attention_f16(
+            output, q, k, v, patch_count, head_count, head_dim);
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static) reduction(|:failed)
+#endif
+    for (item = 0; item < (int64_t)patch_count * head_count; ++item) {
+        uint32_t query_index = (uint32_t)item / head_count;
+        uint32_t head_index = (uint32_t)item % head_count;
+        const float *query = q +
+            ((size_t)query_index * head_count + head_index) * head_dim;
+        float *scores = (float *)malloc((size_t)patch_count * sizeof(float));
+        float *value_column = NULL;
+        float maximum = -INFINITY;
+        double total64 = 0.0;
+        float total = 0.0F;
+        int compat_fast_exp =
+            strstr(vision_compat_mode(), "fastexp") != NULL;
+        int compat_attn_vecdot =
+            strstr(vision_compat_mode(), "attnvec") != NULL;
+        int compat_attn_q_fma8 =
+            strstr(vision_compat_mode(), "attnqfma8") != NULL;
+        int compat_soft64 = compat_fast_exp ||
+            strstr(vision_compat_mode(), "soft64") != NULL;
+        uint32_t key_index, dimension;
+        if (!scores) {
+            failed = 1;
+            continue;
+        }
+        if (compat_attn_vecdot) {
+            value_column = (float *)malloc(
+                (size_t)patch_count * sizeof(*value_column));
+            if (!value_column) {
+                free(scores);
+                failed = 1;
+                continue;
+            }
+        }
+        for (key_index = 0; key_index < patch_count; ++key_index) {
+            const float *key = k +
+                ((size_t)key_index * head_count + head_index) * head_dim;
+            float score;
+            if (compat_attn_q_fma8)
+                score = f32_dot_fma8(query, key, head_dim);
+            else if (compat_attn_vecdot)
+                score = f32_dot_vecdot(query, key, head_dim);
+            else {
+                score = 0.0F;
+                for (dimension = 0; dimension < head_dim; ++dimension)
+                    score += query[dimension] * key[dimension];
+            }
+            scores[key_index] = score;
+            if (score > maximum) maximum = score;
+        }
+        if (compat_fast_exp) {
+            for (key_index = 0; key_index + 8U <= patch_count;
+                 key_index += 8U) {
+#ifdef COLI_VISION_HAS_AVX2
+                __m256 lanes = vision_fast_exp8(_mm256_sub_ps(
+                    _mm256_loadu_ps(scores + key_index),
+                    _mm256_set1_ps(maximum)));
+                __m128 reduced;
+                _mm256_storeu_ps(scores + key_index, lanes);
+                reduced = _mm_add_ps(
+                    _mm256_extractf128_ps(lanes, 1),
+                    _mm256_castps256_ps128(lanes));
+                reduced = _mm_add_ps(
+                    reduced, _mm_movehl_ps(reduced, reduced));
+                reduced = _mm_add_ss(reduced, _mm_movehdup_ps(reduced));
+                total64 += (double)_mm_cvtss_f32(reduced);
+#else
+                float lanes[8];
+                float pair0, pair1, pair2, pair3;
+                uint32_t lane;
+                for (lane = 0; lane < 8U; ++lane) {
+                    lanes[lane] = vision_fast_expf(
+                        scores[key_index + lane] - maximum);
+                    scores[key_index + lane] = lanes[lane];
+                }
+                pair0 = lanes[0] + lanes[4];
+                pair1 = lanes[1] + lanes[5];
+                pair2 = lanes[2] + lanes[6];
+                pair3 = lanes[3] + lanes[7];
+                total64 += (double)((pair0 + pair2) + (pair1 + pair3));
+#endif
+            }
+            for (; key_index < patch_count; ++key_index) {
+                scores[key_index] = expf(scores[key_index] - maximum);
+                total64 += (double)scores[key_index];
+            }
+        } else for (key_index = 0; key_index < patch_count; ++key_index) {
+            scores[key_index] = expf(scores[key_index] - maximum);
+            if (compat_soft64) total64 += (double)scores[key_index];
+            else total += scores[key_index];
+        }
+        if (compat_soft64) total = (float)total64;
+        if (!(total > 0.0F) || !isfinite(total)) {
+            free(value_column);
+            free(scores);
+            failed = 1;
+            continue;
+        }
+        {
+            float inverse = compat_soft64 ?
+                (float)(1.0 / total64) : 1.0F / total;
+            for (key_index = 0; key_index < patch_count; ++key_index)
+                scores[key_index] *= inverse;
+        }
+        for (dimension = 0; dimension < head_dim; ++dimension) {
+            float sum;
+            if (compat_attn_vecdot) {
+                for (key_index = 0; key_index < patch_count; ++key_index)
+                    value_column[key_index] = v[
+                        ((size_t)key_index * head_count + head_index) *
+                        head_dim + dimension];
+                sum = f32_dot_vecdot(scores, value_column, patch_count);
+            } else {
+                sum = 0.0F;
+                for (key_index = 0; key_index < patch_count; ++key_index) {
+                    const float *value = v +
+                        ((size_t)key_index * head_count + head_index) * head_dim;
+                    sum += scores[key_index] * value[dimension];
+                }
+            }
+            output[((size_t)query_index * head_count + head_index) *
+                   head_dim + dimension] = sum;
+        }
+        free(value_column);
+        free(scores);
+    }
+    return failed ? -1 : 0;
+}
+
+static int vision_block_apply(coli_gemma4_vision *vision,
+                              const vision_block *block,
+                              float *hidden, uint32_t patch_count,
+                              uint32_t patch_columns, uint32_t layer) {
+    uint32_t width = vision->gguf.vision_embedding_length;
+    uint32_t ff = vision->gguf.vision_feed_forward_length;
+    uint32_t heads = vision->gguf.vision_head_count;
+    uint32_t head_dim;
+    float epsilon = vision->gguf.vision_epsilon;
+    size_t hidden_values = (size_t)patch_count * width;
+    size_t ff_values = (size_t)patch_count * ff;
+    float *norm = NULL, *q = NULL, *k = NULL, *v = NULL;
+    float *context = NULL, *branch = NULL, *up = NULL, *gate = NULL;
+    int compat_gelu16 = vision_compat_has("gelu16");
+    int64_t index;
+    int result = -1;
+    if (!width || !ff || !heads || width % heads ||
+        (size_t)patch_count > SIZE_MAX / width ||
+        (size_t)patch_count > SIZE_MAX / ff ||
+        hidden_values > SIZE_MAX / sizeof(float) ||
+        ff_values > SIZE_MAX / sizeof(float))
+        return -1;
+    head_dim = width / heads;
+    norm = (float *)malloc(hidden_values * sizeof(float));
+    q = (float *)malloc(hidden_values * sizeof(float));
+    k = (float *)malloc(hidden_values * sizeof(float));
+    v = (float *)malloc(hidden_values * sizeof(float));
+    context = (float *)malloc(hidden_values * sizeof(float));
+    branch = (float *)malloc(hidden_values * sizeof(float));
+    up = (float *)malloc(ff_values * sizeof(float));
+    gate = (float *)malloc(ff_values * sizeof(float));
+    if (!norm || !q || !k || !v || !context || !branch || !up || !gate)
+        goto cleanup;
+
+    if (vision_trace_f32(vision, layer, "input", hidden, hidden_values) != 0)
+        goto cleanup;
+    vision_rmsnorm(norm, hidden, block->ln1, patch_count, width, epsilon);
+    if (vision_trace_f32(vision, layer, "attention-input-norm", norm,
+                         hidden_values) != 0) goto cleanup;
+    bf16_matmul(q, norm, block->q, patch_count, width, width);
+    bf16_matmul(k, norm, block->k, patch_count, width, width);
+    bf16_matmul(v, norm, block->v, patch_count, width, width);
+    vision_rmsnorm(q, q, block->q_norm, patch_count * heads,
+                   head_dim, epsilon);
+    vision_rmsnorm(k, k, block->k_norm, patch_count * heads,
+                   head_dim, epsilon);
+    if (vision_trace_f32(vision, layer, "query-norm", q, hidden_values) != 0 ||
+        vision_trace_f32(vision, layer, "key-norm", k, hidden_values) != 0 ||
+        vision_trace_f32(vision, layer, "value", v, hidden_values) != 0)
+        goto cleanup;
+    vision_rope_2d(q, patch_count, patch_columns, heads, head_dim, 100.0F);
+    vision_rope_2d(k, patch_count, patch_columns, heads, head_dim, 100.0F);
+    vision_rmsnorm(v, v, NULL, patch_count * heads, head_dim, epsilon);
+    if (vision_trace_f32(vision, layer, "query-rope", q, hidden_values) != 0 ||
+        vision_trace_f32(vision, layer, "key-rope", k, hidden_values) != 0 ||
+        vision_trace_f32(vision, layer, "value-norm", v, hidden_values) != 0)
+        goto cleanup;
+    if (vision_attention(context, q, k, v, patch_count,
+                         heads, head_dim) != 0)
+        goto cleanup;
+    if (vision_trace_f32(vision, layer, "attention-context", context,
+                         hidden_values) != 0) goto cleanup;
+    bf16_matmul(branch, context, block->output,
+                patch_count, width, width);
+    if (vision_trace_f32(vision, layer, "attention-output", branch,
+                         hidden_values) != 0) goto cleanup;
+    vision_rmsnorm(branch, branch, block->attention_post_norm,
+                   patch_count, width, epsilon);
+    if (vision_trace_f32(vision, layer, "attention-post-norm", branch,
+                         hidden_values) != 0) goto cleanup;
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (index = 0; index < (int64_t)hidden_values; ++index)
+        hidden[index] += branch[index];
+    if (vision_trace_f32(vision, layer, "attention-residual", hidden,
+                         hidden_values) != 0) goto cleanup;
+
+    vision_rmsnorm(norm, hidden, block->ln2, patch_count, width, epsilon);
+    if (vision_trace_f32(vision, layer, "ffn-input-norm", norm,
+                         hidden_values) != 0) goto cleanup;
+    bf16_matmul(up, norm, block->ff_up, patch_count, width, ff);
+    bf16_matmul(gate, norm, block->ff_gate, patch_count, width, ff);
+    if (vision_trace_f32(vision, layer, "ffn-up", up, ff_values) != 0 ||
+        vision_trace_f32(vision, layer, "ffn-gate", gate, ff_values) != 0)
+        goto cleanup;
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (index = 0; index < (int64_t)ff_values; ++index) {
+        float value = gate[index];
+        if (compat_gelu16) {
+            float rounded = vision_fp16_value(vision_fp16_bits(value));
+            float activated = rounded *
+                (1.0F / (1.0F + expf(-1.702F * rounded)));
+            gate[index] = up[index] *
+                vision_fp16_value(vision_fp16_bits(activated));
+        } else {
+            gate[index] = up[index] * value /
+                          (1.0F + expf(-1.702F * value));
+        }
+    }
+    if (vision_trace_f32(vision, layer, "ffn-activated", gate,
+                         ff_values) != 0) goto cleanup;
+    bf16_matmul(branch, gate, block->ff_down, patch_count, ff, width);
+    if (vision_trace_f32(vision, layer, "ffn-output", branch,
+                         hidden_values) != 0) goto cleanup;
+    vision_rmsnorm(branch, branch, block->ffn_post_norm,
+                   patch_count, width, epsilon);
+    if (vision_trace_f32(vision, layer, "ffn-post-norm", branch,
+                         hidden_values) != 0) goto cleanup;
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (index = 0; index < (int64_t)hidden_values; ++index)
+        hidden[index] += branch[index];
+    if (vision_trace_f32(vision, layer, "output", hidden,
+                         hidden_values) != 0) goto cleanup;
+    result = 0;
+cleanup:
+    free(norm); free(q); free(k); free(v); free(context); free(branch);
+    free(up); free(gate);
+    return result;
+}
+
+int coli_gemma4_vision_open(coli_gemma4_vision *vision, const char *path) {
+    const coli_gemma4_tensor *patch, *position, *projection, *bias, *scale;
+    uint64_t patch_shape[4], projection_shape[2], vector_shape[1];
+    if (!vision || !path) return -1;
+    memset(vision, 0, sizeof(*vision));
+    vision->merge_size = 3;
+    vision->minimum_tokens = 40;
+    vision->maximum_tokens = 280;
+    if (coli_gemma4_gguf_open(&vision->gguf, path) != 0) {
+        vision_error(vision, "%s", coli_gemma4_gguf_last_error(&vision->gguf));
+        return -1;
+    }
+    patch_shape[0] = vision->gguf.vision_patch_size;
+    patch_shape[1] = vision->gguf.vision_patch_size;
+    patch_shape[2] = 3;
+    patch_shape[3] = vision->gguf.vision_embedding_length;
+    projection_shape[0] = vision->gguf.vision_embedding_length;
+    projection_shape[1] = vision->gguf.vision_projection_dim;
+    vector_shape[0] = vision->gguf.vision_embedding_length;
+    patch = coli_gemma4_gguf_find(&vision->gguf, "v.patch_embd.weight");
+    position = coli_gemma4_gguf_find(&vision->gguf, "v.position_embd.weight");
+    projection = coli_gemma4_gguf_find(&vision->gguf, "mm.input_projection.weight");
+    bias = coli_gemma4_gguf_find(&vision->gguf, "v.std_bias");
+    scale = coli_gemma4_gguf_find(&vision->gguf, "v.std_scale");
+    if (!tensor_shape(patch, COLI_GGML_TYPE_F32, 4, patch_shape) ||
+        !position || position->type != COLI_GGML_TYPE_F32 ||
+        position->n_dims != 3 ||
+        position->dims[0] != vision->gguf.vision_embedding_length ||
+        !position->dims[1] || position->dims[2] != 2 ||
+        !tensor_shape(projection, COLI_GGML_TYPE_BF16, 2, projection_shape) ||
+        !tensor_shape(bias, COLI_GGML_TYPE_F32, 1, vector_shape) ||
+        !tensor_shape(scale, COLI_GGML_TYPE_F32, 1, vector_shape)) {
+        vision_error(vision, "Gemma 4 vision core tensors have unexpected shapes");
+        coli_gemma4_gguf_close(&vision->gguf);
+        return -1;
+    }
+    return 0;
+}
+
+void coli_gemma4_vision_close(coli_gemma4_vision *vision) {
+    if (!vision) return;
+    coli_gemma4_gguf_close(&vision->gguf);
+    memset(vision, 0, sizeof(*vision));
+}
+
+const char *coli_gemma4_vision_last_error(const coli_gemma4_vision *vision) {
+    return vision ? vision->last_error : "invalid Gemma 4 vision handle";
+}
+
+static uint32_t aligned_round(uint32_t value, uint32_t factor) {
+    return (uint32_t)(roundf((float)value / (float)factor) * (float)factor);
+}
+
+static uint32_t aligned_floor(float value, uint32_t factor) {
+    return (uint32_t)(floorf(value / (float)factor) * (float)factor);
+}
+
+static uint32_t aligned_ceil(float value, uint32_t factor) {
+    return (uint32_t)(ceilf(value / (float)factor) * (float)factor);
+}
+
+int coli_gemma4_vision_target_size(const coli_gemma4_vision *vision,
+                                   uint32_t source_width,
+                                   uint32_t source_height,
+                                   uint32_t *target_width,
+                                   uint32_t *target_height,
+                                   uint32_t *token_count) {
+    uint32_t alignment, width, height;
+    uint64_t area, patch_area, minimum_pixels, maximum_pixels;
+    if (!vision || !vision->gguf.vision_patch_size || !vision->merge_size ||
+        !source_width || !source_height || !target_width || !target_height ||
+        !token_count ||
+        source_width > 1000000U || source_height > 1000000U ||
+        vision->gguf.vision_patch_size > UINT32_MAX / vision->merge_size)
+        return -1;
+    alignment = vision->gguf.vision_patch_size * vision->merge_size;
+    patch_area = (uint64_t)alignment * alignment;
+    minimum_pixels = patch_area * vision->minimum_tokens;
+    maximum_pixels = patch_area * vision->maximum_tokens;
+    width = aligned_round(source_width, alignment);
+    height = aligned_round(source_height, alignment);
+    if (width < alignment) width = alignment;
+    if (height < alignment) height = alignment;
+    area = (uint64_t)width * height;
+    if (area > maximum_pixels) {
+        float beta = sqrtf((float)((uint64_t)source_width * source_height) /
+                           (float)maximum_pixels);
+        width = aligned_floor((float)source_width / beta, alignment);
+        height = aligned_floor((float)source_height / beta, alignment);
+        if (width < alignment) width = alignment;
+        if (height < alignment) height = alignment;
+    } else if (area < minimum_pixels) {
+        float beta = sqrtf((float)minimum_pixels /
+                           (float)((uint64_t)source_width * source_height));
+        width = aligned_ceil((float)source_width * beta, alignment);
+        height = aligned_ceil((float)source_height * beta, alignment);
+    }
+    if (!width || !height || width % alignment || height % alignment ||
+        (uint64_t)(width / alignment) * (height / alignment) > UINT32_MAX)
+        return -1;
+    *target_width = width;
+    *target_height = height;
+    *token_count = (width / alignment) * (height / alignment);
+    return 0;
+}
+
+int coli_gemma4_vision_prepare_rgb(const coli_gemma4_vision *vision,
+                                   const uint8_t *rgb,
+                                   uint32_t source_width,
+                                   uint32_t source_height,
+                                   coli_gemma4_vision_image *image) {
+    uint32_t width, height, tokens, x, y, channel;
+    uint64_t values;
+    float x_ratio, y_ratio;
+    if (!vision || !rgb || !image || !source_width || !source_height ||
+        source_width > SIZE_MAX / 3U / source_height) return -1;
+    memset(image, 0, sizeof(*image));
+    if (coli_gemma4_vision_target_size(vision, source_width, source_height,
+                                      &width, &height, &tokens) != 0)
+        return -1;
+    values = (uint64_t)width * height * 3;
+    if (values > SIZE_MAX / sizeof(float)) return -1;
+    image->pixels = (float *)malloc((size_t)values * sizeof(float));
+    if (!image->pixels) return -1;
+    x_ratio = width > 1 ?
+        (float)(source_width - 1) / (float)(width - 1) : 0.0F;
+    y_ratio = height > 1 ?
+        (float)(source_height - 1) / (float)(height - 1) : 0.0F;
+    for (y = 0; y < height; ++y) {
+        float py = (float)y * y_ratio;
+        uint32_t y0 = (uint32_t)py;
+        uint32_t y1 = y0 + 1 < source_height ? y0 + 1 : y0;
+        float yf = py - (float)y0;
+        for (x = 0; x < width; ++x) {
+            float px = (float)x * x_ratio;
+            uint32_t x0 = (uint32_t)px;
+            uint32_t x1 = x0 + 1 < source_width ? x0 + 1 : x0;
+            float xf = px - (float)x0;
+            for (channel = 0; channel < 3; ++channel) {
+                float p00 = rgb[((size_t)y0 * source_width + x0) * 3 + channel];
+                float p10 = rgb[((size_t)y0 * source_width + x1) * 3 + channel];
+                float p01 = rgb[((size_t)y1 * source_width + x0) * 3 + channel];
+                float p11 = rgb[((size_t)y1 * source_width + x1) * 3 + channel];
+                float top = p00 + (p10 - p00) * xf;
+                float bottom = p01 + (p11 - p01) * xf;
+                uint8_t resized = (uint8_t)(top + (bottom - top) * yf);
+                float unit = (float)resized / 255.0F;
+                image->pixels[((size_t)y * width + x) * 3 + channel] =
+                    (unit - vision->gguf.vision_image_mean[channel]) /
+                    vision->gguf.vision_image_std[channel];
+            }
+        }
+    }
+    image->width = width;
+    image->height = height;
+    image->patch_columns = width / vision->gguf.vision_patch_size;
+    image->patch_rows = height / vision->gguf.vision_patch_size;
+    image->token_columns = image->patch_columns / vision->merge_size;
+    image->token_rows = image->patch_rows / vision->merge_size;
+    image->value_count = (size_t)values;
+    (void)tokens;
+    return 0;
+}
+
+int coli_gemma4_vision_patch_embeddings(
+    const coli_gemma4_vision *vision,
+    const coli_gemma4_vision_image *image,
+    float **embeddings, uint32_t *patch_count) {
+    const coli_gemma4_tensor *patch, *position;
+    float *weights = NULL, *pos_x = NULL, *pos_y = NULL, *output = NULL;
+    uint32_t patch_size, width, columns, rows;
+    int64_t patch_index;
+    uint64_t patches, output_values, row_bytes, y_offset;
+    size_t patch_values;
+    int result = -1;
+    int failed = 0;
+    int compat_patch_fma8 = vision_compat_has("patchfma8");
+    int compat_patch_vecdot = vision_compat_has("patchvecdot");
+    if (!vision || !image || !image->pixels || !embeddings || !patch_count ||
+        !image->width || !image->height) return -1;
+    *embeddings = NULL;
+    *patch_count = 0;
+    patch_size = vision->gguf.vision_patch_size;
+    width = vision->gguf.vision_embedding_length;
+    columns = image->patch_columns;
+    rows = image->patch_rows;
+    if (!patch_size || !width || !columns || !rows ||
+        columns != image->width / patch_size ||
+        rows != image->height / patch_size) return -1;
+    patches = (uint64_t)columns * rows;
+    output_values = patches * width;
+    patch_values = (size_t)patch_size * patch_size * 3U * width;
+    if (patches > UINT32_MAX || output_values > SIZE_MAX / sizeof(float) ||
+        patch_values > SIZE_MAX / sizeof(float)) return -1;
+    patch = coli_gemma4_gguf_find(&vision->gguf, "v.patch_embd.weight");
+    position = coli_gemma4_gguf_find(&vision->gguf, "v.position_embd.weight");
+    if (!patch || !position || columns > position->dims[1] ||
+        rows > position->dims[1]) return -1;
+    weights = (float *)malloc(patch_values * sizeof(float));
+    pos_x = (float *)malloc((size_t)columns * width * sizeof(float));
+    pos_y = (float *)malloc((size_t)rows * width * sizeof(float));
+    output = (float *)malloc((size_t)output_values * sizeof(float));
+    if (!weights || !pos_x || !pos_y || !output) goto cleanup;
+    row_bytes = (uint64_t)width * sizeof(float);
+    y_offset = position->dims[1] * row_bytes;
+    if (coli_gemma4_gguf_read(&vision->gguf, patch, weights,
+                              patch_values * sizeof(float)) != 0 ||
+        coli_gemma4_gguf_read_slice(
+            &vision->gguf, position, 0, pos_x,
+            (size_t)columns * (size_t)row_bytes) != 0 ||
+        coli_gemma4_gguf_read_slice(
+            &vision->gguf, position, y_offset, pos_y,
+            (size_t)rows * (size_t)row_bytes) != 0)
+        goto cleanup;
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static) reduction(|:failed)
+#endif
+    for (patch_index = 0; patch_index < (int64_t)patches; ++patch_index) {
+        uint32_t y = (uint32_t)patch_index / columns;
+        uint32_t x = (uint32_t)patch_index % columns;
+        uint32_t out;
+        float *flattened = NULL;
+        if (compat_patch_fma8 || compat_patch_vecdot) {
+            uint32_t channel, py, px;
+            flattened = (float *)malloc(
+                (size_t)patch_size * patch_size * 3U * sizeof(*flattened));
+            if (!flattened) {
+                failed = 1;
+                continue;
+            }
+            for (channel = 0; channel < 3; ++channel)
+                for (py = 0; py < patch_size; ++py)
+                    for (px = 0; px < patch_size; ++px) {
+                        size_t pixel_index =
+                            ((size_t)(y * patch_size + py) * image->width +
+                             x * patch_size + px) * 3U + channel;
+                        size_t flattened_index =
+                            ((size_t)channel * patch_size + py) *
+                            patch_size + px;
+                        flattened[flattened_index] =
+                            2.0F * image->pixels[pixel_index] - 1.0F;
+                    }
+        }
+            for (out = 0; out < width; ++out) {
+                const float *kernel = weights +
+                    (size_t)out * patch_size * patch_size * 3U;
+                float sum;
+                uint32_t py, px, channel;
+                if (flattened) {
+                    sum = compat_patch_vecdot ?
+                        f32_dot_vecdot(flattened, kernel,
+                                      patch_size * patch_size * 3U) :
+                        f32_dot_fma8(flattened, kernel,
+                                     patch_size * patch_size * 3U);
+                    sum += pos_x[(size_t)x * width + out];
+                    sum += pos_y[(size_t)y * width + out];
+                } else {
+                    sum = pos_x[(size_t)x * width + out] +
+                          pos_y[(size_t)y * width + out];
+                    for (channel = 0; channel < 3; ++channel)
+                        for (py = 0; py < patch_size; ++py)
+                            for (px = 0; px < patch_size; ++px) {
+                                size_t pixel_index =
+                                    ((size_t)(y * patch_size + py) * image->width +
+                                     x * patch_size + px) * 3U + channel;
+                                size_t kernel_index =
+                                    ((size_t)channel * patch_size + py) *
+                                    patch_size + px;
+                                sum += (2.0F * image->pixels[pixel_index] - 1.0F) *
+                                       kernel[kernel_index];
+                            }
+                }
+                output[((size_t)y * columns + x) * width + out] = sum;
+            }
+        free(flattened);
+    }
+    if (failed) goto cleanup;
+    *embeddings = output;
+    *patch_count = (uint32_t)patches;
+    output = NULL;
+    result = 0;
+cleanup:
+    free(weights);
+    free(pos_x);
+    free(pos_y);
+    free(output);
+    return result;
+}
+
+int coli_gemma4_vision_transform(coli_gemma4_vision *vision,
+                                 float *embeddings,
+                                 uint32_t patch_count,
+                                 uint32_t patch_columns,
+                                 uint32_t layer_count) {
+    return coli_gemma4_vision_transform_range(
+        vision, embeddings, patch_count, patch_columns, 0, layer_count);
+}
+
+int coli_gemma4_vision_transform_range(coli_gemma4_vision *vision,
+                                       float *embeddings,
+                                       uint32_t patch_count,
+                                       uint32_t patch_columns,
+                                       uint32_t first_layer,
+                                       uint32_t layer_count) {
+    uint32_t layer, width, heads, head_dim;
+    if (!vision || !embeddings || !patch_count || !patch_columns ||
+        patch_count % patch_columns ||
+        first_layer > layer_count ||
+        layer_count > vision->gguf.vision_block_count)
+        return -1;
+    width = vision->gguf.vision_embedding_length;
+    heads = vision->gguf.vision_head_count;
+    if (!width || !heads || width % heads) return -1;
+    head_dim = width / heads;
+    if (!head_dim || head_dim % 4U) {
+        vision_error(vision,
+                     "Gemma 4 vision head dimension must be divisible by four");
+        return -1;
+    }
+    for (layer = first_layer; layer < layer_count; ++layer) {
+        vision_block block;
+        memset(&block, 0, sizeof(block));
+        if (vision_block_open(vision, layer, &block) != 0) {
+            vision_error(vision, "cannot load Gemma 4 vision block %u", layer);
+            return -1;
+        }
+        if (vision_block_apply(vision, &block, embeddings,
+                               patch_count, patch_columns, layer) != 0) {
+            vision_block_close(&block);
+            vision_error(vision, "cannot evaluate Gemma 4 vision block %u",
+                         layer);
+            return -1;
+        }
+        vision_block_close(&block);
+    }
+    return 0;
+}
+
+void coli_gemma4_vision_trace_layer(coli_gemma4_vision *vision,
+                                    uint32_t layer,
+                                    const char *directory) {
+    if (!vision) return;
+    vision->trace_layer = layer;
+    vision->trace_directory = directory;
+}
+
+int coli_gemma4_vision_encode(coli_gemma4_vision *vision,
+                              const coli_gemma4_vision_image *image,
+                              float **embeddings, uint32_t *token_count) {
+    uint32_t patch_count = 0, width, projection_width;
+    uint32_t merge, token_columns, token_rows;
+    uint64_t output_tokens, output_values;
+    float pool_scale;
+    float *hidden = NULL, *pooled = NULL, *projected = NULL;
+    float *bias = NULL, *scale = NULL;
+    uint16_t *projection = NULL;
+    uint64_t vector_shape[1], projection_shape[2];
+    int64_t token;
+    int result = -1;
+    if (!vision || !image || !embeddings || !token_count) return -1;
+    *embeddings = NULL;
+    *token_count = 0;
+    width = vision->gguf.vision_embedding_length;
+    projection_width = vision->gguf.vision_projection_dim;
+    merge = vision->merge_size;
+    if (!width || !projection_width || !merge ||
+        !image->patch_columns || !image->patch_rows ||
+        image->patch_columns % merge || image->patch_rows % merge)
+        return -1;
+    token_columns = image->patch_columns / merge;
+    token_rows = image->patch_rows / merge;
+    output_tokens = (uint64_t)token_columns * token_rows;
+    output_values = output_tokens * projection_width;
+    if (!output_tokens || output_tokens > UINT32_MAX ||
+        output_values > SIZE_MAX / sizeof(float) ||
+        output_tokens > SIZE_MAX / width ||
+        output_tokens * width > SIZE_MAX / sizeof(float))
+        return -1;
+    if (coli_gemma4_vision_patch_embeddings(
+            vision, image, &hidden, &patch_count) != 0) {
+        vision_error(vision, "cannot create Gemma 4 vision patch embeddings");
+        goto cleanup;
+    }
+    if (coli_gemma4_vision_transform(
+            vision, hidden, patch_count, image->patch_columns,
+            vision->gguf.vision_block_count) != 0)
+        goto cleanup;
+
+    pooled = (float *)malloc((size_t)output_tokens * width * sizeof(float));
+    projected = (float *)malloc((size_t)output_values * sizeof(float));
+    if (!pooled || !projected) {
+        vision_error(vision, "out of memory completing Gemma 4 vision graph");
+        goto cleanup;
+    }
+    pool_scale = sqrtf((float)width) / (float)(merge * merge);
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (token = 0; token < (int64_t)output_tokens; ++token) {
+        uint32_t output_y = (uint32_t)token / token_columns;
+        uint32_t output_x = (uint32_t)token % token_columns;
+        uint32_t dimension;
+        for (dimension = 0; dimension < width; ++dimension) {
+            float sum = 0.0F;
+            uint32_t y, x;
+            for (y = 0; y < merge; ++y)
+                for (x = 0; x < merge; ++x) {
+                    uint32_t patch_y = output_y * merge + y;
+                    uint32_t patch_x = output_x * merge + x;
+                    sum += hidden[((size_t)patch_y * image->patch_columns +
+                                   patch_x) * width + dimension];
+                }
+            pooled[(size_t)token * width + dimension] =
+                sum * pool_scale;
+        }
+    }
+    vector_shape[0] = width;
+    projection_shape[0] = width;
+    projection_shape[1] = projection_width;
+    if (read_named(vision, "v.std_bias", COLI_GGML_TYPE_F32,
+                   1, vector_shape, (void **)&bias) != 0 ||
+        read_named(vision, "v.std_scale", COLI_GGML_TYPE_F32,
+                   1, vector_shape, (void **)&scale) != 0 ||
+        read_named(vision, "mm.input_projection.weight", COLI_GGML_TYPE_BF16,
+                   2, projection_shape, (void **)&projection) != 0) {
+        vision_error(vision, "cannot load Gemma 4 vision projection tensors");
+        goto cleanup;
+    }
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+    for (token = 0; token < (int64_t)output_tokens; ++token) {
+        uint32_t dimension;
+        float *row = pooled + (size_t)token * width;
+        for (dimension = 0; dimension < width; ++dimension)
+            row[dimension] = (row[dimension] - bias[dimension]) *
+                             scale[dimension];
+    }
+    vision_rmsnorm(pooled, pooled, NULL, (uint32_t)output_tokens,
+                   width, vision->gguf.vision_epsilon);
+    bf16_matmul(projected, pooled, projection,
+                (uint32_t)output_tokens, width, projection_width);
+    *embeddings = projected;
+    *token_count = (uint32_t)output_tokens;
+    projected = NULL;
+    result = 0;
+cleanup:
+    free(hidden); free(pooled); free(projected);
+    free(bias); free(scale); free(projection);
+    return result;
+}
+
+void coli_gemma4_vision_image_close(coli_gemma4_vision_image *image) {
+    if (!image) return;
+    free(image->pixels);
+    memset(image, 0, sizeof(*image));
+}

--- a/c/gemma4_vision.h
+++ b/c/gemma4_vision.h
@@ -1,0 +1,75 @@
+#ifndef COLI_GEMMA4_VISION_H
+#define COLI_GEMMA4_VISION_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "gemma4_gguf.h"
+
+#define COLI_GEMMA4_VISION_ERROR_MAX 512
+
+typedef struct {
+    coli_gemma4_gguf gguf;
+    uint32_t merge_size;
+    uint32_t minimum_tokens;
+    uint32_t maximum_tokens;
+    uint32_t trace_layer;
+    const char *trace_directory;
+    char last_error[COLI_GEMMA4_VISION_ERROR_MAX];
+} coli_gemma4_vision;
+
+typedef struct {
+    uint32_t width;
+    uint32_t height;
+    uint32_t patch_columns;
+    uint32_t patch_rows;
+    uint32_t token_columns;
+    uint32_t token_rows;
+    float *pixels;
+    size_t value_count;
+} coli_gemma4_vision_image;
+
+int coli_gemma4_vision_open(coli_gemma4_vision *vision, const char *path);
+void coli_gemma4_vision_close(coli_gemma4_vision *vision);
+const char *coli_gemma4_vision_last_error(const coli_gemma4_vision *vision);
+int coli_gemma4_vision_target_size(const coli_gemma4_vision *vision,
+                                   uint32_t source_width,
+                                   uint32_t source_height,
+                                   uint32_t *target_width,
+                                   uint32_t *target_height,
+                                   uint32_t *token_count);
+int coli_gemma4_vision_prepare_rgb(const coli_gemma4_vision *vision,
+                                   const uint8_t *rgb,
+                                   uint32_t source_width,
+                                   uint32_t source_height,
+                                   coli_gemma4_vision_image *image);
+int coli_gemma4_vision_patch_embeddings(
+    const coli_gemma4_vision *vision,
+    const coli_gemma4_vision_image *image,
+    float **embeddings, uint32_t *patch_count);
+int coli_gemma4_vision_transform(coli_gemma4_vision *vision,
+                                 float *embeddings,
+                                 uint32_t patch_count,
+                                 uint32_t patch_columns,
+                                 uint32_t layer_count);
+int coli_gemma4_vision_transform_range(coli_gemma4_vision *vision,
+                                       float *embeddings,
+                                       uint32_t patch_count,
+                                       uint32_t patch_columns,
+                                       uint32_t first_layer,
+                                       uint32_t layer_count);
+void coli_gemma4_vision_trace_layer(coli_gemma4_vision *vision,
+                                    uint32_t layer,
+                                    const char *directory);
+int coli_gemma4_vision_encode(coli_gemma4_vision *vision,
+                              const coli_gemma4_vision_image *image,
+                              float **embeddings, uint32_t *token_count);
+int coli_gemma4_vision_load_ppm(const char *path, uint8_t **rgb,
+                                uint32_t *width, uint32_t *height,
+                                char *error, size_t error_capacity);
+int coli_gemma4_vision_load_image(const char *path, uint8_t **rgb,
+                                  uint32_t *width, uint32_t *height,
+                                  char *error, size_t error_capacity);
+void coli_gemma4_vision_image_close(coli_gemma4_vision_image *image);
+
+#endif

--- a/c/model.h
+++ b/c/model.h
@@ -1,0 +1,40 @@
+#ifndef COLI_MODEL_H
+#define COLI_MODEL_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Model graphs decide which experts run. Placement backends decide where the
+ * encoded records live and how their math is executed. Keeping this boundary
+ * explicit lets Gemma use Colibri's cache/prefetch policies without borrowing
+ * GLM's attention, tokenizer, or routing semantics.
+ */
+typedef struct {
+    uint32_t n_layer;
+    uint32_t n_embd;
+    uint32_t n_expert;
+    uint32_t n_expert_used;
+    uint32_t n_expert_ff;
+    uint32_t n_vocab;
+    uint32_t sliding_window;
+} coli_model_config;
+
+typedef struct {
+    void *ctx;
+    int (*prepare_layer)(void *ctx, uint32_t layer,
+                         const uint32_t *expert_ids, uint32_t count);
+    int (*run_experts)(void *ctx, uint32_t layer,
+                       const uint32_t *expert_ids, const float *weights,
+                       uint32_t count, const float *input, float *output);
+    void (*release_layer)(void *ctx, uint32_t layer);
+    int (*prefetch_layer)(void *ctx, uint32_t layer,
+                          const uint32_t *expert_ids, uint32_t count);
+} coli_expert_backend;
+
+typedef struct {
+    int (*prefill)(void *model, const int32_t *tokens, uint32_t count);
+    int (*decode)(void *model, int32_t token, float *logits);
+} coli_model_ops;
+
+#endif

--- a/c/tests/build_llama_gemma4_oracle.ps1
+++ b/c/tests/build_llama_gemma4_oracle.ps1
@@ -1,0 +1,80 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$LlamaRoot,
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Release",
+    [string]$Output = ""
+)
+
+$ErrorActionPreference = "Stop"
+$LlamaRoot = (Resolve-Path $LlamaRoot).Path
+$ScriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Source = Join-Path $ScriptDirectory "llama_gemma4_oracle.cpp"
+if (-not $Output) {
+    $Output = Join-Path $ScriptDirectory "..\build-gemma4\llama-gemma4-oracle.exe"
+}
+$Output = [IO.Path]::GetFullPath($Output)
+$OutputDirectory = Split-Path -Parent $Output
+New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
+
+$VsWhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+if (-not (Test-Path $VsWhere)) {
+    throw "vswhere.exe was not found; install Visual Studio C++ build tools"
+}
+$VisualStudio = & $VsWhere -latest -products * `
+    -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+    -property installationPath
+if (-not $VisualStudio) {
+    throw "a Visual Studio installation with x64 C++ tools was not found"
+}
+$VcVars = Join-Path $VisualStudio "VC\Auxiliary\Build\vcvars64.bat"
+$EnvironmentDump = & cmd.exe /d /s /c "call `"$VcVars`" >nul && set"
+function Get-EnvironmentValue([string]$Name) {
+    $Prefix = "$Name="
+    $Line = $EnvironmentDump | Where-Object {
+        $_.StartsWith($Prefix, [StringComparison]::OrdinalIgnoreCase)
+    } | Select-Object -First 1
+    if (-not $Line) {
+        throw "vcvars64.bat did not define $Name"
+    }
+    return $Line.Substring($Prefix.Length)
+}
+$env:Path = Get-EnvironmentValue "PATH"
+$env:INCLUDE = Get-EnvironmentValue "INCLUDE"
+$env:LIB = Get-EnvironmentValue "LIB"
+
+$LlamaLibrary = Join-Path $LlamaRoot "build\src\$Configuration\llama.lib"
+$GgmlLibraryDirectory = Join-Path $LlamaRoot "build\ggml\src\$Configuration"
+foreach ($Required in @(
+    (Join-Path $LlamaRoot "include\llama.h"),
+    (Join-Path $LlamaRoot "ggml\include\ggml.h"),
+    $LlamaLibrary,
+    (Join-Path $GgmlLibraryDirectory "ggml.lib"),
+    (Join-Path $GgmlLibraryDirectory "ggml-base.lib"),
+    (Join-Path $GgmlLibraryDirectory "ggml-cpu.lib")
+)) {
+    if (-not (Test-Path $Required)) {
+        throw "required llama.cpp build artifact was not found: $Required"
+    }
+}
+
+$Arguments = @(
+    "/nologo", "/O2", "/EHsc", "/std:c++17", "/DNDEBUG",
+    "/I", (Join-Path $LlamaRoot "include"),
+    "/I", (Join-Path $LlamaRoot "ggml\include"),
+    "/Fo$OutputDirectory\llama_gemma4_oracle.obj",
+    $Source,
+    "/link",
+    "/LIBPATH:$(Split-Path -Parent $LlamaLibrary)",
+    "/LIBPATH:$GgmlLibraryDirectory",
+    "llama.lib", "ggml.lib", "ggml-base.lib", "ggml-cpu.lib",
+    "/OUT:$Output"
+)
+& cl.exe @Arguments
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
+$RuntimeDirectory = Join-Path $LlamaRoot "build\bin\$Configuration"
+Write-Host "built: $Output"
+Write-Host "llama.cpp DLL directory: $RuntimeDirectory"

--- a/c/tests/build_llama_gemma4_vision_oracle.ps1
+++ b/c/tests/build_llama_gemma4_vision_oracle.ps1
@@ -1,0 +1,79 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$LlamaRoot,
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Release",
+    [string]$Output = ""
+)
+
+$ErrorActionPreference = "Stop"
+$LlamaRoot = (Resolve-Path $LlamaRoot).Path
+$ScriptDirectory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Source = Join-Path $ScriptDirectory "llama_gemma4_vision_oracle.cpp"
+if (-not $Output) {
+    $Output = Join-Path $ScriptDirectory "..\build-gemma4\llama-gemma4-vision-oracle.exe"
+}
+$Output = [IO.Path]::GetFullPath($Output)
+$OutputDirectory = Split-Path -Parent $Output
+New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
+
+$VsWhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+if (-not (Test-Path $VsWhere)) {
+    throw "vswhere.exe was not found; install Visual Studio C++ build tools"
+}
+$VisualStudio = & $VsWhere -latest -products * `
+    -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+    -property installationPath
+if (-not $VisualStudio) {
+    throw "a Visual Studio installation with x64 C++ tools was not found"
+}
+$VcVars = Join-Path $VisualStudio "VC\Auxiliary\Build\vcvars64.bat"
+$EnvironmentDump = & cmd.exe /d /s /c "call `"$VcVars`" >nul && set"
+function Get-EnvironmentValue([string]$Name) {
+    $Prefix = "$Name="
+    $Line = $EnvironmentDump | Where-Object {
+        $_.StartsWith($Prefix, [StringComparison]::OrdinalIgnoreCase)
+    } | Select-Object -First 1
+    if (-not $Line) { throw "vcvars64.bat did not define $Name" }
+    return $Line.Substring($Prefix.Length)
+}
+$env:Path = Get-EnvironmentValue "PATH"
+$env:INCLUDE = Get-EnvironmentValue "INCLUDE"
+$env:LIB = Get-EnvironmentValue "LIB"
+
+$LlamaLibraryDirectory = Join-Path $LlamaRoot "build\src\$Configuration"
+$MtmdLibraryDirectory = Join-Path $LlamaRoot "build\tools\mtmd\$Configuration"
+$GgmlLibraryDirectory = Join-Path $LlamaRoot "build\ggml\src\$Configuration"
+foreach ($Required in @(
+    (Join-Path $LlamaRoot "tools\mtmd\mtmd.h"),
+    (Join-Path $LlamaLibraryDirectory "llama.lib"),
+    (Join-Path $MtmdLibraryDirectory "mtmd.lib"),
+    (Join-Path $GgmlLibraryDirectory "ggml.lib"),
+    (Join-Path $GgmlLibraryDirectory "ggml-base.lib"),
+    (Join-Path $GgmlLibraryDirectory "ggml-cpu.lib")
+)) {
+    if (-not (Test-Path $Required)) {
+        throw "required llama.cpp build artifact was not found: $Required"
+    }
+}
+
+$Arguments = @(
+    "/nologo", "/O2", "/EHsc", "/std:c++17", "/DNDEBUG",
+    "/I", (Join-Path $LlamaRoot "include"),
+    "/I", (Join-Path $LlamaRoot "ggml\include"),
+    "/I", (Join-Path $LlamaRoot "tools\mtmd"),
+    "/Fo$OutputDirectory\llama_gemma4_vision_oracle.obj",
+    $Source,
+    "/link",
+    "/LIBPATH:$LlamaLibraryDirectory",
+    "/LIBPATH:$MtmdLibraryDirectory",
+    "/LIBPATH:$GgmlLibraryDirectory",
+    "mtmd.lib", "llama.lib", "ggml.lib", "ggml-base.lib", "ggml-cpu.lib",
+    "/OUT:$Output"
+)
+& cl.exe @Arguments
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+$RuntimeDirectory = Join-Path $LlamaRoot "build\bin\$Configuration"
+Write-Host "built: $Output"
+Write-Host "llama.cpp DLL directory: $RuntimeDirectory"

--- a/c/tests/compare_gemma4_vision_trace.py
+++ b/c/tests/compare_gemma4_vision_trace.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Compare native and llama.cpp Gemma 4 vision operation traces."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+
+import numpy as np
+
+
+OPERATIONS = (
+    "attention-input-norm",
+    "query-norm",
+    "key-norm",
+    "value",
+    "query-rope",
+    "key-rope",
+    "value-norm",
+    "attention-context",
+    "attention-output",
+    "attention-post-norm",
+    "attention-residual",
+    "ffn-input-norm",
+    "ffn-up",
+    "ffn-gate",
+    "ffn-activated",
+    "ffn-output",
+    "ffn-post-norm",
+)
+
+
+def metrics(native: np.ndarray, reference: np.ndarray) -> tuple[float, float, float]:
+    if native.shape != reference.shape:
+        raise ValueError(f"shape mismatch: {native.shape} != {reference.shape}")
+    delta = native.astype(np.float64) - reference.astype(np.float64)
+    maximum = float(np.max(np.abs(delta)))
+    rms = float(np.sqrt(np.mean(delta * delta)))
+    cosine = float(np.dot(native.astype(np.float64), reference.astype(np.float64)) /
+                   (np.linalg.norm(native.astype(np.float64)) *
+                    np.linalg.norm(reference.astype(np.float64))))
+    return maximum, rms, cosine
+
+
+def load(path: pathlib.Path) -> np.ndarray:
+    if not path.is_file():
+        raise FileNotFoundError(f"missing trace: {path}")
+    values = np.fromfile(path, dtype="<f4")
+    if not values.size:
+        raise ValueError(f"empty trace: {path}")
+    if not np.isfinite(values).all():
+        raise ValueError(f"non-finite trace: {path}")
+    return values
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("directory", type=pathlib.Path)
+    parser.add_argument("--layer", type=int, default=17)
+    parser.add_argument("--reference-directory", type=pathlib.Path)
+    args = parser.parse_args()
+    reference_directory = args.reference_directory or args.directory
+    if args.layer < 0:
+        parser.error("--layer must be non-negative")
+    native_input = load(
+        args.directory / f"native-vision-layer{args.layer}-input.f32")
+    if args.layer == 0:
+        reference_input_path = reference_directory / "llama-vision-input.f32"
+    else:
+        reference_input_path = reference_directory / (
+            f"llama-vision-layer{args.layer}.f32")
+    if reference_input_path.exists():
+        reference_input = load(reference_input_path)
+        maximum, rms, cosine = metrics(native_input, reference_input)
+        print(f"{'input':24s} max={maximum:.8g} rms={rms:.8g} "
+              f"cosine={cosine:.10g}")
+    for operation in OPERATIONS:
+        native_path = args.directory / (
+            f"native-vision-layer{args.layer}-{operation}.f32")
+        llama_path = reference_directory / (
+            f"llama-vision-layer{args.layer}-{operation}.f32")
+        native = load(native_path)
+        reference = load(llama_path)
+        maximum, rms, cosine = metrics(native, reference)
+        print(f"{operation:24s} max={maximum:.8g} rms={rms:.8g} "
+              f"cosine={cosine:.10g}")
+    native = load(args.directory /
+                  f"native-vision-layer{args.layer}-output.f32")
+    reference = load(reference_directory /
+                     f"llama-vision-layer{args.layer + 1}.f32")
+    maximum, rms, cosine = metrics(native, reference)
+    print(f"{'output':24s} max={maximum:.8g} rms={rms:.8g} "
+          f"cosine={cosine:.10g}")
+
+
+if __name__ == "__main__":
+    main()

--- a/c/tests/fixtures/gemma4_weather_tools.json
+++ b/c/tests/fixtures/gemma4_weather_tools.json
@@ -1,0 +1,23 @@
+[
+  {
+    "type": "function",
+    "function": {
+      "name": "get_weather",
+      "description": "Get current weather.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "unit": {
+            "type": "string",
+            "enum": ["celsius", "fahrenheit"]
+          },
+          "city": {
+            "type": "string",
+            "description": "City name"
+          }
+        },
+        "required": ["city"]
+      }
+    }
+  }
+]

--- a/c/tests/llama_gemma4_oracle.cpp
+++ b/c/tests/llama_gemma4_oracle.cpp
@@ -1,0 +1,349 @@
+#include "ggml-backend.h"
+#include "ggml.h"
+#include "llama.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+struct capture_state {
+    std::string directory;
+    bool captured_input = false;
+    bool captured_attention = false;
+    bool captured_query = false;
+    bool captured_key = false;
+    bool captured_value = false;
+    bool captured_dense_input = false;
+    bool captured_router = false;
+    bool captured_layer = false;
+    bool captured_final_residual = false;
+    bool captured_final_normalized = false;
+    bool captured_logits = false;
+};
+
+static bool write_tensor(const std::string & path, ggml_tensor * tensor) {
+    if (tensor->type != GGML_TYPE_F32 || !ggml_is_contiguous(tensor)) {
+        std::fprintf(stderr, "oracle tensor %s is not contiguous F32\n",
+                     tensor->name);
+        return false;
+    }
+    std::vector<unsigned char> data(ggml_nbytes(tensor));
+    ggml_backend_tensor_get(tensor, data.data(), 0, data.size());
+    FILE * file = std::fopen(path.c_str(), "wb");
+    if (!file) {
+        std::fprintf(stderr, "cannot create %s\n", path.c_str());
+        return false;
+    }
+    bool ok = std::fwrite(data.data(), 1, data.size(), file) == data.size() &&
+              std::fclose(file) == 0;
+    if (!ok) std::fprintf(stderr, "cannot write %s\n", path.c_str());
+    return ok;
+}
+
+static bool write_last_vector(const std::string & path, ggml_tensor * tensor) {
+    if (tensor->type != GGML_TYPE_F32 || !ggml_is_contiguous(tensor) ||
+        tensor->ne[0] <= 0 || tensor->ne[1] <= 0) {
+        std::fprintf(stderr, "oracle tensor %s is not contiguous F32\n",
+                     tensor->name);
+        return false;
+    }
+    const size_t bytes = static_cast<size_t>(tensor->ne[0]) * sizeof(float);
+    const size_t offset = static_cast<size_t>(tensor->ne[1] - 1) * bytes;
+    std::vector<unsigned char> data(bytes);
+    ggml_backend_tensor_get(tensor, data.data(), offset, data.size());
+    FILE * file = std::fopen(path.c_str(), "wb");
+    if (!file) return false;
+    return std::fwrite(data.data(), 1, data.size(), file) == data.size() &&
+           std::fclose(file) == 0;
+}
+
+static bool capture_callback(ggml_tensor * tensor, bool ask, void * user_data) {
+    auto * state = static_cast<capture_state *>(user_data);
+    const char * file_name = nullptr;
+    bool * captured = nullptr;
+    bool last_vector = false;
+    if (std::strcmp(tensor->name, "inp_scaled") == 0) {
+        file_name = "llama-input.f32"; captured = &state->captured_input;
+    } else if (std::strcmp(tensor->name, "attn_post_norm-0") == 0) {
+        file_name = "llama-attention-postnorm.f32"; captured = &state->captured_attention;
+    } else if (std::strcmp(tensor->name, "Qcur_pos-0") == 0) {
+        file_name = "llama-query.f32"; captured = &state->captured_query;
+    } else if (std::strcmp(tensor->name, "Kcur_pos-0") == 0) {
+        file_name = "llama-key.f32"; captured = &state->captured_key;
+    } else if (std::strcmp(tensor->name, "Vcur_normed-0") == 0) {
+        file_name = "llama-value.f32"; captured = &state->captured_value;
+    } else if (std::strcmp(tensor->name, "ffn_norm_1-0") == 0) {
+        file_name = "llama-dense-input.f32"; captured = &state->captured_dense_input;
+    } else if (std::strcmp(tensor->name, "ffn_moe_logits-0") == 0) {
+        file_name = "llama-router-logits.f32"; captured = &state->captured_router;
+    } else if (std::strcmp(tensor->name, "l_out-0") == 0) {
+        file_name = "llama-layer0.f32"; captured = &state->captured_layer;
+    } else if (std::strcmp(tensor->name, "l_out-29") == 0) {
+        file_name = "llama-final-residual.f32";
+        captured = &state->captured_final_residual; last_vector = true;
+    } else if (std::strcmp(tensor->name, "result_norm") == 0) {
+        file_name = "llama-final-normalized.f32";
+        captured = &state->captured_final_normalized; last_vector = true;
+    } else if (std::strcmp(tensor->name, "result_output") == 0) {
+        file_name = "llama-logits.f32";
+        captured = &state->captured_logits; last_vector = true;
+    }
+    if (ask) return file_name != nullptr && (captured == nullptr || !*captured);
+    if (!file_name || !captured || *captured) return true;
+    const std::string path = state->directory + "/" + file_name;
+    if (!(last_vector ? write_last_vector(path, tensor) :
+                        write_tensor(path, tensor))) return false;
+    *captured = true;
+    std::printf("captured %-10s shape=%lld x %lld -> %s\n", tensor->name,
+                static_cast<long long>(tensor->ne[0]),
+                static_cast<long long>(tensor->ne[1]), path.c_str());
+    return true;
+}
+
+static bool write_tokens(const std::string & path,
+                         const std::vector<llama_token> & tokens) {
+    FILE * file = std::fopen(path.c_str(), "wb");
+    if (!file) return false;
+    for (size_t index = 0; index < tokens.size(); ++index)
+        std::fprintf(file, "%s%d", index ? " " : "", tokens[index]);
+    std::fputc('\n', file);
+    return std::fclose(file) == 0;
+}
+
+static int hex_digit(char character) {
+    if (character >= '0' && character <= '9') return character - '0';
+    if (character >= 'a' && character <= 'f') return character - 'a' + 10;
+    if (character >= 'A' && character <= 'F') return character - 'A' + 10;
+    return -1;
+}
+
+int main(int argc, char ** argv) {
+    if (argc == 5 && (std::strcmp(argv[1], "--tokenize") == 0 ||
+                      std::strcmp(argv[1], "--tokenize-special") == 0 ||
+                      std::strcmp(argv[1], "--tokenize-special-hex") == 0 ||
+                      std::strcmp(argv[1], "--tokenize-file") == 0 ||
+                      std::strcmp(argv[1], "--tokenize-special-file") == 0)) {
+        const char * model_path = argv[2];
+        const char * output_path = argv[4];
+        std::vector<char> prompt_storage;
+        const char * prompt = argv[3];
+        size_t prompt_length = std::strlen(prompt);
+        const bool parse_special =
+            std::strcmp(argv[1], "--tokenize-special") == 0 ||
+            std::strcmp(argv[1], "--tokenize-special-hex") == 0 ||
+            std::strcmp(argv[1], "--tokenize-special-file") == 0;
+        const bool add_special = !parse_special;
+        if (std::strcmp(argv[1], "--tokenize-special-hex") == 0) {
+            const size_t hex_length = std::strlen(argv[3]);
+            if (hex_length % 2 != 0) {
+                std::fprintf(stderr, "hex tokenizer input has odd length\n");
+                return 1;
+            }
+            prompt_storage.resize(hex_length / 2);
+            for (size_t index = 0; index < prompt_storage.size(); ++index) {
+                const int high = hex_digit(argv[3][index * 2]);
+                const int low = hex_digit(argv[3][index * 2 + 1]);
+                if (high < 0 || low < 0) {
+                    std::fprintf(stderr, "invalid hex tokenizer input\n");
+                    return 1;
+                }
+                prompt_storage[index] = static_cast<char>((high << 4) | low);
+            }
+            prompt = prompt_storage.data();
+            prompt_length = prompt_storage.size();
+        } else if (std::strcmp(argv[1], "--tokenize") != 0 &&
+            std::strcmp(argv[1], "--tokenize-special") != 0) {
+            FILE * input = std::fopen(argv[3], "rb");
+            if (!input || std::fseek(input, 0, SEEK_END) != 0) {
+                if (input) std::fclose(input);
+                std::fprintf(stderr, "cannot read tokenizer input file\n");
+                return 1;
+            }
+            long length = std::ftell(input);
+            if (length < 0 || std::fseek(input, 0, SEEK_SET) != 0) {
+                std::fclose(input);
+                std::fprintf(stderr, "cannot size tokenizer input file\n");
+                return 1;
+            }
+            prompt_storage.resize(static_cast<size_t>(length));
+            if ((length && std::fread(prompt_storage.data(), 1,
+                                      prompt_storage.size(), input) !=
+                           prompt_storage.size()) || std::fclose(input) != 0) {
+                std::fprintf(stderr, "cannot read tokenizer input file\n");
+                return 1;
+            }
+            prompt = prompt_storage.data();
+            prompt_length = prompt_storage.size();
+        }
+        llama_backend_init();
+        ggml_backend_dev_t devices[] = {
+            ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU), nullptr
+        };
+        llama_model_params params = llama_model_default_params();
+        params.devices = devices;
+        params.n_gpu_layers = 0;
+        params.vocab_only = true;
+        llama_model * model = llama_model_load_from_file(model_path, params);
+        if (!model) {
+            std::fprintf(stderr, "cannot load llama.cpp tokenizer model\n");
+            llama_backend_free();
+            return 1;
+        }
+        const llama_vocab * vocab = llama_model_get_vocab(model);
+        int32_t count = llama_tokenize(vocab, prompt,
+                                       static_cast<int32_t>(prompt_length),
+                                       nullptr, 0, add_special, parse_special);
+        if (count >= 0) {
+            std::fprintf(stderr, "llama.cpp tokenization failed\n");
+            llama_free_model(model);
+            llama_backend_free();
+            return 1;
+        }
+        std::vector<llama_token> tokens(static_cast<size_t>(-count));
+        count = llama_tokenize(vocab, prompt,
+                               static_cast<int32_t>(prompt_length),
+                               tokens.data(), static_cast<int32_t>(tokens.size()),
+                               add_special, parse_special);
+        if (count <= 0) {
+            std::fprintf(stderr, "llama.cpp tokenization failed\n");
+            llama_free_model(model);
+            llama_backend_free();
+            return 1;
+        }
+        tokens.resize(static_cast<size_t>(count));
+        if (!write_tokens(output_path, tokens)) {
+            std::fprintf(stderr, "cannot write llama.cpp tokens\n");
+            llama_free_model(model);
+            llama_backend_free();
+            return 1;
+        }
+        std::printf("tokens: %d -> %s\n", count, output_path);
+        llama_free_model(model);
+        llama_backend_free();
+        return 0;
+    }
+    const bool prompt_special_file =
+        argc == 5 && std::strcmp(argv[1], "--prompt-special-file") == 0;
+    if ((!prompt_special_file && argc != 4) ||
+        (prompt_special_file && argc != 5)) {
+        std::fprintf(stderr,
+                     "usage: %s MODEL.gguf PROMPT OUTPUT_DIR\n"
+                     "       %s --prompt-special-file MODEL.gguf INPUT OUTPUT_DIR\n"
+                     "       %s --tokenize MODEL.gguf PROMPT OUTPUT_FILE\n"
+                     "       %s --tokenize-special MODEL.gguf PROMPT OUTPUT_FILE\n"
+                     "       %s --tokenize-special-hex MODEL.gguf HEX OUTPUT_FILE\n"
+                     "       %s --tokenize-file MODEL.gguf INPUT OUTPUT_FILE\n"
+                     "       %s --tokenize-special-file MODEL.gguf INPUT OUTPUT_FILE\n",
+                     argv[0], argv[0], argv[0], argv[0], argv[0], argv[0],
+                     argv[0]);
+        return 2;
+    }
+    const char * model_path = prompt_special_file ? argv[2] : argv[1];
+    const char * prompt = prompt_special_file ? nullptr : argv[2];
+    std::vector<char> full_prompt_storage;
+    size_t full_prompt_length = prompt ? std::strlen(prompt) : 0;
+    capture_state capture{prompt_special_file ? argv[4] : argv[3]};
+    llama_model * model = nullptr;
+    llama_context * context = nullptr;
+    int status = 1;
+    if (prompt_special_file) {
+        FILE * input = std::fopen(argv[3], "rb");
+        if (!input || std::fseek(input, 0, SEEK_END) != 0) {
+            if (input) std::fclose(input);
+            std::fprintf(stderr, "cannot read full prompt input file\n");
+            return 1;
+        }
+        const long length = std::ftell(input);
+        if (length < 0 || std::fseek(input, 0, SEEK_SET) != 0) {
+            std::fclose(input);
+            return 1;
+        }
+        full_prompt_storage.resize(static_cast<size_t>(length));
+        if ((length && std::fread(full_prompt_storage.data(), 1,
+                                  full_prompt_storage.size(), input) !=
+                       full_prompt_storage.size()) || std::fclose(input) != 0) {
+            std::fprintf(stderr, "cannot read full prompt input file\n");
+            return 1;
+        }
+        prompt = full_prompt_storage.data();
+        full_prompt_length = full_prompt_storage.size();
+    }
+    llama_backend_init();
+
+    llama_model_params model_params = llama_model_default_params();
+    llama_context_params context_params = llama_context_default_params();
+    ggml_backend_dev_t devices[] = {
+        ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU), nullptr
+    };
+    model_params.devices = devices;
+    model_params.n_gpu_layers = 0;
+    model = llama_model_load_from_file(model_path, model_params);
+    if (!model) {
+        std::fprintf(stderr, "cannot load llama.cpp reference model\n");
+        goto cleanup;
+    }
+    context_params.n_ctx = 32;
+    context_params.n_batch = 32;
+    context_params.n_ubatch = 32;
+    context_params.n_threads = 16;
+    context_params.n_threads_batch = 16;
+    context_params.cb_eval = capture_callback;
+    context_params.cb_eval_user_data = &capture;
+    context_params.offload_kqv = false;
+    context_params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_DISABLED;
+    context = llama_init_from_model(model, context_params);
+    if (!context) {
+        std::fprintf(stderr, "cannot create llama.cpp reference context\n");
+        goto cleanup;
+    }
+
+    {
+        const llama_vocab * vocab = llama_model_get_vocab(model);
+        const bool add_special = !prompt_special_file;
+        const bool parse_special = prompt_special_file;
+        int32_t count = llama_tokenize(vocab, prompt,
+                                       static_cast<int32_t>(full_prompt_length),
+                                       nullptr, 0, add_special, parse_special);
+        if (count >= 0) {
+            std::fprintf(stderr, "tokenizer did not report required capacity\n");
+            goto cleanup;
+        }
+        std::vector<llama_token> tokens(static_cast<size_t>(-count));
+        count = llama_tokenize(vocab, prompt,
+                               static_cast<int32_t>(full_prompt_length),
+                               tokens.data(), static_cast<int32_t>(tokens.size()),
+                               add_special, parse_special);
+        if (count <= 0) {
+            std::fprintf(stderr, "prompt tokenization failed\n");
+            goto cleanup;
+        }
+        tokens.resize(static_cast<size_t>(count));
+        if (!write_tokens(capture.directory + "/llama-tokens.txt", tokens)) {
+            std::fprintf(stderr, "cannot write reference token IDs\n");
+            goto cleanup;
+        }
+        llama_batch batch = llama_batch_get_one(tokens.data(), count);
+        if (llama_decode(context, batch) != 0) {
+            std::fprintf(stderr, "llama.cpp reference decode failed\n");
+            goto cleanup;
+        }
+        std::printf("tokens: %d\n", count);
+    }
+    if (!capture.captured_input || !capture.captured_query ||
+        !capture.captured_key || !capture.captured_value ||
+        !capture.captured_attention || !capture.captured_dense_input ||
+        !capture.captured_router || !capture.captured_layer ||
+        !capture.captured_final_residual ||
+        !capture.captured_final_normalized || !capture.captured_logits) {
+        std::fprintf(stderr, "required llama.cpp tensors were not captured\n");
+        goto cleanup;
+    }
+    status = 0;
+
+cleanup:
+    if (context) llama_free(context);
+    if (model) llama_free_model(model);
+    llama_backend_free();
+    return status;
+}

--- a/c/tests/llama_gemma4_vision_oracle.cpp
+++ b/c/tests/llama_gemma4_vision_oracle.cpp
@@ -1,0 +1,293 @@
+#include "ggml-backend.h"
+#include "ggml.h"
+#include "llama.h"
+#include "mtmd.h"
+#include "mtmd-helper.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <thread>
+#include <vector>
+
+struct capture_state {
+    std::string directory;
+    bool trace_operations = false;
+    bool layer0 = false;
+    bool layer8 = false;
+    bool layer17 = false;
+    bool layer26 = false;
+    bool projected = false;
+    size_t projected_width = 0;
+    size_t projected_tokens = 0;
+    size_t operation_count = 0;
+};
+
+struct operation_capture {
+    const char *tensor;
+    const char *file;
+};
+
+static constexpr operation_capture operation_captures[] = {
+    { "inp_raw_scaled",         "llama-vision-scaled-input.f32" },
+    { "pos_embd",              "llama-vision-input.f32" },
+    { "layer_inp_normed-0",  "llama-vision-layer0-attention-input-norm.f32" },
+    { "Qcur-0",              "llama-vision-layer0-query-norm.f32" },
+    { "Kcur-0",              "llama-vision-layer0-key-norm.f32" },
+    { "Vcur-0",              "llama-vision-layer0-value.f32" },
+    { "Qcur_pos-0",          "llama-vision-layer0-query-rope.f32" },
+    { "Kcur_pos-0",          "llama-vision-layer0-key-rope.f32" },
+    { "Vcur_normed-0",       "llama-vision-layer0-value-norm.f32" },
+    { "kqv_out-0",           "llama-vision-layer0-attention-context.f32" },
+    { "attn_out-0",          "llama-vision-layer0-attention-output.f32" },
+    { "attn_post_normed-0",  "llama-vision-layer0-attention-post-norm.f32" },
+    { "ffn_inp-0",           "llama-vision-layer0-attention-residual.f32" },
+    { "ffn_inp_normed-0",    "llama-vision-layer0-ffn-input-norm.f32" },
+    { "ffn_up-0",            "llama-vision-layer0-ffn-up.f32" },
+    { "ffn_gate-0",          "llama-vision-layer0-ffn-gate.f32" },
+    { "ffn_geglu_quick-0",   "llama-vision-layer0-ffn-activated.f32" },
+    { "ffn_out-0",           "llama-vision-layer0-ffn-output.f32" },
+    { "ffn_post_normed-0",   "llama-vision-layer0-ffn-post-norm.f32" },
+    { "layer_out-16",        "llama-vision-layer17.f32" },
+    { "layer_inp_normed-17", "llama-vision-layer17-attention-input-norm.f32" },
+    { "Qcur-17",             "llama-vision-layer17-query-norm.f32" },
+    { "Kcur-17",             "llama-vision-layer17-key-norm.f32" },
+    { "Vcur-17",             "llama-vision-layer17-value.f32" },
+    { "Qcur_pos-17",         "llama-vision-layer17-query-rope.f32" },
+    { "Kcur_pos-17",         "llama-vision-layer17-key-rope.f32" },
+    { "Vcur_normed-17",      "llama-vision-layer17-value-norm.f32" },
+    { "kqv_out-17",          "llama-vision-layer17-attention-context.f32" },
+    { "attn_out-17",         "llama-vision-layer17-attention-output.f32" },
+    { "attn_post_normed-17", "llama-vision-layer17-attention-post-norm.f32" },
+    { "ffn_inp-17",          "llama-vision-layer17-attention-residual.f32" },
+    { "ffn_inp_normed-17",   "llama-vision-layer17-ffn-input-norm.f32" },
+    { "ffn_up-17",           "llama-vision-layer17-ffn-up.f32" },
+    { "ffn_gate-17",         "llama-vision-layer17-ffn-gate.f32" },
+    { "ffn_geglu_quick-17",  "llama-vision-layer17-ffn-activated.f32" },
+    { "ffn_out-17",          "llama-vision-layer17-ffn-output.f32" },
+    { "ffn_post_normed-17",  "llama-vision-layer17-ffn-post-norm.f32" },
+};
+
+static void quiet_log(enum ggml_log_level, const char *, void *) {}
+
+static bool write_tensor(const std::string & path, ggml_tensor * tensor) {
+    if (tensor->type != GGML_TYPE_F32 || !ggml_is_contiguous(tensor)) {
+        std::fprintf(stderr, "%s is not contiguous float32\n", tensor->name);
+        return false;
+    }
+    std::vector<unsigned char> data(ggml_nbytes(tensor));
+    ggml_backend_tensor_get(tensor, data.data(), 0, data.size());
+    FILE * file = std::fopen(path.c_str(), "wb");
+    if (!file) return false;
+    const bool ok = std::fwrite(data.data(), 1, data.size(), file) == data.size();
+    return std::fclose(file) == 0 && ok;
+}
+
+static bool capture_callback(ggml_tensor * tensor, bool ask, void * opaque) {
+    auto * state = static_cast<capture_state *>(opaque);
+    const char * file = nullptr;
+    bool * captured = nullptr;
+    if (state->trace_operations) {
+        for (size_t index = 0;
+             index < sizeof(operation_captures) / sizeof(operation_captures[0]);
+             ++index) {
+            if (std::strcmp(tensor->name, operation_captures[index].tensor) == 0) {
+                if (ask) return true;
+                const std::string path = state->directory + "/" +
+                                         operation_captures[index].file;
+                if (!write_tensor(path, tensor)) return false;
+                ++state->operation_count;
+                std::printf("captured %s [%lld, %lld] -> %s\n", tensor->name,
+                            static_cast<long long>(tensor->ne[0]),
+                            static_cast<long long>(tensor->ne[1]), path.c_str());
+                return true;
+            }
+        }
+    }
+    if (std::strcmp(tensor->name, "layer_out-0") == 0) {
+        file = "llama-vision-layer1.f32";
+        captured = &state->layer0;
+    } else if (std::strcmp(tensor->name, "layer_out-8") == 0) {
+        file = "llama-vision-layer9.f32";
+        captured = &state->layer8;
+    } else if (std::strcmp(tensor->name, "layer_out-17") == 0) {
+        file = "llama-vision-layer18.f32";
+        captured = &state->layer17;
+    } else if (std::strcmp(tensor->name, "layer_out-26") == 0) {
+        file = "llama-vision-layer27.f32";
+        captured = &state->layer26;
+    } else if (std::strcmp(tensor->name, "projected") == 0) {
+        file = "llama-vision-projected.f32";
+        captured = &state->projected;
+    }
+    if (ask) return file && !*captured;
+    if (!file || !captured || *captured) return true;
+    const std::string path = state->directory + "/" + file;
+    if (!write_tensor(path, tensor)) return false;
+    *captured = true;
+    if (std::strcmp(tensor->name, "projected") == 0) {
+        state->projected_width = static_cast<size_t>(tensor->ne[0]);
+        state->projected_tokens = static_cast<size_t>(tensor->ne[1]);
+    }
+    std::printf("captured %s [%lld, %lld] -> %s\n", tensor->name,
+                static_cast<long long>(tensor->ne[0]),
+                static_cast<long long>(tensor->ne[1]), path.c_str());
+    return true;
+}
+
+static bool write_output(const std::string & path, const float * values,
+                         size_t count) {
+    FILE * file = std::fopen(path.c_str(), "wb");
+    if (!file) return false;
+    const bool ok = std::fwrite(values, sizeof(float), count, file) == count;
+    return std::fclose(file) == 0 && ok;
+}
+
+int main(int argc, char ** argv) {
+    const bool trace_operations =
+        argc == 7 && std::strcmp(argv[6], "--trace-operations") == 0;
+    if (argc != 6 && !trace_operations) {
+        std::fprintf(stderr,
+            "usage: %s MODEL.gguf MMPROJ.gguf WIDTH HEIGHT OUTPUT_DIR "
+            "[--trace-operations]\n",
+            argv[0]);
+        return 2;
+    }
+    char * end = nullptr;
+    const unsigned long width_long = std::strtoul(argv[3], &end, 10);
+    if (!end || *end || width_long == 0 || width_long > UINT32_MAX) return 2;
+    const uint32_t width = static_cast<uint32_t>(width_long);
+    const unsigned long height_long = std::strtoul(argv[4], &end, 10);
+    if (!end || *end || height_long == 0 || height_long > UINT32_MAX) return 2;
+    const uint32_t height = static_cast<uint32_t>(height_long);
+    if (static_cast<uint64_t>(width) * height > SIZE_MAX / 3U) return 2;
+    std::filesystem::create_directories(argv[5]);
+
+    llama_log_set(quiet_log, nullptr);
+    mtmd_log_set(quiet_log, nullptr);
+    llama_backend_init();
+    ggml_backend_load_all();
+    llama_model_params model_params = llama_model_default_params();
+    model_params.vocab_only = false;
+    model_params.n_gpu_layers = 0;
+    llama_model * model = llama_model_load_from_file(argv[1], model_params);
+    if (!model) {
+        std::fprintf(stderr, "cannot load text model\n");
+        llama_backend_free();
+        return 1;
+    }
+    llama_context_params context_params = llama_context_default_params();
+    context_params.n_ctx = 512;
+    context_params.n_batch = 512;
+    context_params.n_ubatch = 512;
+    context_params.no_perf = true;
+    llama_context * text_context = llama_init_from_model(model, context_params);
+    if (!text_context) {
+        std::fprintf(stderr, "cannot create text context\n");
+        llama_free_model(model);
+        llama_backend_free();
+        return 1;
+    }
+    capture_state capture;
+    capture.directory = argv[5];
+    capture.trace_operations = trace_operations;
+    mtmd_context_params params = mtmd_context_params_default();
+    params.use_gpu = false;
+    params.warmup = false;
+    params.print_timings = true;
+    const unsigned threads = std::thread::hardware_concurrency();
+    params.n_threads = threads ? static_cast<int>(threads) : 4;
+    params.cb_eval = capture_callback;
+    params.cb_eval_user_data = &capture;
+    mtmd_context * context = mtmd_init_from_file(argv[2], model, params);
+    if (!context) {
+        std::fprintf(stderr, "cannot load multimodal projector\n");
+        llama_free(text_context);
+        llama_free_model(model);
+        llama_backend_free();
+        return 1;
+    }
+
+    const size_t rgb_count = static_cast<size_t>(width) * height * 3U;
+    std::vector<unsigned char> rgb(rgb_count);
+    for (size_t index = 0; index < rgb.size(); ++index)
+        rgb[index] = static_cast<unsigned char>((index * 37U + 11U) & 255U);
+    mtmd_bitmap * bitmap = mtmd_bitmap_init(width, height, rgb.data());
+    mtmd_input_chunks * chunks = mtmd_input_chunks_init();
+    const mtmd_bitmap * bitmap_list[] = { bitmap };
+    const std::string prompt =
+        std::string("<bos><|turn>user\n") + mtmd_default_marker() +
+        "Describe this image.<turn|>\n"
+        "<|turn>model\n<|channel>thought\n<channel|>";
+    mtmd_input_text text { prompt.c_str(), false, true };
+    int result = 1;
+    if (!bitmap || !chunks || mtmd_tokenize(
+            context, chunks, &text, bitmap_list, 1) != 0) {
+        std::fprintf(stderr, "llama.cpp image preprocessing failed\n");
+        goto cleanup;
+    }
+    for (size_t index = 0; index < mtmd_input_chunks_size(chunks); ++index) {
+        const mtmd_input_chunk * chunk = mtmd_input_chunks_get(chunks, index);
+        if (mtmd_input_chunk_get_type(chunk) != MTMD_INPUT_CHUNK_TYPE_IMAGE)
+            continue;
+        if (mtmd_encode_chunk(context, chunk) != 0) {
+            std::fprintf(stderr, "llama.cpp vision encode failed\n");
+            goto cleanup;
+        }
+        const size_t tokens = mtmd_input_chunk_get_n_tokens(chunk);
+        const size_t embedding_width = capture.projected_width;
+        const float * output = mtmd_get_output_embd(context);
+        const std::string output_path =
+            capture.directory + "/llama-vision-output.f32";
+        if (!output || !embedding_width || capture.projected_tokens != tokens ||
+            !write_output(
+                output_path, output, tokens * embedding_width)) {
+            std::fprintf(stderr, "cannot save llama.cpp projected vectors\n");
+            goto cleanup;
+        }
+        std::printf("output %zu x %zu -> %s\n", tokens, embedding_width,
+                    output_path.c_str());
+        const bool operations_complete = !trace_operations ||
+            capture.operation_count ==
+                sizeof(operation_captures) / sizeof(operation_captures[0]);
+        result = capture.layer0 && capture.layer8 && capture.layer17 &&
+                 capture.layer26 && capture.projected && operations_complete
+                    ? 0 : 1;
+        if (result)
+            std::fprintf(stderr, "required vision tensors were not captured\n");
+        break;
+    }
+    if (result == 0 && !trace_operations) {
+        llama_pos new_position = 0;
+        if (mtmd_helper_eval_chunks(context, text_context, chunks, 0, 0,
+                                    512, true, &new_position) != 0) {
+            std::fprintf(stderr, "llama.cpp image-conditioned decode failed\n");
+            result = 1;
+        } else {
+            const float * logits = llama_get_logits_ith(text_context, -1);
+            const int32_t vocabulary = llama_vocab_n_tokens(
+                llama_model_get_vocab(model));
+            const std::string logits_path =
+                capture.directory + "/llama-image-logits.f32";
+            if (!logits || vocabulary <= 0 || !write_output(
+                    logits_path, logits, static_cast<size_t>(vocabulary))) {
+                std::fprintf(stderr, "cannot save image-conditioned logits\n");
+                result = 1;
+            } else {
+                std::printf("image logits %d -> %s\n", vocabulary,
+                            logits_path.c_str());
+            }
+        }
+    }
+cleanup:
+    mtmd_input_chunks_free(chunks);
+    mtmd_bitmap_free(bitmap);
+    mtmd_free(context);
+    llama_free(text_context);
+    llama_free_model(model);
+    llama_backend_free();
+    return result;
+}

--- a/c/tests/test_gemma4.c
+++ b/c/tests/test_gemma4.c
@@ -1,0 +1,447 @@
+#define _CRT_SECURE_NO_WARNINGS
+
+#include "../gemma4_backend.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#define make_dir(path) _mkdir(path)
+#define remove_dir(path) _rmdir(path)
+#else
+#include <sys/stat.h>
+#include <unistd.h>
+#define make_dir(path) mkdir(path, 0700)
+#define remove_dir(path) rmdir(path)
+#endif
+
+#define TEST_DIR "gemma4-test-data"
+#define MANIFEST_FILE TEST_DIR "/manifest.json"
+#define PACKED_NAME "gemma4-test-layer.g4ex"
+#define PACKED_FILE TEST_DIR "/" PACKED_NAME
+#define SOURCE_NAME "gemma4-test-source.bin"
+#define SOURCE_FILE TEST_DIR "/" SOURCE_NAME
+#define USAGE_FILE TEST_DIR "/.gemma4_usage"
+
+static void put_u32(uint8_t *bytes, size_t offset, uint32_t value) {
+    bytes[offset + 0] = (uint8_t)value;
+    bytes[offset + 1] = (uint8_t)(value >> 8);
+    bytes[offset + 2] = (uint8_t)(value >> 16);
+    bytes[offset + 3] = (uint8_t)(value >> 24);
+}
+
+static void put_u64(uint8_t *bytes, size_t offset, uint64_t value) {
+    put_u32(bytes, offset, (uint32_t)value);
+    put_u32(bytes, offset + 4, (uint32_t)(value >> 32));
+}
+
+static void write_unit_q4_matrix(uint8_t *payload, size_t offset) {
+    size_t row, index;
+    for (row = 0; row < 32; ++row) {
+        uint8_t *block = payload + offset + row * 18;
+        block[0] = 0x00;
+        block[1] = 0x3c;
+        for (index = 0; index < 16; ++index) block[2 + index] = 0x88;
+        block[2] = 0x89;
+    }
+}
+
+static int write_fixture(void) {
+    const size_t component_bytes = 32 * 18;
+    const size_t payload_bytes = 3 * component_bytes;
+    const size_t record_stride = 4096;
+    const size_t total_bytes = 4096 + 2 * record_stride;
+    const size_t fused_offset = 64;
+    const size_t fused_stride = 2 * component_bytes;
+    const size_t down_offset = fused_offset + 2 * fused_stride;
+    const size_t down_stride = component_bytes;
+    const size_t source_bytes = down_offset + 2 * down_stride;
+    uint8_t *packed = (uint8_t *)calloc(total_bytes, 1);
+    uint8_t *source = (uint8_t *)calloc(source_bytes, 1);
+    float scales[2] = {0.75F, 1.25F};
+    FILE *file;
+    int expert;
+    if (!packed || !source) { free(packed); free(source); return -1; }
+    memcpy(source + 16, scales, sizeof(scales));
+    memcpy(packed, "G4EXPK01", 8);
+    put_u32(packed, 8, 1);
+    put_u32(packed, 12, 0);
+    put_u32(packed, 16, 2);
+    put_u32(packed, 20, 2);
+    put_u32(packed, 24, 4096);
+    put_u64(packed, 32, 4096);
+    put_u64(packed, 40, payload_bytes);
+    put_u64(packed, 48, record_stride);
+    put_u64(packed, 56, component_bytes);
+    put_u64(packed, 64, component_bytes);
+    put_u64(packed, 72, component_bytes);
+    for (expert = 0; expert < 2; ++expert) {
+        uint8_t *record = packed + 4096 + (size_t)expert * record_stride;
+        write_unit_q4_matrix(record, 0);
+        write_unit_q4_matrix(record, component_bytes);
+        write_unit_q4_matrix(record, 2 * component_bytes);
+        write_unit_q4_matrix(source, fused_offset + (size_t)expert * fused_stride);
+        write_unit_q4_matrix(source, fused_offset + (size_t)expert * fused_stride +
+                                     component_bytes);
+        write_unit_q4_matrix(source, down_offset + (size_t)expert * down_stride);
+    }
+    file = fopen(PACKED_FILE, "wb");
+    if (!file || fwrite(packed, 1, total_bytes, file) != total_bytes) {
+        if (file) fclose(file);
+        free(packed);
+        free(source);
+        return -1;
+    }
+    if (fclose(file) != 0) { free(packed); free(source); return -1; }
+    free(packed);
+
+    file = fopen(SOURCE_FILE, "wb");
+    if (!file || fwrite(source, 1, source_bytes, file) != source_bytes) {
+        if (file) fclose(file);
+        free(source);
+        return -1;
+    }
+    free(source);
+    if (fclose(file) != 0) return -1;
+
+    file = fopen(MANIFEST_FILE, "wb");
+    if (!file) return -1;
+    fprintf(file,
+        "{\n"
+        "  \"format\": \"g4lab-expert-manifest-v2\",\n"
+        "  \"source\": \"%s\",\n"
+        "  \"architecture\": \"gemma4\",\n"
+        "  \"expert_count\": 2,\n"
+        "  \"expert_used_count\": 2,\n"
+        "  \"layers\": [{\n"
+        "    \"layer\": 0, \"expert_count\": 2,\n"
+        "    \"source_layout\": \"fused_gate_up\",\n"
+        "    \"model_width\": 32, \"expert_width\": 32,\n"
+        "    \"payload_bytes\": %zu, \"record_stride\": %zu,\n"
+        "    \"packed_file\": \"%s\",\n"
+        "    \"expert_scale\": {\"ggml_type\": 0, \"source_offset\": 16, \"scalar_bytes\": 4},\n"
+        "    \"components\": [\n"
+        "      {\"role\": \"gate\", \"ggml_type\": 2, \"type_name\": \"Q4_0\", \"slice_bytes\": %zu, \"source_offset\": %zu, \"source_expert_stride\": %zu, \"source_within_expert_offset\": 0},\n"
+        "      {\"role\": \"up\",   \"ggml_type\": 2, \"type_name\": \"Q4_0\", \"slice_bytes\": %zu, \"source_offset\": %zu, \"source_expert_stride\": %zu, \"source_within_expert_offset\": %zu},\n"
+        "      {\"role\": \"down\", \"ggml_type\": 2, \"type_name\": \"Q4_0\", \"slice_bytes\": %zu, \"source_offset\": %zu, \"source_expert_stride\": %zu, \"source_within_expert_offset\": 0}\n"
+        "    ]\n"
+        "  }]\n"
+        "}\n",
+        SOURCE_NAME, payload_bytes, record_stride, PACKED_NAME,
+        component_bytes, fused_offset, fused_stride,
+        component_bytes, fused_offset, fused_stride, component_bytes,
+        component_bytes, down_offset, down_stride);
+    if (fclose(file) != 0) return -1;
+    return 0;
+}
+
+static void cleanup_fixture(void) {
+    remove(MANIFEST_FILE);
+    remove(PACKED_FILE);
+    remove(SOURCE_FILE);
+    remove(USAGE_FILE);
+    remove(USAGE_FILE ".tmp");
+    remove_dir(TEST_DIR);
+}
+
+static int close_enough(float actual, float expected, float tolerance,
+                        const char *label) {
+    if (fabsf(actual - expected) > tolerance) {
+        fprintf(stderr, "%s: expected %.9g, received %.9g\n",
+                label, expected, actual);
+        return 0;
+    }
+    return 1;
+}
+
+int main(void) {
+    coli_gemma4_backend gemma;
+    coli_expert_backend backend;
+    const coli_gemma4_layer *layer;
+    float input[32] = {0};
+    float output[32] = {0};
+    uint32_t ids[2] = {0, 1};
+    float weights[2] = {0.25F, 0.75F};
+    float base, expected;
+    coli_gemma4_cache_stats cache_stats;
+    uint64_t usage_total = 0;
+    int i;
+    int status = 1;
+
+    {
+        uint8_t q6[2 * 210];
+        float q6_input[256];
+        float q6_row[256];
+        float q6_output[2];
+        float q6_sum = 0.0F;
+        size_t index;
+        memset(q6, 0, sizeof(q6));
+        for (index = 0; index < 2; ++index) {
+            uint8_t *block = q6 + index * 210;
+            memset(block, 0x11, 128);
+            memset(block + 128, 0xaa, 64);
+            memset(block + 192, index ? 2 : 1, 16);
+            block[208] = 0x00;
+            block[209] = 0x3c;
+        }
+        for (index = 0; index < 256; ++index) {
+            q6_input[index] = (float)(index + 1);
+            q6_sum += q6_input[index];
+        }
+        if (coli_gemma4_q6_k_row(q6, 2, 256, 1, q6_row) != 0 ||
+            coli_gemma4_q6_k_matvec(q6, 2, 256, q6_input, q6_output) != 0) {
+            fprintf(stderr, "Q6_K helper failed\n");
+            return 1;
+        }
+        for (index = 0; index < 256; ++index) {
+            if (!close_enough(q6_row[index], 2.0F, 0.0F, "Q6_K row"))
+                return 1;
+        }
+        if (!close_enough(q6_output[0], q6_sum, 0.0F, "Q6_K matvec row 0") ||
+            !close_enough(q6_output[1], 2.0F * q6_sum, 0.0F,
+                          "Q6_K matvec row 1")) return 1;
+    }
+
+    cleanup_fixture();
+    if (make_dir(TEST_DIR) != 0) {
+        fprintf(stderr, "failed to create Gemma test directory\n");
+        return 1;
+    }
+    if (!close_enough(coli_gemma4_fp16_to_fp32(0x3c00), 1.0F, 0.0F,
+                      "fp16 one") ||
+        !close_enough(coli_gemma4_fp16_to_fp32(0xc000), -2.0F, 0.0F,
+                      "fp16 minus two")) {
+        return 1;
+    }
+    if (write_fixture() != 0) {
+        fprintf(stderr, "failed to create Gemma test fixture\n");
+        goto cleanup;
+    }
+    if (coli_gemma4_open_packed(&gemma, TEST_DIR) != 0) {
+        fprintf(stderr, "open_packed: %s\n", coli_gemma4_last_error(&gemma));
+        goto cleanup;
+    }
+    if (gemma.config.n_layer != 1 || gemma.config.n_embd != 32 ||
+        gemma.config.n_expert != 2 || gemma.config.n_expert_used != 2 ||
+        gemma.config.n_expert_ff != 32) {
+        fprintf(stderr, "parsed Gemma configuration is incorrect\n");
+        goto close_backend;
+    }
+    layer = coli_gemma4_find_layer(&gemma, 0);
+    if (!layer || layer->payload_bytes != 1728 || !layer->has_scale ||
+        !coli_gemma4_has_packed_layer(&gemma, layer)) {
+        fprintf(stderr, "parsed Gemma layer is incorrect\n");
+        goto close_backend;
+    }
+    input[0] = 1.0F;
+    backend = coli_gemma4_expert_backend(&gemma);
+    if (backend.prepare_layer(backend.ctx, 0, ids, 2) != 0 ||
+        backend.run_experts(backend.ctx, 0, ids, weights, 2, input, output) != 0) {
+        fprintf(stderr, "run_experts: %s\n", coli_gemma4_last_error(&gemma));
+        goto close_backend;
+    }
+    base = coli_gemma4_gelu_tanh(1.0F);
+    expected = base * (0.25F * 0.75F + 0.75F * 1.25F);
+    for (i = 0; i < 32; ++i) {
+        if (!close_enough(output[i], expected, 1.0e-6F,
+                          "weighted expert aggregate"))
+            goto close_backend;
+    }
+    if (remove(PACKED_FILE) != 0 ||
+        coli_gemma4_has_packed_layer(&gemma, layer)) {
+        fprintf(stderr, "failed to switch fixture to direct GGUF fallback\n");
+        goto close_backend;
+    }
+    memset(output, 0, sizeof(output));
+    if (backend.run_experts(backend.ctx, 0, ids, weights, 2, input, output) != 0) {
+        fprintf(stderr, "direct GGUF fallback: %s\n",
+                coli_gemma4_last_error(&gemma));
+        goto close_backend;
+    }
+    for (i = 0; i < 32; ++i) {
+        if (!close_enough(output[i], expected, 1.0e-6F,
+                          "direct GGUF expert aggregate"))
+            goto close_backend;
+    }
+    if (coli_gemma4_cache_configure(&gemma, 2) != 0 ||
+        backend.prepare_layer(backend.ctx, 0, ids, 2) != 0 ||
+        backend.run_experts(backend.ctx, 0, ids, weights, 2, input, output) != 0 ||
+        backend.prepare_layer(backend.ctx, 0, ids, 2) != 0 ||
+        backend.run_experts(backend.ctx, 0, ids, weights, 2, input, output) != 0) {
+        fprintf(stderr, "cached run_experts: %s\n",
+                coli_gemma4_last_error(&gemma));
+        goto close_backend;
+    }
+    coli_gemma4_cache_get_stats(&gemma, &cache_stats);
+    if (cache_stats.capacity != 2 || cache_stats.resident != 2 ||
+        cache_stats.misses != 2 || cache_stats.hits != 2 ||
+        cache_stats.evictions != 0 || cache_stats.bytes_loaded != 3464) {
+        fprintf(stderr, "expert cache statistics are incorrect\n");
+        goto close_backend;
+    }
+    for (i = 0; i < 32; ++i) {
+        if (!close_enough(output[i], expected, 1.0e-6F,
+                          "cached expert aggregate"))
+            goto close_backend;
+    }
+    if (coli_gemma4_cache_configure(&gemma, 2) != 0 ||
+        coli_gemma4_prefetch_configure(&gemma, 1) != 0 ||
+        backend.prepare_layer(backend.ctx, 0, ids, 2) != 0 ||
+        backend.run_experts(backend.ctx, 0, ids, weights, 2,
+                            input, output) != 0 ||
+        backend.prepare_layer(backend.ctx, 0, ids, 2) != 0 ||
+        backend.run_experts(backend.ctx, 0, ids, weights, 2,
+                            input, output) != 0) {
+        fprintf(stderr, "asynchronous expert prefetch failed: %s\n",
+                coli_gemma4_last_error(&gemma));
+        goto close_backend;
+    }
+    coli_gemma4_cache_get_stats(&gemma, &cache_stats);
+    if (cache_stats.prefetch_launches != 1 ||
+        cache_stats.prefetched_records != 2 || cache_stats.misses != 2 ||
+        cache_stats.hits != 2) {
+        fprintf(stderr, "asynchronous prefetch statistics are incorrect\n");
+        goto close_backend;
+    }
+    for (i = 0; i < 32; ++i) {
+        if (!close_enough(output[i], expected, 1.0e-6F,
+                          "prefetched expert aggregate"))
+            goto close_backend;
+    }
+    if (coli_gemma4_cache_configure(&gemma, 2) != 0 ||
+        coli_gemma4_prefetch_configure(&gemma, 1) != 0 ||
+        coli_gemma4_lookahead_configure(&gemma, 1) != 0 ||
+        !(backend = coli_gemma4_expert_backend(&gemma)).prefetch_layer ||
+        backend.prefetch_layer(backend.ctx, 0, ids, 2) != 0 ||
+        backend.prepare_layer(backend.ctx, 0, ids, 2) != 0 ||
+        backend.run_experts(backend.ctx, 0, ids, weights, 2,
+                            input, output) != 0) {
+        fprintf(stderr, "next-layer expert lookahead failed: %s\n",
+                coli_gemma4_last_error(&gemma));
+        goto close_backend;
+    }
+    coli_gemma4_cache_get_stats(&gemma, &cache_stats);
+    if (cache_stats.lookahead_launches != 1 ||
+        cache_stats.lookahead_records != 2 ||
+        cache_stats.lookahead_matches != 2 ||
+        cache_stats.lookahead_selected != 2 ||
+        cache_stats.hits != 2) {
+        fprintf(stderr, "next-layer lookahead statistics are incorrect\n");
+        goto close_backend;
+    }
+    {
+        FILE *usage = fopen(USAGE_FILE, "w");
+        int usage_ok = usage && fprintf(usage, "0 1 20\n0 0 3\n") >= 0;
+        if (usage && fclose(usage) != 0) usage_ok = 0;
+        if (!usage_ok) {
+            fprintf(stderr, "cannot create usage-profile fixture\n");
+            goto close_backend;
+        }
+    }
+    if (coli_gemma4_cache_configure(&gemma, 3) != 0 ||
+        coli_gemma4_cache_set_pinned(&gemma, 1) != 0 ||
+        coli_gemma4_usage_load(&gemma, USAGE_FILE, &usage_total) != 0 ||
+        usage_total != 23 ||
+        backend.prepare_layer(backend.ctx, 0, ids + 1, 1) != 0 ||
+        coli_gemma4_usage_save(&gemma, USAGE_FILE, &usage_total) != 0 ||
+        usage_total != 24) {
+        fprintf(stderr, "persistent usage profile failed: %s\n",
+                coli_gemma4_last_error(&gemma));
+        goto close_backend;
+    }
+    coli_gemma4_cache_get_stats(&gemma, &cache_stats);
+    if (cache_stats.resident != 1 || cache_stats.misses != 0 ||
+        cache_stats.preloads != 1 ||
+        cache_stats.hits != 1 || cache_stats.pinned_hits != 1) {
+        fprintf(stderr, "usage-profile seed did not warm the protected slot\n");
+        goto close_backend;
+    }
+    if (coli_gemma4_cache_configure(&gemma, 3) != 0 ||
+        coli_gemma4_cache_set_pinned(&gemma, 1) != 0 ||
+        coli_gemma4_usage_load(&gemma, USAGE_FILE, &usage_total) != 0 ||
+        usage_total != 24 ||
+        backend.prepare_layer(backend.ctx, 0, ids + 1, 1) != 0) {
+        fprintf(stderr, "saved usage profile cannot warm a new cache: %s\n",
+                coli_gemma4_last_error(&gemma));
+        goto close_backend;
+    }
+    coli_gemma4_cache_get_stats(&gemma, &cache_stats);
+    if (cache_stats.resident != 1 || cache_stats.misses != 0 ||
+        cache_stats.preloads != 1 ||
+        cache_stats.hits != 1 || cache_stats.pinned_hits != 1) {
+        fprintf(stderr, "reloaded usage profile did not seed hottest expert\n");
+        goto close_backend;
+    }
+    if (coli_gemma4_cache_configure(&gemma, 3) != 0 ||
+        coli_gemma4_cache_set_pinned(&gemma, 1) != 0 ||
+        backend.prepare_layer(backend.ctx, 0, ids, 1) != 0) {
+        fprintf(stderr, "cannot initialize learned expert cache: %s\n",
+                coli_gemma4_last_error(&gemma));
+        goto close_backend;
+    }
+    for (i = 0; i < 8; ++i) {
+        if (backend.prepare_layer(backend.ctx, 0, ids + 1, 1) != 0) {
+            fprintf(stderr, "learned expert cache access failed\n");
+            goto close_backend;
+        }
+    }
+    memset(output, 0, sizeof(output));
+    if (backend.run_experts(backend.ctx, 0, ids, weights, 2,
+                            input, output) != 0) {
+        fprintf(stderr, "learned cached run: %s\n",
+                coli_gemma4_last_error(&gemma));
+        goto close_backend;
+    }
+    coli_gemma4_cache_get_stats(&gemma, &cache_stats);
+    if (cache_stats.capacity != 3 || cache_stats.pinned_capacity != 1 ||
+        cache_stats.misses != 2 || cache_stats.hits != 7 ||
+        cache_stats.pinned_hits != 2 || cache_stats.promotions != 1) {
+        fprintf(stderr, "learned expert cache statistics are incorrect\n");
+        goto close_backend;
+    }
+    for (i = 0; i < 32; ++i) {
+        if (!close_enough(output[i], expected, 1.0e-6F,
+                          "learned cached expert aggregate"))
+            goto close_backend;
+    }
+    if (coli_gemma4_cache_configure(&gemma, 1) != 0 ||
+        backend.prepare_layer(backend.ctx, 0, ids, 2) != 0 ||
+        backend.run_experts(backend.ctx, 0, ids, weights, 2, input, output) != 0) {
+        fprintf(stderr, "single-slot cached run: %s\n",
+                coli_gemma4_last_error(&gemma));
+        goto close_backend;
+    }
+    coli_gemma4_cache_get_stats(&gemma, &cache_stats);
+    if (cache_stats.capacity != 1 || cache_stats.resident != 1 ||
+        cache_stats.misses != 4 || cache_stats.hits != 0 ||
+        cache_stats.evictions != 3) {
+        fprintf(stderr, "expert cache eviction statistics are incorrect\n");
+        goto close_backend;
+    }
+    for (i = 0; i < 32; ++i) {
+        if (!close_enough(output[i], expected, 1.0e-6F,
+                          "evicted expert aggregate"))
+            goto close_backend;
+    }
+    if (coli_gemma4_cache_configure(&gemma, 0) != 0) {
+        fprintf(stderr, "failed to disable expert cache\n");
+        goto close_backend;
+    }
+    ids[0] = 2;
+    if (backend.prepare_layer(backend.ctx, 0, ids, 1) == 0) {
+        fprintf(stderr, "out-of-range expert was accepted\n");
+        goto close_backend;
+    }
+    puts("Gemma records, LRU, pinning, usage persistence, and async prefetch passed");
+    status = 0;
+
+close_backend:
+    coli_gemma4_close(&gemma);
+cleanup:
+    cleanup_fixture();
+    return status;
+}

--- a/c/tests/test_gemma4_attention.c
+++ b/c/tests/test_gemma4_attention.c
@@ -1,0 +1,285 @@
+#define _CRT_SECURE_NO_WARNINGS
+
+#include "../gemma4_model.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define FIXTURE "gemma4-attention-test.gguf"
+
+static void w8(FILE *f, uint8_t v) { fwrite(&v, 1, 1, f); }
+static void w32(FILE *f, uint32_t v) {
+    uint8_t b[4]={(uint8_t)v,(uint8_t)(v>>8),(uint8_t)(v>>16),(uint8_t)(v>>24)};
+    fwrite(b,1,4,f);
+}
+static void w64(FILE *f, uint64_t v) { w32(f,(uint32_t)v); w32(f,(uint32_t)(v>>32)); }
+static void wf(FILE *f, float v) { uint32_t b; memcpy(&b,&v,4); w32(f,b); }
+static void ws(FILE *f, const char *s) { size_t n=strlen(s); w64(f,n); fwrite(s,1,n,f); }
+static void mu(FILE *f,const char *k,uint32_t v){ws(f,k);w32(f,4);w32(f,v);}
+static void mf(FILE *f,const char *k,float v){ws(f,k);w32(f,6);wf(f,v);}
+static void tensor(FILE *f,const char *name,uint32_t type,uint32_t nd,
+                   uint64_t d0,uint64_t d1,uint64_t off){
+    ws(f,name);w32(f,nd);w64(f,d0);if(nd==2)w64(f,d1);w32(f,type);w64(f,off);
+}
+static void q4_identity_rows(FILE *f, uint32_t rows, uint32_t columns) {
+    uint32_t row, block, i;
+    for (row=0; row<rows; ++row) {
+        for(block=0;block<columns/32;++block){
+            uint8_t q[16];
+            uint16_t half_one=0x3c00;
+            uint32_t target=row%columns;
+            memset(q,0x88,sizeof(q));
+            if(target/32==block){
+                target%=32;
+                if(target<16)q[target]=(uint8_t)((q[target]&0xf0)|9);
+                else q[target%16]=(uint8_t)((q[target%16]&0x0f)|0x90);
+            }
+            w8(f,(uint8_t)half_one);w8(f,(uint8_t)(half_one>>8));
+            for(i=0;i<16;++i)w8(f,q[i]);
+        }
+    }
+}
+
+static int make_fixture(void) {
+    FILE *f=fopen(FIXTURE,"wb");
+    long p;
+    uint32_t i;
+    if(!f)return -1;
+    fwrite("GGUF",1,4,f);w32(f,3);w64(f,21);w64(f,17);
+    ws(f,"general.architecture");w32(f,8);ws(f,"gemma4");
+    mu(f,"general.alignment",32);mu(f,"gemma4.block_count",1);
+    mu(f,"gemma4.embedding_length",32);mu(f,"gemma4.expert_count",2);
+    mu(f,"gemma4.expert_used_count",1);mu(f,"gemma4.expert_feed_forward_length",32);
+    mu(f,"gemma4.attention.sliding_window",16);mu(f,"gemma4.attention.head_count",2);
+    mu(f,"gemma4.attention.key_length",64);mu(f,"gemma4.attention.key_length_swa",32);
+    mu(f,"gemma4.attention.value_length",64);mu(f,"gemma4.attention.value_length_swa",32);
+    mf(f,"gemma4.attention.layer_norm_rms_epsilon",1e-6F);
+    ws(f,"gemma4.attention.head_count_kv");w32(f,9);w32(f,5);w64(f,1);w32(f,1);
+    ws(f,"gemma4.attention.sliding_window_pattern");w32(f,9);w32(f,7);w64(f,1);w8(f,1);
+    mf(f,"gemma4.rope.freq_base_swa",10000.0F);
+    tensor(f,"token_embd.weight",COLI_GGML_TYPE_F32,2,32,32,0);
+    tensor(f,"blk.0.attn_q.weight",COLI_GGML_TYPE_Q4_0,2,32,64,4096);
+    tensor(f,"blk.0.attn_k.weight",COLI_GGML_TYPE_Q4_0,2,32,32,5248);
+    tensor(f,"blk.0.attn_v.weight",COLI_GGML_TYPE_Q4_0,2,32,32,5824);
+    tensor(f,"blk.0.attn_norm.weight",COLI_GGML_TYPE_F32,1,32,0,6400);
+    tensor(f,"blk.0.attn_q_norm.weight",COLI_GGML_TYPE_F32,1,32,0,6528);
+    tensor(f,"blk.0.attn_k_norm.weight",COLI_GGML_TYPE_F32,1,32,0,6656);
+    tensor(f,"blk.0.attn_output.weight",COLI_GGML_TYPE_Q4_0,2,64,32,6784);
+    tensor(f,"blk.0.ffn_gate.weight",COLI_GGML_TYPE_Q4_0,2,32,32,7936);
+    tensor(f,"blk.0.ffn_up.weight",COLI_GGML_TYPE_Q4_0,2,32,32,8512);
+    tensor(f,"blk.0.ffn_down.weight",COLI_GGML_TYPE_Q4_0,2,32,32,9088);
+    tensor(f,"blk.0.ffn_gate_inp.scale",COLI_GGML_TYPE_F32,1,32,0,9664);
+    tensor(f,"blk.0.ffn_gate_inp.weight",COLI_GGML_TYPE_F32,2,32,2,9792);
+    tensor(f,"blk.0.ffn_down_exps.scale",COLI_GGML_TYPE_F32,1,2,0,10048);
+    tensor(f,"blk.0.ffn_norm.weight",COLI_GGML_TYPE_F32,1,32,0,10080);
+    tensor(f,"blk.0.post_attention_norm.weight",COLI_GGML_TYPE_F32,1,32,0,10208);
+    tensor(f,"blk.0.post_ffw_norm.weight",COLI_GGML_TYPE_F32,1,32,0,10336);
+    tensor(f,"blk.0.post_ffw_norm_1.weight",COLI_GGML_TYPE_F32,1,32,0,10464);
+    tensor(f,"blk.0.post_ffw_norm_2.weight",COLI_GGML_TYPE_F32,1,32,0,10592);
+    tensor(f,"blk.0.pre_ffw_norm_2.weight",COLI_GGML_TYPE_F32,1,32,0,10720);
+    tensor(f,"blk.0.layer_output_scale.weight",COLI_GGML_TYPE_F32,1,1,0,10848);
+    p=ftell(f);if(p<0){fclose(f);return -1;} while(p%32){w8(f,0);++p;}
+    for(i=0;i<32*32;++i)wf(f,0.0F);
+    q4_identity_rows(f,64,32);q4_identity_rows(f,32,32);q4_identity_rows(f,32,32);
+    for(i=0;i<32*3;++i)wf(f,1.0F);
+    q4_identity_rows(f,32,64);
+    q4_identity_rows(f,32,32);q4_identity_rows(f,32,32);q4_identity_rows(f,32,32);
+    for(i=0;i<32;++i)wf(f,1.0F);
+    for(i=0;i<64;++i)wf(f,0.0F);
+    wf(f,1.0F);wf(f,1.0F);
+    for(i=0;i<6;++i)wf(f,0.0F);
+    for(i=0;i<32*6;++i)wf(f,1.0F);
+    wf(f,1.0F);
+    return fclose(f)==0?0:-1;
+}
+
+typedef struct { int prepared, released; } fake_experts;
+
+static int fake_prepare(void *context, uint32_t layer,
+                        const uint32_t *ids, uint32_t count) {
+    fake_experts *fake=(fake_experts *)context;
+    if(layer!=0||count!=1||!ids||ids[0]!=0)return -1;
+    ++fake->prepared;return 0;
+}
+static int fake_run(void *context, uint32_t layer, const uint32_t *ids,
+                    const float *weights, uint32_t count,
+                    const float *input, float *output) {
+    uint32_t i;
+    (void)context;(void)input;
+    if(layer!=0||count!=1||!ids||ids[0]!=0||!weights||
+       fabsf(weights[0]-1.0F)>1e-6F||!output)return -1;
+    for(i=0;i<32;++i)output[i]=0.0F;
+    return 0;
+}
+static void fake_release(void *context, uint32_t layer) {
+    fake_experts *fake=(fake_experts *)context;
+    if(layer==0)++fake->released;
+}
+
+static int test_decoder_layer(const coli_gemma4_gguf *gguf,
+                              const float *input) {
+    coli_gemma4_decoder_layer decoder;
+    coli_gemma4_kv_cache actual_cache, reference_cache;
+    fake_experts fake={0,0};
+    coli_expert_backend backend={
+        .ctx=&fake,
+        .prepare_layer=fake_prepare,
+        .run_experts=fake_run,
+        .release_layer=fake_release
+    };
+    float actual[32],attention_output[32],after_attention[32];
+    float dense_input[32],dense_output[32],dense_normalized[32];
+    float expected[32];
+    uint32_t i;
+    int status=-1;
+    memset(&decoder,0,sizeof(decoder));
+    memset(&actual_cache,0,sizeof(actual_cache));
+    memset(&reference_cache,0,sizeof(reference_cache));
+    if(coli_gemma4_decoder_layer_open(&decoder,gguf,0)!=0){
+        fprintf(stderr,"decoder open: %s\n",
+                coli_gemma4_decoder_layer_last_error(&decoder));goto cleanup;
+    }
+    if(decoder.dense_mlp.intermediate_width!=32||
+       coli_gemma4_kv_cache_init(&actual_cache,&decoder.attention,2)!=0||
+       coli_gemma4_kv_cache_init(&reference_cache,&decoder.attention,2)!=0||
+       coli_gemma4_decoder_layer_step(&decoder,&actual_cache,&backend,0,
+                                      input,actual)!=0||
+       coli_gemma4_attention_step(&decoder.attention,&reference_cache,0,input,
+                                  attention_output)!=0||
+       coli_gemma4_rmsnorm(attention_output,decoder.post_attention_norm,32,
+                           gguf->rms_epsilon,after_attention)!=0)
+        goto cleanup;
+    for(i=0;i<32;++i)after_attention[i]+=input[i];
+    if(coli_gemma4_rmsnorm(after_attention,decoder.ffn_norm,32,
+                           gguf->rms_epsilon,dense_input)!=0||
+       coli_gemma4_dense_mlp_run(&decoder.dense_mlp,dense_input,dense_output)!=0||
+       coli_gemma4_rmsnorm(dense_output,decoder.post_ffw_norm_1,32,
+                           gguf->rms_epsilon,dense_normalized)!=0||
+       coli_gemma4_rmsnorm(dense_normalized,decoder.post_ffw_norm,32,
+                           gguf->rms_epsilon,expected)!=0)
+        goto cleanup;
+    for(i=0;i<32;++i){
+        expected[i]=(after_attention[i]+expected[i])*decoder.layer_output_scale;
+        if(fabsf(actual[i]-expected[i])>1e-5F){
+            fprintf(stderr,"decoder ordering mismatch at %u\n",i);goto cleanup;
+        }
+    }
+    if(fake.prepared!=1||fake.released!=1){
+        fprintf(stderr,"expert backend lifecycle mismatch\n");goto cleanup;
+    }
+    status=0;
+cleanup:
+    coli_gemma4_kv_cache_close(&actual_cache);
+    coli_gemma4_kv_cache_close(&reference_cache);
+    coli_gemma4_decoder_layer_close(&decoder);
+    return status;
+}
+
+int main(void) {
+    coli_gemma4_gguf gguf;
+    coli_gemma4_attention attention;
+    coli_gemma4_kv_cache cache;
+    float input[32],q[64],k[32],v[32],output[32];
+    float sequence_input[64],sequence_output[64],sequence_expected[32];
+    float q0[64],q1[64],k0[32],k1[32],v0[32],v1[32],context[64];
+    float ss=0.0F,inv1,ss2=0.0F,inv2;
+    float before_q0, before_q16, expected_q0, expected_q16;
+    const float *cached_key, *cached_value;
+    uint32_t i;
+    int status=1;
+    remove(FIXTURE);
+    for(i=0;i<32;++i){input[i]=(float)(i+1);ss+=input[i]*input[i];}
+    if(make_fixture()!=0){fprintf(stderr,"fixture write failed\n");return 1;}
+    if(coli_gemma4_gguf_open(&gguf,FIXTURE)!=0){
+        fprintf(stderr,"GGUF open: %s\n",coli_gemma4_gguf_last_error(&gguf));goto cleanup;
+    }
+    if(coli_gemma4_attention_open(&attention,&gguf,0)!=0){
+        fprintf(stderr,"attention open: %s\n",coli_gemma4_attention_last_error(&attention));goto close_gguf;
+    }
+    if(attention.query_heads!=2||attention.kv_heads!=1||attention.head_dim!=32||
+       !attention.sliding||attention.key_equals_value||
+       coli_gemma4_attention_project(&attention,input,q,k,v)!=0){
+        fprintf(stderr,"attention geometry or projection failed\n");goto close_attention;
+    }
+    inv1=1.0F/sqrtf(ss/32.0F+1e-6F);
+    for(i=0;i<32;++i){float x=input[i]*inv1;ss2+=x*x;}
+    inv2=1.0F/sqrtf(ss2/32.0F+1e-6F);
+    for(i=0;i<32;++i){
+        float expected=input[i]*inv1*inv2;
+        if(fabsf(q[i]-expected)>1e-5F||fabsf(q[32+i]-expected)>1e-5F||
+           fabsf(k[i]-expected)>1e-5F||fabsf(v[i]-expected)>1e-5F){
+            fprintf(stderr,"attention value mismatch at %u\n",i);goto close_attention;
+        }
+    }
+    before_q0=q[0];before_q16=q[16];
+    expected_q0=before_q0*cosf(1.0F)-before_q16*sinf(1.0F);
+    expected_q16=before_q16*cosf(1.0F)+before_q0*sinf(1.0F);
+    if(coli_gemma4_attention_apply_rope(&attention,1,q,k)!=0||
+       fabsf(q[0]-expected_q0)>1e-6F||fabsf(q[16]-expected_q16)>1e-6F){
+        fprintf(stderr,"RoPE mismatch\n");goto close_attention;
+    }
+    memset(&cache,0,sizeof(cache));
+    if(coli_gemma4_kv_cache_init(&cache,&attention,20)!=0||cache.capacity!=16||
+       coli_gemma4_kv_cache_store(&cache,0,k,v)!=0||
+       coli_gemma4_kv_cache_find(&cache,0,&cached_key,&cached_value)!=0||
+       cached_key[0]!=k[0]||cached_value[0]!=v[0]||
+       coli_gemma4_kv_cache_store(&cache,16,k,v)!=0||
+       coli_gemma4_kv_cache_find(&cache,0,&cached_key,&cached_value)==0||
+       coli_gemma4_kv_cache_find(&cache,16,&cached_key,&cached_value)!=0){
+        fprintf(stderr,"sliding KV cache mismatch\n");
+        coli_gemma4_kv_cache_close(&cache);goto close_attention;
+    }
+    coli_gemma4_kv_cache_close(&cache);
+    memset(&cache,0,sizeof(cache));
+    if(coli_gemma4_kv_cache_init(&cache,&attention,2)!=0||
+       coli_gemma4_attention_step(&attention,&cache,0,input,output)!=0){
+        fprintf(stderr,"causal attention step failed\n");
+        coli_gemma4_kv_cache_close(&cache);goto close_attention;
+    }
+    for(i=0;i<32;++i){
+        float expected=input[i]*inv1*inv2;
+        if(fabsf(output[i]-expected)>1e-5F){
+            fprintf(stderr,"causal attention output mismatch at %u\n",i);
+            coli_gemma4_kv_cache_close(&cache);goto close_attention;
+        }
+    }
+    coli_gemma4_kv_cache_close(&cache);
+    memcpy(sequence_input,input,sizeof(input));
+    for(i=0;i<32;++i)sequence_input[32+i]=(float)(32-i);
+    memset(context,0,sizeof(context));
+    if(coli_gemma4_attention_project(&attention,sequence_input,q0,k0,v0)!=0||
+       coli_gemma4_attention_project(&attention,sequence_input+32,q1,k1,v1)!=0||
+       coli_gemma4_attention_apply_rope(&attention,0,q0,k0)!=0||
+       coli_gemma4_attention_apply_rope(&attention,1,q1,k1)!=0)
+        goto close_attention;
+    for(i=0;i<2;++i){
+        uint32_t d;
+        float score0=0.0F,score1=0.0F,maximum,e0,e1,denominator;
+        const float *qh=q0+(size_t)i*32;
+        float *ch=context+(size_t)i*32;
+        for(d=0;d<32;++d){score0+=qh[d]*k0[d];score1+=qh[d]*k1[d];}
+        maximum=score0>score1?score0:score1;
+        e0=expf(score0-maximum);e1=expf(score1-maximum);denominator=e0+e1;
+        for(d=0;d<32;++d)ch[d]=(e0*v0[d]+e1*v1[d])/denominator;
+    }
+    if(coli_gemma4_matrix_matvec(&attention.output,context,sequence_expected)!=0||
+       coli_gemma4_kv_cache_init(&cache,&attention,2)!=0||
+       coli_gemma4_attention_noncausal(&attention,&cache,0,sequence_input,2,
+                                       sequence_output)!=0){
+        fprintf(stderr,"non-causal image attention failed\n");
+        coli_gemma4_kv_cache_close(&cache);goto close_attention;
+    }
+    for(i=0;i<32;++i)if(fabsf(sequence_output[i]-sequence_expected[i])>1e-5F){
+        fprintf(stderr,"non-causal image attention mismatch at %u\n",i);
+        coli_gemma4_kv_cache_close(&cache);goto close_attention;
+    }
+    coli_gemma4_kv_cache_close(&cache);
+    if(test_decoder_layer(&gguf,input)!=0)goto close_attention;
+    puts("Gemma attention and decoder-layer ordering passed");status=0;
+close_attention: coli_gemma4_attention_close(&attention);
+close_gguf: coli_gemma4_gguf_close(&gguf);
+cleanup: remove(FIXTURE);return status;
+}

--- a/c/tests/test_gemma4_model.c
+++ b/c/tests/test_gemma4_model.c
@@ -1,0 +1,141 @@
+#define _CRT_SECURE_NO_WARNINGS
+
+#include "../gemma4_model.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define FIXTURE "gemma4-router-test.gguf"
+
+static void write_u8(FILE *file, uint8_t value) { fwrite(&value, 1, 1, file); }
+static void write_u32(FILE *file, uint32_t value) {
+    uint8_t b[4] = {(uint8_t)value, (uint8_t)(value >> 8),
+                    (uint8_t)(value >> 16), (uint8_t)(value >> 24)};
+    fwrite(b, 1, sizeof(b), file);
+}
+static void write_u64(FILE *file, uint64_t value) {
+    write_u32(file, (uint32_t)value);
+    write_u32(file, (uint32_t)(value >> 32));
+}
+static void write_f32(FILE *file, float value) {
+    uint32_t bits;
+    memcpy(&bits, &value, sizeof(bits));
+    write_u32(file, bits);
+}
+static void write_string(FILE *file, const char *value) {
+    size_t length = strlen(value);
+    write_u64(file, length);
+    fwrite(value, 1, length, file);
+}
+static void write_meta_u32(FILE *file, const char *key, uint32_t value) {
+    write_string(file, key); write_u32(file, 4); write_u32(file, value);
+}
+static void write_meta_f32(FILE *file, const char *key, float value) {
+    write_string(file, key); write_u32(file, 6); write_f32(file, value);
+}
+static void write_tensor(FILE *file, const char *name, uint32_t dims,
+                         uint64_t d0, uint64_t d1, uint64_t offset) {
+    write_string(file, name); write_u32(file, dims); write_u64(file, d0);
+    if (dims == 2) write_u64(file, d1);
+    write_u32(file, COLI_GGML_TYPE_F32); write_u64(file, offset);
+}
+
+static int make_fixture(void) {
+    FILE *file = fopen(FIXTURE, "wb");
+    long position;
+    uint32_t i;
+    const float projection[16] = {
+        1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1
+    };
+    if (!file) return -1;
+    fwrite("GGUF", 1, 4, file); write_u32(file, 3); write_u64(file, 4); write_u64(file, 13);
+    write_string(file, "general.architecture"); write_u32(file, 8); write_string(file, "gemma4");
+    write_meta_u32(file, "general.alignment", 32);
+    write_meta_u32(file, "gemma4.block_count", 1);
+    write_meta_u32(file, "gemma4.embedding_length", 4);
+    write_meta_u32(file, "gemma4.expert_count", 4);
+    write_meta_u32(file, "gemma4.expert_used_count", 2);
+    write_meta_u32(file, "gemma4.expert_feed_forward_length", 32);
+    write_meta_u32(file, "gemma4.attention.sliding_window", 2);
+    write_meta_u32(file, "gemma4.attention.head_count", 1);
+    write_meta_f32(file, "gemma4.attention.layer_norm_rms_epsilon", 1.0e-6F);
+    write_string(file, "gemma4.attention.head_count_kv"); write_u32(file, 9);
+    write_u32(file, 5); write_u64(file, 1); write_u32(file, 1);
+    write_string(file, "gemma4.attention.sliding_window_pattern"); write_u32(file, 9);
+    write_u32(file, 7); write_u64(file, 1); write_u8(file, 1);
+    write_meta_u32(file, "gemma4.attention.key_length_swa", 4);
+    write_tensor(file, "token_embd.weight", 2, 4, 8, 0);
+    write_tensor(file, "blk.0.ffn_gate_inp.scale", 1, 4, 0, 128);
+    write_tensor(file, "blk.0.ffn_gate_inp.weight", 2, 4, 4, 144);
+    write_tensor(file, "blk.0.ffn_down_exps.scale", 1, 4, 0, 208);
+    position = ftell(file);
+    if (position < 0) { fclose(file); return -1; }
+    while ((position++ % 32) != 0) write_u8(file, 0);
+    for (i = 0; i < 32; ++i) write_f32(file, 0.0F);
+    for (i = 0; i < 4; ++i) write_f32(file, 1.0F);
+    for (i = 0; i < 16; ++i) write_f32(file, projection[i]);
+    write_f32(file, 0.5F); write_f32(file, 2.0F);
+    write_f32(file, 1.0F); write_f32(file, 1.0F);
+    return fclose(file) == 0 ? 0 : -1;
+}
+
+static int close_enough(float a, float b) { return fabsf(a - b) < 1.0e-6F; }
+
+int main(void) {
+    coli_gemma4_gguf gguf;
+    coli_gemma4_router router;
+    float hidden[4] = {4,3,2,1}, probabilities[4], weights[2], effective[2];
+    float norm_weight[4] = {1,2,3,4}, norm_output[4];
+    uint32_t ids[2];
+    float norm, score0, score1, expected0;
+    int status = 1;
+    remove(FIXTURE);
+    if (make_fixture() != 0) { fprintf(stderr, "fixture write failed\n"); return 1; }
+    if (coli_gemma4_gguf_open(&gguf, FIXTURE) != 0) {
+        fprintf(stderr, "GGUF open failed: %s\n", coli_gemma4_gguf_last_error(&gguf));
+        goto cleanup;
+    }
+    if (gguf.tensor_count != 4 || gguf.config.n_layer != 1 ||
+        gguf.config.n_embd != 4 || gguf.config.n_vocab != 8 ||
+        gguf.head_count_kv[0] != 1 || !gguf.sliding_window_pattern[0]) {
+        fprintf(stderr, "GGUF metadata mismatch\n"); goto close_gguf;
+    }
+    if (coli_gemma4_router_open(&router, &gguf, 0) != 0) {
+        fprintf(stderr, "router open failed: %s\n", coli_gemma4_router_last_error(&router));
+        goto close_gguf;
+    }
+    if (coli_gemma4_router_route(&router, hidden, probabilities, ids,
+                                 weights, effective) != 0) {
+        fprintf(stderr, "router evaluation failed\n"); goto close_router;
+    }
+    norm = 1.0F / sqrtf((16.0F + 9.0F + 4.0F + 1.0F) / 4.0F + 1.0e-6F);
+    score0 = 4.0F * norm * 0.5F;
+    score1 = 3.0F * norm * 0.5F;
+    expected0 = expf(score0) / (expf(score0) + expf(score1));
+    if (ids[0] != 0 || ids[1] != 1 || !close_enough(weights[0], expected0) ||
+        !close_enough(weights[1], 1.0F - expected0) ||
+        !close_enough(effective[0], weights[0] * 0.5F) ||
+        !close_enough(effective[1], weights[1] * 2.0F)) {
+        fprintf(stderr, "router top-k or weights mismatch\n"); goto close_router;
+    }
+    if (coli_gemma4_rmsnorm(hidden, norm_weight, 4, 1.0e-6F,
+                            norm_output) != 0 ||
+        !close_enough(norm_output[0], 4.0F * norm) ||
+        !close_enough(norm_output[1], 6.0F * norm) ||
+        !close_enough(norm_output[2], 6.0F * norm) ||
+        !close_enough(norm_output[3], 4.0F * norm)) {
+        fprintf(stderr, "RMSNorm mismatch\n"); goto close_router;
+    }
+    puts("Gemma GGUF index and exact router semantics passed");
+    status = 0;
+close_router:
+    coli_gemma4_router_close(&router);
+close_gguf:
+    coli_gemma4_gguf_close(&gguf);
+cleanup:
+    remove(FIXTURE);
+    return status;
+}

--- a/c/tests/test_gemma4_sampling.c
+++ b/c/tests/test_gemma4_sampling.c
@@ -1,0 +1,32 @@
+#include "gemma4_sampling.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+
+int main(void) {
+    const float logits[] = {0.0F, 1.0F, 2.0F, 3.0F, 4.0F};
+    coli_gemma4_sampler left, right;
+    uint32_t token, other, index;
+    float probability;
+    if (coli_gemma4_sampler_init(&left, 0.0F, 0, 1.0F, 7) != 0 ||
+        coli_gemma4_sample(&left, logits, 5, &token, &probability) != 0 ||
+        token != 4 || probability != 1.0F) return 1;
+    if (coli_gemma4_sampler_init(&left, 1.0F, 1, 1.0F, 7) != 0 ||
+        coli_gemma4_sample(&left, logits, 5, &token, &probability) != 0 ||
+        token != 4 || probability != 1.0F) return 1;
+    if (coli_gemma4_sampler_init(&left, 1.0F, 0, 0.1F, 7) != 0 ||
+        coli_gemma4_sample(&left, logits, 5, &token, &probability) != 0 ||
+        token != 4 || probability != 1.0F) return 1;
+    if (coli_gemma4_sampler_init(&left, 0.8F, 2, 0.95F, 42) != 0 ||
+        coli_gemma4_sampler_init(&right, 0.8F, 2, 0.95F, 42) != 0) return 1;
+    for (index = 0; index < 64; ++index) {
+        if (coli_gemma4_sample(&left, logits, 5, &token, NULL) != 0 ||
+            coli_gemma4_sample(&right, logits, 5, &other, NULL) != 0 ||
+            token != other || token < 3) return 1;
+    }
+    if (coli_gemma4_sampler_init(&left, -1.0F, 0, 1.0F, 1) == 0 ||
+        coli_gemma4_sampler_init(&left, 1.0F, 0, NAN, 1) == 0) return 1;
+    puts("Gemma 4 sampling tests passed");
+    return 0;
+}

--- a/c/tests/test_gemma4_tokenizer.c
+++ b/c/tests/test_gemma4_tokenizer.c
@@ -1,0 +1,126 @@
+#include "gemma4_tokenizer.h"
+
+#include <stdio.h>
+#include <string.h>
+
+int main(void) {
+    char *tokens[] = {
+        "<pad>", "<eos>", "<bos>", "<unk>", "h", "e", "l", "o",
+        "\xe2\x96\x81", "he", "hel", "hell", "hello", "\n\n",
+        "<0xF0>", "<0x9F>", "<0x99>", "<0x82>",
+        "<|turn>", "<turn|>", "<|channel>", "<channel|>",
+        "s", "y", "t", "m", "u", "r", "d", "g", "\n",
+        "<|image>", "<image|>"
+    };
+    char *merges[] = {"h e", "he l", "hel l", "hell o"};
+    uint32_t token_types[] = {
+        3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3
+    };
+    const uint32_t expected[] = {2, 12, 8, 12, 13, 14, 15, 16, 17};
+    uint32_t actual[128];
+    size_t count = 0, index;
+    coli_gemma4_gguf gguf;
+    coli_gemma4_tokenizer tokenizer;
+    int failed = 0;
+    memset(&gguf, 0, sizeof(gguf));
+    memcpy(gguf.tokenizer_model, "gemma4", sizeof("gemma4"));
+    gguf.config.n_vocab = (uint32_t)(sizeof(tokens) / sizeof(tokens[0]));
+    gguf.tokenizer_tokens = tokens;
+    gguf.tokenizer_token_count = sizeof(tokens) / sizeof(tokens[0]);
+    gguf.tokenizer_merges = merges;
+    gguf.tokenizer_merge_count = sizeof(merges) / sizeof(merges[0]);
+    gguf.tokenizer_token_types = token_types;
+    gguf.tokenizer_token_type_count = sizeof(token_types) / sizeof(token_types[0]);
+    gguf.tokenizer_bos_id = 2;
+    gguf.tokenizer_add_bos = 1;
+    if (coli_gemma4_tokenizer_init(&tokenizer, &gguf) != 0) {
+        fprintf(stderr, "%s\n", coli_gemma4_tokenizer_last_error(&tokenizer));
+        return 1;
+    }
+    if (coli_gemma4_tokenize(&tokenizer, "hello hello\n\n\xf0\x9f\x99\x82",
+                             strlen("hello hello\n\n\xf0\x9f\x99\x82"),
+                             1, actual, 32, &count) != 0 ||
+        count != sizeof(expected) / sizeof(expected[0])) {
+        failed = 1;
+    }
+    for (index = 0; !failed && index < count; ++index)
+        if (actual[index] != expected[index]) failed = 1;
+    if (!failed) {
+        const uint32_t special_expected[] = {2, 18, 19, 20, 21};
+        const char *special_text =
+            "<bos><|turn><turn|><|channel><channel|>";
+        if (coli_gemma4_tokenize_ex(&tokenizer, special_text,
+                                    strlen(special_text), 0, 1,
+                                    actual, 32, &count) != 0 ||
+            count != sizeof(special_expected) / sizeof(special_expected[0])) {
+            failed = 1;
+        }
+        for (index = 0; !failed && index < count; ++index)
+            if (actual[index] != special_expected[index]) failed = 1;
+    }
+    if (!failed) {
+        static const char rendered[] =
+            "<bos><|turn>system\nhello<turn|>\n<|turn>user\nhello"
+            "<turn|>\n<|turn>model\n<|channel>thought\n<channel|>";
+        uint32_t expected_system[128];
+        size_t expected_count = 0;
+        if (coli_gemma4_tokenize_ex(
+                &tokenizer, rendered, sizeof(rendered) - 1, 0, 1,
+                expected_system, 128, &expected_count) != 0 ||
+            coli_gemma4_tokenize_chat_turn(
+                &tokenizer, "  hello\r\n", strlen("  hello\r\n"),
+                "\thello ", strlen("\thello "), 1,
+                actual, 128, &count) != 0 || count != expected_count) {
+            failed = 1;
+        }
+        for (index = 0; !failed && index < count; ++index)
+            if (actual[index] != expected_system[index]) failed = 1;
+        if (!failed && coli_gemma4_tokenize_chat_turn(
+                &tokenizer, "hello", 5, "hello", 5, 0,
+                actual, 32, &count) == 0) failed = 1;
+    }
+    if (!failed) {
+        char piece[16];
+        size_t piece_bytes = 0;
+        if (coli_gemma4_decode_token(&tokenizer, 8, piece, sizeof(piece),
+                                     &piece_bytes) != 0 ||
+            piece_bytes != 1 || strcmp(piece, " ") != 0 ||
+            coli_gemma4_decode_token(&tokenizer, 14, piece, sizeof(piece),
+                                     &piece_bytes) != 0 ||
+            piece_bytes != 1 || (unsigned char)piece[0] != 0xf0U ||
+            !coli_gemma4_token_is_control(&tokenizer, 19) ||
+            !coli_gemma4_token_is_eog(&tokenizer, 19) ||
+            coli_gemma4_token_is_eog(&tokenizer, 18)) failed = 1;
+    }
+    if (!failed) {
+        uint32_t prefix[64], suffix[64], combined[128], expected_image[128];
+        size_t prefix_count = 0, suffix_count = 0, expected_image_count = 0;
+        static const char image_rendered[] =
+            "<bos><|turn>user\n<|image><image|>hello<turn|>\n"
+            "<|turn>model\n<|channel>thought\n<channel|>";
+        if (coli_gemma4_tokenize_image_chat_turn_with_tools(
+                &tokenizer, NULL, 0, NULL, 0, "hello", 5, 1,
+                prefix, 64, &prefix_count, suffix, 64, &suffix_count) != 0 ||
+            !prefix_count || !suffix_count || prefix[prefix_count-1] != 31 ||
+            suffix[0] != 32 ||
+            coli_gemma4_tokenize_ex(
+                &tokenizer, image_rendered, sizeof(image_rendered)-1, 0, 1,
+                expected_image, 128, &expected_image_count) != 0 ||
+            prefix_count + suffix_count != expected_image_count) {
+            failed = 1;
+        }
+        memcpy(combined,prefix,prefix_count*sizeof(*combined));
+        memcpy(combined+prefix_count,suffix,suffix_count*sizeof(*combined));
+        for(index=0;!failed&&index<expected_image_count;++index)
+            if(combined[index]!=expected_image[index])failed=1;
+    }
+    if (failed) {
+        fprintf(stderr, "Gemma 4 tokenizer output mismatch (count=%zu)\n", count);
+        for (index = 0; index < count; ++index) fprintf(stderr, " %u", actual[index]);
+        fputc('\n', stderr);
+    }
+    coli_gemma4_tokenizer_close(&tokenizer);
+    if (!failed) puts("Gemma 4 tokenizer tests passed");
+    return failed;
+}

--- a/c/tests/test_gemma4_tools.c
+++ b/c/tests/test_gemma4_tools.c
@@ -1,0 +1,141 @@
+#include "gemma4_tools.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void) {
+    static const char tools[] =
+        "[{\"type\":\"function\",\"function\":{"
+        "\"name\":\"get_weather\","
+        "\"description\":\"Get current weather.\","
+        "\"parameters\":{\"type\":\"object\",\"properties\":{"
+        "\"unit\":{\"type\":\"string\","
+        "\"enum\":[\"celsius\",\"fahrenheit\"]},"
+        "\"city\":{\"type\":\"string\",\"description\":\"City name\"}},"
+        "\"required\":[\"city\"]}}}]";
+    static const char expected[] =
+        "<|tool>declaration:get_weather{description:<|\"|>Get current weather."
+        "<|\"|>,parameters:{properties:{city:{description:<|\"|>City name"
+        "<|\"|>,type:<|\"|>STRING<|\"|>},unit:{enum:[<|\"|>celsius"
+        "<|\"|>,<|\"|>fahrenheit<|\"|>],type:<|\"|>STRING<|\"|>}},"
+        "required:[<|\"|>city<|\"|>],type:<|\"|>OBJECT<|\"|>}}<tool|>";
+    static const char nested_tools[] =
+        "[{\"type\":\"function\",\"function\":{\"name\":\"plan\","
+        "\"description\":\"\",\"parameters\":{\"type\":\"object\","
+        "\"properties\":{\"days\":{\"type\":\"array\",\"items\":{"
+        "\"type\":\"object\",\"properties\":{\"date\":{"
+        "\"type\":\"string\"}},\"required\":[\"date\"]}},"
+        "\"options\":{\"type\":\"object\",\"properties\":{\"detail\":{"
+        "\"type\":\"boolean\",\"nullable\":true}},\"required\":[]}},"
+        "\"required\":[]}}}]";
+    static const char nested_expected[] =
+        "<|tool>declaration:plan{description:<|\"|><|\"|>,parameters:{"
+        "properties:{days:{items:{properties:{date:{type:<|\"|>STRING"
+        "<|\"|>}},required:[<|\"|>date<|\"|>],type:<|\"|>OBJECT<|\"|>},"
+        "type:<|\"|>ARRAY<|\"|>},options:{properties:{detail:{nullable:true,"
+        "type:<|\"|>BOOLEAN<|\"|>}},type:<|\"|>OBJECT<|\"|>}},type:<|\"|>"
+        "OBJECT<|\"|>}}<tool|>";
+    char error[COLI_GEMMA4_TOOLS_ERROR_MAX];
+    coli_gemma4_tool_call calls[2];
+    char *rendered = NULL;
+    size_t rendered_bytes = 0, call_count = 0;
+    int failed = 0;
+    if (coli_gemma4_render_tools(tools, sizeof(tools) - 1,
+                                 &rendered, &rendered_bytes,
+                                 error, sizeof(error)) != 0 ||
+        rendered_bytes != sizeof(expected) - 1 ||
+        memcmp(rendered, expected, sizeof(expected) - 1) != 0) {
+        fprintf(stderr, "tool render mismatch: %s\n", error);
+        if (rendered) fprintf(stderr, "actual: %s\n", rendered);
+        failed = 1;
+    }
+    free(rendered);
+    rendered = NULL;
+    if (!failed &&
+        (coli_gemma4_render_tools(
+             nested_tools, sizeof(nested_tools) - 1,
+             &rendered, &rendered_bytes, error, sizeof(error)) != 0 ||
+         rendered_bytes != sizeof(nested_expected) - 1 ||
+         memcmp(rendered, nested_expected, sizeof(nested_expected) - 1) != 0)) {
+        fprintf(stderr, "nested tool render mismatch: %s\n", error);
+        if (rendered) fprintf(stderr, "actual: %s\n", rendered);
+        failed = 1;
+    }
+    free(rendered);
+    rendered = NULL;
+    if (!failed) {
+        static const char generated[] =
+            "note<|tool_call>call:get_weather{city:<|\"|>Rome<|\"|>}"
+            "<tool_call|><|tool_call>call:get_time{}<tool_call|>"
+            "<|tool_response>";
+        if (coli_gemma4_parse_tool_calls(
+                generated, sizeof(generated) - 1, calls, 2, &call_count,
+                error, sizeof(error)) != 0 || call_count != 2 ||
+            strcmp(calls[0].name, "get_weather") ||
+            strcmp(calls[1].name, "get_time") ||
+            calls[0].arguments_bytes !=
+                strlen("{city:<|\"|>Rome<|\"|>}") ||
+            memcmp(generated + calls[0].arguments_offset,
+                   "{city:<|\"|>Rome<|\"|>}",
+                   calls[0].arguments_bytes) != 0) {
+            fprintf(stderr, "tool call parse mismatch: %s\n", error);
+            failed = 1;
+        }
+    }
+    if (!failed) {
+        static const char response_json[] =
+            "{\"temp_c\":31,\"city\":\"Rome\",\"conditions\":\"sunny\"}";
+        static const char response_expected[] =
+            "response:get_weather{city:<|\"|>Rome<|\"|>,conditions:<|\"|>"
+            "sunny<|\"|>,temp_c:31}<tool_response|>";
+        if (coli_gemma4_render_tool_response(
+                "get_weather", response_json, sizeof(response_json) - 1, 0,
+                &rendered, &rendered_bytes, error, sizeof(error)) != 0 ||
+            rendered_bytes != sizeof(response_expected) - 1 ||
+            memcmp(rendered, response_expected,
+                   sizeof(response_expected) - 1) != 0) {
+            fprintf(stderr, "tool response render mismatch: %s\n", error);
+            if (rendered) fprintf(stderr, "actual: %s\n", rendered);
+            failed = 1;
+        }
+        free(rendered);
+        rendered = NULL;
+    }
+    if (!failed) {
+        static const char scalar_expected[] =
+            "<|tool_response>response:get_time{value:<|\"|>noon<|\"|>}"
+            "<tool_response|>";
+        if (coli_gemma4_render_tool_response(
+                "get_time", "\"noon\"", 6, 1,
+                &rendered, &rendered_bytes, error, sizeof(error)) != 0 ||
+            rendered_bytes != sizeof(scalar_expected) - 1 ||
+            memcmp(rendered, scalar_expected,
+                   sizeof(scalar_expected) - 1) != 0) {
+            fprintf(stderr, "scalar tool response mismatch: %s\n", error);
+            failed = 1;
+        }
+        free(rendered);
+        rendered = NULL;
+    }
+    if (!failed && coli_gemma4_render_tool_response(
+            "get_time", "\"unterminated", 13, 0,
+            &rendered, &rendered_bytes, error, sizeof(error)) == 0) {
+        fprintf(stderr, "unterminated tool response JSON was accepted\n");
+        failed = 1;
+    }
+    free(rendered);
+    rendered = NULL;
+    if (!failed &&
+        (coli_gemma4_render_tools("[]", 2, &rendered, &rendered_bytes,
+                                  error, sizeof(error)) != 0 ||
+         rendered_bytes != 0 || !rendered || rendered[0])) failed = 1;
+    free(rendered);
+    rendered = NULL;
+    if (!failed && coli_gemma4_render_tools(
+            "{}", 2, &rendered, &rendered_bytes,
+            error, sizeof(error)) == 0) failed = 1;
+    free(rendered);
+    if (!failed) puts("Gemma 4 tool renderer tests passed");
+    return failed;
+}

--- a/c/tests/test_gemma4_vision.c
+++ b/c/tests/test_gemma4_vision.c
@@ -1,0 +1,99 @@
+#define _CRT_SECURE_NO_WARNINGS
+
+#include "gemma4_vision.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int check(int condition, const char *message) {
+    if (!condition) fprintf(stderr, "FAIL: %s\n", message);
+    return condition ? 0 : 1;
+}
+
+int main(void) {
+    coli_gemma4_vision vision;
+    coli_gemma4_vision_image image;
+    uint32_t width, height, tokens;
+    float transform_probe[32] = {0};
+    const uint8_t rgb[6] = {255, 0, 0, 0, 0, 255};
+    int failures = 0;
+    const char *ppm_path = "gemma4-test-image.ppm";
+    uint8_t *loaded_rgb = NULL;
+    char ppm_error[256];
+    FILE *ppm;
+    memset(&vision, 0, sizeof(vision));
+    vision.gguf.vision_patch_size = 16;
+    vision.gguf.vision_image_mean[0] = 0.0F;
+    vision.gguf.vision_image_mean[1] = 0.0F;
+    vision.gguf.vision_image_mean[2] = 0.0F;
+    vision.gguf.vision_image_std[0] = 1.0F;
+    vision.gguf.vision_image_std[1] = 1.0F;
+    vision.gguf.vision_image_std[2] = 1.0F;
+    vision.merge_size = 3;
+    vision.minimum_tokens = 40;
+    vision.maximum_tokens = 280;
+    failures += check(coli_gemma4_vision_target_size(
+        &vision, 640, 480, &width, &height, &tokens) == 0,
+        "ordinary target size failed");
+    failures += check(width == 624 && height == 480 && tokens == 130,
+                      "ordinary target size differs from smart resize");
+    failures += check(coli_gemma4_vision_target_size(
+        &vision, 4000, 2000, &width, &height, &tokens) == 0,
+        "maximum target size failed");
+    failures += check(width == 1104 && height == 528 && tokens == 253,
+                      "maximum target size differs from smart resize");
+    vision.minimum_tokens = 1;
+    vision.maximum_tokens = 1;
+    memset(&image, 0, sizeof(image));
+    failures += check(coli_gemma4_vision_prepare_rgb(
+        &vision, rgb, 2, 1, &image) == 0, "bilinear RGB preparation failed");
+    failures += check(image.width == 48 && image.height == 48 &&
+                      image.patch_columns == 3 && image.patch_rows == 3 &&
+                      image.token_columns == 1 && image.token_rows == 1,
+                      "prepared image geometry is wrong");
+    failures += check(image.value_count == 48U * 48U * 3U,
+                      "prepared image value count is wrong");
+    if (image.pixels) {
+        size_t last = image.value_count - 3;
+        failures += check(fabsf(image.pixels[0] - 1.0F) < 1e-7F &&
+                          image.pixels[1] == 0.0F && image.pixels[2] == 0.0F,
+                          "left endpoint pixel is wrong");
+        failures += check(image.pixels[last] == 0.0F &&
+                          image.pixels[last + 1] == 0.0F &&
+                          fabsf(image.pixels[last + 2] -
+                                (254.0F / 255.0F)) < 1e-7F,
+                          "right endpoint pixel is wrong");
+    }
+    vision.gguf.vision_embedding_length = 8;
+    vision.gguf.vision_head_count = 2;
+    vision.gguf.vision_block_count = 0;
+    failures += check(coli_gemma4_vision_transform(
+        &vision, transform_probe, 4, 2, 0) == 0,
+        "zero-block transformer boundary failed");
+    failures += check(coli_gemma4_vision_transform(
+        &vision, transform_probe, 4, 3, 0) != 0,
+        "invalid transformer geometry was accepted");
+    ppm = fopen(ppm_path, "wb");
+    failures += check(ppm != NULL, "could not create PPM fixture");
+    if (ppm) {
+        const char header[] = "P6\n# fixture\n2 1\n255\n";
+        failures += check(fwrite(header, 1, sizeof(header) - 1, ppm) ==
+                          sizeof(header) - 1 &&
+                          fwrite(rgb, 1, sizeof(rgb), ppm) == sizeof(rgb) &&
+                          fclose(ppm) == 0, "could not write PPM fixture");
+        failures += check(coli_gemma4_vision_load_image(
+            ppm_path, &loaded_rgb, &width, &height,
+            ppm_error, sizeof(ppm_error)) == 0, "PPM loading failed");
+        failures += check(width == 2 && height == 1 && loaded_rgb &&
+                          memcmp(loaded_rgb, rgb, sizeof(rgb)) == 0,
+                          "PPM pixels differ from fixture");
+    }
+    remove(ppm_path);
+    free(loaded_rgb);
+    coli_gemma4_vision_image_close(&image);
+    if (failures) return 1;
+    puts("Gemma 4 vision sizing and RGB preprocessing passed");
+    return 0;
+}

--- a/c/tests/test_inspect_gguf.py
+++ b/c/tests/test_inspect_gguf.py
@@ -1,0 +1,85 @@
+import importlib.util
+import struct
+import tempfile
+import unittest
+from pathlib import Path
+
+
+TOOLS = Path(__file__).resolve().parents[1] / "tools"
+SPEC = importlib.util.spec_from_file_location("inspect_gguf", TOOLS / "inspect_gguf.py")
+inspect_gguf = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(inspect_gguf)
+
+
+def string(value):
+    raw = value.encode("utf-8")
+    return struct.pack("<Q", len(raw)) + raw
+
+
+def metadata_string(key, value):
+    return string(key) + struct.pack("<I", 8) + string(value)
+
+
+def metadata_u32(key, value):
+    return string(key) + struct.pack("<II", 4, value)
+
+
+def metadata_array_u32(key, values):
+    return (string(key) + struct.pack("<IIQ", 9, 4, len(values)) +
+            struct.pack("<" + "I" * len(values), *values))
+
+
+def tensor(name, dims=(4,), tensor_type=0, offset=0):
+    return (string(name) + struct.pack("<I", len(dims)) +
+            struct.pack("<" + "Q" * len(dims), *dims) +
+            struct.pack("<IQ", tensor_type, offset))
+
+
+def fixture(path):
+    metadata = [
+        metadata_string("general.architecture", "nemotron_h_moe"),
+        metadata_u32("nemotron_h_moe.block_count", 3),
+        metadata_array_u32("nemotron_h_moe.attention.head_count_kv", [0, 2, 0]),
+        metadata_array_u32("nemotron_h_moe.feed_forward_length", [0, 0, 16]),
+        # A large irrelevant scalar array exercises the bounded skip path.
+        metadata_array_u32("test.skipped", list(range(5000))),
+    ]
+    tensors = [
+        tensor("blk.0.ssm_in.weight", (4, 8), 30),
+        tensor("blk.1.attn_q.weight", (4, 4), 30),
+        tensor("blk.2.ffn_up_exps.weight", (4, 8, 2), 40),
+    ]
+    path.write_bytes(b"GGUF" + struct.pack("<IQQ", 3, len(tensors), len(metadata)) +
+                     b"".join(metadata) + b"".join(tensors))
+
+
+class InspectGGUFTests(unittest.TestCase):
+    def test_inventory_and_hybrid_schedule(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "tiny.gguf"
+            fixture(path)
+            result = inspect_gguf.inspect(path)
+        self.assertEqual(result["metadata"]["general.architecture"], "nemotron_h_moe")
+        self.assertEqual(result["tensor_type_counts"], {"30": 2, "40": 1})
+        self.assertEqual([row["mixer"] for row in result["schedule"]],
+                         ["ssm", "attention", "unknown"])
+        self.assertEqual([row["moe"] for row in result["schedule"]],
+                         [False, False, True])
+
+    def test_truncated_file_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "bad.gguf"
+            path.write_bytes(b"GGUF" + struct.pack("<IQQ", 3, 1, 0))
+            with self.assertRaises(inspect_gguf.GGUFError):
+                inspect_gguf.inspect(path)
+
+    def test_wrong_magic_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "bad.gguf"
+            path.write_bytes(b"nope")
+            with self.assertRaises(inspect_gguf.GGUFError):
+                inspect_gguf.inspect(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tests/validate_gemma4_attention.py
+++ b/c/tests/validate_gemma4_attention.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Cross-check two-token Gemma 4 causal attention against NumPy."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import struct
+import subprocess
+import tempfile
+
+import numpy as np
+
+
+SCALAR_FORMATS = {
+    0: "B",
+    1: "b",
+    2: "H",
+    3: "h",
+    4: "I",
+    5: "i",
+    6: "f",
+    7: "?",
+    10: "Q",
+    11: "q",
+    12: "d",
+}
+
+
+def read_exact(handle, count: int) -> bytes:
+    value = handle.read(count)
+    if len(value) != count:
+        raise ValueError("unexpected end of GGUF")
+    return value
+
+
+def read_scalar(handle, value_type: int):
+    try:
+        value_format = SCALAR_FORMATS[value_type]
+    except KeyError as error:
+        raise ValueError(f"unsupported GGUF metadata type {value_type}") from error
+    return struct.unpack("<" + value_format,
+                         read_exact(handle, struct.calcsize(value_format)))[0]
+
+
+def read_string(handle) -> str:
+    length = read_scalar(handle, 10)
+    return read_exact(handle, length).decode("utf-8")
+
+
+def read_value(handle, value_type: int):
+    if value_type == 8:
+        return read_string(handle)
+    if value_type == 9:
+        element_type = read_scalar(handle, 4)
+        length = read_scalar(handle, 10)
+        return [read_value(handle, element_type) for _ in range(length)]
+    return read_scalar(handle, value_type)
+
+
+def tensor_index(path: pathlib.Path):
+    with path.open("rb") as handle:
+        if read_exact(handle, 4) != b"GGUF":
+            raise ValueError("not a GGUF file")
+        version, tensor_count, metadata_count = struct.unpack(
+            "<IQQ", read_exact(handle, 20))
+        if version not in (2, 3):
+            raise ValueError(f"unsupported GGUF version {version}")
+        alignment = 32
+        selected_metadata = {}
+        for _ in range(metadata_count):
+            key = read_string(handle)
+            value_type = read_scalar(handle, 4)
+            value = read_value(handle, value_type)
+            if key == "general.alignment":
+                alignment = int(value)
+            if key in ("gemma4.attention.head_count",
+                       "gemma4.attention.layer_norm_rms_epsilon"):
+                selected_metadata[key] = value
+        tensors = {}
+        for _ in range(tensor_count):
+            name = read_string(handle)
+            dimension_count = read_scalar(handle, 4)
+            dimensions = tuple(read_scalar(handle, 10)
+                               for _ in range(dimension_count))
+            tensor_type = read_scalar(handle, 4)
+            offset = read_scalar(handle, 10)
+            tensors[name] = (tensor_type, dimensions, offset)
+        data_offset = (handle.tell() + alignment - 1) // alignment * alignment
+    return data_offset, tensors, selected_metadata
+
+
+def q4_0_matvec(model: pathlib.Path, data_offset: int, tensor, vector):
+    tensor_type, dimensions, offset = tensor
+    if tensor_type != 2 or len(dimensions) != 2:
+        raise ValueError("attention output must be a two-dimensional Q4_0 tensor")
+    columns, rows = map(int, dimensions)
+    if columns % 32 or vector.shape != (columns,):
+        raise ValueError("attention output dimensions do not match context")
+    blocks = columns // 32
+    byte_count = rows * blocks * 18
+    with model.open("rb") as handle:
+        handle.seek(data_offset + offset)
+        encoded = np.frombuffer(read_exact(handle, byte_count), dtype=np.uint8)
+    encoded = encoded.reshape(rows, blocks, 18)
+    scales = encoded[:, :, :2].copy().view("<f2").reshape(rows, blocks).astype(np.float32)
+    packed = encoded[:, :, 2:]
+    low = (packed & 15).astype(np.int16) - 8
+    high = (packed >> 4).astype(np.int16) - 8
+    blocked = vector.reshape(blocks, 32)
+    dots = np.einsum("rbi,bi->rb", low.astype(np.float32), blocked[:, :16],
+                     dtype=np.float32)
+    dots += np.einsum("rbi,bi->rb", high.astype(np.float32), blocked[:, 16:],
+                      dtype=np.float32)
+    return np.sum(scales * dots, axis=1, dtype=np.float32)
+
+
+def run(command):
+    subprocess.run([str(part) for part in command], check=True,
+                   stdout=subprocess.DEVNULL)
+
+
+def validate_layer(executable: pathlib.Path, model: pathlib.Path, layer: int,
+                   inputs: np.ndarray, data_offset: int, tensors,
+                   query_heads: int):
+    width = inputs.shape[1]
+    prefix = f"blk.{layer}."
+    output_tensor = tensors[prefix + "attn_output.weight"]
+    context_width = int(output_tensor[1][0])
+    query_tensor = tensors[prefix + "attn_q.weight"]
+    key_tensor = tensors[prefix + "attn_k.weight"]
+    query_width = int(query_tensor[1][1])
+    kv_width = int(key_tensor[1][1])
+    head_dim = query_width // query_heads
+    kv_heads = kv_width // head_dim
+    if context_width != query_width or query_heads % kv_heads:
+        raise ValueError(f"invalid attention geometry for layer {layer}")
+    queries_per_kv = query_heads // kv_heads
+
+    with tempfile.TemporaryDirectory(prefix="gemma4-attention-") as directory:
+        temporary = pathlib.Path(directory)
+        input_path = temporary / "inputs.f32"
+        output_path = temporary / "attention.f32"
+        inputs.tofile(input_path)
+        run([executable, "attention-seq", model, "--layer", layer,
+             "--tokens", 2, "--input-f32", input_path,
+             "--output-f32", output_path])
+        queries, keys, values = [], [], []
+        for position in range(2):
+            token_path = temporary / f"input-{position}.f32"
+            query_path = temporary / f"query-{position}.f32"
+            key_path = temporary / f"key-{position}.f32"
+            value_path = temporary / f"value-{position}.f32"
+            inputs[position].tofile(token_path)
+            run([executable, "attention-proj", model, "--layer", layer,
+                 "--position", position, "--input-f32", token_path,
+                 "--query-f32", query_path, "--key-f32", key_path,
+                 "--value-f32", value_path])
+            queries.append(np.fromfile(query_path, dtype="<f4").reshape(query_heads, head_dim))
+            keys.append(np.fromfile(key_path, dtype="<f4").reshape(kv_heads, head_dim))
+            values.append(np.fromfile(value_path, dtype="<f4").reshape(kv_heads, head_dim))
+
+        reference = []
+        for position in range(2):
+            context = np.empty((query_heads, head_dim), dtype=np.float32)
+            for head in range(query_heads):
+                kv_head = head // queries_per_kv
+                scores = np.asarray([
+                    np.sum(queries[position][head] * keys[past][kv_head],
+                           dtype=np.float32)
+                    for past in range(position + 1)
+                ], dtype=np.float32)
+                weights = np.exp(scores - np.max(scores)).astype(np.float32)
+                weights /= np.sum(weights, dtype=np.float32)
+                context[head] = np.sum(
+                    np.stack([weights[past] * values[past][kv_head]
+                              for past in range(position + 1)]),
+                    axis=0, dtype=np.float32)
+            reference.append(q4_0_matvec(model, data_offset, output_tensor,
+                                          context.reshape(context_width)))
+        reference = np.concatenate(reference)
+        actual = np.fromfile(output_path, dtype="<f4")
+    difference = actual - reference
+    return (float(np.max(np.abs(difference))),
+            float(np.sqrt(np.mean(difference * difference, dtype=np.float64))))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("executable", type=pathlib.Path)
+    parser.add_argument("model", type=pathlib.Path)
+    parser.add_argument("--layers", type=int, nargs="+", default=[0, 5])
+    arguments = parser.parse_args()
+    executable = arguments.executable.resolve()
+    model = arguments.model.resolve()
+    data_offset, tensors, metadata = tensor_index(model)
+    query_heads = metadata["gemma4.attention.head_count"]
+    width = int(tensors["token_embd.weight"][1][0])
+    indexes = np.arange(2 * width, dtype=np.float32)
+    inputs = (np.sin(indexes * np.float32(0.017)) * np.float32(0.04) +
+              np.cos(indexes * np.float32(0.003)) * np.float32(0.01))
+    inputs = inputs.reshape(2, width).astype("<f4")
+    for layer in arguments.layers:
+        maximum, rms = validate_layer(executable, model, layer, inputs,
+                                      data_offset, tensors, query_heads)
+        print(f"layer {layer}: max_abs={maximum:.9g} rms={rms:.9g}")
+
+
+if __name__ == "__main__":
+    main()

--- a/c/tests/validate_gemma4_full.py
+++ b/c/tests/validate_gemma4_full.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Cross-check Colibri's complete Gemma 4 text graph against llama.cpp."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import subprocess
+import tempfile
+
+import numpy as np
+
+from validate_gemma4_llama_layer0 import metric
+
+
+def run(command, environment=None):
+    result = subprocess.run(
+        [str(part) for part in command], env=environment, text=True,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    if result.returncode:
+        detail = "\n".join((result.stdout, result.stderr)).strip()
+        raise RuntimeError(
+            f"command failed ({result.returncode}): "
+            f"{' '.join(map(str, command))}\n{detail[-4000:]}"
+        )
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("executable", type=pathlib.Path)
+    parser.add_argument("oracle", type=pathlib.Path)
+    parser.add_argument("model", type=pathlib.Path)
+    parser.add_argument("packed", type=pathlib.Path)
+    parser.add_argument("--llama-bin", type=pathlib.Path,
+                        help="directory containing llama.cpp runtime DLLs")
+    parser.add_argument("--prompt", default="Hello")
+    parser.add_argument("--chat-file", type=pathlib.Path,
+                        help="UTF-8 user message to wrap in the canonical chat frame")
+    arguments = parser.parse_args()
+
+    executable = arguments.executable.resolve()
+    oracle = arguments.oracle.resolve()
+    model = arguments.model.resolve()
+    packed = arguments.packed.resolve()
+    environment = os.environ.copy()
+    if arguments.llama_bin:
+        environment["PATH"] = (str(arguments.llama_bin.resolve()) +
+                               os.pathsep + environment.get("PATH", ""))
+
+    with tempfile.TemporaryDirectory(prefix="gemma4-full-") as directory:
+        temporary = pathlib.Path(directory)
+        if arguments.chat_file:
+            chat_file = arguments.chat_file.resolve()
+            user = chat_file.read_bytes().strip(b" \t\r\n")
+            rendered = (b"<bos><|turn>user\n" + user +
+                        b"<turn|>\n<|turn>model\n"
+                        b"<|channel>thought\n<channel|>")
+            rendered_path = temporary / "rendered-chat.txt"
+            rendered_path.write_bytes(rendered)
+            oracle_command = [oracle, "--prompt-special-file", model,
+                              rendered_path, temporary]
+            native_command = [executable, "next-token-file", model, packed,
+                              chat_file, "--chat"]
+        else:
+            oracle_command = [oracle, model, arguments.prompt, temporary]
+            native_command = [executable, "next-token", model, packed,
+                              arguments.prompt]
+
+        oracle_result = run(oracle_command, environment=environment)
+        for line in oracle_result.stdout.splitlines():
+            if line.startswith(("captured ", "tokens:")):
+                print(line)
+
+        native_residual = temporary / "colibri-final-residual.f32"
+        native_logits = temporary / "colibri-logits.f32"
+        native_command += ["--top", "10", "--residual-f32", native_residual,
+                           "--logits-f32", native_logits]
+        native_result = run(native_command)
+        print(native_result.stdout.rstrip())
+
+        actual_residual = np.fromfile(native_residual, dtype="<f4")
+        actual_logits = np.fromfile(native_logits, dtype="<f4")
+        reference_residual = np.fromfile(
+            temporary / "llama-final-residual.f32", dtype="<f4")
+        reference_logits = np.fromfile(
+            temporary / "llama-logits.f32", dtype="<f4")
+        results = {
+            "final_residual": metric(actual_residual, reference_residual),
+            "logits": metric(actual_logits, reference_logits),
+        }
+        actual_top = np.argsort(actual_logits)[-10:][::-1]
+        reference_top = np.argsort(reference_logits)[-10:][::-1]
+
+        print("\nboundary                 max_abs          rms       cosine")
+        for name, values in results.items():
+            maximum, rms, cosine = values
+            print(f"{name:22s} {maximum:12.6g} {rms:12.6g} {cosine:12.9f}")
+        print("Colibri top-10:", " ".join(map(str, actual_top)))
+        print("llama.cpp top-10:", " ".join(map(str, reference_top)))
+
+        if results["final_residual"][2] < 0.999 or results["logits"][2] < 0.999:
+            raise SystemExit("full-model comparison exceeded cosine tolerance")
+        if actual_top[0] != reference_top[0]:
+            raise SystemExit("Colibri and llama.cpp selected different top-1 tokens")
+        print("llama.cpp full-model oracle: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/c/tests/validate_gemma4_layer.py
+++ b/c/tests/validate_gemma4_layer.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Cross-check Gemma 4's resident dense MLP and decoder block composition."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import tempfile
+
+import numpy as np
+
+import validate_gemma4_attention as common
+
+
+def read_f32_tensor(model: pathlib.Path, data_offset: int, tensor):
+    tensor_type, dimensions, offset = tensor
+    if tensor_type != 0:
+        raise ValueError("expected an F32 tensor")
+    return np.fromfile(model, dtype="<f4", count=int(np.prod(dimensions)),
+                       offset=data_offset + offset).copy()
+
+
+def rmsnorm(values: np.ndarray, weight: np.ndarray, epsilon: float):
+    sum_squares = np.float32(0.0)
+    for value in values:
+        sum_squares = np.float32(sum_squares + np.float32(value * value))
+    mean = np.float32(sum_squares / np.float32(values.size))
+    inverse = np.float32(1.0) / np.sqrt(np.float32(mean + epsilon))
+    return ((values * inverse).astype(np.float32) * weight).astype(np.float32)
+
+
+def dense_reference(model: pathlib.Path, data_offset: int, tensors,
+                    layer: int, inputs: np.ndarray):
+    prefix = f"blk.{layer}."
+    gate = common.q4_0_matvec(model, data_offset,
+                              tensors[prefix + "ffn_gate.weight"], inputs)
+    up = common.q4_0_matvec(model, data_offset,
+                            tensors[prefix + "ffn_up.weight"], inputs)
+    coefficient = np.float32(0.7978845608028654)
+    cubic = np.float32(0.044715)
+    activated = np.float32(0.5) * gate * (
+        np.float32(1.0) + np.tanh(coefficient *
+                                  (gate + cubic * gate * gate * gate)))
+    hidden = (activated * up).astype(np.float32)
+    return common.q4_0_matvec(model, data_offset,
+                              tensors[prefix + "ffn_down.weight"], hidden)
+
+
+def difference(actual: np.ndarray, reference: np.ndarray):
+    delta = actual - reference
+    return (float(np.max(np.abs(delta))),
+            float(np.sqrt(np.mean(delta * delta, dtype=np.float64))))
+
+
+def validate_layer(executable: pathlib.Path, model: pathlib.Path,
+                   packed: pathlib.Path, layer: int, inputs: np.ndarray,
+                   data_offset: int, tensors, epsilon: float):
+    prefix = f"blk.{layer}."
+    width = inputs.shape[1]
+    norms = {
+        name: read_f32_tensor(model, data_offset, tensors[prefix + name])
+        for name in (
+            "post_attention_norm.weight",
+            "ffn_norm.weight",
+            "post_ffw_norm_1.weight",
+            "pre_ffw_norm_2.weight",
+            "post_ffw_norm_2.weight",
+            "post_ffw_norm.weight",
+        )
+    }
+    layer_scale = read_f32_tensor(
+        model, data_offset, tensors[prefix + "layer_output_scale.weight"])[0]
+    with tempfile.TemporaryDirectory(prefix="gemma4-layer-") as directory:
+        temporary = pathlib.Path(directory)
+        input_path = temporary / "inputs.f32"
+        attention_path = temporary / "attention.f32"
+        layer_path = temporary / "layer.f32"
+        inputs.tofile(input_path)
+        common.run([executable, "attention-seq", model, "--layer", layer,
+                    "--tokens", 2, "--input-f32", input_path,
+                    "--output-f32", attention_path])
+        common.run([executable, "layer-seq", model, packed, "--layer", layer,
+                    "--tokens", 2, "--input-f32", input_path,
+                    "--output-f32", layer_path])
+        attention = np.fromfile(attention_path, dtype="<f4").reshape(2, width)
+        reference = []
+        dense_errors = []
+        for token in range(2):
+            after_attention = (inputs[token] + rmsnorm(
+                attention[token], norms["post_attention_norm.weight"],
+                epsilon)).astype(np.float32)
+            dense_input = rmsnorm(after_attention, norms["ffn_norm.weight"],
+                                  epsilon)
+            dense_input_path = temporary / f"dense-input-{token}.f32"
+            dense_output_path = temporary / f"dense-output-{token}.f32"
+            dense_input.tofile(dense_input_path)
+            common.run([executable, "dense-mlp", model, "--layer", layer,
+                        "--input-f32", dense_input_path,
+                        "--output-f32", dense_output_path])
+            dense_output = np.fromfile(dense_output_path, dtype="<f4")
+            dense_errors.append(difference(
+                dense_output,
+                dense_reference(model, data_offset, tensors, layer, dense_input)))
+
+            routed_input_path = temporary / f"routed-input-{token}.f32"
+            routed_output_path = temporary / f"routed-output-{token}.f32"
+            after_attention.tofile(routed_input_path)
+            common.run([executable, "routed-mlp", model, packed,
+                        "--layer", layer, "--input-f32", routed_input_path,
+                        "--output-f32", routed_output_path])
+            routed_output = np.fromfile(routed_output_path, dtype="<f4")
+            dense_normalized = rmsnorm(
+                dense_output, norms["post_ffw_norm_1.weight"], epsilon)
+            routed_normalized = rmsnorm(
+                routed_output, norms["post_ffw_norm_2.weight"], epsilon)
+            combined = (dense_normalized + routed_normalized).astype(np.float32)
+            block = rmsnorm(combined, norms["post_ffw_norm.weight"], epsilon)
+            reference.append(((after_attention + block) * layer_scale).astype(np.float32))
+        actual = np.fromfile(layer_path, dtype="<f4").reshape(2, width)
+    return max(error[0] for error in dense_errors), difference(
+        actual.reshape(-1), np.stack(reference).reshape(-1))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("executable", type=pathlib.Path)
+    parser.add_argument("model", type=pathlib.Path)
+    parser.add_argument("packed", type=pathlib.Path)
+    parser.add_argument("--layers", type=int, nargs="+", default=[0, 5])
+    arguments = parser.parse_args()
+    executable = arguments.executable.resolve()
+    model = arguments.model.resolve()
+    packed = arguments.packed.resolve()
+    data_offset, tensors, metadata = common.tensor_index(model)
+    epsilon = float(metadata["gemma4.attention.layer_norm_rms_epsilon"])
+    width = int(tensors["token_embd.weight"][1][0])
+    indexes = np.arange(2 * width, dtype=np.float32)
+    inputs = (np.sin(indexes * np.float32(0.011)) * np.float32(0.035) +
+              np.cos(indexes * np.float32(0.007)) * np.float32(0.015))
+    inputs = inputs.reshape(2, width).astype("<f4")
+    for layer in arguments.layers:
+        dense_maximum, (layer_maximum, layer_rms) = validate_layer(
+            executable, model, packed, layer, inputs, data_offset, tensors,
+            epsilon)
+        print(f"layer {layer}: dense_max_abs={dense_maximum:.9g} "
+              f"block_max_abs={layer_maximum:.9g} block_rms={layer_rms:.9g}")
+
+
+if __name__ == "__main__":
+    main()

--- a/c/tests/validate_gemma4_llama_layer0.py
+++ b/c/tests/validate_gemma4_llama_layer0.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Cross-check Colibri's first Gemma 4 decoder layer against llama.cpp."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import subprocess
+import tempfile
+
+import numpy as np
+
+import validate_gemma4_attention as common
+import validate_gemma4_layer as layer
+
+
+LIMITS = {
+    "query": 0.05,
+    "key": 0.005,
+    "value": 0.05,
+    "attention_postnorm": 0.5,
+    "dense_input": 0.2,
+    "router_probability": 0.00001,
+    "layer_output": 0.5,
+}
+MINIMUM_COSINE = 0.999
+
+
+def run(command, environment=None, quiet=False):
+    result = subprocess.run(
+        [str(part) for part in command], env=environment,
+        text=True, stdout=subprocess.PIPE if quiet else None,
+        stderr=subprocess.PIPE if quiet else None,
+    )
+    if result.returncode:
+        detail = "\n".join((result.stdout or "", result.stderr or "")).strip()
+        raise RuntimeError(f"command failed ({result.returncode}): {' '.join(map(str, command))}\n{detail[-4000:]}")
+    return result
+
+
+def metric(actual: np.ndarray, reference: np.ndarray):
+    actual = actual.astype(np.float32, copy=False).reshape(-1)
+    reference = reference.astype(np.float32, copy=False).reshape(-1)
+    delta = actual - reference
+    denominator = float(np.linalg.norm(actual) * np.linalg.norm(reference))
+    cosine = float(np.dot(actual, reference) / denominator) if denominator else 1.0
+    cosine = min(1.0, max(-1.0, cosine))
+    return (float(np.max(np.abs(delta))),
+            float(np.sqrt(np.mean(delta * delta, dtype=np.float64))),
+            cosine)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("executable", type=pathlib.Path)
+    parser.add_argument("oracle", type=pathlib.Path)
+    parser.add_argument("model", type=pathlib.Path)
+    parser.add_argument("packed", type=pathlib.Path)
+    parser.add_argument("--llama-bin", type=pathlib.Path,
+                        help="directory containing llama.cpp runtime DLLs")
+    parser.add_argument("--prompt", default="A",
+                        help="oracle prompt; the default tokenizes to BOS plus one token")
+    arguments = parser.parse_args()
+    executable = arguments.executable.resolve()
+    oracle = arguments.oracle.resolve()
+    model = arguments.model.resolve()
+    packed = arguments.packed.resolve()
+
+    data_offset, tensors, metadata = common.tensor_index(model)
+    prefix = "blk.0."
+    width = int(tensors[prefix + "post_attention_norm.weight"][1][0])
+    query_width = int(tensors[prefix + "attn_q.weight"][1][1])
+    key_width = int(tensors[prefix + "attn_k.weight"][1][1])
+    value_width = int(tensors[prefix + "attn_v.weight"][1][1])
+    epsilon = np.float32(metadata["gemma4.attention.layer_norm_rms_epsilon"])
+    oracle_environment = os.environ.copy()
+    if arguments.llama_bin:
+        oracle_environment["PATH"] = (str(arguments.llama_bin.resolve()) +
+                                      os.pathsep + oracle_environment.get("PATH", ""))
+
+    results = []
+    with tempfile.TemporaryDirectory(prefix="gemma4-llama-") as directory:
+        temporary = pathlib.Path(directory)
+        oracle_result = run([oracle, model, arguments.prompt, temporary],
+                            environment=oracle_environment, quiet=True)
+        for line_text in (oracle_result.stdout or "").splitlines():
+            if line_text.startswith(("captured ", "tokens:")):
+                print(line_text)
+
+        inputs = np.fromfile(temporary / "llama-input.f32", dtype="<f4")
+        if inputs.size % width:
+            raise ValueError("llama.cpp input tensor has an invalid size")
+        inputs = inputs.reshape(-1, width)
+        token_count = inputs.shape[0]
+        references = {
+            "query": np.fromfile(temporary / "llama-query.f32", dtype="<f4").reshape(token_count, query_width),
+            "key": np.fromfile(temporary / "llama-key.f32", dtype="<f4").reshape(token_count, key_width),
+            "value": np.fromfile(temporary / "llama-value.f32", dtype="<f4").reshape(token_count, value_width),
+        }
+        actual = {name: [] for name in references}
+        for position, values in enumerate(inputs):
+            input_path = temporary / f"input-{position}.f32"
+            query_path = temporary / f"colibri-query-{position}.f32"
+            key_path = temporary / f"colibri-key-{position}.f32"
+            value_path = temporary / f"colibri-value-{position}.f32"
+            values.tofile(input_path)
+            run([executable, "attention-proj", model, "--layer", 0,
+                 "--position", position, "--input-f32", input_path,
+                 "--query-f32", query_path, "--key-f32", key_path,
+                 "--value-f32", value_path], quiet=True)
+            actual["query"].append(np.fromfile(query_path, dtype="<f4"))
+            actual["key"].append(np.fromfile(key_path, dtype="<f4"))
+            actual["value"].append(np.fromfile(value_path, dtype="<f4"))
+        for name in references:
+            results.append((name, *metric(np.stack(actual[name]), references[name])))
+
+        attention_path = temporary / "colibri-attention.f32"
+        run([executable, "attention-seq", model, "--layer", 0,
+             "--tokens", token_count, "--input-f32", temporary / "llama-input.f32",
+             "--output-f32", attention_path], quiet=True)
+        raw_attention = np.fromfile(attention_path, dtype="<f4").reshape(token_count, width)
+        post_weight = layer.read_f32_tensor(
+            model, data_offset, tensors[prefix + "post_attention_norm.weight"])
+        post_attention = np.stack([
+            layer.rmsnorm(values, post_weight, epsilon)
+            for values in raw_attention
+        ])
+        reference_post = np.fromfile(
+            temporary / "llama-attention-postnorm.f32", dtype="<f4").reshape(token_count, width)
+        results.append(("attention_postnorm", *metric(post_attention, reference_post)))
+
+        after_attention = inputs + reference_post
+        dense_weight = layer.read_f32_tensor(
+            model, data_offset, tensors[prefix + "ffn_norm.weight"])
+        dense_input = np.stack([
+            layer.rmsnorm(values, dense_weight, epsilon)
+            for values in after_attention
+        ])
+        reference_dense = np.fromfile(
+            temporary / "llama-dense-input.f32", dtype="<f4").reshape(token_count, width)
+        results.append(("dense_input", *metric(dense_input, reference_dense)))
+
+        router_logits = np.fromfile(
+            temporary / "llama-router-logits.f32", dtype="<f4").reshape(token_count, -1)
+        router_actual = []
+        for position, values in enumerate(after_attention):
+            input_path = temporary / f"router-input-{position}.f32"
+            probability_path = temporary / f"router-probability-{position}.f32"
+            values.astype(np.float32).tofile(input_path)
+            run([executable, "route", model, "--layer", 0,
+                 "--input-f32", input_path,
+                 "--probabilities-f32", probability_path], quiet=True)
+            router_actual.append(np.fromfile(probability_path, dtype="<f4"))
+        shifted = router_logits - np.max(router_logits, axis=1, keepdims=True)
+        router_reference = np.exp(shifted).astype(np.float32)
+        router_reference /= np.sum(router_reference, axis=1, keepdims=True,
+                                   dtype=np.float32)
+        router_actual = np.stack(router_actual)
+        if not np.array_equal(np.argsort(-router_actual, axis=1)[:, :8],
+                              np.argsort(-router_reference, axis=1)[:, :8]):
+            raise SystemExit("Colibri and llama.cpp selected different top-8 experts")
+        results.append(("router_probability",
+                        *metric(router_actual, router_reference)))
+
+        layer_path = temporary / "colibri-layer0.f32"
+        run([executable, "layer-seq", model, packed, "--layer", 0,
+             "--tokens", token_count, "--input-f32", temporary / "llama-input.f32",
+             "--output-f32", layer_path], quiet=True)
+        actual_layer = np.fromfile(layer_path, dtype="<f4").reshape(token_count, width)
+        reference_layer = np.fromfile(
+            temporary / "llama-layer0.f32", dtype="<f4").reshape(token_count, width)
+        results.append(("layer_output", *metric(actual_layer, reference_layer)))
+
+    failed = False
+    print("\nboundary                 max_abs          rms       cosine")
+    for name, maximum, rms, cosine in results:
+        print(f"{name:22s} {maximum:12.6g} {rms:12.6g} {cosine:12.9f}")
+        failed |= maximum > LIMITS[name] or cosine < MINIMUM_COSINE
+    if failed:
+        raise SystemExit("llama.cpp oracle comparison exceeded its tolerance")
+    print("llama.cpp layer-0 oracle: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/c/tests/validate_gemma4_vision.py
+++ b/c/tests/validate_gemma4_vision.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Compare Colibri's Gemma 4 vision tower with llama.cpp."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import subprocess
+import tempfile
+
+import numpy as np
+
+
+TRACE_OPERATIONS = (
+    "attention-input-norm",
+    "query-norm",
+    "key-norm",
+    "value",
+    "query-rope",
+    "key-rope",
+    "value-norm",
+    "attention-context",
+    "attention-output",
+    "attention-post-norm",
+    "attention-residual",
+    "ffn-input-norm",
+    "ffn-up",
+    "ffn-gate",
+    "ffn-activated",
+    "ffn-output",
+    "ffn-post-norm",
+)
+
+
+def run(command, env=None):
+    completed = subprocess.run(command, env=env, text=True,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.STDOUT)
+    if completed.returncode:
+        print(completed.stdout)
+        raise SystemExit(f"command failed ({completed.returncode}): {command[0]}")
+
+
+def metrics(actual, reference, label):
+    if actual.shape != reference.shape:
+        raise SystemExit(f"{label}: shape mismatch {actual.shape} != {reference.shape}")
+    if not np.isfinite(actual).all() or not np.isfinite(reference).all():
+        raise SystemExit(f"{label}: non-finite values")
+    difference = actual.astype(np.float64) - reference.astype(np.float64)
+    maximum = float(np.max(np.abs(difference)))
+    rms = float(np.sqrt(np.mean(difference * difference)))
+    a = actual.astype(np.float64).ravel()
+    b = reference.astype(np.float64).ravel()
+    cosine = float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
+    print(f"{label}: max={maximum:.7g} rms={rms:.7g} cosine={cosine:.9f}")
+    return maximum, rms, cosine
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("executable", type=pathlib.Path)
+    parser.add_argument("oracle", type=pathlib.Path)
+    parser.add_argument("model", type=pathlib.Path)
+    parser.add_argument("packed", type=pathlib.Path)
+    parser.add_argument("mmproj", type=pathlib.Path)
+    parser.add_argument("--llama-bin", required=True, type=pathlib.Path)
+    args = parser.parse_args()
+    env = os.environ.copy()
+    env["PATH"] = str(args.llama_bin) + os.pathsep + env.get("PATH", "")
+    with tempfile.TemporaryDirectory(prefix="gemma4-vision-") as temporary:
+        directory = pathlib.Path(temporary)
+        trace_directory = directory / "operation-trace"
+        trace_directory.mkdir()
+        native_layer = directory / "native-layer1.f32"
+        native_scaled_input = directory / "native-scaled-input.f32"
+        native_layer9 = directory / "native-layer9.f32"
+        native_layer18 = directory / "native-layer18.f32"
+        native_exact_layer18 = directory / "native-exact-layer18.f32"
+        native_last_layer = directory / "native-layer27.f32"
+        native_projected = directory / "native-projected.f32"
+        native_logits = directory / "native-image-logits.f32"
+        decoder_logits = directory / "native-decoder-from-llama-image.f32"
+        image = directory / "synthetic.ppm"
+        pixels = bytes((index * 37 + 11) & 255 for index in range(48 * 48 * 3))
+        image.write_bytes(b"P6\n48 48\n255\n" + pixels)
+        run([str(args.executable), "vision-encode-probe", str(args.mmproj),
+             "48", "48", "--layers", "1", "--prepared-f32",
+             str(native_scaled_input), "--output-f32",
+             str(native_layer)])
+        run([str(args.oracle), str(args.model), str(args.mmproj), "48", "48",
+             str(directory)], env=env)
+        run([str(args.oracle), str(args.model), str(args.mmproj), "48", "48",
+             str(trace_directory), "--trace-operations"], env=env)
+        run([str(args.executable), "vision-encode-probe", str(args.mmproj),
+             "48", "48", "--layers", "18", "--start-layer", "17",
+             "--input-f32", str(trace_directory / "llama-vision-layer17.f32"),
+             "--trace-layer", "17", "--trace-dir", str(trace_directory),
+             "--output-f32", str(native_exact_layer18)])
+        run([str(args.executable), "vision-encode-probe", str(args.mmproj),
+             "48", "48", "--layers", "9", "--output-f32",
+             str(native_layer9)])
+        run([str(args.executable), "vision-encode-probe", str(args.mmproj),
+             "48", "48", "--layers", "18", "--output-f32",
+             str(native_layer18)])
+        run([str(args.executable), "vision-encode-probe", str(args.mmproj),
+             "48", "48", "--layers", "27", "--output-f32",
+             str(native_last_layer)])
+        run([str(args.executable), "vision-encode-probe", str(args.mmproj),
+             "48", "48", "--output-f32", str(native_projected)])
+        run([str(args.executable), "next-token", str(args.model),
+             str(args.packed), "Describe this image.", "--chat",
+             "--image", str(image), "--mmproj", str(args.mmproj),
+             "--top", "1", "--logits-f32", str(native_logits)])
+        run([str(args.executable), "next-token", str(args.model),
+             str(args.packed), "Describe this image.", "--chat",
+             "--image", str(image), "--mmproj", str(args.mmproj),
+             "--image-embeddings-f32",
+             str(directory / "llama-vision-projected.f32"),
+             "--top", "1", "--logits-f32", str(decoder_logits)])
+        native_scaled = np.fromfile(native_scaled_input, dtype="<f4")
+        llama_scaled = np.fromfile(
+            trace_directory / "llama-vision-scaled-input.f32", dtype="<f4")
+        scaled = metrics(native_scaled, llama_scaled, "vision scaled input")
+        if not np.array_equal(native_scaled, llama_scaled):
+            raise SystemExit("vision scaled input differs from llama.cpp")
+        layer = metrics(np.fromfile(native_layer, dtype="<f4"),
+                        np.fromfile(directory / "llama-vision-layer1.f32",
+                                    dtype="<f4"),
+                        "vision layer 0")
+        layer8 = metrics(np.fromfile(native_layer9, dtype="<f4"),
+                         np.fromfile(directory / "llama-vision-layer9.f32",
+                                     dtype="<f4"),
+                         "vision layer 8")
+        layer17 = metrics(np.fromfile(native_layer18, dtype="<f4"),
+                          np.fromfile(directory / "llama-vision-layer18.f32",
+                                      dtype="<f4"),
+                          "vision layer 17")
+        exact_layer17 = metrics(
+            np.fromfile(native_exact_layer18, dtype="<f4"),
+            np.fromfile(trace_directory / "llama-vision-layer18.f32",
+                        dtype="<f4"),
+            "vision layer 17 from exact llama.cpp input")
+        for operation in TRACE_OPERATIONS:
+            metrics(
+                np.fromfile(
+                    trace_directory / f"native-vision-layer17-{operation}.f32",
+                    dtype="<f4"),
+                np.fromfile(
+                    trace_directory / f"llama-vision-layer17-{operation}.f32",
+                    dtype="<f4"),
+                f"vision layer 17 {operation}")
+        last_layer = metrics(np.fromfile(native_last_layer, dtype="<f4"),
+                             np.fromfile(directory / "llama-vision-layer27.f32",
+                                         dtype="<f4"),
+                             "vision layer 26")
+        projected = metrics(np.fromfile(native_projected, dtype="<f4"),
+                            np.fromfile(directory / "llama-vision-projected.f32",
+                                        dtype="<f4"),
+                            "vision projected")
+        oracle_output = np.fromfile(directory / "llama-vision-output.f32",
+                                    dtype="<f4")
+        oracle_projected = np.fromfile(
+            directory / "llama-vision-projected.f32", dtype="<f4")
+        if not np.array_equal(oracle_output, oracle_projected):
+            raise SystemExit("llama.cpp callback and public output differ")
+        native_logit_values = np.fromfile(native_logits, dtype="<f4")
+        llama_logit_values = np.fromfile(
+            directory / "llama-image-logits.f32", dtype="<f4")
+        logits = metrics(native_logit_values, llama_logit_values,
+                         "image-conditioned logits")
+        decoder_logit_values = np.fromfile(decoder_logits, dtype="<f4")
+        decoder_logits_metric = metrics(
+            decoder_logit_values, llama_logit_values,
+            "decoder logits from llama.cpp image vectors")
+        native_top = np.argsort(-native_logit_values)[:10]
+        llama_top = np.argsort(-llama_logit_values)[:10]
+        print("image-conditioned native top 10:",
+              " ".join(f"{token}:{native_logit_values[token]:.6f}"
+                       for token in native_top))
+        print("image-conditioned llama top 10:",
+              " ".join(f"{token}:{llama_logit_values[token]:.6f}"
+                       for token in llama_top))
+        if set(native_top) != set(llama_top):
+            raise SystemExit(
+                "image-conditioned top-10 candidate set differs from llama.cpp")
+        if native_top[0] != llama_top[0]:
+            raise SystemExit("image-conditioned top-1 token differs from llama.cpp")
+        decoder_top = np.argsort(-decoder_logit_values)[:10]
+        if not np.array_equal(decoder_top, llama_top):
+            raise SystemExit("decoder top-10 ranking differs from llama.cpp")
+    if layer[1] > 0.003 or layer[2] < 0.999999 or layer[0] > 0.2:
+        raise SystemExit("vision layer-0 comparison failed")
+    for checkpoint, label in ((layer8, "8"), (layer17, "17")):
+        if checkpoint[1] > 1.0 or checkpoint[2] < 0.9999 or checkpoint[0] > 50.0:
+            raise SystemExit(f"vision layer-{label} comparison failed")
+    if exact_layer17[1] > 0.01 or exact_layer17[0] > 0.2:
+        raise SystemExit("vision layer-17 exact-input operation trace failed")
+    if last_layer[1] > 1.0 or last_layer[2] < 0.9999 or last_layer[0] > 50.0:
+        raise SystemExit("vision layer-26 comparison failed")
+    if projected[1] > 0.02 or projected[2] < 0.9999 or projected[0] > 0.3:
+        raise SystemExit("vision projection comparison failed")
+    if logits[1] > 0.25 or logits[2] < 0.999 or logits[0] > 2.0:
+        raise SystemExit("image-conditioned logit comparison failed")
+    if decoder_logits_metric[2] < 0.999 or decoder_logits_metric[0] > 2.0:
+        raise SystemExit("image-conditioned decoder comparison failed")
+    if os.environ.get("COLI_GEMMA4_VISION_COMPAT") == "llama-avx2":
+        for checkpoint, label in (
+                (layer, "0"), (layer8, "8"), (layer17, "17"),
+                (exact_layer17, "17 exact-input"),
+                (last_layer, "26"), (projected, "projection")):
+            if checkpoint[0] != 0.0 or checkpoint[1] != 0.0:
+                raise SystemExit(
+                    f"llama-avx2 vision {label} is not bit-identical")
+
+
+if __name__ == "__main__":
+    main()

--- a/c/tests/validate_gemma4_vision_patch.py
+++ b/c/tests/validate_gemma4_vision_patch.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Cross-check Gemma 4 patch convolution and X/Y positions against NumPy."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import struct
+import subprocess
+import tempfile
+
+import numpy as np
+
+
+SCALARS = {0: "B", 1: "b", 2: "H", 3: "h", 4: "I", 5: "i",
+           6: "f", 7: "?", 10: "Q", 11: "q", 12: "d"}
+
+
+def exact(handle, count):
+    data = handle.read(count)
+    if len(data) != count:
+        raise ValueError("unexpected end of GGUF")
+    return data
+
+
+def scalar(handle, kind):
+    fmt = SCALARS[kind]
+    return struct.unpack("<" + fmt, exact(handle, struct.calcsize(fmt)))[0]
+
+
+def string(handle):
+    return exact(handle, scalar(handle, 10)).decode("utf-8")
+
+
+def value(handle, kind):
+    if kind == 8:
+        return string(handle)
+    if kind == 9:
+        element = scalar(handle, 4)
+        return [value(handle, element) for _ in range(scalar(handle, 10))]
+    return scalar(handle, kind)
+
+
+def index_gguf(path):
+    with path.open("rb") as handle:
+        if exact(handle, 4) != b"GGUF":
+            raise ValueError("not a GGUF")
+        version, tensor_count, metadata_count = struct.unpack("<IQQ", exact(handle, 20))
+        if version not in (2, 3):
+            raise ValueError("unsupported GGUF version")
+        metadata = {}
+        for _ in range(metadata_count):
+            key = string(handle)
+            metadata[key] = value(handle, scalar(handle, 4))
+        tensors = {}
+        for _ in range(tensor_count):
+            name = string(handle)
+            dims = tuple(scalar(handle, 10) for _ in range(scalar(handle, 4)))
+            tensors[name] = (scalar(handle, 4), dims, scalar(handle, 10))
+        alignment = int(metadata.get("general.alignment", 32))
+        data_offset = (handle.tell() + alignment - 1) // alignment * alignment
+    return data_offset, metadata, tensors
+
+
+def read_f32(path, data_offset, tensor):
+    kind, dims, offset = tensor
+    if kind != 0:
+        raise ValueError("expected F32 tensor")
+    count = int(np.prod(dims))
+    return np.memmap(path, dtype="<f4", mode="r",
+                     offset=data_offset + offset, shape=(count,))
+
+
+def smart_size(width, height, alignment=48, minimum=40, maximum=280):
+    aligned_w = max(alignment, round(width / alignment) * alignment)
+    aligned_h = max(alignment, round(height / alignment) * alignment)
+    min_pixels = minimum * alignment * alignment
+    max_pixels = maximum * alignment * alignment
+    if aligned_w * aligned_h > max_pixels:
+        beta = np.sqrt(np.float32(width * height) / np.float32(max_pixels))
+        aligned_w = max(alignment, int(np.floor(np.float32(width) / beta /
+                                               alignment)) * alignment)
+        aligned_h = max(alignment, int(np.floor(np.float32(height) / beta /
+                                               alignment)) * alignment)
+    elif aligned_w * aligned_h < min_pixels:
+        beta = np.sqrt(np.float32(min_pixels) / np.float32(width * height))
+        aligned_w = int(np.ceil(np.float32(width) * beta / alignment)) * alignment
+        aligned_h = int(np.ceil(np.float32(height) * beta / alignment)) * alignment
+    return aligned_w, aligned_h
+
+
+def resize_reference(rgb, width, height):
+    source_h, source_w, _ = rgb.shape
+    result = np.empty((height, width, 3), dtype=np.uint8)
+    x_ratio = np.float32(source_w - 1) / np.float32(width - 1) if width > 1 else np.float32(0)
+    y_ratio = np.float32(source_h - 1) / np.float32(height - 1) if height > 1 else np.float32(0)
+    for y in range(height):
+        py = np.float32(y) * y_ratio
+        y0 = min(int(py), source_h - 1)
+        y1 = min(y0 + 1, source_h - 1)
+        yf = py - np.float32(y0)
+        for x in range(width):
+            px = np.float32(x) * x_ratio
+            x0 = min(int(px), source_w - 1)
+            x1 = min(x0 + 1, source_w - 1)
+            xf = px - np.float32(x0)
+            top = rgb[y0, x0].astype(np.float32) + (
+                rgb[y0, x1].astype(np.float32) - rgb[y0, x0]) * xf
+            bottom = rgb[y1, x0].astype(np.float32) + (
+                rgb[y1, x1].astype(np.float32) - rgb[y1, x0]) * xf
+            result[y, x] = (top + (bottom - top) * yf).astype(np.uint8)
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("executable", type=pathlib.Path)
+    parser.add_argument("mmproj", type=pathlib.Path)
+    args = parser.parse_args()
+    data_offset, metadata, tensors = index_gguf(args.mmproj)
+    source_w = source_h = 48
+    source = ((np.arange(source_w * source_h * 3, dtype=np.uint64) * 37 + 11) & 255)
+    source = source.astype(np.uint8).reshape(source_h, source_w, 3)
+    target_w, target_h = smart_size(source_w, source_h)
+    resized = resize_reference(source, target_w, target_h).astype(np.float32) / np.float32(255)
+    mean = np.asarray(metadata["clip.vision.image_mean"], dtype=np.float32)
+    std = np.asarray(metadata["clip.vision.image_std"], dtype=np.float32)
+    scaled = np.float32(2) * ((resized - mean) / std) - np.float32(1)
+    patch = int(metadata["clip.vision.patch_size"])
+    model_width = int(metadata["clip.vision.embedding_length"])
+    columns, rows = target_w // patch, target_h // patch
+    patches = np.stack([
+        scaled[y*patch:(y+1)*patch, x*patch:(x+1)*patch]
+        .transpose(2, 0, 1).reshape(-1)
+        for y in range(rows) for x in range(columns)
+    ]).astype(np.float32)
+    kernels = read_f32(args.mmproj, data_offset,
+                       tensors["v.patch_embd.weight"]).reshape(model_width, -1)
+    positions = read_f32(args.mmproj, data_offset,
+                         tensors["v.position_embd.weight"])
+    table_rows = tensors["v.position_embd.weight"][1][1]
+    positions = positions.reshape(2, table_rows, model_width)
+    reference = patches @ kernels.T
+    for y in range(rows):
+        for x in range(columns):
+            reference[y * columns + x] += positions[0, x] + positions[1, y]
+    with tempfile.TemporaryDirectory(prefix="gemma4-vision-patch-") as directory:
+        output = pathlib.Path(directory) / "patches.f32"
+        subprocess.run([str(args.executable), "vision-patch-probe", str(args.mmproj),
+                        str(source_w), str(source_h), "--output-f32", str(output)],
+                       check=True, stdout=subprocess.DEVNULL)
+        actual = np.fromfile(output, dtype="<f4").reshape(reference.shape)
+    difference = actual - reference
+    maximum = float(np.max(np.abs(difference)))
+    rms = float(np.sqrt(np.mean(difference * difference)))
+    cosine = float(np.dot(actual.ravel(), reference.ravel()) /
+                   (np.linalg.norm(actual) * np.linalg.norm(reference)))
+    selected = [(0, 0), (0, 71), (0, 1151),
+                (len(patches)//2, 1), (len(patches)-1, 511)]
+    scalar_errors = []
+    for patch_index, output_index in selected:
+        y, x = divmod(patch_index, columns)
+        total = np.float32(positions[0, x, output_index] +
+                           positions[1, y, output_index])
+        for input_index in range(patches.shape[1]):
+            total = np.float32(total + np.float32(
+                patches[patch_index, input_index] * kernels[output_index, input_index]))
+        scalar_errors.append(abs(float(actual[patch_index, output_index] - total)))
+    scalar_maximum = max(scalar_errors)
+    print(f"patch embedding: blas-max={maximum:.6g} rms={rms:.6g} "
+          f"cosine={cosine:.9f} scalar-max={scalar_maximum:.6g}")
+    # BLAS is free to reassociate 768 float32 products, so its absolute maximum
+    # is informational. The selected scalar oracle preserves the native loop's
+    # accumulation order and catches layout/position errors directly.
+    if scalar_maximum > 2e-4 or rms > 5e-4 or cosine < 0.9999995:
+        raise SystemExit("patch embedding comparison failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/c/tools/clean.py
+++ b/c/tools/clean.py
@@ -23,6 +23,7 @@ FILES = [
     "qwen36", "qwen36.exe",
     "qwen38", "qwen38.exe",
     "glm53", "glm53.exe",
+    "gemma4", "gemma4.exe",
     "glm", "glm.exe",                       # pre-rename name of the colibri engine
     "iobench", "iobench.exe",
     "backend_cuda.o", "backend_loader.o",

--- a/c/tools/inspect_gguf.py
+++ b/c/tools/inspect_gguf.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Bounded, dependency-free GGUF metadata/tensor inventory.
+
+This deliberately does not decode tensor payloads.  It is used while bringing
+up new Colibri engines to establish the exact metadata, tensor names, shapes,
+types, and hybrid layer schedule without allocating tokenizer arrays.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import struct
+from pathlib import Path
+
+
+META_SIZES = {0: 1, 1: 1, 2: 2, 3: 2, 4: 4, 5: 4, 6: 4, 7: 1,
+              10: 8, 11: 8, 12: 8}
+META_FORMATS = {0: "B", 1: "b", 2: "H", 3: "h", 4: "I", 5: "i",
+                6: "f", 7: "?", 10: "Q", 11: "q", 12: "d"}
+MAX_STRING = 256 * 1024 * 1024
+MAX_ITEMS = 1_000_000_000
+LAYER_RE = re.compile(r"^blk\.(\d+)\.(.+)$")
+
+
+class GGUFError(ValueError):
+    pass
+
+
+class Reader:
+    def __init__(self, path: Path):
+        self.path = path
+        self.file = path.open("rb")
+        self.size = path.stat().st_size
+
+    def close(self):
+        self.file.close()
+
+    def read(self, size: int) -> bytes:
+        if size < 0 or self.file.tell() + size > self.size:
+            raise GGUFError("unexpected end of GGUF file")
+        value = self.file.read(size)
+        if len(value) != size:
+            raise GGUFError("unexpected end of GGUF file")
+        return value
+
+    def scalar(self, fmt: str):
+        return struct.unpack("<" + fmt, self.read(struct.calcsize(fmt)))[0]
+
+    def string(self) -> str:
+        length = self.scalar("Q")
+        if length > MAX_STRING:
+            raise GGUFError(f"unreasonably large GGUF string ({length} bytes)")
+        return self.read(length).decode("utf-8", errors="replace")
+
+    def skip(self, size: int):
+        if size < 0 or self.file.tell() + size > self.size:
+            raise GGUFError("GGUF skip exceeds file size")
+        self.file.seek(size, os.SEEK_CUR)
+
+
+def read_value(reader: Reader, value_type: int, capture: bool = True, depth: int = 0):
+    if depth > 16:
+        raise GGUFError("GGUF metadata nesting is too deep")
+    if value_type in META_FORMATS:
+        value = reader.scalar(META_FORMATS[value_type])
+        return value if capture else None
+    if value_type == 8:
+        value = reader.string()
+        return value if capture else None
+    if value_type != 9:
+        raise GGUFError(f"unknown GGUF metadata type {value_type}")
+    element_type = reader.scalar("I")
+    count = reader.scalar("Q")
+    if count > MAX_ITEMS:
+        raise GGUFError(f"unreasonably large GGUF array ({count} items)")
+    if not capture and element_type in META_SIZES:
+        reader.skip(count * META_SIZES[element_type])
+        return None
+    # Large token arrays are irrelevant to architecture discovery. Strings
+    # remain length-prefixed, so they must be walked but need not be retained.
+    keep = capture and count <= 4096
+    values = [] if keep else None
+    for _ in range(count):
+        value = read_value(reader, element_type, keep, depth + 1)
+        if keep:
+            values.append(value)
+    return values if keep else {"count": count, "element_type": element_type}
+
+
+def inspect(path: Path) -> dict:
+    reader = Reader(path)
+    try:
+        if reader.read(4) != b"GGUF":
+            raise GGUFError("not a GGUF file")
+        version = reader.scalar("I")
+        if version not in (2, 3):
+            raise GGUFError(f"unsupported GGUF version {version}")
+        tensor_count = reader.scalar("Q")
+        metadata_count = reader.scalar("Q")
+        if tensor_count > 10_000_000 or metadata_count > 10_000_000:
+            raise GGUFError("unreasonable GGUF table size")
+        metadata = {}
+        for _ in range(metadata_count):
+            key = reader.string()
+            value_type = reader.scalar("I")
+            capture = (key.startswith("general.") or key.startswith("nemotron_h_moe.")
+                       or key.startswith("tokenizer.ggml."))
+            metadata[key] = read_value(reader, value_type, capture)
+        tensors = []
+        layer_kinds: dict[int, set[str]] = {}
+        type_counts: dict[int, int] = {}
+        for _ in range(tensor_count):
+            name = reader.string()
+            n_dims = reader.scalar("I")
+            if not 1 <= n_dims <= 8:
+                raise GGUFError(f"invalid dimension count for {name}: {n_dims}")
+            dims = [reader.scalar("Q") for _ in range(n_dims)]
+            tensor_type = reader.scalar("I")
+            offset = reader.scalar("Q")
+            tensors.append({"name": name, "dims": dims, "type": tensor_type,
+                            "offset": offset})
+            type_counts[tensor_type] = type_counts.get(tensor_type, 0) + 1
+            match = LAYER_RE.match(name)
+            if match:
+                layer = int(match.group(1))
+                suffix = match.group(2)
+                kind = "ssm" if suffix.startswith("ssm_") or suffix in ("ssm_a", "ssm_d") else \
+                       "attention" if suffix.startswith("attn_") and suffix != "attn_norm.weight" else \
+                       "moe" if suffix.startswith("ffn_") else "other"
+                layer_kinds.setdefault(layer, set()).add(kind)
+        alignment = int(metadata.get("general.alignment", 32))
+        data_offset = (reader.file.tell() + alignment - 1) & ~(alignment - 1)
+        schedule = []
+        for layer in sorted(layer_kinds):
+            kinds = layer_kinds[layer]
+            mixer = "ssm" if "ssm" in kinds else "attention" if "attention" in kinds else "unknown"
+            schedule.append({"layer": layer, "mixer": mixer, "moe": "moe" in kinds})
+        return {"path": str(path.resolve()), "file_size": reader.size,
+                "version": version, "tensor_count": tensor_count,
+                "metadata_count": metadata_count, "metadata": metadata, "data_offset": data_offset,
+                "tensor_type_counts": {str(k): v for k, v in sorted(type_counts.items())},
+                "schedule": schedule, "tensors": tensors}
+    finally:
+        reader.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("gguf", type=Path)
+    parser.add_argument("--json", action="store_true", help="emit the complete inventory as JSON")
+    parser.add_argument("--tensors", action="store_true", help="include tensor rows in text output")
+    args = parser.parse_args()
+    try:
+        result = inspect(args.gguf)
+    except (OSError, GGUFError) as error:
+        parser.error(str(error))
+    if args.json:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0
+    meta = result["metadata"]
+    print(f"architecture: {meta.get('general.architecture', '<missing>')}")
+    print(f"version: {result['version']}  tensors: {result['tensor_count']}  metadata: {result['metadata_count']}")
+    print(f"file: {result['file_size']} bytes  tensor types: {result['tensor_type_counts']}")
+    for key in sorted(meta):
+        if key.startswith("nemotron_h_moe.") or key.startswith("tokenizer.ggml."):
+            print(f"{key} = {meta[key]}")
+    print("schedule: " + " ".join(
+        f"{row['layer']}:{'moe' if row['mixer'] == 'unknown' and row['moe'] else row['mixer']}"
+        for row in result["schedule"]))
+    if args.tensors:
+        for tensor in result["tensors"]:
+            print(f"{tensor['name']} {tensor['dims']} type={tensor['type']} offset={tensor['offset']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/gemma4.md
+++ b/docs/gemma4.md
@@ -1,0 +1,815 @@
+# Gemma 4 integration
+
+Gemma 4 support is being added as a distinct model graph. It deliberately does
+not add Gemma branches to the GLM execution path: Colibri's placement and
+streaming policies are reusable, while attention, routing, normalization,
+tokenization, and output semantics are model-specific.
+
+## Current milestone: native Gemma 4 vision tower
+
+The first native integration milestone is implemented in:
+
+- `c/model.h`: the placement-independent model/expert backend contract;
+- `c/gemma4_backend.c`: validated loading of g4lab manifests and packed
+  expert-major records, Q4_0 expert execution, learned per-expert scaling,
+  weighted selected-expert aggregation, an optional exact-record LRU cache, a
+  protected live-learning tier, restart-persistent usage profiles, and optional
+  asynchronous cold-record staging driven through Colibri's placement-
+  independent prepare/run/release contract;
+- `c/gemma4_gguf.c`: a native GGUF v2/v3 metadata and tensor index for the
+  tensor types used by the target model;
+- `c/gemma4_model.c`: Gemma's router RMS normalization, complete-expert
+  softmax, stable top-k selection, selected-probability renormalization, and
+  routed-branch RMSNorm, plus reusable resident Q4_0 and Q6_K matrices and the
+  Q/K/V and output projection boundaries, default/proportional RoPE,
+  local/global KV storage, causal grouped-query attention, non-causal image-
+  embedding chunks, the resident
+  gated-GELU MLP, complete decoder-layer residual/norm ordering, scaled token
+  embeddings, persistent 30-layer execution, final normalization, the tied
+  vocabulary head, and final logit soft-capping;
+- `c/gemma4_tokenizer.c`: the GGUF-native Gemma 4 tokenizer, including
+  space-to-`▁` normalization, raw UTF-8 BPE over non-newline spans, ranked
+  merges, newline handling, byte-token fallback, automatic BOS insertion,
+  control-token partitioning, canonical initial/continuation user frames, and
+  exact image-open/image-close frame partitioning;
+- `c/gemma4_sampling.c`: deterministic greedy and seeded temperature/top-k/
+  top-p selection over the native vocabulary logits;
+- `c/gemma4_vision.c`: validated loading of the separate Gemma 4 vision GGUF,
+  BF16 tensor indexing, reference-compatible dynamic image sizing, bilinear RGB
+  resize, normalization, patch/output-token geometry, scaled 16x16 RGB patch
+  convolution, learned independent X/Y position lookup, all 27 streamed BF16
+  transformer blocks, per-head 2D NeoX RoPE, full non-causal attention,
+  gated quick-GELU feed-forward layers, 3x3 average pooling, learned output
+  calibration, and the final 1,152-to-2,816 projection;
+- `c/gemma4.c`: a small command-line probe using that backend.
+
+It consumes a directory created by the companion lab:
+
+```powershell
+& $g4lab pack $model --out ".\packed-gemma4" --layer 0
+```
+
+A one-layer pack is intentional for bring-up. Its manifest describes all routed
+layers, while only `layer-00.g4ex` is present. The `info` command labels the
+remaining entries as `direct GGUF fallback`: those experts are read from their
+original fused gate/up and down tensor slices. The original GGUF must remain at
+the manifest's recorded source path for fallback records and the small learned
+scale vector.
+
+Build it with Colibri's existing Makefile:
+
+```powershell
+cd c
+make gemma4
+```
+
+Inspect the packed model boundary:
+
+```powershell
+.\gemma4.exe info C:\path\to\packed-gemma4
+```
+
+Inspect and validate the full text-model GGUF directly:
+
+```powershell
+.\gemma4.exe model-info C:\path\to\gemma4.gguf
+```
+
+This reads the GGUF directory without loading all weights and reports the real
+layer width, vocabulary, MoE configuration, and local/global attention
+schedule. On the 26B-A4B file, global layers are 5, 11, 17, 23, and 29; the
+other layers use the 1,024-token sliding window.
+
+Tokenize ordinary prompt text directly from the GGUF vocabulary and merge
+tables:
+
+```powershell
+.\gemma4.exe tokenize C:\path\to\gemma4.gguf `
+  "Hello, world!"
+```
+
+For exact UTF-8 input on Windows (including emoji or non-Latin scripts), use a
+file so command-line code-page conversion cannot alter the bytes:
+
+```powershell
+.\gemma4.exe tokenize-file C:\path\to\gemma4.gguf `
+  C:\path\to\prompt-utf8.txt
+```
+
+Both commands add the model's BOS token by default. Pass `--no-bos` when a raw
+tokenization boundary is needed.
+
+Build a canonical text-only user turn and inspect the exact tokens that will
+feed generation:
+
+```powershell
+.\gemma4.exe chat-user C:\path\to\gemma4.gguf `
+  "Explain why the sky is blue."
+```
+
+The UTF-8-safe form is:
+
+```powershell
+.\gemma4.exe chat-user-file C:\path\to\gemma4.gguf `
+  C:\path\to\user-message-utf8.txt
+```
+
+This implements the text-only path from the target GGUF's embedded Google Gemma
+4 canonical chat template: optional system turn, user turn, closed boundaries,
+`<|turn>model`, and the empty thought-channel generation prefix. User and system
+content are trimmed exactly as the template specifies. Interactive tool calls
+and responses are supported.
+
+Inspect the canonical image-first frame and the precise point where projected
+vision vectors enter the decoder:
+
+```powershell
+.\gemma4.exe image-chat-user C:\path\to\gemma4.gguf `
+  "What is shown in this image?"
+```
+
+The command prints prefix IDs ending in `<|image>`, an image-embedding slot, and
+suffix IDs beginning with `<image|>`. The model API accepts `N x 2816` float32
+projector outputs at that slot. It evaluates the complete image chunk with
+non-causal self-attention in every decoder layer, stores its keys and values,
+then resumes normal causal text evaluation. This is the real Gemma 4 decoder
+boundary: image vectors are not token embeddings and must not be represented by
+repeated placeholder IDs. The separate `gemma-4-26B-it-mmproj.gguf` vision tower
+now produces these vectors natively; connecting decoded image files and those
+vectors to interactive generation is the next integration boundary.
+
+Inspect that projector and calculate the exact resize/token geometry for an
+image without loading its 1.19 GB of tensor payloads:
+
+```powershell
+.\gemma4.exe vision-info `
+  C:\path\to\gemma-4-26B-it-mmproj.gguf 1920 1080
+```
+
+The native vision API accepts interleaved RGB8 pixels. It aligns both dimensions
+to `patch_size * pooling_size` (48 here), preserves aspect ratio, enforces the
+40–280 projected-token range, bilinearly resizes with the same endpoint mapping
+as llama.cpp, and returns normalized interleaved float32 pixels plus patch and
+pooled-token geometry. Binary PPM remains dependency-free. Windows uses WIC for
+PNG/JPEG; non-Windows Makefile builds enable the same codecs when their
+`pkg-config` metadata is available.
+
+Run image-conditioned generation directly from an image file. Binary PPM
+(`P6`, 8-bit RGB) is portable and dependency-free. Windows builds decode PNG
+and JPEG through WIC, and non-Windows builds use detected libpng/libjpeg:
+
+```powershell
+.\gemma4.exe generate C:\path\to\gemma4.gguf `
+  C:\path\to\packed-gemma4 "Describe this image." --chat `
+  --image C:\path\to\image.ppm `
+  --mmproj C:\path\to\gemma-4-26B-it-mmproj.gguf --max-new 64
+```
+
+The same options work with `next-token` for deterministic logit inspection.
+Both options must be supplied together and require `--chat`. Colibri builds the
+canonical prefix through `<|image>`, evaluates the projector output as one
+non-causal decoder chunk, then evaluates the suffix beginning with `<image|>`
+before sampling. Image positions therefore occupy real KV positions without
+inventing placeholder token IDs. Inspect decoding and prepared geometry without
+running the transformer using `vision-image-info MMPROJ.gguf IMAGE`.
+
+Run the first computed vision-graph boundary on a deterministic RGB image and
+optionally save all patch vectors:
+
+```powershell
+.\gemma4.exe vision-patch-probe `
+  C:\path\to\gemma-4-26B-it-mmproj.gguf 48 48 `
+  --output-f32 C:\path\to\patch-embeddings.f32
+```
+
+The probe performs preprocessing, scales pixels to `2*x-1`, applies the real
+F32 `[16,16,3,1152]` convolution kernel, and adds rows from the separate learned
+X and Y position tables. The GGUF reader supports bounded tensor-slice reads, so
+only the used rows of the 94 MB position tensor are read.
+
+Run the complete native vision tower on that deterministic image and save the
+decoder-ready image vectors:
+
+```powershell
+.\gemma4.exe vision-encode-probe `
+  C:\path\to\gemma-4-26B-it-mmproj.gguf 48 48 `
+  --output-f32 C:\path\to\projected-image.f32
+```
+
+For the 48x48 source, smart resize produces 21x21 patches, the 3x3 pool produces
+49 image tokens, and the output file contains `49 * 2816` consecutive float32
+values. Add `--layers N` to stop after N transformer blocks; this diagnostic
+form writes the 441 width-1,152 patch vectors before pooling and projection.
+
+Build and run the independent llama.cpp comparison with:
+
+```powershell
+powershell -ExecutionPolicy Bypass `
+  -File tests\build_llama_gemma4_vision_oracle.ps1 `
+  -LlamaRoot C:\path\to\llama.cpp
+
+python tests\validate_gemma4_vision.py `
+  .\gemma4.exe `
+  .\build-gemma4\llama-gemma4-vision-oracle.exe `
+  C:\path\to\gemma4.gguf C:\path\to\packed-gemma4 `
+  C:\path\to\gemma-4-26B-it-mmproj.gguf `
+  --llama-bin C:\path\to\llama.cpp\build\bin\Release
+```
+
+Add a system instruction to the tokenizer probe with `--system`, or use
+`--system-file` to preserve arbitrary UTF-8 exactly on Windows:
+
+```powershell
+.\gemma4.exe chat-user C:\path\to\gemma4.gguf `
+  "Hello, Gemma!" --system "Answer briefly."
+```
+
+Declare OpenAI-compatible function tools with `--tools-file`. The file must be
+a JSON array of `{"type":"function","function":...}` declarations; the
+repository includes a complete small example at
+`tests/fixtures/gemma4_weather_tools.json`. Colibri validates the schema and
+renders Gemma 4's compact declaration syntax, including sorted properties,
+descriptions, string enums, arrays, nested objects, required fields, nullable
+fields, and optional response schemas:
+
+```powershell
+.\gemma4.exe chat-user C:\path\to\gemma4.gguf `
+  "Weather in Rome?" --system "Be exact." `
+  --tools-file tests\fixtures\gemma4_weather_tools.json
+```
+
+Run a manual tool-call probe with the full model using:
+
+```powershell
+.\gemma4.exe generate C:\path\to\gemma4.gguf `
+  C:\path\to\packed-gemma4 "What is the weather in Rome? Use the tool." `
+  --chat --tools-file tests\fixtures\gemma4_weather_tools.json `
+  --show-special --max-new 32
+```
+
+To complete the tool round trip, use the persistent `chat` command instead:
+
+```powershell
+.\gemma4.exe chat C:\path\to\gemma4.gguf `
+  C:\path\to\packed-gemma4 `
+  --tools-file tests\fixtures\gemma4_weather_tools.json `
+  --show-special --max-context 512 --max-new 64
+```
+
+When Gemma requests a function, the session prints its name and compact Gemma
+arguments, then prompts with `result JSON>`. Enter one complete JSON value, for
+example `{"city":"Rome","temp_c":31,"conditions":"sunny"}`. Colibri
+validates it, renders the canonical `<|tool_response>` block, evaluates that
+block into the existing KV cache, and resumes the same model turn. Multiple
+calls in one handoff are prompted and injected in order. Enter `/exit` at a
+result prompt to end the session without injecting a response.
+
+Run the complete text model and inspect its deterministic next-token ranking:
+
+```powershell
+.\gemma4.exe next-token C:\path\to\gemma4.gguf `
+  C:\path\to\packed-gemma4 "Hello" --top 10
+```
+
+Add `--chat` to apply the canonical single-user chat frame before evaluation.
+When `--chat` is active, `--system TEXT` or `--system-file FILE` prepends the
+canonical system turn. Supplying a system prompt without `--chat` is rejected.
+`--tools-file FILE` likewise requires `--chat`; tool declarations force the
+canonical system turn even when no system instruction is present.
+The command keeps all 30 attention/dense layers resident, maintains one causal
+KV cache per layer, asks the Colibri expert backend for each routed top-8, then
+applies the final RMS norm, tied Q6_K vocabulary head, and logit soft-cap. Use
+`--residual-f32 FILE` or `--logits-f32 FILE` to save exact validation artifacts.
+For UTF-8 text on Windows, use `next-token-file` with the same arguments and a
+path to the user-message file in place of the command-line text.
+
+Generate text with the same persistent model and KV state:
+
+```powershell
+.\gemma4.exe generate C:\path\to\gemma4.gguf `
+  C:\path\to\packed-gemma4 "Say hello in one short sentence." `
+  --chat --system "Answer in a friendly, concise style." --max-new 64
+```
+
+`generate-file` is the UTF-8-safe equivalent. Generation remains greedy by
+default. A positive temperature enables seeded sampling, using the GGUF's
+declared top-k/top-p defaults unless explicitly overridden:
+
+```powershell
+.\gemma4.exe generate C:\path\to\gemma4.gguf `
+  C:\path\to\packed-gemma4 "Write a cheerful greeting." --chat `
+  --temperature 0.8 --top-k 40 --top-p 0.9 --seed 123 --max-new 64
+```
+
+Each step decodes Gemma's SentencePiece-style token bytes, feeds the selected
+token back through the 30 persistent layers, and stops on EOS or `<turn|>`.
+Control/channel tokens are hidden by default; pass `--show-special` to inspect
+the raw chat protocol while debugging. With tools enabled, this exposes
+`<|tool_call>...<tool_call|><|tool_response>` so a manual caller can inspect the
+requested function and arguments. The non-interactive `generate` command stops
+at the tool-response handoff token. Interactive `chat` instead requests JSON,
+injects the canonical response into the active cache, and resumes generation.
+The same seed and parameters produce the same token sequence.
+
+Start an interactive multi-turn session without reloading model weights or KV
+state between turns:
+
+```powershell
+.\gemma4.exe chat C:\path\to\gemma4.gguf `
+  C:\path\to\packed-gemma4 --max-context 512 --max-new 64 `
+  --system-file C:\path\to\system-prompt-utf8.txt `
+  --temperature 0.8 --seed 123
+```
+
+Enter `/exit` to quit. The optional system turn is evaluated once, immediately
+before the first user turn. After every response, the selected `<turn|>` is
+evaluated into all layer caches; subsequent messages append the canonical
+continuation user frame at the next position. If a response reaches `--max-new`,
+the runtime inserts and evaluates `<turn|>` before accepting another user turn
+so session state never contains an unterminated model message.
+
+Expert records stream directly from the packed layer or source GGUF by default.
+For repeated inference in the same process, `generate`, `next-token`, and `chat`
+accept `--expert-cache N`, where `N` is a global number of encoded expert-record
+slots. The records remain quantized and are decoded only when selected, so this
+does not change routing or floating-point results. For this 26B model each slot
+is 3,346,432 bytes: 256 slots can grow to about 817 MiB, in addition to resident
+model state. Cache allocation is lazy, and a hit/miss/eviction summary is
+printed when the command exits. For example:
+
+```powershell
+.\gemma4.exe chat C:\path\to\gemma4.gguf `
+  C:\path\to\packed-gemma4 --expert-cache 256
+```
+
+On the local four-step raw-generation probe, cached and uncached greedy output
+was identical. A 256-slot run recorded 240 hits and 720 misses, loaded 2,297.1
+MiB of records, and took 6.09 seconds versus 6.52 seconds without the userspace
+cache. Windows' filesystem cache already absorbs much of this small warm-run I/O;
+the explicit cache primarily establishes the Colibri placement boundary and
+exposes deterministic reuse telemetry for the next learned-pinning/prefetch
+phase.
+
+Longer sessions can reserve part of that cache as a learned hot tier with
+`--expert-pins P`, where `P` must be smaller than `N`. Gemma reuses Colibri's
+LFRU scoring rule: frequency is primary, recency breaks close scores, and a
+streamed expert must exceed the coldest protected record by 25% plus four
+accesses before promotion. The swap exchanges resident encoded records and does
+not reread either expert. Live heat resets when the process exits so an old
+workload cannot prevent adaptation. Cumulative selection counts can persist
+separately with `--expert-usage FILE`. The file uses Colibri's compatible
+`layer expert count` format, is replaced atomically, and seeds protected slots
+with the globally hottest records before inference. Interactive chat saves it
+after every completed turn as well as at clean exit.
+
+```powershell
+.\gemma4.exe chat C:\path\to\gemma4.gguf `
+  C:\path\to\packed-gemma4 --expert-cache 256 --expert-pins 64 `
+  --expert-usage C:\path\to\packed-gemma4\.gemma4_usage
+```
+
+Protected slots are intended for longer, repetitive sessions. Leave
+`--expert-pins` at its default of zero for short one-shot prompts, where there
+is not enough history to overcome the admission hysteresis. A real-model smoke
+test with 256 total and 64 protected slots produced the same greedy text as the
+uncached and plain-LRU runs; the synthetic suite deterministically exercises an
+actual hot-record promotion and verifies its numerical output.
+
+The real restart probe evaluated the same two-token prompt twice. Its first run
+saved 480 routed selections; the second loaded those 480, saved 960 cumulative
+selections, and produced the same greedy token. Warm seeding increased cache
+hits from 14 to 128 and reduced demand misses from 466 to 352. The 64 deliberate
+startup record loads are reported separately as `preloads`, not as misses.
+
+`--expert-prefetch` changes `prepare_layer` from a blocking load into a
+background staging request. The decoder launches it immediately after routing,
+computes Gemma's independent resident dense MLP on the caller thread, and joins
+the worker before routed-expert math. Cache hits stay synchronous and do not
+launch a worker. The option requires `--expert-cache`; it changes scheduling
+only, not selected experts, weights, or arithmetic.
+
+```powershell
+.\gemma4.exe generate C:\path\to\gemma4.gguf `
+  C:\path\to\packed-gemma4 "Hi" --max-new 3 `
+  --expert-cache 256 --expert-prefetch
+```
+
+In the paired real-model four-step probe, synchronous staging took 7.55 seconds
+and asynchronous staging took 6.29 seconds, a 16.6% reduction. Both runs
+generated identical text and performed the same 720 demand loads; telemetry
+reported `prefetch=120/720` (worker launches/records) for the asynchronous run.
+
+`--expert-lookahead` extends that worker across layer boundaries. After layer
+N finishes, the next router runs on the current residual as a prediction and
+stages its missing records while layer N+1 computes attention. The authoritative
+router still runs after attention and alone decides expert IDs and weights, so
+lookahead changes placement only. It requires both `--expert-cache` and
+`--expert-prefetch`:
+
+```powershell
+.\gemma4.exe next-token MODEL.gguf PACKED_DIR "Hello" `
+  --expert-cache 256 --expert-prefetch --expert-lookahead
+```
+
+On the local two-position real-model probe, prediction covered 363/464 selected
+experts (78.2%) and preserved identical top-three IDs and logits. Two paired
+orders averaged 4.80 seconds without lookahead and 4.18 seconds with it (12.9%
+lower wall time); individual pair wins ranged from 3.1% to 20.3%, showing why
+the policy remains opt-in and measurable.
+
+The source tree includes a validated persistent-buffer CUDA Q4_0 expert kernel,
+but the focused Makefile integration in this PR builds the dependency-free CPU
+backend. Wiring the optional CUDA source into Colibri's existing platform CUDA
+build conventions is follow-up work. During development, the focused benchmark
+kept one encoded record resident in the host cache and reused CUDA allocations.
+
+On the local 4 GB Quadro P1000, CUDA averaged 1.45 ms/expert versus 1.60 ms on
+CPU (9.4% faster). Agreement was strong: maximum absolute error `4.66e-10`, RMS
+`1.25e-10`. First-call process startup and device initialization remain slower,
+so the GPU path is useful for persistent inference rather than one-shot probes.
+
+This first integration deliberately exposes Gemma through the standalone
+`gemma4` executable. Wiring it into Colibri's evolving OpenAI-compatible
+gateway and WebUI is follow-up work so that the engine implementation can be
+reviewed independently from gateway scheduling and streaming-tool changes.
+
+The input/output boundaries can also be probed independently:
+
+```powershell
+.\gemma4.exe embed C:\path\to\gemma4.gguf 2 `
+  --output-f32 bos-embedding.f32
+.\gemma4.exe lm-head C:\path\to\gemma4.gguf `
+  --input-f32 final-residual.f32 --top 10
+```
+
+Run only the exact router boundary for a saved residual state:
+
+```powershell
+.\gemma4.exe route C:\path\to\gemma4.gguf `
+  --layer 0 --input-f32 C:\path\to\layer-residual.f32 `
+  --probabilities-f32 C:\path\to\router-probabilities.f32
+```
+
+`route` applies the router's scale-only RMS normalization, its learned input
+scale, the `1/sqrt(hidden_size)` factor, softmax over all 128 experts, stable
+top-8 selection, and top-8 renormalization. It prints both normalized weights
+and effective weights after the learned expert scale.
+
+Replay a real hidden state through one Colibri-native expert:
+
+```powershell
+.\gemma4.exe expert C:\path\to\packed-gemma4 `
+  --layer 0 --expert 0 `
+  --input-f32 C:\path\to\hidden-state.f32 `
+  --output-f32 C:\path\to\colibri-expert-output.f32
+```
+
+The output can be compared byte-for-byte with g4lab using the same input. This
+proves that the native Colibri backend preserves the packed record layout,
+Q4_0 decoding, gated GELU MLP, learned expert scale, and selected-expert
+aggregation.
+
+Connect the router to the streamed expert backend:
+
+```powershell
+.\gemma4.exe routed-mlp C:\path\to\gemma4.gguf `
+  C:\path\to\packed-gemma4 --layer 0 `
+  --input-f32 C:\path\to\layer-residual.f32 `
+  --output-f32 C:\path\to\routed-branch-output.f32
+```
+
+This command routes from the residual input, separately applies
+`pre_ffw_norm_2`, executes the selected packed or direct-GGUF experts, applies
+each learned expert scale exactly once, and writes the weighted routed-branch
+aggregate. Passing the GGUF explicitly also makes older manifests with
+working-directory-relative source paths portable.
+
+Inspect the normalized attention projections before RoPE:
+
+```powershell
+.\gemma4.exe attention-proj C:\path\to\gemma4.gguf `
+  --layer 0 --position 123 --input-f32 C:\path\to\layer-residual.f32 `
+  --query-f32 C:\path\to\query.f32 `
+  --key-f32 C:\path\to\key.f32 `
+  --value-f32 C:\path\to\value.f32
+```
+
+The layer handle keeps the encoded Q4_0 projection matrices resident and
+reusable. It applies `attn_norm` to the residual, runs Q/K/V projections,
+applies Q/K RMSNorm independently to each head, and rotates Q/K for the given
+position. Value heads use scale-free RMSNorm. Sliding layers use 16 query heads
+and 8 KV heads at dimension 256 with default base-10,000 RoPE. Global layers
+use 16 query heads and 2 KV heads at dimension 512, load proportional frequency
+factors from `rope_freqs.weight`, and derive values from the unnormalized key
+projection, matching the model's missing global `attn_v.weight` tensors.
+
+The model API also provides KV storage with distinct policies: sliding layers
+use a bounded ring capped by the model's 1,024-token window, while global layers
+retain append-only positions up to the caller's context allocation. Cache slots
+carry their absolute position, so a wrapped sliding slot cannot be mistaken for
+the older token it replaced.
+
+Run a sequence through the complete attention branch:
+
+```powershell
+.\gemma4.exe attention-seq C:\path\to\gemma4.gguf `
+  --layer 0 --tokens 2 --input-f32 C:\path\to\two-residuals.f32 `
+  --output-f32 C:\path\to\attention-output.f32
+```
+
+The input and output contain `tokens * model_width` consecutive float32
+values. For each token, this projects and normalizes Q/K/V, applies the layer's
+RoPE variant, stores K/V under the correct cache policy, performs causal
+grouped-query softmax over retained positions, and applies the resident Q4_0
+output projection. Gemma 4's normalized Q/K attention uses a score scale of
+`1.0`; no additional `1/sqrt(head_dim)` factor is applied.
+
+The focused real-model NumPy oracle can be rerun from `c`:
+
+```powershell
+python tests\validate_gemma4_attention.py `
+  .\gemma4.exe C:\path\to\gemma4.gguf
+```
+
+It uses the native projection probe for the already-validated rotated Q/K/V
+boundary, then independently evaluates grouped-query causal softmax, decodes
+the Q4_0 output projection, and compares the final sequence output.
+
+Probe the resident dense MLP by itself:
+
+```powershell
+.\gemma4.exe dense-mlp C:\path\to\gemma4.gguf `
+  --layer 0 --input-f32 C:\path\to\normalized-residual.f32 `
+  --output-f32 C:\path\to\dense-branch-output.f32
+```
+
+This keeps all three Q4_0 matrices resident and evaluates the model's
+2816-to-2112-to-2816 gate/up/down path with tanh-approximate GELU gating.
+
+Run a complete decoder layer, including both feed-forward branches:
+
+```powershell
+.\gemma4.exe layer-seq C:\path\to\gemma4.gguf `
+  C:\path\to\packed-gemma4 --layer 0 --tokens 2 `
+  --input-f32 C:\path\to\two-residuals.f32 `
+  --output-f32 C:\path\to\layer-output.f32
+```
+
+After attention, this applies `post_attention_norm` and the first residual add.
+The dense branch consumes `ffn_norm`; the routed branch routes from that same
+residual while experts consume `pre_ffw_norm_2`. Their outputs receive
+`post_ffw_norm_1` and `post_ffw_norm_2`, respectively, before addition. The
+combined branch receives `post_ffw_norm`, is added to the residual, and is
+multiplied by `layer_output_scale`. Expert access still goes through the
+placement-independent backend, so packed records and direct-GGUF fallback have
+identical graph semantics.
+
+The complete-layer boundary oracle can be rerun from `c`:
+
+```powershell
+python tests\validate_gemma4_layer.py `
+  .\gemma4.exe C:\path\to\gemma4.gguf `
+  C:\path\to\packed-gemma4
+```
+
+An optional whole-stack comparison against a current llama.cpp build is also
+available. Build llama.cpp with Visual Studio first, then build the small tensor
+capture helper:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tests\build_llama_gemma4_oracle.ps1 `
+  -LlamaRoot C:\path\to\llama.cpp
+```
+
+Run the layer-0 comparison with the llama.cpp DLL directory on its search path:
+
+```powershell
+python tests\validate_gemma4_llama_layer0.py `
+  .\gemma4.exe `
+  .\build-gemma4\llama-gemma4-oracle.exe `
+  C:\path\to\gemma4.gguf C:\path\to\packed-gemma4 `
+  --llama-bin C:\path\to\llama.cpp\build\bin\Release
+```
+
+The helper uses llama.cpp's public evaluation callback and does not modify the
+llama.cpp checkout. The comparison covers rotated Q/K, scale-free normalized V,
+post-normalized attention, the dense-branch input, all router probabilities,
+and the complete first decoder-layer output.
+
+Run the full raw-prompt comparison, or add `--chat-file` for a canonical UTF-8
+user turn:
+
+```powershell
+python tests\validate_gemma4_full.py `
+  .\gemma4.exe `
+  .\build-gemma4\llama-gemma4-oracle.exe `
+  C:\path\to\gemma4.gguf C:\path\to\packed-gemma4 `
+  --llama-bin C:\path\to\llama.cpp\build\bin\Release `
+  --chat-file C:\path\to\user-message-utf8.txt
+```
+
+## Real-model validation
+
+The native index opens the 14,439,363,584-byte QAT Q4_0 model and validates 658
+tensors, 30 layers, width 2,816, vocabulary 262,144, 128 experts, and top-8
+routing. On the saved layer-0 input from the companion lab:
+
+- the C router and an independent NumPy implementation selected the same eight
+  experts in the same order;
+- the maximum probability difference was `4.28e-8`;
+- the routed aggregate was compared with eight independent `g4lab expert-cpu`
+  replays, with maximum absolute error `1.79e-6` and RMS error `3.41e-7`.
+- sliding layer 0 and global layer 5 attention projections were checked against
+  independent NumPy Q4_0 dequantization. The worst Q/K/V maximum absolute error
+  was `3.81e-6`; every projected value was finite.
+- default and proportional RoPE at position 123 were checked on those same
+  layers. The worst rotated-Q error was `2.86e-6` and the worst rotated-K error
+  was `2.98e-7`; the synthetic suite also covers sliding-cache wraparound.
+- two-token causal attention plus output projection was checked independently
+  on sliding layer 0 and global layer 5. Maximum absolute errors were
+  `3.81e-6` and `4.29e-6`, respectively, with RMS error below `3.7e-7`.
+- the resident gated-GELU MLP was independently decoded from Q4_0 on layers 0
+  and 5, with maximum absolute errors `2.38e-6` and `4.29e-6`. A focused
+  two-token oracle then recomposed every decoder norm, branch add, residual,
+  routed expert call, and layer scalar; its outputs matched `layer-seq`
+  exactly on both layers.
+- a current llama.cpp graph independently evaluated the same two-token layer-0
+  input. Colibri selected the same router top-8, router probabilities differed
+  by at most `1.14e-6`, and the complete layer output reached cosine similarity
+  above `0.99994` with RMS error below `0.015`.
+- the native tokenizer matched current llama.cpp token-for-token on ASCII,
+  repeated spaces/newlines, emoji, accented Latin text, an em dash, CJK text,
+  and multi-digit input; the synthetic suite also exercises byte fallback.
+- the canonical single-user chat frame, including its control-token boundaries
+  and UTF-8 content, matched llama.cpp's special-token parse exactly (18/18
+  tokens on the saved real-model probe).
+- the canonical system-plus-user frame was derived from the target GGUF's
+  embedded 2026-07-09 Google template and matched llama.cpp token-for-token
+  (25/25 IDs), including whitespace trimming and the empty thought channel.
+- the canonical image-first frame was partitioned exactly around `<|image>` and
+  `<image|>`. Recombining its five prefix and seventeen suffix IDs matched
+  current llama.cpp's special-token parse exactly (22/22 IDs) on the target
+  GGUF.
+- a synthetic two-token image chunk independently recomputed Q/K/V, RoPE,
+  two-key softmax, and output projection. The first image position attended the
+  later image position as required, matching the native non-causal path within
+  `1e-5`; the same decoder then returns to causal evaluation.
+- the native projector index opened the real 1,194,828,160-byte GGUF v3 and
+  validated 356 tensors, 27 blocks, width 1,152, feed-forward width 4,304,
+  16 heads, patch size 16, and decoder projection width 2,816. Its core F32/BF16
+  tensor shapes match the Gemma 4 vision graph.
+- reference-compatible smart resize maps a 1920x1080 source to 1056x576 and
+  264 projected tokens (22x12). Synthetic tests cover ordinary/max-area sizing,
+  bilinear RGB endpoint values, normalization, and 16-pixel patch/3x3 pool
+  geometry.
+- the real patch/position probe mapped a deterministic 48x48 source to 441
+  width-1,152 vectors in about 91 ms. An independent NumPy convolution and X/Y
+  lookup reached cosine similarity `0.999999642` and RMS error `2.79e-4`; five
+  scalar-order spot checks differed by at most `1.57e-4`.
+- the complete native vision tower evaluated those 441 patches through all 27
+  blocks, pooled them to 49 tokens, calibrated them, and projected each token to
+  width 2,816 in about 46 seconds on the local Release build. Against current
+  llama.cpp, layer 0 reached cosine similarity `0.999999807` with RMS error
+  `0.00137`; the final 137,984 projected values reached cosine `0.999975707`
+  with RMS error `0.00800` and maximum absolute error `0.1301`.
+- the restored matching llama.cpp runtime also evaluated the complete
+  image-conditioned decoder. End-to-end vocabulary logits reached cosine
+  `0.999673543`, RMS `0.18775`, and maximum error `0.92984`; both paths produced
+  the same top-10 candidate set, although projector drift inverted the nearly
+  tied top two (`27.9531` versus `27.9500` natively). Feeding llama.cpp's saved
+  projected vectors into the native decoder reproduced llama.cpp's exact
+  top-10 order, isolating that inversion to accumulated vision-projector
+  arithmetic rather than image insertion or decoder/KV semantics.
+- the oracle now captures transformer-depth checkpoints in the same run. The
+  native-vs-llama.cpp RMS/cosine curve is layer 0 `0.00137/0.999999807`, layer
+  8 `0.00484/0.999999974`, layer 17 `0.05046/0.999999499`, and layer 26
+  `0.69951/0.999957335`. The late, nonlinear growth localizes the remaining
+  ordering discrepancy to accumulated tower arithmetic (especially reduction
+  order in repeated BF16 matmuls and attention), while projection compresses
+  the final hidden-state difference back to RMS `0.00800`.
+- matching ggml's BF16 activation conversion before projector matrix products
+  restored the previously inverted top-two order: both runtimes now select
+  token `236776` first. The oracle enforces top-1 equality in addition to the
+  existing top-10 set and decoder-ranking checks. Conversion is hoisted once
+  per activation tensor, keeping the full validation at about 410 seconds
+  instead of the naive inner-product implementation's 676 seconds.
+- a live 26-token system-plus-user prompt completed the full 30-layer path and
+  greedily produced `Hi`, confirming the frame is accepted by generation as
+  well as the standalone tokenizer.
+- a real weather-function declaration produced a 93-token prompt that matched
+  the GGUF Jinja template plus llama.cpp tokenizer exactly (93/93 IDs). The
+  native synthetic suite independently covers schema validation, property
+  sorting, enums, and empty tool lists.
+- a live 97-token tool prompt made the Q4 model emit
+  `<|tool_call>call:get_weather{city:<|"|>Rome<|"|>}<tool_call|>` and stop on
+  `<|tool_response>`, confirming the declaration-to-call handoff end to end.
+- a live interactive tool round trip accepted
+  `{"city":"Rome","temp_c":31,"conditions":"sunny"}`, evaluated the
+  canonical response block in the same KV cache, resumed the model turn, and
+  produced `The weather in Rome is currently sunny with a temperature of
+  31°C.` before `<turn|>`.
+- native Q6_K decoding reproduced llama.cpp's scaled BOS embedding bit-exactly.
+  Given llama.cpp's saved final residual, the final norm differed by at most
+  `9.54e-6`, vocabulary logits reached cosine similarity `0.999962`, and both
+  implementations selected token `3324` as top-1.
+- the complete native 30-layer pass over `BOS + Hello` selected that same token
+  `3324`. Its final residual reached cosine similarity `0.999837` and its logits
+  reached `0.999280`; the first nine ranked candidate IDs were identical and in
+  the same order. The local Release run completed in about five seconds.
+- an 18-token canonical UTF-8 chat prompt was then evaluated end to end by both
+  runtimes. The final residual and logits reached cosine similarities `0.999904`
+  and `0.999905`, respectively, and all top-10 candidate IDs matched in exactly
+  the same order, led by token `236776`.
+- a live greedy chat smoke test for “Say hello in one short sentence.” produced
+  `Hello there!` and terminated correctly on `<turn|>` after four generated
+  tokens.
+- paired temperature `0.8`, top-k `20`, top-p `0.9` runs with seed `123` were
+  byte-for-byte reproducible and produced `Hello! How can I help you today` in
+  the bounded eight-token probe.
+- a persistent two-turn test first established “my name is Alice” and received
+  `OK<turn|>`, then asked “What is my name?” in the same process and received
+  `Your name is Alice.<turn|>`, confirming retained context and turn-boundary KV
+  alignment.
+
+- cached and uncached real-model generation produced identical greedy text; a
+  256-record cache reported 240 hits over the four evaluated token positions,
+  while the synthetic suite verifies exact output through both cache hits and
+  forced single-slot LRU evictions.
+- the protected-tier suite raises a streamed expert above Colibri's LFRU
+  hysteresis, swaps it into the hot tier without a disk reload, records later
+  protected hits, and preserves the exact weighted expert output.
+- a saved usage profile atomically round-trips cumulative counts and seeds the
+  hottest protected record in a fresh backend; the real two-process smoke test
+  doubled its cumulative selection count and improved warm-start cache hits
+  while preserving generated output.
+- asynchronous staging overlapped those same real-model record reads with the
+  resident dense branch, reduced paired wall time by 16.6%, and produced the
+  same greedy text; the synthetic suite verifies cold-worker and all-hit paths.
+
+## Deliberate boundary
+
+This milestone is a usable persistent CPU text-chat generator with canonical
+system instructions, complete interactive tool declaration/call/response
+continuation, the correct multimodal decoder insertion/attention boundary, and
+native projector inspection/image-to-patch preprocessing and patch/position
+embedding, the complete native vision transformer and decoder-width projection,
+plus bounded LRU,
+live/persistent learned placement, and lossless I/O overlap.
+The follow-up integration stages are now implemented: the matching llama.cpp
+runtime and image-conditioned final-logit oracle, portable libpng/libjpeg codec
+paths, persistent per-slot Gemma KV reuse, constrained grammar sampling, and
+OpenAI/Anthropic tool-call serving. The streaming parser recognizes Gemma's
+native call sentinels across arbitrary engine-chunk boundaries, emits each
+complete structured call, supports multiple calls, and never exposes protocol
+markers as assistant text. Cooperative prefill/decode cancellation and opt-in
+parallel execution through isolated Gemma workers and aggregate per-worker
+expert/profile telemetry are also implemented and validated. The explicit
+MSVC/AVX2 compatibility path is now bit-identical to llama.cpp through the
+projected image vectors; final top-1 and top-10 behavior also matches.
+
+The saved oracle was also used to test individual compatibility changes before
+the `0.29.0` release. None was safe as a standalone production change. The
+operation trace subsequently identified the compatible combination and it is
+available as the explicit `llama-avx2` isolation path. This path combines
+ggml-compatible patch vec-dot, RMS accumulation, RoPE frequency iteration,
+BF16 tinyBLAS/FMA, tiled attention, and FP16 quick-GELU semantics while leaving
+default portable arithmetic unchanged.
+
+The probe now supports exact boundary replay and per-operation traces. This
+example evaluates only block 17 from a saved llama.cpp layer-16 boundary and
+writes each native intermediate for `compare_gemma4_vision_trace.py`:
+
+```powershell
+$env:COLI_GEMMA4_VISION_COMPAT = "llama-avx2"
+.\gemma4.exe vision-encode-probe MMPROJ.gguf 48 48 `
+  --layers 18 --start-layer 17 --input-f32 llama-vision-layer17.f32 `
+  --trace-layer 17 --trace-dir trace --output-f32 native-layer18.f32
+python tests\compare_gemma4_vision_trace.py trace --layer 17
+```
+
+Pass `--prepared-f32 PATH` to also write the planar, scaled image tensor at the
+convolution boundary. The validator requires this tensor to be bit-identical
+to llama.cpp. Matching llama.cpp's ratio-first bilinear coordinate arithmetic
+removed 361 one-byte resize discrepancies on the canonical 48x48 input.
+
+The full validator runs this exact-input trace automatically. With default
+arithmetic, block-17 RMS is `0.00592096`. The completed `llama-avx2` path is
+bit-identical at every captured operation. Two final association fixes close
+the previous residuals: flash attention adds each double tile sum to the
+current float accumulator before rounding, and patch convolution uses ggml's
+four-register vec-dot plus two `_mm_hadd_ps` reductions. Layers 0, 8, 17, and
+26 and all `137,984` projected values now have RMS and maximum error `0`.
+The full tower takes about `59.3 s`, within 15% of the portable path.
+The final canonical run measured layer-17 RMS `0.05016`, layer-26 RMS `0.71726`,
+projection RMS `0.008595`, and vocabulary-logit RMS `0.21298`; top-1 and the
+top-10 candidate set matched llama.cpp.
+
+With portable production arithmetic, the exact resize correction measures layer-17
+RMS `0.050049`, layer-26 RMS `0.715061`, projection RMS `0.008437`, and logit
+RMS `0.215213`; top-1 and the top-10 candidate set still match. With
+`llama-avx2`, image-conditioned logit RMS is `0.214735`, exactly equal to the
+native decoder's result when fed llama.cpp image vectors; this isolates the
+remaining logit difference to decoder arithmetic rather than vision.
+
+Keeping those stages separate makes graph errors distinguishable from storage,
+quantization, and cache-placement errors.


### PR DESCRIPTION
## Summary

Add a standalone Gemma 4 MoE runtime that follows Colibri's dependency-free CPU design and disk-streamed expert model.

The smallest reviewable scope includes:

- GGUF loading, tokenizer/chat templates, sampling, tool declaration rendering, and image preprocessing/vision execution
- a tiered expert backend with bounded RAM residency, disk streaming, usage persistence, and asynchronous prefetch
- focused C tests plus llama.cpp oracle and numerical-validation utilities
- integration with Colibri's existing Makefile and CI, plus inspection tooling and implementation documentation

This PR intentionally does **not** add another build system, launcher/OpenAI gateway/WebUI integration, release packaging. CUDA kernel source validated during development is included, but wiring it into Colibri's existing platform-specific CUDA build conventions is left for follow-up.

## AI disclosure

The implementation, tests, and documentation in this PR were fully generated with OpenAI Codex under my direction. I reviewed the resulting changes, resolved the upstream integration and scope, built and tested the code on Windows, exercised real Gemma 4 inference on CPU and CUDA during development, and take responsibility for the submitted code.

## Validation

- [x] Clean warning-enabled GCC/w64devkit build of `gemma4.exe` and all seven Gemma C test executables
- [x] Seven focused Gemma C tests passed under GCC/w64devkit after the Make-only cleanup
- [x] `git diff --check`
- [ ] `make -C c check`

The complete local check is currently blocked by pre-existing Windows/toolchain failures outside this diff:

1. The default DeepSeek V4 unit build forces `-flto`, but this w64devkit GCC reports that LTO support is unavailable. With the supported `LTO=0` override, the untouched DeepSeek V4 test still fails to link `coli_v4_layer_gpu*`, `coli_v4_engine_config`, and `coli_v4_route_bf16`.
2. Running the Python gate independently executes 773 tests (49 skipped) and ends with two untouched FP8 harness failures: a subprocess command does not quote the `C:\Program Files\...` compiler path, and the E2E harness omits the Windows-required `-D_FILE_OFFSET_BITS=64` definition.

Additional development validation, before narrowing the checked-in build integration to Make, included a warning-free Visual Studio 2022/CUDA 12.4 build, 7/7 focused tests, and real `gemma-4-26B-A4B` Q4 generation on a Quadro P1000 4 GB that produced `Hello`.

## Compatibility

- [x] The default Gemma CPU build has no new mandatory third-party dependency
- [x] The checked-in build integration uses Colibri's existing Makefile
- [x] No model files, generated binaries, packed weights, or benchmark artifacts are included
- [x] PR targets `dev` and remains a single focused commit based on current `upstream/dev`

## Follow-up

Separate changes can wire the validated CUDA kernel into Colibri's existing CUDA conventions and integrate Gemma with the current launcher/OpenAI gateway/WebUI and release packaging after the engine API and model behavior are reviewed.
