### PR TITLE
fix(release): compute the Python the archive needs, stop listing it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,29 +135,20 @@ jobs:
           # run it -- the second half of #720.
           mkdir -p dist/tools
           cp c/tools/k3_tokenizer.py dist/tools/
-          # Gli script che `coli` lancia, letti da coli invece che elencati qui.
-          # Una lista scritta a mano in questo punto e' gia' costata #1296: si
-          # copiava k3_tokenizer.py e basta, mentre coli ne invoca tre altri, e
-          # `coli convert` nel pacchetto pubblicato moriva con "No such file or
-          # directory". Il passo di verifica piu' sotto controllava l'unico file
-          # presente, quindi la release passava.
-          for s in $(grep -oE 'TOOLS,"[a-z0-9_]+\.py"' c/coli | sed 's/.*"\(.*\)"/\1/' | sort -u); do
-            test -f "c/tools/$s" || { echo "FAIL: coli invokes tools/$s, which does not exist"; exit 1; }
-            cp "c/tools/$s" "dist/tools/$s"
-          done
           cp c/coli dist/
           # Windows has nothing to click otherwise: `coli` is an extensionless
           # Python script, and the .exe files are engines that exit at once
           # without a model (#1241). coli.cmd is both the double-click entry
           # point and what `coli chat ...` resolves to in cmd/PowerShell.
           if [ "${{ matrix.ext }}" = ".exe" ]; then cp c/coli.cmd dist/; fi
-          cp c/version.py dist/
-          cp c/openai_server.py dist/
-          cp c/v4_dsml.py dist/        # openai_server imports v4_dsml (vendored DeepSeek V4 DSML primitives); without it the packaged server won't import
-          cp c/family_registry.py dist/ # authoritative model-family dispatch/capability registry
-          cp c/resource_plan.py dist/
-          cp c/doctor.py dist/
-          cp c/autotune.py dist/
+          # I file Python non sono piu' elencati qui. Erano sette, scelti a mano,
+          # con i commenti che spiegavano quale importava quale: un inseguimento
+          # del codice fatto a occhio, e il codice era avanti. #1296: mancavano
+          # quattro script invocati da coli e tre moduli importati, fra cui
+          # qwen38_image, per cui mandare un'immagine al pacchetto pubblicato
+          # rispondeva "image support needs Pillow and numpy" mentre il file
+          # semplicemente non era stato spedito.
+          python3 c/tools/pack_python.py c dist
           cp LICENSE dist/
           # web/dist sits NEXT TO coli in the archive; both coli and openai_server.py
           # probe that layout as well as the source checkout's one-level-up form.
@@ -198,10 +189,12 @@ jobs:
           # Kimi K3 needs tokenizer.json synthesized from tiktoken.model; without this
           # script in the archive the engine ships but cannot be driven by coli chat.
           test -f tools/k3_tokenizer.py || { echo "FAIL: k3_tokenizer.py missing from archive"; exit 1; }
-          # E ogni script che coli lancia: e' il controllo che mancava a #1296.
-          for s in $(grep -oE 'TOOLS,"[a-z0-9_]+\.py"' coli | sed 's/.*"\(.*\)"/\1/' | sort -u); do
-            test -f "tools/$s" || { echo "FAIL: coli invokes tools/$s, missing from archive"; exit 1; }
-          done
+          # E tutto cio' che coli raggiunge, import e sottoprocessi. Il controllo
+          # qui sopra guarda l'unico file che il passo di copia aveva appena
+          # scritto: conferma se stesso, ed e' il motivo per cui la v1.10.0 e'
+          # uscita verde con quattro comandi rotti dentro.
+          python3 ../c/tools/pack_python.py ../c . --check \
+            || { echo "FAIL: the archive is missing Python that coli needs"; exit 1; }
           # encoding='utf-8' explicitly: on Windows open() defaults to the ANSI code
           # page (cp1252), which cannot decode this UTF-8 file, so the v1.4.0 tag build
           # failed here with a UnicodeDecodeError while the file itself was perfectly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,16 @@ jobs:
           # run it -- the second half of #720.
           mkdir -p dist/tools
           cp c/tools/k3_tokenizer.py dist/tools/
