### PR TITLE
fix(metal): bit-exact fp8-e4m3 decode via ieee754 exponent bitcast

### DIFF
--- a/c/backend_metal.mm
+++ b/c/backend_metal.mm
@@ -137,7 +137,7 @@ kernel void mm_gemv(device const uchar* w      [[buffer(0)]],   // raw weight by
         wv = as_type<float>(0x7fc00000u);           // qNaN -- matches quant.h's e4m3_decode
       } else {
         float mag = (exp == 0) ? (float(mant) * 0.001953125f)                 // subnormal: mant*2^-9
-                                : (1.0f + float(mant)*0.125f) * exp2(float(int(exp) - 7));
+                                : (1.0f + float(mant)*0.125f) * as_type<float>((uint(exp) + 120u) << 23);
         wv = sign ? -mag : mag;
       }
       acc += wv * xr[i] * scl[i/128];


### PR DESCRIPTION
# Title

fix(metal): bit-exact fp8-e4m3 decode via ieee754 exponent bitcast

## Overview

This pull request resolves a test failure in `make -C c metal-test` on Apple M1 hardware (Apple7 GPU architecture), where the FP8 LUT exactness check reported 96/256 mismatches against the CPU reference decoder.

## Problem

In `c/backend_metal.mm`, the `mm_gemv` kernel decodes normalized FP8 E4M3 values using:

```metal
float mag = (exp == 0) ? (float(mant) * 0.001953125f)
                        : (1.0f + float(mant)*0.125f) * exp2(float(int(exp) - 7));
```

Because the Metal shader library compiles with fast-math enabled by default, `exp2()` uses hardware approximation instructions.

On Apple M1 (Apple7 architecture), `exp2()` on negative arguments (`exp` in `1..6`, representing powers `2^-6` through `2^-1`) evaluates 1 to 2 ULPs below the exact IEEE-754 value. For example, `exp2(-6.0f)` returns `0.0156249981` (`0x3c7ffffe`) instead of `0.015625` (`0x3c800000`).

While Apple M4 (Apple9 architecture) evaluates these specific powers accurately enough to match the reference, Apple M1 causes 96 codes (`6 exponent values x 2 signs x 8 mantissas`) to fail the strict bit-level comparison (`yg[b] != ref`) in `c/tests/test_backend_metal.mm:run_fp8_lut()`.

## Solution

Construct the power of two directly in IEEE-754 binary32 format instead of calling `exp2()`:

- In single-precision float representation, the exponent field has a bias of 127 and occupies bits 23 to 30.
- For `2^(exp - 7)`, the biased exponent is `(exp - 7) + 127 = exp + 120`.
- For all valid normalized codes (`exp` in `1..15`), `exp + 120` ranges from 121 to 135, which falls safely within normal float boundaries.
- Shifting this value by 23 bits and bit-casting using `as_type<float>((uint(exp) + 120u) << 23)` forms the exact power of two with 0 fractional bits.

Multiplying `(1.0f + float(mant) * 0.125f)` by an exact power of two is exact under IEEE-754 rules. This guarantees bitwise parity with the CPU reference across all GPU architectures (M1 through M4) while executing faster than a transcendental call and preserving fast-math optimizations for the rest of the shader library.

## Changes

File: `c/backend_metal.mm`

```diff
@@ -137,7 +137,7 @@ kernel void mm_gemv(device const uchar* w      [[buffer(0)]],   // raw weight by
         wv = as_type<float>(0x7fc00000u);           // qNaN -- matches quant.h's e4m3_decode
       } else {
         float mag = (exp == 0) ? (float(mant) * 0.001953125f)                 // subnormal: mant*2^-9
-                                : (1.0f + float(mant)*0.125f) * exp2(float(int(exp) - 7));
+                                : (1.0f + float(mant)*0.125f) * as_type<float>((uint(exp) + 120u) << 23);
         wv = sign ? -mag : mag;
       }
       acc += wv * xr[i] * scl[i/128];
```

## Verification

1. `make -C c metal-test`
   - Before: `fp8 LUT exactness (256/256 codes via GPU kernel) 96/256 mismatches *** MISMATCH`
   - After: `fp8 LUT exactness (256/256 codes via GPU kernel) 0/256 mismatches ok`
   - Result: All test cases pass; exit code 0.

2. `make check`
   - Ran 670 tests in 66.468s.
   - Result: OK (skipped=65); exit code 0.
