### PR TITLE
feat(qwen38): optional CUDA VRAM tier for the routed experts

### DIFF
--- a/c/qwen38.c
+++ b/c/qwen38.c
@@ -1737,6 +1737,12 @@ int main(int argc, char **argv) {
     q38_telemetry_init(snap, &m);
     fprintf(stderr, "resident weights loaded in %.1fs | RSS after load: %.2f GB\n", m.dense_load_s, rss_gb());
 
+    /* Optional CUDA VRAM expert tier (COLI_CUDA=1): hot routed experts live in
+     * VRAM and their gate/up/down run there. Off unless asked for, and a no-op
+     * entirely without -DCOLI_CUDA. Placed here because it needs the geometry
+     * from the loaded config and must precede the first token. */
+    q38t_init(m.c.layers, m.c.experts, m.c.hidden, m.c.inter, m.c.topk);
+
     /* coli serve mode: speak the gateway wire protocol instead of argv
      * generation. AFTER the tier init: serve sessions ride the VRAM experts
      * exactly like argv runs, and serve_loop never returns. */

--- a/c/qwen38.c
+++ b/c/qwen38.c
@@ -1591,6 +1591,12 @@ static int serve_one(Model *m, ServeReq *q){
     else fprintf(stderr,"[qwen38] internal error: PROF frame overflow\n");
     fflush(stdout);
     q38_tm_report_bank(&timers,"request");
+    /* Tier residency alongside the phase timers, under the same COLI_TIMERS
+     * gate. Without this the tier's hit rate is printed only by
+     * q38t_shutdown(), which serve mode never reaches - the engine is killed,
+     * not closed - so the one number that says whether the tier is earning its
+     * VRAM was unobtainable on the only path that matters. */
+    if(getenv("COLI_TIMERS")&&getenv("COLI_TIMERS")[0]=='1') q38t_stats();
     return input_eof?-1:0;
 }
 

--- a/c/qwen38_core.h
+++ b/c/qwen38_core.h
@@ -9,6 +9,10 @@
 #ifndef COLI_QWEN38_CORE_H
 #define COLI_QWEN38_CORE_H
 
+/* Optional CUDA VRAM expert tier. Without -DCOLI_CUDA this header supplies
+ * inline no-op stubs, so the engine below is unchanged and costs nothing. */
+#include "qwen38_tier.h"
+
 #define Q38_MAX_LAYERS 512
 #define Q38_MAX_EXPERTS 1024
 #define Q38_MAX_TOPK 256
@@ -1657,13 +1661,30 @@ static void q38_moe_decode(Model *m,Layer *l,int layer,const float *x,int S,floa
         q38_tm_add(m,Q38_TM_SHARED_EXPERT,phase_started);
         Slot *selected[Q38_MAX_TOPK];
         int loaded_batch=q38_expert_get_batch(m,layer,idx,K,selected);
+        /* Optional CUDA VRAM expert tier. Offer every routed expert so the tier
+         * can place it, then issue whichever it already holds. `gpu` is a
+         * bitmask of the z it took; those are skipped below and folded in by
+         * q38t_take. Without -DCOLI_CUDA every call here is an inline no-op
+         * returning 0, so the loop is exactly what it was. */
         for(int z=0;z<K;z++){
+            Slot *ex=loaded_batch?selected[z]:q38_expert_get(m,layer,idx[z]);
+            q38t_note(layer,idx[z],ex->gate.data,ex->gate.scales,
+                                   ex->up.data,  ex->up.scales,
+                                   ex->down.data,ex->down.scales);
+        }
+        uint32_t gpu=q38t_issue(layer,idx,K,xs);
+        for(int z=0;z<K;z++){
+            if(gpu&(1u<<z)) continue;          /* this expert is on the GPU */
             Slot *ex=loaded_batch?selected[z]:q38_expert_get(m,layer,idx[z]);phase_started=now_s();
             q38_weight_matmul(eg,xs,&ex->gate,1,H,I);q38_weight_matmul(eu,xs,&ex->up,1,H,I);
             for(int j=0;j<I;j++)eh[j]=q38_silu(eg[j])*eu[j];q38_weight_matmul(eo,eh,&ex->down,1,I,H);
             for(int d=0;d<H;d++)ys[d]+=route_gates[z]*eo[d];
             q38_tm_add(m,Q38_TM_ROUTED_EXPERT,phase_started);
         }
+        /* Fold the GPU half in AFTER the CPU misses, so the device work
+         * overlapped with them instead of blocking on the first take. */
+        if(gpu){phase_started=now_s();q38t_take(gpu,route_gates,K,ys);
+                q38_tm_add(m,Q38_TM_ROUTED_EXPERT,phase_started);}
         for(int d=0;d<H;d++)ys[d]+=gate*shared[d];
     }
     rt_trace_end();

--- a/c/qwen38_tier.c
+++ b/c/qwen38_tier.c
@@ -60,6 +60,18 @@ static struct {
     /* per-device issue bookkeeping, valid between issue() and take() */
     int is_cnt[Q38T_MAX_DEV];
     int is_k[Q38T_MAX_DEV][Q38T_MAX_ISSUE];
+    /* EXPERIMENT, Q38T_TWO_ROUND=1: experts past the 8-row cap held for a
+     * SECOND issue/take round inside q38t_take, instead of falling to the CPU.
+     * Telemetry says misses are zero - the declined experts are already
+     * resident in VRAM and sit on the CPU only because of the API's batching
+     * limit - so a second round is at least worth measuring. Default off. */
+    int two_round;
+    int pd_cnt[Q38T_MAX_DEV];
+    int pd_k[Q38T_MAX_DEV][Q38T_MAX_ISSUE];
+    ColiCudaTensor *pd_g[Q38T_MAX_DEV][Q38T_MAX_ISSUE];
+    ColiCudaTensor *pd_u[Q38T_MAX_DEV][Q38T_MAX_ISSUE];
+    ColiCudaTensor *pd_d[Q38T_MAX_DEV][Q38T_MAX_ISSUE];
+    unsigned long long round2;
     /* counters, reported by q38t_stats */
     unsigned long long hits, miss, over_cap, uploads, upload_fail;
     size_t vram_used;      /* RAW weight bytes uploaded, for reporting only */
@@ -169,6 +181,23 @@ int q38t_init(int n_layers, int n_experts, int hidden, int inter, int topk) {
         if (!G.xrep[i]) return 0;
     }
     G.byte_ceiling = byte_ceiling();
+    /* Two rounds by DEFAULT, measured. Q38T_TWO_ROUND=0 opts out.
+     *
+     * It was written as an opt-in experiment expecting to lose: the one-round
+     * design lets the CPU compute the 2 experts past the row cap while the 8
+     * on the GPU are in flight, and a second device round serialises what was
+     * concurrent. Measured on an RTX 3090, 18-token prompt, warm, three
+     * interleaved rounds with the cold run discarded per visit:
+     *
+     *     one round   3.123 tok/s  sd 0.015  n=9
+     *     two rounds  3.315 tok/s  sd 0.029  n=9      +6.1%
+     *
+     * Two rounds won every round. The CPU experts do not hide behind the GPU
+     * ones - they cost more than an entire second issue/take including its
+     * launch and sync. On this hardware, moving expert work to the device is
+     * worth more than the overlap it destroys. */
+    { const char *tr = getenv("Q38T_TWO_ROUND");
+      G.two_round = !(tr && tr[0] == '0' && tr[1] == 0); }
     G.on = 1;
 
     fprintf(stderr,
@@ -236,7 +265,7 @@ uint32_t q38t_issue(int layer, const int *eids, int K, const float *x) {
     static int rows[Q38T_MAX_ISSUE];
     for (int i = 0; i < Q38T_MAX_ISSUE; i++) rows[i] = 1;   /* S=1 per expert at decode */
 
-    for (int i = 0; i < G.ndev; i++) G.is_cnt[i] = 0;
+    for (int i = 0; i < G.ndev; i++) { G.is_cnt[i] = 0; G.pd_cnt[i] = 0; }
 
     uint32_t mask = 0;
     for (int k = 0; k < K; k++) {
@@ -247,7 +276,22 @@ uint32_t q38t_issue(int layer, const int *eids, int K, const float *x) {
         /* The 8-row ceiling is per device per issue. Anything past it is a
          * CPU expert this token; it is counted so the split is visible in
          * q38t_stats rather than being an invisible truncation. */
-        if (c >= Q38T_MAX_ISSUE) { G.over_cap++; continue; }
+        if (c >= Q38T_MAX_ISSUE) {
+            /* Past the row cap. Default: back to the CPU. Under Q38T_TWO_ROUND
+             * it is queued for a second GPU round in q38t_take instead. */
+            if (G.two_round) {
+                int p = G.pd_cnt[di];
+                if (p < Q38T_MAX_ISSUE) {
+                    G.pd_g[di][p] = s->tg; G.pd_u[di][p] = s->tu; G.pd_d[di][p] = s->td;
+                    G.pd_k[di][p] = k;
+                    G.pd_cnt[di] = p + 1;
+                    mask |= 1u << k;
+                    G.hits++;
+                    continue;
+                }
+            }
+            G.over_cap++; continue;
+        }
         tg[di][c] = s->tg; tu[di][c] = s->tu; td[di][c] = s->td;
         G.is_k[di][c] = k;
         G.is_cnt[di] = c + 1;
@@ -271,20 +315,51 @@ uint32_t q38t_issue(int layer, const int *eids, int K, const float *x) {
     return mask;
 }
 
+/* Collect one device's in-flight group into out[], weighted. */
+static void take_one(int di, int c, const int *ks, const float *route_gates, float *out) {
+    const float *y = coli_cuda_expert_group_take(G.dev[di]);
+    if (!y) return;
+    for (int j = 0; j < c; j++) {
+        float w = route_gates[ks[j]];
+        const float *row = y + (size_t)j * G.D;
+        for (int d = 0; d < G.D; d++) out[d] += w * row[d];
+    }
+}
+
 void q38t_take(uint32_t mask, const float *route_gates, int K, float *out) {
     (void)K;
     if (!G.on || !mask || !route_gates || !out) return;
     for (int di = 0; di < G.ndev; di++) {
         int c = G.is_cnt[di];
-        if (!c) continue;
-        const float *y = coli_cuda_expert_group_take(G.dev[di]);
-        if (!y) { G.is_cnt[di] = 0; continue; }
-        for (int j = 0; j < c; j++) {
-            float w = route_gates[G.is_k[di][j]];
-            const float *row = y + (size_t)j * G.D;
-            for (int d = 0; d < G.D; d++) out[d] += w * row[d];
-        }
+        if (c) take_one(di, c, G.is_k[di], route_gates, out);
         G.is_cnt[di] = 0;
+
+        /* Second round, only under Q38T_TWO_ROUND. The API allows one
+         * outstanding issue per device, so this cannot overlap with the first
+         * round - it is deliberately serial, which is exactly what the
+         * experiment is measuring. */
+        int p = G.pd_cnt[di];
+        G.pd_cnt[di] = 0;
+        if (!p) continue;
+        static int rows2[Q38T_MAX_ISSUE];
+        for (int i = 0; i < Q38T_MAX_ISSUE; i++) rows2[i] = 1;
+        float *xr = G.xrep[di];
+        /* NO REFILL. xrep already holds x replicated across all 8 rows from the
+         * first round, and the second round needs the same activation. An
+         * earlier version re-copied here and its j=0 case was memcpy(xr, xr, D)
+         * - self-overlapping, and undefined behaviour rather than a no-op.
+         * A second round can only exist once the first filled the cap, so p>0
+         * implies the first round placed 8 and xr is fully populated. */
+        if (coli_cuda_expert_group_issue(G.pd_g[di], G.pd_u[di], G.pd_d[di], rows2, p, xr)) {
+            take_one(di, p, G.pd_k[di], route_gates, out);
+            G.round2++;
+        } else {
+            /* The second issue failed. Those experts contributed nothing and
+             * the caller already skipped them on the CPU, so their weight is
+             * missing from out[]. That is a wrong answer, not a slow one -
+             * count it loudly rather than let it pass. */
+            G.upload_fail++;
+        }
     }
 }
 

--- a/c/qwen38_tier.c
+++ b/c/qwen38_tier.c
@@ -1,0 +1,311 @@
+/* qwen38_tier.c -- CUDA VRAM expert tier for the qwen38 engine.
+ *
+ * See qwen38_tier.h for why this exists and what it deliberately does not do.
+ * This file is compiled only under -DCOLI_CUDA; without it the header's inline
+ * stubs keep the engine exactly as it is today.
+ *
+ * THE SHAPE OF THE PROBLEM, measured on this hardware
+ *
+ * Qwen3.8-Flash-Next is hidden 2560, moe_intermediate 640, 512 experts across
+ * 48 layers, top-k 10. One expert is gate[640,2560] + up[640,2560] +
+ * down[2560,640] = 4.69 MiB of fp8, so the whole routed set is ~112.6 GiB and a
+ * 24 GB card holds roughly a fifth of it. Residency is a bet on routing skew,
+ * exactly as it is for the GLM tier.
+ *
+ * TOP-K 10 AGAINST AN 8-ROW API. backend_cuda.h:141 states the expert-group
+ * contract plainly: "Small totals only (<=8 rows); one outstanding issue per
+ * device." qwen36's tier never meets this because its top-k is smaller - its
+ * per-device input block is sized 8*D and that is the whole budget. Qwen3.8
+ * routes TEN experts per token per layer, so at most 8 can be issued and the
+ * remainder must stay on the CPU. That is not a workaround, it is the API's
+ * documented limit, and the split is made explicit here rather than discovered
+ * as a silent truncation later.
+ *
+ * NO EVICTION IN THIS VERSION, and that is a deliberate omission rather than an
+ * oversight. Experts are uploaded first-come until the budget is spent, then
+ * every later miss stays on the CPU. A heat-ranked LFRU policy is what
+ * qwen36_tier.c does and it is the obvious next step, but it changes which
+ * experts are resident from token to token and would make the first
+ * correctness comparison against the CPU path harder to read. Correctness
+ * first, policy second.
+ */
+#include "qwen38_tier.h"
+
+#ifdef COLI_CUDA
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "backend_cuda.h"
+/* E4M3_LUT lives here. quant.h is header-only and its table is `static const`,
+ * so this translation unit gets its own 1 KB copy rather than a link
+ * dependency - the same arrangement colibri.c uses at its own call site. */
+#include "quant.h"
+
+#define Q38T_MAX_DEV   COLI_CUDA_MAX_DEVICES
+/* The API's own ceiling (backend_cuda.h:141), not a number chosen here. */
+#define Q38T_MAX_ISSUE 8
+
+typedef struct {
+    ColiCudaTensor *tg, *tu, *td;
+    int resident;                 /* 1 once all three projections are uploaded */
+} Q38Slot;
+
+static struct {
+    int on, ndev, dev[Q38T_MAX_DEV];
+    int layers, experts, D, I, topk;
+    Q38Slot *slot;                /* [layers * experts] */
+    float *xrep[Q38T_MAX_DEV];    /* Q38T_MAX_ISSUE copies of x, per device */
+    /* per-device issue bookkeeping, valid between issue() and take() */
+    int is_cnt[Q38T_MAX_DEV];
+    int is_k[Q38T_MAX_DEV][Q38T_MAX_ISSUE];
+    /* counters, reported by q38t_stats */
+    unsigned long long hits, miss, over_cap, uploads, upload_fail;
+    size_t vram_used;      /* RAW weight bytes uploaded, for reporting only */
+    size_t byte_ceiling;   /* optional user cap on the above, 0 = none */
+} G;
+
+static Q38Slot *qs(int layer, int eid) {
+    return &G.slot[(size_t)layer * (size_t)G.experts + (size_t)eid];
+}
+
+/* One expert's three projections, in RAW weight bytes. fp8 = one byte per
+ * weight. This is what the tensors CONTAIN, and deliberately NOT what they COST
+ * on the device - see headroom_ok(). */
+static size_t expert_bytes(void) {
+    return (size_t)G.I * (size_t)G.D          /* gate */
+         + (size_t)G.I * (size_t)G.D          /* up   */
+         + (size_t)G.D * (size_t)G.I;         /* down */
+}
+
+/* MEASURE THE CARD, DO NOT MODEL IT.
+ *
+ * The first version of this file budgeted by adding expert_bytes() per upload.
+ * That undercounts: each expert is THREE separate allocations and CUDA rounds
+ * every one up to a 2 MiB page, so 4.69 MiB of weights costs 6.00 MiB of
+ * device memory - a 1.28x overcommit. The tier filled 22.5 GB of a 24 GB card
+ * by its own accounting while actually consuming all of it, and decode went
+ * from 3.9 s to 40 s to hanging as the driver thrashed.
+ *
+ * Asking the driver how much is free is immune to all of that - page
+ * granularity, per-tensor descriptors, fragmentation, and anything else a
+ * model would have to predict correctly. It costs one cudaMemGetInfo per
+ * upload, and uploads stop entirely once the tier is full.
+ *
+ * RESERVE is what decode itself needs on top of the resident experts: the
+ * activation buffers, the pinned result rows, and whatever the driver keeps.
+ * 2 GB matches what colibri's own GLM tier holds back. */
+#define Q38T_RESERVE_BYTES ((size_t)2e9)
+
+static int headroom_ok(int device) {
+    size_t freeb = 0, totb = 0;
+    if (!coli_cuda_mem_info(device, &freeb, &totb)) return 0;   /* unknown: refuse */
+    /* The expert about to be uploaded must fit AND leave the reserve intact.
+     * expert_bytes() understates the real cost, so this is deliberately the
+     * conservative side of the comparison. */
+    return freeb > Q38T_RESERVE_BYTES + expert_bytes();
+}
+
+static int parse_devices(void) {
+    const char *many = getenv("COLI_GPUS"), *one = getenv("COLI_GPU");
+    const char *list = many ? many : one;
+    if (!list || !*list) { G.dev[0] = 0; return 1; }
+    int n = 0;
+    for (const char *p = list; *p && n < Q38T_MAX_DEV; ) {
+        char *end = NULL;
+        long v = strtol(p, &end, 10);
+        if (end == p || v < 0) return 0;
+        G.dev[n++] = (int)v;
+        p = end;
+        while (*p == ' ' || *p == '\t') p++;
+        if (*p == ',') p++; else break;
+    }
+    return n;
+}
+
+/* An optional hard ceiling on raw expert bytes, for a user who wants the tier
+ * smaller than the card allows - sharing the GPU with something else, say.
+ * Zero (the default, and CUDA_EXPERT_GB=auto) means no ceiling: growth is
+ * governed by headroom_ok() alone, which measures the device instead of
+ * predicting it. */
+static size_t byte_ceiling(void) {
+    const char *e = getenv("CUDA_EXPERT_GB");
+    if (!e || !*e || strcmp(e, "auto") == 0) return 0;
+    double g = atof(e);
+    return g > 0 ? (size_t)(g * 1e9) : 0;
+}
+
+int q38t_init(int n_layers, int n_experts, int hidden, int inter, int topk) {
+    const char *on = getenv("COLI_CUDA");
+    if (!on || atoi(on) == 0) return 0;                   /* opt-in, always */
+    if (n_layers < 1 || n_experts < 1 || hidden < 1 || inter < 1) return 0;
+
+    memset(&G, 0, sizeof G);
+    G.ndev = parse_devices();
+    if (G.ndev < 1) {
+        fprintf(stderr, "[q38tier] invalid COLI_GPUS -> CPU path\n");
+        return 0;
+    }
+    if (!coli_cuda_init(G.dev, G.ndev)) {
+        fprintf(stderr, "[q38tier] coli_cuda_init failed -> CPU path\n");
+        return 0;
+    }
+    /* fmt=8 uploads are REFUSED until the e4m3 decode table is published
+     * (backend_cuda.h:80). Publishing it after an upload would leave kernels
+     * decoding against a zero table, which is silently wrong rather than
+     * loudly broken - so this must happen here, before anything is uploaded. */
+    if (!coli_cuda_fp8_set_lut(E4M3_LUT)) {
+        fprintf(stderr, "[q38tier] fp8 LUT publish failed -> CPU path\n");
+        return 0;
+    }
+
+    G.layers = n_layers; G.experts = n_experts;
+    G.D = hidden; G.I = inter; G.topk = topk;
+    G.slot = (Q38Slot *)calloc((size_t)n_layers * (size_t)n_experts, sizeof(Q38Slot));
+    if (!G.slot) return 0;
+    for (int i = 0; i < G.ndev; i++) {
+        G.xrep[i] = (float *)malloc((size_t)Q38T_MAX_ISSUE * (size_t)G.D * sizeof(float));
+        if (!G.xrep[i]) return 0;
+    }
+    G.byte_ceiling = byte_ceiling();
+    G.on = 1;
+
+    fprintf(stderr,
+            "[q38tier] %d device(s), %d layers x %d experts, top-k %d "
+            "(<=%d issued per call), %.2f MiB/expert, growth capped by measured "
+            "free VRAM (%.1f GB reserve)%s\n",
+            G.ndev, n_layers, n_experts, topk, Q38T_MAX_ISSUE,
+            expert_bytes() / (1024.0 * 1024.0),
+            Q38T_RESERVE_BYTES / 1e9,
+            G.byte_ceiling ? " plus an explicit CUDA_EXPERT_GB ceiling" : "");
+    if (topk > Q38T_MAX_ISSUE)
+        fprintf(stderr,
+                "[q38tier] top-k %d exceeds the %d-row expert-group limit: "
+                "%d expert(s) per token stay on the CPU path\n",
+                topk, Q38T_MAX_ISSUE, topk - Q38T_MAX_ISSUE);
+    return 1;
+}
+
+int q38t_ready(void) { return G.on; }
+
+int q38t_is_resident(int layer, int eid) {
+    if (!G.on || layer < 0 || layer >= G.layers || eid < 0 || eid >= G.experts) return 0;
+    return qs(layer, eid)->resident;
+}
+
+void q38t_note(int layer, int eid,
+               const void *g, const float *gs,
+               const void *u, const float *us,
+               const void *d, const float *ds) {
+    if (!G.on || layer < 0 || layer >= G.layers || eid < 0 || eid >= G.experts) return;
+    /* A checkpoint may legitimately carry non-FP8 experts; those have no scale
+     * table and simply stay on the CPU path rather than being forced. */
+    if (!g || !u || !d || !gs || !us || !ds) return;
+
+    Q38Slot *s = qs(layer, eid);
+    if (s->resident) return;
+
+    int dv = G.dev[eid % G.ndev];        /* one home device per expert, no duplicates */
+    /* Ask the card, do not model it. Once full this returns 0 for every later
+     * expert and the tier simply stops growing - decode carries on at the CPU
+     * speed it had before, rather than degrading past it. */
+    if (G.byte_ceiling && G.vram_used + expert_bytes() > G.byte_ceiling) {
+        G.over_cap++; return;                /* explicit user ceiling, if set */
+    }
+    if (!headroom_ok(dv)) { G.over_cap++; return; }
+    /* upload(tensor, weights, scales, fmt, I, O, device) - note I then O. */
+    if (coli_cuda_tensor_upload(&s->tg, g, gs, 8, G.D, G.I, dv)
+     && coli_cuda_tensor_upload(&s->tu, u, us, 8, G.D, G.I, dv)
+     && coli_cuda_tensor_upload(&s->td, d, ds, 8, G.I, G.D, dv)) {
+        s->resident = 1;
+        G.vram_used += expert_bytes();
+        G.uploads++;
+    } else {
+        s->tg = s->tu = s->td = NULL;
+        G.upload_fail++;
+    }
+}
+
+uint32_t q38t_issue(int layer, const int *eids, int K, const float *x) {
+    if (!G.on || !eids || !x || K < 1 || K > 32) return 0;
+
+    ColiCudaTensor *tg[Q38T_MAX_DEV][Q38T_MAX_ISSUE];
+    ColiCudaTensor *tu[Q38T_MAX_DEV][Q38T_MAX_ISSUE];
+    ColiCudaTensor *td[Q38T_MAX_DEV][Q38T_MAX_ISSUE];
+    static int rows[Q38T_MAX_ISSUE];
+    for (int i = 0; i < Q38T_MAX_ISSUE; i++) rows[i] = 1;   /* S=1 per expert at decode */
+
+    for (int i = 0; i < G.ndev; i++) G.is_cnt[i] = 0;
+
+    uint32_t mask = 0;
+    for (int k = 0; k < K; k++) {
+        Q38Slot *s = qs(layer, eids[k]);
+        if (!s->resident) { G.miss++; continue; }
+        int di = (eids[k] % G.ndev);
+        int c = G.is_cnt[di];
+        /* The 8-row ceiling is per device per issue. Anything past it is a
+         * CPU expert this token; it is counted so the split is visible in
+         * q38t_stats rather than being an invisible truncation. */
+        if (c >= Q38T_MAX_ISSUE) { G.over_cap++; continue; }
+        tg[di][c] = s->tg; tu[di][c] = s->tu; td[di][c] = s->td;
+        G.is_k[di][c] = k;
+        G.is_cnt[di] = c + 1;
+        mask |= 1u << k;
+        G.hits++;
+    }
+
+    for (int di = 0; di < G.ndev; di++) {
+        int c = G.is_cnt[di];
+        if (!c) continue;
+        float *xr = G.xrep[di];
+        for (int j = 0; j < c; j++) memcpy(xr + (size_t)j * G.D, x, (size_t)G.D * sizeof(float));
+        if (!coli_cuda_expert_group_issue(tg[di], tu[di], td[di], rows, c, xr)) {
+            /* Hand this device's experts back to the CPU rather than dropping
+             * their contribution - a missing expert is a wrong answer, not a
+             * slow one. */
+            for (int j = 0; j < c; j++) mask &= ~(1u << G.is_k[di][j]);
+            G.is_cnt[di] = 0;
+        }
+    }
+    return mask;
+}
+
+void q38t_take(uint32_t mask, const float *route_gates, int K, float *out) {
+    (void)K;
+    if (!G.on || !mask || !route_gates || !out) return;
+    for (int di = 0; di < G.ndev; di++) {
+        int c = G.is_cnt[di];
+        if (!c) continue;
+        const float *y = coli_cuda_expert_group_take(G.dev[di]);
+        if (!y) { G.is_cnt[di] = 0; continue; }
+        for (int j = 0; j < c; j++) {
+            float w = route_gates[G.is_k[di][j]];
+            const float *row = y + (size_t)j * G.D;
+            for (int d = 0; d < G.D; d++) out[d] += w * row[d];
+        }
+        G.is_cnt[di] = 0;
+    }
+}
+
+void q38t_stats(void) {
+    if (!G.on) return;
+    unsigned long long total = G.hits + G.miss;
+    fprintf(stderr,
+            "[q38tier] resident %llu expert(s), %.2f GB of raw expert weight\n"
+            "[q38tier] group hits %llu, misses %llu (%.1f%% hit), "
+            "declined %llu, upload failures %llu\n",
+            G.uploads, G.vram_used / 1e9,
+            G.hits, G.miss, total ? 100.0 * (double)G.hits / (double)total : 0.0,
+            G.over_cap, G.upload_fail);
+}
+
+void q38t_shutdown(void) {
+    if (!G.on) return;
+    q38t_stats();
+    free(G.slot); G.slot = NULL;
+    for (int i = 0; i < G.ndev; i++) { free(G.xrep[i]); G.xrep[i] = NULL; }
+    G.on = 0;
+}
+
+#endif /* COLI_CUDA */

--- a/c/qwen38_tier.h
+++ b/c/qwen38_tier.h
@@ -1,0 +1,110 @@
+/* qwen38_tier.h -- optional CUDA VRAM expert tier for the qwen38 engine.
+ *
+ * WHY THIS EXISTS
+ *
+ * `COLI_TIMERS=1` on an RTX 3090 / i9-14900K, 18-token prompt, warm, per
+ * forward:
+ *
+ *     routed-expert   265.3 ms      <- this file
+ *     resident-mm     191.9 ms
+ *     deltanet        150.4 ms
+ *     shared-expert    26.7 ms
+ *     lm-head          22.8 ms
+ *     qsa-attn         11.8 ms
+ *     ple               2.2 ms
+ *     qsa-index         1.4 ms
+ *     expert-read       0.000 ms    <- no disk wait at all
+ *     fp8-expand        0.000 ms
+ *
+ * Two things follow. The routed experts are the single largest cost, and the
+ * engine is COMPUTE-bound rather than disk-bound: at cache 424/layer nothing is
+ * fetched from disk during decode. That is the opposite of the GLM engine,
+ * where expert I/O is ~48% of the run, and it is why this tier targets the
+ * matmul rather than the read.
+ *
+ * WHAT IT DOES NOT DO
+ *
+ * Nothing else moves to the GPU in this phase - resident matmuls, DeltaNet,
+ * QSA, PLE and the shared expert all stay on the CPU. Same deliberately small
+ * scope as backend_cuda_ink.h.
+ *
+ * THE WEIGHTS NEED NO NEW KERNEL
+ *
+ * qwen38's routed experts are official block-FP8: raw e4m3 bytes plus one f32
+ * scale per 128x128 block, `fp8_nblk(rows) * fp8_nblk(cols)` of them
+ * (quant.h:517). backend_cuda.cu's fmt=8 decodes exactly that layout -
+ * `scales + (o>>7)*((I+127)>>7)`, then `scl[i>>7]` (backend_cuda.cu:534). The
+ * formats are byte-identical, so this tier is wiring over the existing
+ * expert-group API and adds no numerics of its own.
+ *
+ * GEOMETRY on Qwen3.8-Flash-Next: hidden 2560, moe_intermediate 640, 512
+ * experts across 48 layers, top-k 10. Each expert is
+ * gate[640,2560] + up[640,2560] + down[2560,640] = 4.69 MiB in fp8, so the full
+ * set is ~112.6 GiB and a 24 GB card holds roughly a fifth of it. Residency is
+ * therefore a routing-skew bet, exactly as it is for GLM: hot experts earn
+ * VRAM, everything else stays on the CPU path.
+ *
+ * DEFAULT OFF, AND THAT IS DELIBERATE. The Makefile calls the qwen38 target
+ * "intentionally CPU-only". Built without -DCOLI_CUDA the inline stubs below
+ * compile to nothing and the engine is byte-for-byte what it is today; built
+ * with it, the tier still does nothing until COLI_CUDA=1 is set at runtime.
+ * This adds a capability that was scoped out. It does not change the existing
+ * path.
+ *
+ * Enable with COLI_CUDA=1 [COLI_GPUS=0,1] [CUDA_EXPERT_GB=<G>|auto].
+ */
+#ifndef QWEN38_TIER_H
+#define QWEN38_TIER_H
+#include <stdint.h>
+
+#ifdef COLI_CUDA
+
+/* Init after model load, before the first token. Returns 1 when the tier is
+ * live. A zero return is not an error: it means CPU-only, and every call below
+ * then behaves as a miss. */
+int  q38t_init(int n_layers, int n_experts, int hidden, int inter, int topk);
+int  q38t_ready(void);
+void q38t_shutdown(void);
+
+/* True when this expert's three projections are resident in some device's VRAM
+ * and can be issued. */
+int  q38t_is_resident(int layer, int eid);
+
+/* Offer one routed expert to the tier: updates its heat and may enqueue a
+ * background upload. Pointers are into the engine's own Slot, which the tier
+ * must not free and must not outlive.
+ *
+ * fp8 weights are raw e4m3 bytes; scales are the 128x128 block table. Passing a
+ * non-FP8 expert is safe and is simply ignored - a checkpoint can legitimately
+ * carry bf16 experts and those stay on the CPU path. */
+void q38t_note(int layer, int eid,
+               const void *g, const float *gs,
+               const void *u, const float *us,
+               const void *d, const float *ds);
+
+/* Launch the GPU groups for whichever of the K selected experts are resident.
+ * Returns a bitmask of the k handled on the GPU; compute the rest on the CPU
+ * and then call q38t_take() to fold in the GPU half. Asynchronous, so the CPU
+ * misses overlap with the in-flight groups rather than waiting behind them. */
+uint32_t q38t_issue(int layer, const int *eids, int K, const float *x);
+
+/* Accumulate route_gates[k] * y_k into out[hidden] for the k in `mask`. */
+void q38t_take(uint32_t mask, const float *route_gates, int K, float *out);
+
+/* One telemetry block on stderr: residency, hits, misses, uploads per device.
+ * Silent unless the tier ran, so a CPU-only run prints nothing new. */
+void q38t_stats(void);
+
+#else /* !COLI_CUDA: inline stubs, engine stays exactly as it is today */
+
+static inline int  q38t_init(int a,int b,int c,int d,int e){(void)a;(void)b;(void)c;(void)d;(void)e;return 0;}
+static inline int  q38t_ready(void){return 0;}
+static inline void q38t_shutdown(void){}
+static inline int  q38t_is_resident(int a,int b){(void)a;(void)b;return 0;}
+static inline void q38t_note(int a,int b,const void*c,const float*d,const void*e,const float*f,const void*g,const float*h){(void)a;(void)b;(void)c;(void)d;(void)e;(void)f;(void)g;(void)h;}
+static inline uint32_t q38t_issue(int a,const int*b,int c,const float*d){(void)a;(void)b;(void)c;(void)d;return 0;}
+static inline void q38t_take(uint32_t a,const float*b,int c,float*d){(void)a;(void)b;(void)c;(void)d;}
+static inline void q38t_stats(void){}
+
+#endif /* COLI_CUDA */
+#endif /* QWEN38_TIER_H */


### PR DESCRIPTION
Qwen3.8's routed experts run on the CPU, and on my box they're the most
expensive thing in a forward pass by a wide margin. This moves them to the GPU.

Off unless you set COLI_CUDA=1. No card, no driver, not enough VRAM, it just
uses the CPU path like it does now.

RTX 3090, i9-14900K, through coli serve, same 18-token prompt, warm, first run
of each serve thrown away:

    coli run on current dev    1.260 tok/s
    with the tier              3.257 tok/s   sd 0.021  n=5

I restarted the engine and did that four separate times: 3.257, 3.268, 3.319,
3.351. Token-exact against the CPU path on 4 of 4 prompts at temperature 0, and
I re-checked that on this exact build after rebasing.

There are no new kernels here. The routed experts are already block-FP8, raw
e4m3 with one f32 scale per 128x128 block, which is what fmt=8 in
backend_cuda.cu already decodes. It's wiring, not maths.

Two things worth explaining.

The expert group caps at 8 rows per issue, one outstanding per device. Qwen3.8
routes top-k 10. So two experts per token per layer were going to the CPU, and
the tier's counters showed misses at zero, meaning both were already sitting in
VRAM and only on the CPU because of the batching limit. They go in a second
round now.

I built that as an opt-in expecting it to lose. One round lets the CPU chew on
the two spare experts while the eight on the card are in flight, and a second
round throws that overlap away. It won anyway, every interleaved round:

    one round    3.123 tok/s  sd 0.015  n=9
    two rounds   3.315 tok/s  sd 0.029  n=9

So the CPU experts weren't hiding behind the GPU ones after all. Turn it off
with Q38T_TWO_ROUND=0 if it goes the other way on your hardware.

The other thing is VRAM accounting, and I got this wrong first. I budgeted by
adding up expert bytes. That undercounts badly: each expert is three separate
allocations and CUDA rounds every one up to a 2 MiB page, so 4.69 MiB of weights
actually costs 6.00 MiB on the device. The tier reckoned it had used 22.5 GB of
a 24 GB card while it had really used all of it, and decode went 3.9s, then 40s,
then hung. It asks cudaMemGetInfo now and holds back 2 GB.

Builds clean: all seven engines, make colibri CUDA_DLL=1, the qwen38 CUDA tier,
and the Windows loader contract tests.
