### PR TITLE
fix(qwen36): three CUDA expert-tier bugs (#1339, #1340, #1341)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1650,6 +1650,12 @@ tests/test_qwen36_tier_int8$(EXE): tests/test_qwen36_tier_int8.c tests/qwen36_fa
 tests/test_qwen36_tier_multidev$(EXE): tests/test_qwen36_tier_multidev.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h
 	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
 
+# Same fake backend, single device: proves qt_shutdown returns (under an
+# alarm(10) watchdog) instead of hanging forever when a group is still open
+# and an LFRU swap is parked waiting for cv_take (#1340).
+tests/test_qwen36_tier_shutdown$(EXE): tests/test_qwen36_tier_shutdown.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h
+	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
+
 tests/test_serve_poll$(EXE): tests/test_serve_poll.c serve_poll.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 

--- a/c/Makefile
+++ b/c/Makefile
@@ -1656,6 +1656,15 @@ tests/test_qwen36_tier_multidev$(EXE): tests/test_qwen36_tier_multidev.c tests/q
 tests/test_qwen36_tier_shutdown$(EXE): tests/test_qwen36_tier_shutdown.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h
 	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
 
+# Same fake backend, but driving the ENGINE: the warmstart in qwen36.c hands the
+# tier raw pointers into the RAM expert slots, so only a test that includes
+# qwen36.c can prove the weights behind them are still there afterwards -- on an
+# int8 container there is no packed copy to rebuild them from (#1341). Includes
+# qwen36_tier.c in its own TU like the other tier tests, so nothing else is
+# compiled in and no model file is needed.
+tests/test_qwen36_tier_int8_engine$(EXE): tests/test_qwen36_tier_int8_engine.c tests/qwen36_fake_cuda.h qwen36.c qwen36_tier.c qwen36_tier.h backend_cuda.h cli_args.h st.h json.h compat.h
+	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
+
 tests/test_serve_poll$(EXE): tests/test_serve_poll.c serve_poll.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 

--- a/c/Makefile
+++ b/c/Makefile
@@ -1641,7 +1641,13 @@ tests/test_cli_args$(EXE): tests/test_cli_args.c cli_args.h
 # coli_cuda_* e registra cosa riceve. E' il solo modo di provare in CI che un
 # esperto arriva davvero in VRAM e nel formato giusto (#1331) -- un test che si
 # fermasse a "qt_init ritorna 1" sarebbe passato anche col difetto.
-tests/test_qwen36_tier_int8$(EXE): tests/test_qwen36_tier_int8.c qwen36_tier.c qwen36_tier.h backend_cuda.h
+tests/test_qwen36_tier_int8$(EXE): tests/test_qwen36_tier_int8.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h
+	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
+
+# Same fake backend (tests/qwen36_fake_cuda.h), two devices: proves the tier's
+# per-device input-replica block (G.is_x) is sized and strided so device 1's
+# block cannot run past the end of the buffer or into device 0's (#1339).
+tests/test_qwen36_tier_multidev$(EXE): tests/test_qwen36_tier_multidev.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h
 	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
 
 tests/test_serve_poll$(EXE): tests/test_serve_poll.c serve_poll.h

--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -2645,6 +2645,59 @@ static void serve_loop(Model *m){
     }
 }
 
+/* Warmstart body, lifted out of main so a test can drive it against an
+ * in-memory model without a container (the QT_NO_WARMSTART check stays at the
+ * call site). expert_is_int4 is what main probed from the on-disk expert size.
+ */
+static void tier_warmstart(Model *m, int expert_is_int4) {
+    /* Plan the set (heat order), then load+stage IN PARALLEL. The
+     * load path is thread-safe: expert_get locks the layer cache
+     * (g_pilot_mx), st_read_raw uses pread; entries are unique. */
+    double t0 = now_s();
+    int cap_total = m->c.n_layers * m->c.n_experts;
+    int *wpl = malloc((size_t)cap_total*sizeof(int));
+    int *wpe = malloc((size_t)cap_total*sizeof(int));
+    int wn = qt_plan_fill(wpl, wpe, cap_total);
+    /* Load ALL experts into RAM, not just the planned (VRAM) set:
+     * otherwise the first touch of a CPU-fallback expert triggers a
+     * ~12 ms container read in the middle of decode (measured: 139
+     * ms/token on a single-GPU run). Planned ones also go to VRAM. */
+    uint8_t *planned = calloc((size_t)cap_total, 1);
+    for (int i = 0; i < wn; i++) planned[wpl[i]*m->c.n_experts + wpe[i]] = 1;
+    int keep8 = getenv("COLI_KEEP_INT8") != NULL;
+    #pragma omp parallel for schedule(dynamic, 16)
+    for (int gi = 0; gi < cap_total; gi++) {
+        int l = gi / m->c.n_experts, eidw = gi % m->c.n_experts;
+        Slot *e; expert_get(m, l, eidw, &e);
+        /* int4: i puntatori impacchettati; int8: i pesi stessi. Prima
+         * qui si esigeva e->g4, che su un container int8 e' NULL: la
+         * promozione non partiva mai e il budget restava riservato a
+         * vuoto (#1331). */
+        const uint8_t *wg = expert_is_int4 ? e->g4 : (const uint8_t *)e->g;
+        const uint8_t *wu = expert_is_int4 ? e->u4 : (const uint8_t *)e->u;
+        const uint8_t *wd = expert_is_int4 ? e->d4 : (const uint8_t *)e->d;
+        if (planned[gi] && wg) {
+            qt_note_planned(l, eidw, wg, wu, wd, e->gs, e->us, e->ds);
+            /* The staging copy is done. On an int4 container the int8 copy
+             * can go RIGHT AWAY so it never shows up in peak RSS: g4/u4/d4
+             * stay as the source of truth, and slot_ensure_int8() rebuilds
+             * the int8 block on an LFRU eviction with no container access.
+             * An int8 container has no second copy -- e->g4 is NULL -- so
+             * freeing e->g there both dangles the pointer qt_note_planned
+             * just stored (any later stage() reads freed memory) and leaves
+             * slot_ensure_int8() unable to bring the expert back: it returns
+             * early without g4, and the CPU fallback in the decode loop then
+             * dereferences NULL. Keep it (#1341). COLI_KEEP_INT8 keeps its
+             * meaning for int4. */
+            if (!keep8 && expert_is_int4 && e->g) { free(e->g); e->g = e->u = e->d = NULL; }
+        }
+    }
+    qt_fill_wait();
+    free(wpl); free(wpe); free(planned);
+    fprintf(stderr, "[qtier] warmstart (parallel): all %d experts in RAM (int8 only for non-residents), %d in VRAM -- %.1f s\n",
+            cap_total, wn, now_s()-t0);
+}
+
 int main(int argc, char **argv) {
     const char *snap = getenv("SNAP");
     if (!snap) { coli_print_launcher_help("Qwen3.6"); return 1; }
@@ -2782,47 +2835,7 @@ int main(int argc, char **argv) {
          * when HEAT_FILE exists, natural order otherwise), loading all RAM
          * slots along the way. */
         const char *nws = getenv("QT_NO_WARMSTART");
-        if (!(nws && *nws=='1')) {
-            /* Plan the set (heat order), then load+stage IN PARALLEL. The
-             * load path is thread-safe: expert_get locks the layer cache
-             * (g_pilot_mx), st_read_raw uses pread; entries are unique. */
-            double t0 = now_s();
-            int cap_total = m.c.n_layers * m.c.n_experts;
-            int *wpl = malloc((size_t)cap_total*sizeof(int));
-            int *wpe = malloc((size_t)cap_total*sizeof(int));
-            int wn = qt_plan_fill(wpl, wpe, cap_total);
-            /* Load ALL experts into RAM, not just the planned (VRAM) set:
-             * otherwise the first touch of a CPU-fallback expert triggers a
-             * ~12 ms container read in the middle of decode (measured: 139
-             * ms/token on a single-GPU run). Planned ones also go to VRAM. */
-            uint8_t *planned = calloc((size_t)cap_total, 1);
-            for (int i = 0; i < wn; i++) planned[wpl[i]*m.c.n_experts + wpe[i]] = 1;
-            int keep8 = getenv("COLI_KEEP_INT8") != NULL;
-            #pragma omp parallel for schedule(dynamic, 16)
-            for (int gi = 0; gi < cap_total; gi++) {
-                int l = gi / m.c.n_experts, eidw = gi % m.c.n_experts;
-                Slot *e; expert_get(&m, l, eidw, &e);
-                /* int4: i puntatori impacchettati; int8: i pesi stessi. Prima
-                 * qui si esigeva e->g4, che su un container int8 e' NULL: la
-                 * promozione non partiva mai e il budget restava riservato a
-                 * vuoto (#1331). */
-                const uint8_t *wg = expert_is_int4 ? e->g4 : (const uint8_t *)e->g;
-                const uint8_t *wu = expert_is_int4 ? e->u4 : (const uint8_t *)e->u;
-                const uint8_t *wd = expert_is_int4 ? e->d4 : (const uint8_t *)e->d;
-                if (planned[gi] && wg) {
-                    qt_note_planned(l, eidw, wg, wu, wd, e->gs, e->us, e->ds);
-                    /* The staging copy is done; free the int8 copy RIGHT AWAY
-                     * so it never shows up in peak RSS. On LFRU eviction
-                     * slot_ensure_int8() rematerializes from g4 (no container
-                     * access). */
-                    if (!keep8 && e->g) { free(e->g); e->g = e->u = e->d = NULL; }
-                }
-            }
-            qt_fill_wait();
-            free(wpl); free(wpe); free(planned);
-            fprintf(stderr, "[qtier] warmstart (parallel): all %d experts in RAM (int8 only for non-residents), %d in VRAM -- %.1f s\n",
-                    cap_total, wn, now_s()-t0);
-        }
+        if (!(nws && *nws=='1')) tier_warmstart(&m, expert_is_int4);
     }
 
     /* coli serve mode: speak the gateway wire protocol instead of argv

--- a/c/qwen36_tier.c
+++ b/c/qwen36_tier.c
@@ -97,6 +97,17 @@ static void *uploader(void *arg){
             /* LFRU swap: free the victim only when no group is in flight */
             while(G.issue_open && !G.th_stop) pthread_cond_wait(&G.cv_take,&G.mx);
             QSlot *v=qs(vl,ve);
