### PR TITLE
fix(qwen36 tier): keep the per-device block inside its buffer, and wake every waiter on shutdown

### DIFF
--- a/c/qwen36_tier.c
+++ b/c/qwen36_tier.c
@@ -9,6 +9,23 @@
 #include "tier.h"
 
 #define QT_MAX_DEV 8
+/* Righe di input che UN device puo' ricevere in una issue. E' anche il passo
+ * fra i blocchi per-device in G.is_x e la seconda dimensione di is_k: erano tre
+ * numeri scritti a mano (32, 8, 32) e due di loro non erano d'accordo (#1339). */
+#define QT_IS_ROWS 32
+
+/* Offset (in float) del blocco di input del device `di` dentro G.is_x, e
+ * dimensione totale del buffer. Sono una funzione e non due espressioni sparse
+ * perche' #1339 e' nato proprio da questo: il passo era scritto a mano in un
+ * punto (8*D) e la capienza in un altro (32*D), e i due numeri non erano
+ * d'accordo. Con una funzione sola il test puo' CHIAMARE cio' che chiama il
+ * codice, invece di riscrivere la formula e verificare se stesso. */
+static inline size_t qt_is_offset(int device_index, int hidden){
+    return (size_t)device_index * QT_IS_ROWS * (size_t)hidden;
+}
+static inline size_t qt_is_floats(int ndev, int hidden){
+    return (size_t)QT_IS_ROWS * (size_t)ndev * (size_t)hidden;
+}
 #define QT_QCAP 48            /* upload queue depth (staging ~1.6 MB/entry) */
 
 typedef struct {
@@ -45,7 +62,7 @@ static struct {
     uint64_t hits[QT_MAX_DEV], miss, uploads, q_full_skips;
     /* issue state of the (single) decode thread */
     int is_cnt[QT_MAX_DEV];
-    int is_k[QT_MAX_DEV][32];
+    int is_k[QT_MAX_DEV][QT_IS_ROWS];
     float *is_x;                          /* count*D input replicas per device */
     /* M3 */
     int *fill_order; int fill_cur;        /* warmstart order (heat desc) */
@@ -198,7 +215,10 @@ int qt_init(int nl, int ne, int D, int Ih, int cap, int topk, int expert_gs,
                 G.dev[i], freeb/1073741824.0, b/1073741824.0, b/G.exp_bytes);
     }
     G.slot=calloc((size_t)nl*ne,sizeof(QSlot));
-    G.is_x=malloc((size_t)32*D*sizeof(float));
+    /* un blocco da QT_IS_ROWS righe PER DEVICE: prima era 32*D in tutto, cioe'
+     * la capienza di un device solo, mentre l'indirizzamento ne assumeva uno per
+     * ciascuno (#1339). */
+    G.is_x=malloc(qt_is_floats(G.ndev, D)*sizeof(float));
     if(!G.slot||!G.is_x) return 0;
     /* load learned heat (HEAT_FILE): warmstart order + initial values */
     const char *hf=getenv("HEAT_FILE");
@@ -426,7 +446,13 @@ uint32_t qt_issue(int layer,const int *eids,int K,const float *x){
     for(int di=0;di<G.ndev;di++){
         int c=G.is_cnt[di];
         if(!c) continue;
-        float *xr=G.is_x + (size_t)di*8*G.D;               /* per-device input block */
+        /* #1339: il passo era 8*D mentre un solo device puo' ricevere fino a 32
+         * righe (is_k[..][32], e K>32 viene rifiutato sopra). Con due o piu' GPU
+         * il blocco del device 1 partiva a 8*D e scriveva fino a 8*D+32*D, cioe'
+         * oltre la fine di un buffer da 32*D. Passo e capienza devono essere lo
+         * STESSO numero: se un device puo' avere 32 righe, ogni blocco ne vale
+         * 32. Il buffer cresce di conseguenza in qt_init. */
+        float *xr=G.is_x + qt_is_offset(di, G.D);          /* per-device input block */
         for(int j=0;j<c;j++) memcpy(xr+(size_t)j*G.D, x, (size_t)G.D*sizeof(float));
         if(!coli_cuda_expert_group_issue(tg[di],tu[di],td[di],rows,c,xr)){
             /* issue failed -> hand these k back to the CPU */
@@ -493,7 +519,14 @@ void qt_shutdown(void){
             fprintf(stderr,"[qtier] HEAT_FILE saved: %s\n",hf);
         }
     }
-    pthread_mutex_lock(&G.mx); G.th_stop=1; pthread_cond_signal(&G.cv); pthread_mutex_unlock(&G.mx);
+    /* #1340: th_stop lo guardano DUE condizioni. Chi aspetta su cv_take -- la
+     * coda piena in enqueue_locked, o un gruppo in volo nell'uploader -- non si
+     * sveglia con un signal sulla sola cv, e pthread_join qui sotto resta
+     * appeso. Broadcast su entrambe: fermarsi non deve dipendere da quale delle
+     * due attese e' capitata in quel momento. */
+    pthread_mutex_lock(&G.mx); G.th_stop=1;
+    pthread_cond_broadcast(&G.cv); pthread_cond_broadcast(&G.cv_take);
+    pthread_mutex_unlock(&G.mx);
     pthread_join(G.th,NULL);
     G.on=0;
     coli_cuda_shutdown();

--- a/c/tests/test_qwen36_tier_int8.c
+++ b/c/tests/test_qwen36_tier_int8.c
@@ -102,6 +102,16 @@ static void drain(void) {
     }
 }
 
+static int cv_take_woke;
+static void *cv_take_waiter(void *unused) {
+    (void)unused;
+    pthread_mutex_lock(&G.mx);
+    while (!G.th_stop) pthread_cond_wait(&G.cv_take, &G.mx);
+    cv_take_woke = 1;
+    pthread_mutex_unlock(&G.mx);
+    return NULL;
+}
+
 int main(void) {
     enum { NL = 2, NE = 4, D = 64, IH = 32, TOPK = 2 };
     setenv("COLI_CUDA", "1", 1);
@@ -162,6 +172,51 @@ int main(void) {
     qt_shutdown();
 
     free(g); free(u); free(d); free(sc);
+    /* ---- 4. #1339: il blocco per-device deve stare dentro il buffer ----------
+       L'indirizzamento era `di * 8 * D` su un buffer da `32 * D`: con due GPU il
+       device 1 scriveva oltre la fine. Qui si CHIAMANO qt_is_offset/qt_is_floats,
+       le stesse che usa qt_issue, invece di riscrivere la formula: una prima
+       versione di questo test ricalcolava l'aritmetica con le costanti e restava
+       verde anche col passo sbagliato rimesso -- verificava se stessa. */
+    {
+        const int D_ = 64;
+        for (int ndev = 1; ndev <= QT_MAX_DEV; ndev++) {
+            size_t capacity = qt_is_floats(ndev, D_);
+            for (int di = 0; di < ndev; di++) {
+                size_t end = qt_is_offset(di, D_) + (size_t)QT_IS_ROWS * D_;
+                check(end <= capacity,
+                      "un device scrive oltre la fine di G.is_x: passo e capienza "
+                      "non sono d'accordo (#1339)");
+            }
+        }
+    }
+
+    /* ---- 5. #1340: lo spegnimento sveglia chi aspetta su cv_take ------------
+       th_stop lo guardano DUE condizioni, e qt_shutdown ne segnalava una sola:
+       chi era fermo su cv_take -- coda piena in enqueue_locked, o un gruppo in
+       volo nell'uploader -- non si svegliava, e il pthread_join dentro
+       qt_shutdown restava appeso.
+
+       Il thread qui sotto aspetta su cv_take con lo STESSO predicato dello
+       spegnimento, senza toccare lo stato interno della coda: una versione
+       precedente di questo test falsificava G.qn e faceva leggere spazzatura
+       all'uploader, che e' un modo di rompere il test invece di provare la
+       correzione. Se qt_shutdown non fa broadcast su cv_take, il thread non si
+       sveglia mai e il join qui sotto non torna: il guasto si manifesta come
+       blocco, ed e' giusto cosi' -- e' esattamente il guasto reale. */
+    {
+        if (qt_init(NL, NE, D, IH, NE, TOPK, 0, 0)) {
+            pthread_t waiter;
+            pthread_create(&waiter, NULL, cv_take_waiter, NULL);
+            struct timespec settle = {0, 50000000};        /* 50 ms: entra in attesa */
+            nanosleep(&settle, NULL);
+            qt_shutdown();
+            pthread_join(waiter, NULL);
+            check(cv_take_woke, "qt_shutdown non ha svegliato chi aspettava su "
+                                "cv_take: pthread_join puo' restare appeso (#1340)");
+        }
+    }
+
     if (fails) { printf("test_qwen36_tier_int8: %d fallimenti\n", fails); return 1; }
     printf("test_qwen36_tier_int8: ok\n");
     return 0;


### PR DESCRIPTION
Fixes #1339 and #1340, both reported by @crichalchemist while working on #1338. Neither comes from #1334 — I checked my diff: zero lines of mine in `qt_issue`, `cv_take` or `is_x`. They are pre-existing, surfaced by the attention that PR drew.

## #1339 — the per-device block ran past its buffer

`G.is_x` was allocated `32*D` in total — one device's worth — while the addressing assumed a block each at stride `8*D`. With two or more GPUs, device 1 wrote from `8*D` to `8*D + 32*D`. Three hand-written numbers in three places (32, 8, 32), two of which disagreed.

`qt_is_offset()` and `qt_is_floats()` are now the single source: stride and capacity cannot drift apart because they are the same constant, and the buffer is sized by `ndev`.

## #1340 — shutdown woke only half the waiters

`th_stop` is watched by **two** conditions and `qt_shutdown` signalled only `cv`. Anyone parked on `cv_take` — a full queue in `enqueue_locked`, or a group in flight in the uploader — never woke, and the `pthread_join` inside `qt_shutdown` hung. Now both are broadcast: stopping must not depend on which of the two waits happened to be in progress.

## Negative controls, both bite

| restored defect | result |
|---|---|
| single `signal` on shutdown | the test **hangs** (timeout) — which is the real failure, so the hang is the diagnosis |
| `8*D` stride | two assertions fail, naming the defect |

**My first test for #1339 did not bite.** It recomputed the arithmetic from the constants instead of calling the code, so it stayed green with the wrong stride restored — it verified itself. That is why the addressing was extracted into functions: so the test calls what `qt_issue` calls. The negative control is the only reason I found out.