### PR TITLE
feat(qwen38): image preprocessing, pinned against the official processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ c/*.obj
 c/kimi_k3_tiny/.vendor_kimi_k3/
 c/kimi_k3_tiny/.coli_usage
 c/qwen38_vision_tiny/
+c/qwen38_mm_tiny/

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ c/*.obj
 # vendor modeling cache for the tiny K3 oracle (maintainer tool)
 c/kimi_k3_tiny/.vendor_kimi_k3/
 c/kimi_k3_tiny/.coli_usage
+c/qwen38_vision_tiny/

--- a/c/Makefile
+++ b/c/Makefile
@@ -1151,6 +1151,15 @@ qwen38-vision-check: tests/test_qwen38_vision$(EXE)
 	$(PYTHON) tools/make_qwen38_vision_tiny.py --out ./qwen38_vision_tiny
 	./tests/test_qwen38_vision$(EXE) ./qwen38_vision_tiny
 
+# Il percorso completo: frame IMAGE, torre, sostituzione degli embedding,
+# generazione. Prova che due immagini diverse danno risposte diverse, che e'
+# l'unica domanda a cui una fixture con pesi casuali sa rispondere onestamente.
+.PHONY: qwen38-vision-serve-check
+qwen38-vision-serve-check: qwen38$(EXE)
+	$(PYTHON) tools/make_qwen38_multimodal_tiny.py --out ./qwen38_mm_tiny
+	$(PYTHON) tools/make_edge_tiny_tokenizer.py --vocab-size 64 ./qwen38_mm_tiny
+	$(PYTHON) tests/test_qwen38_vision_serve.py --binary ./qwen38$(EXE) --fixture ./qwen38_mm_tiny
+
 tests/test_qwen38_prefix$(EXE): tests/test_qwen38_prefix.c qwen38.c qwen38_core.h qwen38_nfc.h qwen38_nfc_tables.h st.h json.h compat.h quant.h route_trace.h serve_codec.h tok_unicode.h tok_unicode_o200k.h
 	$(CC) $(NOCUDA_CFLAGS) $< -o $@ $(NOCUDA_LDFLAGS)
 

--- a/c/Makefile
+++ b/c/Makefile
@@ -1141,6 +1141,16 @@ tests/test_qwen38_config$(EXE): tests/test_qwen38_config.c qwen38.c qwen38_core.
 tests/test_qwen38_serve_framing$(EXE): tests/test_qwen38_serve_framing.c qwen38.c qwen38_core.h qwen38_nfc.h qwen38_nfc_tables.h st.h json.h compat.h quant.h route_trace.h serve_codec.h tok_unicode.h tok_unicode_o200k.h
 	$(CC) $(NOCUDA_CFLAGS) $< -o $@ $(NOCUDA_LDFLAGS)
 
+tests/test_qwen38_vision$(EXE): tests/test_qwen38_vision.c qwen38_vision.h st.h json.h compat.h
+	$(CC) $(CFLAGS) -Wno-unused-function $< -o $@ $(LDFLAGS)
+
+# Genera la fixture della torre e la confronta con l'oracolo upstream. Non serve
+# il checkpoint: 240k parametri casuali, meno di un megabyte.
+.PHONY: qwen38-vision-check
+qwen38-vision-check: tests/test_qwen38_vision$(EXE)
+	$(PYTHON) tools/make_qwen38_vision_tiny.py --out ./qwen38_vision_tiny
+	./tests/test_qwen38_vision$(EXE) ./qwen38_vision_tiny
+
 tests/test_qwen38_prefix$(EXE): tests/test_qwen38_prefix.c qwen38.c qwen38_core.h qwen38_nfc.h qwen38_nfc_tables.h st.h json.h compat.h quant.h route_trace.h serve_codec.h tok_unicode.h tok_unicode_o200k.h
 	$(CC) $(NOCUDA_CFLAGS) $< -o $@ $(NOCUDA_LDFLAGS)
 

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -1480,6 +1480,62 @@ def _image_bytes_from_url(url):
         raise APIError(400, f"cannot read image {path}: {problem}", "messages")
 
 
+# Qwen3.8 splices images as <|vision_start|> + N x <|image_pad|> + <|vision_end|>,
+# and N is not a constant: the resolution is dynamic, so it comes from the grid
+# the preprocessor chose. Hardcoding it would put the right vectors in the wrong
+# number of slots, which the engine refuses rather than guesses about.
+QWEN38_VISION_START = "<|vision_start|>"
+QWEN38_IMAGE_PAD = "<|image_pad|>"
+QWEN38_VISION_END = "<|vision_end|>"
+
+
+def _preprocess_qwen38_image(data, model_dir, max_tokens=None):
+    try:
+        import sys as _sys
+        from pathlib import Path as _Path
+        _sys.path.insert(0, str(_Path(__file__).resolve().parent / "tools"))
+        from qwen38_image import preprocess
+    except ImportError as problem:
+        raise APIError(400, f"image support needs Pillow and numpy ({problem}).",
+                       "messages")
+    return preprocess(data, model_dir, max_tokens)
+
+
+def expand_qwen38_images(messages, model_dir, max_tokens=None):
+    """Replace image parts with their placeholders and pull out the patches.
+
+    Returns (rewritten messages, images). The messages come back as plain text,
+    so the renderer treats them like any other turn."""
+    images = []
+    rewritten = []
+    for message in messages:
+        content = message.get("content") if isinstance(message, dict) else None
+        if not isinstance(content, list):
+            rewritten.append(message)
+            continue
+        pieces = []
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            kind = part.get("type")
+            if kind == "text":
+                pieces.append(part.get("text", ""))
+            elif kind in ("image_url", "input_image"):
+                url = (part.get("image_url") or {}).get("url") if kind == "image_url" \
+                      else part.get("image_url") or part.get("url")
+                data = _image_bytes_from_url(url)
+                patches, grid_h, grid_w = _preprocess_qwen38_image(
+                    data, model_dir, max_tokens)
+                tokens = (grid_h // 2) * (grid_w // 2)
+                images.append((patches, grid_h, grid_w))
+                pieces.append(QWEN38_VISION_START + QWEN38_IMAGE_PAD * tokens
+                              + QWEN38_VISION_END)
+            else:
+                raise APIError(400, f"unsupported content part {kind!r}.", "messages")
+        rewritten.append({**message, "content": "".join(pieces)})
+    return rewritten, images
+
+
 def expand_glm53_images(messages, model_dir):
     """Sostituisce le parti immagine coi loro segnaposto e ne estrae le patch.
 
@@ -3680,6 +3736,15 @@ class APIHandler(BaseHTTPRequestHandler):
         if ARCH == "glm53":
             messages, images = expand_glm53_images(
                 messages, getattr(self.server.engine, "model_dir", None))
+            if len(images) > 1:
+                raise APIError(400, "one image per request for now; the engine "
+                                    "holds a single pending image.", "messages")
+            image = images[0] if images else None
+        elif ARCH == "qwen38":
+            ceiling = os.environ.get("Q38_MAX_IMAGE_TOKENS")
+            messages, images = expand_qwen38_images(
+                messages, getattr(self.server.engine, "model_dir", None),
+                int(ceiling) if ceiling else None)
             if len(images) > 1:
                 raise APIError(400, "one image per request for now; the engine "
                                     "holds a single pending image.", "messages")

--- a/c/qwen38.c
+++ b/c/qwen38.c
@@ -60,6 +60,7 @@ static int qwen38_max_ctx(void) {
 #include <unistd.h>
 #endif
 #include "st.h"
+#include "qwen38_vision.h"
 #include "json.h"   /* tokenizer.json parsing (reuse minimal parser) */
 #include "tok_unicode.h"
 #include "tok_unicode_o200k.h"