+          # Gli script che `coli` lancia, letti da coli invece che elencati qui.
+          # Una lista scritta a mano in questo punto e' gia' costata #1296: si
+          # copiava k3_tokenizer.py e basta, mentre coli ne invoca tre altri, e
+          # `coli convert` nel pacchetto pubblicato moriva con "No such file or
+          # directory". Il passo di verifica piu' sotto controllava l'unico file
+          # presente, quindi la release passava.
+          for s in $(grep -oE 'TOOLS,"[a-z0-9_]+\.py"' c/coli | sed 's/.*"\(.*\)"/\1/' | sort -u); do
+            test -f "c/tools/$s" || { echo "FAIL: coli invokes tools/$s, which does not exist"; exit 1; }
+            cp "c/tools/$s" "dist/tools/$s"
+          done
           cp c/coli dist/
           # Windows has nothing to click otherwise: `coli` is an extensionless
           # Python script, and the .exe files are engines that exit at once
@@ -188,6 +198,10 @@ jobs:
           # Kimi K3 needs tokenizer.json synthesized from tiktoken.model; without this
           # script in the archive the engine ships but cannot be driven by coli chat.
           test -f tools/k3_tokenizer.py || { echo "FAIL: k3_tokenizer.py missing from archive"; exit 1; }
+          # E ogni script che coli lancia: e' il controllo che mancava a #1296.
+          for s in $(grep -oE 'TOOLS,"[a-z0-9_]+\.py"' coli | sed 's/.*"\(.*\)"/\1/' | sort -u); do
+            test -f "tools/$s" || { echo "FAIL: coli invokes tools/$s, missing from archive"; exit 1; }
+          done
           # encoding='utf-8' explicitly: on Windows open() defaults to the ANSI code
           # page (cp1252), which cannot decode this UTF-8 file, so the v1.4.0 tag build
           # failed here with a UnicodeDecodeError while the file itself was perfectly

--- a/c/tests/test_family_registry.py
+++ b/c/tests/test_family_registry.py
@@ -1,5 +1,6 @@
 import json
 import re
+import sys
 import tempfile
 import unittest
 from dataclasses import replace
@@ -1169,50 +1170,51 @@ class FamilyRegistryTest(unittest.TestCase):
                                 f"({family.id}); a reader in that language cannot "
                                 f"tell the family is supported")
 
-    def test_release_ships_every_tool_coli_invokes(self):
-        """Ogni script che `coli` lancia deve finire nell'archivio.
+    def test_release_ships_everything_coli_reaches(self):
+        """L'archivio deve contenere ogni file Python che coli raggiunge.
 
-        #1296: il pacchetto v1.10.0 conteneva un solo file in tools/,
-        k3_tokenizer.py, scelto a mano nel workflow. coli ne invoca altri tre,
-        fra cui convert_fp8_to_int4.py, e `coli convert` nel pacchetto
-        pubblicato moriva con "No such file or directory". C'era anche un passo
-        di verifica: controllava la presenza dell'unico file copiato, cioe'
-        confermava se stesso.
+        #1296: il pacchetto v1.10.0 aveva quattro comandi rotti. release.yml
+        copiava sette .py scelti a mano piu' un solo file in tools/, e il
+        codice era andato avanti. Mancavano convert_fp8_to_int4.py,
+        eval_glm.py, fetch_benchmarks.py, mirror_plan.py, e i moduli cluster,
+        glm53_image, qwen38_image.
 
-        Il workflow ora ricava la lista da coli con una grep. Questo test
-        protegge l'assunzione di quella grep: se domani coli costruisse il
-        percorso di uno script in un altro modo -- una variabile, un f-string,
-        os.path.join a pezzi -- la grep non lo vedrebbe, il file non verrebbe
-        copiato, e saremmo di nuovo a #1296 con la release verde.
+        Ora la lista la calcola c/tools/pack_python.py. Questo test fissa i
+        due punti ciechi che avevano fatto passare il difetto, perche' sono i
+        due modi in cui un file sfugge a chi guarda a occhio:
 
