### PR TITLE
perf(quant): compute four output rows per pass in matmul_fp8

### DIFF
--- a/c/quant.h
+++ b/c/quant.h
@@ -523,21 +523,44 @@ static inline int64_t fp8_nblk(int n){ return ((int64_t)n + FP8_BLOCK - 1) / FP8
 static void matmul_fp8(float *y, const float *x, const uint8_t *q8, const float *bscale,
                        int S, int I, int O){
     int64_t nblkI = fp8_nblk(I);
+    /* Four output rows per pass, each with its own accumulator.  Every row's
+       addition sequence is identical to the one-row form - same operands, same
+       column order - so results are bit-identical; only the interleaving of four
+       independent dependency chains differs.  The gain is latency hiding plus one
+       load of xs[i] feeding four rows.  A tail of fewer than four rows clamps the
+       spare indices onto the last valid row and the stores are guarded, which
+       avoids a separate remainder loop. */
     #pragma omp parallel for schedule(static)
-    for(int o=0;o<O;o++){
-        const uint8_t *w = q8 + (int64_t)o*I;
-        int64_t blkO = o / FP8_BLOCK;
-        const float *scl = bscale + blkO*nblkI;
+    for(int o=0;o<O;o+=4){
+        int o1=o+1<O ? o+1 : o, o2=o+2<O ? o+2 : o, o3=o+3<O ? o+3 : o;
+        const uint8_t *w0=q8+(int64_t)o*I,  *w1=q8+(int64_t)o1*I;
+        const uint8_t *w2=q8+(int64_t)o2*I, *w3=q8+(int64_t)o3*I;
+        const float *scl0=bscale+((int64_t)o /FP8_BLOCK)*nblkI;
+        const float *scl1=bscale+((int64_t)o1/FP8_BLOCK)*nblkI;
+        const float *scl2=bscale+((int64_t)o2/FP8_BLOCK)*nblkI;
+        const float *scl3=bscale+((int64_t)o3/FP8_BLOCK)*nblkI;
         for(int s=0;s<S;s++){
             const float *xs = x + (int64_t)s*I;
-            double a=0;
+            double a0=0,a1=0,a2=0,a3=0;
             for(int64_t bi=0; bi*FP8_BLOCK<I; bi++){
                 int base=(int)(bi*FP8_BLOCK); int blen=FP8_BLOCK; if(base+blen>I) blen=I-base;
-                float sc=scl[bi]; float acc=0;
-                for(int i=base;i<base+blen;i++) acc += e4m3_decode(w[i])*xs[i];
-                a += (double)acc*sc;
+                float acc0=0,acc1=0,acc2=0,acc3=0;
+                for(int i=base;i<base+blen;i++){
+                    float xv=xs[i];
+                    acc0 += e4m3_decode(w0[i])*xv;
+                    acc1 += e4m3_decode(w1[i])*xv;
+                    acc2 += e4m3_decode(w2[i])*xv;
+                    acc3 += e4m3_decode(w3[i])*xv;
+                }
+                a0 += (double)acc0*scl0[bi];
+                a1 += (double)acc1*scl1[bi];
+                a2 += (double)acc2*scl2[bi];
+                a3 += (double)acc3*scl3[bi];
             }
-            y[(int64_t)s*O+o]=(float)a;
+            y[(int64_t)s*O+o]=(float)a0;
+            if(o1!=o) y[(int64_t)s*O+o1]=(float)a1;
+            if(o2!=o) y[(int64_t)s*O+o2]=(float)a2;
+            if(o3!=o) y[(int64_t)s*O+o3]=(float)a3;
         }
     }
 }


### PR DESCRIPTION
`matmul_fp8` computes one output row per pass. Computing **four**, each with its own accumulator, is **bit-exact** and substantially faster.

### Why it is bit-exact
Each output row's sequence of additions is unchanged — same operands, same column order, same intermediate roundings. Only the *interleaving* of four **independent** accumulator chains differs, and interleaving independent chains cannot alter any row's result. No reassociation, no partial sums, no column blocking, no change to dequantisation or scale application.

The speedup comes from four independent floating-point dependency chains hiding latency, plus one load of `xs[i]` feeding four rows. A tail of fewer than four rows clamps the spare indices onto the last valid row and guards the stores, avoiding a separate remainder loop.

### Measured
Apple M3 Max, prompt of 256 tokens, 40 generated tokens, N=2, both arms deterministic, within-arm spread 0.2%:

| arm | TTFT | decode | tok/s |
|---|---|---|---|
| `12a5c46` | 203.9 s | 49.97 s | 0.7805 |
| this patch | 169.2 s | 41.18 s | **0.9471 (+21.34%)** |

**Bit-exactness is measured, not argued:** the patched arm reproduces the unmodified engine's generated-text md5 `74bb489b74731bc2ce2595c7ede07309` exactly.

Found by attaching `sample` to the decode window: `matmul_fp8.omp_outlined` was 71,430 self-samples here versus 35,291 in a faster fork; after this patch it is 31,223.

### Caveat, stated explicitly
`c/quant.h` is shared with other engines, so this compiles into `colibri` and `kimi_k3` as well. **I have not verified those builds or benchmarked them** — only the DeepSeek-V4 engine is measured. Treat the cross-engine effect as unverified.

Companion change for the FP4 path is in a separate PR; together they measure +36.80% tok/s and -18.0% TTFT.


---

### Update — rebased, and the bit-exactness claim corrected

The original claim above ("bit-exact, measured not argued") was **wrong as this project builds**, and CI was right. The four-accumulator shape is algebraically identical to the one-row loop, but that is a statement about the C abstract machine, not about codegen: under the default `-O3 -march=native`, GCC contracts the multiply-adds differently in the four-chain form and the result drifts by roughly one unit in the last place. The measurement that produced the original figure was taken on an M3 Max with clang and NEON — not the path where the contraction differs.

**Fix:** contraction is now constrained for this kernel only, scoped with `push_options`/`pop_options` so nothing else in the header changes. On x86-64 with AVX2+FMA, `tests/test_qwen38_native_weights` goes from 179 of 258 rows differing to a clean pass.

**Rejected alternative, recorded because it is the obvious one:** rounding each product into a named `float` before accumulating does *not* work — GCC contracts across statements, and it still fails 179 of 258.

**clang is deliberately not constrained.** There the reference and this kernel already contract identically and the test passes; forcing contraction off under clang makes them disagree, and the same test then fails on arm64.

### Performance, scoped honestly

- **arm64** — the guard is invisible to clang (`__clang__` is defined alongside `__GNUC__`), so the compiled binary is byte-identical with and without it. The previously measured +21.34% tok/s therefore still applies unmodified to that path: it is literally the same binary.
- **x86-64** — **not measured.** The guard applies there, and forbidding the fused multiply-add in that loop may return some of the gain. I have no x86-64 host; my only such environment is emulated, so any timing from it would be meaningless.

`tests/test_qwen38_native_weights` passes locally on arm64/clang and on x86-64/gcc.

---

### Update 2 — the fp-contract guard was a no-op; the fix is now compiler-selected

CI was right again, and my previous correction was itself wrong. `Engine (Linux, CPU)` stayed red on `8355ef5`, and the reason is that **the guard I added does nothing**.

**What is actually true about GCC.** `#pragma GCC optimize ("fp-contract=off")` is silently ignored: contraction is resolved as a language/dialect option at parse time, not through the per-function optimize attribute. Measured on gcc 13.4, clean build per cell, against `tests/test_qwen38_native_weights`:

| form | effect |
|---|---|
| `#pragma GCC optimize ("fp-contract=off")` | ignored (no-op) |
| `#pragma GCC optimize ("-ffp-contract=off")` | ignored (no-op) |
| `__attribute__((optimize("-ffp-contract=off")))` | ignored (no-op) |
| `#pragma STDC FP_CONTRACT OFF` | unimplemented — GCC warns `ignoring '#pragma STDC FP_CONTRACT'` |
| command-line `-ffp-contract=off` | works |

Only the command-line flag has any effect, and that is a global numerics decision this kernel should not be making for the whole project.

**Why the earlier evidence misled me.** The `179 of 258` probe was real, but it used the *command-line* flag; translating that result into a source pragma was the invalid step. And the four-row kernel's pass/fail is arch-dependent: with no guard at all it is exact at `-march=znver3` and `-march=x86-64-v3`, but **not** at `-march=haswell`. I had only ever checked arches that pass. Compounding it, `ARCH=` alone does not invalidate object files, so one of my sweeps linked objects built under mixed `-march` and reported the opposite result on identical source. Both of those are my error, not CI's.

**The fix.** The four-row kernel is now selected under `__clang__` only; GCC keeps upstream's one-row kernel verbatim. Under GCC this header preprocesses **byte-for-byte identically to `dev`** (1935 lines, zero diff), so the Linux CI path is provably unchanged rather than merely retested. The diff against `dev` contains **zero deleted lines** — upstream's kernel is untouched.

**Verification**

| gate | result |
|---|---|
| GCC-preprocessed header vs `dev` | identical, 1935 lines |
| gcc x86, clean build: haswell / znver3 / x86-64-v3 | pass |
| clang x86, same three arches | pass |
| arm64/clang full `make test-c` | `rc=0`, all pass |
| arm64 test binary md5 | `4964e2e290eab04d39d0ba326fdd4406` — unchanged |
| pragma/contract warnings | 0 |

The arm64 binary being byte-identical is the point: the measured win is preserved exactly, and nothing on the clang path moved.

**Consequence for the scope of this PR, stated plainly.** As it now stands the speedup lands on clang only; GCC builds get upstream's kernel and no gain. Extending it to GCC would mean compiling the fp8 kernel with `-ffp-contract=off`, which changes numerics beyond this function — your call, not mine. Happy to pursue that separately if you want it, or to leave this as the clang-only win.
