### PR TITLE
Security: confine image_url local reads and pin CI actions by SHA

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,7 +46,7 @@ jobs:
         shell: msys2 {0}
     steps:
       - uses: actions/checkout@v4
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
           msystem: UCRT64
           update: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   push:
     branches: [dev, main]
 
+# CI only reads the tree; no job here writes to the repo. Pin the token to
+# read-only so a compromised step (or action) cannot push, tag or release.
+permissions:
+  contents: read
+
 jobs:
   engine:
     name: Engine (Linux, CPU)
@@ -55,7 +60,7 @@ jobs:
       - name: Lint both Dockerfiles
         # docker/Dockerfile is not built here (see above) but it is still shipped
         # and followed by users, so it gets checked for syntax at least.
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
         with:
           dockerfile: docker/Dockerfile
           failure-threshold: error
@@ -170,7 +175,7 @@ jobs:
       - uses: actions/checkout@v4
       - if: matrix.os == 'windows-latest'
         id: msys2
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
           msystem: UCRT64
           update: false
@@ -310,7 +315,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install CUDA toolkit (compiler only)
-        uses: Jimver/cuda-toolkit@v0.2.19
+        uses: Jimver/cuda-toolkit@4bd727d5619dc6fa323b1e76c3aa5dca94f5ec6d # v0.2.19
         with:
           # v0.2.19's version table stops at 12.6.2 — 12.6.3 fails the install
           # step with "Version not available" before nvcc is ever reached.
@@ -679,9 +684,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: MSVC environment (puts cl.exe on PATH for nvcc -ccbin)
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
       - name: Install CUDA toolkit (compiler only)
-        uses: Jimver/cuda-toolkit@v0.2.19
+        uses: Jimver/cuda-toolkit@4bd727d5619dc6fa323b1e76c3aa5dca94f5ec6d # v0.2.19
         with:
           # Same pin as engine-cuda-syntax: v0.2.19's version table stops at
           # 12.6.2. This installs to the default "C:\Program Files\NVIDIA GPU
