### PR TITLE
build: list the headers each engine includes as Makefile prerequisites

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -716,7 +716,7 @@ $(file >.build-config,$(BUILD_CONFIG))
 endif
 .build-config: ;
 
-colibri$(EXE): colibri.c cli_args.h st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h quant.h sample.h kv_persist.h telemetry.h route_trace.h omp_tune.h kv_fp8.h kv_tq.h $(CUDA_OBJ) $(METAL_OBJ) $(VK_OBJ) $(VK_SPV) .build-config
+colibri$(EXE): colibri.c cli_args.h st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h quant.h sample.h kv_persist.h telemetry.h route_trace.h omp_tune.h kv_fp8.h kv_tq.h abl.h backend_cuda.h backend_metal.h backend_vulkan.h decode_batch.h edge_adapters.h edge_runtime.h edge_tok_internal.h schema_gbnf.h segment_adapter_internal.h segment_adapters.h segment_runtime.h tier.h $(CUDA_OBJ) $(METAL_OBJ) $(VK_OBJ) $(VK_SPV) .build-config
 	$(CC) $(CFLAGS) colibri.c $(CUDA_OBJ) $(METAL_OBJ) $(VK_OBJ) -o colibri$(EXE) $(LDFLAGS)
 
 # Vulkan backend object (plain C + vulkan headers) and its SPIR-V shaders.
@@ -997,7 +997,7 @@ fp8-bench: fp8_bench$(EXE)
 # the GPU sits idle. Same guard #783 put on kimi_k3, which since gaining an
 # MXFP4 expert path no longer needs it. tests/test_makefile_cuda_scope.py
 # asserts this shape.
-olmoe$(EXE): olmoe.c cli_args.h st.h json.h compat.h sample.h tok.h tok_unicode.h tok_unicode_o200k.h omp_tune.h route_trace.h serve_codec.h
+olmoe$(EXE): olmoe.c cli_args.h st.h json.h compat.h sample.h tok.h tok_unicode.h tok_unicode_o200k.h omp_tune.h route_trace.h serve_codec.h edge_adapters.h edge_runtime.h edge_tok_internal.h fused_simd.h segment_adapter_internal.h segment_adapters.h segment_runtime.h
 	$(CC) $(NOCUDA_CFLAGS) olmoe.c -o olmoe$(EXE) $(NOCUDA_LDFLAGS)
 
 # Qwen3.6-35B-A3B engine (hybrid Gated Attention + Gated DeltaNet + streaming
@@ -1019,7 +1019,7 @@ QWEN36_TIER_SRC =
 QWEN36_CFLAGS   = $(NOCUDA_CFLAGS)
 QWEN36_LDFLAGS  = $(NOCUDA_LDFLAGS)
 endif
-qwen36$(EXE): qwen36.c cli_args.h qwen36_tier.h st.h json.h compat.h $(QWEN36_TIER_SRC) $(CUDA_OBJ)
+qwen36$(EXE): qwen36.c cli_args.h qwen36_tier.h st.h json.h compat.h edge_adapter_internal.h edge_adapters.h edge_runtime.h segment_adapter_internal.h segment_adapters.h segment_runtime.h $(QWEN36_TIER_SRC) $(CUDA_OBJ)
 	$(CC) $(QWEN36_CFLAGS) qwen36.c $(QWEN36_TIER_SRC) $(CUDA_OBJ) -o qwen36$(EXE) $(QWEN36_LDFLAGS)
 
 # Qwen3.8-Flash-Next text-only sibling. This target is intentionally CPU-only;
@@ -1071,7 +1071,7 @@ tests/test_qwen36_json_escape$(EXE): tests/test_qwen36_json_escape.c qwen36.c qw
 tests/bench_qwen36_dense_batch$(EXE): tests/bench_qwen36_dense_batch.c qwen36.c qwen36_tier.h st.h json.h compat.h $(QWEN36_TIER_SRC) $(CUDA_OBJ)
 	$(CC) $(QWEN36_CFLAGS) $< $(QWEN36_TIER_SRC) $(CUDA_OBJ) -o $@ $(QWEN36_LDFLAGS)
 