-        Percio' qui si contano le invocazioni in due modi diversi e si pretende
-        che diano lo stesso numero.
+        - un import dentro una funzione, dopo un sys.path.insert. E' il caso
+          di qwen38_image in openai_server.py, e l'ImportError li' e'
+          catturato e riscritto come "image support needs Pillow and numpy":
+          nel pacchetto pubblicato mandare un'immagine dava la colpa
+          all'ambiente dell'utente per un file che non avevamo spedito.
+        - un sottoprocesso scritto con lo spazio dopo la virgola,
+          os.path.join(TOOLS, "mirror_plan.py"). La mia prima grep cercava
+          TOOLS," senza spazio e non lo vedeva: quattro invocazioni, non tre.
         """
         repo = Path(__file__).resolve().parents[2]
-        coli = (repo / "c" / "coli").read_text(encoding="utf-8")
+        sys.path.insert(0, str(repo / "c" / "tools"))
+        try:
+            import pack_python
+        finally:
+            sys.path.pop(0)
 
-        # 1. Come li vede la grep del workflow.
-        seen = set(re.findall(r'TOOLS,\s*"([a-z0-9_]+\.py)"', coli))
-        self.assertTrue(seen, "nessuno script trovato in coli: la grep del "
-                              "workflow non copierebbe piu' niente")
+        reached = {path.name for path in pack_python.needed(repo / "c")}
 
-        # 2. Ogni .py nominato accanto a TOOLS, comunque sia scritto.
-        every = set(re.findall(r'TOOLS[^\n]*?([a-z0-9_]+\.py)', coli))
-        self.assertEqual(every, seen,
-                         "coli nomina uno script in una forma che la grep di "
-                         "release.yml non riconosce: finirebbe fuori "
-                         "dall'archivio come in #1296")
+        # I sette file che mancavano davvero dall'archivio v1.10.0.
+        for name in ("convert_fp8_to_int4.py", "eval_glm.py",
+                     "fetch_benchmarks.py", "mirror_plan.py",
+                     "cluster.py", "glm53_image.py", "qwen38_image.py"):
+            self.assertIn(name, reached,
+                          f"{name} mancava dall'archivio v1.10.0 e il calcolo "
+                          f"non lo ritrova: #1296 si ripeterebbe")
 
-        # 3. Esistono, e il workflow li copia e li verifica.
         release = (repo / ".github" / "workflows" / "release.yml").read_text(
             encoding="utf-8")
-        for script in sorted(seen):
-            self.assertTrue((repo / "c" / "tools" / script).exists(),
-                            f"coli invoca tools/{script}, che non esiste")
-        self.assertIn("dist/tools/$s", release,
-                      "release.yml non copia piu' gli script ricavati da coli")
-        self.assertIn('test -f "tools/$s"', release,
-                      "release.yml non verifica piu' che siano nell'archivio")
+        self.assertIn("pack_python.py c dist", release,
+                      "release.yml non calcola piu' i file da copiare")
+        self.assertIn("--check", release,
+                      "release.yml non verifica piu' l'archivio estratto")
 
     def test_the_python_job_builds_every_engine_a_test_skips_without(self):
         """Un test protetto da skipUnless(ENGINE.exists()) sparisce se il job
@@ -1359,8 +1361,21 @@ class FamilyRegistryTest(unittest.TestCase):
                 else:
                     self.assertIn("deepseek-v4", ci)
                     self.assertIn("cp c/deepseek_v4", release)
-        for text in (makefile, release, docker):
+        for text in (makefile, docker):
             self.assertIn("family_registry.py", text)
+        # release.yml non nomina piu' i singoli .py: da #1296 la lista la
+        # calcola pack_python.py seguendo gli import a partire da coli. Il
+        # contratto qui e' sempre lo stesso -- family_registry.py deve finire
+        # nell'archivio -- ma va verificato alla fonte nuova, se no si
+        # controlla che esista una riga invece che il file venga spedito.
+        sys.path.insert(0, str(repo / "c" / "tools"))
+        try:
+            import pack_python
+        finally:
+            sys.path.pop(0)
+        shipped = {path.name for path in pack_python.needed(repo / "c")}
+        self.assertIn("family_registry.py", shipped,
+                      "l'archivio non spedirebbe family_registry.py")
 
 
 if __name__ == "__main__":

--- a/c/tests/test_family_registry.py
+++ b/c/tests/test_family_registry.py
@@ -1169,6 +1169,51 @@ class FamilyRegistryTest(unittest.TestCase):
                                 f"({family.id}); a reader in that language cannot "
                                 f"tell the family is supported")
 