@@ -694,7 +699,7 @@ jobs:
           # runtime headers/import lib ship as a separate installer component —
           # with '["nvcc"]' alone this fails at `#include <cuda_runtime.h>`.
           sub-packages: '["nvcc", "cudart"]'
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
           msystem: UCRT64
           update: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - if: matrix.os == 'windows-latest'
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
         with:
           msystem: UCRT64
           update: false

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -1597,7 +1597,16 @@ GLM53_IMAGE_OPEN, GLM53_IMAGE, GLM53_IMAGE_CLOSE = (
 
 
 def _image_bytes_from_url(url):
-    """data: URI, file:// o percorso sul disco -> i byte dell'immagine."""
+    """data: URI, file:// o percorso sul disco -> i byte dell'immagine.
+
+    A local path is read with the server process's own permissions. On a
+    server that binds beyond loopback (which already requires an API key),
+    an authenticated client could otherwise read any file the process can
+    reach -- e.g. "file:///etc/passwd". Two guards without breaking the
+    documented loopback single-user case: '..' is refused outright (never
+    needed for a real image path), and if COLI_IMAGE_ROOT is set the resolved
+    path must stay inside it, mirroring serve_static's relative_to() check.
+    Errors stay generic so the reply never confirms a path or its permissions."""
     if not isinstance(url, str) or not url:
         raise APIError(400, "image_url.url must be a non-empty string.", "messages")
     if url.startswith("data:"):
@@ -1615,12 +1624,21 @@ def _image_bytes_from_url(url):
         raise APIError(400, "remote image URLs are not fetched; send the image "
                             "as a base64 data: URI or a path on this machine.",
                        "messages")
-    path = url[7:] if url.startswith("file://") else url
+    raw = url[7:] if url.startswith("file://") else url
+    if ".." in Path(raw).parts:
+        raise APIError(400, "image path is not allowed.", "messages")
     try:
-        with open(path, "rb") as handle:
+        target = Path(raw).resolve()
+        image_root = os.environ.get("COLI_IMAGE_ROOT")
+        if image_root:
+            target.relative_to(Path(image_root).resolve())
+    except (ValueError, OSError):
+        raise APIError(400, "image path is not allowed.", "messages")
+    try:
+        with open(target, "rb") as handle:
             return handle.read()
-    except OSError as problem:
-        raise APIError(400, f"cannot read image {path}: {problem}", "messages")
+    except OSError:
+        raise APIError(400, "cannot read the requested image.", "messages")
 
 
 # Qwen3.8 splices images as <|vision_start|> + N x <|image_pad|> + <|vision_end|>,

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -2,6 +2,7 @@ import http.client
 import io
 import json
 import math
+import os
 import socket
 import tempfile
 import threading
@@ -17,7 +18,7 @@ from pathlib import Path
 from openai_server import (APIError, APIHandler, APIServer, ClientCancelled,
                            DEFAULT_CHAT_STOP_SEQUENCES, END, GenerationScheduler,
                            READY, Engine, InklingStreamSplit, StopFilter, ThinkingStreamSplit,
-                           _engine_error, cap_for_arch, conversation_cache_slot, model_arch,
+                           _engine_error, _image_bytes_from_url, cap_for_arch, conversation_cache_slot, model_arch,
                            generation_options, parse_tool_calls, parse_dsv4_tool_calls,
                            parse_arch_tool_calls, parse_k3_tool_calls, parse_qwen38_tool_calls,
                            read_engine_turn, render_chat, render_chat_kimi, render_chat_olmoe,
@@ -2565,6 +2566,49 @@ class ReasoningEffortTest(unittest.TestCase):
         text = render_chat(self.MESSAGES, enable_thinking=False,
                            reasoning_effort="xhigh")
         self.assertNotIn("Reasoning Effort", text)
+
+
+class ImageUrlPathGuard(unittest.TestCase):
+    """image_url.url points at a local file read with the server's rights.
+    A '..' path is refused; COLI_IMAGE_ROOT confines reads; errors stay
+    generic so a reply never confirms a path or its permissions."""
+
+    def setUp(self):
+        self._saved = os.environ.pop("COLI_IMAGE_ROOT", None)
+
+    def tearDown(self):
+        os.environ.pop("COLI_IMAGE_ROOT", None)
+        if self._saved is not None:
+            os.environ["COLI_IMAGE_ROOT"] = self._saved
+
+    def test_reads_a_plain_file_by_default(self):
+        with tempfile.TemporaryDirectory() as root:
+            img = Path(root) / "pic.png"
+            img.write_bytes(b"\x89PNG\r\n")
+            self.assertEqual(_image_bytes_from_url(str(img)), b"\x89PNG\r\n")
+            self.assertEqual(_image_bytes_from_url("file://" + str(img)),
+                             b"\x89PNG\r\n")
+
+    def test_dotdot_is_refused(self):
+        with self.assertRaises(APIError) as caught:
+            _image_bytes_from_url("/var/data/../../etc/passwd")
+        self.assertEqual(caught.exception.status, 400)
+        self.assertNotIn("passwd", str(caught.exception))
+
+    def test_image_root_confines_reads(self):
+        with tempfile.TemporaryDirectory() as root, \
+                tempfile.NamedTemporaryFile() as outside:
+            os.environ["COLI_IMAGE_ROOT"] = root
+            inside = Path(root) / "ok.png"
+            inside.write_bytes(b"ok")
+            self.assertEqual(_image_bytes_from_url(str(inside)), b"ok")
+            with self.assertRaises(APIError):
+                _image_bytes_from_url(outside.name)
+
+    def test_error_does_not_leak_the_path(self):
+        with self.assertRaises(APIError) as caught:
+            _image_bytes_from_url("/no/such/secret-name.png")
+        self.assertNotIn("secret-name", str(caught.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Security hardening from a review of the repository (C memory-safety, the Python server, the web/desktop front-ends, and CI). The review found nothing malicious and no RCE path via a crafted checkpoint: the C weight parsing already validates shape/offset and guards integer overflow (`st.h`, `coli_v4_layer_validate`). This PR closes the actionable, low-risk findings.

## Changes

### 1. `fix(server)` — local file read via `image_url.url`
`_image_bytes_from_url` reads a local path with the server process's own permissions. On a server that binds beyond loopback (which already requires an API key), an authenticated client could send `file:///etc/passwd` and read any file the process can reach, and the `OSError` message echoed the full path back, confirming a file's existence and permissions.

- Refuse `..` outright (never needed for a real image path).
- If `COLI_IMAGE_ROOT` is set, the resolved path must stay inside it, using the same `relative_to()` check `serve_static` already uses.
- Errors are generic, so a reply no longer confirms a path or its permissions.
- The documented loopback single-user case (a plain path or `file://` URI) is unchanged.
- Covered by `ImageUrlPathGuard` (4 tests). `test_openai_server` stays green (165 tests).

### 2. `ci` — GitHub Actions supply chain
- Third-party actions were referenced by mutable tags (`msys2/setup-msys2@v2`, `hadolint/hadolint-action@v3.1.0`, `Jimver/cuda-toolkit@v0.2.19`, `ilammy/msvc-dev-cmd@v1`). A tag can be moved by whoever controls the action's account, so a compromised maintainer would run arbitrary code with the job's `GITHUB_TOKEN` — including the `contents: write` token in `release.yml`. Each is pinned to the commit SHA the tag currently points at, with the version kept in a trailing comment.
- `ci.yml` had no `permissions` block; it only reads the tree, so its token is pinned to `contents: read` as defense in depth.
- Official `actions/*` are left on tags (lower risk, avoids a massive diff).

## Validation
- `python3 -m unittest tests.test_openai_server` → 165 tests OK
- `actionlint` on the three workflows → no new errors (only pre-existing shellcheck notes)
- YAML valid across all four workflows

## Suggested follow-ups (not included — they need a decision or end-to-end testing)
- **Model-download supply chain (highest severity):** the download scripts (`download_fp8.py` and `c/tools/*`) validate only file size, not a SHA-256 / signature. `hf_hub_download` already verifies the LFS hash, but the `curl` fallback and the ModelScope path do not. `fetch_deepgemm.sh` already pins by git commit and is a good model. Left out because it rewrites download logic for hundreds of GB that cannot be validated without a full download.
- **`release.yml`:** add `actions/attest-build-provenance` (SLSA, native to GitHub) to attest the binaries' provenance; today there is only a `SHA256SUMS.txt` generated by the same pipeline (proves integrity, not provenance).
- **`--repo` without an allowlist** in the conversion scripts.