### PR TITLE
fix(pilot): the prefetch worker outlives the Model it dereferences

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -11079,7 +11079,13 @@ int main(int argc, char **argv){
         atexit(cluster_close_all);
     }
 #endif
-    Model m; double t0=now_s(); model_init(&m,snap,cap,ebits,dbits);
+    /* static, not a stack local: the PILOT prefetch worker is detached and
+     * loops forever, and it keeps this address in the global pilot_m. A stack
+     * Model dies when main returns while that thread is still dereferencing
+     * it -- ASan: stack-use-after-return, READ of size 8, in a worker thread,
+     * with the run's tokens already correct (#1262). Static storage outlives
+     * every thread, so the pointer the worker holds stays valid. */
+    static Model m; double t0=now_s(); model_init(&m,snap,cap,ebits,dbits);
     /* KV_TQ requires power-of-two row widths: both codecs rotate through a
      * radix-2 FWHT, and coli_kvq_quant_row returns an inert radius 0 for any
      * other width. On a model whose kv_lora/qk_rope are not powers of two that

--- a/c/olmoe.c
+++ b/c/olmoe.c
@@ -1493,7 +1493,13 @@ int main(int argc, char **argv) {
             fprintf(stderr, "CTX must be 1..4096 (got %d)\n", ctx_cap);
             return 1;
         }
-        Model m; model_init(&m, snap, cap, bits);
+    /* static, not a stack local: the PILOT prefetch worker is detached and
+     * loops forever, and it keeps this address in the global pilot_m. A stack
+     * Model dies when main returns while that thread is still dereferencing
+     * it -- ASan: stack-use-after-return, READ of size 8, in a worker thread,
+     * with the run's tokens already correct (#1262). Static storage outlives
+     * every thread, so the pointer the worker holds stays valid. */
+        static Model m; model_init(&m, snap, cap, bits);
         m.max_t = ctx_cap;
         m.K = calloc(m.c.n_layers, sizeof(float*)); m.V = calloc(m.c.n_layers, sizeof(float*));
         for (int i = 0; i < m.c.n_layers; i++) {
@@ -1525,7 +1531,13 @@ int main(int argc, char **argv) {
             fprintf(stderr, "CTX must be 1..4096 (got %d)\n", ctx_cap);
             return 1;
         }
-        Model m; model_init(&m, snap, cap, bits);
+    /* static, not a stack local: the PILOT prefetch worker is detached and
+     * loops forever, and it keeps this address in the global pilot_m. A stack
+     * Model dies when main returns while that thread is still dereferencing
+     * it -- ASan: stack-use-after-return, READ of size 8, in a worker thread,
+     * with the run's tokens already correct (#1262). Static storage outlives
+     * every thread, so the pointer the worker holds stays valid. */
+        static Model m; model_init(&m, snap, cap, bits);
         printf("resident weights loaded in %.1fs | RSS after load: %.2f GB\n", m.dense_load_s, rss_gb());
         Tok T;
         char tokpath[2048]; snprintf(tokpath, sizeof(tokpath), "%s/tokenizer.json", snap);
@@ -1551,7 +1563,13 @@ int main(int argc, char **argv) {
     int np, nfull; int *prompt = read_int_array(ref,"prompt_ids",&np); int *full = read_int_array(ref,"full_ids",&nfull);
     int n_new = nfull - np;
 
-    Model m; model_init(&m, snap, cap, bits);
+    /* static, not a stack local: the PILOT prefetch worker is detached and
+     * loops forever, and it keeps this address in the global pilot_m. A stack
+     * Model dies when main returns while that thread is still dereferencing
+     * it -- ASan: stack-use-after-return, READ of size 8, in a worker thread,
+     * with the run's tokens already correct (#1262). Static storage outlives
+     * every thread, so the pointer the worker holds stays valid. */
+    static Model m; model_init(&m, snap, cap, bits);
     printf("resident weights loaded in %.1fs | RSS after load: %.2f GB\n", m.dense_load_s, rss_gb());
 
     if (getenv("PPL") && atoi(getenv("PPL")) == 1) {   /* loss-meter mode: teacher-forced NLL */

--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -2606,7 +2606,13 @@ int main(int argc, char **argv) {
         if (getenv("ENC_DEBUG") && np <= 300) { fprintf(stderr, "[enc] prompt ids: "); for (int i=0;i<np;i++) fprintf(stderr, "%d ", prompt[i]); fprintf(stderr, "\n"); }
     }
 
-    Model m; model_init(&m, snap, cap, bits);
+    /* static, not a stack local: the PILOT prefetch worker is detached and
+     * loops forever, and it keeps this address in the global pilot_m. A stack
+     * Model dies when main returns while that thread is still dereferencing
+     * it -- ASan: stack-use-after-return, READ of size 8, in a worker thread,
+     * with the run's tokens already correct (#1262). Static storage outlives
+     * every thread, so the pointer the worker holds stays valid. */
+    static Model m; model_init(&m, snap, cap, bits);
     g_expert_gs = m.c.expert_gs;
     if (g_expert_gs) fprintf(stderr, "[qwen36] group-scaled experts: gs=%d\n", g_expert_gs);
     fprintf(stderr, "resident weights loaded in %.1fs | RSS after load: %.2f GB\n", m.dense_load_s, rss_gb());

--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -1145,6 +1145,9 @@ static void validate_cfg(const Cfg *c, int n_layers_from_config) {
 }
 
 static void load_meta(Cfg *c, const char *snap) {
+    /* is_attn was sized by load_cfg from config.json and is NOT resized here, so
+     * every write below is bounded by this count, not by whatever the meta says. */
+    const int is_attn_len = c->n_layers;
     char path[2048]; snprintf(path, sizeof(path), "%s/qwen36_meta.json", snap);
     FILE *f = fopen(path, "rb"); if (!f) { printf("[meta] %s not found; using i%%4==3 + defaults\n", path); return; }
     fseek(f,0,SEEK_END); long n=ftell(f); fseek(f,0,SEEK_SET);
@@ -1165,6 +1168,16 @@ static void load_meta(Cfg *c, const char *snap) {
         G("dn_vheads", dn_vheads); G("dn_kheads", dn_kheads); G("dn_kdim", dn_kdim);
         G("dn_vdim", dn_vdim); G("dn_convk", dn_convk); G("dn_conv_dim", dn_conv_dim);
         #undef G
+        /* validate_cfg makes exactly this check, and used to be the only one --
+         * but it runs AFTER load_meta returns, one line too late to stop the
+         * is_attn writes below. A container whose config.json said 4 layers and
+         * whose meta said 8 therefore wrote past a 4-byte allocation before
+         * anything refused it: ASan heap-buffer-overflow at the layer_types
+         * loop, reached from an ordinary model directory. Refuse here, while
+         * is_attn is still the only thing that has been sized. */
+        CFG_NEED(c->n_layers == is_attn_len,
+                 "config.json says %d layers, qwen36_meta.json says %d",
+                 is_attn_len, c->n_layers);
         if((v=json_get(r,"partial_rotary_factor"))&&v->t==J_NUM) c->partial_rotary_factor=(float)v->num;
         if((v=json_get(r,"rope_theta"))&&v->t==J_NUM) c->theta=(float)v->num;
         if((v=json_get(r,"rms_eps"))&&v->t==J_NUM) c->eps=(float)v->num;

--- a/c/tests/test_family_registry.py
+++ b/c/tests/test_family_registry.py
@@ -904,6 +904,7 @@ class FamilyRegistryTest(unittest.TestCase):
         release = (repo / ".github" / "workflows" / "release.yml").read_text(
             encoding="utf-8")
         docker = (repo / "docker" / "Dockerfile.slim").read_text(encoding="utf-8")
+        clean = (repo / "c" / "tools" / "clean.py").read_text(encoding="utf-8")
         make_rules = re.sub(r"\\\n[ \t]*", " ", makefile)
         install_rule = re.search(r"(?m)^install:\s*(.*)$", make_rules)
         self.assertIsNotNone(install_rule)
@@ -937,6 +938,16 @@ class FamilyRegistryTest(unittest.TestCase):
                                   f"{family.id}: release.yml copies "
                                   f"c/{family.engine_artifact} but never builds it")
                     self.assertIn(f"$(LIBEXECDIR)/{family.engine_artifact}", makefile)
+                    # `make clean` must actually remove the engine. When it does
+                    # not, a rebuild with different EXTRA_CFLAGS reports "up to
+                    # date" and the caller silently keeps the OLD binary. The
+                    # ASan step of the Qwen3.6 oracle job re-ran an
+                    # un-instrumented qwen36 that way for as long as it existed
+                    # (#1262): green, with the sanitizer never having run.
+                    self.assertIn(f'"{family.engine_artifact}"', clean,
+                                  f"{family.id}: tools/clean.py does not remove "
+                                  f"c/{family.engine_artifact}, so a rebuild with "
+                                  f"different flags is a silent no-op")
                 else:
                     self.assertIn("deepseek-v4", ci)
                     self.assertIn("cp c/deepseek_v4", release)

--- a/c/tools/clean.py
+++ b/c/tools/clean.py
@@ -14,6 +14,14 @@ FILES = [
     "inkling", "inkling.exe",
     "kimi_k3", "kimi_k3.exe",
     "olmoe", "olmoe.exe",
+    # Missing here means `make clean` leaves the binary in place, and a rebuild
+    # with different EXTRA_CFLAGS then reports "up to date". That is how the
+    # `Qwen3.6 tiny oracle` job re-ran an UN-INSTRUMENTED binary from its ASan
+    # step for as long as it existed (#1262), reporting green while the
+    # sanitizer had never run. test_family_registry keeps this list and the
+    # registry in step.
+    "qwen36", "qwen36.exe",
+    "glm53", "glm53.exe",
     "glm", "glm.exe",                       # pre-rename name of the colibri engine
     "iobench", "iobench.exe",
     "backend_cuda.o", "backend_loader.o",


### PR DESCRIPTION
Closes #1262.

## The defect

The PILOT prefetch worker is `pthread_detach`ed, loops forever, and nothing stops it. It keeps the Model address in the global `pilot_m`. That Model was a **stack local in main**, so when main returns the frame dies while the worker is still dereferencing it:

    AddressSanitizer: stack-use-after-return
    READ of size 8 ... thread T4
    Matching tokens: 16/16

The correct tokens are consistent with the defect rather than evidence against it: the work is finished by then, and what remains is a thread reading a frame that no longer exists.

Present in **three engines**, all with a never-stopped worker holding a stack Model: `qwen36.c` (main), `olmoe.c` (three branches of main), `colibri.c` (main). colibri's other stack Model, in `cluster_worker_run`, never reaches the pilot path and is left alone.

## Why this fix

Two ways to close a lifetime gap: widen the object's lifetime or bound the thread's. Static storage outlives every thread, so the pointer the worker holds stays valid through exit, and main runs once and never recurses so nothing else changes. Bounding the thread instead needs a stop flag plus a join on every return path in main; that is more risk than a teardown race earns, and a wrong version of it hangs the process.

## Demonstrated, not argued

I could not make the race fire, so the fix rests on the lifetime rather than on a red test going green. What I could measure is the mechanism, by printing the Model address against `/proc/self/maps`:

    before   Model=0x7ffebbd911c0   stack=[7ffebbd7a000-7ffebbd9b000]   INSIDE the stack
    after    Model=0x5e867a557100   stack=[7ffde5aa2000-7ffde5ac3000]   outside it

**Stating the limit plainly:** 28 attempts did not reproduce it, including with `detect_stack_use_after_return=1`, four OpenMP threads, and twelve concurrent processes, on the same GCC 13.3.0 the CI runs. The window is between main returning and the process exiting.

## Why CI was green while this was broken

Worth recording, because the green was a false negative. The `Qwen3.6 tiny oracle` job builds `qwen36` twice, the second time with sanitizers. Two things made that second build a no-op: `c/tools/clean.py`'s `FILES` list did not contain `qwen36`, so `make clean` removed nothing, and the `qwen36` target has no dependency on the build configuration, so different `EXTRA_CFLAGS` did not invalidate it. The step named "Same run under ASan + UBSan" was re-running the **un-instrumented** binary, at `nm | grep -c __asan` = 0.

#1250 adds `qwen36` and `qwen38` to that list, which is why a defect that was always there surfaced on that branch and nowhere else. #1250 did not introduce this; it repaired the check that was hiding it.

That also means **#1232 and #1271 are green under the same blind spot** — both touch `qwen36.c`, and neither has actually run a sanitized binary.

## Checks

- qwen36 token-exact at caps 1, 4, 8 and 16
- `test_qwen36_cache_index`, `test_qwen36_ctx`, `test_qwen36_dense_batch`, `test_qwen36_json_escape` pass
- qwen36, olmoe and colibri all build; no new warnings (the four in `qwen36.c` are pre-existing and fixed by #1232)
- sanitized qwen36 (31 `__asan` symbols, so genuinely instrumented) clean over repeated runs