+    def test_release_ships_every_tool_coli_invokes(self):
+        """Ogni script che `coli` lancia deve finire nell'archivio.
+
+        #1296: il pacchetto v1.10.0 conteneva un solo file in tools/,
+        k3_tokenizer.py, scelto a mano nel workflow. coli ne invoca altri tre,
+        fra cui convert_fp8_to_int4.py, e `coli convert` nel pacchetto
+        pubblicato moriva con "No such file or directory". C'era anche un passo
+        di verifica: controllava la presenza dell'unico file copiato, cioe'
+        confermava se stesso.
+
+        Il workflow ora ricava la lista da coli con una grep. Questo test
+        protegge l'assunzione di quella grep: se domani coli costruisse il
+        percorso di uno script in un altro modo -- una variabile, un f-string,
+        os.path.join a pezzi -- la grep non lo vedrebbe, il file non verrebbe
+        copiato, e saremmo di nuovo a #1296 con la release verde.
+
+        Percio' qui si contano le invocazioni in due modi diversi e si pretende
+        che diano lo stesso numero.
+        """
+        repo = Path(__file__).resolve().parents[2]
+        coli = (repo / "c" / "coli").read_text(encoding="utf-8")
+
+        # 1. Come li vede la grep del workflow.
+        seen = set(re.findall(r'TOOLS,\s*"([a-z0-9_]+\.py)"', coli))
+        self.assertTrue(seen, "nessuno script trovato in coli: la grep del "
+                              "workflow non copierebbe piu' niente")
+
+        # 2. Ogni .py nominato accanto a TOOLS, comunque sia scritto.
+        every = set(re.findall(r'TOOLS[^\n]*?([a-z0-9_]+\.py)', coli))
+        self.assertEqual(every, seen,
+                         "coli nomina uno script in una forma che la grep di "
+                         "release.yml non riconosce: finirebbe fuori "
+                         "dall'archivio come in #1296")
+
+        # 3. Esistono, e il workflow li copia e li verifica.
+        release = (repo / ".github" / "workflows" / "release.yml").read_text(
+            encoding="utf-8")
+        for script in sorted(seen):
+            self.assertTrue((repo / "c" / "tools" / script).exists(),
+                            f"coli invoca tools/{script}, che non esiste")
+        self.assertIn("dist/tools/$s", release,
+                      "release.yml non copia piu' gli script ricavati da coli")
+        self.assertIn('test -f "tools/$s"', release,
+                      "release.yml non verifica piu' che siano nell'archivio")
+
     def test_the_python_job_builds_every_engine_a_test_skips_without(self):
         """Un test protetto da skipUnless(ENGINE.exists()) sparisce se il job
         non compila quel motore, e sparisce in silenzio: la classe si salta,

--- a/c/tools/pack_python.py
+++ b/c/tools/pack_python.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Quali file Python deve contenere un archivio di release, calcolati.
+
+#1296: `coli convert` nel pacchetto v1.10.0 moriva con "can't open file
+'tools/convert_fp8_to_int4.py'". Il workflow copiava una lista scritta a mano,
+e la lista era indietro rispetto al codice. Tre script invocati da coli e tre
+moduli importati non c'erano.
+
+Uno dei tre e' istruttivo: openai_server.py fa
+
+    _sys.path.insert(0, str(_Path(__file__).resolve().parent / "tools"))
+    from qwen38_image import preprocess
+
+dentro una funzione, e l'ImportError e' catturato e riscritto come "image
+support needs Pillow and numpy". Nel pacchetto pubblicato mandare un'immagine
+rispondeva quindi che mancavano delle dipendenze all'utente, mentre il file non
+era stato spedito. Un import cercato con una regex, o a occhio, non lo trova:
+per questo qui si usa ast.
+
+Due modi di raggiungere un file, ed entrambi contano:
+  - import, seguiti in chiusura a partire da coli
+  - subprocess, cioe' os.path.join(TOOLS, "qualcosa.py")
+
+Uso:
+    pack_python.py <c-dir> <dist-dir>            copia
+    pack_python.py <c-dir> <dist-dir> --check    verifica, esce 1 se manca
+"""
+import ast
+import pathlib
+import re
+import shutil
+import sys
+
+
+def local_modules(src):
+    """I nostri moduli per nome. Tutto il resto e' stdlib o terze parti."""
+    found = {p.stem: p for p in src.glob("*.py")}
+    for path in (src / "tools").glob("*.py"):
+        found.setdefault(path.stem, path)
+    return found
+
+
+def imports_of(path):
+    """I nomi importati da un file, comunque sia scritto l'import: dentro una
+    funzione, dopo un sys.path.insert, in un try. ast li vede tutti."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"))
+    except SyntaxError:
+        return set()
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            names.add(node.module.split(".")[0])
+    return names
+
+
+def invoked_scripts(path):
+    """Gli script lanciati come processo, non importati: os.path.join(TOOLS, "x.py")."""
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    return set(re.findall(r'TOOLS,\s*"([a-z0-9_]+\.py)"', text))
+
+
+def needed(src):
+    """Tutto cio' che coli raggiunge, come percorsi sotto <c-dir>."""
+    local = local_modules(src)
+    reached, queue = set(), [src / "coli"]
+    scripts = set()
+    while queue:
+        path = queue.pop()
+        scripts |= invoked_scripts(path)
+        for name in imports_of(path):
+            if name in local and name not in reached:
+                reached.add(name)
+                queue.append(local[name])
+    paths = {local[name] for name in reached}
+    for script in sorted(scripts):
+        candidate = src / "tools" / script
+        if not candidate.exists():
+            raise SystemExit(f"FAIL: coli invokes tools/{script}, which does not exist")
+        paths.add(candidate)
+    return sorted(paths)
+
+
+def main(argv):
+    if len(argv) < 3:
+        raise SystemExit(__doc__)
+    src, dist = pathlib.Path(argv[1]), pathlib.Path(argv[2])
+    check = "--check" in argv[3:]
+    missing = []
+    files = needed(src)
+    for path in files:
+        rel = pathlib.Path("tools") / path.name if path.parent.name == "tools" \
+            else pathlib.Path(path.name)
+        dest = dist / rel
+        if check:
+            if not dest.exists():
+                missing.append(str(rel))
+            continue
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, dest)
+    if missing:
+        print("FAIL: coli reaches these and they are not in the archive:")
+        for name in missing:
+            print(f"  {name}")
+        return 1
+    print(f"{len(files)} Python files reachable from coli "
+          f"({'all present' if check else 'copied'})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Fixes #1296.

The report is about one script. Looking properly, **four commands of the published v1.10.0 package are broken and seven files are missing.**

## What was missing

`release.yml` copied seven `.py` files chosen by hand, with comments explaining which imported which, plus exactly one file into `tools/`. That is chasing the code by eye, and the code had moved on.

| missing from the v1.10.0 archive | how `coli` reaches it |
|---|---|
| `convert_fp8_to_int4.py` | subprocess (`coli convert`) |
| `eval_glm.py` | subprocess |
| `fetch_benchmarks.py` | subprocess |
| `mirror_plan.py` | subprocess (`coli mirror`) |
| `cluster.py` | import, inside a function |
| `glm53_image.py` | import, after a `sys.path.insert` |
| `qwen38_image.py` | import, after a `sys.path.insert` |

`qwen38_image` is the worst of them. `openai_server.py` does:

```python
_sys.path.insert(0, str(_Path(__file__).resolve().parent / "tools"))
from qwen38_image import preprocess
except ImportError as problem:
    raise APIError(400, f"image support needs Pillow and numpy ({problem}).")
```

So in the published package, sending an image to qwen38 answered that **the user** was missing Pillow and numpy, for a file we had not shipped. That is the vision support announced in the v1.10.0 notes, broken in the prebuilt, blaming the person who downloaded it.

## The check that made it possible

```yaml
test -f tools/k3_tokenizer.py || { echo "FAIL: k3_tokenizer.py missing from archive"; exit 1; }
```

It verified the presence of the one file the copy step had just written. A check that looks where it just put its own hand confirms itself. That is why the release went out green.

## The fix

`c/tools/pack_python.py` computes the closure from `coli`, following both ways a file is reached: imports, and subprocess invocations. The copy step and the archive check call the same computation, so there is one source instead of two that drift.

It parses with `ast`, not a regex, because the import that caused the worst symptom is inside a function after a `sys.path.insert`, and a regex does not see it. My own first attempt at this used a regex `TOOLS,"..."` and missed `mirror_plan.py`, which is written with a space after the comma. That is how the count went from three to four.

## Verification

Full sequence simulated (copy, tar, extract, check): 14 files, check passes; remove the file from #1296 and it exits 1.

| negative control | result |
|---|---|
| computation stops following subprocesses | loses `convert_fp8_to_int4.py` |
| computation goes back to a regex | loses `cluster.py` |

`test_family_registry`: 43 tests, green.

One pre-existing assertion moved rather than deleted: `assertIn("family_registry.py", release)` now checks the closure instead of the workflow text. The contract is that the file ships, not that a line naming it exists.

## This does not repair v1.10.0

The archives already downloaded still have four broken commands. A v1.10.1 re-tag is the fix for those people, and I am preparing it.
