### PR TITLE
glm53: serve expert weights from a file mapping instead of copying them in

### DIFF
--- a/c/glm53.c
+++ b/c/glm53.c
@@ -78,6 +78,10 @@ static int g_vk_ready = 0;
 #include <time.h>
 #ifndef _WIN32
 #include <sys/resource.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#define GLM53_HAVE_MMAP 1
 #endif
 #include "hyper_connections.h"   /* mHC, condiviso con deepseek_v4.c */
 
@@ -1145,7 +1149,17 @@ typedef struct ERef {
     int contig;                           /* i sei pezzi sono consecutivi in un file */
 } ERef;
 
-typedef struct { int eid; uint8_t *base; uint64_t used; } Slot;
+/* I sei pezzi non sono adiacenti nel file, ma non devono esserlo nemmeno in
+ * memoria: expert_mats ci costruisce sopra solo tre viste in sola lettura. */
+typedef struct { int eid; uint8_t *piece[GLM53_EXPERT_PIECES]; uint8_t *own; uint64_t used; } Slot;
+
+/* Una mappatura per file, non per esperto: gli offset dei pezzi non sono
+ * allineati alla pagina, ma mappando il file intero ci pensa il kernel. */
+#define GLM53_MAXFD 4096
+static uint8_t *g_fmap[GLM53_MAXFD];
+static size_t   g_fmaplen[GLM53_MAXFD];
+static long     g_map_serve, g_map_copy;
+static int      g_map_active, g_map_all;
 typedef struct LCache { Slot *s; int n, cap; } LCache;
 
 /* Lunghezze e posizioni dei sei pezzi dentro allo slot. Gate e up sono
@@ -1225,8 +1239,64 @@ static double memory_available_gb(void) {
     return gb;
 }
 
+/* Un pezzo e' mappabile se il suo file e' mappato, ci sta dentro, ed e'
+ * allineato a 4 byte (le scale si leggono come float *). */
+static int piece_mappable(const GModel *m, const ERef *ref, int q) {
+    const int fd = ref->fd[q];
+    if (fd <= 0 || fd >= GLM53_MAXFD || !g_fmap[fd]) return 0;
+    if ((size_t)ref->off[q] + (size_t)m->e_len[q] > g_fmaplen[fd]) return 0;
+    return (ref->off[q] & 3) == 0;
+}
+
+/* Gli esperti si leggevano copiando 14 MB per slot da byte che il kernel teneva
+ * gia' in page cache. I sei pezzi si possono puntare direttamente nella
+ * mappatura del file: nessuna copia, e la residenza la gestisce il kernel.
+ * Su Windows non si mappa e resta il percorso originale. */
+static void expert_map_init(GModel *m) {
+#ifdef GLM53_HAVE_MMAP
+    if (getenv("GLM53_NO_MMAP") || !m->eref) return;
+    const Cfg *c = &m->c;
+    int files = 0;
+    for (int i = 0; i < c->n_layers; i++)
+        for (int e = 0; e < c->n_experts; e++) {
+            const ERef *ref = &m->eref[(size_t)i * c->n_experts + e];
+            if (ref->fd[0] <= 0) continue;
+            for (int q = 0; q < GLM53_EXPERT_PIECES; q++) {
+                const int fd = ref->fd[q];
+                if (fd <= 0 || fd >= GLM53_MAXFD || g_fmap[fd]) continue;
+                struct stat stt;
+                if (fstat(fd, &stt) != 0 || stt.st_size <= 0) continue;
+                void *pm = mmap(NULL, (size_t)stt.st_size, PROT_READ, MAP_SHARED, fd, 0);
+                if (pm == MAP_FAILED) continue;
+                g_fmap[fd] = (uint8_t *)pm;
+                g_fmaplen[fd] = (size_t)stt.st_size;
+                files++;
+            }
+        }
+    if (!files) return;
+    g_map_active = 1;
+    long full = 0, partial = 0;
+    for (int i = 0; i < c->n_layers; i++)
+        for (int e = 0; e < c->n_experts; e++) {
+            const ERef *ref = &m->eref[(size_t)i * c->n_experts + e];
+            if (ref->fd[0] <= 0) continue;
+            int ok = 1;
+            for (int q = 0; q < GLM53_EXPERT_PIECES; q++)
+                if (!piece_mappable(m, ref, q)) { ok = 0; break; }
+            if (ok) full++; else partial++;
+        }
+    g_map_all = (partial == 0 && full > 0);
+    if (getenv("GLM53_VERBOSE"))
+        fprintf(stderr, "[MAP] %d file mappati, esperti mappabili %ld/%ld%s\n",
+                files, full, full + partial, g_map_all ? " (tutti: nessuna copia)" : "");
+#else
+    (void)m;
+#endif
+}
+
 static void expert_cache_init(GModel *m) {
     const Cfg *c = &m->c;
+    expert_map_init(m);
     const char *setting = getenv("GLM53_EXPERT_GB");
     /* Il default si misura: quello che resta libero dopo i pesi residenti,
      * meno un margine per lo stato della conversazione, i temporanei del
@@ -1248,6 +1318,9 @@ static void expert_cache_init(GModel *m) {
     int sparse = m->layer_end - from;
     if (sparse < 0) sparse = 0;
     int cap = (int)((budget * 1e9) / ((double)m->e_slot * (sparse > 0 ? sparse : 1)));
+    /* Se ogni esperto arriva dalla mappatura, uno slot non costa memoria
+     * nostra: tenerne uno per esperto toglie di mezzo lo sfratto. */
+    if (g_map_all) cap = c->n_experts;
     if (g_cap_override > 0) cap = g_cap_override;      /* scelta esplicita: vince */
     if (cap < 1) cap = 1;
     if (cap > c->n_experts) cap = c->n_experts;
@@ -1280,15 +1353,37 @@ static Slot *slot_find(GModel *m, int layer, int eid) {
 
 static void expert_read(GModel *m, int layer, int eid, Slot *slot) {
     const ERef *ref = &m->eref[(size_t)layer * m->c.n_experts + eid];
-    if (!slot->base) {
-        slot->base = malloc((size_t)m->e_slot);
-        if (!slot->base) { fprintf(stderr, "OOM su uno slot esperto\n"); exit(1); }
+    if (g_map_active) {
+        int ok = 1;
+        for (int p = 0; p < GLM53_EXPERT_PIECES; p++)
+            if (!piece_mappable(m, ref, p)) { ok = 0; break; }
+        if (ok) {
+            for (int p = 0; p < GLM53_EXPERT_PIECES; p++)
+                slot->piece[p] = g_fmap[ref->fd[p]] + ref->off[p];
+            slot->eid = eid;
+#ifdef _OPENMP
+#pragma omp atomic
+#endif
+            g_map_serve++;
+            return;
+        }
     }
+    /* Fallback: si torna a scrivere in memoria NOSTRA, non nella mappatura di
+     * sola lettura che questo slot poteva star usando prima. */
+    if (!slot->own) {
+        slot->own = malloc((size_t)m->e_slot);
+        if (!slot->own) { fprintf(stderr, "OOM su uno slot esperto\n"); exit(1); }
+    }
+    for (int p = 0; p < GLM53_EXPERT_PIECES; p++) slot->piece[p] = slot->own + m->e_at[p];
+#ifdef _OPENMP
+#pragma omp atomic
+#endif
+    g_map_copy++;
     if (ref->contig) {
-        st_pread_full(ref->fd[0], slot->base, m->e_slot, ref->off[0], "expert");
+        st_pread_full(ref->fd[0], slot->own, m->e_slot, ref->off[0], "expert");
     } else {
         for (int p = 0; p < GLM53_EXPERT_PIECES; p++)
-            st_pread_full(ref->fd[p], slot->base + m->e_at[p], m->e_len[p],
+            st_pread_full(ref->fd[p], slot->own + m->e_at[p], m->e_len[p],
                           ref->off[p], "expert piece");
     }
     slot->eid = eid;
@@ -1327,11 +1422,11 @@ static Slot *expert_slot(GModel *m, int layer, int eid) {
 static void expert_mats(const GModel *m, const Slot *slot, Mat *gate, Mat *up, Mat *down) {
     const int hidden = m->c.hidden, inter = m->c.moe_inter;
     const Mat shape[3] = {
-        { 4, NULL, NULL, slot->base + m->e_at[0], (const float *)(slot->base + m->e_at[1]),
+        { 4, NULL, NULL, slot->piece[0], (const float *)slot->piece[1],
           inter, hidden, 64 },
-        { 4, NULL, NULL, slot->base + m->e_at[2], (const float *)(slot->base + m->e_at[3]),
+        { 4, NULL, NULL, slot->piece[2], (const float *)slot->piece[3],
           inter, hidden, 64 },
-        { 4, NULL, NULL, slot->base + m->e_at[4], (const float *)(slot->base + m->e_at[5]),
+        { 4, NULL, NULL, slot->piece[4], (const float *)slot->piece[5],
           hidden, inter, 64 },
     };
     *gate = shape[0]; *up = shape[1]; *down = shape[2];
@@ -1925,7 +2020,7 @@ static void model_release(GModel *m) {
     if (m->ecache) {
         for (int i = 0; i < m->c.n_layers; i++) {
             LCache *cache = &m->ecache[i];
-            for (int j = 0; j < cache->cap; j++) free(cache->s[j].base);
+            for (int j = 0; j < cache->cap; j++) free(cache->s[j].own);
             free(cache->s);
         }
         free(m->ecache);


### PR DESCRIPTION
### The problem

An expert is 14.16 MB in six pieces (gate/up/down, each weights + scales). On a slot miss `expert_read` malloc's a 14.16 MB slot and `pread`s the six pieces into it — copying bytes the kernel is already holding in page cache. Those private copies also make the slot cache compete with the page cache for the same RAM.

### The fix

Measured first: **0 of 12096 experts** have their six pieces consecutive in the file, so a slot cannot just point at one contiguous run. But nothing requires the pieces to be adjacent *in memory* either — `expert_mats` only builds three read-only `Mat` views over them. So a slot becomes six pointers rather than one buffer, and each piece points straight into its file's mapping.

On GLM-5.3-Flash int4-g64 (182 GB, 45 layers, 12096 routed experts) all of them qualify and the copy disappears entirely:

```
[MAP] 59 file mappati, esperti mappabili 12096/12096 (tutti: nessuna copia)
```

### Numbers

8-core EPYC 7F32, 247 GB RAM, model on NVMe, `--ngen 60 --temp 0 --no-think`, two runs each:

| | tok/s |
|---|---|
| `GLM53_NO_MMAP=1` (current behaviour) | 1.319 / 1.322 |
| mapped | **1.965 / 1.971** |

**+49%.** `teacher_forcing` — the argmax at every prompt position — is identical either way, so this is purely a memory-placement change.

### Details worth knowing

- Mapping is per **file**, not per expert: piece offsets are not page-aligned, but mapping the whole file lets the kernel deal with that. A piece is used only if its file mapped, it fits, and its offset is 4-byte aligned (the scale pieces are dereferenced as `float *`).
- Slots are reused and their buffer was never freed, so a recycled slot must not be `pread` into while it still points at a read-only mapping. Hence the split between `piece[]` (what `expert_mats` reads) and `own` (the malloc'd buffer, allocated only for experts that cannot be mapped). Teardown frees `own`, never a mapping.
- When every expert is mappable a slot costs no memory of ours, so eviction has nothing to reclaim and `cap` becomes `n_experts`.
- Guarded by the file's existing `#ifndef _WIN32`; on Windows `GLM53_HAVE_MMAP` is undefined, `g_map_active` stays 0 and every read takes the original `pread` path. **Compiled and verified both ways.**
- `GLM53_NO_MMAP=1` forces the copy path at runtime.

### Interaction with #1321

When everything maps, the slot cache no longer holds private copies, so the expert-cache budget that #1321 corrects stops mattering (`cap` is overridden to `n_experts`). #1321 still matters where mapping is unavailable — Windows, or a checkpoint whose pieces are not 4-byte aligned — so the two are complementary rather than duplicates, but **this one supersedes it on the common path**. Happy to rebase either onto the other, in whichever order suits you, or to close #1321 if you would rather have just this.

### Caveats

One machine, one model. The 4-byte alignment and whole-file mapping assumptions hold for this checkpoint's layout; a checkpoint that fails them falls back to the existing copy path per piece rather than breaking. I have not tested on Windows or macOS beyond confirming the non-mmap path compiles.
