### PR TITLE
fix(glm53): --no-think asked for maximum reasoning and closed the block

### DIFF
--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -1825,11 +1825,23 @@ def render_chat_glm53(messages, enable_thinking=False, reasoning_effort=None, to
     elif tool_choice == "none":
         tools = None                              # il client li ha vietati: non si offrono
 
-    # low e high passano, tutto il resto e' Max: e' la scala del template, non
-    # la nostra. `none` non arriva qui, spegne il ragionamento a monte.
-    effort = {"minimal": "Low", "low": "Low", "medium": "High",
-              "high": "High", "xhigh": "Max"}.get(reasoning_effort, "Max")
-    prompt = ["[gMASK]<sop>", f"<|system|>Reasoning Effort: {effort}"]
+    prompt = ["[gMASK]<sop>"]
+    if enable_thinking:
+        # SOLO col ragionamento acceso. Con --no-think il prompt chiude gia' il
+        # blocco, e lasciare "Reasoning Effort: Max" davanti a un <think></think>
+        # chiuso dice al modello due cose opposte: rifletti al massimo, e hai
+        # finito di riflettere. Il modello risponde riaprendo un <think>, lo
+        # splitter -- che era partito correttamente in modalita' testo -- lo vede
+        # e ci rientra, e da li' in poi tutta la risposta viene archiviata come
+        # pensiero: l'utente vede riflettere e poi nessuna risposta (#1278).
+        # render_chat (GLM-5.2) mette questa riga sotto la stessa condizione da
+        # sempre, ed e' l'unico dei due che non ha mai avuto questa segnalazione.
+        #
+        # low e high passano, tutto il resto e' Max: e' la scala del template,
+        # non la nostra. `none` non arriva qui, spegne il ragionamento a monte.
+        effort = {"minimal": "Low", "low": "Low", "medium": "High",
+                  "high": "High", "xhigh": "Max"}.get(reasoning_effort, "Max")
+        prompt.append(f"<|system|>Reasoning Effort: {effort}")
     if tools:
         prompt.append(_glm53_tool_block(tools))
 

--- a/c/tests/test_glm53_chat_template.py
+++ b/c/tests/test_glm53_chat_template.py
@@ -146,8 +146,24 @@ def main() -> int:
     if not off.endswith("<|assistant|><think></think>"):
         print(f"FAIL: col ragionamento spento il prompt finisce con {off[-40:]!r}")
         return 1
-    if off[:-len("</think>")] != on:
-        print("FAIL: acceso e spento differiscono per piu' della chiusura del blocco")
+    # Questa asserzione prima pretendeva che acceso e spento differissero SOLO
+    # per </think>. Era sbagliata, ed e' costata #1278: lasciava "Reasoning
+    # Effort: Max" davanti a un blocco gia' chiuso, cioe' diceva al modello di
+    # riflettere al massimo e insieme che aveva finito. Il modello riapre un
+    # <think>, lo splitter ci rientra e archivia la risposta come pensiero:
+    # l'utente vede riflettere e poi niente.
+    #
+    # Adesso pretende le DUE differenze che devono esserci e nessun'altra: il
+    # blocco chiuso, e nessuna riga di effort. E' la stessa forma che
+    # render_chat (GLM-5.2) produce da sempre.
+    if "Reasoning Effort" in off:
+        print("FAIL: col ragionamento spento il prompt chiede ancora di riflettere")
+        return 1
+    stripped = on.replace("[gMASK]<sop>", "", 1)
+    stripped = stripped[stripped.index("<|user|>"):] if "<|user|>" in stripped else stripped
+    if off[:-len("</think>")] != "[gMASK]<sop>" + stripped:
+        print("FAIL: acceso e spento differiscono per piu' della chiusura del blocco "
+              "e della riga di effort")
         return 1
 
     print(f"PASS GLM-5.3 chat template: {checked} rese identiche a "


### PR DESCRIPTION
Closes #1278, where GLM-5.3 with `--no-think` thinks briefly and then ends without producing an answer.

## The prompt said two opposite things

    <|system|>Reasoning Effort: Max ... <|assistant|><think></think>

Reason maximally, and you have finished reasoning.

The model answers that by opening a fresh `<think>`. The splitter had correctly started in **text** mode — the prompt closed the block, so output should be pure answer — sees the new marker, re-enters reasoning, and files everything after it as thought. What reaches the user is thinking, then nothing. Which is exactly the report.

## The evidence this is the cause

`render_chat` (GLM-5.2) emits that line under `if enable_thinking` and has done since it was written. `render_chat_glm53` emitted it unconditionally. Same family, same template lineage, same switch — and only one of the two has this report.

    GLM-5.2  --no-think:  [gMASK]<sop><|user|>What are you?<|assistant|><think></think>
    GLM-5.3  --no-think:  [gMASK]<sop><|system|>Reasoning Effort: Max<|user|>...<think></think>

What I ruled out first, so this is not the first guess that fit: the `<think></think>` form is byte-identical to what the template writes for a past turn with no reasoning (line 152), so the closing itself is right; the flag reaches the renderer through the only path that exists; the splitter starts in text mode; and `</think>` is not a stop sequence.

## What did not change

The **24 template-pinned cases still render byte-identical**. They all have thinking ON, which is the only case `chat_template.jinja` actually defines — the template has no switch for turning reasoning off, which is why our off-form needed inventing in the first place.

## The assertion that let this through was mine

The pinned test required thinking-on and thinking-off to differ **only** by `</think>`. That is the same mistake in test form: it treats the effort line as belonging in both. It now requires the two differences that must be there and no others — closed block, no effort line — and rejects a prompt that still asks for reasoning while closing the block.

## Stating the limit

**I could not reproduce on the real checkpoint.** Two runs against the 183 GB model timed out at roughly two minutes per token, on a machine also uploading 182 GB and running another training job. So this is a fix for a verified inconsistency with a mechanism that matches the symptom, not a confirmed reproduction.

@acedogblast — if you can try this branch, the check is one line: with `--no-think` the prompt should no longer contain `Reasoning Effort`. If it still ends on thinking after that, the cause is elsewhere and I would rather know.