### PR TITLE
fix(cli): reject numeric arguments we can only read half of

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -716,7 +716,7 @@ $(file >.build-config,$(BUILD_CONFIG))
 endif
 .build-config: ;
 
-colibri$(EXE): colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h quant.h sample.h kv_persist.h telemetry.h route_trace.h omp_tune.h kv_fp8.h kv_tq.h $(CUDA_OBJ) $(METAL_OBJ) $(VK_OBJ) $(VK_SPV) .build-config
+colibri$(EXE): colibri.c cli_args.h st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h quant.h sample.h kv_persist.h telemetry.h route_trace.h omp_tune.h kv_fp8.h kv_tq.h $(CUDA_OBJ) $(METAL_OBJ) $(VK_OBJ) $(VK_SPV) .build-config
 	$(CC) $(CFLAGS) colibri.c $(CUDA_OBJ) $(METAL_OBJ) $(VK_OBJ) -o colibri$(EXE) $(LDFLAGS)
 
 # Vulkan backend object (plain C + vulkan headers) and its SPIR-V shaders.
@@ -997,7 +997,7 @@ fp8-bench: fp8_bench$(EXE)
 # the GPU sits idle. Same guard #783 put on kimi_k3, which since gaining an
 # MXFP4 expert path no longer needs it. tests/test_makefile_cuda_scope.py
 # asserts this shape.
-olmoe$(EXE): olmoe.c st.h json.h compat.h sample.h tok.h tok_unicode.h tok_unicode_o200k.h omp_tune.h route_trace.h serve_codec.h
+olmoe$(EXE): olmoe.c cli_args.h st.h json.h compat.h sample.h tok.h tok_unicode.h tok_unicode_o200k.h omp_tune.h route_trace.h serve_codec.h
 	$(CC) $(NOCUDA_CFLAGS) olmoe.c -o olmoe$(EXE) $(NOCUDA_LDFLAGS)
 
 # Qwen3.6-35B-A3B engine (hybrid Gated Attention + Gated DeltaNet + streaming
@@ -1019,13 +1019,13 @@ QWEN36_TIER_SRC =
 QWEN36_CFLAGS   = $(NOCUDA_CFLAGS)
 QWEN36_LDFLAGS  = $(NOCUDA_LDFLAGS)
 endif
-qwen36$(EXE): qwen36.c qwen36_tier.h st.h json.h compat.h $(QWEN36_TIER_SRC) $(CUDA_OBJ)
+qwen36$(EXE): qwen36.c cli_args.h qwen36_tier.h st.h json.h compat.h $(QWEN36_TIER_SRC) $(CUDA_OBJ)
 	$(CC) $(QWEN36_CFLAGS) qwen36.c $(QWEN36_TIER_SRC) $(CUDA_OBJ) -o qwen36$(EXE) $(QWEN36_LDFLAGS)
 
 # Qwen3.8-Flash-Next text-only sibling. This target is intentionally CPU-only;
 # qwen38.c owns the direct checkpoint loader and SERVE=1 protocol, with no
 # CUDA/Metal tier advertised by the control plane.
-qwen38$(EXE): qwen38.c qwen38_core.h qwen38_nfc.h qwen38_nfc_tables.h st.h json.h compat.h quant.h route_trace.h tok.h tok_unicode.h tok_unicode_o200k.h serve_codec.h
+qwen38$(EXE): qwen38.c cli_args.h qwen38_core.h qwen38_nfc.h qwen38_nfc_tables.h st.h json.h compat.h quant.h route_trace.h tok.h tok_unicode.h tok_unicode_o200k.h serve_codec.h
 	$(CC) $(NOCUDA_CFLAGS) qwen38.c -o qwen38$(EXE) $(NOCUDA_LDFLAGS)
 
 .PHONY: qwen38-tiny-generate qwen38-tiny-check
@@ -1071,7 +1071,7 @@ tests/test_qwen36_json_escape$(EXE): tests/test_qwen36_json_escape.c qwen36.c qw
 tests/bench_qwen36_dense_batch$(EXE): tests/bench_qwen36_dense_batch.c qwen36.c qwen36_tier.h st.h json.h compat.h $(QWEN36_TIER_SRC) $(CUDA_OBJ)
 	$(CC) $(QWEN36_CFLAGS) $< $(QWEN36_TIER_SRC) $(CUDA_OBJ) -o $@ $(QWEN36_LDFLAGS)
 
