### PR TITLE
docs: report GLM-5.3-Flash PRO 6000 speed and quality findings

### DIFF
--- a/docs/experiments/glm53-flash-rtx-pro-6000-2026-09-04.md
+++ b/docs/experiments/glm53-flash-rtx-pro-6000-2026-09-04.md
@@ -1,0 +1,130 @@
+# GLM-5.3-Flash on one RTX PRO 6000: progress through September 4, 2026
+
+**External implementation report:** these measurements use a separately patched llama.cpp runtime and do not benchmark or validate Colibri's `c/glm53.c` engine. They are shared for review of numerical correctness, long-context measurement and profiling methodology.
+
+The best measured result is **36.1237 generated tokens/s per user for four concurrent users**, each with an 89,400-token prefix, one sampled seed, and 512 measured output tokens. The target remains **60 tokens/s per user**. Correctness and profiling work has narrowed the remaining questions, but neither performance nor useful-answer acceptance has been reached.
+
+## Configuration and measurement
+
+The experiment uses one **NVIDIA RTX PRO 6000 Blackwell, 96 GB**, a community **AJ-IQ2_XXS GLM-5.3-Flash GGUF**, and a patched, text-only llama.cpp runtime. The two target shards total **87,346,006,560 bytes (81.35 GiB)**. All 46/46 target layers were GPU-offloaded; no CPU expert spill was configured. The runtime reports 313,326,811,966 loaded parameters. This count has not been reconciled tensor by tensor with the publisher's 320B-total/18B-active model headline.
+
+Four slots each have a 90,112-token allocation. Prefixes were prepared sequentially before a barrier released all four measured streams. Each user's rate uses the **same wall interval, from the earliest first output to the latest last output**. Its numerator excludes that user's first output chunk, which establishes the start boundary: **511 tokens for the best run's 512-token outputs**. The measurement includes skew between streams and excludes long-prefix preparation. EOS was enabled.
+
+| Runtime | Target cache | DFlash2 draft weights | Native draft depth | Common-window tokens/s per user |
+| --- | --- | --- | ---: | ---: |
+| v8 | Q8 | BF16 | 3 | 35.3066 |
+| v8 | Q8 | Q8 | 3 | **36.1237** |
+| v9 | Q4 | Q8 | 7 | 25.3180 |
+| v9 | Q4 | Q8 | 3 | 35.5771 |
+
+Every row produced exactly 512 streamed and reported tokens per user, reused the full 89,400-token prefix, and evaluated one appended prompt token. The best run's common window was **14.145857224 seconds**, with **12.558695700 seconds** of four-way output overlap. Its warm-append first-token latency was 72–187 ms, excluding prefill. There was one measured run per configuration with different prompt nonces; a repeated-run median is unavailable. The Q4 rows use the separate v9 cache implementation, so this is not a controlled cache-precision ablation.
+
+Q8 draft GPU weights used **1,187.23 MiB**, versus **2,234.07 MiB** for BF16, saving **1,046.84 MiB**. Available-memory samples establish observed fit, not peak-memory headroom.
+
+## Correctness findings
+
+The sparse attention work corrected a CUDA padding launch-dimension problem and retained exact key/mask checks. The v8 change kept 512-wide VKQ accumulation, rescaling, and final staging/reduction in FP32. It passed **13/13 CUDA fixture stages**, against **11/13** for the prior control, without relaxing the **3e-4 absolute / 1e-3 relative-L2** tolerances. Maximum Q8 long-parity absolute error fell from **1.90997124e-3** to **1.12354755e-5**. Sampled independent FP64 checks corroborated the numerical correction; this does not establish real-model semantic correctness.
+
+The earlier long-output workload used an ignored `enable_thinking` setting; this template instead consumes `reasoning_effort`. Its outputs included excessive reasoning and repetition, so the speed table does **not** establish useful-answer throughput.
+
+A separate matched 4K source-grounded task compared Low/High reasoning with speculation disabled and with the Q8 draft. Each arm contained 32 requested rows across four users. Rendered prompts and token hashes matched across speculation modes at the same effort.
+
+| Reasoning effort | No speculation | Q8 draft, depth 3 |
+| --- | ---: | ---: |
+| Low | 27/32 correct rows | 27/32 correct rows |
+| High | 31/32 correct rows | 31/32 correct rows |
+
+Both High arms produced identical final answers. Their remaining error approved a record with expected quantity 20 and received quantity 21 despite a rule requiring zero difference. One High/no-spec reasoning trace also triggered a repetition heuristic, independently of its correct final rows. These bounded results do not assign the errors to target quantization or speculative decoding.
+
+The evaluator also incorrectly applied a limit-stop cache formula to EOS. A new source-derived contract distinguishes exact no-spec occupancy from bounded speculative EOS occupancy. All four matched arms passed the corrected accounting. The exact 512-token limit-stop contract remains unchanged; historical failed receipts remain failed.
+
+## Profiling and next experiment
+
+Neither profiling attempt produced valid bottleneck evidence. The first capture began after decoding. During the second, outputs stopped after **13/21/14/17 tokens** while profiling started; stopping collection timed out, and the report contained **no CUDA events**. Timing is consistent with an instrumentation-associated stall, but does not prove its internal cause or establish which tracing backend was active.
+
+The next workflow is prepared but **not executed**: explicitly request software CUDA tracing, start collection while idle after prefills, stop after generation, and audit a three-second interval inside all four output streams. A short canary must first show actual CUDA activity and completed accounting before another long-context trace. Profiled timing remains diagnostic. The experiment is stopped, and baseline-service recovery was verified at **01:12:30 UTC on September 4**.
+
+## Provenance
+
+- Publisher: [zai-org/GLM-5.3-Flash](https://huggingface.co/zai-org/GLM-5.3-Flash); the tested GGUF/runtime is a separate community conversion.
+- Model: [aj9o9/GLM-5.3-Flash-GGUF](https://huggingface.co/aj9o9/GLM-5.3-Flash-GGUF/tree/07c62fcdeaf1c05d22bd123c3da8058a1b1e63e2), revision `07c62fcdeaf1c05d22bd123c3da8058a1b1e63e2`.
+- Runtime base: [llama.cpp PR 27752](https://github.com/ggml-org/llama.cpp/pull/27752), commit `c9ddd6821c93871c53741344d35d1e440d60d9ea`, plus separately recorded experimental patches.
+- v8 snapshot-manifest SHA-256: `6b9542d8a7a966f6ebc789b333e2eabfddd198165503d37b4d6b5e8b54efce06`.
+- Cumulative v8 source-patch SHA-256: `9d84fdbffbeef057fd44091d2290377e5a13b26c2895dff9141e931b12f32e27`.
+- Experimental DFlash2 Q8 draft SHA-256: `d21f4f7166e5ade490479bb3886909bf37220bc618b4d8047c26400075d5f747`.
+- Best-run raw-receipt SHA-256: `6c7b54fa0d6ff9aaea3a31f14ff37e239023ced76e1a0f17a72e03db786741aa`.
+
+## Measurement details and normalized command reconstruction
+
+This is an external **llama.cpp** experiment on GLM-5.3-Flash. It does not measure Colibri's `c/glm53.c` engine. The accompanying evidence JSON is an allowlisted derivative of retained receipts, with original receipt hashes for audit linkage. It contains no raw prompts, generated answers, machine identities, endpoint addresses or service configuration.
+
+### Hardware and coverage
+
+The September 3 canary inventory records one **RTX PRO 6000 Blackwell 96 GB**, **Intel Core Ultra 9 285K**, and **62 GiB host RAM**. CPU/RAM are prior inventory, not a fresh hardware survey for this publication. The storage device, filesystem and storage benchmark were not recorded in the reviewed measurement sources. The profile metadata records driver **610.43.02** and Nsight Systems export version **2026.4.1.191**.
+
+The measured application was a custom text-only llama.cpp build targeting `120a-real`. The pinned SGLang container image supplied the build/runtime environment; SGLang did not serve this GGUF. Model shard hashes, upstream commit, required CPU MoE fix, runtime snapshot manifests, source patch hash and Q8 draft hash are in [the minimized evidence summary](https://github.com/lEWFkRAD/qwen38-rtx-pro-6000/blob/0b09b0c9bafd36ce8a557837dff2f6844a109477/glm53-flash/evidence-summary.json).
+
+The target remained AJ-IQ2_XXS throughout. Q8-cache rows used **v8**; Q4-cache rows used **v9**, which adds Q4 pooling support. They are distinct snapshots. The private Q8 DFlash2 conversion has SHA-256 `d21f4f7166e5ade490479bb3886909bf37220bc618b4d8047c26400075d5f747`; it is not distributed with this report.
+
+### Effective best-run server command
+
+The following is a **normalized reconstruction**, not the original host command and not a turnkey deployment script. Placeholder paths replace deployment-specific locations. It assumes an already prepared immutable custom runtime and the exact Q8 draft; obtaining upstream llama.cpp alone does not reproduce those bytes. It omits container/service ownership and recovery orchestration.
+
+```bash
+env \
+  NVIDIA_TF32_OVERRIDE=0 \
+  LD_LIBRARY_PATH="<CUSTOM_RUNTIME>/build-sm120/bin:<CUDA_LIBRARY_DIR>" \
+  LLAMA_GLM5NEXT_SPARSE_DECODE=1 \
+  LLAMA_GLM5NEXT_SPARSE_TELEMETRY=1 \
+  LLAMA_GLM5NEXT_FUSED_KPOOL=1 \
+  LLAMA_GLM5NEXT_FUSED_KPOOL_DIAG=1 \
+  LLAMA_GLM5NEXT_NATIVE_RS=1 \
+  "<CUSTOM_RUNTIME>/build-sm120/bin/llama-server" \
+  --model "<MODEL_DIR>/GLM-5.3-Flash-AJ-IQ2_XXS-00001-of-00002.gguf" \
+  --n-gpu-layers 99 --flash-attn on \
+  --ctx-size 360448 --parallel 4 --no-kv-unified \
+  --batch-size 512 --ubatch-size 512 \
+  --cache-type-k q8_0 --cache-type-v q8_0 \
+  --cache-ram 0 --no-context-shift \
+  --model-draft "<DRAFT_DIR>/GLM-5.3-Flash-DFlash2-Q8_0-pure.gguf" \
+  --spec-type draft-dflash --spec-draft-ngl all \
+  --spec-draft-n-max 3 --spec-draft-n-min 1 --spec-draft-p-min 0 \
+  --cache-type-k-draft f16 --cache-type-v-draft f16 --ctx-checkpoints 0 \
+  --jinja --metrics --log-verbosity 3 \
+  --threads 16 --threads-batch 16 \
+  --host "<LOOPBACK_BIND_ADDRESS>" --port "<LOCAL_PORT>"
+```
+
+CUDA graphs, graph reuse and ordinary fusion were enabled: the launcher did not set `GGML_CUDA_DISABLE_GRAPHS`, `LLAMA_GRAPH_REUSE_DISABLE`, or `GGML_CUDA_DISABLE_FUSION`. The separate `GGML_CUDA_GRAPH_OPT` optimization was not enabled. These are the frozen launcher's choices, not assumptions about an arbitrary user's inherited environment. No Nsight wrapper was active for the four performance-table rows.
+
+All 46/46 target layers were reported offloaded. The container used one GPU, a 52 GiB memory/swap-total limit, and a read-only runtime/model mount. The 16-thread setting and memory limit are configuration, not hardware capacity measurements. Peak VRAM was not established.
+
+For the other observations, replace only the documented inputs: BF16 draft with v8/Q8 cache/depth3; v9/Q4 cache/Q8 draft/depth7; v9/Q4 cache/Q8 draft/depth3. This table records distinct runs, not a fully controlled one-variable experiment.
+
+### Effective benchmark command and workload
+
+```bash
+python3 "<FROZEN_BENCHMARK_DIR>/run-native-sustained-common-window.py" \
+  --base-url "<LOCAL_API_BASE>" \
+  --output "<RESULT_DIR>/sustained90k.json"
+```
+
+The same directory must contain the exact `run-four-user-depth.py` and `run-warm-cache-discriminator.py` helpers. The benchmark's source hash is in the evidence summary. This reconstruction shows the workload selection; the original invocation's operational timeout override is not in the performance receipt. The process was separately bounded by its canary window and service lifetime.
+
+The frozen harness fixes **four users, 89,400 rendered prefix tokens each, one sampled seed each, and 512 measured generated tokens each**. It uses the native `/completion` API with pinned slots, full token-array prompts, `cache_prompt=true`, temperature0, top_p1, seed530053, and returned token IDs. A sequential one-token prefill must evaluate/cache the entire prefix. The sampled seed is then appended to that exact prefix. Four threads wait at one barrier before beginning measured requests. `--ignore-eos` was **not** supplied.
+
+The 360,448-token server context is divided into four **90,112-token slots**. The harness separately uses a conservative **90,000-token accounting limit**; its 89,401-token input and 512-token output fit within both. The measured limit-stop cache occupancy must be exactly **89,912**, with `cache_n=89400`, `prompt_n=1`, and 512 streamed/reported generated tokens.
+
+### Warm-up, timing and limitations
+
+- There was **one measured full benchmark per configuration**, with different generated prompt nonces. No repeated-run median or confidence interval is available.
+- Native short correctness checks preceded the measured queue. The Q8-draft and Q4/depth7 short checks ran on the corresponding full-context servers; the Q4/depth3 comparison reused the already established Q4 gate. There was no extra full 90K benchmark warm-up run.
+- The immediate preparation for each measurement was four sequential full-prefix prefills and one seed each. This work warms the exact prefix caches and is excluded from the decode interval. Best-run preparation was roughly 145–149 seconds per slot; exact durations and prompt-processing rates are in the evidence JSON.
+- Every user's reported common-window rate is `(streamed tokens - first output chunk tokens) / (latest last output - earliest first output)`. All four best-run first chunks contained one token, so the numerator is **511**, while total generated output remains512. The best window was14.145857224 seconds, yielding36.123650332 tokens/s each. Warm-append TTFT excludes prefix preparation.
+- Model outputs from this historical workload included reasoning/repetition. Its `enable_thinking=false` template argument was ignored. The later finite task explicitly selects `reasoning_effort`; its correctness results do not retroactively validate the earlier output.
+- The finite EOS evaluator uses a source-derived occupancy contract, distinct from the unchanged exact limit-stop contract above. Correct accounting does not imply correct answers.
+- Both profiling attempts remain invalid. One began after output; the other stalled and recorded no CUDA events. No bottleneck or HES-specific failure cause is established.
+
+The next software-trace/idle-start workflow is prepared but unrun. It requires actual CUDA events and a valid interior four-user interval in a short canary before a new long trace. The target remains four correct, useful outputs at at least60 generated tokens/s **per user**.
+
+The [companion report PR](https://github.com/lEWFkRAD/qwen38-rtx-pro-6000/pull/6) includes the [minimized evidence summary](https://github.com/lEWFkRAD/qwen38-rtx-pro-6000/blob/0b09b0c9bafd36ce8a557837dff2f6844a109477/glm53-flash/evidence-summary.json), pinned to its publication commit. Original raw logs and internal deployment details are excluded.

--- a/docs/experiments/glm53-flash-rtx-pro-6000-2026-09-04.md
+++ b/docs/experiments/glm53-flash-rtx-pro-6000-2026-09-04.md
@@ -2,13 +2,30 @@
 
 **External implementation report:** these measurements use a separately patched llama.cpp runtime and do not benchmark or validate Colibri's `c/glm53.c` engine. They are shared for review of numerical correctness, long-context measurement and profiling methodology.
 
-The best measured result is **36.1237 generated tokens/s per user for four concurrent users**, each with an 89,400-token prefix, one sampled seed, and 512 measured output tokens. The target remains **60 tokens/s per user**. Correctness and profiling work has narrowed the remaining questions, but neither performance nor useful-answer acceptance has been reached.
+The final unprofiled comparison measured **34.3605159041 generated tokens/s per user without speculation** and **42.9185939037 with a Q8 DFlash2 draft at depth 3**, for four concurrent users with 89,400-token prefixes, one sampled seed each, and 512 measured output tokens each. The Q8 arm was 24.91% faster, but all four outputs exhausted the budget in reasoning without a final answer. The no-spec arm produced two unanswered and two incorrect responses. **GLM optimization was stopped because answer quality failed.** Neither arm reached the target of 60 tokens/s per user with useful, correct answers.
 
 ## Configuration and measurement
 
 The experiment uses one **NVIDIA RTX PRO 6000 Blackwell, 96 GB**, a community **AJ-IQ2_XXS GLM-5.3-Flash GGUF**, and a patched, text-only llama.cpp runtime. The two target shards total **87,346,006,560 bytes (81.35 GiB)**. All 46/46 target layers were GPU-offloaded; no CPU expert spill was configured. The runtime reports 313,326,811,966 loaded parameters. This count has not been reconciled tensor by tensor with the publisher's 320B-total/18B-active model headline.
 
-Four slots each have a 90,112-token allocation. Prefixes were prepared sequentially before a barrier released all four measured streams. Each user's rate uses the **same wall interval, from the earliest first output to the latest last output**. Its numerator excludes that user's first output chunk, which establishes the start boundary: **511 tokens for the best run's 512-token outputs**. The measurement includes skew between streams and excludes long-prefix preparation. EOS was enabled.
+Four slots each have a 90,112-token allocation. Prefixes were prepared sequentially before a barrier released all four measured streams. Each user's rate uses the **same wall interval, from the earliest first output to the latest last output**. Its numerator excludes that user's first output chunk, which establishes the start boundary: **511 tokens for these 512-token outputs**. The measurement includes skew between streams and excludes long-prefix preparation. EOS was enabled.
+
+### Final September 4 comparison: explicit Low reasoning
+
+Both arms used the unchanged v8 runtime and Q8 target KV cache, with no profiler. There was **one measured run per arm**, no repeated-run median and no separate full-workload warm-up. Each arm prepared its four complete prefixes and sampled seeds before the measured interval.
+
+| Speculation | Common window (s) | Generated tokens/s per user | Final-answer outcome |
+| --- | ---: | ---: | --- |
+| None | 14.871720827068 | 34.3605159041 | Two unanswered; two incorrect |
+| Q8 DFlash2, depth 3 | 11.906261448050 | 42.9185939037 | Four unanswered |
+
+All eight streams reached 512 measured tokens with valid token/cache accounting. Each rate is **511/common-window**, independently recomputed from raw token events. The Q8 arm spent all 512 tokens on reasoning in every slot and produced zero final-answer tokens. No-spec reasoning-token counts were 512/30/53/512; final-answer counts were 0/481/458/0, with one closing marker in each of the two answered streams. Those answers had substantive source-rule errors, not only formatting differences. Neither arm passed useful-answer acceptance.
+
+Original source, rendered-prompt and 89,400-token prefix hashes matched across all four slots, as did benchmark-source hashes. Saved sampling settings differed only in the intended speculative mode. **The sampled prefill seed differed in slot 3**, so the measured continuation inputs matched exactly in only three slots. All four generated token sequences differed. This single pair supports the observed speed difference, but does not establish that speculation caused the quality difference or isolate target quantization as its cause.
+
+### Historical September 3 configuration sweep
+
+The earlier table below used a different workload and an ignored thinking-template argument. Its best result, 36.1237 tokens/s per user, is historical and is not a controlled comparison with the explicit-Low September 4 arms.
 
 | Runtime | Target cache | DFlash2 draft weights | Native draft depth | Common-window tokens/s per user |
 | --- | --- | --- | ---: | ---: |
@@ -17,7 +34,7 @@ Four slots each have a 90,112-token allocation. Prefixes were prepared sequentia
 | v9 | Q4 | Q8 | 7 | 25.3180 |
 | v9 | Q4 | Q8 | 3 | 35.5771 |
 
-Every row produced exactly 512 streamed and reported tokens per user, reused the full 89,400-token prefix, and evaluated one appended prompt token. The best run's common window was **14.145857224 seconds**, with **12.558695700 seconds** of four-way output overlap. Its warm-append first-token latency was 72–187 ms, excluding prefill. There was one measured run per configuration with different prompt nonces; a repeated-run median is unavailable. The Q4 rows use the separate v9 cache implementation, so this is not a controlled cache-precision ablation.
+Every historical row produced exactly 512 streamed and reported tokens per user, reused the full 89,400-token prefix, and evaluated one appended prompt token. That sweep's best run had a common window of **14.145857224 seconds**, with **12.558695700 seconds** of four-way output overlap. Its warm-append first-token latency was 72–187 ms, excluding prefill. There was one measured run per configuration with different prompt nonces; a repeated-run median is unavailable. The Q4 rows use the separate v9 cache implementation, so this is not a controlled cache-precision ablation.
 
 Q8 draft GPU weights used **1,187.23 MiB**, versus **2,234.07 MiB** for BF16, saving **1,046.84 MiB**. Available-memory samples establish observed fit, not peak-memory headroom.
 
@@ -38,11 +55,11 @@ Both High arms produced identical final answers. Their remaining error approved 
 
 The evaluator also incorrectly applied a limit-stop cache formula to EOS. A new source-derived contract distinguishes exact no-spec occupancy from bounded speculative EOS occupancy. All four matched arms passed the corrected accounting. The exact 512-token limit-stop contract remains unchanged; historical failed receipts remain failed.
 
-## Profiling and next experiment
+## Profiling and disposition
 
 Neither profiling attempt produced valid bottleneck evidence. The first capture began after decoding. During the second, outputs stopped after **13/21/14/17 tokens** while profiling started; stopping collection timed out, and the report contained **no CUDA events**. Timing is consistent with an instrumentation-associated stall, but does not prove its internal cause or establish which tracing backend was active.
 
-The next workflow is prepared but **not executed**: explicitly request software CUDA tracing, start collection while idle after prefills, stop after generation, and audit a three-second interval inside all four output streams. A short canary must first show actual CUDA activity and completed accounting before another long-context trace. Profiled timing remains diagnostic. The experiment is stopped, and baseline-service recovery was verified at **01:12:30 UTC on September 4**.
+A software-tracing workflow was prepared but **not executed**. The final September 4 comparison above ran without profiling. Subsequent GLM speed and profiling work was stopped after the answer-quality failures; no new valid bottleneck profile or accepted deployment follows from these results.
 
 ## Provenance
 
@@ -52,11 +69,14 @@ The next workflow is prepared but **not executed**: explicitly request software 
 - v8 snapshot-manifest SHA-256: `6b9542d8a7a966f6ebc789b333e2eabfddd198165503d37b4d6b5e8b54efce06`.
 - Cumulative v8 source-patch SHA-256: `9d84fdbffbeef057fd44091d2290377e5a13b26c2895dff9141e931b12f32e27`.
 - Experimental DFlash2 Q8 draft SHA-256: `d21f4f7166e5ade490479bb3886909bf37220bc618b4d8047c26400075d5f747`.
-- Best-run raw-receipt SHA-256: `6c7b54fa0d6ff9aaea3a31f14ff37e239023ced76e1a0f17a72e03db786741aa`.
+- Historical September 3 best-run raw-receipt SHA-256: `6c7b54fa0d6ff9aaea3a31f14ff37e239023ced76e1a0f17a72e03db786741aa`.
+- Final September 4 no-spec raw-receipt SHA-256: `095b77702f67ce2445987c07382a1a420e1e363ed41efdfd130fb45b49d6875f`.
+- Final September 4 Q8-draft raw-receipt SHA-256: `3df0a4cd5ded5089986d0ac2b6346a7f5461c6be92f8002eefa02965cba59a47`.
+- Final comparison benchmark-source SHA-256: `c9cb3b3364dca10092bd28510e96857ec868f486e3a8ae53940f25ad61e384ca`.
 
 ## Measurement details and normalized command reconstruction
 
-This is an external **llama.cpp** experiment on GLM-5.3-Flash. It does not measure Colibri's `c/glm53.c` engine. The accompanying evidence JSON is an allowlisted derivative of retained receipts, with original receipt hashes for audit linkage. It contains no raw prompts, generated answers, machine identities, endpoint addresses or service configuration.
+This is an external **llama.cpp** experiment on GLM-5.3-Flash. It does not measure Colibri's `c/glm53.c` engine. The linked companion evidence JSON is an allowlisted derivative of earlier retained receipts, with original receipt hashes for audit linkage. **That immutable snapshot covers the historical sweep, finite quality matrix and failed profiles; it does not contain the final September 4 unprofiled comparison.** This report adds minimized numeric findings and original receipt hashes for that later comparison. Raw prompts, generated answers and internal deployment records are not included.
 
 ### Hardware and coverage
 
@@ -66,9 +86,9 @@ The measured application was a custom text-only llama.cpp build targeting `120a-
 
 The target remained AJ-IQ2_XXS throughout. Q8-cache rows used **v8**; Q4-cache rows used **v9**, which adds Q4 pooling support. They are distinct snapshots. The private Q8 DFlash2 conversion has SHA-256 `d21f4f7166e5ade490479bb3886909bf37220bc618b4d8047c26400075d5f747`; it is not distributed with this report.
 
-### Effective best-run server command
+### Historical September 3 best-run server command
 
-The following is a **normalized reconstruction**, not the original host command and not a turnkey deployment script. Placeholder paths replace deployment-specific locations. It assumes an already prepared immutable custom runtime and the exact Q8 draft; obtaining upstream llama.cpp alone does not reproduce those bytes. It omits container/service ownership and recovery orchestration.
+The following is a **normalized reconstruction**, not the original host command and not a turnkey deployment script. Placeholder paths replace deployment-specific locations. It assumes an already prepared immutable custom runtime and the exact Q8 draft; obtaining upstream llama.cpp alone does not reproduce those bytes.
 
 ```bash
 env \
@@ -101,7 +121,7 @@ All 46/46 target layers were reported offloaded. The container used one GPU, a 5
 
 For the other observations, replace only the documented inputs: BF16 draft with v8/Q8 cache/depth3; v9/Q4 cache/Q8 draft/depth7; v9/Q4 cache/Q8 draft/depth3. This table records distinct runs, not a fully controlled one-variable experiment.
 
-### Effective benchmark command and workload
+### Historical September 3 benchmark command and workload
 
 ```bash
 python3 "<FROZEN_BENCHMARK_DIR>/run-native-sustained-common-window.py" \
@@ -115,7 +135,7 @@ The frozen harness fixes **four users, 89,400 rendered prefix tokens each, one s
 
 The 360,448-token server context is divided into four **90,112-token slots**. The harness separately uses a conservative **90,000-token accounting limit**; its 89,401-token input and 512-token output fit within both. The measured limit-stop cache occupancy must be exactly **89,912**, with `cache_n=89400`, `prompt_n=1`, and 512 streamed/reported generated tokens.
 
-### Warm-up, timing and limitations
+### Historical warm-up, timing and limitations
 
 - There was **one measured full benchmark per configuration**, with different generated prompt nonces. No repeated-run median or confidence interval is available.
 - Native short correctness checks preceded the measured queue. The Q8-draft and Q4/depth7 short checks ran on the corresponding full-context servers; the Q4/depth3 comparison reused the already established Q4 gate. There was no extra full 90K benchmark warm-up run.
@@ -125,6 +145,21 @@ The 360,448-token server context is divided into four **90,112-token slots**. Th
 - The finite EOS evaluator uses a source-derived occupancy contract, distinct from the unchanged exact limit-stop contract above. Correct accounting does not imply correct answers.
 - Both profiling attempts remain invalid. One began after output; the other stalled and recorded no CUDA events. No bottleneck or HES-specific failure cause is established.
 
-The next software-trace/idle-start workflow is prepared but unrun. It requires actual CUDA events and a valid interior four-user interval in a short canary before a new long trace. The target remains four correct, useful outputs at at least60 generated tokens/s **per user**.
+### Final September 4 benchmark command and coverage
 
-The [companion report PR](https://github.com/lEWFkRAD/qwen38-rtx-pro-6000/pull/6) includes the [minimized evidence summary](https://github.com/lEWFkRAD/qwen38-rtx-pro-6000/blob/0b09b0c9bafd36ce8a557837dff2f6844a109477/glm53-flash/evidence-summary.json), pinned to its publication commit. Original raw logs and internal deployment details are excluded.
+The later explicit-Low comparison used the same v8/Q8-cache server shape and a new quality-aware harness. The Q8 arm retained the depth-3 draft settings above. The no-spec arm omitted the draft-model/speculation arguments and `LLAMA_GLM5NEXT_NATIVE_RS`, the native recurrent-state snapshot/rollback flag; both retained `--ctx-checkpoints 0`. The normalized client invocation for each arm was:
+
+```bash
+python3 -B "<FINAL_BENCHMARK_DIR>/quality_benchmark.py" \
+  --base-url "<LOCAL_API_BASE>" \
+  --mode sustained --reasoning-effort low \
+  --speculative-mode "<none|q8-dflash3>" \
+  --dataset-seed glm53-direct-speed-20260904d-v1 \
+  --timeout 1800 \
+  --launch-inspect "<SAVED_RUNTIME_INSPECTION_JSON>" \
+  --output "<RESULT_DIR>/<ARM>-sustained90k.json"
+```
+
+The arm placeholder denotes one of the two literal mode values, not a shell expression. The custom harness and its required helpers must match the recorded source hashes; this command is not a complete public reproduction package. No capture arguments or finite-task source plan were supplied. Both arms requested Low through `reasoning_effort`, retained ordinary EOS, and used the same four-prefix/seed/512-token accounting protocol. The final outcomes and seed-matching limitation are recorded above. No further GLM benchmark or profile was run after the quality-based stop.
+
+The [companion report PR](https://github.com/lEWFkRAD/qwen38-rtx-pro-6000/pull/6) includes the [earlier minimized evidence summary](https://github.com/lEWFkRAD/qwen38-rtx-pro-6000/blob/0b09b0c9bafd36ce8a557837dff2f6844a109477/glm53-flash/evidence-summary.json), pinned to its publication commit. Its coverage ends before the final unprofiled comparison; it must not be treated as a receipt for the 42.9186 result. Original raw logs and internal deployment details are excluded.

--- a/docs/glm53-flash.md
+++ b/docs/glm53-flash.md
@@ -177,3 +177,11 @@ but that **two different images give two different answers**.
 dequantisation of the same bytes. It needs a converted checkpoint, so it does not
 run in CI, and it is the first thing to reach for when the real model answers
 strangely.
+
+## External implementation field report
+
+The [September 4 RTX PRO 6000 field report](experiments/glm53-flash-rtx-pro-6000-2026-09-04.md)
+records a separate, patched llama.cpp experiment with an AJ IQ2 GGUF: four
+concurrent ~90K contexts, numerical and answer-quality checks, and two invalid
+profiling attempts. It is external evidence for implementation and measurement
+review; it does not benchmark or validate Colibri's `c/glm53.c` engine.


### PR DESCRIPTION
## Summary

Add an external llama.cpp field report for GLM-5.3-Flash on one RTX PRO 6000 Blackwell 96 GB, linked from the GLM-5.3 documentation. The final unprofiled v8/Q8-KV comparison measured 34.3605159041 generated tokens/s per user without speculation and 42.9185939037 with Q8 DFlash2 depth 3, for four users with 89,400-token prefixes, one sampled seed each and 512 measured output tokens each. Each arm has one measured run; these are not repeated-run medians.

Q8 was 24.91% faster, but all four outputs spent 512 tokens in reasoning and produced no final answer. No-spec produced two unanswered and two incorrect responses. Original source/prompt/token hashes match, but slot 3's sampled seed differs, so this is not an exact four-slot continuation comparison. GLM optimization was stopped because answer quality failed; neither the 60 tokens/s/user target nor useful-answer acceptance was reached.

The report preserves the clearly labeled historical speed table, sparse-padding and FP32 attention findings, finite Low/High quality matrix, speculative EOS accounting and two invalid profiles. These measure a separately patched llama.cpp runtime, not Colibri's engine. Hardware, normalized commands, warm-up policy, run counts, provenance and reproducibility gaps are explicit. The linked immutable companion evidence snapshot covers earlier results only and is explicitly not evidence for the final 42.9186 result.

## Validation

- Reconciled final rates, raw-event windows, reasoning/final-token counts and seed-matching limits against retained receipts and an independent local audit; reviewed the report for raw prompts, outputs, identities and internal operations.
- Checked Markdown links and `git diff --check`; verified final receipt and benchmark hashes locally. No raw benchmark artifacts are added to Colibri.
- [ ] `make -C c check` — not run for this documentation-only change.
- [ ] CUDA changes were tested with `make -C c cuda-test` — not applicable; no engine changes.
- [ ] Performance claims include hardware, commands, and repeatable measurements — hardware and command details are included, but these are single observations; repeated-run medians and a complete public reproduction package remain unavailable.

## Compatibility

- [x] The default CPU build remains dependency-free.
- [x] No model files, generated binaries, or benchmark artifacts are included; this PR adds Markdown only and links the minimized evidence separately.
