### PR TITLE
ci: build the engines the Python job's tests skip without

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,6 +773,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      # Sette test in tests/test_kimi_usage_cli.py e tests/test_inkling_prefix_serve.py
+      # sono protetti da skipUnless(ENGINE.exists()). Questo job non compilava
+      # nessun motore, quindi si saltavano tutti e sette e il job restava verde
+      # perche' era vuoto -- la stessa forma del job dei sanitizer che
+      # rieseguiva un binario non strumentato. Uno di quei test era rosso da
+      # settimane senza che nessuno potesse vederlo.
+      - name: Build the engines those tests exercise
+        run: make -C c kimi_k3 inkling
       - name: Python test suite
         run: cd c && python3 -m unittest discover -s tests -p 'test_*.py'
 

--- a/c/tests/test_family_registry.py
+++ b/c/tests/test_family_registry.py
@@ -1169,6 +1169,62 @@ class FamilyRegistryTest(unittest.TestCase):
                                 f"({family.id}); a reader in that language cannot "
                                 f"tell the family is supported")
 
+    def test_the_python_job_builds_every_engine_a_test_skips_without(self):
+        """Un test protetto da skipUnless(ENGINE.exists()) sparisce se il job
+        non compila quel motore, e sparisce in silenzio: la classe si salta,
+        il job resta verde, e nessuno distingue "passato" da "mai eseguito".
+
+        E' successo davvero. Il job Python non compilava nessun motore, quindi
+        sette test fra test_kimi_usage_cli e test_inkling_prefix_serve non
+        giravano da sempre, e uno era rosso da quando il messaggio di kimi_k3
+        e' stato riscritto. E' la stessa forma del job dei sanitizer che
+        rieseguiva un binario senza strumentazione: verde perche' vuoto.
+
+        Il controllo va nella direzione che serve. Non chiede che il job
+        compili una certa lista, che sarebbe un'altra costante da tenere
+        allineata a mano: parte dai test, guarda su quale binario si saltano,
+        e pretende che il job lo costruisca.
+        """
+        repo = Path(__file__).resolve().parents[2]
+        tests_dir = repo / "c" / "tests"
+        guard = re.compile(r'ENGINE\s*=\s*HERE\s*/\s*\(?\s*"([a-z0-9_]+)\.exe"'
+                           r'.*?else\s*"([a-z0-9_]+)"', re.S)
+        needed = {}
+        for path in sorted(tests_dir.glob("test_*.py")):
+            text = path.read_text(encoding="utf-8")
+            if "skipUnless" not in text or "ENGINE.exists()" not in text:
+                continue
+            m = guard.search(text)
+            if m:
+                needed[m.group(2)] = path.name
+        self.assertTrue(needed,
+                        "nessun test guardato da ENGINE.exists() trovato: il "
+                        "controllo non sta piu' guardando niente")
+        ci = (repo / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        # Il corpo del job va da "  python:" fino al job successivo, cioe' la
+        # prossima riga indentata di due spazi esatti. Tagliare al primo "\n  "
+        # non funziona: le righe interne sono indentate di quattro e cominciano
+        # anch'esse per due spazi, quindi il corpo verrebbe vuoto e il test
+        # fallirebbe sempre, per la ragione sbagliata.
+        job = re.search(r"(?m)^  python:\n(.*?)(?=^  \S|\Z)", ci, re.S)
+        self.assertIsNotNone(job, "il job 'python:' non esiste piu' in ci.yml")
+        body = job.group(1)
+        # I bersagli veri di make, non il corpo del job: un commento che nomina
+        # "test_inkling_prefix_serve.py" contiene la parola "inkling" e farebbe
+        # passare il controllo senza che nulla venga compilato. Il controllo
+        # negativo di questo test lo ha dimostrato togliendo inkling dalla
+        # riga di build: passava lo stesso.
+        built = set()
+        for run_line in re.findall(r"(?m)^\s*run:\s*(.+)$", body):
+            m = re.search(r"\bmake\b(?:\s+-C\s+\S+)?\s+(.*)", run_line)
+            if m:
+                built.update(tok for tok in m.group(1).split() if not tok.startswith("-"))
+        for engine, where in sorted(needed.items()):
+            self.assertIn(engine, built,
+                          f"{where} si salta se '{engine}' non e' compilato, e il "
+                          f"job Python della CI non lo compila: quei test non "
+                          f"girano mai e il job resta verde perche' e' vuoto")
+
     def test_every_readme_banner_matches_the_declared_version(self):
         """Il banner dei README deve dire la versione che dichiara version.py.
 

--- a/c/tests/test_kimi_usage_cli.py
+++ b/c/tests/test_kimi_usage_cli.py
@@ -41,9 +41,26 @@ class KimiUsageTest(unittest.TestCase):
                 self.assertNotIn("config.json", out,
                                  f"{flag} was treated as a model directory")
 
-    def test_no_arguments_prints_usage_and_fails(self):
+    def test_no_arguments_points_at_the_launcher_and_fails(self):
+        """Senza argomenti il messaggio non e' piu' l'elenco dei flag, ed e'
+        giusto cosi': chi lancia il motore a mani vuote quasi sempre voleva
+        `coli`, e un elenco di flag lo lascia dove si trova. Il contratto qui
+        e' che dica che manca il modello e nomini il launcher; l'elenco
+        completo resta il contratto di --help, provato sopra.
+
+        Questa asserzione chiedeva `<model_dir>`, `--ngen` e `--ids` anche a
+        questo percorso, ed era rossa da quando il messaggio e' stato
+        riscritto. Nessuno se n'e' accorto perche' l'intera classe si salta
+        se kimi_k3 non e' compilato, e il job Python della CI non compilava
+        nessun motore: verde perche' vuota.
+        """
         r = run()
-        self.assertUsage(r.stdout + r.stderr, "no args")
+        out = r.stdout + r.stderr
+        self.assertIn("without a model", out,
+                      "no args: does not say what is missing")
+        self.assertIn("coli chat", out,
+                      "no args: does not name the launcher, which is what the "
+                      "person almost certainly wanted")
         self.assertNotEqual(r.returncode, 0, "a missing model dir is a failure")
 
     def test_usage_names_the_launcher(self):


### PR DESCRIPTION
Seven tests, in `tests/test_kimi_usage_cli.py` and `tests/test_inkling_prefix_serve.py`, are guarded by `skipUnless(ENGINE.exists())`.

The `python` job checks out, installs Python, and runs the suite. It builds no engine. So all seven skipped, every time, and the job was green because it was empty.

This is the same shape as the sanitiser job that had been re-running an un-instrumented binary: from the outside, "passed" and "never ran" look identical.

## What was hidden

`test_no_arguments_prints_usage_and_fails` had been red since kimi_k3's no-argument message was rewritten. It asserted the full flag list (`<model_dir>`, `--ngen`, `--ids`) on that path too, but that path now points people at the launcher:

```
colibri: this is the Kimi K3 engine, and it was started without a model.
The engine is not the program you run directly -- the launcher is:

    ./coli chat  --model <model directory>    interactive chat
```

The new message is better, not worse: someone who runs the engine bare almost always wanted `coli`, and a list of flags leaves them where they were. So the test now asserts what that path actually owes the reader, that a model is missing and what the launcher is called. The full list stays the contract of `--help`, which the other three tests already cover and which passes.

## Keeping it from coming back

The new contract test starts from the tests rather than from a list: it finds every test file that skips on a missing binary, reads which binary, and requires the job to build it. A list of engines here would be one more constant to keep in sync by hand, which is the defect this whole class keeps taking.

Its own negative control caught a flaw in it. Checking for the engine name anywhere in the job body passed even with `inkling` removed from the build, because the comment above it names `test_inkling_prefix_serve.py`. It now reads the `make` targets only:

| state | result |
|---|---|
| job builds `kimi_k3 inkling` | passes |
| `inkling` removed from the build line | `AssertionError: 'inkling' not found in {'kimi_k3'}` |

## Verification

`test_family_registry`: 42 tests, green. The two previously-invisible files: 7 tests, green, with 3 skips that are genuine (they need a running server, not a binary).
