### PR TITLE
fix(qwen36): do not free the int8 weights the tier is still pointing at

### DIFF
--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -2811,11 +2811,27 @@ int main(int argc, char **argv) {
                 const uint8_t *wd = expert_is_int4 ? e->d4 : (const uint8_t *)e->d;
                 if (planned[gi] && wg) {
                     qt_note_planned(l, eidw, wg, wu, wd, e->gs, e->us, e->ds);
-                    /* The staging copy is done; free the int8 copy RIGHT AWAY
-                     * so it never shows up in peak RSS. On LFRU eviction
-                     * slot_ensure_int8() rematerializes from g4 (no container
-                     * access). */
-                    if (!keep8 && e->g) { free(e->g); e->g = e->u = e->d = NULL; }
+                    /* Liberare la copia int8 subito tiene basso il picco di RSS,
+                     * e su un container int4 e' sicuro: quel che si libera e'
+                     * `e->g`, mentre il tier tiene `e->g4`, un'allocazione
+                     * distinta, e slot_ensure_int8() sa rimaterializzare da li'
+                     * dopo uno sfratto LFRU.
+                     *
+                     * Su un container int8 NIENTE di tutto cio' e' vero, ed e' la
+                     * regressione di #1341: il puntatore appena consegnato al
+                     * tier E' `e->g`. Liberarlo lascia il tier con un puntatore
+                     * a memoria morta per il re-staging, e slot_ensure_int8()
+                     * -- che esce subito quando g4 e' NULL -- non ha nulla da
+                     * cui ricostruire, quindi il fallback CPU dereferenzia NULL.
+                     *
+                     * Il costo onesto e' questo: un container int8 non ha una
+                     * copia impacchettata a meta' dimensione da tenere al posto
+                     * dell'altra, quindi il risparmio di RAM che l'int4 ottiene
+                     * qui l'int8 non puo' ottenerlo. Fingere il contrario e'
+                     * esattamente cio' che ha creato il bug. */
+                    if (!keep8 && e->g && expert_is_int4) {
+                        free(e->g); e->g = e->u = e->d = NULL;
+                    }
                 }
             }
             qt_fill_wait();

