### PR TITLE
fix(rss): count the memory we own, not what the kernel can reclaim

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1659,6 +1659,11 @@ tests/test_qwen36_tier_int8$(EXE): tests/test_qwen36_tier_int8.c qwen36_tier.c q
 tests/test_serve_poll$(EXE): tests/test_serve_poll.c serve_poll.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
+# Linux-only: legge /proc/self/status. La regola c'e' comunque, il test si
+# salta da solo dove /proc non esiste.
+tests/test_rss_anon$(EXE): tests/test_rss_anon.c
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
 tests/test_798_guards$(EXE): tests/test_798_guards.c st.h json.h compat.h route_trace.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -810,17 +810,44 @@ static double current_rss_gb(void) {
     return rss_gb();  /*Return peak memory usage if we can't measure current usage*/
   }
 
-  char line[256];
-  unsigned long long kb = 0;
+    char line[256];
+    unsigned long long kb = 0, anon_kb = 0, vmrss_kb = 0;
+    int have_anon = 0, have_vmrss = 0;
 
-  while (fgets(line, sizeof(line), f)) {
-    if (strncmp(line, "VmRSS:", 6) == 0) {
-      if (sscanf(line + 6, "%llu", &kb) == 1) {
-        fclose(f);
-        return (double)kb / (1024.0 * 1024.0);
+    /* RssAnon, non VmRSS: sono le pagine che il processo POSSIEDE davvero.
+     *
+     * VmRSS conta anche le pagine di file mappate, che il kernel recupera da
+     * solo quando serve memoria. Con COLI_MAP_EXPERTS=1 (#1325) gli esperti
+     * arrivano da una mappatura invece che da una copia, quindi VmRSS sale di
+     * gigabyte senza che un byte in piu' sia sottratto al sistema -- e
+     * rss_guard, che SFRATTA esperti quando la misura supera il budget, si
+     * metterebbe a sfrattare per liberare memoria che non stava occupando.
+     * Non un avviso cosmetico: cache distrutta e lavoro rifatto.
+     *
+     * Misurato su GLM-5.3 (391 GB di container, 25 GB di RAM): con la
+     * mappatura accesa il pianificatore riportava 18.2 GB e avvisava di uno
+     * sforamento di 0.8 GB che non esisteva.
+     *
+     * Senza mappatura RssAnon e VmRSS coincidono quasi esattamente, perche' la
+     * memoria degli esperti e' malloc'ata e quindi anonima: questo cambio NON
+     * altera il comportamento del percorso pread di oggi, ed e' la ragione per
+     * cui e' sicuro farlo PRIMA di accendere la mappatura.
+     *
+     * RssAnon esiste da Linux 4.5; se manca si torna a VmRSS, cioe' al
+     * comportamento precedente, che resta corretto quando nulla e' mappato. */
+    while (fgets(line, sizeof(line), f)) {
+      if (!have_anon && strncmp(line, "RssAnon:", 8) == 0) {
+        if (sscanf(line + 8, "%llu", &anon_kb) == 1) have_anon = 1;
+      } else if (!have_vmrss && strncmp(line, "VmRSS:", 6) == 0) {
+        if (sscanf(line + 6, "%llu", &vmrss_kb) == 1) have_vmrss = 1;
       }
+      if (have_anon && have_vmrss) break;
     }
-  }
+    if (have_anon || have_vmrss) {
+      kb = have_anon ? anon_kb : vmrss_kb;
+      fclose(f);
+      return (double)kb / (1024.0 * 1024.0);
+    }
 
   fclose(f);
   if(!announced_proc_failure) {

--- a/c/tests/test_rss_anon.c
+++ b/c/tests/test_rss_anon.c
@@ -12,6 +12,17 @@
  * una allocazione anonima -- se non facesse la seconda, avremmo reso la guardia
  * cieca invece che precisa, che sarebbe peggio del difetto. */
 #include <stdio.h>
+
+/* Il contratto verificato qui e' quello di /proc/self/status, che esiste solo
+ * su Linux: la guardia RSS su altre piattaforme usa gia' un'altra strada
+ * (rss_gb). Non c'e' niente da portare -- portarlo vorrebbe dire inventare un
+ * equivalente di RssAnon che il codice sotto test non usa. Su tutto il resto
+ * il test si dichiara saltato invece di fallire, cosi' `make check` resta
+ * verde ovunque e nessuno lo scopre da un rosso in CI. */
+#if !defined(__linux__)
+int main(void) { printf("test_rss_anon: non-Linux, skip\n"); return 0; }
+#else
+
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
@@ -105,3 +116,5 @@ int main(void) {
     printf("test_rss_anon: ok\n");
     return 0;
 }
+
+#endif /* __linux__ */

--- a/c/tests/test_rss_anon.c
+++ b/c/tests/test_rss_anon.c
@@ -1,0 +1,107 @@
+/* La guardia RSS deve contare la memoria che il processo POSSIEDE, non quella
+ * che il kernel puo' riprendersi da solo.
+ *
+ * rss_guard() sfratta esperti quando la misura supera il budget. Leggendo
+ * VmRSS, che include le pagine di file mappate, con COLI_MAP_EXPERTS=1 (#1325)
+ * la misura sale di gigabyte senza che un byte in piu' sia stato sottratto al
+ * sistema: la guardia si metterebbe a sfrattare per liberare memoria che non
+ * stava occupando.
+ *
+ * Il test mappa un file vero e pretende le DUE cose che rendono sicura la
+ * correzione: la misura non deve seguire la mappatura, e deve invece seguire
+ * una allocazione anonima -- se non facesse la seconda, avremmo reso la guardia
+ * cieca invece che precisa, che sarebbe peggio del difetto. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+static int fails;
+static void check(int ok, const char *what) {
+    if (!ok) { printf("  FAIL: %s\n", what); fails++; }
+}
+
+/* La stessa lettura che fa current_rss_gb in colibri.c: RssAnon con VmRSS come
+ * ripiego. Duplicata qui e non inclusa perche' colibri.c e' un'unita' enorme e
+ * questo test deve restare veloce; il contratto verificato e' identico. */
+static double rss_anon_gb(void) {
+    FILE *f = fopen("/proc/self/status", "r");
+    if (!f) return -1;
+    char line[256];
+    unsigned long long anon = 0, vm = 0;
+    int ha = 0, hv = 0;
+    while (fgets(line, sizeof line, f)) {
+        if (!ha && !strncmp(line, "RssAnon:", 8)) { if (sscanf(line+8, "%llu", &anon)==1) ha=1; }
+        else if (!hv && !strncmp(line, "VmRSS:", 6)) { if (sscanf(line+6, "%llu", &vm)==1) hv=1; }
+        if (ha && hv) break;
+    }
+    fclose(f);
+    if (!ha && !hv) return -1;
+    return (double)(ha ? anon : vm) / (1024.0 * 1024.0);
+}
+
+static double vmrss_gb(void) {
+    FILE *f = fopen("/proc/self/status", "r");
+    if (!f) return -1;
+    char line[256]; unsigned long long kb = 0;
+    while (fgets(line, sizeof line, f))
+        if (!strncmp(line, "VmRSS:", 6)) { sscanf(line+6, "%llu", &kb); break; }
+    fclose(f);
+    return (double)kb / (1024.0 * 1024.0);
+}
+
+int main(void) {
+    if (rss_anon_gb() < 0) { printf("test_rss_anon: /proc non leggibile, salto\n"); return 0; }
+
+    const size_t MAPPED = 256u << 20;          /* 256 MB: ben oltre il rumore */
+    char path[] = "/tmp/coli_rss_anon_XXXXXX";
+    int fd = mkstemp(path);
+    if (fd < 0) { perror("mkstemp"); return 1; }
+    if (ftruncate(fd, (off_t)MAPPED) != 0) { perror("ftruncate"); return 1; }
+
+    double anon_before = rss_anon_gb(), vm_before = vmrss_gb();
+
+    /* ---- 1. una mappatura di file toccata NON deve muovere la misura ---- */
+    char *m = mmap(NULL, MAPPED, PROT_READ, MAP_PRIVATE, fd, 0);
+    if (m == MAP_FAILED) { perror("mmap"); return 1; }
+    volatile char sink = 0;
+    for (size_t i = 0; i < MAPPED; i += 4096) sink ^= m[i];   /* falla residente */
+    (void)sink;
+
+    double anon_mapped = rss_anon_gb(), vm_mapped = vmrss_gb();
+
+    check(vm_mapped - vm_before > 0.15,
+          "il test non ha reso residente la mappatura: senza questo non prova nulla");
+    check(anon_mapped - anon_before < 0.05,
+          "la misura segue le pagine di file mappate: la guardia sfratterebbe "
+          "esperti per liberare memoria che il kernel puo' recuperare da solo");
+
+    munmap(m, MAPPED);
+    close(fd); unlink(path);
+
+    /* ---- 2. una allocazione ANONIMA deve invece muoverla ---- */
+    double anon_pre = rss_anon_gb();
+    const size_t ANON = 256u << 20;
+    char *a = malloc(ANON);
+    if (!a) { printf("  FAIL: malloc\n"); return 1; }
+    /* volatile e letta dopo: senza questo il compilatore elimina la scrittura
+     * (la memoria non viene mai riletta prima della free) e le pagine non
+     * vengono mai toccate davvero -- misurato: RssAnon fermo a +4 kB su 256 MB
+     * allocati. Un test che alloca senza toccare non misura niente. */
+    volatile char *va = (volatile char *)a;
+    for (size_t i = 0; i < ANON; i += 4096) va[i] = (char)(i & 0x7f);
+    volatile char keep = 0;
+    for (size_t i = 0; i < ANON; i += (4096 * 64)) keep ^= va[i];
+    (void)keep;
+    double anon_post = rss_anon_gb();
+    check(anon_post - anon_pre > 0.15,
+          "la misura NON segue la memoria anonima: la guardia sarebbe cieca, "
+          "che e' peggio del difetto che stiamo correggendo");
+    free(a);
+
+    if (fails) { printf("test_rss_anon: %d fallimenti\n", fails); return 1; }
+    printf("test_rss_anon: ok\n");
+    return 0;
+}


### PR DESCRIPTION
Groundwork for flipping `COLI_MAP_EXPERTS` on by default (#1325). This has to land **before** the mapping, not after.

## The defect

`current_rss_gb()` read `VmRSS`, which includes mapped file pages. With mapping enabled those pages inflate the reading by gigabytes while nothing extra is taken from the system — and `rss_guard()` does not merely warn: it **evicts experts** when the reading exceeds the budget. It would have destroyed the cache to free memory the kernel can reclaim on its own.

Measured on GLM-5.3 (391 GB container, 25.4 GB of RAM): with mapping on, the planner reported an 18.2 GB budget and warned of a 0.8 GB overshoot that did not exist. I found this while producing the low-RAM datapoint for #1325, so it is an observation rather than a hypothesis.

## The fix

Read `RssAnon`, falling back to `VmRSS` where `RssAnon` is absent (pre-4.5 kernels), which is exactly today's behaviour.

**Why it is safe to land now, with mapping still off:** without mapping the two are nearly identical, because expert memory is `malloc`'d and therefore anonymous. The `pread` path does not change behaviour.

## The test requires two things, not one

- the reading must **not** follow a file mapping that has been made resident;
- the reading must **still** follow an anonymous allocation.

Without the second, we would have made the guard blind rather than accurate — worse than the defect it fixes.

| control | result |
|---|---|
| old `VmRSS` reading restored | fails, naming the spurious eviction |
| current | green |

## One error in the test, worth recording

The first version allocated 256 MB and wrote it with `memset` without ever reading it back, so `-O1` eliminated the store and the pages were never faulted in — `RssAnon` moved by 4 kB out of 256 MB. A test that allocates without touching measures nothing. The writes are now volatile and read back.