### PR TITLE
docs: eight families, in all four READMEs, and a contract so it stays true

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -12,8 +12,10 @@ miliardi a 2,8 mila miliardi di parametri** — su hardware consumer ed eterogen
 in C puro e senza dipendenze del motore, trattando storage, RAM e VRAM come
 un'unica gerarchia di inferenza.
 
-Oggi girano sei famiglie: **GLM-5.2** (744B), **Inkling** (975B), **Kimi K3**
-(2,8T), **DeepSeek V4 Flash** (284B), **Qwen3.6** (35B-A3B) e **OLMoE** (7B) — un
+Oggi girano otto famiglie: **GLM-5.2** (744B), **GLM-5.3-Flash** (321B, con
+vision), **Inkling** (975B), **Kimi K3** (2,8T), **DeepSeek V4 Flash** (284B),
+**Qwen3.8-Flash-Next** (125B + 51B n-gram), **Qwen3.6** (35B-A3B) e
+**OLMoE** (7B) — un
 file C ciascuna, la stessa interfaccia `coli chat` / `coli serve` / `coli web`. [Elenco completo](README.md#other-supported-models)
 
 > **Colibrì è un motore di inferenza che puoi usare oggi, e una piattaforma di
@@ -336,10 +338,10 @@ e per il gateway API opzionale.
   end-to-end, revisionati e sviluppati apertamente.
 - **Più modelli aperti.** L'algoritmo di tiering è indipendente dal modello:
   qualsiasi MoE con expert instradati può essere organizzato allo stesso modo.
-  Sette famiglie funzionano già (GLM-5.2, GLM-5.3-Flash con la vision,
-  Inkling, Kimi K3, DeepSeek V4 Flash, Qwen3.6, OLMoE); altre famiglie
-  open-weight, **MiniMax** tra le candidate, si guadagnano un engine come le
-  prime sette: quando qualcuno le misura end-to-end.
+  Otto famiglie funzionano già (GLM-5.2, GLM-5.3-Flash con la vision,
+  Inkling, Kimi K3, DeepSeek V4 Flash, Qwen3.8-Flash-Next, Qwen3.6, OLMoE);
+  altre famiglie open-weight, **MiniMax** tra le candidate, si guadagnano un
+  engine come le prime otto: quando qualcuno le misura end-to-end.
 
 ## Sostenere il progetto
 

--- a/README.md
+++ b/README.md
@@ -583,10 +583,11 @@ checkpoint validation, and the generated tiny independent oracle.
   lower cost per useful token. Everything lands the way this project works:
   measured end to end, reviewed, and developed in the open.
 - **More open models.** The tiering algorithm is model-agnostic: any MoE with
-  routed experts can be staged the same way. Seven families run today (GLM-5.2,
-  Inkling, Kimi K3, DeepSeek V4 Flash, Qwen3.8-Flash-Next, Qwen3.6, OLMoE); further open-weight
-  families — **MiniMax** among the candidates — earn an engine the way the
-  first seven did: when someone measures one end to end.
+  routed experts can be staged the same way. Eight families run today (GLM-5.2,
+  GLM-5.3-Flash, Inkling, Kimi K3, DeepSeek V4 Flash, Qwen3.8-Flash-Next,
+  Qwen3.6, OLMoE); further open-weight families — **MiniMax** among the
+  candidates — earn an engine the way the first eight did: when someone
+  measures one end to end.
 
 ## Supporting the project
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,9 +10,9 @@
 **小巧引擎，庞大模型。**在消费级与异构硬件上运行**前沿 MoE 模型——从 744B 到
 2.8T 参数**——以引擎零依赖的纯 C 实现，将存储、RAM 与 VRAM 视为统一的推理层级。
 
-目前可运行七个模型家族：**GLM-5.2**（744B）、**GLM-5.3-Flash**（321B，含视觉）、
+目前可运行八个模型家族：**GLM-5.2**（744B）、**GLM-5.3-Flash**（321B，含视觉）、
 **Inkling**（975B）、**Kimi K3**（2.8T）、**DeepSeek V4 Flash**（284B）、
-**Qwen3.6**（35B-A3B）与 **OLMoE**（7B）
+**Qwen3.8-Flash-Next**（125B + 51B n-gram）、**Qwen3.6**（35B-A3B）与 **OLMoE**（7B）
 ——各自一个 C 文件，共用同一套 `coli chat` / `coli serve` / `coli web` 前端。[完整列表](README.md#other-supported-models)
 
 > **Colibrì 既是今天就能运行的推理引擎，也是一个开放的研究平台。**它的首要目标是在
@@ -311,8 +311,8 @@ oracle 说明，请参阅[中文版 DeepSeek V4 文档](docs/deepseek-v4.zh-CN.m
   放置、调度、I/O、CPU/GPU 内核、异构重叠、KV 状态与路由感知推测。目标是降低硬件要求
   和每个有效 token 的成本，所有成果都以端到端测量为准、经审查并公开开发。
 - **支持更多开放模型。**层级算法与模型无关，任何带路由专家的 MoE 都能用相同方式分层。
-  目前已有七个模型家族可用（GLM-5.2、GLM-5.3-Flash、Inkling、Kimi K3、DeepSeek V4 Flash、
-  Qwen3.6、OLMoE）；更多开放权重家族（候选包括 **MiniMax**）将沿用同样的
+  目前已有八个模型家族可用（GLM-5.2、GLM-5.3-Flash、Inkling、Kimi K3、DeepSeek V4 Flash、
+  Qwen3.8-Flash-Next、Qwen3.6、OLMoE）；更多开放权重家族（候选包括 **MiniMax**）将沿用同样的
   规则获得引擎支持：有人完成端到端实测之后。
 
 ## 支持项目

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -10,9 +10,9 @@
 **小巧引擎，龐大模型。**在消費級與異質硬體上執行**前沿 MoE 模型——從 744B 到
 2.8T 參數**——以引擎零相依套件的純 C 實作，將儲存、RAM 與 VRAM 視為統一的推論階層。
 
-目前可執行七個模型家族：**GLM-5.2**（744B）、**GLM-5.3-Flash**（321B，含視覺）、
+目前可執行八個模型家族：**GLM-5.2**（744B）、**GLM-5.3-Flash**（321B，含視覺）、
 **Inkling**（975B）、**Kimi K3**（2.8T）、**DeepSeek V4 Flash**（284B）、
-**Qwen3.6**（35B-A3B）與 **OLMoE**（7B）
+**Qwen3.8-Flash-Next**（125B + 51B n-gram）、**Qwen3.6**（35B-A3B）與 **OLMoE**（7B）
 ——各自一個 C 檔案，共用同一套 `coli chat` / `coli serve` / `coli web` 前端。[完整清單](README.md#other-supported-models)
 
 > **Colibrì 既是今天就能執行的推論引擎，也是一個開放的研究平台。**它的首要目標是在
@@ -291,8 +291,8 @@ COLI_MODEL=/nvme/glm52_i4 ./coli doctor   # 唯讀就緒檢查
   配置、排程、I/O、CPU/GPU 核心、異質重疊、KV 狀態與路由感知推測。目標是降低硬體要求
   和每個有效 token 的成本，所有成果都以端到端測量為準、經審查並公開開發。
 - **支援更多開放模型。**階層演算法與模型無關，任何帶路由專家的 MoE 都能用相同方式分層。
-  目前已有七個模型家族可用（GLM-5.2、GLM-5.3-Flash、Inkling、Kimi K3、DeepSeek V4 Flash、
-  Qwen3.6、OLMoE）；更多開放權重家族（候選包括 **MiniMax**）將沿用同樣的
+  目前已有八個模型家族可用（GLM-5.2、GLM-5.3-Flash、Inkling、Kimi K3、DeepSeek V4 Flash、
+  Qwen3.8-Flash-Next、Qwen3.6、OLMoE）；更多開放權重家族（候選包括 **MiniMax**）將沿用同樣的
   規則獲得引擎支援：有人完成端到端實測之後。
 
 ## 支持專案

--- a/c/tests/test_family_registry.py
+++ b/c/tests/test_family_registry.py
@@ -1120,6 +1120,48 @@ class FamilyRegistryTest(unittest.TestCase):
                 f"non-interactive default ({family.limits.default_max_output}) -- "
                 f"reasoning can consume it before the answer starts")
 
+    def test_every_readme_names_every_family(self):
+        """Ogni README, tradotto compreso, deve nominare ogni famiglia.
+
+        E' la terza volta oggi che un conteggio ripetuto in due posti diverge:
+        release.yml costruiva sei motori e ne copiava sette, i contatori degli
+        adapter dicevano 7 con 8 famiglie registrate, e i README dichiaravano
+        sei, sette e otto famiglie contemporaneamente -- l'inglese si
+        contraddiceva da solo fra riga 21 e riga 586.
+
+        Il nome della famiglia e' il controllo giusto, non il numerale: sono
+        quattro lingue e il numerale si scrive in quattro modi, mentre
+        `Qwen3.8-Flash-Next` si scrive uguale ovunque. Chi aggiunge una famiglia
+        e dimentica le traduzioni lo scopre qui invece che da un utente che
+        legge la sua lingua e non trova il modello.
+        """
+        repo = Path(__file__).resolve().parents[2]
+        readmes = ["README.md", "README.it.md", "README.zh-CN.md", "README.zh-TW.md"]
+        for name in readmes:
+            path = repo / name
+            if not path.exists():
+                continue
+            text = path.read_text(encoding="utf-8")
+            for family in FAMILIES:
+                # Il nome senza il suffisso di taglia: i README scrivono
+                # "**Qwen3.6** (35B-A3B)", non "Qwen3.6-35B-A3B", perche' la
+                # dimensione sta fra parentesi. Cercare il display_name intero
+                # fallirebbe su una differenza di formattazione invece che su
+                # una famiglia mancante, che e' quello che qui interessa.
+                parts = []
+                for piece in family.display_name.split("-"):
+                    if re.fullmatch(r"A?\d+(\.\d+)?B", piece):
+                        break
+                    parts.append(piece)
+                token = "-".join(parts) or family.display_name
+                # assertTrue e non assertIn: assertIn stampa il README intero
+                # nel messaggio di errore, e mille righe di markdown nascondono
+                # la riga che dice cosa manca.
+                self.assertTrue(token in text,
+                                f"{name}: does not mention {family.display_name} "
+                                f"({family.id}); a reader in that language cannot "
+                                f"tell the family is supported")
+
     def test_build_install_ci_and_release_cover_registered_engines(self):
         repo = Path(__file__).resolve().parents[2]
         makefile = (repo / "c" / "Makefile").read_text(encoding="utf-8")


### PR DESCRIPTION
Preparing the release surfaced that the four READMEs disagreed with each other **and with themselves**. Eight places state a family count, two per file, and they said six, seven and eight at once:

    README.md:21       Eight   (with Qwen3.8)
    README.md:586      Seven   (with Qwen3.8, missing GLM-5.3)
    README.it.md:15    sei     (missing GLM-5.3 AND Qwen3.8)
    README.it.md:339   Sette   (with GLM-5.3, missing Qwen3.8)
    zh-CN, zh-TW       seven in both places, both missing Qwen3.8

The English file contradicts itself between line 21 and line 586, and **each file omits a different family**.

My own #1267 is part of this. It fixed the Italian paragraph that states the count inside a nested quote and missed the opening sentence, because I did not look for a second one.

## The fix is the contract, not the eight edits

This is the **third time today** the same shape has bitten: `release.yml` built six engines and copied seven (#1267), the adapter counters asserted 7 against 8 registered families (#1250's merge), and now this. A count repeated in two places is a count that will diverge.

`test_family_registry` now requires every README — translations included — to name every registered family.

It checks the **name**, not the numeral. There are four languages and the numeral is written four ways (`Eight`, `otto`, `八个`, `八個`), while `Qwen3.8-Flash-Next` is spelled the same everywhere. Whoever adds a family and forgets the translations finds out here, rather than from a reader who opens the page in their own language and cannot find the model.

Verified by removing Qwen3.8 from the Italian:

    AssertionError: README.it.md: does not mention Qwen3.8-Flash-Next (qwen38);
    a reader in that language cannot tell the family is supported

`assertTrue` rather than `assertIn`, so the failure names the missing family instead of printing a thousand lines of markdown around it.

## Why now

This is release prep. v1.9.0 shipped with the same defect in the opposite direction — the translations said six families and never mentioned GLM-5.3-Flash — and I would rather the next release not repeat it in a language I do not read.