+            if(G.th_stop && G.issue_open){
+                /* Shutting down with a group still open: qt_take() -- the only
+                 * thing that clears issue_open -- will never come. Abandon
+                 * this swap instead of freeing a victim tensor the in-flight
+                 * group may still reference; qt_lfru_tick_locked already
+                 * cleared the victim's resident flag before enqueueing, so
+                 * restore it to keep the flag consistent with the tensor it
+                 * still holds. */
+                v->resident=1; qs(layer,eid)->queued=0;
+                pthread_mutex_unlock(&G.mx); free(w); free(sc); continue;
+            }
             ColiCudaTensor *a=v->tg,*b=v->tu,*ct=v->td;
             v->tg=v->tu=v->td=NULL;
             pthread_mutex_unlock(&G.mx);
@@ -497,7 +508,10 @@ void qt_shutdown(void){
             fprintf(stderr,"[qtier] HEAT_FILE saved: %s\n",hf);
         }
     }
-    pthread_mutex_lock(&G.mx); G.th_stop=1; pthread_cond_signal(&G.cv); pthread_mutex_unlock(&G.mx);
+    /* Wake cv_take too: the uploader's LFRU victim wait (and qt_note_block /
+     * qt_note_planned / qt_fill_wait, all waiting on the same condvar) would
+     * otherwise never notice th_stop and pthread_join below would hang (#1340). */
+    pthread_mutex_lock(&G.mx); G.th_stop=1; pthread_cond_signal(&G.cv); pthread_cond_broadcast(&G.cv_take); pthread_mutex_unlock(&G.mx);
     pthread_join(G.th,NULL);
     G.on=0;
     coli_cuda_shutdown();

--- a/c/qwen36_tier.c
+++ b/c/qwen36_tier.c
@@ -46,7 +46,7 @@ static struct {
     /* issue state of the (single) decode thread */
     int is_cnt[QT_MAX_DEV];
     int is_k[QT_MAX_DEV][32];
-    float *is_x;                          /* count*D input replicas per device */
+    float *is_x; size_t is_x_floats;      /* 32*D input replicas per device */
     /* M3 */
     int *fill_order; int fill_cur;        /* warmstart order (heat desc) */
     int issue_open;                       /* guard: no tensor_free while a group is in flight */
@@ -198,7 +198,11 @@ int qt_init(int nl, int ne, int D, int Ih, int cap, int topk, int expert_gs,
                 G.dev[i], freeb/1073741824.0, b/1073741824.0, b/G.exp_bytes);
     }
     G.slot=calloc((size_t)nl*ne,sizeof(QSlot));
-    G.is_x=malloc((size_t)32*D*sizeof(float));
+    /* qt_issue strides each device's block by 32*D floats (its max row
+     * count), not 8*D: a device other than 0 with a full 32-row issue used
+     * to run past its own slice and off the end of this allocation (#1339). */
+    G.is_x_floats=(size_t)G.ndev*32*D;
+    G.is_x=malloc(G.is_x_floats*sizeof(float));
     if(!G.slot||!G.is_x) return 0;
     /* load learned heat (HEAT_FILE): warmstart order + initial values */
     const char *hf=getenv("HEAT_FILE");