@@ -1137,6 +1138,19 @@ static const ColiServeWireProfile q38_wire = {
 /* Returns 2=SUBMIT, 1=STOP(active), 3=CANCEL(active), 0=ignored, -1=EOF/fatal.
  * A SUBMIT encountered during a synchronous turn is consumed and rejected so
  * its payload cannot desynchronize the following control frame. */
+/* Un'immagine in attesa del SUBMIT che la usa. Se ne arriva una seconda prima
+ * del SUBMIT, la prima viene buttata e lo si dice: rispondere sulla foto
+ * precedente senza avvisare sarebbe peggio di rifiutare. */
+static struct { unsigned char *patches; uint64_t bytes; int grid_h, grid_w; int present; } g_pending_image;
+/* Il modello del turno in corso, per poter rifiutare un'immagine gia' alla
+ * lettura del frame invece che dopo averla accettata. */
+static Model *g_serve_model;
+
+static void q38_pending_image_clear(void){
+    free(g_pending_image.patches);
+    memset(&g_pending_image,0,sizeof g_pending_image);
+}
+
 static int serve_read_req(FILE *in,FILE *out,ServeReq *q,const char *active_id){
     ColiServeCommand command;
     ColiServeReadResult result=coli_serve_read_command(in,&q38_wire,&command);
@@ -1152,6 +1166,22 @@ static int serve_read_req(FILE *in,FILE *out,ServeReq *q,const char *active_id){
         int active=active_id&&!strcmp(command.id,active_id);
         int control=active?(command.kind==COLI_SERVE_COMMAND_STOP?1:3):0;
         coli_serve_command_dispose(&command);return control;
+    }
+    if(command.kind==COLI_SERVE_COMMAND_IMAGE){
+        if(!g_serve_model||!g_serve_model->vis_ready){
+            coli_serve_write_error(out,command.id,
+                "this engine has no vision tower; images are not supported");
+            coli_serve_command_dispose(&command);return 0;
+        }
+        if(g_pending_image.present)
+            fprintf(stderr,"[qwen38] a second image arrived before its SUBMIT; dropping the first\n");
+        q38_pending_image_clear();
+        g_pending_image.patches=coli_serve_command_take_payload(&command);
+        g_pending_image.bytes=command.payload_bytes;
+        g_pending_image.grid_h=command.grid_h;
+        g_pending_image.grid_w=command.grid_w;
+        g_pending_image.present=1;
+        coli_serve_command_dispose(&command);return 0;
     }
     if(command.kind!=COLI_SERVE_COMMAND_SUBMIT){coli_serve_command_dispose(&command);return 0;}
     if(active_id){
@@ -1437,6 +1467,25 @@ static int q38_format_prof(char *out,size_t capacity,double wall_s,int prompt_to
 static int serve_one(Model *m, ServeReq *q){
     int *ids=NULL, np=0;
     encode_text_n(q->payload,(size_t)q->plen,&ids,&np); /* byte-counted prompt; qwen38 adds no BOS */
+    if(g_pending_image.present){
+        /* Le patch arrivano gia' float32 dal gateway: qui si controlla solo che
+         * ce ne sia un numero intero e che la griglia le giustifichi, perche' un
+         * conteggio storto darebbe una torre alimentata con byte disallineati. */
+        Cfg *vc=&m->c;
+        int features=vc->vis_in_ch*vc->vis_temporal*vc->vis_patch*vc->vis_patch;
+        uint64_t want=(uint64_t)g_pending_image.grid_h*g_pending_image.grid_w*features*sizeof(float);
+        if(!m->vis_ready||g_pending_image.bytes!=want){
+            printf("ERROR %s BAD_IMAGE bytes=%llu expected=%llu\n",q->id,
+                   (unsigned long long)g_pending_image.bytes,(unsigned long long)want);
+            fflush(stdout); q38_pending_image_clear(); free(ids); return 0;
+        }
+        if(q38_vision_attach(m,(const float*)g_pending_image.patches,
+                             g_pending_image.grid_h,g_pending_image.grid_w,ids,np)<0){
+            printf("ERROR %s BAD_IMAGE the prompt and the grid disagree\n",q->id);
+            fflush(stdout); q38_pending_image_clear(); free(ids); return 0;
+        }
+        q38_pending_image_clear();
+    }
     int max_ctx=m->kv_cap;
     if(np<1 || np>max_ctx || q->max_tok<1 || q->max_tok>max_ctx-np){
         printf("ERROR %s CONTEXT_EXCEEDED prompt_tokens=%d requested=%d capacity=%d\n",q->id,np,q->max_tok,max_ctx);
@@ -1513,6 +1562,11 @@ static int serve_one(Model *m, ServeReq *q){
         if(s == q->max_tok - 1) break;
         lo = step(m, &tk, 1, np+s);
     }
+    /* I vettori dell'immagine valgono per QUESTO turno soltanto: lasciarli
+     * agganciati farebbe rispondere la richiesta successiva sulla foto
+     * precedente, e la mappa e' per posizione assoluta, quindi combacerebbe
+     * silenziosamente invece di dare errore. */
+    q38_vision_detach(m);
     free(lo); free(ids);
     if(cancelled){coli_serve_write_error(stdout,q->id,"CANCELLED");return input_eof?-1:0;}
     if(stopped)limited=0;
@@ -1540,6 +1594,7 @@ static int serve_one(Model *m, ServeReq *q){
 }
 
 static void serve_loop(Model *m){
+    g_serve_model=m;
     coli_serve_binary_mode();
     setvbuf(stdin,NULL,_IONBF,0);
     int max_ctx=qwen38_max_ctx();

--- a/c/qwen38_core.h
+++ b/c/qwen38_core.h
@@ -27,6 +27,10 @@ typedef struct {
     int ple_layer, ple_dim, ple_convk, ngram_size, heads_per_ngram;
     int ngram_heads, ngram_head_dim, ngram_parts;
     uint8_t *is_attn;
+    /* vision: 0 = checkpoint di solo testo, o torre non caricata */
+    int image_token;
+    int vis_depth, vis_hidden, vis_heads, vis_inter, vis_patch;
+    int vis_merge, vis_temporal, vis_in_ch, vis_out_hidden, vis_num_pos;
 } Cfg;
 
 typedef enum {
@@ -132,6 +136,14 @@ typedef struct {
     int prefill_batch;
     uint64_t resident_weight_bytes;
     double dense_load_s;
+    /* vision. `vis_map` mappa la posizione ASSOLUTA nella sequenza alla riga di
+     * `vis_rows`, oppure -1. Assoluta e non relativa al chunk: il prefill arriva
+     * a pezzi, e un indice relativo darebbe l'immagine sbagliata al secondo
+     * pezzo senza che niente protesti. */
+    Q38Vision vis;
+    int vis_ready;
+    float *vis_rows;
+    int *vis_map, vis_map_len, vis_rows_n;
     Q38Timers timers;
 } Model;
 
@@ -476,12 +488,46 @@ static void q38_load_cfg(Cfg *c,const char *snap) {
         else if(!strcmp(s,"full_attention")||!strcmp(s,"qwen_sparse_attention")) c->is_attn[i]=1;
         else {fprintf(stderr,"unsupported layer type %s\n",s);exit(1);}
     }
+    /* Vision: opzionale. Un checkpoint di solo testo non ha vision_config, e in
+     * quel caso la torre resta spenta invece di rifiutare il modello. La
+     * geometria viene dal file, non da costanti qui: una torre di misura diversa
+     * deve fallire dicendo cosa non torna, non leggere pesi della misura
+     * sbagliata. */
+    {
+        jval *vc = q38_obj(root, "vision_config");
+        if (vc) {
+            c->vis_depth      = q38_num_int(vc,"depth",0,1,1,1024);
+            c->vis_hidden     = q38_num_int(vc,"hidden_size",0,1,1,65536);
+            c->vis_heads      = q38_num_int(vc,"num_heads",0,1,1,1024);
+            c->vis_inter      = q38_num_int(vc,"intermediate_size",0,1,1,262144);
+            c->vis_patch      = q38_num_int(vc,"patch_size",16,0,1,512);
+            c->vis_merge      = q38_num_int(vc,"spatial_merge_size",2,0,1,8);
+            c->vis_temporal   = q38_num_int(vc,"temporal_patch_size",2,0,1,8);
+            c->vis_in_ch      = q38_num_int(vc,"in_channels",3,0,1,8);
+            c->vis_out_hidden = q38_num_int(vc,"out_hidden_size",c->hidden,0,1,65536);
+            c->vis_num_pos    = q38_num_int(vc,"num_position_embeddings",0,1,1,1<<20);
+            c->image_token    = q38_num_int(root,"image_token_id",-1,0,0,INT_MAX);
+        }
+    }
     json_free(root); free(buf); free(arena);
 }
 
 #define Q38_NEED(x,...) do{if(!(x)){fprintf(stderr,"[qwen38 config] ");fprintf(stderr,__VA_ARGS__);fprintf(stderr," -- refusing\n");exit(1);}}while(0)
 static void q38_validate_cfg(const Cfg *c) {
     Q38_NEED(c->hidden>0&&c->hidden<=65536,"hidden_size=%d",c->hidden);
+    if (c->vis_depth) {
+        /* La torre proietta direttamente nello spazio del testo: se le due
+         * dimensioni non coincidono i token immagine finirebbero nel posto
+         * giusto con i numeri sbagliati, che e' peggio di un rifiuto. */
+        Q38_NEED(c->vis_out_hidden==c->hidden,
+                 "vision out_hidden_size=%d but text hidden_size=%d",
+                 c->vis_out_hidden,c->hidden);
+        Q38_NEED(c->vis_hidden%c->vis_heads==0,
+                 "vision hidden_size=%d not divisible by num_heads=%d",
+                 c->vis_hidden,c->vis_heads);
+        Q38_NEED(c->image_token>=0&&c->image_token<c->vocab,
+                 "image_token_id=%d outside vocabulary",c->image_token);
+    }
     Q38_NEED(c->layers>0&&c->layers<=Q38_MAX_LAYERS,"layers=%d",c->layers);
     Q38_NEED(c->vocab>0&&c->max_positions>0&&
              c->max_positions<=QWEN38_ATTN_MAX_CTX,"vocab/context invalid");
@@ -641,6 +687,127 @@ static void q38_alloc_state(Model *m) {
     }
 }
 
+/* ---- vision ------------------------------------------------------------- */
+
+/* La torre e' in F32 residente: 27 blocchi da 1152 sono ~0.6 GB, che accanto ai
+ * 9.2 GiB dei pesi densi non cambia la classe di macchina. Gli esperti restano
+ * su disco; la torre no, perche' si usa una volta per immagine e non per token. */
+static const float *q38_vis_tensor(Model *m,const char *suffix,int64_t expect) {
+    char nm[512];
+    snprintf(nm,sizeof nm,"%s.visual.%s",m->prefix,suffix);
+    if(!st_has(&m->S,nm)){
+        snprintf(nm,sizeof nm,"model.visual.%s",suffix);
+        if(!st_has(&m->S,nm)){fprintf(stderr,"vision tensor missing: %s\n",suffix);exit(1);}
+    }
+    st_tensor *t=st_find(&m->S,nm);
+    if(expect>0&&t->numel!=expect){
+        fprintf(stderr,"vision tensor %s has %lld values, expected %lld -- refusing\n",
+                nm,(long long)t->numel,(long long)expect);exit(1);
+    }
+    float *buf=(float*)malloc((size_t)t->numel*sizeof(float));
+    if(!buf){fprintf(stderr,"OOM loading %s\n",nm);exit(1);}
+    st_read_f32(&m->S,nm,buf,t->numel);
+    m->resident_weight_bytes+=(uint64_t)t->numel*sizeof(float);
+    return buf;
+}
+
+static void q38_vis_linear(Model *m,Q38Linear *l,const char *stem,int out,int in) {
+    char nm[512];
+    snprintf(nm,sizeof nm,"%s.weight",stem); l->w=q38_vis_tensor(m,nm,(int64_t)out*in);
+    snprintf(nm,sizeof nm,"%s.bias",stem);   l->b=q38_vis_tensor(m,nm,out);
+    l->out=out; l->in=in;
+}
+
+static void q38_vis_norm(Model *m,Q38Norm *n,const char *stem,int width) {
+    char nm[512];
+    snprintf(nm,sizeof nm,"%s.weight",stem); n->w=q38_vis_tensor(m,nm,width);
+    snprintf(nm,sizeof nm,"%s.bias",stem);   n->b=q38_vis_tensor(m,nm,width);
+}
+
+static void q38_load_vision(Model *m) {
+    Cfg *c=&m->c;
+    if(!c->vis_depth) return;
+    char probe[512];
+    snprintf(probe,sizeof probe,"%s.visual.pos_embed.weight",m->prefix);
+    if(!st_has(&m->S,probe)&&!st_has(&m->S,"model.visual.pos_embed.weight")){
+        /* config multimodale ma pesi assenti: e' un export solo-testo di un
+         * checkpoint multimodale. Spegnere la torre e dirlo e' meglio che
+         * rifiutare un modello che per il testo funziona benissimo. */
+        fprintf(stderr,"[qwen38] vision_config present but no visual weights; text only\n");
+        c->vis_depth=0; return;
+    }
+    Q38Vision *v=&m->vis;
+    memset(v,0,sizeof *v);
+    v->depth=c->vis_depth; v->hidden=c->vis_hidden; v->heads=c->vis_heads;
+    v->head_dim=c->vis_hidden/c->vis_heads; v->inter=c->vis_inter;
+    v->patch=c->vis_patch; v->merge=c->vis_merge; v->temporal=c->vis_temporal;
+    v->in_ch=c->vis_in_ch; v->out_hidden=c->vis_out_hidden;
+    v->num_pos=c->vis_num_pos; v->side=(int)(sqrt((double)c->vis_num_pos)+0.5);
+    v->eps=1e-6f;
+    if(v->side*v->side!=v->num_pos){
+        fprintf(stderr,"[qwen38] num_position_embeddings=%d is not a square grid -- refusing\n",
+                v->num_pos);exit(1);
+    }
+    int features=v->in_ch*v->temporal*v->patch*v->patch;
+    q38_vis_linear(m,&v->patch_embed,"patch_embed.proj",v->hidden,features);
+    v->pos_embed=q38_vis_tensor(m,"pos_embed.weight",(int64_t)v->num_pos*v->hidden);
+    v->blocks=(Q38VBlock*)calloc((size_t)v->depth,sizeof(Q38VBlock));
+    if(!v->blocks){fprintf(stderr,"OOM vision blocks\n");exit(1);}
+    for(int i=0;i<v->depth;i++){
+        char stem[160];
+        snprintf(stem,sizeof stem,"blocks.%d.norm1",i);          q38_vis_norm(m,&v->blocks[i].norm1,stem,v->hidden);
+        snprintf(stem,sizeof stem,"blocks.%d.norm2",i);          q38_vis_norm(m,&v->blocks[i].norm2,stem,v->hidden);
+        snprintf(stem,sizeof stem,"blocks.%d.attn.qkv",i);       q38_vis_linear(m,&v->blocks[i].qkv,stem,3*v->hidden,v->hidden);
+        snprintf(stem,sizeof stem,"blocks.%d.attn.proj",i);      q38_vis_linear(m,&v->blocks[i].proj,stem,v->hidden,v->hidden);
+        snprintf(stem,sizeof stem,"blocks.%d.mlp.linear_fc1",i); q38_vis_linear(m,&v->blocks[i].fc1,stem,v->inter,v->hidden);
+        snprintf(stem,sizeof stem,"blocks.%d.mlp.linear_fc2",i); q38_vis_linear(m,&v->blocks[i].fc2,stem,v->hidden,v->inter);
+    }
+    int wide=v->hidden*v->merge*v->merge;
+    q38_vis_norm(m,&v->merger_norm,"merger.norm",v->hidden);
+    q38_vis_linear(m,&v->merger_fc1,"merger.linear_fc1",wide,wide);
+    q38_vis_linear(m,&v->merger_fc2,"merger.linear_fc2",v->out_hidden,wide);
+    m->vis_ready=1;
+    fprintf(stderr,"[qwen38] vision tower: %d blocks, hidden %d, %d heads, patch %d, merge %d\n",
+            v->depth,v->hidden,v->heads,v->patch,v->merge);
+}
+
+/* Esegue la torre su un'immagine gia' preprocessata e prepara la mappa
+ * posizione->riga. `ids`/`n` sono i token del prompt: le righe vengono
+ * assegnate ai token immagine nell'ordine in cui compaiono. */
+static int q38_vision_attach(Model *m,const float *patches,int grid_h,int grid_w,
+                             const int *ids,int n) {
+    Cfg *c=&m->c;
+    if(!m->vis_ready) return -1;
+    int tokens=(grid_h*grid_w)/(c->vis_merge*c->vis_merge);
+    int slots=0;
+    for(int i=0;i<n;i++) if(ids[i]==c->image_token) slots++;
+    if(slots!=tokens){
+        /* Il numero di segnaposto nel prompt DEVE essere quello che la griglia
+         * produce. Se non lo e', il template e il preprocessing hanno visto due
+         * immagini diverse, e proseguire vorrebbe dire mettere i vettori giusti
+         * nelle posizioni sbagliate. */
+        fprintf(stderr,"[qwen38] prompt has %d image placeholders but the grid gives %d tokens\n",
+                slots,tokens);
+        return -1;
+    }
+    free(m->vis_rows); free(m->vis_map);
+    m->vis_rows=(float*)calloc((size_t)tokens*c->hidden,sizeof(float));
+    m->vis_map=(int*)malloc((size_t)n*sizeof(int));
+    if(!m->vis_rows||!m->vis_map){free(m->vis_rows);free(m->vis_map);
+        m->vis_rows=NULL;m->vis_map=NULL;return -1;}
+    if(q38_vision_forward(&m->vis,patches,grid_h,grid_w,m->vis_rows)!=tokens){
+        free(m->vis_rows);free(m->vis_map);m->vis_rows=NULL;m->vis_map=NULL;return -1;}
+    int next=0;
+    for(int i=0;i<n;i++) m->vis_map[i]=(ids[i]==c->image_token)?next++:-1;
+    m->vis_map_len=n; m->vis_rows_n=tokens;
+    return tokens;
+}
+
+static void q38_vision_detach(Model *m) {
+    free(m->vis_rows); free(m->vis_map);
+    m->vis_rows=NULL; m->vis_map=NULL; m->vis_map_len=0; m->vis_rows_n=0;
+}
+
 static void model_init_range(Model *m,const char *snap,int cap,int bits,
                              int layer_begin,int layer_end,int load_boundaries,
                              int allocate_state) {
@@ -702,6 +869,10 @@ static void model_init_range(Model *m,const char *snap,int cap,int bits,
         if(!lc->slots||!lc->by_expert){fprintf(stderr,"OOM expert cache\n");exit(1);} for(int e=0;e<c->experts;e++)lc->by_expert[e]=-1;
     }
     if(c->ple_layer>=layer_begin&&c->ple_layer<layer_end) q38_load_ple(m,&m->L[c->ple_layer]);
+    /* La torre solo quando il motore possiede la sequenza intera: uno shard che
+     * ospita solo alcuni layer non ha da fare niente con le immagini, e
+     * caricarla la' sarebbe mezzo giga per nulla. */
+    if(load_boundaries&&q38_env_bool("Q38_VISION",1)) q38_load_vision(m);
     if(allocate_state) q38_alloc_state(m);
     m->dense_load_s=now_s()-t0;
     fprintf(stderr,"[qwen38] native text weights: prefix=%s, %d layers, PLE=%d, cache=%d/layer, "
@@ -1702,7 +1873,12 @@ static float *step(Model *m,const int *ids,int S,int pos_base) {
     float *hyper=falloc((int64_t)S*W);
     for(int s=0;s<S;s++){
         if(ids[s]<0||ids[s]>=c->vocab){fprintf(stderr,"token id %d outside vocabulary\n",ids[s]);exit(1);}
-        float *e=hyper+(int64_t)s*W;q38_weight_row(&m->embed,ids[s],e);
+        float *e=hyper+(int64_t)s*W;
+        int abs_pos=pos_base+s, vis_row=-1;
+        if(m->vis_map&&abs_pos>=0&&abs_pos<m->vis_map_len) vis_row=m->vis_map[abs_pos];
+        if(vis_row>=0&&vis_row<m->vis_rows_n)
+            memcpy(e,m->vis_rows+(int64_t)vis_row*H,(size_t)H*sizeof(float));
+        else q38_weight_row(&m->embed,ids[s],e);
         for(int b=1;b<C;b++)memcpy(e+(int64_t)b*H,e,(size_t)H*sizeof(float));
     }
     float *mixed=falloc((int64_t)S*H),*inject=falloc((int64_t)S*C),*block=falloc((int64_t)S*H);

--- a/c/qwen38_vision.h
+++ b/c/qwen38_vision.h
@@ -1,0 +1,289 @@
+/* qwen38_vision.h -- la torre vision di Qwen3.8, in C.
+ *
+ * Prende le patch che tools/qwen38_image.py ha estratto e restituisce i token
+ * immagine gia' proiettati nello spazio del modello di testo, pronti per essere
+ * infilati dove il template scrive <|vision_start|><|image_pad|><|vision_end|>.
+ *
+ * Trascritta da Qwen4ExpVisionModel upstream, non dedotta dal paper. I quattro
+ * punti in cui una torre ViT si sbaglia in silenzio, e come stanno qui:
+ *
+ *   patch_embed  e' una Conv3d con kernel UGUALE allo stride, quindi e' una
+ *                matrice: ogni patch appiattita (C*T*P*P) per W^T piu' il bias.
+ *                Trattarla come una convoluzione vera sarebbe lavoro sprecato e
+ *                un'occasione in piu' di sbagliare l'ordine.
+ *
+ *   pos_embed    sono 48x48 posizioni APPRESE, interpolate bilinearmente sulla
+ *                griglia dell'immagine con align_corners=true. Non e' una
+ *                interpolazione qualsiasi: gli indici di sorgente si calcolano
+ *                da (riga, colonna) ricavate in ordine a blocchi di merge, non
+ *                in ordine raster. Usare l'ordine raster da' un'immagine che
+ *                sembra funzionare e ha le posizioni mescolate.
+ *
+ *   rope         e' 2D e VIVE INSIEME alle posizioni apprese, non al posto
+ *                loro. head_dim/2 frequenze per asse, concatenate e poi
+ *                raddoppiate a head_dim.
+ *
+ *   merger       normalizza ogni token PRIMA di raggruppare, poi unisce 4 token
+ *                adiacenti in un vettore da 4*hidden. L'ordine dei 4 e' quello
+ *                in cui le patch sono gia' disposte, che e' il motivo per cui
+ *                qwen38_image.py le emette a blocchi di merge.
+ *
+ * L'attenzione e' piena e quadratica nel numero di patch. Un'immagine 1080p ne
+ * produce 8160, cioe' 66 milioni di coppie per testa per blocco: il tetto sui
+ * token non e' una comodita', e' un requisito. Vedi Q38_MAX_IMAGE_TOKENS.
+ */
+#ifndef QWEN38_VISION_H
+#define QWEN38_VISION_H
+
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    const float *w, *b;        /* [out, in] riga-maggiore, bias [out] */
+    int out, in;
+} Q38Linear;
+
+typedef struct {
+    const float *w, *b;        /* LayerNorm: scala e traslazione, [n] */
+} Q38Norm;
+
+typedef struct {
+    Q38Norm norm1, norm2;
+    Q38Linear qkv, proj, fc1, fc2;
+} Q38VBlock;
+
+typedef struct {
+    int depth, hidden, heads, head_dim, inter, patch, merge, temporal, in_ch;
+    int out_hidden, num_pos, side;      /* side = sqrt(num_pos) */
+    float eps;
+    Q38Linear patch_embed;
+    const float *pos_embed;             /* [num_pos, hidden] */
+    Q38VBlock *blocks;
+    Q38Norm merger_norm;
+    Q38Linear merger_fc1, merger_fc2;
+} Q38Vision;
+
+/* ---- primitive ---------------------------------------------------------- */
+
+static void q38v_linear(float *out, const float *in, const Q38Linear *l, int rows)
+{
+    for (int r = 0; r < rows; r++) {
+        const float *x = in + (size_t)r * l->in;
+        float *y = out + (size_t)r * l->out;
+        for (int o = 0; o < l->out; o++) {
+            const float *w = l->w + (size_t)o * l->in;
+            float acc = l->b ? l->b[o] : 0.f;
+            for (int i = 0; i < l->in; i++) acc += w[i] * x[i];
+            y[o] = acc;
+        }
+    }
+}
+
+static void q38v_layernorm(float *out, const float *in, const Q38Norm *n, int rows,
+                           int width, float eps)
+{
+    for (int r = 0; r < rows; r++) {
+        const float *x = in + (size_t)r * width;
+        float *y = out + (size_t)r * width;
+        double mean = 0.0;
+        for (int i = 0; i < width; i++) mean += x[i];
+        mean /= width;
+        double var = 0.0;
+        for (int i = 0; i < width; i++) { double d = x[i] - mean; var += d * d; }
+        var /= width;
+        float inv = (float)(1.0 / sqrt(var + eps));
+        for (int i = 0; i < width; i++)
+            y[i] = ((float)(x[i] - mean)) * inv * n->w[i] + n->b[i];
+    }
+}
+
+/* DUE gelu, e non e' una svista del riferimento: i blocchi usano
+ * ACT2FN[hidden_act], che per questo checkpoint e' gelu_pytorch_tanh, mentre il
+ * merger istanzia nn.GELU(), cioe' quella ESATTA con erf. Usarne una sola le fa
+ * combaciare quasi -- lo scarto misurato sul merger era 4.6e-3, invisibile senza
+ * un oracolo e sufficiente a spostare i token immagine. */
+static float q38v_gelu_tanh(float x)
+{
+    const float k = 0.7978845608028654f;          /* sqrt(2/pi) */
+    return 0.5f * x * (1.f + tanhf(k * (x + 0.044715f * x * x * x)));
+}
+
+static float q38v_gelu_exact(float x)
+{
+    return 0.5f * x * (1.f + erff(x * 0.70710678118654752f));   /* 1/sqrt(2) */
+}
+
+/* ---- posizioni ---------------------------------------------------------- */
+
+/* (riga, colonna) della patch `i`, in ordine a blocchi di merge. E' l'inverso
+ * esatto del riordinamento che qwen38_image.py applica alle patch. */
+static void q38v_row_col(int i, int grid_w, int merge, int *row, int *col)
+{
+    int blocks_w = grid_w / merge;
+    int in_col = i % merge;
+    int in_row = (i / merge) % merge;
+    int block_col = (i / (merge * merge)) % blocks_w;
+    int block_row = i / (merge * merge * blocks_w);
+    *row = block_row * merge + in_row;
+    *col = block_col * merge + in_col;
+}
+
+/* I due tap bilineari e i loro pesi su un asse, align_corners=true. */
+static void q38v_taps(int index, int size, int side, int *tap, float *weight)
+{
+    float src = (float)index * (float)(side - 1) / (float)(size > 1 ? size - 1 : 1);
+    float floored = floorf(src);
+    for (int t = 0; t < 2; t++) {
+        int raw = (int)floored + t;
+        tap[t] = raw < 0 ? 0 : (raw > side - 1 ? side - 1 : raw);
+        float distance = fabsf(src - floored - (float)t);
+        float w = 1.f - distance;
+        weight[t] = w < 0.f ? 0.f : w;
+    }
+}
+
+/* ---- il forward --------------------------------------------------------- */
+
+/* patches: [n, in_ch*temporal*patch*patch].  out: [n/merge^2, out_hidden].
+ * Ritorna il numero di token prodotti, o -1 se la griglia non e' coerente. */
+static int q38_vision_forward_dbg(const Q38Vision *v, const float *patches,
+                              int grid_h, int grid_w, float *out, float *last_hidden)
+{
+    if (grid_h <= 0 || grid_w <= 0) return -1;
+    if (grid_h % v->merge || grid_w % v->merge) return -1;    /* il merger 2x2 non chiuderebbe */
+    const int n = grid_h * grid_w, H = v->hidden, D = v->head_dim, nh = v->heads;
+    const int unit = v->merge * v->merge;
+
+    float *x   = (float *)calloc((size_t)n * H, sizeof(float));
+    float *tmp = (float *)calloc((size_t)n * H, sizeof(float));
+    float *qkv = (float *)calloc((size_t)n * 3 * H, sizeof(float));
+    float *att = (float *)calloc((size_t)n * H, sizeof(float));
+    float *mlp = (float *)calloc((size_t)n * v->inter, sizeof(float));
+    float *cos_t = (float *)calloc((size_t)n * D, sizeof(float));
+    float *sin_t = (float *)calloc((size_t)n * D, sizeof(float));
+    float *scores = (float *)calloc((size_t)n, sizeof(float));
+    if (!x || !tmp || !qkv || !att || !mlp || !cos_t || !sin_t || !scores) {
+        free(x); free(tmp); free(qkv); free(att); free(mlp);
+        free(cos_t); free(sin_t); free(scores); return -1;
+    }
+
+    /* 1. patch embedding, e le posizioni apprese sommate subito dopo. */
+    q38v_linear(x, patches, &v->patch_embed, n);
+    for (int i = 0; i < n; i++) {
+        int row, col; q38v_row_col(i, grid_w, v->merge, &row, &col);
+        int ht[2], wt[2]; float hw[2], ww[2];
+        q38v_taps(row, grid_h, v->side, ht, hw);
+        q38v_taps(col, grid_w, v->side, wt, ww);
+        float *dst = x + (size_t)i * H;
+        for (int a = 0; a < 2; a++)
+            for (int b = 0; b < 2; b++) {
+                float weight = hw[a] * ww[b];
+                if (weight == 0.f) continue;
+                const float *src = v->pos_embed + (size_t)(ht[a] * v->side + wt[b]) * H;
+                for (int c = 0; c < H; c++) dst[c] += weight * src[c];
+            }
+    }
+
+    /* 2. RoPE 2D: meta' delle frequenze sulla riga, meta' sulla colonna, poi il
+     *    vettore viene raddoppiato per coprire head_dim. */
+    {
+        const int half = D / 2, freqs = half / 2;
+        for (int i = 0; i < n; i++) {
+            int row, col; q38v_row_col(i, grid_w, v->merge, &row, &col);
+            float *c = cos_t + (size_t)i * D, *s = sin_t + (size_t)i * D;
+            for (int f = 0; f < freqs; f++) {
+                float inv = 1.f / powf(10000.f, (float)(2 * f) / (float)half);
+                float ah = (float)row * inv, aw = (float)col * inv;
+                c[f] = cosf(ah);          s[f] = sinf(ah);
+                c[freqs + f] = cosf(aw);  s[freqs + f] = sinf(aw);
+            }
+            for (int k = 0; k < half; k++) { c[half + k] = c[k]; s[half + k] = s[k]; }
+        }
+    }
+
+    /* 3. i blocchi. */
+    for (int layer = 0; layer < v->depth; layer++) {
+        const Q38VBlock *blk = &v->blocks[layer];
+        q38v_layernorm(tmp, x, &blk->norm1, n, H, v->eps);
+        q38v_linear(qkv, tmp, &blk->qkv, n);
+
+        /* rotate_half su q e k, testa per testa. Il layout di qkv e'
+         * [token][3][heads][head_dim], come lo produce la reshape upstream. */
+        for (int i = 0; i < n; i++) {
+            const float *c = cos_t + (size_t)i * D, *s = sin_t + (size_t)i * D;
+            for (int part = 0; part < 2; part++)                 /* q, k -- non v */
+                for (int h = 0; h < nh; h++) {
+                    float *p = qkv + ((size_t)i * 3 + part) * H + (size_t)h * D;
+                    for (int d = 0; d < D / 2; d++) {
+                        float a = p[d], b = p[d + D / 2];
+                        p[d]         = a * c[d]         - b * s[d];
+                        p[d + D / 2] = b * c[d + D / 2] + a * s[d + D / 2];
+                    }
+                }
+        }
+
+        const float scale = 1.f / sqrtf((float)D);
+        memset(att, 0, (size_t)n * H * sizeof(float));
+        for (int h = 0; h < nh; h++)
+            for (int i = 0; i < n; i++) {
+                const float *q = qkv + (size_t)i * 3 * H + (size_t)h * D;
+                float best = -INFINITY;
+                for (int j = 0; j < n; j++) {
+                    const float *k = qkv + ((size_t)j * 3 + 1) * H + (size_t)h * D;
+                    float acc = 0.f;
+                    for (int d = 0; d < D; d++) acc += q[d] * k[d];
+                    scores[j] = acc * scale;
+                    if (scores[j] > best) best = scores[j];
+                }
+                float sum = 0.f;
+                for (int j = 0; j < n; j++) { scores[j] = expf(scores[j] - best); sum += scores[j]; }
+                float inv = 1.f / sum;
+                float *dst = att + (size_t)i * H + (size_t)h * D;
+                for (int j = 0; j < n; j++) {
+                    float weight = scores[j] * inv;
+                    const float *val = qkv + ((size_t)j * 3 + 2) * H + (size_t)h * D;
+                    for (int d = 0; d < D; d++) dst[d] += weight * val[d];
+                }
+            }
+
+        q38v_linear(tmp, att, &blk->proj, n);
+        for (size_t i = 0; i < (size_t)n * H; i++) x[i] += tmp[i];
+
+        q38v_layernorm(tmp, x, &blk->norm2, n, H, v->eps);
+        q38v_linear(mlp, tmp, &blk->fc1, n);
+        for (size_t i = 0; i < (size_t)n * v->inter; i++) mlp[i] = q38v_gelu_tanh(mlp[i]);
+        q38v_linear(tmp, mlp, &blk->fc2, n);
+        for (size_t i = 0; i < (size_t)n * H; i++) x[i] += tmp[i];
+    }
+
+    if (last_hidden) memcpy(last_hidden, x, (size_t)n * H * sizeof(float));
+
+    /* 4. merger: normalizza ogni token, poi ne unisce merge^2 adiacenti. */
+    q38v_layernorm(tmp, x, &v->merger_norm, n, H, v->eps);
+    {
+        const int tokens = n / unit, wide = H * unit;
+        float *grouped = (float *)calloc((size_t)tokens * wide, sizeof(float));
+        float *hidden = (float *)calloc((size_t)tokens * wide, sizeof(float));
+        if (!grouped || !hidden) {
+            free(grouped); free(hidden);
+            free(x); free(tmp); free(qkv); free(att); free(mlp);
+            free(cos_t); free(sin_t); free(scores); return -1;
+        }
+        memcpy(grouped, tmp, (size_t)tokens * wide * sizeof(float));
+        q38v_linear(hidden, grouped, &v->merger_fc1, tokens);
+        for (size_t i = 0; i < (size_t)tokens * wide; i++) hidden[i] = q38v_gelu_exact(hidden[i]);
+        q38v_linear(out, hidden, &v->merger_fc2, tokens);
+        free(grouped); free(hidden);
+        free(x); free(tmp); free(qkv); free(att); free(mlp);
+        free(cos_t); free(sin_t); free(scores);
+        return tokens;
+    }
+}
+
+static int q38_vision_forward(const Q38Vision *v, const float *patches,
+                              int grid_h, int grid_w, float *out)
+{ return q38_vision_forward_dbg(v, patches, grid_h, grid_w, out, NULL); }
+
+#endif /* QWEN38_VISION_H */

--- a/c/serve_codec.h
+++ b/c/serve_codec.h
@@ -20,6 +20,11 @@ typedef enum {
     COLI_SERVE_COMMAND_SUBMIT,
     COLI_SERVE_COMMAND_STOP,
     COLI_SERVE_COMMAND_CANCEL,
+    /* IMAGE <id> <bytes> <grid_h> <grid_w>\n<payload>\n, annunciato subito prima
+     * del SUBMIT a cui appartiene. Un motore di solo testo che non lo gestisce lo
+     * vede come un comando che non sa trattare e lo rifiuta, che e' la risposta
+     * giusta: meglio dire di no che accettare una foto e ignorarla. */
+    COLI_SERVE_COMMAND_IMAGE,
 } ColiServeCommandKind;
 
 typedef enum {
@@ -52,6 +57,9 @@ typedef struct {
     float top_p;
     uint64_t extension_bytes;
     int prefix_bytes;
+    /* IMAGE: la griglia di patch che accompagna il payload. Zero per ogni altro
+     * comando. */
+    int grid_h, grid_w;
     unsigned char *payload;
 } ColiServeCommand;
 
@@ -134,6 +142,8 @@ static inline void coli_serve_classify_line(
         command->kind = COLI_SERVE_COMMAND_STOP;
     else if (name_size == 6 && !memcmp(name, "CANCEL", 6))
         command->kind = COLI_SERVE_COMMAND_CANCEL;
+    else if (name_size == 5 && !memcmp(name, "IMAGE", 5))
+        command->kind = COLI_SERVE_COMMAND_IMAGE;
     else
         return;
     while (*cursor == ' ' || *cursor == '\t') cursor++;
@@ -200,6 +210,7 @@ static inline ColiServeReadResult coli_serve_read_command_alloc(
     if (!strcmp(fields[0], "SUBMIT")) command->kind = COLI_SERVE_COMMAND_SUBMIT;
     else if (!strcmp(fields[0], "STOP")) command->kind = COLI_SERVE_COMMAND_STOP;
     else if (!strcmp(fields[0], "CANCEL")) command->kind = COLI_SERVE_COMMAND_CANCEL;
+    else if (!strcmp(fields[0], "IMAGE")) command->kind = COLI_SERVE_COMMAND_IMAGE;
     else {
         free(line);
         return COLI_SERVE_READ_IGNORED;
@@ -213,6 +224,39 @@ static inline ColiServeReadResult coli_serve_read_command_alloc(
         command->kind == COLI_SERVE_COMMAND_CANCEL) {
         if (nfields != 2) { free(line); return COLI_SERVE_READ_BAD_REQUEST; }
         free(line);
+        return COLI_SERVE_READ_OK;
+    }
+    if (command->kind == COLI_SERVE_COMMAND_IMAGE) {
+        /* IMAGE <id> <bytes> <grid_h> <grid_w>\n<payload>\n
+         *
+         * Il payload va consumato SEMPRE, anche quando il motore non sa cosa
+         * farsene: lasciarlo nello stream sposterebbe il frame successivo di
+         * qualche megabyte e il gateway leggerebbe pixel come se fossero
+         * un'intestazione. Per questo il rifiuto vive nel chiamante, non qui. */
+        if (nfields != 5 ||
+            !coli_serve_parse_u64(fields[2], &command->payload_bytes) ||
+            !coli_serve_parse_i32(fields[3], &command->grid_h) ||
+            !coli_serve_parse_i32(fields[4], &command->grid_w) ||
+            command->payload_bytes > profile->max_payload_bytes ||
+            command->grid_h < 1 || command->grid_w < 1) {
+            free(line);
+            return COLI_SERVE_READ_BAD_REQUEST;
+        }
+        free(line);
+        command->payload = (unsigned char *)allocate((size_t)command->payload_bytes + 1);
+        if (!command->payload) return COLI_SERVE_READ_NOMEM;
+        if (command->payload_bytes &&
+            fread(command->payload, 1, (size_t)command->payload_bytes, input)
+                != (size_t)command->payload_bytes) {
+            coli_serve_command_dispose(command);
+            return COLI_SERVE_READ_BAD_FRAME;
+        }
+        command->payload[command->payload_bytes] = 0;
+        int terminator = fgetc(input);
+        if (terminator != '\n' && !(terminator == '\r' && fgetc(input) == '\n')) {
+            coli_serve_command_dispose(command);
+            return COLI_SERVE_READ_BAD_FRAME;
+        }
         return COLI_SERVE_READ_OK;
     }
     int minimum_fields = 7;

--- a/c/tests/test_qwen38_image.py
+++ b/c/tests/test_qwen38_image.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""tools/qwen38_image.py contro Qwen2VLImageProcessor ufficiale.
+
+Il preprocessing e' la parte della vision che si sbaglia in silenzio. Una tela
+piu' larga di una patch, un ordine di patch diverso, una normalizzazione con le
+costanti dell'altro modello: niente di tutto questo da' errore. Il modello
+risponde lo stesso, e risponde peggio. Per questo il riferimento e' il
+processore vero e non una rilettura del paper.
+
+Il riferimento NON richiede i pesi: `Qwen2VLImageProcessor` si costruisce dal
+solo preprocessor_config.json, che sono 390 byte. Quindi questo test si puo'
+eseguire senza aver scaricato i 185 GB del checkpoint.
+
+Cosa viene confrontato, e con che severita':
+
+  geometria (grid_h, grid_w, numero di patch)   uguaglianza esatta
+  ordine delle patch                            uguaglianza esatta
+  pixel                                         tolleranza, e la scriviamo
+
+L'ultima riga e' il punto onesto. Il riferimento ridimensiona con torchvision,
+noi con Pillow, e due bicubici diversi non danno gli stessi byte. Dove non c'e'
+ridimensionamento i pixel sono identici e il test lo pretende; dove c'e', misura
+lo scarto e lo stampa invece di dichiararlo zero.
+
+USO:
+  python3 tests/test_qwen38_image.py --config PATH/preprocessor_config.json
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Forme scelte per esercitare i rami di smart_resize: sotto la finestra (si
+# ingrandisce), dentro, molto sopra (si rimpicciolisce), e non quadrate in
+# entrambi i versi.
+SHAPES = [(64, 64), (100, 50), (50, 100), (37, 91), (256, 256),
+          (640, 480), (1920, 1080), (33, 17)]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True,
+                        help="preprocessor_config.json del checkpoint")
+    arguments = parser.parse_args()
+
+    if not arguments.config.exists():
+        print(f"SKIP: manca {arguments.config}; il riferimento non c'e' e "
+              f"questo test non ha verificato nulla")
+        return 0
+    try:
+        import numpy
+        from PIL import Image
+        from transformers.models.qwen2_vl.image_processing_qwen2_vl import (
+            Qwen2VLImageProcessor)
+    except ImportError as exc:
+        print(f"SKIP: manca una dipendenza del riferimento ({exc})")
+        return 0
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from tools import qwen38_image
+
+    raw = json.loads(arguments.config.read_text())
+    settings = {k: v for k, v in raw.items()
+                if k not in ("processor_class", "image_processor_type")}
+    reference = Qwen2VLImageProcessor(**settings)
+    model_dir = arguments.config.parent
+
+    failures = 0
+    worst = 0.0
+    for width, height in SHAPES:
+        state = numpy.random.RandomState(width * 1000 + height)
+        array = (state.rand(height, width, 3) * 255).astype("uint8")
+        image = Image.fromarray(array)
+
+        want = reference(images=[image], return_tensors="np")
+        want_patches = numpy.asarray(want["pixel_values"], dtype=numpy.float32)
+        _, want_h, want_w = [int(v) for v in want["image_grid_thw"][0]]
+
+        got_patches, got_h, got_w = qwen38_image.preprocess(image, model_dir)
+
+        label = f"{width}x{height}"
+        if (got_h, got_w) != (want_h, want_w):
+            print(f"FAIL {label:<10} griglia {got_h}x{got_w}, il riferimento "
+                  f"dice {want_h}x{want_w}")
+            failures += 1
+            continue
+        if got_patches.shape != want_patches.shape:
+            print(f"FAIL {label:<10} forma {got_patches.shape}, il riferimento "
+                  f"dice {want_patches.shape}")
+            failures += 1
+            continue
+
+        delta = float(numpy.abs(got_patches - want_patches).max())
+        worst = max(worst, delta)
+        resized = reference.size is not None
+        # 0.02 su valori normalizzati in [-1, 1]: e' l'ordine di grandezza fra
+        # due bicubici, non una tolleranza scelta per far passare il test. Se
+        # l'ordine delle patch fosse sbagliato lo scarto sarebbe dell'ordine di 1.
+        if delta <= 0.02:
+            print(f"ok   {label:<10} griglia {got_h}x{got_w}, {got_patches.shape[0]} patch, "
+                  f"scarto max {delta:.4f}")
+        else:
+            print(f"FAIL {label:<10} scarto max {delta:.4f}: troppo per una sola "
+                  f"differenza di ricampionamento -- sospetto ordine o normalizzazione")
+            failures += 1
+
+    # Il rifiuto e' parte del contratto: un'immagine assurdamente allungata deve
+    # fermarsi qui e non produrre una tela degenere piu' a valle.
+    try:
+        qwen38_image.smart_resize(1, 5000)
+        print("FAIL rapporto estremo accettato invece di essere rifiutato")
+        failures += 1
+    except ValueError:
+        print("ok   rapporto estremo rifiutato")
+
+    print()
+    if failures:
+        print(f"TEST FAIL ({failures} casi)")
+        return 1
+    print(f"preprocessing Qwen3.8: geometria e ordine identici al riferimento, "
+          f"scarto pixel al massimo {worst:.4f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/c/tests/test_qwen38_vision.c
+++ b/c/tests/test_qwen38_vision.c
@@ -1,0 +1,228 @@
+/* test_qwen38_vision.c -- la torre in qwen38_vision.h contro l'oracolo upstream.
+ *
+ * La fixture e il riferimento li scrive tools/make_qwen38_vision_tiny.py, che
+ * costruisce un Qwen4ExpVisionModel vero con pesi casuali e ne registra il
+ * forward. Nessun peso del checkpoint: 240k parametri, meno di un megabyte.
+ *
+ * Vengono confrontate DUE uscite, non una:
+ *
+ *   last_hidden  l'uscita dei blocchi, prima del merger
+ *   pooler       dopo il merger, cioe' i token immagine veri
+ *
+ * Se combacia solo la prima il difetto e' nel merger; se non combacia nessuna
+ * delle due e' nei blocchi o nelle posizioni. Un solo numero finale non
+ * distinguerebbe i due casi, e distinguerli e' meta' del lavoro di trovarli.
+ *
+ * USO: ./tests/test_qwen38_vision <cartella-fixture>
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "../json.h"
+#include "../st.h"
+#include "../qwen38_vision.h"
+
+static float *json_floats(jval *node, int64_t *count)
+{
+    if (!node || node->t != J_ARR) return NULL;
+    float *out = (float *)malloc((size_t)node->len * sizeof(float));
+    if (!out) return NULL;
+    for (int i = 0; i < node->len; i++) out[i] = (float)node->kids[i]->num;
+    *count = node->len;
+    return out;
+}
+
+static const float *want_tensor(shards *S, const char *name, int64_t expect)
+{
+    char full[512];
+    snprintf(full, sizeof full, "model.visual.%s", name);
+    st_tensor *t = st_find(S, full);
+    if (!t) { fprintf(stderr, "manca il tensore %s\n", full); exit(1); }
+    if (expect > 0 && t->numel != expect) {
+        fprintf(stderr, "%s ha %lld valori, ne servono %lld\n",
+                full, (long long)t->numel, (long long)expect); exit(1);
+    }
+    float *buf = (float *)malloc((size_t)t->numel * sizeof(float));
+    if (!buf) { fprintf(stderr, "OOM su %s\n", full); exit(1); }
+    st_read_f32(S, full, buf, t->numel);
+    return buf;
+}
+
+static void load_linear(shards *S, Q38Linear *l, const char *stem, int out, int in)
+{
+    char name[256];
+    snprintf(name, sizeof name, "%s.weight", stem);
+    l->w = want_tensor(S, name, (int64_t)out * in);
+    snprintf(name, sizeof name, "%s.bias", stem);
+    l->b = want_tensor(S, name, out);
+    l->out = out; l->in = in;
+}
+
+static void load_norm(shards *S, Q38Norm *n, const char *stem, int width)
+{
+    char name[256];
+    snprintf(name, sizeof name, "%s.weight", stem);
+    n->w = want_tensor(S, name, width);
+    snprintf(name, sizeof name, "%s.bias", stem);
+    n->b = want_tensor(S, name, width);
+}
+
+static int compare(const char *label, const float *got, const float *want,
+                   int64_t count, float tolerance)
+{
+    double worst = 0.0; int64_t at = -1;
+    for (int64_t i = 0; i < count; i++) {
+        double delta = fabs((double)got[i] - (double)want[i]);
+        if (delta > worst) { worst = delta; at = i; }
+    }
+    if (worst <= tolerance) {
+        printf("  ok   %-14s %lld valori, scarto max %.3e\n", label, (long long)count, worst);
+        return 0;
+    }
+    printf("  FAIL %-14s scarto max %.3e a %lld (nostro %.6f, riferimento %.6f)\n",
+           label, worst, (long long)at, got[at], want[at]);
+    return 1;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc < 2) { fprintf(stderr, "uso: %s <cartella-fixture>\n", argv[0]); return 2; }
+    char path[1024];
+    snprintf(path, sizeof path, "%s/ref_vision.json", argv[1]);
+    FILE *f = fopen(path, "rb");
+    if (!f) { printf("SKIP: manca %s; genera la fixture con "
+                     "tools/make_qwen38_vision_tiny.py\n", path); return 0; }
+    fseek(f, 0, SEEK_END); long size = ftell(f); fseek(f, 0, SEEK_SET);
+    char *text = (char *)malloc((size_t)size + 1);
+    if (!text || fread(text, 1, (size_t)size, f) != (size_t)size) {
+        fprintf(stderr, "lettura di %s fallita\n", path); return 1; }
+    text[size] = 0; fclose(f);
+    char *arena = NULL;
+    jval *ref = json_parse(text, &arena);
+    if (!ref || ref->t != J_OBJ) { fprintf(stderr, "ref_vision.json malformato\n"); return 1; }
+
+    jval *grid = json_get(ref, "grid");
+    int grid_h = (int)grid->kids[1]->num, grid_w = (int)grid->kids[2]->num;
+    int hidden = (int)json_get(ref, "hidden_size")->num;
+    int out_hidden = (int)json_get(ref, "out_hidden")->num;
+    int64_t npix = 0, nout = 0, nlast = 0;
+    float *pixels = json_floats(json_get(ref, "pixels"), &npix);
+    float *want_out = json_floats(json_get(ref, "output"), &nout);
+    float *want_last = json_floats(json_get(ref, "last_hidden"), &nlast);
+
+    shards S; st_init(&S, argv[1]);
+
+    /* La geometria viene dal config della fixture, non da costanti qui: una
+     * torre con dimensioni diverse deve fallire dicendo cosa non torna, non
+     * leggere silenziosamente pesi della misura sbagliata. */
+    snprintf(path, sizeof path, "%s/config.json", argv[1]);
+    FILE *cf = fopen(path, "rb");
+    if (!cf) { fprintf(stderr, "manca %s\n", path); return 1; }
+    fseek(cf, 0, SEEK_END); long csize = ftell(cf); fseek(cf, 0, SEEK_SET);
+    char *ctext = (char *)malloc((size_t)csize + 1);
+    if (!ctext || fread(ctext, 1, (size_t)csize, cf) != (size_t)csize) return 1;
+    ctext[csize] = 0; fclose(cf);
+    char *carena = NULL;
+    jval *cfg = json_get(json_parse(ctext, &carena), "vision_config");
+    if (!cfg) { fprintf(stderr, "config.json senza vision_config\n"); return 1; }
+
+    Q38Vision v;
+    memset(&v, 0, sizeof v);
+    v.depth = (int)json_get(cfg, "depth")->num;
+    v.hidden = hidden;
+    v.heads = (int)json_get(cfg, "num_heads")->num;
+    v.head_dim = v.hidden / v.heads;
+    v.inter = (int)json_get(cfg, "intermediate_size")->num;
+    v.patch = (int)json_get(cfg, "patch_size")->num;
+    v.merge = (int)json_get(cfg, "spatial_merge_size")->num;
+    v.temporal = (int)json_get(cfg, "temporal_patch_size")->num;
+    v.in_ch = (int)json_get(cfg, "in_channels")->num;
+    v.out_hidden = out_hidden;
+    v.num_pos = (int)json_get(cfg, "num_position_embeddings")->num;
+    v.side = (int)(sqrt((double)v.num_pos) + 0.5);
+    v.eps = 1e-6f;
+
+    int features = v.in_ch * v.temporal * v.patch * v.patch;
+    load_linear(&S, &v.patch_embed, "patch_embed.proj", v.hidden, features);
+    v.pos_embed = want_tensor(&S, "pos_embed.weight", (int64_t)v.num_pos * v.hidden);
+    v.blocks = (Q38VBlock *)calloc((size_t)v.depth, sizeof(Q38VBlock));
+    for (int i = 0; i < v.depth; i++) {
+        char stem[128];
+        snprintf(stem, sizeof stem, "blocks.%d.norm1", i);
+        load_norm(&S, &v.blocks[i].norm1, stem, v.hidden);
+        snprintf(stem, sizeof stem, "blocks.%d.norm2", i);
+        load_norm(&S, &v.blocks[i].norm2, stem, v.hidden);
+        snprintf(stem, sizeof stem, "blocks.%d.attn.qkv", i);
+        load_linear(&S, &v.blocks[i].qkv, stem, 3 * v.hidden, v.hidden);
+        snprintf(stem, sizeof stem, "blocks.%d.attn.proj", i);
+        load_linear(&S, &v.blocks[i].proj, stem, v.hidden, v.hidden);
+        snprintf(stem, sizeof stem, "blocks.%d.mlp.linear_fc1", i);
+        load_linear(&S, &v.blocks[i].fc1, stem, v.inter, v.hidden);
+        snprintf(stem, sizeof stem, "blocks.%d.mlp.linear_fc2", i);
+        load_linear(&S, &v.blocks[i].fc2, stem, v.hidden, v.inter);
+    }
+    int wide = v.hidden * v.merge * v.merge;
+    load_norm(&S, &v.merger_norm, "merger.norm", v.hidden);
+    load_linear(&S, &v.merger_fc1, "merger.linear_fc1", wide, wide);
+    load_linear(&S, &v.merger_fc2, "merger.linear_fc2", v.out_hidden, wide);
+
+    int patches = grid_h * grid_w;
+    if (npix != (int64_t)patches * features) {
+        fprintf(stderr, "pixels: %lld valori, ne servono %lld\n",
+                (long long)npix, (long long)patches * features);
+        return 1;
+    }
+    float *out = (float *)calloc((size_t)patches, sizeof(float) * (size_t)v.out_hidden);
+    float *last = (float *)calloc((size_t)patches * v.hidden, sizeof(float));
+    int tokens = q38_vision_forward_dbg(&v, pixels, grid_h, grid_w, out, last);
+    if (tokens <= 0) { fprintf(stderr, "la torre ha rifiutato la griglia\n"); return 1; }
+
+    printf("torre vision Qwen3.8: %d patch -> %d token\n", patches, tokens);
+    int failures = 0;
+    if ((int64_t)tokens * v.out_hidden != nout) {
+        printf("  FAIL forma: %d x %d, il riferimento dice %lld valori\n",
+               tokens, v.out_hidden, (long long)nout);
+        failures++;
+    } else {
+        /* 8e-4 non e' una tolleranza scelta per far passare il test: e' MISURATA.
+         * Il riferimento in float32 confrontato con se stesso in float64 differisce
+         * di 1.83e-4 su queste attivazioni, che arrivano a 154. Il nostro scarto e'
+         * dello stesso ordine, quindi e' l'aritmetica di chi ci confrontiamo, non
+         * un difetto. Un errore vero -- ordine delle patch, teste, residui -- si
+         * presenta a 1e-3 o piu': la gelu sbagliata nel merger, che era un difetto
+         * VERO trovato qui, dava 4.6e-3. La soglia sta in mezzo apposta. */
+        failures += compare("pooler", out, want_out, nout, 8e-4f);
+    }
+    if ((int64_t)patches * v.hidden == nlast)
+        failures += compare("last_hidden", last, want_last, nlast, 8e-4f);
+
+    /* Il merger da solo: se alimentato con l'uscita del RIFERIMENTO produce il
+     * pooler del riferimento, allora il merger e' corretto e lo scarto sul
+     * pooler e' quello dei blocchi amplificato dalla sua LayerNorm -- non un
+     * difetto suo. Senza questa distinzione i due casi sono indistinguibili. */
+    {
+        int wide2 = v.hidden * v.merge * v.merge, tok2 = patches / (v.merge * v.merge);
+        float *normed = (float *)calloc((size_t)patches * v.hidden, sizeof(float));
+        float *hid = (float *)calloc((size_t)tok2 * wide2, sizeof(float));
+        float *got = (float *)calloc((size_t)tok2 * v.out_hidden, sizeof(float));
+        q38v_layernorm(normed, want_last, &v.merger_norm, patches, v.hidden, v.eps);
+        q38v_linear(hid, normed, &v.merger_fc1, tok2);
+        for (int i = 0; i < tok2 * wide2; i++) hid[i] = q38v_gelu_exact(hid[i]);
+        q38v_linear(got, hid, &v.merger_fc2, tok2);
+        failures += compare("merger da solo", got, want_out, nout, 8e-4f);
+        free(normed); free(hid); free(got);
+    }
+
+    /* Una griglia che il merge non chiude deve essere rifiutata, non arrotondata. */
+    if (q38_vision_forward(&v, pixels, 3, 3, out) != -1) {
+        printf("  FAIL una griglia 3x3 con merge 2 e' stata accettata\n");
+        failures++;
+    } else {
+        printf("  ok   griglia non divisibile per il merge rifiutata\n");
+    }
+
+    printf("\n%s\n", failures ? "TEST FAIL" : "la torre combacia con l'oracolo upstream");
+    return failures ? 1 : 0;
+}

--- a/c/tests/test_qwen38_vision.c
+++ b/c/tests/test_qwen38_vision.c
@@ -88,9 +88,13 @@ static int compare(const char *label, const float *got, const float *want,
 
 int main(int argc, char **argv)
 {
-    if (argc < 2) { fprintf(stderr, "uso: %s <cartella-fixture>\n", argv[0]); return 2; }
+    /* `make test-c` esegue ogni tests/test_* SENZA argomenti. Senza fixture
+     * questo test non ha verificato niente, e dirlo saltato e' l'unica risposta
+     * onesta: uscire con errore lo farebbe fallire su ogni macchina che non ha
+     * ancora generato la fixture, e uscire con successo sarebbe una bugia. */
+    const char *fixture = (argc >= 2) ? argv[1] : "./qwen38_vision_tiny";
     char path[1024];
-    snprintf(path, sizeof path, "%s/ref_vision.json", argv[1]);
+    snprintf(path, sizeof path, "%s/ref_vision.json", fixture);
     FILE *f = fopen(path, "rb");
     if (!f) { printf("SKIP: manca %s; genera la fixture con "
                      "tools/make_qwen38_vision_tiny.py\n", path); return 0; }
@@ -112,12 +116,12 @@ int main(int argc, char **argv)
     float *want_out = json_floats(json_get(ref, "output"), &nout);
     float *want_last = json_floats(json_get(ref, "last_hidden"), &nlast);
 
-    shards S; st_init(&S, argv[1]);
+    shards S; st_init(&S, fixture);
 
     /* La geometria viene dal config della fixture, non da costanti qui: una
      * torre con dimensioni diverse deve fallire dicendo cosa non torna, non
      * leggere silenziosamente pesi della misura sbagliata. */
-    snprintf(path, sizeof path, "%s/config.json", argv[1]);
+    snprintf(path, sizeof path, "%s/config.json", fixture);
     FILE *cf = fopen(path, "rb");
     if (!cf) { fprintf(stderr, "manca %s\n", path); return 1; }
     fseek(cf, 0, SEEK_END); long csize = ftell(cf); fseek(cf, 0, SEEK_SET);

--- a/c/tests/test_qwen38_vision_serve.py
+++ b/c/tests/test_qwen38_vision_serve.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Il percorso completo delle immagini in Qwen3.8: frame IMAGE, torre, generazione.
+
+Non verifica che il modello RISPONDA: con pesi casuali risponderebbe comunque, e
+risponderebbe identico anche ignorando del tutto l'immagine. Verifica che **due
+immagini diverse diano due risposte diverse**, che e' l'unica domanda a cui una
+fixture casuale sa rispondere onestamente, ed e' anche quella che smaschera il
+difetto piu' probabile: patch caricate, torre eseguita, e poi il risultato
+buttato via da qualche parte fra il merger e gli embedding.
+
+Poi controlla i rifiuti, perche' accettare un'immagine sbagliata e' peggio che
+rifiutarla: un conteggio di byte che non corrisponde alla griglia, e un prompt in
+cui i segnaposto non sono quanti la griglia ne produce.
+
+USO:
+  python3 tests/test_qwen38_vision_serve.py --binary ./qwen38 --fixture ./qwen38_mm_tiny
+"""
+import argparse
+import json
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+
+def read_until(process, prefixes, limit=400):
+    """Legge righe finche' non ne arriva una che comincia per uno dei prefissi."""
+    for _ in range(limit):
+        line = process.stdout.readline()
+        if not line:
+            return None
+        # Le righe di controllo del mux sono racchiuse da \x01: senza toglierli
+        # un confronto per prefisso non trova mai nulla e il test aspetta per sempre.
+        text = line.decode("utf-8", "replace").strip("\r\n\x01")
+        for prefix in prefixes:
+            if text.startswith(prefix):
+                return text
+    return None
+
+
+def turn(process, request_id, prompt_ids, patches, grid_h, grid_w, image_token):
+    """Manda IMAGE + SUBMIT e restituisce (verdetto, testo raccolto)."""
+    payload = bytes(bytearray([min(t, 255) for t in prompt_ids]))
+    if patches is not None:
+        blob = struct.pack(f"<{len(patches)}f", *patches)
+        process.stdin.write(
+            f"IMAGE {request_id} {len(blob)} {grid_h} {grid_w}\n".encode() + blob + b"\n")
+    header = f"SUBMIT {request_id} 0 {len(payload)} 4 0.0 1.0\n".encode()
+    process.stdin.write(header + payload + b"\n")
+    process.stdin.flush()
+    first = read_until(process, ("ACCEPT", "ERROR"))
+    if first is None or first.startswith("ERROR"):
+        return (first or "nessuna risposta"), ""
+    collected = []
+    for _ in range(200):
+        line = process.stdout.readline()
+        if not line:
+            break
+        text = line.decode("utf-8", "replace").strip("\r\n\x01")
+        if text.startswith("DATA"):
+            collected.append(text)
+        if text.startswith("DONE") or text.startswith("ERROR"):
+            return text, "\n".join(collected)
+    return "senza DONE", "\n".join(collected)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", type=Path, required=True)
+    parser.add_argument("--fixture", type=Path, required=True)
+    arguments = parser.parse_args()
+
+    meta_path = arguments.fixture / "vision_meta.json"
+    if not arguments.binary.exists() or not meta_path.exists():
+        print(f"SKIP: serve {arguments.binary} e la fixture; generala con "
+              f"tools/make_qwen38_multimodal_tiny.py")
+        return 0
+    meta = json.loads(meta_path.read_text())
+    grid_h, grid_w = meta["grid_h"], meta["grid_w"]
+    features, image_token = meta["features"], meta["image_token"]
+    tokens = meta["tokens"]
+    count = grid_h * grid_w * features
+
+    environment = {"SNAP": str(arguments.fixture), "SERVE": "1", "SERVE_BATCH": "1",
+                   "OMP_NUM_THREADS": "2", "PATH": "/usr/bin:/bin"}
+    process = subprocess.Popen([str(arguments.binary.resolve()), "1", "4"],
+                               stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                               stderr=subprocess.DEVNULL, env=environment)
+    failures = 0
+    try:
+        if read_until(process, ("READY",)) is None:
+            print("FAIL il motore non ha mai detto READY")
+            return 1
+        print("ok   il motore e' pronto")
+
+        prompt = [image_token] * tokens + [3, 4]
+
+        # Due immagini deliberatamente diverse: una a gradiente crescente, una a
+        # gradiente opposto. Se il risultato della torre non arrivasse agli
+        # embedding, le due risposte sarebbero identiche.
+        first = [((i % 97) / 97.0) for i in range(count)]
+        second = [1.0 - value for value in first]
+
+        verdict_a, text_a = turn(process, "a1", prompt, first, grid_h, grid_w, image_token)
+        verdict_b, text_b = turn(process, "b1", prompt, second, grid_h, grid_w, image_token)
+        for label, verdict in (("prima immagine", verdict_a), ("seconda immagine", verdict_b)):
+            if not verdict.startswith("DONE"):
+                print(f"FAIL {label}: {verdict}")
+                failures += 1
+        if not failures:
+            if text_a and text_b and text_a != text_b:
+                print("ok   due immagini diverse danno due risposte diverse")
+            else:
+                print("FAIL le due immagini hanno dato la stessa risposta: la torre "
+                      "gira ma il suo risultato non arriva agli embedding")
+                failures += 1
+
+        # Byte che non corrispondono alla griglia: va rifiutato, non arrotondato.
+        verdict, _ = turn(process, "c1", prompt, first[:-features], grid_h, grid_w, image_token)
+        if verdict.startswith("ERROR"):
+            print("ok   un conteggio di byte incoerente con la griglia e' rifiutato")
+        else:
+            print(f"FAIL byte incoerenti accettati: {verdict}")
+            failures += 1
+
+        # Segnaposto in numero sbagliato: il prompt e la griglia devono concordare.
+        verdict, _ = turn(process, "d1", [image_token] * (tokens - 1) + [3],
+                          first, grid_h, grid_w, image_token)
+        if verdict.startswith("ERROR"):
+            print("ok   un prompt con troppi pochi segnaposto e' rifiutato")
+        else:
+            print(f"FAIL segnaposto mancanti accettati: {verdict}")
+            failures += 1
+
+        # Senza immagine il motore deve continuare a funzionare come prima.
+        verdict, _ = turn(process, "e1", [3, 4, 5], None, 0, 0, image_token)
+        if verdict.startswith("DONE"):
+            print("ok   una richiesta di solo testo funziona ancora")
+        else:
+            print(f"FAIL il solo testo si e' rotto: {verdict}")
+            failures += 1
+    finally:
+        try:
+            process.stdin.close()
+        except Exception:
+            pass
+        process.terminate()
+        process.wait(timeout=10)
+
+    print()
+    if failures:
+        print(f"TEST FAIL ({failures} casi)")
+        return 1
+    print("percorso immagini Qwen3.8: frame, torre e generazione collegati")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/c/tools/make_qwen38_multimodal_tiny.py
+++ b/c/tools/make_qwen38_multimodal_tiny.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Fixture multimodale tiny per Qwen3.8: testo piu' torre vision, in un modello solo.
+
+Unisce quello che gia' sanno fare make_qwen38_tiny.py (il modello di testo) e
+make_qwen38_vision_tiny.py (la torre) in un checkpoint che il motore carica
+davvero, cosi' il percorso completo -- frame IMAGE, torre, sostituzione degli
+embedding, generazione -- si puo' provare senza i 185 GB.
+
+Il test che ci gira sopra non verifica che il modello risponda: con pesi casuali
+risponderebbe comunque, e risponderebbe anche ignorando del tutto l'immagine.
+Verifica che DUE IMMAGINI DIVERSE DIANO DUE RISPOSTE DIVERSE, che e' l'unica
+domanda a cui una fixture casuale sa rispondere onestamente.
+
+USO:
+  python3 tools/make_qwen38_multimodal_tiny.py --out ./qwen38_mm_tiny
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+SEED = 20260830
+
+
+def build(out: Path, *, grid_h=4, grid_w=4, seed=SEED):
+    import torch
+    from safetensors.torch import save_file
+    from transformers.models.qwen4_exp.configuration_qwen4_exp import Qwen4ExpVisionConfig
+    from transformers.models.qwen4_exp.modeling_qwen4_exp import Qwen4ExpVisionModel
+
+    import make_qwen38_tiny
+
+    out.mkdir(parents=True, exist_ok=True)
+    text_dir = out / "_text"
+    make_qwen38_tiny.build(text_dir, emit_ref=False)
+    text_config = json.loads((text_dir / "config.json").read_text())
+
+    vocab = text_config.get("vocab_size") or text_config["text_config"]["vocab_size"]
+    hidden = text_config.get("hidden_size") or text_config["text_config"]["hidden_size"]
+    # Il segnaposto immagine deve stare nel vocabolario del modello di testo, o
+    # il motore rifiuterebbe il token prima ancora di arrivare alla torre.
+    image_token = vocab - 1
+
+    vision = Qwen4ExpVisionConfig(
+        depth=2, hidden_size=64, num_heads=4, intermediate_size=128,
+        patch_size=16, spatial_merge_size=2, temporal_patch_size=2,
+        in_channels=3, out_hidden_size=hidden, num_position_embeddings=64,
+        hidden_act="gelu_pytorch_tanh",
+    )
+    torch.manual_seed(seed)
+    tower = Qwen4ExpVisionModel(vision).eval()
+    with torch.no_grad():
+        for parameter in tower.parameters():
+            parameter.copy_(torch.randn_like(parameter) * 0.6)
+
+    from safetensors.torch import load_file
+    tensors = dict(load_file(str(text_dir / "model.safetensors")))
+    for name, value in tower.state_dict().items():
+        tensors[f"model.visual.{name}"] = value.detach().contiguous()
+    save_file(tensors, str(out / "model.safetensors"))
+
+    merged = dict(text_config)
+    merged["vision_config"] = vision.to_dict()
+    merged["image_token_id"] = image_token
+    (out / "config.json").write_text(json.dumps(merged, indent=2))
+    for extra in ("generation_config.json",):
+        source = text_dir / extra
+        if source.exists():
+            (out / extra).write_text(source.read_text())
+
+    features = vision.in_channels * vision.temporal_patch_size * vision.patch_size ** 2
+    tokens = (grid_h * grid_w) // (vision.spatial_merge_size ** 2)
+    (out / "vision_meta.json").write_text(json.dumps({
+        "grid_h": grid_h, "grid_w": grid_w, "features": features,
+        "image_token": image_token, "tokens": tokens,
+    }))
+    print(f"  fixture multimodale: vocab {vocab}, hidden {hidden}, "
+          f"segnaposto immagine {image_token}, {tokens} token per immagine")
+    print(f"  scritta in {out}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, required=True)
+    arguments = parser.parse_args()
+    import sys
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    try:
+        build(arguments.out)
+    except ImportError as exc:
+        raise SystemExit(f"serve transformers e safetensors: {exc}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/c/tools/make_qwen38_vision_tiny.py
+++ b/c/tools/make_qwen38_vision_tiny.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Fixture e oracolo per la torre vision di Qwen3.8, senza scaricare i pesi.
+
+La torre viene costruita da `Qwen4ExpVisionModel` upstream con dimensioni
+minuscole e pesi casuali deterministici, e il suo forward viene registrato. Il
+motore C legge la stessa fixture e deve produrre gli stessi numeri.
+
+Perche' la torre viene isolata dal modello di testo invece di generare una
+fixture multimodale intera: la torre ha una geometria sua (interpolazione delle
+posizioni apprese, RoPE 2D, merge di 4 token adiacenti) e sbagliarne un pezzo si
+vede come uno scarto piccolo dopo il merger, non come un errore. Se il confronto
+avvenisse solo sui token finali del modello, un difetto nella torre arriverebbe
+mescolato a tutto il resto e sarebbe molto piu' difficile da localizzare.
+
+La fixture NON richiede il checkpoint: 240k parametri casuali, qualche centinaio
+di kB. Serve solo transformers.
+
+USO:
+  python3 tools/make_qwen38_vision_tiny.py --out ./qwen38_vision_tiny
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+SEED = 20260830
+
+
+def build(out: Path, *, grid_h=4, grid_w=4, seed=SEED):
+    import torch
+    from safetensors.torch import save_file
+    from transformers.models.qwen4_exp.configuration_qwen4_exp import Qwen4ExpVisionConfig
+    from transformers.models.qwen4_exp.modeling_qwen4_exp import Qwen4ExpVisionModel
+
+    # Piccole ma non degeneri: piu' di una testa perche' lo split per testa e' un
+    # punto in cui si sbaglia, due blocchi perche' con uno solo un residuo
+    # scambiato non si vede, e una griglia 4x4 perche' con 2x2 il merge coprirebbe
+    # tutta l'immagine e l'ordine dei blocchi non verrebbe esercitato.
+    config = Qwen4ExpVisionConfig(
+        depth=2, hidden_size=64, num_heads=4, intermediate_size=128,
+        patch_size=16, spatial_merge_size=2, temporal_patch_size=2,
+        in_channels=3, out_hidden_size=32, num_position_embeddings=64,
+        hidden_act="gelu_pytorch_tanh",
+    )
+    torch.manual_seed(seed)
+    model = Qwen4ExpVisionModel(config).eval()
+    # La scala dei pesi NON e' un dettaglio estetico. A 0.05 i prodotti q.k sono
+    # cosi' piccoli che il softmax esce praticamente uniforme: l'attenzione
+    # diventa la media dei valori e smette di dipendere dai punteggi. Con quella
+    # fixture una torre SENZA RoPE passava il confronto -- verificato, non
+    # temuto. A 0.6 i punteggi hanno un intervallo vero e la rope si vede.
+    with torch.no_grad():
+        for name, parameter in model.named_parameters():
+            parameter.copy_(torch.randn_like(parameter) * 0.6)
+
+    features = config.in_channels * config.temporal_patch_size * config.patch_size ** 2
+    pixels = torch.randn(grid_h * grid_w, features, generator=torch.Generator().manual_seed(seed + 1))
+    grid = torch.tensor([[1, grid_h, grid_w]])
+    with torch.no_grad():
+        result = model(pixels, grid_thw=grid)
+
+    out.mkdir(parents=True, exist_ok=True)
+    tensors = {f"model.visual.{k}": v.detach().contiguous()
+               for k, v in model.state_dict().items()}
+    save_file(tensors, str(out / "model.safetensors"))
+    (out / "config.json").write_text(json.dumps(
+        {"model_type": "qwen4_exp", "vision_config": config.to_dict()}, indent=2))
+
+    reference = {
+        "grid": [1, grid_h, grid_w],
+        "features": features,
+        "pixels": pixels.flatten().tolist(),
+        "tokens": int(result.pooler_output.shape[0]),
+        "out_hidden": int(result.pooler_output.shape[1]),
+        "output": result.pooler_output.flatten().tolist(),
+        # Anche l'uscita PRIMA del merger: se solo questa combacia il difetto e'
+        # nel merger, se non combacia nessuna delle due e' nei blocchi. Un solo
+        # numero finale non distinguerebbe i due casi.
+        "last_hidden": result.last_hidden_state.flatten().tolist(),
+        "hidden_size": config.hidden_size,
+    }
+    (out / "ref_vision.json").write_text(json.dumps(reference))
+    print(f"  fixture: {len(tensors)} tensori, griglia {grid_h}x{grid_w}, "
+          f"{result.pooler_output.shape[0]} token da {result.pooler_output.shape[1]}")
+    print(f"  scritta in {out}")
+    return reference
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--grid-h", type=int, default=4)
+    parser.add_argument("--grid-w", type=int, default=4)
+    arguments = parser.parse_args()
+    try:
+        build(arguments.out, grid_h=arguments.grid_h, grid_w=arguments.grid_w)
+    except ImportError as exc:
+        raise SystemExit(f"serve transformers e safetensors: {exc}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/c/tools/qwen38_image.py
+++ b/c/tools/qwen38_image.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Da un'immagine alle patch che la torre vision di Qwen3.8 si aspetta.
+
+Il motore C prende patch gia' estratte e non sa niente di JPEG, di
+ridimensionamenti o di normalizzazioni: quel lavoro sta qui, dove Python c'e'
+gia' per il template di chat e per il gateway.
+
+Cosa fa, nell'ordine del processore ufficiale (`Qwen2VLImageProcessor`):
+
+  1. decodifica e converte in RGB
+  2. sceglie la tela con smart_resize -- aritmetica intera, allineata a 32
+     (patch 16 per merge 2), dentro alla finestra di pixel del checkpoint
+  3. ridimensiona, riscala di 1/255 e normalizza con media e deviazione 0.5
+  4. spezza in patch nell'ordine che vuole la torre: a blocchi di merge,
+     e dentro ogni patch canale, ripetizione temporale, riga, colonna
+
+Due differenze da GLM-5.3 che contano, e che sono la ragione per cui questo
+file esiste invece di riusare glm53_image.py.
+
+**La risoluzione e' dinamica, non fissa.** GLM-5.3 porta tutto su una tela di
+448 e riempie con zeri. Qwen conserva le proporzioni e sceglie la tela in modo
+che l'AREA cada dentro [shortest_edge, longest_edge] pixel: niente padding, ma
+il numero di token dipende dall'immagine. Un 1080p produce 2040 token, che su un
+motore che legge gli esperti dal disco e' un prefill che nessuno aspetta -- lo
+stesso motivo per cui GLM53_MAX_IMAGE_TOKENS esiste.
+
+**La normalizzazione e' 0.5/0.5**, non le costanti CLIP.
+
+Un avvertimento onesto sul punto 3, identico a quello di GLM-5.3. Il processore
+di riferimento ridimensiona con torchvision, e riprodurne il bicubico senza
+portarsi dietro torch non e' possibile: qui si usa quello di Pillow. Geometria,
+ordine delle patch e normalizzazione sono identici e verificati contro il
+riferimento; i valori dei pixel differiscono di quanto differiscono due
+bicubici, che il test misura e scrive invece di dichiararlo zero.
+
+USO:
+  python3 tools/qwen38_image.py foto.jpg --out patches.f32
+  python3 tools/qwen38_image.py foto.jpg --json          # solo la griglia
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+PATCH = 16
+MERGE = 2
+TEMPORAL = 2
+# La finestra in PIXEL della tela, non in token: e' cosi' che la scrive il
+# checkpoint (size.shortest_edge / size.longest_edge).
+MIN_PIXELS = 65536
+MAX_PIXELS = 16777216
+MEAN = (0.5, 0.5, 0.5)
+STD = (0.5, 0.5, 0.5)
+# Il riferimento rifiuta oltre questo rapporto invece di produrre una tela
+# degenere. Rifiutare e' la risposta giusta: un'immagine 1x500 non ha una
+# rappresentazione sensata a patch quadrate.
+MAX_RATIO = 200
+
+
+def smart_resize(height, width, *, factor=PATCH * MERGE,
+                 min_pixels=MIN_PIXELS, max_pixels=MAX_PIXELS):
+    """La tela allineata a `factor`, con l'area dentro alla finestra.
+
+    Aritmetica intera e nell'ordine del riferimento: prima si arrotonda al
+    multiplo di factor, POI si corregge se l'area e' fuori finestra. Invertire i
+    due passi da' tele diverse di una patch su certe forme, e una patch di
+    differenza e' una griglia diversa, cioe' un numero di token diverso."""
+    if height <= 0 or width <= 0:
+        raise ValueError(f"dimensioni non valide: {width}x{height}")
+    if max(height, width) / min(height, width) > MAX_RATIO:
+        raise ValueError(
+            f"rapporto {max(height, width) / min(height, width):.1f} oltre {MAX_RATIO}: "
+            f"un'immagine cosi' allungata non ha una tela sensata a patch quadrate")
+    h_bar = max(factor, round(height / factor) * factor)
+    w_bar = max(factor, round(width / factor) * factor)
+    if h_bar * w_bar > max_pixels:
+        beta = math.sqrt((height * width) / max_pixels)
+        h_bar = max(factor, math.floor(height / beta / factor) * factor)
+        w_bar = max(factor, math.floor(width / beta / factor) * factor)
+    elif h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (height * width))
+        h_bar = math.ceil(height * beta / factor) * factor
+        w_bar = math.ceil(width * beta / factor) * factor
+    return h_bar, w_bar
+
+
+def patchify(pixels, numpy, patch=PATCH, merge=MERGE, temporal=TEMPORAL):
+    """[3, H, W] normalizzato -> [griglia, 3*T*16*16], nell'ordine della torre.
+
+    L'ordine non e' quello della griglia riga per riga: e' a blocchi di merge,
+    perche' e' cosi' che il merger 2x2 poi li richiude. Dentro ogni patch i
+    valori vanno canale, ripetizione temporale, riga, colonna."""
+    channels, height, width = pixels.shape
+    grid_h, grid_w = height // patch, width // patch
+    blocks = pixels.reshape(channels, grid_h // merge, merge, patch,
+                            grid_w // merge, merge, patch)
+    # [gh/m, gw/m, m, m, C, p, p]
+    blocks = blocks.transpose(1, 4, 2, 5, 0, 3, 6)
+    blocks = numpy.repeat(blocks[..., None, :, :], temporal, axis=-3)
+    return numpy.ascontiguousarray(
+        blocks.reshape(grid_h * grid_w, channels * temporal * patch * patch),
+        dtype=numpy.float32), grid_h, grid_w
+
+
+def load_config(model_dir):
+    """I parametri veri del checkpoint, quando c'e'.
+
+    preprocessor_config.json e' la fonte giusta, ma un export che non ce l'ha ha
+    comunque vision_config dentro config.json: patch, merge e ripetizione
+    temporale devono venire dal modello che si sta usando, non da costanti
+    scritte qui, o su un checkpoint con una geometria diversa si taglierebbero
+    patch della misura sbagliata senza che nulla protesti."""
+    settings = {}
+    if not model_dir:
+        return settings
+    root = Path(model_dir)
+    processor = root / "preprocessor_config.json"
+    if processor.exists():
+        raw = json.loads(processor.read_text())
+        for key in ("patch_size", "merge_size", "temporal_patch_size",
+                    "image_mean", "image_std"):
+            if key in raw:
+                settings[key] = raw[key]
+        size = raw.get("size") or {}
+        if "shortest_edge" in size:
+            settings["min_pixels"] = size["shortest_edge"]
+        if "longest_edge" in size:
+            settings["max_pixels"] = size["longest_edge"]
+    config = root / "config.json"
+    if config.exists():
+        vision = json.loads(config.read_text()).get("vision_config") or {}
+        for their, ours in (("patch_size", "patch_size"),
+                            ("spatial_merge_size", "merge_size"),
+                            ("temporal_patch_size", "temporal_patch_size")):
+            if their in vision:
+                settings.setdefault(ours, vision[their])
+    return settings
+
+
+def preprocess(source, model_dir=None, max_tokens=None):
+    """Immagine -> (patch float32, grid_h, grid_w).
+
+    `max_tokens` e' un tetto NOSTRO, non del checkpoint: la finestra ufficiale
+    arriva a 2040 token per un 1080p, e su un motore che legge gli esperti dal
+    disco quel prefill non lo aspetta nessuno. Rimpicciolisce, non ritaglia:
+    quello che si perde e' dettaglio, non pezzi di immagine."""
+    try:
+        import numpy
+        from PIL import Image
+    except ImportError as exc:                    # pragma: no cover
+        raise SystemExit(f"serve Pillow e numpy: {exc}")
+
+    settings = load_config(model_dir)
+    patch = int(settings.get("patch_size", PATCH))
+    merge = int(settings.get("merge_size", MERGE))
+    temporal = int(settings.get("temporal_patch_size", TEMPORAL))
+    mean = tuple(settings.get("image_mean", MEAN))
+    std = tuple(settings.get("image_std", STD))
+    min_pixels = int(settings.get("min_pixels", MIN_PIXELS))
+    max_pixels = int(settings.get("max_pixels", MAX_PIXELS))
+
+    if max_tokens:
+        # Un token copre merge*patch per lato, quindi un tetto in token e' un
+        # tetto in pixel di tela.
+        ceiling = int(max_tokens) * (merge * patch) ** 2
+        max_pixels = min(max_pixels, ceiling)
+        min_pixels = min(min_pixels, max_pixels)
+
+    image = Image.open(source) if not hasattr(source, "mode") else source
+    image = image.convert("RGB")
+    width, height = image.size
+    target_h, target_w = smart_resize(height, width, factor=patch * merge,
+                                      min_pixels=min_pixels, max_pixels=max_pixels)
+    if (target_w, target_h) != (width, height):
+        image = image.resize((target_w, target_h), Image.BICUBIC)
+
+    pixels = numpy.asarray(image, dtype=numpy.float32) / 255.0     # [H, W, 3]
+    pixels = (pixels - numpy.array(mean, dtype=numpy.float32)) / numpy.array(
+        std, dtype=numpy.float32)
+    pixels = numpy.ascontiguousarray(pixels.transpose(2, 0, 1))    # [3, H, W]
+    return patchify(pixels, numpy, patch=patch, merge=merge, temporal=temporal)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("image", type=Path)
+    parser.add_argument("--model", type=Path, default=None,
+                        help="cartella del checkpoint, per prendere la geometria vera")
+    parser.add_argument("--out", type=Path, default=None, help="patch float32 grezze")
+    parser.add_argument("--max-tokens", type=int, default=None)
+    parser.add_argument("--json", action="store_true", help="solo la griglia, su stdout")
+    arguments = parser.parse_args()
+
+    patches, grid_h, grid_w = preprocess(arguments.image, arguments.model,
+                                         arguments.max_tokens)
+    if arguments.json:
+        print(json.dumps({"grid_h": grid_h, "grid_w": grid_w,
+                          "patches": int(patches.shape[0]),
+                          "features": int(patches.shape[1]),
+                          "tokens": grid_h * grid_w // (MERGE * MERGE)}))
+    if arguments.out:
+        arguments.out.write_bytes(patches.tobytes())
+        print(f"{patches.shape[0]} patch x {patches.shape[1]} -> {arguments.out}",
+              file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/qwen38.md
+++ b/docs/qwen38.md
@@ -215,6 +215,38 @@ lever here. It shrinks rather than crops: what is lost is detail, not pieces.
 
 **Normalisation is 0.5/0.5**, not the CLIP constants.
 
-The tower is 27 blocks, hidden 1152, 16 heads, patch 16, spatial merge 2,
-projecting to 2560. The prompt side is already documented by the template, which
-splices images as `<|vision_start|><|image_pad|><|vision_end|>`.
+### The tower
+
+`qwen38_vision.h` implements it: 27 blocks, hidden 1152, 16 heads, patch 16,
+spatial merge 2, projecting to 2560. Verified against the upstream
+`Qwen4ExpVisionModel`, again without the checkpoint -- the fixture is a 240 kB
+tower with random weights:
+
+```
+make -C c qwen38-vision-check
+```
+
+Two findings from building it are worth carrying, because both were invisible
+until an oracle was there to see them.
+
+**The merger uses a different GELU from the blocks.** The blocks take
+`ACT2FN[hidden_act]`, which is `gelu_pytorch_tanh` here; the merger instantiates
+`nn.GELU()`, the exact erf one. Using one for both matches to 4.6e-3 -- close
+enough to look right and far enough to move the image tokens.
+
+**A fixture can be too weak to test what it claims to.** The first version scaled
+the random weights to 0.05, which makes the q.k products so small that softmax
+comes out essentially uniform: attention degenerates into the mean of the values
+and stops depending on the scores. A tower with **no RoPE at all** passed that
+fixture. At 0.6 the scores have a real range, and the four negative controls
+(rope off, wrong GELU, raster patch order, flat position interpolation) all fail
+as they should.
+
+The tolerance is measured, not chosen: the reference in float32 differs from
+itself in float64 by 1.83e-4 on these activations, so a gap of that order is the
+arithmetic rather than a defect, and the threshold sits between it and the
+4.6e-3 the real bug produced.
+
+The prompt side is settled by the template, which splices images as
+`<|vision_start|><|image_pad|><|vision_end|>`. Wiring the tower into the engine's
+sequence, and accepting images at the gateway, is the remaining step.

--- a/docs/qwen38.md
+++ b/docs/qwen38.md
@@ -247,6 +247,34 @@ itself in float64 by 1.83e-4 on these activations, so a gap of that order is the
 arithmetic rather than a defect, and the threshold sits between it and the
 4.6e-3 the real bug produced.
 
-The prompt side is settled by the template, which splices images as
-`<|vision_start|><|image_pad|><|vision_end|>`. Wiring the tower into the engine's
-sequence, and accepting images at the gateway, is the remaining step.
+### Wired up
+
+Images work end to end. Send an OpenAI `image_url` part with a base64 data URI or
+a local path; the gateway preprocesses it, replaces the part with
+`<|vision_start|>` + N x `<|image_pad|>` + `<|vision_end|>`, and hands the patches
+to the engine in an `IMAGE` frame ahead of the `SUBMIT` they belong to. The engine
+runs the tower once and substitutes its output for the embedding of each
+placeholder.
+
+N is not a constant. The resolution is dynamic, so the placeholder count comes
+from the grid the preprocessor chose, and the engine **refuses** a request where
+the prompt and the grid disagree rather than guessing which vectors go where.
+`Q38_MAX_IMAGE_TOKENS` caps it; a 1080p photo is 2040 tokens without one.
+
+```
+make -C c qwen38-vision-serve-check
+```
+
+That gate does not check the model answers -- with random weights it would answer
+regardless, and would answer identically while ignoring the picture entirely. It
+checks that **two different images produce two different answers**, which is the
+only question a random fixture can answer honestly, and the one that catches the
+likeliest defect: patches loaded, tower run, result dropped somewhere between the
+merger and the embeddings. It also checks the refusals, since accepting a wrong
+image is worse than refusing it.
+
+Remote URLs are refused rather than fetched, as elsewhere: a request should not
+make the server open a connection of the sender's choosing.
+
+One image per request for now -- the engine holds a single pending image, and a
+second arriving before its `SUBMIT` drops the first and says so.

--- a/docs/qwen38.md
+++ b/docs/qwen38.md
@@ -30,7 +30,8 @@ COLI_MODEL=~/Models/Qwen3.8-Flash-Next-FP8 ./c/coli chat
 `coli serve` and `coli web` use the same text-only gateway path. Qwen3.8 thinks
 by default; `reasoning_effort` accepts `low`, `medium`, `high`, and `xhigh`, and
 `enable_thinking: false` emits the model's official empty thinking prefix.
-Tools, image content, audio, and grammar constraints are rejected explicitly.
+Tools, audio and grammar constraints are rejected explicitly, and so are
+images -- for now, see **Vision** below.
 
 The official FP8 repository is about 185.5 GB in decimal units (roughly 173
 GiB). The default CPU engine keeps resident BF16 matrices in their native
@@ -177,3 +178,43 @@ A/B diagnosis. It does not change the single-token decode path.
 
 The weights remain covered by the Qwen Community License 1.0 in the downloaded
 checkpoint. They are not redistributed by Colibri.
+
+## Vision
+
+The released checkpoint is multimodal and the engine already reads its
+`model.language_model` prefix, so the vision tensors are present and reachable.
+The tower itself is not implemented yet; images are still refused rather than
+silently dropped.
+
+What exists today is the half that decides whether vision is *correct* rather
+than nearly correct: `tools/qwen38_image.py`, pinned against the official
+`Qwen2VLImageProcessor` in `tests/test_qwen38_image.py`.
+
+```
+python3 tests/test_qwen38_image.py --config <model>/preprocessor_config.json
+```
+
+Neither needs the weights. The reference processor is built from
+`preprocessor_config.json` alone, which is 390 bytes, so the preprocessing can be
+developed and verified without the 185 GB.
+
+Measured against it on eight shapes: **geometry and patch order identical**, and
+pixels bit-identical wherever no resampling happens (0.0000 on 256x256 and
+640x480), 0.0157 worst case where it does, which is Pillow's bicubic against
+torchvision's. A wrong patch order would show as a discrepancy near 1, not 0.01.
+
+Two things differ from GLM-5.3's tower and are the reason this is its own file:
+
+**The resolution is dynamic.** GLM-5.3 fits everything onto a 448 canvas and
+pads. Qwen keeps the aspect ratio and picks a canvas whose *area* falls inside
+`[shortest_edge, longest_edge]`, so there is no padding but the token count
+depends on the image. A 1080p photo becomes **2040 tokens**, which on a
+disk-streaming engine is a prefill nobody will sit through -- the same reason
+`GLM53_MAX_IMAGE_TOKENS` exists, and `preprocess(max_tokens=...)` is the same
+lever here. It shrinks rather than crops: what is lost is detail, not pieces.
+
+**Normalisation is 0.5/0.5**, not the CLIP constants.
+
+The tower is 27 blocks, hidden 1152, 16 heads, patch 16, spatial merge 2,
+projecting to 2560. The prompt side is already documented by the template, which
+splices images as `<|vision_start|><|image_pad|><|vision_end|>`.


### PR DESCRIPTION
**This is half of vision, and the half that decides whether it is correct rather than nearly correct.** The tower is not implemented and images are still refused; this is the piece the tower would otherwise be built on top of blind.

I would rather ship it separately than bundle it into a tower PR where it becomes invisible, because it is independently verifiable *today* and the tower is not.

## Why preprocessing is worth its own gate

It is where vision goes wrong silently. A canvas one patch too wide, a different patch order, the other model's normalisation constants — none of that raises. The model answers anyway, and answers worse. So the reference is the real `Qwen2VLImageProcessor`, not a re-reading of the paper.

**It does not need the weights.** The reference builds from `preprocessor_config.json` alone, which is 390 bytes. All of this was developed and verified without downloading the 185 GB checkpoint, which is also why the same approach will work for whoever writes the tower.

## Measured

Eight shapes, chosen to hit every branch of `smart_resize` — below the pixel window so the canvas grows, inside it, far above so it shrinks, and non-square in both directions:

| | |
|---|---|
| geometry and patch order | **identical on all eight** |
| pixels, no resampling (256x256, 640x480) | **0.0000** |
| pixels, with resampling | 0.0157 worst case |

That last figure is Pillow's bicubic against torchvision's, and it is measured and printed rather than declared zero. What makes the tolerance meaningful instead of permissive: **a wrong patch order shows up near 1, not 0.01.** The two exact rows are the real check.

An extreme aspect ratio is refused rather than turned into a degenerate canvas, matching the reference. A 1x5000 image has no sensible representation in square patches, and failing here beats failing further down.

## Two differences from GLM-5.3, and why this is its own file

**Resolution is dynamic.** GLM-5.3 fits everything onto a 448 canvas and pads. Qwen keeps the aspect ratio and picks a canvas whose *area* lands inside `[shortest_edge, longest_edge]`, so there is no padding but the token count depends on the image.

That has a consequence worth stating plainly: **a 1080p photo becomes 2040 tokens.** On an engine that streams experts from disk that is a prefill nobody will sit through, which is exactly why `GLM53_MAX_IMAGE_TOKENS` exists. `preprocess(max_tokens=...)` is the same lever, and it shrinks rather than crops — what is lost is detail, not pieces of the image.

**Normalisation is 0.5/0.5**, not the CLIP constants.

## For whoever picks up the tower

27 blocks, hidden 1152, 16 heads, patch 16, spatial merge 2, projecting to 2560, `gelu_pytorch_tanh`, 2304 learned position embeddings. `deepstack_visual_indexes` is empty, so there is no deepstack merging to reproduce. The prompt side is already settled by the template, which splices images as `<|vision_start|><|image_pad|><|vision_end|>`.

Stacked conceptually after #1279 (tool calling) but independent of it: this branch is cut from dev and shares no code with it.