### PR TITLE
build: list serve_poll.h among qwen36's prerequisites

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1026,7 +1026,7 @@ QWEN36_TIER_SRC =
 QWEN36_CFLAGS   = $(NOCUDA_CFLAGS)
 QWEN36_LDFLAGS  = $(NOCUDA_LDFLAGS)
 endif
-qwen36$(EXE): qwen36.c cli_args.h qwen36_tier.h st.h json.h compat.h edge_adapter_internal.h edge_adapters.h edge_runtime.h segment_adapter_internal.h segment_adapters.h segment_runtime.h $(QWEN36_TIER_SRC) $(CUDA_OBJ)
+qwen36$(EXE): qwen36.c serve_poll.h cli_args.h qwen36_tier.h st.h json.h compat.h edge_adapter_internal.h edge_adapters.h edge_runtime.h segment_adapter_internal.h segment_adapters.h segment_runtime.h $(QWEN36_TIER_SRC) $(CUDA_OBJ)
 	$(CC) $(QWEN36_CFLAGS) qwen36.c $(QWEN36_TIER_SRC) $(CUDA_OBJ) -o qwen36$(EXE) $(QWEN36_LDFLAGS)
 
 # Qwen3.8-Flash-Next text-only sibling. This target is intentionally CPU-only;


### PR DESCRIPTION
`dev` went red on `Python tests` right after #1284 landed:

```
FAIL: test_every_engine_rule_lists_the_headers_its_source_includes
AssertionError: Lists differ: ['qwen36 (qwen36.c) is missing: serve_poll.h'] != []
```

**The test is right and the drift is mine.** #1336 added `#include "serve_poll.h"` to `qwen36.c`; the hand-written prerequisite list in #1284 was compiled before that header existed. So touching `serve_poll.h` left `qwen36` unrebuilt — the exact silent staleness #1284 exists to prevent, on the first header to arrive after it.

Verified behaviourally rather than by list: `touch serve_poll.h && make qwen36` now relinks, where before it answered *up to date*. Checked the other six engines too — no further drift.

Worth saying plainly: this is the contract earning its place within an hour of landing. A hand-maintained list drifts the moment someone adds an include, and the only reason we know is that #1284 made the drift fail a test instead of producing a stale binary. It also means the derived-list version @Avicennasis was asked for is the durable answer, and this manual line is the interim.