--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -2817,19 +2817,28 @@ int main(int argc, char **argv) {
                      * distinta, e slot_ensure_int8() sa rimaterializzare da li'
                      * dopo uno sfratto LFRU.
                      *
-                     * Su un container int8 NIENTE di tutto cio' e' vero, ed e' la
-                     * regressione di #1341: il puntatore appena consegnato al
-                     * tier E' `e->g`. Liberarlo lascia il tier con un puntatore
-                     * a memoria morta per il re-staging, e slot_ensure_int8()
-                     * -- che esce subito quando g4 e' NULL -- non ha nulla da
-                     * cui ricostruire, quindi il fallback CPU dereferenzia NULL.
+                     * Su un container int8 niente di cio' e' vero, ed e' la
+                     * regressione di #1341: il puntatore consegnato al tier E'
+                     * `e->g`. Liberarlo lascia il tier con memoria morta per il
+                     * re-staging, e slot_ensure_int8() -- che esce subito quando
+                     * g4 e' NULL -- non ha nulla da cui ricostruire, quindi il
+                     * fallback CPU dereferenzia NULL.
                      *
-                     * Il costo onesto e' questo: un container int8 non ha una
+                     * La condizione qui NON nomina i formati apposta. Scrivere
+                     * "libera solo se int4" funzionerebbe oggi e codificherebbe
+                     * la corrispondenza ATTUALE fra formato e proprieta' della
+                     * memoria: chi domani aggiunge un terzo formato che aliasa
+                     * `e->g` non ha motivo di sospettare che quel controllo
+                     * parli di ownership. `wg != e->g` dice invece l'invariante
+                     * vero e per sempre -- non liberare cio' che hai appena
+                     * consegnato -- e un formato futuro che aliasa e' corretto
+                     * senza che nessuno se ne ricordi.
+                     *
+                     * Il costo resta, e va detto: un container int8 non ha una
                      * copia impacchettata a meta' dimensione da tenere al posto
                      * dell'altra, quindi il risparmio di RAM che l'int4 ottiene
-                     * qui l'int8 non puo' ottenerlo. Fingere il contrario e'
-                     * esattamente cio' che ha creato il bug. */
-                    if (!keep8 && e->g && expert_is_int4) {
+                     * qui l'int8 non puo' ottenerlo. */
+                    if (!keep8 && e->g && wg != (const uint8_t *)e->g) {
                         free(e->g); e->g = e->u = e->d = NULL;
                     }
                 }

--- a/c/tests/test_qwen36_tier_int8.c
+++ b/c/tests/test_qwen36_tier_int8.c
@@ -143,6 +143,23 @@ int main(void) {
         if (captured[i] != (unsigned char)(i & 0x7f)) { intact = 0; break; }
     check(intact, "i pesi int8 sono stati alterati durante lo staging (XOR di troppo?)");
 
+    /* ---- 1b. il tier CONSERVA il puntatore: chi glielo passa non puo' liberarlo
+       ----------------------------------------------------------------------
+       #1341: la mia prima versione consegnava al tier i pesi int8 e la riga
+       dopo li liberava. Il test guardava che i byte ARRIVASSERO, non che
+       restassero validi, quindi non se n'e' accorto. Qui si pretende che il
+       tier stia ancora puntando alla memoria viva del chiamante -- se la
+       ritiene, il chiamante deve tenerla in vita, ed e' un contratto che va
+       scritto invece che sperato. */
+    {
+        QSlot *slot = qs(layers[0], eids[0]);
+        check(slot->g4 == g,
+              "il tier deve ritenere il puntatore che gli e' stato dato: chi lo "
+              "libera dopo averlo consegnato crea un use-after-free (#1341)");
+        check(slot->u4 == u && slot->d4 == d,
+              "anche up/down devono restare quelli consegnati");
+    }
+
     qt_shutdown();
 
     /* ---- 2. int8 + scale raggruppate: il kernel non sa esprimerle ---- */


### PR DESCRIPTION
Fixes #1341, reported by @crichalchemist. **This is my regression from #1334.**

## The chain

```c
qt_note_planned(l, eidw, wg, wu, wd, ...);   /* the tier RETAINS wg */
if (!keep8 && e->g) { free(e->g); ... }      /* and the next line frees it */
```

On int4 that free is safe: what is freed is the int8 copy, while the tier holds `e->g4`, a separate allocation, and `slot_ensure_int8()` can rebuild from it. On int8 the pointer handed over **is** `e->g` — dangling pointer for re-staging, and `slot_ensure_int8()` returns immediately when `g4` is NULL, so the CPU fallback dereferences NULL.

The comment directly under my change already said *"on eviction slot_ensure_int8() rematerializes from g4"* — true for int4, false for int8. The code was stating the precondition my new branch broke, and I read it as describing the surrounding code rather than constraining what I was adding.

## Fixed so it stays fixed

My first version said `expert_is_int4`. That works today and encodes the *current* correspondence between format and memory ownership — whoever adds a third format that aliases `e->g` has no reason to suspect that check is about ownership.

The condition now names no format:

```c
if (!keep8 && e->g && wg != (const uint8_t *)e->g)
```

**Do not free what you just handed over.** A future aliasing format is correct without anyone remembering; a future format with a separate copy still frees as before. Verified across five cases including two formats that do not exist yet.

## The honest cost

An int8 container has no half-size packed copy to keep instead of the full one, so the RAM saving int4 gets here is not available to int8. Pretending otherwise is what created the bug.

## What the test does and does not do

The tier test gains the missing contract: the tier **retains** the pointer, so the caller must not free it.

Stated plainly: **that check does not catch the caller-side violation.** Restore the unconditional free and the test stays green, because the defect lives in the warmstart, which needs a real CUDA tier to execute. This is precisely the class of bug a software backend would make testable in CI — a concrete example rather than an argument.