@@ -426,7 +430,7 @@ uint32_t qt_issue(int layer,const int *eids,int K,const float *x){
     for(int di=0;di<G.ndev;di++){
         int c=G.is_cnt[di];
         if(!c) continue;
-        float *xr=G.is_x + (size_t)di*8*G.D;               /* per-device input block */
+        float *xr=G.is_x + (size_t)di*32*G.D;              /* per-device input block */
         for(int j=0;j<c;j++) memcpy(xr+(size_t)j*G.D, x, (size_t)G.D*sizeof(float));
         if(!coli_cuda_expert_group_issue(tg[di],tu[di],td[di],rows,c,xr)){
             /* issue failed -> hand these k back to the CPU */

--- a/c/tests/qwen36_fake_cuda.h
+++ b/c/tests/qwen36_fake_cuda.h
@@ -1,0 +1,96 @@
+/* qwen36_fake_cuda.h -- fake CUDA backend shared by the qwen36 tier tests.
+ *
+ * Defines every coli_cuda_* symbol qwen36_tier.c links against (its
+ * signatures come from backend_cuda.h, which the tier includes on its own)
+ * and RECORDS what it receives, so a test can assert on real upload/issue
+ * traffic without a GPU or the CUDA toolkit. A test that only checked
+ * "qt_init returns 1" would pass even with the tier fully broken.
+ *
+ * Two settable hooks beyond plain recording:
+ *   fake_ndev        - device count returned by coli_cuda_available_device_count
+ *                       and coli_cuda_device_count (default 1).
+ *   fake_issue_hook   - called by coli_cuda_expert_group_issue with the issuing
+ *                       device (taken from g[0]->device), the row count and the
+ *                       input pointer; its return value is what issue returns.
+ *                       NULL (the default) reproduces the old always-0 stub. */
+#ifndef QWEN36_FAKE_CUDA_H
+#define QWEN36_FAKE_CUDA_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <time.h>
+
+/* MinGW non ha setenv: il tier legge la sua configurazione dall'ambiente, e il
+ * test deve poterla impostare anche su Windows. */
+#if defined(_WIN32)
+#include <stdlib.h>
+static int test_setenv(const char *name, const char *value, int overwrite) {
+    (void)overwrite; return _putenv_s(name, value);
+}
+#define setenv test_setenv
+#endif
+#include "../backend_cuda.h"
+
+struct ColiCudaTensor { int fmt, I, O, device, gs; const void *w; };
+
+static int fake_uploads;
+static int last_fmt = -1;
+static size_t last_bytes;
+static unsigned char captured[4096];
+static size_t captured_len;
+
+static int fake_ndev = 1;
+static int (*fake_issue_hook)(int device, int count, const float *x) = NULL;
+
+static int upload_common(ColiCudaTensor **t, const void *w, int fmt,
+                         int I, int O, int device, int gs) {
+    ColiCudaTensor *n = (ColiCudaTensor *)calloc(1, sizeof *n);
+    n->fmt = fmt; n->I = I; n->O = O; n->device = device; n->gs = gs; n->w = w;
+    *t = n;
+    fake_uploads++;
+    last_fmt = fmt;
+    last_bytes = (size_t)I * O / (fmt == 1 ? 1 : 2);
+    if (fake_uploads == 1) {
+        captured_len = last_bytes < sizeof captured ? last_bytes : sizeof captured;
+        memcpy(captured, w, captured_len);
+    }
+    return 1;
+}
+int coli_cuda_tensor_upload(ColiCudaTensor **t, const void *w, const float *s,
+                            int fmt, int I, int O, int device) {
+    (void)s; return upload_common(t, w, fmt, I, O, device, 0);
+}
+int coli_cuda_tensor_upload_g(ColiCudaTensor **t, const void *w, const float *s,
+                              int fmt, int I, int O, int device, int gs) {
+    (void)s; return upload_common(t, w, fmt, I, O, device, gs);
+}
+void coli_cuda_tensor_free(ColiCudaTensor *t) { free(t); }
+int coli_cuda_available_device_count(void) { return fake_ndev; }
+int coli_cuda_device_count(void) { return fake_ndev; }
+int coli_cuda_init(const int *d, int n) { (void)d; (void)n; return 1; }
+void coli_cuda_shutdown(void) {}
+int coli_cuda_mem_info(int device, size_t *freeb, size_t *total) {
+    (void)device;
+    *freeb = 2ull << 30; *total = 4ull << 30;      /* 2 GiB liberi */
+    return 1;
+}
+int coli_cuda_expert_group_issue(ColiCudaTensor *const *g, ColiCudaTensor *const *u,
+                                 ColiCudaTensor *const *d, const int *rows,
+                                 int count, const float *x) {
+    (void)u; (void)d; (void)rows;
+    if (fake_issue_hook) return fake_issue_hook(count > 0 ? g[0]->device : -1, count, x);
+    return 0;
+}
+const float *coli_cuda_expert_group_take(int device) { (void)device; return NULL; }
+void coli_cuda_group_stats(uint64_t *calls, uint64_t *experts, uint64_t *rows,
+                           double *h2d, double *kernel, double *d2h) {
+    if (calls) *calls = 0; if (experts) *experts = 0; if (rows) *rows = 0;
+    if (h2d) *h2d = 0; if (kernel) *kernel = 0; if (d2h) *d2h = 0;
+}
+void coli_cuda_stats(int device, size_t *count, size_t *bytes) {
+    (void)device; if (count) *count = 0; if (bytes) *bytes = 0;
+}
+
+#endif /* QWEN36_FAKE_CUDA_H */

--- a/c/tests/test_qwen36_tier_int8.c
+++ b/c/tests/test_qwen36_tier_int8.c
@@ -17,75 +17,9 @@
 #include <string.h>
 
 /* ---- backend CUDA finto: le firme vengono da backend_cuda.h, che il tier
-   include per conto suo; qui si definisce solo il corpo. ---- */
-#include <stdint.h>
-#include <time.h>
-
-/* MinGW non ha setenv: il tier legge la sua configurazione dall'ambiente, e il
- * test deve poterla impostare anche su Windows. */
-#if defined(_WIN32)
-#include <stdlib.h>
-static int test_setenv(const char *name, const char *value, int overwrite) {
-    (void)overwrite; return _putenv_s(name, value);
-}
-#define setenv test_setenv
-#endif
-#include "../backend_cuda.h"
-
-struct ColiCudaTensor { int fmt, I, O, device, gs; const void *w; };
-
-static int fake_uploads;
-static int last_fmt = -1;
-static size_t last_bytes;
-static unsigned char captured[4096];
-static size_t captured_len;
-
-static int upload_common(ColiCudaTensor **t, const void *w, int fmt,
-                         int I, int O, int device, int gs) {
-    ColiCudaTensor *n = (ColiCudaTensor *)calloc(1, sizeof *n);
-    n->fmt = fmt; n->I = I; n->O = O; n->device = device; n->gs = gs; n->w = w;
-    *t = n;
-    fake_uploads++;
-    last_fmt = fmt;
-    last_bytes = (size_t)I * O / (fmt == 1 ? 1 : 2);
-    if (fake_uploads == 1) {
-        captured_len = last_bytes < sizeof captured ? last_bytes : sizeof captured;
-        memcpy(captured, w, captured_len);
-    }
-    return 1;
-}
-int coli_cuda_tensor_upload(ColiCudaTensor **t, const void *w, const float *s,
-                            int fmt, int I, int O, int device) {
-    (void)s; return upload_common(t, w, fmt, I, O, device, 0);
-}
-int coli_cuda_tensor_upload_g(ColiCudaTensor **t, const void *w, const float *s,
-                              int fmt, int I, int O, int device, int gs) {
-    (void)s; return upload_common(t, w, fmt, I, O, device, gs);
-}
-void coli_cuda_tensor_free(ColiCudaTensor *t) { free(t); }
-int coli_cuda_available_device_count(void) { return 1; }
-int coli_cuda_device_count(void) { return 1; }
-int coli_cuda_init(const int *d, int n) { (void)d; (void)n; return 1; }
-void coli_cuda_shutdown(void) {}
-int coli_cuda_mem_info(int device, size_t *freeb, size_t *total) {
-    (void)device;
-    *freeb = 2ull << 30; *total = 4ull << 30;      /* 2 GiB liberi */
-    return 1;
-}
-int coli_cuda_expert_group_issue(ColiCudaTensor *const *g, ColiCudaTensor *const *u,
-                                 ColiCudaTensor *const *d, const int *rows,
-                                 int count, const float *x) {
-    (void)g; (void)u; (void)d; (void)rows; (void)count; (void)x; return 0;
-}
-const float *coli_cuda_expert_group_take(int device) { (void)device; return NULL; }
-void coli_cuda_group_stats(uint64_t *calls, uint64_t *experts, uint64_t *rows,
-                           double *h2d, double *kernel, double *d2h) {
-    if (calls) *calls = 0; if (experts) *experts = 0; if (rows) *rows = 0;
-    if (h2d) *h2d = 0; if (kernel) *kernel = 0; if (d2h) *d2h = 0;
-}
-void coli_cuda_stats(int device, size_t *count, size_t *bytes) {
-    (void)device; if (count) *count = 0; if (bytes) *bytes = 0;
-}
+   include per conto suo; il corpo (condiviso con gli altri test del tier) e'
+   in qwen36_fake_cuda.h. ---- */
+#include "qwen36_fake_cuda.h"
 
 #include "../qwen36_tier.c"
 

--- a/c/tests/test_qwen36_tier_int8_engine.c
+++ b/c/tests/test_qwen36_tier_int8_engine.c
@@ -1,0 +1,243 @@
+/* The warmstart must not free the int8 weights the tier still points at (#1341).
+ *
+ * The defect lives in the engine, not the tier: the warmstart hands the tier
+ * the live RAM weights -- `wg = expert_is_int4 ? e->g4 : (const uint8_t *)e->g`
+ * -- and qt_note_planned parks that pointer in the tier's slot. The very next
+ * statement used to free it unconditionally:
+ *
+ *     if (!keep8 && e->g) { free(e->g); e->g = e->u = e->d = NULL; }
+ *
+ * with a comment claiming an LFRU eviction "rematerializes from g4". That is
+ * true only for an int4 container. On an int8 container e->g4 is NULL: there is
+ * no second copy, slot_ensure_int8() returns early (`if (s->g || !s->g4)
+ * return;`), and the CPU fallback in the decode loop dereferences a NULL e->g.
+ * The tier's stored pointer is dangling on top of that, so any later stage()
+ * reads freed memory.
+ *
+ * Proving that needs the ENGINE, not just the tier -- the two earlier tier
+ * tests would pass with the engine freeing everything underneath them. So this
+ * one includes qwen36.c the way tests/test_qwen36_ctx.c does, builds an
+ * in-memory int8 model with NO container behind it (every slot pre-populated
+ * and indexed, so expert_get takes its hit path and never reads a file), and
+ * drives tier_warmstart() directly against the fake CUDA backend shared with
+ * the other tier tests.
+ *
+ * Include order matters: qwen36.c first (it never references coli_cuda_*),
+ * then the fake backend, then qwen36_tier.c -- which puts the tier's own
+ * statics (qs(), G) in this TU, so the test can read back the exact pointer
+ * the tier kept. No symbol collides between the two sources.
+ */
+#define main qwen36_main_unused
+#include "../qwen36.c"
+#undef main
+
+/* compat.h (pulled in by qwen36.c) maps setenv/unsetenv to
+ * SetEnvironmentVariableA, which updates the Win32 environment block -- but
+ * getenv() reads the CRT's own copy and never sees it, so the tier would
+ * silently not get COLI_CUDA here. Drop that mapping before the fake backend
+ * installs its _putenv_s version, and unset the same way. Same reasoning as
+ * tests/test_qwen36_ctx.c. */
+#ifdef _WIN32
+#undef setenv
+#undef unsetenv
+#define unsetenv(name) _putenv_s(name, "")
+#endif
+
+#include "qwen36_fake_cuda.h"
+
+#include "../qwen36_tier.c"
+
+static int fails;
+static void ck(int ok, const char *what) {
+    if (ok) { printf("  ok   %s\n", what); return; }
+    printf("  FAIL %s\n", what);
+    fails++;
+}
+
+enum { NL = 1, NE = 4, EXP_D = 64, EXP_IH = 32, TOPK = 1 };
+enum { NG = EXP_IH * EXP_D, ND = EXP_D * EXP_IH };   /* gate/up and down elements */
+
+/* Byte the setup writes at element i of matrix `which` (0=g,1=u,2=d) of expert
+ * eid. Kept in int4 range so the same generator can feed the packed model. */
+static int8_t want_byte(int eid, int which, int64_t i) {
+    return (int8_t)(((int)i + eid * 3 + which * 5) % 15 - 7);
+}
+
+/* An in-memory model with one layer of int8 experts and no container: cap ==
+ * n_experts (what qt_init demands) and every slot published in the layer's
+ * index, so expert_get() hits and load_expert_merged() is never reached. */
+static void build_model(Model *m) {
+    memset(m, 0, sizeof *m);
+    m->c.n_layers = NL; m->c.n_experts = NE;
+    m->c.hidden = EXP_D; m->c.inter = EXP_IH;
+    m->c.topk = TOPK; m->c.expert_gs = 0;
+    m->active_of  = calloc(NL, sizeof(int));
+    m->is_pinned  = calloc((size_t)NL * NE, 1);
+    m->is_queued  = calloc((size_t)NL * NE, 1);
+    m->cache      = calloc(NL, sizeof(LCache));
+    LCache *lc = &m->cache[0];
+    lc->cap = NE; lc->n = NE;
+    lc->slots = calloc(NE, sizeof(Slot));
+    lc->slot_by_expert = malloc(NE * sizeof(int));
+    for (int e = 0; e < NE; e++) {
+        Slot *s = &lc->slots[e];
+        slot_ensure_allocated(m, s);      /* the engine's own g|u|d block */
+        s->eid = e;
+        s->pinned = 1;                    /* nothing may evict during the test */
+        s->used = ++m->clock;
+        lc->slot_by_expert[e] = e;
+    }
+}
+
+static void fill_int8(Model *m) {
+    for (int e = 0; e < NE; e++) {
+        Slot *s = &m->cache[0].slots[e];
+        for (int64_t i = 0; i < NG; i++) { s->g[i] = want_byte(e, 0, i); s->u[i] = want_byte(e, 1, i); }
+        for (int64_t i = 0; i < ND; i++) s->d[i] = want_byte(e, 2, i);
+        for (int64_t i = 0; i < EXP_IH; i++) { s->gs[i] = 1.f; s->us[i] = 1.f; }
+        for (int64_t i = 0; i < EXP_D; i++) s->ds[i] = 1.f;
+    }
+}
+
+/* Same weights, but stored the way an int4 container stores them: packed
+ * g4|u4|d4 as the source of truth plus the unpacked int8 copy, exactly as
+ * load_expert_merged() leaves a slot when the tier is running. */
+static void fill_int4(Model *m) {
+    int64_t want_w = NG + NG + ND;
+    uint8_t *raw = malloc((size_t)(want_w / 2));
+    for (int e = 0; e < NE; e++) {
+        Slot *s = &m->cache[0].slots[e];
+        for (int64_t i = 0; i < want_w; i += 2) {
+            int which = i < NG ? 0 : (i < 2 * NG ? 1 : 2);
+            int64_t off = i - (which == 0 ? 0 : (which == 1 ? NG : 2 * NG));
+            uint8_t lo = (uint8_t)(want_byte(e, which, off)     & 0xF);
+            uint8_t hi = (uint8_t)(want_byte(e, which, off + 1) & 0xF);
+            raw[i >> 1] = (uint8_t)(lo | (hi << 4));
+        }
+        unpack_int4_to_int8(s->g, raw, want_w);
+        s->is_int4 = 1;
+        int64_t gp = NG / 2, up = NG / 2, dp = ND / 2;
+        s->g4 = malloc((size_t)gp); s->u4 = malloc((size_t)up); s->d4 = malloc((size_t)dp);
+        memcpy(s->g4, raw,           (size_t)gp);
+        memcpy(s->u4, raw + gp,      (size_t)up);
+        memcpy(s->d4, raw + gp + up, (size_t)dp);
+        for (int64_t i = 0; i < EXP_IH; i++) { s->gs[i] = 1.f; s->us[i] = 1.f; }
+        for (int64_t i = 0; i < EXP_D; i++) s->ds[i] = 1.f;
+    }
+    free(raw);
+}
+
+static void free_model(Model *m) {
+    LCache *lc = &m->cache[0];
+    for (int e = 0; e < NE; e++) {
+        Slot *s = &lc->slots[e];
+        free(s->g); free(s->gs);
+        free(s->g4); free(s->u4); free(s->d4);
+    }
+    free(lc->slots); free(lc->slot_by_expert);
+    free(m->cache); free(m->active_of); free(m->is_pinned); free(m->is_queued);
+}
+
+/* qt_fill_wait() returns when the queue is empty, and the uploader dequeues
+ * BEFORE uploading -- so wait on the observable end state instead. */
+static int wait_resident(void) {
+    for (int i = 0; i < 500; i++) {
+        int all = 1;
+        for (int e = 0; e < NE; e++) if (!qt_is_resident(0, e)) all = 0;
+        if (all) return 1;
+        struct timespec ts = {0, 2000000};          /* 2 ms */
+        nanosleep(&ts, NULL);
+    }
+    return 0;
+}
+
+/* Every weight the warmstart touched must still read back as written: an int8
+ * expert has no second copy to rebuild it from. */
+static int bytes_intact(Slot *s, int eid) {
+    for (int64_t i = 0; i < NG; i++)
+        if (s->g[i] != want_byte(eid, 0, i) || s->u[i] != want_byte(eid, 1, i)) return 0;
+    for (int64_t i = 0; i < ND; i++)
+        if (s->d[i] != want_byte(eid, 2, i)) return 0;
+    return 1;
+}
+
+/* --- an int8 container: the warmstart must leave the weights computable ---- */
+static void case_int8(void) {
+    printf("int8 container\n");
+    Model m; build_model(&m); fill_int8(&m);
+
+    setenv("COLI_CUDA", "1", 1);
+    setenv("COLI_GPUS", "0", 1);
+    unsetenv("QT_NO_WARMSTART");
+    unsetenv("COLI_KEEP_INT8");
+    fake_uploads = 0;
+
+    if (!qt_init(NL, NE, EXP_D, EXP_IH, NE, TOPK, 0 /* per-row */, 0 /* int8 */)) {
+        printf("  FAIL the tier refuses a per-row int8 container\n");
+        fails++; free_model(&m); return;
+    }
+    tier_warmstart(&m, 0);
+    qt_fill_wait();
+
+    ck(wait_resident(), "every planned int8 expert reached VRAM");
+    ck(fake_uploads == 3 * NE, "three uploads per planned expert (gate, up, down)");
+
+    int computable = 1, intact = 1, tier_live = 1;
+    for (int e = 0; e < NE; e++) {
+        Slot *s; expert_get(&m, 0, e, &s);
+        slot_ensure_int8(&m, s);          /* the decode loop's CPU fallback */
+        if (!s->g || !s->u || !s->d) { computable = 0; intact = 0; }
+        else if (!bytes_intact(s, e)) intact = 0;
+        if (qs(0, e)->g4 != (const uint8_t *)s->g) tier_live = 0;
+    }
+    /* outcome: planned_int8_experts_stay_computable_on_cpu */
+    ck(computable, "a planned int8 expert still has weights for the CPU fallback");
+    ck(intact, "those weights are the bytes the loader wrote");
+    /* outcome: tier_pointer_still_targets_live_weights */
+    ck(tier_live, "the pointer the tier kept still targets the live int8 block");
+
+    qt_shutdown();
+    free_model(&m);
+}
+
+/* --- an int4 container: the RSS optimisation must survive the fix ---------- */
+static void case_int4(void) {
+    printf("int4 container\n");
+    Model m; build_model(&m); fill_int4(&m);
+
+    setenv("COLI_CUDA", "1", 1);
+    setenv("COLI_GPUS", "0", 1);
+    unsetenv("QT_NO_WARMSTART");
+    unsetenv("COLI_KEEP_INT8");
+    fake_uploads = 0;
+
+    if (!qt_init(NL, NE, EXP_D, EXP_IH, NE, TOPK, 0 /* per-row */, 1 /* int4 */)) {
+        printf("  FAIL regression: the tier no longer starts on an int4 container\n");
+        fails++; free_model(&m); return;
+    }
+    tier_warmstart(&m, 1);
+    qt_fill_wait();
+    ck(wait_resident(), "every planned int4 expert reached VRAM");
+
+    int freed = 1, remat = 1;
+    for (int e = 0; e < NE; e++) {
+        Slot *s; expert_get(&m, 0, e, &s);
+        if (s->g) freed = 0;
+        slot_ensure_int8(&m, s);
+        if (!s->g || !bytes_intact(s, e)) remat = 0;
+    }
+    /* outcome: int4_path_still_frees_its_second_copy */
+    ck(freed, "int4 still drops the int8 copy right after staging (peak RSS)");
+    ck(remat, "slot_ensure_int8 rebuilds it from the packed g4/u4/d4");
+
+    qt_shutdown();
+    free_model(&m);
+}
+
+int main(void) {
+    case_int8();
+    case_int4();
+    if (fails) { printf("FAILED %d\n", fails); return 1; }
+    printf("OK test_qwen36_tier_int8_engine\n");
+    return 0;
+}

--- a/c/tests/test_qwen36_tier_multidev.c
+++ b/c/tests/test_qwen36_tier_multidev.c
@@ -1,0 +1,112 @@
+/* The tier's per-device input-replica block overruns G.is_x (#1339).
+ *
+ * The defect: qt_init allocated G.is_x as 32*D floats total (one device's
+ * worth), but qt_issue strides each device's block by 8*D floats and then
+ * writes up to 32 rows into it -- device di's block starts at 8*di*D but can
+ * span 32*D floats, so any di>0 with a full 32-row issue writes past both its
+ * own slice and the end of the allocation. With two devices and 32 resident
+ * experts routed to device 1, device 1's block starts at 8*D and ends at
+ * 8*D+32*D = 40*D, well past the 32*D-float buffer -- silent heap corruption
+ * that only ASan (or a real GPU driver) would ever complain about.
+ *
+ * This uses the same fake CUDA backend as test_qwen36_tier_int8.c
+ * (tests/qwen36_fake_cuda.h) with fake_ndev=2 and a fake_issue_hook that
+ * records exactly which (device, x pointer, row count) each issue call used,
+ * so the test can check the recorded blocks against the real allocation
+ * bounds without a GPU or ASan. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "qwen36_fake_cuda.h"
+
+#include "../qwen36_tier.c"
+
+static int fails;
+static void check(int ok, const char *what) {
+    if (!ok) { printf("  FAIL: %s\n", what); fails++; }
+}
+
+enum { MAX_REC = 8 };
+static struct { int device, count; const float *x; } records[MAX_REC];
+static int nrec;
+static int record_issue(int device, int count, const float *x) {
+    if (nrec < MAX_REC) {
+        records[nrec].device = device; records[nrec].count = count; records[nrec].x = x;
+        nrec++;
+    }
+    return 1;
+}
+
+int main(void) {
+    enum { NL = 1, NE = 64, D = 64, IH = 32, TOPK = 32 };
+    setenv("COLI_CUDA", "1", 1);
+    setenv("COLI_GPUS", "0,1", 1);
+    setenv("QT_NO_WARMSTART", "1", 1);
+    fake_ndev = 2;
+
+    if (!qt_init(NL, NE, D, IH, NE, TOPK, 0 /* per-row */, 1 /* int4 */)) {
+        printf("  FAIL: il tier non parte con due device finti\n");
+        return 1;
+    }
+
+    /* Make every expert resident: qt_note_block blocks on queue space, so a
+     * single qt_fill_wait() after the loop is enough to drain the rest. */
+    static unsigned char g4[NE][D * IH / 2], u4[NE][D * IH / 2], d4[NE][D * IH / 2];
+    static float sc[NE][2 * IH + D];   /* gs=0 -> sc_gu=IH, sc_d=D */
+    for (int eid = 0; eid < NE; eid++) {
+        memset(g4[eid], (unsigned char)(eid + 1), sizeof g4[eid]);
+        memset(u4[eid], (unsigned char)(eid + 2), sizeof u4[eid]);
+        memset(d4[eid], (unsigned char)(eid + 3), sizeof d4[eid]);
+        for (int i = 0; i < 2 * IH + D; i++) sc[eid][i] = 1.0f;
+        qt_note_block(0, eid, g4[eid], u4[eid], d4[eid], sc[eid], sc[eid] + IH, sc[eid] + 2 * IH);
+    }
+    qt_fill_wait();
+    for (int eid = 0; eid < NE; eid++)
+        check(qt_is_resident(0, eid), "expert did not become resident during warmstart");
+
+    fake_issue_hook = record_issue;
+    float x[D];
+    for (int i = 0; i < D; i++) x[i] = (float)i;
+
+    /* All 32 issued experts are odd -> home(eid)=eid%2 routes every one of
+     * them to device 1, the case that overruns today. */
+    int eids[32];
+    for (int k = 0; k < 32; k++) eids[k] = 2 * k + 1;
+    uint32_t mask = qt_issue(0, eids, 32, x);
+    check(mask == 0xFFFFFFFFu, "issuing 32 resident odd-numbered experts did not set all 32 mask bits");
+    check(nrec == 1 && records[0].device == 1 && records[0].count == 32,
+          "32 odd-numbered experts should issue as one 32-row group on device 1");
+
+    int base2 = nrec;
+    int eids2[32];
+    for (int k = 0; k < 16; k++) { eids2[k] = 2 * k; eids2[16 + k] = 2 * k + 1; }
+    uint32_t mask2 = qt_issue(0, eids2, 32, x);
+    check(mask2 == 0xFFFFFFFFu, "issuing a mixed even/odd batch did not set all 32 mask bits");
+
+    int inside = 1;
+    for (int i = 0; i < nrec; i++) {
+        const float *lo = G.is_x, *hi = G.is_x + G.is_x_floats;
+        if (!(records[i].x >= lo && records[i].x + (size_t)records[i].count * G.D <= hi))
+            inside = 0;
+    }
+    check(inside, "blocks_stay_inside_the_replica_buffer");
+
+    check(nrec == base2 + 2, "the mixed batch should issue once per device (two calls)");
+    if (nrec == base2 + 2) {
+        const float *a0 = records[base2].x, *a1 = records[base2 + 1].x;
+        size_t c0 = (size_t)records[base2].count, c1 = (size_t)records[base2 + 1].count;
+        int disjoint = (a0 + c0 * G.D <= a1) || (a1 + c1 * G.D <= a0);
+        check(disjoint, "device_blocks_do_not_overlap");
+    }
+
+    float val[32]; for (int k = 0; k < 32; k++) val[k] = 1.0f;
+    float out[D]; memset(out, 0, sizeof out);
+    qt_take(mask2, val, 32, out);   /* take returns NULL in the fake backend; fine */
+
+    qt_shutdown();
+
+    if (fails) { printf("test_qwen36_tier_multidev: %d fallimenti\n", fails); return 1; }
+    printf("test_qwen36_tier_multidev: ok\n");
+    return 0;
+}

