### PR TITLE
fix(doctor): omit GPU plan for CPU-only engine

### DIFF
--- a/c/doctor.py
+++ b/c/doctor.py
@@ -540,9 +540,17 @@ def run_doctor(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0, *,
     try:
         if resolved is None:
             raise ValueError("placement requires a registered model family")
-        plan = build_plan(model, ram_gb, context, gpu_indices, vram_gb,
+        # The placement report describes this installed engine, not merely the
+        # hardware visible on the host. A CPU-only binary cannot spend VRAM;
+        # passing discovered GPUs through here made doctor contradict its own
+        # accelerator check and emit CUDA-only tuning advice. Keep inventory
+        # details in accelerator.gpu above, but build an executable plan below.
+        plan_gpus = detected_gpus if linkage.get("linked") else []
+        plan_gpu_indices = gpu_indices if linkage.get("linked") else []
+        plan_vram_gb = vram_gb if linkage.get("linked") else 0
+        plan = build_plan(model, ram_gb, context, plan_gpu_indices, plan_vram_gb,
                           available_memory=available_memory, available_disk=available_disk,
-                          gpus=detected_gpus, kv_slots=kv_slots)
+                          gpus=plan_gpus, kv_slots=kv_slots)
         model_info = plan["model"]
         checks.append(_check("model.shards", "pass", "safetensors headers are valid",
                              shards=model_info["shards"], model_bytes=model_info["model_bytes"]))

--- a/c/tests/test_doctor.py
+++ b/c/tests/test_doctor.py
@@ -138,12 +138,29 @@ class DoctorTest(unittest.TestCase):
     def test_cpu_engine_with_detected_gpu_is_only_a_warning(self):
         gpu = {"index": 0, "name": "fixture", "total_bytes": 12 * GB,
                "free_bytes": 10 * GB}
-        report = self.report(gpu_indices=None, gpus=[gpu])
+        report = self.report(gpu_indices=[0], vram_gb=8, gpus=[gpu])
         check = self.checks_by_id(report)["accelerator.gpu"]
 
         self.assertEqual(check["status"], "warn")
+        self.assertEqual(report["plan"]["tiers"]["vram"]["devices"], [])
+        self.assertEqual(report["plan"]["tiers"]["vram"]["budget_bytes"], 0)
+        self.assertEqual(report["plan"]["warnings"], [])
+        self.assertNotIn("COLI_CUDA_PIPE", report["plan"]["tune"])
+        self.assertNotIn("GPU", report["plan"]["expected_bottleneck"])
         self.assertEqual(report["status"], "warning")
         self.assertEqual(exit_code(report), 0)
+
+    def test_gpu_engine_with_detected_gpu_keeps_vram_plan(self):
+        gpu = {"index": 0, "name": "fixture", "total_bytes": 12 * GB,
+               "free_bytes": 10 * GB}
+        report = self.report(gpu_indices=None, gpus=[gpu],
+                             linkage={"linked": True, "missing": False})
+
+        self.assertGreater(report["plan"]["tiers"]["vram"]["budget_bytes"], 0)
+        self.assertEqual(report["plan"]["tiers"]["vram"]["devices"], [
+            {**gpu, "reserve_bytes": 2 * GB, "usable_bytes": 8 * GB},
+        ])
+        self.assertIn("COLI_CUDA_PIPE", report["plan"]["tune"])
 
     def test_gpu_check_uses_backend_neutral_identifier(self):
         gpu = {"index": 0, "name": "Intel Arc B570", "total_bytes": 10 * GB,


### PR DESCRIPTION
## Summary

- make `coli doctor` build its placement report from the installed engine's GPU capability, not just host GPU inventory
- clear GPU selectors and requested VRAM when the selected engine is CPU-only or its backend is unavailable
- cover both CPU-only and GPU-enabled binaries with regression tests

## Reproduction

On Windows with the v1.10.1 Qwen3.6 release binary and an NVIDIA RTX A2000, `coli doctor` correctly warned:

```text
[warn] accelerator.gpu    GPU detected but the engine is CPU-only
```

but the same report then advertised a VRAM hot tier, described a mixed CPU/GPU bottleneck, and recommended `COLI_CUDA_PIPE=1`. The plan therefore described hardware the installed engine could not use.

After this change the GPU remains visible in the diagnostic warning, while the executable placement plan reports the CPU path, zero VRAM budget, and no CUDA-only tuning.

## Tests

- `python -m unittest discover -s tests -p test_doctor.py -v` - 36 passed
- validated the modified diagnostic against the real 41-shard Qwen3.6 container: CPU-only warning retained; VRAM tier removed
- full Python discovery ran 723 tests; 9 environment-only errors require Unix `rm` or `make`, neither available in this Windows shell
- `make check` could not run because GNU Make is not installed in this environment