-inkling$(EXE): inkling.c cli_args.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h omp_tune.h route_trace.h kv_prefix.h serve_codec.h $(INK_CUDA_OBJ) $(METAL_OBJ)
+inkling$(EXE): inkling.c cli_args.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h omp_tune.h route_trace.h kv_prefix.h serve_codec.h backend_cuda_ink.h backend_metal.h edge_adapters.h edge_runtime.h edge_tok_internal.h segment_adapter_internal.h segment_adapters.h segment_runtime.h $(INK_CUDA_OBJ) $(METAL_OBJ)
 	$(CC) $(CFLAGS) inkling.c $(INK_CUDA_OBJ) $(METAL_OBJ) -o inkling$(EXE) $(LDFLAGS)
 
 # ENGINES WITHOUT A CUDA BACKEND (#783).
@@ -1092,7 +1092,7 @@ NOCUDA_LDFLAGS = $(filter-out -lcudart -lstdc++ -lcuda -L$(CUDA_HOME)/lib64 \
 glm53$(EXE): glm53.c cli_args.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h hyper_connections.h delta_attention.h sparse_index.h vision_tower.h $(VK_OBJ) $(VK_SPV)
 	$(CC) $(CFLAGS) glm53.c $(VK_OBJ) -o glm53$(EXE) $(LDFLAGS)
 
-kimi_k3$(EXE): kimi_k3.c cli_args.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h omp_tune.h route_trace.h kv_prefix.h serve_codec.h backend_cuda.h $(CUDA_OBJ) $(VK_OBJ) $(VK_SPV) $(METAL_OBJ)
+kimi_k3$(EXE): kimi_k3.c cli_args.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h omp_tune.h route_trace.h kv_prefix.h serve_codec.h backend_cuda.h backend_metal.h backend_vulkan.h edge_adapters.h edge_runtime.h edge_tok_internal.h hybrid_split.h segment_adapter_internal.h segment_adapters.h segment_runtime.h $(CUDA_OBJ) $(VK_OBJ) $(VK_SPV) $(METAL_OBJ)
 	$(CC) $(CFLAGS) kimi_k3.c $(CUDA_OBJ) $(VK_OBJ) $(METAL_OBJ) -o kimi_k3$(EXE) $(LDFLAGS)
 
 # Use a baseline that matches the compiler target. macOS already targets a

--- a/c/Makefile
+++ b/c/Makefile
@@ -1025,7 +1025,7 @@ qwen36$(EXE): qwen36.c cli_args.h qwen36_tier.h st.h json.h compat.h edge_adapte
 # Qwen3.8-Flash-Next text-only sibling. This target is intentionally CPU-only;
 # qwen38.c owns the direct checkpoint loader and SERVE=1 protocol, with no
 # CUDA/Metal tier advertised by the control plane.
-qwen38$(EXE): qwen38.c cli_args.h qwen38_core.h qwen38_nfc.h qwen38_nfc_tables.h st.h json.h compat.h quant.h route_trace.h tok.h tok_unicode.h tok_unicode_o200k.h serve_codec.h
+qwen38$(EXE): qwen38.c cli_args.h qwen38_core.h qwen38_nfc.h qwen38_nfc_tables.h st.h json.h compat.h quant.h route_trace.h tok.h tok_unicode.h tok_unicode_o200k.h serve_codec.h edge_adapter_internal.h edge_adapters.h edge_runtime.h qwen38_vision.h segment_adapter_internal.h segment_adapters.h segment_runtime.h
 	$(CC) $(NOCUDA_CFLAGS) qwen38.c -o qwen38$(EXE) $(NOCUDA_LDFLAGS)
 
 .PHONY: qwen38-tiny-generate qwen38-tiny-check
@@ -1089,7 +1089,7 @@ NOCUDA_LDFLAGS = $(filter-out -lcudart -lstdc++ -lcuda -L$(CUDA_HOME)/lib64 \
 # GLM-5.3-Flash: CPU puro, esperti in streaming dal contenitore int4 gs64.
 # Nessun oggetto CUDA/Vulkan/Metal fra le dipendenze perche' il motore non ne
 # ha ancora: quando li avra', questa riga somigliera' a quella di kimi_k3.
-glm53$(EXE): glm53.c cli_args.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h hyper_connections.h delta_attention.h sparse_index.h vision_tower.h $(VK_OBJ) $(VK_SPV)
+glm53$(EXE): glm53.c cli_args.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h hyper_connections.h delta_attention.h sparse_index.h vision_tower.h backend_vulkan.h edge_adapter_internal.h edge_adapters.h edge_runtime.h segment_adapter_internal.h segment_adapters.h segment_runtime.h $(VK_OBJ) $(VK_SPV)
 	$(CC) $(CFLAGS) glm53.c $(VK_OBJ) -o glm53$(EXE) $(LDFLAGS)
 
 kimi_k3$(EXE): kimi_k3.c cli_args.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h omp_tune.h route_trace.h kv_prefix.h serve_codec.h backend_cuda.h backend_metal.h backend_vulkan.h edge_adapters.h edge_runtime.h edge_tok_internal.h hybrid_split.h segment_adapter_internal.h segment_adapters.h segment_runtime.h $(CUDA_OBJ) $(VK_OBJ) $(VK_SPV) $(METAL_OBJ)

--- a/c/tests/test_makefile_deps.py
+++ b/c/tests/test_makefile_deps.py
@@ -6,64 +6,95 @@ that is absent from its rule's prerequisite list produces the worst kind of
 build result: `make` reports success, changes nothing, and leaves a STALE
 binary that looks freshly built.
 
-Reproduce on a tree without the accompanying fix:
+Reproduce on a tree without the accompanying fix, without a compiler:
 
-    make colibri                      # builds
-    touch edge_runtime.h && make colibri
-    -> "make: 'colibri' is up to date."   # colibri.c includes it
+    touch colibri && sleep 1 && touch edge_runtime.h
+    make -q colibri; echo $?
+    -> 0        # "up to date", though colibri.c includes edge_runtime.h
 
-whereas touching a header the rule DOES list (st.h) relinks as expected.
+whereas touching a header the rule DOES list (st.h) exits 1, meaning make
+would relink. This test is the enforcement a comment cannot provide: nothing
+else compares the two lists, and the drift is invisible from inside a green
+build.
 
-This test is the enforcement a comment cannot provide: nothing else compares
-the two lists, and the drift is invisible from inside a green build.
+The engine list is DERIVED from the Makefile, never kept here. A hand-written
+list can only catch a rule that was renamed or removed; it cannot catch a rule
+that was never added, which is the case that actually happened -- glm53 and
+qwen38 sat with incomplete prerequisites while a hand-listed version of this
+test passed green. Anything matching `NAME$(EXE):` with a `NAME.c` beside it
+is a target built from one translation unit, so its prerequisites are
+checkable, and the next engine added is covered without anyone remembering.
 """
 import re
 import unittest
 from pathlib import Path
 
+from family_registry import FAMILIES
+
 C_DIR = Path(__file__).resolve().parent.parent
 
-# Engine binaries whose rule compiles a single .c directly into the target.
-ENGINE_RULES = {
-    "colibri$(EXE)": "colibri.c",
-    "inkling$(EXE)": "inkling.c",
-    "kimi_k3$(EXE)": "kimi_k3.c",
-    "qwen36$(EXE)": "qwen36.c",
-    "olmoe$(EXE)": "olmoe.c",
-}
+# `NAME$(EXE): prereqs`. Targets with a path separator (tests/foo$(EXE)) are
+# deliberately excluded: this checks the engines built at the top of c/.
+RULE_RE = re.compile(r"(?m)^([A-Za-z0-9_]+)\$\(EXE\):[ \t]*(.*)$")
+INCLUDE_RE = re.compile(r'^[ \t]*#[ \t]*include[ \t]*"([^"]+)"', re.M)
 
-RULE_RE = re.compile(r"^([A-Za-z0-9_./$()]+)\s*:\s+(.*)$")
-INCLUDE_RE = re.compile(r'^#include "([^"]+)"', re.M)
+# deepseek_v4 is built by Makefile.deepseek-v4 through a phony delegating
+# target, so it has no `NAME$(EXE):` rule here and no prerequisite list of its
+# own to check. test_family_registry pins that separately.
+SEPARATE_MAKEFILE = {"deepseek-v4"}
 
 
-def _prereqs_by_target():
-    out = {}
-    for line in (C_DIR / "Makefile").read_text().split("\n"):
-        m = RULE_RE.match(line)
-        if m and m.group(1) in ENGINE_RULES:
-            out[m.group(1)] = set(m.group(2).split())
-    return out
+def _engine_rules():
+    """Every target built from a single same-named .c, taken from the Makefile.
+
+    Line continuations are folded first: a rule wrapped across lines would
+    otherwise present a truncated prerequisite list and report headers as
+    missing that are listed on the next line.
+    """
+    text = (C_DIR / "Makefile").read_text(encoding="utf-8")
+    joined = re.sub(r"\\\n[ \t]*", " ", text)
+    rules = {}
+    for name, prereqs in RULE_RE.findall(joined):
+        source = C_DIR / f"{name}.c"
+        if source.exists():
+            rules[name] = (source, set(prereqs.split("#", 1)[0].split()))
+    return rules
 
 
 class MakefileHeaderDepsTest(unittest.TestCase):
-    def test_every_engine_rule_lists_the_headers_its_source_includes(self):
-        prereqs = _prereqs_by_target()
-        self.assertEqual(
-            set(prereqs), set(ENGINE_RULES),
-            "an engine rule was renamed or removed -- update ENGINE_RULES",
-        )
-        problems = []
-        for target, source in sorted(ENGINE_RULES.items()):
-            src = C_DIR / source
-            if not src.exists():
+    def test_the_engine_list_is_derived_and_not_empty(self):
+        """A parse that matches nothing would make every other check vacuous.
+
+        The rule syntax is the input to this whole file. If it ever changes,
+        the header check below starts passing for zero targets and says
+        nothing, which reads exactly like a clean tree. The registry is the
+        authority on what must be buildable, so cross-check against it rather
+        than against a second list kept here.
+        """
+        rules = _engine_rules()
+        self.assertTrue(rules, "no `NAME$(EXE):` rule with a matching NAME.c was "
+                               "found -- the Makefile rule syntax changed and "
+                               "this file now checks nothing")
+        for family in FAMILIES:
+            if family.build_target in SEPARATE_MAKEFILE:
                 continue
-            included = set(INCLUDE_RE.findall(src.read_text()))
+            with self.subTest(family=family.id):
+                self.assertIn(
+                    family.build_target, rules,
+                    f"{family.id}: registered family whose build target is not "
+                    f"a checkable `{family.build_target}$(EXE):` rule")
+
+    def test_every_engine_rule_lists_the_headers_its_source_includes(self):
+        problems = []
+        for target, (source, prereqs) in sorted(_engine_rules().items()):
+            included = set(INCLUDE_RE.findall(source.read_text(encoding="utf-8")))
             # Only headers that exist in c/ are ours to track; system headers
             # and anything generated elsewhere are not prerequisites.
             local = {h for h in included if (C_DIR / h).exists()}
-            missing = sorted(local - prereqs[target])
+            missing = sorted(local - prereqs)
             if missing:
-                problems.append(f"{target} ({source}) is missing: {' '.join(missing)}")
+                problems.append(f"{target} ({source.name}) is missing: "
+                                f"{' '.join(missing)}")
         self.assertEqual(
             problems, [],
             "Headers included by an engine but absent from its Makefile "

--- a/c/tests/test_makefile_deps.py
+++ b/c/tests/test_makefile_deps.py
@@ -1,0 +1,77 @@
+"""Makefile header prerequisites must cover what each engine actually includes.
+
+`make` tracks file timestamps, not #include graphs, and this Makefile has no
+-MMD/-include dependency generation. So a header that an engine includes but
+that is absent from its rule's prerequisite list produces the worst kind of
+build result: `make` reports success, changes nothing, and leaves a STALE
+binary that looks freshly built.
+
+Reproduce on a tree without the accompanying fix:
+
+    make colibri                      # builds
+    touch edge_runtime.h && make colibri
+    -> "make: 'colibri' is up to date."   # colibri.c includes it
+
+whereas touching a header the rule DOES list (st.h) relinks as expected.
+
+This test is the enforcement a comment cannot provide: nothing else compares
+the two lists, and the drift is invisible from inside a green build.
+"""
+import re
+import unittest
+from pathlib import Path
+
+C_DIR = Path(__file__).resolve().parent.parent
+
+# Engine binaries whose rule compiles a single .c directly into the target.
+ENGINE_RULES = {
+    "colibri$(EXE)": "colibri.c",
+    "inkling$(EXE)": "inkling.c",
+    "kimi_k3$(EXE)": "kimi_k3.c",
+    "qwen36$(EXE)": "qwen36.c",
+    "olmoe$(EXE)": "olmoe.c",
+}
+
+RULE_RE = re.compile(r"^([A-Za-z0-9_./$()]+)\s*:\s+(.*)$")
+INCLUDE_RE = re.compile(r'^#include "([^"]+)"', re.M)
+
+
+def _prereqs_by_target():
+    out = {}
+    for line in (C_DIR / "Makefile").read_text().split("\n"):
+        m = RULE_RE.match(line)
+        if m and m.group(1) in ENGINE_RULES:
+            out[m.group(1)] = set(m.group(2).split())
+    return out
+
+
+class MakefileHeaderDepsTest(unittest.TestCase):
+    def test_every_engine_rule_lists_the_headers_its_source_includes(self):
+        prereqs = _prereqs_by_target()
+        self.assertEqual(
+            set(prereqs), set(ENGINE_RULES),
+            "an engine rule was renamed or removed -- update ENGINE_RULES",
+        )
+        problems = []
+        for target, source in sorted(ENGINE_RULES.items()):
+            src = C_DIR / source
+            if not src.exists():
+                continue
+            included = set(INCLUDE_RE.findall(src.read_text()))
+            # Only headers that exist in c/ are ours to track; system headers
+            # and anything generated elsewhere are not prerequisites.
+            local = {h for h in included if (C_DIR / h).exists()}
+            missing = sorted(local - prereqs[target])
+            if missing:
+                problems.append(f"{target} ({source}) is missing: {' '.join(missing)}")
+        self.assertEqual(
+            problems, [],
+            "Headers included by an engine but absent from its Makefile "
+            "prerequisites. Editing one of these alone will NOT relink the "
+            "binary -- make will report success and leave a stale artifact "
+            ":\n  " + "\n  ".join(problems),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### The problem

`make` tracks file timestamps, not `#include` graphs, and `c/Makefile` has no `-MMD`/`-include` dependency generation — each engine rule names its prerequisites by hand. Those lists have drifted behind what the sources actually include.

The failure mode is the quiet one: `make` reports success, changes nothing, and leaves a **stale binary that looks freshly built**.

### Reproduce

```
cd c
make colibri                          # builds
touch edge_runtime.h && make colibri
make: 'colibri' is up to date.        # ...but colibri.c includes edge_runtime.h
```

Touching a header the rule *does* list relinks normally:

```
touch st.h && make colibri
gcc -O3 -march=native ... -o colibri  # relinked
```

So this is specific to the omitted headers, not a general staleness issue.

### What's missing

Every one of these is a header the engine source `#include`s and that exists in `c/`:

| engine | missing |
|---|---|
| `colibri` | 13 — `abl.h` `backend_cuda.h` `backend_metal.h` `backend_vulkan.h` `decode_batch.h` `edge_adapters.h` `edge_runtime.h` `edge_tok_internal.h` `schema_gbnf.h` `segment_adapter_internal.h` `segment_adapters.h` `segment_runtime.h` `tier.h` |
| `inkling` | 8 — `backend_cuda_ink.h` `backend_metal.h` `edge_adapters.h` `edge_runtime.h` `edge_tok_internal.h` `segment_adapter_internal.h` `segment_adapters.h` `segment_runtime.h` |
| `kimi_k3` | 9 — `backend_metal.h` `backend_vulkan.h` `edge_adapters.h` `edge_runtime.h` `edge_tok_internal.h` `hybrid_split.h` `segment_adapter_internal.h` `segment_adapters.h` `segment_runtime.h` |
| `olmoe` | 7 — `edge_adapters.h` `edge_runtime.h` `edge_tok_internal.h` `fused_simd.h` `segment_adapter_internal.h` `segment_adapters.h` `segment_runtime.h` |
| `qwen36` | 6 — `edge_adapter_internal.h` `edge_adapters.h` `edge_runtime.h` `segment_adapter_internal.h` `segment_adapters.h` `segment_runtime.h` |

### The fix

Adds the missing headers to the five engine rules, plus `c/tests/test_makefile_deps.py` so the two lists cannot silently drift apart again. The test compares each engine rule's prerequisites against the headers its source includes, counting only headers that exist in `c/` (system headers and generated files are not prerequisites).

It was checked in both directions rather than just observed to pass — **red** against the unfixed `Makefile`, **green** with the fix — so it discriminates rather than passing vacuously. The existing `unittest discover -s tests -p 'test_*.py'` picks it up with no Makefile change.

`make -C c test-python`: **705 tests, OK (skipped=35)**.

### Notes

Found while merging this into a downstream fork, where an equivalent test was already in place and went red on contact. No behaviour change — prerequisites and one new test only.