--- a/c/tests/test_qwen36_tier_shutdown.c
+++ b/c/tests/test_qwen36_tier_shutdown.c
@@ -1,0 +1,132 @@
+/* qt_shutdown hangs when a group is open and a swap is queued (#1340).
+ *
+ * The defect: qt_shutdown sets G.th_stop and signals only G.cv, then
+ * pthread_join()s the uploader. But the uploader's LFRU victim path waits on
+ * G.cv_take -- "while(G.issue_open && !G.th_stop) pthread_cond_wait(&G.cv_take,
+ * &G.mx)" -- and nothing ever broadcasts G.cv_take from qt_shutdown. If a
+ * caller issued a group (qt_issue, which sets G.issue_open=1) and never took
+ * it (qt_take is what clears issue_open and broadcasts G.cv_take), a queued
+ * swap parks the uploader on that wait forever, and qt_shutdown's
+ * pthread_join never returns.
+ *
+ * This test reproduces exactly that sequence with the fake CUDA backend
+ * (tests/qwen36_fake_cuda.h, no GPU needed): budget one expert in, issue it
+ * without taking it, queue an LFRU swap directly (what qt_lfru_tick_locked
+ * does), then call qt_shutdown() under an alarm(10) so a hang fails loudly
+ * instead of wedging CI. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <unistd.h>
+#include <time.h>
+
+#include "qwen36_fake_cuda.h"
+
+#include "../qwen36_tier.c"
+
+static int fails;
+static void check(int ok, const char *what) {
+    if (!ok) { printf("  FAIL: %s\n", what); fails++; }
+}
+
+static int issue_ok(int device, int count, const float *x) {
+    (void)device; (void)count; (void)x; return 1;
+}
+
+static void on_alarm(int sig) {
+    (void)sig;
+    (void)!write(2,"FAIL: qt_shutdown hung\n",23);
+    _exit(1);
+}
+
+/* Poll a G.mx-guarded predicate without a busy spin. */
+static int wait_for_resident(int layer, int eid, int want, int max_polls) {
+    for (int i = 0; i < max_polls; i++) {
+        pthread_mutex_lock(&G.mx);
+        int r = qs(layer, eid)->resident;
+        pthread_mutex_unlock(&G.mx);
+        if (r == want) return 1;
+        struct timespec ts = {0, 2000000};   /* 2 ms */
+        nanosleep(&ts, NULL);
+    }
+    return 0;
+}
+
+int main(void) {
+    enum { D = 64 };
+    setenv("COLI_CUDA", "1", 1);
+    setenv("COLI_GPUS", "0", 1);
+    setenv("QT_NO_WARMSTART", "1", 1);
+    /* exp_bytes = 3*D*IH/2 + (2*IH+D)*4 + 4096 = 3072+512+4096 = 7680 B.
+     * 0.00001 GiB ~= 10737 B: enough for one expert (7680), not two (15360). */
+    setenv("CUDA_EXPERT_GB", "0.00001", 1);
+    fake_ndev = 1;
+
+    if (!qt_init(1, 2, D, 32, 2, 1, 0 /* per-row */, 1 /* int4 */)) {
+        printf("  FAIL: il tier non parte\n");
+        return 1;
+    }
+
+    static unsigned char g4[2][D * 32 / 2], u4[2][D * 32 / 2], d4[2][D * 32 / 2];
+    static float sc[2][2 * 32 + D];
+    for (int eid = 0; eid < 2; eid++) {
+        memset(g4[eid], (unsigned char)(eid + 1), sizeof g4[eid]);
+        memset(u4[eid], (unsigned char)(eid + 2), sizeof u4[eid]);
+        memset(d4[eid], (unsigned char)(eid + 3), sizeof d4[eid]);
+        for (int i = 0; i < 2 * 32 + D; i++) sc[eid][i] = 1.0f;
+    }
+    /* Expert 0 fits the budget and gets uploaded; expert 1's pointers are
+     * stored (needed for the later swap) but the budget refuses its upload. */
+    qt_note(0, 0, g4[0], u4[0], d4[0], sc[0], sc[0] + 32, sc[0] + 2 * 32);
+    qt_note(0, 1, g4[1], u4[1], d4[1], sc[1], sc[1] + 32, sc[1] + 2 * 32);
+    wait_for_resident(0, 0, 1, 500);
+    check(qt_is_resident(0, 0), "expert 0 should have fit the one-expert budget");
+    check(!qt_is_resident(0, 1), "expert 1 should have been refused by the exhausted budget");
+
+    /* Open a group on the resident expert and deliberately never take it --
+     * that is what leaves G.issue_open set going into shutdown. */
+    fake_issue_hook = issue_ok;
+    float x[D]; for (int i = 0; i < D; i++) x[i] = (float)i;
+    int resident_eid = 0;
+    uint32_t mask = qt_issue(0, &resident_eid, 1, x);
+    check(mask == 1u, "issuing the resident expert should set mask bit 0");
+
+    /* Queue an LFRU swap directly -- exactly what qt_lfru_tick_locked does. */
+    pthread_mutex_lock(&G.mx);
+    qs(0, resident_eid)->resident = 0;
+    int queued = enqueue_locked(0, 1, 0, resident_eid, 0);
+    pthread_mutex_unlock(&G.mx);
+    check(queued, "the swap should have been enqueued (queue has room, victim provided)");
+
+    /* Give the uploader a moment to dequeue the swap and park on the victim
+     * wait (poll G.qn==0 under the lock, up to 1s). */
+    int parked = 0;
+    for (int i = 0; i < 500; i++) {
+        pthread_mutex_lock(&G.mx);
+        int qn = G.qn;
+        pthread_mutex_unlock(&G.mx);
+        if (qn == 0) { parked = 1; break; }
+        struct timespec ts = {0, 2000000};
+        nanosleep(&ts, NULL);
+    }
+    check(parked, "the uploader should have dequeued the swap within 1s");
+
+    signal(SIGALRM, on_alarm);
+    alarm(10);
+    qt_shutdown();
+    alarm(0);
+    check(!G.on, "shutdown_returns_while_a_group_is_open");
+    /* The abandoned swap must leave the victim exactly as the open group left
+     * it, and must not have driven the incoming expert's upload after
+     * shutdown began. The uploader is already joined here, so reading G
+     * needs no lock. */
+    check(qs(0, resident_eid)->resident && qs(0, resident_eid)->tg,
+          "shutdown_abandons_the_swap_instead_of_freeing_the_victim");
+    check(!qs(0, 1)->queued && !qs(0, 1)->resident && G.uploads == 1,
+          "shutdown_abandons_the_swap_instead_of_uploading_the_incoming_expert");
+
+    if (fails) { printf("test_qwen36_tier_shutdown: %d fallimenti\n", fails); return 1; }
+    printf("test_qwen36_tier_shutdown: ok\n");
+    return 0;
+}

