### PR TITLE
test(serve): build the disconnect scenario instead of hoping for it

### DIFF
--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -1009,8 +1009,41 @@ class DispatcherTest(unittest.TestCase):
         with patch("openai_server.subprocess.Popen", return_value=process):
             engine = Engine("glm", "model")
         output = []
+        # Il consumatore se ne va DOPO aver ricevuto qualcosa: e' lo scenario che
+        # il nome promette, e va costruito invece che sperato. Con cancelled che
+        # tornava True da subito, la corsa era fra il ramo idle -- che cancella
+        # prima di ogni dato -- e l'arrivo del frame: su Windows vinceva il primo
+        # e l'asserzione su output falliva senza che nulla fosse rotto (#1328).
+        # Qui il flag si alza dentro il sink, e nel ramo "data" decode() consegna
+        # il token PRIMA che cancelled() venga interrogato: l'ordine e' garantito
+        # dal codice, non dallo scheduler.
+        #
+        # Il tetto sui poll non e' decorativo. Senza, un guasto che impedisce la
+        # consegna del token lascerebbe il flag basso per sempre: niente cancel,
+        # niente eccezione, e il test si APPENDE invece di fallire -- misurato
+        # rompendo decode() apposta. Il ramo idle interroga cancelled() ogni 50 ms,
+        # quindi dopo un secondo si cancella comunque e l'asserzione su output
+        # fallisce subito, dicendo la cosa giusta. Deterministico quando funziona,
+        # rapido a fallire quando no.
+        #
+        # Il caso "cancella prima del primo frame" resta coperto, in modo
+        # deterministico, da test_cancels_generation_before_first_frame (#908):
+        # prima i due si sovrapponevano a caso e uno dei due vinceva a sorte.
+        disconnected = False
+        polls = 0
+
+        def sink(text):
+            nonlocal disconnected
+            output.append(text)
+            disconnected = True
+
+        def consumer_gone():
+            nonlocal polls
+            polls += 1
+            return disconnected or polls > 20
+
         with self.assertRaises(ClientCancelled):
-            engine.generate("hello", 8, 0.7, 0.9, output.append, cancelled=lambda: True)
+            engine.generate("hello", 8, 0.7, 0.9, sink, cancelled=consumer_gone)
         engine.close()
         self.assertEqual(output, ["x"])
         self.assertEqual(process.writes[-1].split(), [b"CANCEL", request_id])


### PR DESCRIPTION
Fixes #1328.

`test_cancels_generation_after_consumer_disconnects` failed intermittently on the Windows job, on PRs that cannot reach that code (#1327 renders prompts). Not a Windows bug: a race, and Windows is only where the window is widest.

## The race

`cancelled` returned True immediately, so the **idle** branch — which exists precisely to cancel before the first frame (#908) — raced the arrival of the frame itself. Idle wins, no token is delivered, `output == ["x"]` fails with nothing broken.

The two tests also overlapped: the pre-first-frame case already has its own deterministic test, and the two were non-deterministically covering the same thing.

## The fix, in two halves

**The flag flips inside the sink.** In the `data` branch `decode(value)` delivers the token *before* `cancelled()` is polled, so the ordering is guaranteed by the code rather than the scheduler — and it is the scenario the test's name promises: the consumer leaves *after* receiving something.

**The poll cap, which I added only after measuring that it was needed.** With the flag alone, a fault that prevents delivery leaves it low forever: no cancel, no exception, and the test **hangs** instead of failing. I broke `decode()` deliberately and watched it hang. The idle branch polls every 50 ms, so a one-second cap cancels anyway and the assertion fails immediately with the right diagnosis.

## Controls

| state | result |
|---|---|
| healthy | 20/20 green |
| `decode()` broken | fails in **2s**: `Lists differ: [] != ['x']` |
| data-branch cancel disabled | still passes, correctly: the contract is that cancellation happens, not which branch performs it |

`test_openai_server` suite green.

## Why bother

The cost was never the wasted rerun. Twice in two days that job was red without a real failure, and a gate people learn to re-run without reading is a gate that will eventually be re-run past a genuine break.