-inkling$(EXE): inkling.c st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h omp_tune.h route_trace.h kv_prefix.h serve_codec.h $(INK_CUDA_OBJ) $(METAL_OBJ)
+inkling$(EXE): inkling.c cli_args.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h omp_tune.h route_trace.h kv_prefix.h serve_codec.h $(INK_CUDA_OBJ) $(METAL_OBJ)
 	$(CC) $(CFLAGS) inkling.c $(INK_CUDA_OBJ) $(METAL_OBJ) -o inkling$(EXE) $(LDFLAGS)
 
 # ENGINES WITHOUT A CUDA BACKEND (#783).
@@ -1089,10 +1089,10 @@ NOCUDA_LDFLAGS = $(filter-out -lcudart -lstdc++ -lcuda -L$(CUDA_HOME)/lib64 \
 # GLM-5.3-Flash: CPU puro, esperti in streaming dal contenitore int4 gs64.
 # Nessun oggetto CUDA/Vulkan/Metal fra le dipendenze perche' il motore non ne
 # ha ancora: quando li avra', questa riga somigliera' a quella di kimi_k3.
-glm53$(EXE): glm53.c st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h hyper_connections.h delta_attention.h sparse_index.h vision_tower.h $(VK_OBJ) $(VK_SPV)
+glm53$(EXE): glm53.c cli_args.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h hyper_connections.h delta_attention.h sparse_index.h vision_tower.h $(VK_OBJ) $(VK_SPV)
 	$(CC) $(CFLAGS) glm53.c $(VK_OBJ) -o glm53$(EXE) $(LDFLAGS)
 
-kimi_k3$(EXE): kimi_k3.c st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h omp_tune.h route_trace.h kv_prefix.h serve_codec.h backend_cuda.h $(CUDA_OBJ) $(VK_OBJ) $(VK_SPV) $(METAL_OBJ)
+kimi_k3$(EXE): kimi_k3.c cli_args.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h omp_tune.h route_trace.h kv_prefix.h serve_codec.h backend_cuda.h $(CUDA_OBJ) $(VK_OBJ) $(VK_SPV) $(METAL_OBJ)
 	$(CC) $(CFLAGS) kimi_k3.c $(CUDA_OBJ) $(VK_OBJ) $(METAL_OBJ) -o kimi_k3$(EXE) $(LDFLAGS)
 
 # Use a baseline that matches the compiler target. macOS already targets a
@@ -1632,6 +1632,9 @@ tests/test_v4_serve_framing$(EXE): tests/test_v4_serve_framing.c deepseek_v4.c \
 endif
 
 tests/test_route_trace$(EXE): tests/test_route_trace.c route_trace.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
+tests/test_cli_args$(EXE): tests/test_cli_args.c cli_args.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_798_guards$(EXE): tests/test_798_guards.c st.h json.h compat.h route_trace.h

--- a/c/cli_args.h
+++ b/c/cli_args.h
@@ -1,0 +1,55 @@
+/* Lettura degli argomenti numerici dalla riga di comando.
+ *
+ * atoi() non ha modo di dire "non e' un numero": restituisce 0 per una stringa
+ * che non lo e', e per una che lo e' a meta' restituisce la meta' che ha letto
+ * senza dire niente. Il caso che si vede davvero e' un refuso nella capienza:
+ *
+ *     ./qwen38 3x2      ->  atoi = 3     ->  cache=3/layer invece di 32
+ *
+ * Nessun errore. Il motore parte con una cache dieci volte piu' piccola, legge
+ * dal disco molto piu' del dovuto, e chi l'ha lanciato conclude che il motore
+ * e' lento invece che di aver sbagliato a digitare. E' il modo peggiore in cui
+ * un programma puo' sbagliare: fa una cosa diversa da quella chiesta e non lo
+ * dice.
+ *
+ * strtol invece dice dove ha smesso di leggere, e qui si pretende che abbia
+ * letto tutto. */
+#ifndef COLI_CLI_ARGS_H
+#define COLI_CLI_ARGS_H
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* `what` nomina l'argomento come lo chiama chi lo scrive sulla riga di comando
+ * ("cache/layer", non "cap"): il messaggio serve a chi ha sbagliato a digitare,
+ * non a chi legge il sorgente. */
+static int coli_arg_int(const char *arg, const char *what)
+{
+    char *end = NULL;
+    long v;
+
+    errno = 0;
+    v = strtol(arg, &end, 10);
+    /* Prima cosa: end == arg vuol dire che non ha letto nemmeno una cifra.
+     * Va controllato PRIMA di saltare gli spazi finali, se no un argomento
+     * fatto di soli spazi passerebbe valendo zero -- lo skip sposterebbe end
+     * oltre lo spazio e la stringa sembrerebbe consumata per intero. */
+    if (end == arg) goto bad;
+    /* strtol salta gli spazi iniziali da solo; quelli finali li salto qui, se
+     * no un "32\r" arrivato da uno script salvato con le terminazioni di riga
+     * di Windows verrebbe rifiutato con un messaggio incomprensibile, e i
+     * binari Windows li spediamo. */
+    while (*end == ' ' || *end == '\t' || *end == '\r' || *end == '\n') end++;
+    /* *end != 0: ne ha letta una parte e poi ha trovato altro, il caso "3x2". */
+    if (*end != '\0' || errno == ERANGE ||
+        v < (long)INT_MIN || v > (long)INT_MAX) {
+bad:
+        fprintf(stderr, "%s: expected a whole number, got \"%s\"\n", what, arg);
+        exit(2);
+    }
+    return (int)v;
+}
+
+#endif /* COLI_CLI_ARGS_H */

--- a/c/cli_args.h
+++ b/c/cli_args.h
@@ -12,8 +12,10 @@
  * un programma puo' sbagliare: fa una cosa diversa da quella chiesta e non lo
  * dice.
  *
- * strtol invece dice dove ha smesso di leggere, e qui si pretende che abbia
- * letto tutto. */
+ * Due funzioni e non una: coli_parse_int decide e riporta, coli_arg_int e' il
+ * guscio che stampa ed esce. La divisione non e' estetica, e' quello che rende
+ * la decisione verificabile senza un processo figlio -- e quindi su Windows,
+ * che non ha fork(). */
 #ifndef COLI_CLI_ARGS_H
 #define COLI_CLI_ARGS_H
 
@@ -22,21 +24,21 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-/* `what` nomina l'argomento come lo chiama chi lo scrive sulla riga di comando
- * ("cache/layer", non "cap"): il messaggio serve a chi ha sbagliato a digitare,
- * non a chi legge il sorgente. */
-static int coli_arg_int(const char *arg, const char *what)
+/* 1 se `arg` e' un intero scritto per intero, 0 altrimenti. *out tocco solo
+ * quando accetto. */
+static int coli_parse_int(const char *arg, int *out)
 {
     char *end = NULL;
     long v;
 
+    if (!arg) return 0;
     errno = 0;
     v = strtol(arg, &end, 10);
     /* Prima cosa: end == arg vuol dire che non ha letto nemmeno una cifra.
      * Va controllato PRIMA di saltare gli spazi finali, se no un argomento
      * fatto di soli spazi passerebbe valendo zero -- lo skip sposterebbe end
      * oltre lo spazio e la stringa sembrerebbe consumata per intero. */
-    if (end == arg) goto bad;
+    if (end == arg) return 0;
     /* strtol salta gli spazi iniziali da solo; quelli finali li salto qui, se
      * no un "32\r" arrivato da uno script salvato con le terminazioni di riga
      * di Windows verrebbe rifiutato con un messaggio incomprensibile, e i
@@ -44,12 +46,23 @@ static int coli_arg_int(const char *arg, const char *what)
     while (*end == ' ' || *end == '\t' || *end == '\r' || *end == '\n') end++;
     /* *end != 0: ne ha letta una parte e poi ha trovato altro, il caso "3x2". */
     if (*end != '\0' || errno == ERANGE ||
-        v < (long)INT_MIN || v > (long)INT_MAX) {
-bad:
-        fprintf(stderr, "%s: expected a whole number, got \"%s\"\n", what, arg);
+        v < (long)INT_MIN || v > (long)INT_MAX) return 0;
+    *out = (int)v;
+    return 1;
+}
+
+/* `what` nomina l'argomento come lo chiama chi lo scrive sulla riga di comando
+ * ("cache/layer", non "cap"): il messaggio serve a chi ha sbagliato a digitare,
+ * non a chi legge il sorgente. */
+static int coli_arg_int(const char *arg, const char *what)
+{
+    int v = 0;
+    if (!coli_parse_int(arg, &v)) {
+        fprintf(stderr, "%s: expected a whole number, got \"%s\"\n",
+                what, arg ? arg : "");
         exit(2);
     }
-    return (int)v;
+    return v;
 }
 
 #endif /* COLI_CLI_ARGS_H */

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -57,6 +57,7 @@
 #if defined(_WIN32) && (defined(__x86_64__) || defined(__i386__))
 #include <cpuid.h>                                /* hwinfo_emit: CPU brand string senza /proc */
 #endif
+#include "cli_args.h"
 #include "st.h"
 #ifdef __linux__
 #include "uring.h"
@@ -10861,10 +10862,10 @@ int main(int argc, char **argv){
     /* cap itself is resolved below, once g_metal_enabled and the SSD probe (both
      * needed for the platform default) are known -- see coli_resolve_cap(). */
     int cap_given = argc>1;
-    int cap_arg = cap_given?atoi(argv[1]):0;
+    int cap_arg = cap_given?coli_arg_int(argv[1],"cache/layer"):0;
     int cap_env = getenv("CAP")?atoi(getenv("CAP")):0;
-    int ebits= argc>2?atoi(argv[2]):8;
-    int dbits= argc>3?atoi(argv[3]):ebits;
+    int ebits= argc>2?coli_arg_int(argv[2],"expert bits"):8;
+    int dbits= argc>3?coli_arg_int(argv[3],"dense bits"):ebits;
 #if !defined(_WIN32)
     if(getenv("EXPERT_WORKER")){
         int port=getenv("CLUSTER_WORKER_PORT")?atoi(getenv("CLUSTER_WORKER_PORT")):9100;

--- a/c/glm53.c
+++ b/c/glm53.c
@@ -65,6 +65,7 @@
 #include <stdint.h>
 #include <stdarg.h>
 
+#include "cli_args.h"
 #include "json.h"
 #include "st.h"
 #include "quant.h"
@@ -2578,7 +2579,7 @@ int main(int argc, char **argv) {
     for (int i = 1; i < argc; i++) {
         if (!strcmp(argv[i], "--model") && i + 1 < argc) dir = argv[++i];
         else if (!strcmp(argv[i], "--ids") && i + 1 < argc) ids = argv[++i];
-        else if (!strcmp(argv[i], "--greedy") && i + 1 < argc) greedy = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--greedy") && i + 1 < argc) greedy = coli_arg_int(argv[++i], "--greedy");
         else if (!strcmp(argv[i], "--logits")) show_logits = 1;
         else if (!strcmp(argv[i], "--prompt") && i + 1 < argc) prompt_text = argv[++i];
         else if (!strcmp(argv[i], "--patches") && i + 1 < argc) patch_file = argv[++i];
@@ -2588,10 +2589,10 @@ int main(int argc, char **argv) {
             /* Capienza posizionale: e' cosi' che il gateway lancia ogni motore
              * (openai_server.py, Engine.__init__). Zero vuol dire "decidila
              * tu", che qui e' il budget misurato dalla RAM disponibile. */
-            const int cap = atoi(argv[i]);
+            const int cap = coli_arg_int(argv[i], "cache/layer");
             if (cap > 0) g_cap_override = cap;
         }
-        else { fprintf(stderr, "argomento sconosciuto: %s\n", argv[i]); return 2; }
+        else { fprintf(stderr, "unknown argument: %s\n", argv[i]); return 2; }
     }
     /* SERVE=1 e SNAP=<dir>: il motore non e' piu' una CLI ma il capo di una
      * pipa, e il modello arriva dall'ambiente perche' e' cosi' che lo lancia

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -32,6 +32,7 @@
 #include <sys/resource.h>
 #include <sys/select.h>                              /* serve-loop stdin poll (POSIX); inkling serves on Linux */
 #endif
+#include "cli_args.h"
 #include "st.h"
 #include "tok.h"
 #ifdef _OPENMP
@@ -2411,11 +2412,11 @@ int main(int argc, char **argv) {
     for (int i = 1; i < argc; i++) {
         if (!strcmp(argv[i], "-p") && i+1 < argc) prompt = argv[++i];
         else if (!strcmp(argv[i], "-f") && i+1 < argc) pfile = argv[++i];
-        else if (!strcmp(argv[i], "-n") && i+1 < argc) n_new = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "-n") && i+1 < argc) n_new = coli_arg_int(argv[++i], "-n");
         else if (!strcmp(argv[i], "--chat")) chat = 1;
         else if (!strcmp(argv[i], "--audio") && i+1 < argc) audiopath = argv[++i];
-        else if (npos == 0) { cap = atoi(argv[i]); npos++; }
-        else if (npos == 1) { bits = atoi(argv[i]); npos++; }
+        else if (npos == 0) { cap = coli_arg_int(argv[i], "cache/layer"); npos++; }
+        else if (npos == 1) { bits = coli_arg_int(argv[i], "expert bits"); npos++; }
         else refpath = argv[i];
     }
     /* --audio <file>: raw u8 DMel frames, [n_frames, mel_bins] row-major —

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -104,6 +104,7 @@
 #include <sys/sysctl.h>
 #include <mach/mach.h>
 #endif
+#include "cli_args.h"
 #include "st.h"
 #include "tok.h"
 #include "quant.h"
@@ -3047,7 +3048,7 @@ int main(int argc, char **argv){
     if(!snap||!*snap){ fprintf(stderr,"set SNAP=<Kimi K3 snapshot directory>\n"); return 1; }
     int ngen=32, chat=0;
     for(int i=serving?1:2;i<argc;i++){
-        if(!strcmp(argv[i],"--ngen")&&i+1<argc) ngen=atoi(argv[++i]);
+        if(!strcmp(argv[i],"--ngen")&&i+1<argc) ngen=coli_arg_int(argv[++i], "--ngen");
         else if(!strcmp(argv[i],"--ids")&&i+1<argc) idstr=argv[++i];
         else if(!strcmp(argv[i],"--chat")) chat=1;
         else if(!strcmp(argv[i],"--system")&&i+1<argc) sysmsg=argv[++i];

--- a/c/olmoe.c
+++ b/c/olmoe.c
@@ -31,6 +31,7 @@
 #include <sys/resource.h>
 #include <unistd.h>
 #endif
+#include "cli_args.h"
 #include "st.h"
 #ifdef _OPENMP
 #include <omp.h>   /* omp_set_num_threads/omp_get_max_threads per omp_tune.h */
@@ -1476,8 +1477,8 @@ int main(int argc, char **argv) {
     if (g_wide < 1) g_wide = 1;
     if (g_wide > 4) g_wide = 4;
     int hot_n  = getenv("HOT")   ? atoi(getenv("HOT"))   : 0;
-    int cap    = argc > 1 ? atoi(argv[1]) : 16;
-    int bits   = argc > 2 ? atoi(argv[2]) : 8;
+    int cap    = argc > 1 ? coli_arg_int(argv[1], "cache/layer") : 16;
+    int bits   = argc > 2 ? coli_arg_int(argv[2], "expert bits") : 8;
     if (bits < 2 || bits > 8) {
         fprintf(stderr, "quant_bits must be 2..8 (got %d)\n", bits);
         return 1;

--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -57,6 +57,7 @@ static int qwen36_max_ctx(void) {
 #include <sys/resource.h>
 #include <unistd.h>
 #endif
+#include "cli_args.h"
 #include "st.h"
 #include "json.h"   /* tokenizer.json parsing (reuse minimal parser) */
 #include "qwen36_tier.h"   /* optional transparent Vulkan compute backend for MoE experts */
@@ -2615,8 +2616,8 @@ int main(int argc, char **argv) {
     if (getenv("OPENAI")) g_openai = 1;                       /* OpenAI-compatible output */
     const char *mv = getenv("MODEL"); if (mv && *mv) g_model = mv;
     int hot_n = getenv("HOT") ? atoi(getenv("HOT")) : 0;
-    int cap   = argc > 1 ? atoi(argv[1]) : 16;
-    int bits  = argc > 2 ? atoi(argv[2]) : 4;
+    int cap   = argc > 1 ? coli_arg_int(argv[1], "cache/layer") : 16;
+    int bits  = argc > 2 ? coli_arg_int(argv[2], "expert bits") : 4;
     /* cap < 1 leaves every layer cache empty, so expert_get finds no slot to
      * evict and waits for a publish that can never come. The old lru=0 fallback
      * turned that into a heap OOB instead; neither is a failure mode to ship. */

--- a/c/qwen38.c
+++ b/c/qwen38.c
@@ -59,6 +59,7 @@ static int qwen38_max_ctx(void) {
 #include <sys/resource.h>
 #include <unistd.h>
 #endif
+#include "cli_args.h"
 #include "st.h"
 #include "qwen38_vision.h"
 #include "json.h"   /* tokenizer.json parsing (reuse minimal parser) */
@@ -1629,8 +1630,8 @@ int main(int argc, char **argv) {
     if (getenv("OPENAI")) g_openai = 1;                       /* OpenAI-compatible output */
     const char *mv = getenv("MODEL");
     if (mv && *mv) snprintf(g_model, sizeof g_model, "%s", mv);
-    int cap   = argc > 1 ? atoi(argv[1]) : 1;
-    int bits  = argc > 2 ? atoi(argv[2]) : 8;
+    int cap   = argc > 1 ? coli_arg_int(argv[1], "cache/layer") : 1;
+    int bits  = argc > 2 ? coli_arg_int(argv[2], "expert bits") : 8;
     /* cap < 1 leaves every layer cache empty, so expert_get finds no slot to
      * evict and waits for a publish that can never come. The old lru=0 fallback
      * turned that into a heap OOB instead; neither is a failure mode to ship. */

--- a/c/tests/test_cli_args.c
+++ b/c/tests/test_cli_args.c
@@ -1,55 +1,23 @@
-/* coli_arg_int: cio' che atoi accettava a meta' ora e' un errore.
+/* coli_parse_int: cio' che atoi accettava a meta' ora e' un rifiuto.
  *
  * Il caso che ha motivato tutto questo e' "3x2" scritto al posto di "32": atoi
  * restituiva 3, il motore partiva con una cache dieci volte piu' piccola, e
  * l'unico sintomo era che andava piano. Nessun messaggio.
  *
- * coli_arg_int chiama exit(2) quando rifiuta, quindi ogni caso si prova in un
- * processo figlio: e' l'uscita che interessa, non un valore di ritorno. */
+ * Si prova il parser puro e non il guscio che esce: cosi' il test e' un
+ * confronto fra valori, senza fork() -- che su Windows non c'e'. */
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <sys/wait.h>
-#include <unistd.h>
 
 #include "../cli_args.h"
 
 static int fails = 0;
 
-/* Ritorna il codice di uscita del figlio, o -1 se e' morto di segnale. */
-static int run_in_child(const char *arg, int *value_out)
-{
-    int fd[2], status;
-    pid_t pid;
-    int v = 0;
-
-    if (pipe(fd) != 0) return -1;
-    /* Senza questo il figlio eredita cio' che il padre ha ancora nel buffer di
-     * stdout, e quando coli_arg_int chiama exit() lo scarica: ogni FAIL gia'
-     * stampato ricompare una volta per ogni caso successivo. */
-    fflush(NULL);
-    pid = fork();
-    if (pid == 0) {
-        close(fd[0]);
-        v = coli_arg_int(arg, "cache/layer");
-        /* Ci arriva solo se ha accettato. */
-        if (write(fd[1], &v, sizeof v) != (ssize_t)sizeof v) _exit(3);
-        _exit(0);
-    }
-    close(fd[1]);
-    if (read(fd[0], &v, sizeof v) == (ssize_t)sizeof v && value_out) *value_out = v;
-    close(fd[0]);
-    waitpid(pid, &status, 0);
-    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
-}
-
 static void accepts(const char *arg, int expect)
 {
-    int got = 0;
-    int code = run_in_child(arg, &got);
-    if (code != 0) {
-        printf("  FAIL \"%s\": rifiutato (exit %d), doveva valere %d\n",
-               arg, code, expect);
+    int got = -12345;
+    if (!coli_parse_int(arg, &got)) {
+        printf("  FAIL \"%s\": rifiutato, doveva valere %d\n", arg, expect);
         fails++;
     } else if (got != expect) {
         printf("  FAIL \"%s\": vale %d invece di %d\n", arg, got, expect);
@@ -59,10 +27,14 @@ static void accepts(const char *arg, int expect)
 
 static void rejects(const char *arg)
 {
-    int code = run_in_child(arg, NULL);
-    if (code != 2) {
-        printf("  FAIL \"%s\": accettato o uscita %d invece di 2 -- e' il bug "
-               "originale, un argomento non valido letto a meta'\n", arg, code);
+    int got = -12345;
+    if (coli_parse_int(arg, &got)) {
+        printf("  FAIL \"%s\": accettato come %d -- e' il bug originale, un "
+               "argomento non valido letto a meta'\n", arg, got);
+        fails++;
+    } else if (got != -12345) {
+        printf("  FAIL \"%s\": rifiutato ma ha scritto %d nell'uscita\n",
+               arg, got);
         fails++;
     }
 }
@@ -78,6 +50,7 @@ int main(void)
     accepts("32 ", 32);       /* e noi quelli finali */
     accepts("32\r", 32);      /* uno script salvato con le terminazioni Windows */
     accepts("32\n", 32);
+    accepts("2147483647", 2147483647);
 
     /* Quello che prima passava in silenzio. */
     rejects("3x2");           /* il refuso vero: atoi diceva 3 */
@@ -89,6 +62,8 @@ int main(void)
     rejects("3.5");
     rejects("99999999999999999999");   /* ERANGE */
     rejects("-99999999999999999999");
+    rejects("2147483648");    /* un piu' di INT_MAX: non entra in un int */
+    rejects(NULL);
 
     if (fails) { printf("test_cli_args: %d fallimenti\n", fails); return 1; }
     printf("test_cli_args: ok\n");

--- a/c/tests/test_cli_args.c
+++ b/c/tests/test_cli_args.c
@@ -1,0 +1,96 @@
+/* coli_arg_int: cio' che atoi accettava a meta' ora e' un errore.
+ *
+ * Il caso che ha motivato tutto questo e' "3x2" scritto al posto di "32": atoi
+ * restituiva 3, il motore partiva con una cache dieci volte piu' piccola, e
+ * l'unico sintomo era che andava piano. Nessun messaggio.
+ *
+ * coli_arg_int chiama exit(2) quando rifiuta, quindi ogni caso si prova in un
+ * processo figlio: e' l'uscita che interessa, non un valore di ritorno. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../cli_args.h"
+
+static int fails = 0;
+
+/* Ritorna il codice di uscita del figlio, o -1 se e' morto di segnale. */
+static int run_in_child(const char *arg, int *value_out)
+{
+    int fd[2], status;
+    pid_t pid;
+    int v = 0;
+
+    if (pipe(fd) != 0) return -1;
+    /* Senza questo il figlio eredita cio' che il padre ha ancora nel buffer di
+     * stdout, e quando coli_arg_int chiama exit() lo scarica: ogni FAIL gia'
+     * stampato ricompare una volta per ogni caso successivo. */
+    fflush(NULL);
+    pid = fork();
+    if (pid == 0) {
+        close(fd[0]);
+        v = coli_arg_int(arg, "cache/layer");
+        /* Ci arriva solo se ha accettato. */
+        if (write(fd[1], &v, sizeof v) != (ssize_t)sizeof v) _exit(3);
+        _exit(0);
+    }
+    close(fd[1]);
+    if (read(fd[0], &v, sizeof v) == (ssize_t)sizeof v && value_out) *value_out = v;
+    close(fd[0]);
+    waitpid(pid, &status, 0);
+    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+}
+
+static void accepts(const char *arg, int expect)
+{
+    int got = 0;
+    int code = run_in_child(arg, &got);
+    if (code != 0) {
+        printf("  FAIL \"%s\": rifiutato (exit %d), doveva valere %d\n",
+               arg, code, expect);
+        fails++;
+    } else if (got != expect) {
+        printf("  FAIL \"%s\": vale %d invece di %d\n", arg, got, expect);
+        fails++;
+    }
+}
+
+static void rejects(const char *arg)
+{
+    int code = run_in_child(arg, NULL);
+    if (code != 2) {
+        printf("  FAIL \"%s\": accettato o uscita %d invece di 2 -- e' il bug "
+               "originale, un argomento non valido letto a meta'\n", arg, code);
+        fails++;
+    }
+}
+
+int main(void)
+{
+    /* Quello che deve continuare a funzionare. */
+    accepts("32", 32);
+    accepts("0", 0);          /* il limite cap >= 1 e' del chiamante, non di qui */
+    accepts("-5", -5);
+    accepts("+32", 32);
+    accepts(" 32", 32);       /* strtol salta gli spazi iniziali */
+    accepts("32 ", 32);       /* e noi quelli finali */
+    accepts("32\r", 32);      /* uno script salvato con le terminazioni Windows */
+    accepts("32\n", 32);
+
+    /* Quello che prima passava in silenzio. */
+    rejects("3x2");           /* il refuso vero: atoi diceva 3 */
+    rejects("32abc");
+    rejects("abc");
+    rejects("");
+    rejects(" ");
+    rejects("0x20");          /* base 16 non e' quello che intendeva chi scrive */
+    rejects("3.5");
+    rejects("99999999999999999999");   /* ERANGE */
+    rejects("-99999999999999999999");
+
+    if (fails) { printf("test_cli_args: %d fallimenti\n", fails); return 1; }
+    printf("test_cli_args: ok\n");
+    return 0;
+}


### PR DESCRIPTION
```
./qwen38 3x2
```

`atoi` returns 3. The engine starts with `cache=3/layer` instead of 32, reads roughly ten times more from disk than it should, and the only symptom is that it feels slow. No message, no non-zero exit. Whoever ran it concludes the engine is slow, not that they mistyped.

That is the worst way a program can be wrong: it does something other than what was asked, and does not say so.

## What changed

`coli_arg_int` parses with `strtol` and requires that it consumed the whole string. It replaces the 15 `atoi(argv[...])` sites across all seven engines.

| input | before | now |
|---|---|---|
| `32` | 32 | 32 |
| `3x2` | 3, silently | `cache/layer: expected a whole number, got "3x2"`, exit 2 |
| `32abc` | 32, silently | rejected |
| `0x20` | 0 | rejected |
| `3.5` | 3 | rejected |
| `99999999999999999999` | undefined | rejected |
| `32\r` | 32 | 32 |

Trailing whitespace is tolerated on purpose. We ship Windows binaries, and a `32` read out of a script saved with CRLF line endings must not die with a message nobody can act on.

`atoi(getenv(...))` is deliberately out of scope. There are 137 of those, it is a different and lower risk, and a 137-site diff does not get reviewed.

## The Italian message

`glm53` answered an unknown argument with `argomento sconosciuto: %s`, the only Italian string a user meets in an otherwise English project. It now says `unknown argument`.

Worth stating clearly, because I first read this backwards: **glm53 was the only engine doing the right thing.** It is the one that rejects arguments it does not recognise and exits 2. The other six accept anything and carry on. The Italian message was simply the only part that was visible, which made the well-behaved engine look like the broken one.

## Verification

The point of the test is that it fails without the fix. Restoring `atoi`:

```
exit 1, 9 cases caught
FAIL "3x2": accettato o uscita 0 invece di 2 -- e' il bug originale
```

All seven engines build, and still accept valid arguments: `./qwen38 32` gives `cache=32/layer` as before, and no arguments still gives the default.

The test is registered with a Makefile rule, which per the comment at `TEST_RULES` is what makes a test a gate rather than a file that happens to exist.

Two bugs of my own that this found on the way, both fixed here: the trailing-whitespace skip originally ran before the `end == arg` check, so an argument of only spaces passed as 0; and the test forked without flushing stdout, so each `exit()` in a child re-printed the parent's buffer.
