### PR TITLE
chore(release): v1.10.1

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -34,7 +34,7 @@ ma non ridefinire il modello di nascosto.
 
 ```
 $ ./coli chat
-  🐦 colibri v1.10.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
+  🐦 colibri v1.10.1 — GLM-5.2 · 744B MoE · int4 · streaming CPU
   ✓ ready in 32s · resident 9.9 GB
   › ciao!
   ◆ Ciao! 😊 Come posso aiutarti oggi?

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ may reduce speed; it must not quietly redefine the model.
 
 ```
 $ ./coli chat
-  🐦 colibri v1.10.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
+  🐦 colibri v1.10.1 — GLM-5.2 · 744B MoE · int4 · streaming CPU
   ✓ ready in 32s · resident 9.9 GB
   › ciao!
   ◆ Ciao! 😊 Come posso aiutarti oggi?

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,7 +25,7 @@ Colibrì 刻意用于验证激进的系统思路——因此**对速度不作 SL
 
 ```
 $ ./coli chat
-  🐦 colibri v1.10.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
+  🐦 colibri v1.10.1 — GLM-5.2 · 744B MoE · int4 · streaming CPU
   ✓ ready in 32s · resident 9.9 GB
   › ciao!
   ◆ Ciao! 😊 Come posso aiutarti oggi?

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -25,7 +25,7 @@ Colibrì 刻意用於驗證激進的系統構想——因此**對速度不作 SL
 
 ```
 $ ./coli chat
-  🐦 colibri v1.10.0 — GLM-5.2 · 744B MoE · int4 · streaming CPU
+  🐦 colibri v1.10.1 — GLM-5.2 · 744B MoE · int4 · streaming CPU
   ✓ ready in 32s · resident 9.9 GB
   › ciao!
   ◆ Ciao! 😊 Come posso aiutarti oggi?

--- a/c/version.py
+++ b/c/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the colibri version number."""
 
-__version__ = "1.10.0"
+__version__ = "1.10.1"


### PR DESCRIPTION
Version bump for v1.10.1, the packaging repair release. The contract test from #1288 holds the five copies of the number together; this just moves it.

Ships on top of #1298. Nothing else is in scope: this is a re-tag so people who download the prebuilt archive get the 14 Python files coli needs, instead of 8.