--- a/c/tests/test_qwen36_tier_shutdown.c
+++ b/c/tests/test_qwen36_tier_shutdown.c
@@ -12,7 +12,7 @@
  * This test reproduces exactly that sequence with the fake CUDA backend
  * (tests/qwen36_fake_cuda.h, no GPU needed): budget one expert in, issue it
  * without taking it, queue an LFRU swap directly (what qt_lfru_tick_locked
- * does), then call qt_shutdown() under an alarm(10) so a hang fails loudly
+ * does), then call qt_shutdown() under a 10 s watchdog so a hang fails loudly
  * instead of wedging CI. */
 #include <stdio.h>
 #include <stdlib.h>
@@ -34,10 +34,22 @@ static int issue_ok(int device, int count, const float *x) {
     (void)device; (void)count; (void)x; return 1;
 }
 
-static void on_alarm(int sig) {
-    (void)sig;
-    (void)!write(2,"FAIL: qt_shutdown hung\n",23);
-    _exit(1);
+/* A hang must fail, not sit forever in CI. alarm()/SIGALRM would do it on
+ * POSIX, but MinGW has neither, and the Windows job is the one that proved
+ * it. A detached thread that sleeps and then checks a flag does the same
+ * job everywhere the test already builds (it uses pthread and nanosleep). */
+static volatile int shutdown_done = 0;
+static void *hang_watchdog(void *arg) {
+    (void)arg;
+    for (int i = 0; i < 100 && !shutdown_done; i++) {   /* 100 x 100 ms = 10 s */
+        struct timespec ts = {0, 100000000};
+        nanosleep(&ts, NULL);
+    }
+    if (!shutdown_done) {
+        (void)!write(2, "FAIL: qt_shutdown hung\n", 23);
+        _exit(1);
+    }
+    return NULL;
 }
 
 /* Poll a G.mx-guarded predicate without a busy spin. */
@@ -112,10 +124,11 @@ int main(void) {
     }
     check(parked, "the uploader should have dequeued the swap within 1s");
 
-    signal(SIGALRM, on_alarm);
-    alarm(10);
+    pthread_t watchdog;
+    if (pthread_create(&watchdog, NULL, hang_watchdog, NULL) == 0)
+        pthread_detach(watchdog);
     qt_shutdown();
-    alarm(0);
+    shutdown_done = 1;
     check(!G.on, "shutdown_returns_while_a_group_is_open");
     /* The abandoned swap must leave the victim exactly as the open group left
      * it, and must not have driven the incoming expert's upload after


### PR DESCRIPTION
## Summary

Three pre-existing bugs in the Qwen3.6 CUDA expert tier, found while porting the tier to Vulkan (#1338) and filed as #1339, #1340, #1341. One commit per issue, each with a test that fails on the tree before its fix. The tests link `qwen36_tier.c` against a fake CUDA backend (`tests/qwen36_fake_cuda.h`, factored out of the existing `test_qwen36_tier_int8.c`), so they run in the plain CPU build and in CI.

- **#1339** `qt_issue` strides each device's input block by `8*D` floats into a buffer of `32*D` floats. With two or more GPUs, a full 32-row issue on device 1 writes past the end of the allocation. Fix: allocate `ndev*32*D` floats and stride by `32*D`. The new struct field `is_x_floats` exists so the test can assert against the real allocation rather than restate the arithmetic.
- **#1340** `qt_shutdown` signals `cv` but never `cv_take`, so the uploader parked on the LFRU victim wait (and `qt_note_*`/`qt_fill_wait` waiters) never notice `th_stop` and `pthread_join` hangs when a group is still open. Fix: broadcast `cv_take` too; the uploader abandons a swap it wakes into during shutdown instead of freeing a victim tensor an in-flight group may still reference.
- **#1341** After #1334, the warmstart hands the tier the live int8 weights and then frees them, assuming eviction rematerialises from `g4`. That only holds for int4; int8 has no second copy, so the tier's pointer dangles and the CPU fallback dereferences NULL. Fix: free the int8 copy only for int4 containers. The warmstart is extracted into `tier_warmstart()` so the engine-level test can drive it without `main`.

Notes for review: with int8 weights kept, the tier's slot pointer aliases a live engine slot; that is safe because `qt_init` requires `cap == n_experts`, so a planned slot is never recycled. The `cv_take` broadcast makes a benign post-shutdown enqueue reachable if a caller races `qt_note_*` against `qt_shutdown` (previously that caller blocked forever); left as is to keep the diff surgical. `qt_shutdown` still frees none of `G`'s allocations (pre-existing, untouched).

## Validation

- [x] `make -C c check` (OK, skipped=35) and `make -C c test-asan` (clean under ASan+UBSan)
- [x] CUDA changes were tested with `make -C c cuda-test` (if applicable) — on a Colab Tesla T4 (driver 580.82.07, CUDA 12.8), commit d937ad2: `make -C c cuda-test CUDA_ARCH=native` passes; the four tier tests pass; `make qwen36 CUDA=1 CUDA_ARCH=native` builds with 0 warnings; the CI tiny fixture (`--ebits 8`, int8 experts) decodes 16/16 tokens against the torch reference with the tier off, on (64/64 experts resident, 100 % VRAM hits), and on with a starved budget (`CUDA_EXPERT_GB=0.00002`: 1/64 resident, 317 CPU misses through the int8 fallback that #1341 fixes), tier-on output identical to tier-off. One warning appeared in that run from Colab's older gcc in the engine-test build, `qwen36.c:1450 -Waggressive-loop-optimizations`, in the pre-existing nibble-unpack tail loop that this PR does not touch; gcc 13 (CI) is clean.
- [x] Performance claims include hardware, commands, and repeatable measurements (no performance claims)

RED evidence, each against the tree without its fix:
- #1339: `test_qwen36_tier_multidev` under ASan with the old stride:
  ```
  =================================================================
  ==1336655==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x525000002100 at pc 0x7b42016fb303 bp 0x7ffeb9de4710 sp 0x7ffeb9de3eb8
  WRITE of size 256 at 0x525000002100 thread T0
      #2 0x5d36d942a1fc in qt_issue tests/../qwen36_tier.c:450
      #3 0x5d36d942c61f in main tests/test_qwen36_tier_multidev.c:76
  0x525000002100 is located 0 bytes after 8192-byte region [0x525000000100,0x525000002100)
  SUMMARY: AddressSanitizer: heap-buffer-overflow ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc:115 in memcpy
  ```
- #1340: `test_qwen36_tier_shutdown` hangs in `qt_shutdown`; the test's 10 s watchdog fires (`FAIL: qt_shutdown hung`). With the broadcast but without the drop path, the post-shutdown state checks fail (victim tensor freed, incoming expert uploaded after shutdown began).
- #1341: `test_qwen36_tier_int8_engine` against the tree with the extraction but the old free condition:
  ```
  int8 container
    ok   every planned int8 expert reached VRAM
    ok   three uploads per planned expert (gate, up, down)
    FAIL a planned int8 expert still has weights for the CPU fallback
    FAIL those weights are the bytes the loader wrote
    FAIL the pointer the tier kept still targets the live int8 block
  int4 container
    ok   every planned int4 expert reached VRAM
    ok   int4 still drops the int8 copy right after staging (peak RSS)
    ok   slot_ensure_int8 rebuilds it from the packed g4/u4/d4
  FAILED 3
  ```

Build: 0 warnings under the Makefile's flags for the tests and `make qwen36`.

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included

Fixes #1339, fixes #1340, fixes #1341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BacNGNxAJ1M57UdYE2M3N
