### PR TITLE
feat(qwen36): the dense trunk places itself -- COLI_PLACE=auto, priced in bytes saved per byte of VRAM

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1674,6 +1674,15 @@ tests/test_qwen36_tier_shutdown$(EXE): tests/test_qwen36_tier_shutdown.c tests/q
 # int8 container there is no packed copy to rebuild them from (#1341). Includes
 # qwen36_tier.c in its own TU like the other tier tests, so nothing else is
 # compiled in and no model file is needed.
+# Same fake backend, the RULES the three regression tests above are instances
+# of: budget accounting balances on every device (reservations are consumed or
+# returned, never leaked), shutdown wakes all four cv_take waiters at once, and
+# issue blocks stay inside, disjoint and at their device's slot under random
+# routing on 1-3 devices. Under test-asan the third doubles as a fuzz for the
+# #1339 class.
+tests/test_qwen36_tier_invariants$(EXE): tests/test_qwen36_tier_invariants.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h
+	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
+
 tests/test_qwen36_tier_int8_engine$(EXE): tests/test_qwen36_tier_int8_engine.c tests/qwen36_fake_cuda.h qwen36.c qwen36_tier.c qwen36_tier.h backend_cuda.h cli_args.h st.h json.h compat.h
 	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
 

--- a/c/Makefile
+++ b/c/Makefile
@@ -1683,6 +1683,14 @@ tests/test_qwen36_tier_shutdown$(EXE): tests/test_qwen36_tier_shutdown.c tests/q
 tests/test_qwen36_tier_invariants$(EXE): tests/test_qwen36_tier_invariants.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h
 	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
 
+# Same fake backend: the automatic placement (COLI_PLACE unset/"auto") puts
+# the offered dense trunk into VRAM by bytes-saved-per-byte, prices displaced
+# experts by heat, keeps the trunk on the CPU when the marginal experts are
+# hotter, honours an explicit list and "off", and takes placed bytes out of
+# the expert budget -- on one and on two devices.
+tests/test_qwen36_tier_autoplace$(EXE): tests/test_qwen36_tier_autoplace.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h
+	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
+
 tests/test_qwen36_tier_int8_engine$(EXE): tests/test_qwen36_tier_int8_engine.c tests/qwen36_fake_cuda.h qwen36.c qwen36_tier.c qwen36_tier.h backend_cuda.h cli_args.h st.h json.h compat.h
 	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
 

--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -2032,8 +2032,12 @@ static void deltanet(Model *m, Layer *l, int layer, float *x, int S, int pos_bas
     float scale = 1.f / sqrtf((float)kdim);
     int H = c->hidden;
 
-    float *qkv = falloc(conv_dim);
-    float *z   = falloc(value_dim);
+    /* qkv and z live in ONE buffer: the fused GPU projection writes
+     * [conv_dim ++ value_dim] in a single GEMV, and the CPU fallback fills the
+     * same two regions. Either way the code below reads qkv/z unchanged. */
+    float *qkvz = falloc((int64_t)conv_dim + value_dim);
+    float *qkv = qkvz;
+    float *z   = qkvz + conv_dim;
     float *b   = falloc(vh);
     float *a   = falloc(vh);
     float *beta= falloc(vh);
@@ -2053,9 +2057,12 @@ static void deltanet(Model *m, Layer *l, int layer, float *x, int S, int pos_bas
         const float *xs = x + (int64_t)s * H;
         extern double g_dn_sub[4];
         double _d0 = tm_on()? tm_now():0;
-        /* projections (single-token matmuls) */
-        matmul_d(qkv, xs, l->dn_qkv, 1, H, conv_dim);
-        matmul_d(z,   xs, l->dn_z,   1, H, value_dim);
+        /* projections (single-token matmuls). One fused GEMV when this layer's
+         * dnproj is placed on a GPU, the two CPU matmuls otherwise. */
+        if (!qt_dnproj_matmul(layer, qkvz, xs, H, conv_dim + value_dim)) {
+            matmul_d(qkv, xs, l->dn_qkv, 1, H, conv_dim);
+            matmul_d(z,   xs, l->dn_z,   1, H, value_dim);
+        }
         matmul(b,   xs, l->dn_b,   1, H, vh);
         matmul(a,   xs, l->dn_a,   1, H, vh);
         if (tm_on() && S==1){ double t=tm_now(); g_dn_sub[0]+=t-_d0; _d0=t; }
@@ -2171,7 +2178,8 @@ static void deltanet(Model *m, Layer *l, int layer, float *x, int S, int pos_bas
             }
         }
     }
-    free(qkv); free(z); free(b); free(a); free(beta); free(gg);
+    free(qkvz);   /* qkv and z are regions of this one allocation */
+    free(b); free(a); free(beta); free(gg);
     free(conv_out); free(q); free(k); free(outv); free(outr); free(kv); free(delta);
 }
 
@@ -2863,6 +2871,41 @@ int main(int argc, char **argv) {
                 qt_lmhead_init(g_qdw[i].q, g_qdw[i].sc, g_qdw[i].I, g_qdw[i].O);
                 break;
             }
+        /* R4 step 2: DeltaNet input projections, per layer, wherever
+         * COLI_PLACE puts them. qkv and z are both [O_x, hidden] int8 with
+         * per-row scales, so fusing them is a concatenation along O -- two
+         * memcpys, no requantization, and the GPU sees one GEMV per layer
+         * instead of two. The host copy is freed right after the upload. */
+        {
+            int placed = 0, O_qkv = m.c.dn_conv_dim, O_z = m.c.dn_vheads * m.c.dn_vdim;
+            int Of = O_qkv + O_z, Hd = m.c.hidden;
+            double vram = 0;
+            for (int i = 0; i < m.c.n_layers; i++) {
+                if (m.c.is_attn[i]) continue;
+                int dev = qt_place_of("dnproj", i);
+                if (dev == QT_PLACE_CPU) continue;
+                const int8_t *q1 = NULL, *q2 = NULL; const float *s1 = NULL, *s2 = NULL;
+                for (int j = 0; j < g_qdw_n; j++) {
+                    if (g_qdw[j].w == m.L[i].dn_qkv) { q1 = g_qdw[j].q; s1 = g_qdw[j].sc; }
+                    if (g_qdw[j].w == m.L[i].dn_z)   { q2 = g_qdw[j].q; s2 = g_qdw[j].sc; }
+                }
+                if (!q1 || !q2) continue;      /* dense-i8 off: CPU path stands */
+                int8_t *qf = malloc((size_t)Of * Hd);
+                float  *sf = malloc((size_t)Of * sizeof(float));
+                if (!qf || !sf) { free(qf); free(sf); break; }
+                memcpy(qf, q1, (size_t)O_qkv * Hd);
+                memcpy(qf + (size_t)O_qkv * Hd, q2, (size_t)O_z * Hd);
+                memcpy(sf, s1, (size_t)O_qkv * sizeof(float));
+                memcpy(sf + O_qkv, s2, (size_t)O_z * sizeof(float));
+                if (qt_dnproj_init(i, qf, sf, Hd, Of, dev)) {
+                    placed++; vram += (double)Of * Hd;
+                }
+                free(qf); free(sf);
+            }
+            if (placed)
+                fprintf(stderr, "[dnp] %d DeltaNet-Projektionen auf GPU (%.2f GB VRAM)\n",
+                        placed, vram / 1073741824.0);
+        }
         /* Warmstart: fill the VRAM budget BEFORE the first token (heat order
          * when HEAT_FILE exists, natural order otherwise), loading all RAM
          * slots along the way. */

--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -2694,8 +2694,13 @@ static void tier_warmstart(Model *m, int expert_is_int4) {
         const uint8_t *wg = expert_is_int4 ? e->g4 : (const uint8_t *)e->g;
         const uint8_t *wu = expert_is_int4 ? e->u4 : (const uint8_t *)e->u;
         const uint8_t *wd = expert_is_int4 ? e->d4 : (const uint8_t *)e->d;
-        if (planned[gi] && wg) {
+        if (planned[gi]) {
+            /* Reported even when wg is NULL: the tier reserved budget for
+             * this expert in qt_plan_fill, and a planned expert that is never
+             * reported keeps that reservation forever. With no weights the
+             * tier hands the bytes back instead of uploading. */
             qt_note_planned(l, eidw, wg, wu, wd, e->gs, e->us, e->ds);
+            if (!wg) continue;
             /* The staging copy is done. On an int4 container the int8 copy
              * can go RIGHT AWAY so it never shows up in peak RSS: g4/u4/d4
              * stay as the source of truth, and slot_ensure_int8() rebuilds

--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -2244,7 +2244,8 @@ static float *step(Model *m, const int *ids, int S, int pos_base) {
     rmsnorm_row(last, x + (int64_t)(S-1)*D, m->final_norm, D, c->eps);
     float *logit = falloc(c->vocab);
     double _th = tm_on() ? tm_now() : 0.0;
-    matmul_d(logit, last, m->lm_head, 1, D, c->vocab);
+    if (!qt_lmhead_matmul(logit, last, D, c->vocab))
+        matmul_d(logit, last, m->lm_head, 1, D, c->vocab);
     if (tm_on()) { tm_add(S, 5, tm_now()-_th); if (S==1) g_tm_dec_tokens++; else g_tm_pre_tokens += S; }
     free(x); free(last);
     if (lf) fclose(lf);
@@ -2854,6 +2855,14 @@ int main(int argc, char **argv) {
                 m.c.expert_gs, expert_is_int4)) {
         fprintf(stderr, "[gpu] MoE experts -> CUDA VRAM tier\n");
         atexit(qt_shutdown);
+        /* R4 role split: park the dense-i8 lm_head on COLI_LMHEAD_GPU. The
+         * qdw entry keyed by m.lm_head holds the int8 rows + per-row scales
+         * the CPU path uses; the GPU applies the identical semantics. */
+        for (int i = 0; i < g_qdw_n; i++)
+            if (g_qdw[i].w == m.lm_head) {
+                qt_lmhead_init(g_qdw[i].q, g_qdw[i].sc, g_qdw[i].I, g_qdw[i].O);
+                break;
+            }
         /* Warmstart: fill the VRAM budget BEFORE the first token (heat order
          * when HEAT_FILE exists, natural order otherwise), loading all RAM
          * slots along the way. */

--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -2859,6 +2859,23 @@ int main(int argc, char **argv) {
         int64_t want = 2*(int64_t)m.c.inter*m.c.hidden + (int64_t)m.c.hidden*m.c.inter;
         if (pt && pt->nbytes == want) expert_is_int4 = 0;   /* int8: un byte per elemento */
     }
+    /* Offer the dense trunk to the placer before the tier decides its budget:
+     * sizes only, from the same dense-i8 entries the uploads below will use.
+     * No entry (dense-i8 off) means nothing to offer, and the CPU path stands. */
+    {
+        int O_qkv = m.c.dn_conv_dim, O_z = m.c.dn_vheads * m.c.dn_vdim;
+        for (int i = 0; i < g_qdw_n; i++)
+            if (g_qdw[i].w == m.lm_head)
+                qt_trunk_offer("lmhead", 0, (size_t)g_qdw[i].I * g_qdw[i].O + (size_t)g_qdw[i].O * sizeof(float));
+        for (int i = 0; i < m.c.n_layers; i++) {
+            if (m.c.is_attn[i]) continue;
+            int have = 0;
+            for (int j = 0; j < g_qdw_n; j++)
+                if (g_qdw[j].w == m.L[i].dn_qkv || g_qdw[j].w == m.L[i].dn_z) have++;
+            if (have == 2)
+                qt_trunk_offer("dnproj", i, (size_t)(O_qkv + O_z) * m.c.hidden + (size_t)(O_qkv + O_z) * sizeof(float));
+        }
+    }
     if (qt_init(m.c.n_layers, m.c.n_experts, m.c.hidden, m.c.inter, cap, m.c.topk,
                 m.c.expert_gs, expert_is_int4)) {
         fprintf(stderr, "[gpu] MoE experts -> CUDA VRAM tier\n");

--- a/c/qwen36_tier.c
+++ b/c/qwen36_tier.c
@@ -152,6 +152,90 @@ static void *uploader(void *arg){
  * so CPU and GPU compute the same numbers up to accumulation order. */
 static struct { ColiCudaTensor *t; int dev, dev_ok, on; } G_lmh;
 
+/* ---- placement table (COLI_PLACE) --------------------------------------- */
+/* Parsed lazily on first query and cached: qt_place_of runs per layer during
+ * init and must not re-parse the environment 30 times. */
+#define QT_PLACE_MAX 8
+#define QT_SPLIT_MAX 8
+static struct {
+    char name[16];
+    struct { int dev, count; } seg[QT_SPLIT_MAX];   /* count<=0: all remaining */
+    int nseg;
+} G_place[QT_PLACE_MAX];
+static int G_place_n = 0, G_place_done = 0;
+
+/* one component spec: "cpu" | "<dev>" | "<dev>:<n>+<dev>:<n>..." */
+static void place_add(const char *name, size_t nlen, const char *spec){
+    if(G_place_n >= QT_PLACE_MAX) return;
+    if(nlen >= sizeof(G_place[0].name)) nlen = sizeof(G_place[0].name)-1;
+    memcpy(G_place[G_place_n].name, name, nlen);
+    G_place[G_place_n].name[nlen] = 0;
+    int ns = 0;
+    for(const char *p = spec; *p && ns < QT_SPLIT_MAX; ){
+        while(*p==' ') p++;
+        int dev, count = -1;
+        if(!strncmp(p,"cpu",3)){ dev = QT_PLACE_CPU; p += 3; }
+        else { dev = atoi(p); while(*p && *p!=':' && *p!='+') p++; }
+        if(*p==':'){ count = atoi(p+1); p++; while(*p && *p!='+') p++; }
+        G_place[G_place_n].seg[ns].dev = dev;
+        G_place[G_place_n].seg[ns].count = count;
+        ns++;
+        if(*p=='+') p++; else break;
+    }
+    G_place[G_place_n].nseg = ns;
+    G_place_n++;
+}
+
+static void place_parse(void){
+    G_place_done = 1;
+    const char *e = getenv("COLI_PLACE");
+    if(!e || !*e) return;
+    const char *p = e;
+    while(*p){
+        while(*p==' '||*p==','||*p==';') p++;
+        const char *name = p;
+        while(*p && *p!='=' && *p!=',' && *p!=';') p++;
+        if(*p!='='){ while(*p && *p!=','&&*p!=';') p++; continue; }
+        size_t nlen = (size_t)(p - name);
+        p++;                                   /* past '=' */
+        char spec[64]; size_t si = 0;
+        while(*p && *p!=',' && *p!=';' && si < sizeof(spec)-1) spec[si++] = *p++;
+        spec[si] = 0;
+        place_add(name, nlen, spec);
+    }
+    fprintf(stderr,"[place] COLI_PLACE=%s\n", e);
+}
+
+/* Was this component named at all? Distinguishes "experts=cpu" (an explicit
+ * request to disable the tier) from "not mentioned" (keep today's default). */
+static int qt_place_named(const char *component){
+    if(!G_place_done) place_parse();
+    for(int i=0;i<G_place_n;i++) if(!strcmp(G_place[i].name,component)) return 1;
+    return 0;
+}
+
+int qt_place_of(const char *component, int layer){
+    if(!G_place_done) place_parse();
+    for(int i = 0; i < G_place_n; i++){
+        if(strcmp(G_place[i].name, component)) continue;
+        int seen = 0;
+        for(int s = 0; s < G_place[i].nseg; s++){
+            int cnt = G_place[i].seg[s].count;
+            if(cnt <= 0) return G_place[i].seg[s].dev;      /* rest of the layers */
+            if(layer < seen + cnt) return G_place[i].seg[s].dev;
+            seen += cnt;
+        }
+        return QT_PLACE_CPU;             /* past the last segment: stay on CPU */
+    }
+    return QT_PLACE_CPU;
+}
+
+/* ---- DeltaNet input projections ----------------------------------------- */
+/* One fused qkv++z tensor per DeltaNet layer. Indexed by model layer index,
+ * so the array is n_layers wide and the attention slots stay empty. */
+#define QT_DN_MAX_LAYERS 128
+static struct { ColiCudaTensor *t; int dev, on; } G_dnp[QT_DN_MAX_LAYERS];
+
 
 int qt_init(int nl, int ne, int D, int Ih, int cap, int topk, int expert_gs,
             int expert_is_int4){
@@ -177,6 +261,21 @@ int qt_init(int nl, int ne, int D, int Ih, int cap, int topk, int expert_gs,
         for(int i=0;i<want && i<QT_MAX_DEV;i++) G.dev[G.ndev++]=i;
         fprintf(stderr,"[qtier] COLI_GPUS unset: selecting %d visible device(s)\n",G.ndev);
     }
+    /* A device named only in COLI_PLACE still needs a CUDA context before
+     * anything can be uploaded to it. Fold those in here rather than making
+     * the caller repeat every device in COLI_GPUS as well -- forgetting that
+     * would silently drop a component back to the CPU mid-A/B. */
+    {
+        static const char *comps[] = {"lmhead","dnproj","dnout","attnproj"};
+        for(size_t ci=0; ci<sizeof comps/sizeof *comps; ci++)
+            for(int l=0; l<nl && G.ndev<QT_MAX_DEV; l++){
+                int d=qt_place_of(comps[ci],l);
+                if(d==QT_PLACE_CPU) continue;
+                int seen=0; for(int i=0;i<G.ndev;i++) if(G.dev[i]==d) seen=1;
+                if(!seen){ G.dev[G.ndev++]=d;
+                    fprintf(stderr,"[place] dev %d aus COLI_PLACE zur CUDA-Init ergaenzt\n",d); }
+            }
+    }
     if(G.ndev<1){ fprintf(stderr,"[qtier] no visible CUDA devices -> CPU path\n"); return 0; }
     if(!coli_cuda_init(G.dev,G.ndev)){ fprintf(stderr,"[qtier] coli_cuda_init failed -> CPU path\n"); return 0; }
     int have=coli_cuda_device_count();
@@ -192,20 +291,53 @@ int qt_init(int nl, int ne, int D, int Ih, int cap, int topk, int expert_gs,
      * while lm_head is one latency-tolerant call per token. If it is the ONLY
      * device, experts stay on it — a role split needs two cards. */
     {
+        int reserved[QT_MAX_DEV], nres=0;
+        /* lm_head: COLI_LMHEAD_GPU stays honoured, COLI_PLACE wins when both
+         * are set (it is the newer, general form). */
         const char *lhx=getenv("COLI_LMHEAD_GPU");
-        if(lhx && *lhx){
-            int ld=atoi(lhx), w=0, present=0;
-            for(int i=0;i<G.ndev;i++){ if(G.dev[i]==ld) present=1; else G.dev[w++]=G.dev[i]; }
+        int ld=qt_place_of("lmhead",0);
+        if(ld==QT_PLACE_CPU && lhx && *lhx) ld=atoi(lhx);
+        if(ld!=QT_PLACE_CPU){
+            int present=0; for(int i=0;i<G.ndev;i++) if(G.dev[i]==ld) present=1;
+            if(present){ G_lmh.dev=ld; G_lmh.dev_ok=1; reserved[nres++]=ld; }
+            else fprintf(stderr,"[qtier] lm_head-Device %d nicht verfuegbar -> CPU\n",ld);
+        }
+        /* every other component's devices, deduplicated */
+        static const char *comps[] = {"dnproj","dnout","attnproj"};
+        for(size_t ci=0; ci<sizeof comps/sizeof *comps; ci++)
+            for(int l=0; l<nl; l++){
+                int d=qt_place_of(comps[ci],l);
+                if(d==QT_PLACE_CPU) continue;
+                int seen=0; for(int r=0;r<nres;r++) if(reserved[r]==d) seen=1;
+                if(!seen && nres<QT_MAX_DEV) reserved[nres++]=d;
+            }
+        /* experts=<dev> pins the tier to one card, experts=cpu turns it off.
+         * Explicit beats inference: with BOTH cards reserved for other
+         * components, the fallback below would hand the experts back to both
+         * -- including the slow card, whose take() paces every layer (the
+         * measured reason asymmetric expert placement lost). */
+        int ed=qt_place_of("experts",0);
+        if(ed!=QT_PLACE_CPU){
+            int present=0; for(int i=0;i<G.ndev;i++) if(G.dev[i]==ed) present=1;
             if(present){
-                /* remember: the device HAS a CUDA context even after it leaves
-                 * the placement list — qt_lmhead_init keys on this, not on the
-                 * compacted list */
-                G_lmh.dev=ld; G_lmh.dev_ok=1;
-                if(w>0){
-                    G.ndev=w;
-                    fprintf(stderr,"[qtier] dev %d reserved for lm_head: excluded from expert placement\n",ld);
-                } /* w==0: lm_head device is the only one — experts stay on it */
-            } else fprintf(stderr,"[qtier] COLI_LMHEAD_GPU=%d not in COLI_GPUS -> lm_head stays on CPU\n",ld);
+                G.dev[0]=ed; G.ndev=1;
+                fprintf(stderr,"[place] Experten auf Device %d festgelegt\n",ed);
+            } else fprintf(stderr,"[place] experts=%d nicht verfuegbar -> COLI_GPUS bleibt\n",ed);
+        } else if(G_place_n && qt_place_named("experts")){
+            fprintf(stderr,"[place] experts=cpu -> VRAM-Tier aus\n");
+            return 0;
+        } else if(nres){
+            int w=0;
+            for(int i=0;i<G.ndev;i++){
+                int res=0; for(int r=0;r<nres;r++) if(G.dev[i]==reserved[r]) res=1;
+                if(!res) G.dev[w++]=G.dev[i];
+            }
+            /* w==0: the reserved devices are the only ones -- experts stay on
+             * them, exactly as the single-card lm_head case did. */
+            if(w>0 && w<G.ndev){
+                G.ndev=w;
+                fprintf(stderr,"[qtier] %d Device(s) reserviert: aus der Experten-Platzierung genommen\n",nres);
+            }
         }
     }
 
@@ -285,6 +417,29 @@ int qt_lmhead_init(const int8_t *q, const float *sc, int I, int O){
     fprintf(stderr,"[lmh] lm_head [%d x %d] int8 resident on CUDA dev %d (%.2f GB)\n",
             O,I,dev,(double)O*I/1073741824.0);
     return 1;
+}
+
+int qt_dnproj_init(int layer, const int8_t *q, const float *sc,
+                   int I, int O, int device){
+    if(layer < 0 || layer >= QT_DN_MAX_LAYERS) return 0;
+    if(device == QT_PLACE_CPU || !q || !sc) return 0;
+    /* No G.on requirement: the projections are independent of the expert tier,
+     * so they can be measured on a card that holds no experts at all. */
+    if(!coli_cuda_tensor_upload(&G_dnp[layer].t, q, sc, 1, I, O, device)){
+        fprintf(stderr,"[dnp] layer %d upload failed -> stays on CPU\n", layer);
+        return 0;
+    }
+    G_dnp[layer].dev = device; G_dnp[layer].on = 1;
+    return 1;
+}
+
+int qt_dnproj_matmul(int layer, float *y, const float *x, int I, int O){
+    if(layer < 0 || layer >= QT_DN_MAX_LAYERS || !G_dnp[layer].on) return 0;
+    if(coli_cuda_matmul(&G_dnp[layer].t,y,x,NULL,NULL,1,1,I,O,G_dnp[layer].dev,0))
+        return 1;
+    fprintf(stderr,"[dnp] layer %d GPU matmul failed; CPU from here on\n", layer);
+    G_dnp[layer].on = 0;
+    return 0;
 }
 
 int qt_lmhead_matmul(float *y, const float *x, int I, int O){

--- a/c/qwen36_tier.c
+++ b/c/qwen36_tier.c
@@ -547,6 +547,7 @@ int qt_init(int nl, int ne, int D, int Ih, int cap, int topk, int expert_gs,
             if(qt_place_of(G_offer[o].name, G_offer[o].layer)==G.dev[i]) trunk += G_offer[o].bytes;
         size_t cap_i = 0;
         for(int j=0;j<ncap;j++) if(capdev[j]==G.dev[i]) cap_i = capacity[j];
+        G_trunk_bytes[i] = trunk;                 /* by expert-device index, for qt_stats */
         G.budget[i] = cap_i > trunk ? cap_i - trunk : 0;
         fprintf(stderr,"[qtier] dev %d: budget %.2f GB for experts (~%zu experts)%s\n",
                 G.dev[i], G.budget[i]/1073741824.0, G.budget[i]/G.exp_bytes,
@@ -867,8 +868,11 @@ void qt_stats(void){
     for(int i=0;i<G.ndev;i++){
         size_t tc=0,tb=0; coli_cuda_stats(G.dev[i],&tc,&tb);
         hits+=G.hits[i];
-        fprintf(stderr,"[qtier]   dev %d: hits %llu | %zu tensors, %.2f GB VRAM used (budget %.2f GB)\n",
-                G.dev[i], (unsigned long long)G.hits[i], tc, tb/1073741824.0, G.budget[i]/1073741824.0);
+        /* tb counts every tensor on the device, trunk included; say how much of
+         * it is trunk so "used > budget" does not read like an overrun. */
+        fprintf(stderr,"[qtier]   dev %d: hits %llu | %zu tensors, %.2f GB VRAM used (%.2f GB trunk + experts, budget %.2f GB)\n",
+                G.dev[i], (unsigned long long)G.hits[i], tc, tb/1073741824.0,
+                G_trunk_bytes[i]/1073741824.0, G.budget[i]/1073741824.0);
     }
     double tot=(double)(hits+G.miss);
     fprintf(stderr,"[qtier] VRAM hit rate: %.1f %% | LFRU swaps %llu\n",

--- a/c/qwen36_tier.c
+++ b/c/qwen36_tier.c
@@ -254,6 +254,11 @@ int qt_is_resident(int layer,int eid){
  * reserved here); victim>=0: LFRU swap (budget neutral). */
 static int enqueue_locked(int layer,int eid,int v_layer,int v_eid,int reserved){
     QSlot *s=qs(layer,eid);
+    /* Nothing is accepted once shutdown has been requested: a waiter woken by
+     * the shutdown broadcast (qt_note_block / qt_note_planned on a full queue)
+     * would otherwise enqueue into a queue the uploader may already have left,
+     * and that entry stays queued=1 with its staging buffers forever. */
+    if(G.th_stop) return 0;
     if(s->resident||s->queued||!s->g4) return 0;
     if(G.qn>=QT_QCAP){ G.q_full_skips++; return 0; }
     int hd=home(eid);
@@ -368,9 +373,19 @@ int qt_plan_fill(int *layers,int *eids,int max){
 void qt_note_planned(int layer,int eid,
              const uint8_t *g4,const uint8_t *u4,const uint8_t *d4,
              const float *gs,const float *us,const float *ds){
-    if(!G.on || !g4) return;
+    if(!G.on) return;
     QSlot *s=qs(layer,eid);
     pthread_mutex_lock(&G.mx);
+    if(!g4){
+        /* The loader had nothing to hand over. qt_plan_fill reserved budget
+         * and set planned=1 for this expert; returning here without undoing
+         * both keeps the bytes out of the budget for the life of the process
+         * and "if(resident||queued||planned) continue" never reconsiders the
+         * expert. #1331 was this leak for every expert of an int8 container. */
+        if(s->planned){ G.used[home(eid)]-=G.exp_bytes; s->planned=0; }
+        pthread_mutex_unlock(&G.mx);
+        return;
+    }
     if(!s->g4){ s->g4=g4; s->u4=u4; s->d4=d4; s->gs=gs; s->us=us; s->ds=ds; }
     while(G.qn>=QT_QCAP && !G.th_stop) pthread_cond_wait(&G.cv_take,&G.mx);
     if(!enqueue_locked(layer,eid,-1,-1,1)){

--- a/c/qwen36_tier.c
+++ b/c/qwen36_tier.c
@@ -146,6 +146,13 @@ static void *uploader(void *arg){
     }
 }
 
+/* R4 role split: lm_head as a resident int8 tensor on its own device.
+ * The dense-i8 quantization (engine-side) provides q/sc with the same
+ * per-row semantics quant_matmul's fmt=1 applies (y[o] = acc * sc[o]),
+ * so CPU and GPU compute the same numbers up to accumulation order. */
+static struct { ColiCudaTensor *t; int dev, dev_ok, on; } G_lmh;
+
+
 int qt_init(int nl, int ne, int D, int Ih, int cap, int topk, int expert_gs,
             int expert_is_int4){
     const char *e=getenv("COLI_CUDA");
@@ -175,6 +182,32 @@ int qt_init(int nl, int ne, int D, int Ih, int cap, int topk, int expert_gs,
     int have=coli_cuda_device_count();
     if(have<G.ndev){ G.ndev=have; }
     if(G.ndev<1){ fprintf(stderr,"[qtier] no CUDA devices -> CPU path\n"); return 0; }
+
+    /* R4 role split: the lm_head device (COLI_LMHEAD_GPU) is initialized above
+     * but removed from the expert PLACEMENT list. Zeroing its budget instead
+     * is not enough: home() still hashes experts onto it, and those can never
+     * be placed — measured as a hit-rate collapse 89.9% -> 49.5% (only the
+     * half of the hot set homed to the remaining device got resident). Its
+     * take() would also pace every layer (Quadro: 12.8 ms/token vs 3070 2.4),
+     * while lm_head is one latency-tolerant call per token. If it is the ONLY
+     * device, experts stay on it — a role split needs two cards. */
+    {
+        const char *lhx=getenv("COLI_LMHEAD_GPU");
+        if(lhx && *lhx){
+            int ld=atoi(lhx), w=0, present=0;
+            for(int i=0;i<G.ndev;i++){ if(G.dev[i]==ld) present=1; else G.dev[w++]=G.dev[i]; }
+            if(present){
+                /* remember: the device HAS a CUDA context even after it leaves
+                 * the placement list — qt_lmhead_init keys on this, not on the
+                 * compacted list */
+                G_lmh.dev=ld; G_lmh.dev_ok=1;
+                if(w>0){
+                    G.ndev=w;
+                    fprintf(stderr,"[qtier] dev %d reserved for lm_head: excluded from expert placement\n",ld);
+                } /* w==0: lm_head device is the only one — experts stay on it */
+            } else fprintf(stderr,"[qtier] COLI_LMHEAD_GPU=%d not in COLI_GPUS -> lm_head stays on CPU\n",ld);
+        }
+    }
 
     /* per-device budget: CUDA_EXPERT_GB, or auto = free minus 1 GB headroom.
      * Scale counts follow the container: per-row (expert_gs=0) or grouped
@@ -240,6 +273,28 @@ int qt_init(int nl, int ne, int D, int Ih, int cap, int topk, int expert_gs,
 }
 
 int qt_ready(void){ return G.on; }
+
+int qt_lmhead_init(const int8_t *q, const float *sc, int I, int O){
+    if(!G_lmh.dev_ok||!G.on||!q||!sc) return 0;
+    int dev=G_lmh.dev;
+    if(!coli_cuda_tensor_upload(&G_lmh.t,q,sc,1,I,O,dev)){
+        fprintf(stderr,"[lmh] lm_head upload failed -> stays on CPU\n");
+        return 0;
+    }
+    G_lmh.dev=dev; G_lmh.on=1;
+    fprintf(stderr,"[lmh] lm_head [%d x %d] int8 resident on CUDA dev %d (%.2f GB)\n",
+            O,I,dev,(double)O*I/1073741824.0);
+    return 1;
+}
+
+int qt_lmhead_matmul(float *y, const float *x, int I, int O){
+    if(!G_lmh.on) return 0;
+    /* cached-tensor path: upload params are ignored once *t exists */
+    if(coli_cuda_matmul(&G_lmh.t,y,x,NULL,NULL,1,1,I,O,G_lmh.dev,0)) return 1;
+    fprintf(stderr,"[lmh] GPU matmul failed; falling back to CPU from here on\n");
+    G_lmh.on=0;
+    return 0;
+}
 
 /* Is (layer,eid) currently VRAM-resident? (used to free RAM-side int8 copies) */
 int qt_is_resident(int layer,int eid){

--- a/c/qwen36_tier.c
+++ b/c/qwen36_tier.c
@@ -214,7 +214,54 @@ static int qt_place_named(const char *component){
     return 0;
 }
 
+/* ---- DeltaNet input projections ----------------------------------------- */
+/* One fused qkv++z tensor per DeltaNet layer. Indexed by model layer index,
+ * so the array is n_layers wide and the attention slots stay empty. */
+#define QT_DN_MAX_LAYERS 128
+static struct { ColiCudaTensor *t; int dev, on; } G_dnp[QT_DN_MAX_LAYERS];
+
+/* ---- automatic placement (COLI_PLACE unset or "auto") ------------------ */
+/* The hand-written list above is a measurement tool. Nobody running a 6 GB
+ * card should have to work out that 1.2 GB of dense trunk is worth more than
+ * 800 experts (#1040); the engine knows every size involved and decides.
+ *
+ * Rule: bytes saved on the memory bus per token, per byte of VRAM spent.
+ *   dense component  -> read on EVERY token: value 1.0 per byte.
+ *   routed expert    -> read with the probability p_e that a token routes to
+ *                       it (heat share when a HEAT_FILE exists, topk/n_experts
+ *                       otherwise), and the CPU fallback reads the int8 slot,
+ *                       which is twice the bytes an int4 expert occupies in
+ *                       VRAM: value 2*p_e per byte (1*p_e on an int8 container).
+ * A trunk item goes to the device with the most room if its value beats the
+ * value of the coldest experts it would push out of that device -- the
+ * experts at the tail of the heat order that still fit today. Without heat
+ * that tail is worth 2*topk/n_experts per byte (0.06 on the 35B) and the
+ * trunk always wins; with heat, a card whose marginal expert is routed on
+ * more than every second token keeps its experts. That is the R4
+ * measurement: on two near-full 8 GB cards, moving all projections onto one
+ * card cost 0.7 GB of hot experts and lost 13 ms of savings again.
+ *
+ * The engine OFFERS the trunk before qt_init (qt_trunk_offer: component,
+ * layer, bytes -- sizes only, pointers come later as before); the decision
+ * lands in the same table qt_place_of() reads, so nothing downstream
+ * changes. Placed bytes are subtracted from that device's expert budget,
+ * which the hand-written list never did (the 0.7 GB above was the
+ * discovery). COLI_PLACE=off keeps today's behaviour: nothing placed. */
+#define QT_OFFER_MAX 1024
+static struct { char name[16]; int layer; size_t bytes; } G_offer[QT_OFFER_MAX];
+static int G_offer_n;
+static int G_auto_on;                                  /* auto placement decided */
+static int G_auto_lmh = QT_PLACE_CPU;
+static int G_auto_dnp[QT_DN_MAX_LAYERS];               /* per layer, or QT_PLACE_CPU */
+static size_t G_trunk_bytes[QT_MAX_DEV];               /* placed trunk per device index */
+
 int qt_place_of(const char *component, int layer){
+    if(G_auto_on){
+        if(!strcmp(component, "lmhead")) return G_auto_lmh;
+        if(!strcmp(component, "dnproj"))
+            return (layer >= 0 && layer < QT_DN_MAX_LAYERS) ? G_auto_dnp[layer] : QT_PLACE_CPU;
+        return QT_PLACE_CPU;               /* experts follow COLI_GPUS; dnout/attnproj not yet placed */
+    }
     if(!G_place_done) place_parse();
     for(int i = 0; i < G_place_n; i++){
         if(strcmp(G_place[i].name, component)) continue;
@@ -230,11 +277,100 @@ int qt_place_of(const char *component, int layer){
     return QT_PLACE_CPU;
 }
 
-/* ---- DeltaNet input projections ----------------------------------------- */
-/* One fused qkv++z tensor per DeltaNet layer. Indexed by model layer index,
- * so the array is n_layers wide and the attention slots stay empty. */
-#define QT_DN_MAX_LAYERS 128
-static struct { ColiCudaTensor *t; int dev, on; } G_dnp[QT_DN_MAX_LAYERS];
+
+void qt_trunk_offer(const char *component, int layer, size_t bytes){
+    if(!component || !bytes || G_offer_n >= QT_OFFER_MAX) return;
+    if(layer < 0 || layer >= QT_DN_MAX_LAYERS) return;
+    snprintf(G_offer[G_offer_n].name, sizeof G_offer[0].name, "%s", component);
+    G_offer[G_offer_n].layer = layer; G_offer[G_offer_n].bytes = bytes;
+    G_offer_n++;
+}
+
+static int auto_mode(void){
+    const char *e = getenv("COLI_PLACE");
+    return !e || !*e || !strcmp(e, "auto");
+}
+
+/* p_e of the k coldest experts that still fit on device index di, summed as
+ * bytes-per-token they save; heat from the HEAT_FILE table when present. */
+static int cmp_double_desc(const void *a, const void *b){
+    double x=*(const double*)a, y=*(const double*)b; return x<y ? 1 : x>y ? -1 : 0;
+}
+static int auto_dnp_count(int dev){
+    int c = 0; for(int l = 0; l < QT_DN_MAX_LAYERS; l++) if(G_auto_dnp[l] == dev) c++; return c;
+}
+
+static double auto_displaced_value(int di, size_t room, int k, size_t exp_bytes,
+                                   int nl, int ne, int topk, const uint32_t *heat0,
+                                   double *p_marginal_out){
+    size_t homed = 0;
+    for(int e = 0; e < ne; e++) if(e % G.ndev == di) homed++;
+    homed *= (size_t)nl;
+    size_t fit = room / exp_bytes;
+    if(fit >= homed){ *p_marginal_out = 0; return 0; }   /* room to spare: displaces nothing */
+    if(k <= 0){ *p_marginal_out = 0; return 0; }
+    double cpu_factor = (G.wfmt == 1) ? 1.0 : 2.0;      /* CPU reads the int8 slot */
+    if(!heat0){
+        double p = (double)topk / ne;
+        *p_marginal_out = p;
+        return (double)k * cpu_factor * p * (double)exp_bytes;
+    }
+    /* heat share per expert on this device, sorted descending; the marginal
+     * ones sit at ranks [fit-k, fit) */
+    size_t n = homed; double *p = malloc(n * sizeof *p); size_t m = 0;
+    for(int l = 0; l < nl; l++){
+        double sum = 0;
+        for(int e = 0; e < ne; e++) sum += (double)heat0[(size_t)l*ne + e];
+        for(int e = 0; e < ne; e++){
+            if(e % G.ndev != di) continue;
+            double pe = sum > 0 ? (double)topk * heat0[(size_t)l*ne + e] / sum : (double)topk / ne;
+            p[m++] = pe > 1.0 ? 1.0 : pe;
+        }
+    }
+    qsort(p, m, sizeof *p, cmp_double_desc);
+    double value = 0, pm = 0; int cnt = 0;
+    for(size_t r = (fit > (size_t)k ? fit - k : 0); r < fit && r < m; r++){ value += cpu_factor * p[r] * (double)exp_bytes; pm = p[r]; cnt++; }
+    free(p);
+    *p_marginal_out = pm;
+    return value;
+}
+
+static void auto_place(int nl, int ne, int topk, const size_t *capacity, const uint32_t *heat0){
+    size_t room[QT_MAX_DEV];
+    for(int i = 0; i < G.ndev; i++){ room[i] = capacity[i]; G_trunk_bytes[i] = 0; }
+    for(int l = 0; l < QT_DN_MAX_LAYERS; l++) G_auto_dnp[l] = QT_PLACE_CPU;
+    G_auto_lmh = QT_PLACE_CPU;
+    int placed = 0, kept = 0;
+    /* lmhead first (one call per token, latency-tolerant), then the
+     * projections in layer order */
+    for(int pass = 0; pass < 2; pass++)
+        for(int o = 0; o < G_offer_n; o++){
+            int is_lmh = !strcmp(G_offer[o].name, "lmhead");
+            if((pass == 0) != is_lmh) continue;
+            if(!is_lmh && strcmp(G_offer[o].name, "dnproj")) continue;   /* v1: these two */
+            size_t bytes = G_offer[o].bytes;
+            int di = 0;
+            for(int i = 1; i < G.ndev; i++) if(room[i] > room[di]) di = i;
+            if(room[di] < bytes){ kept++; continue; }
+            int k = (int)((bytes + G.exp_bytes - 1) / G.exp_bytes);
+            double pm = 0;
+            double lose = auto_displaced_value(di, room[di], k, G.exp_bytes, nl, ne, topk, heat0, &pm);
+            if((double)bytes < lose){
+                fprintf(stderr,"[place] auto: %s layer %d stays on CPU -- %.1f MB would displace %d experts "
+                               "worth %.1f MB/token on dev %d (p_marginal %.3f)\n",
+                        G_offer[o].name, G_offer[o].layer, bytes/1048576.0, k, lose/1048576.0, G.dev[di], pm);
+                kept++; continue;
+            }
+            if(is_lmh) G_auto_lmh = G.dev[di]; else G_auto_dnp[G_offer[o].layer] = G.dev[di];
+            room[di] -= bytes; G_trunk_bytes[di] += bytes; placed++;
+        }
+    G_auto_on = 1;
+    for(int i = 0; i < G.ndev; i++)
+        fprintf(stderr,"[place] auto: dev %d holds %.1f MB of trunk (lmhead%s, %d dnproj layers), %.2f GB left for experts\n",
+                G.dev[i], G_trunk_bytes[i]/1048576.0, G_auto_lmh == G.dev[i] ? " yes" : " no",
+                auto_dnp_count(G.dev[i]), room[i]/1073741824.0);
+    (void)placed; (void)kept;
+}
 
 
 int qt_init(int nl, int ne, int D, int Ih, int cap, int topk, int expert_gs,
@@ -248,6 +384,11 @@ int qt_init(int nl, int ne, int D, int Ih, int cap, int topk, int expert_gs,
     if(topk>32){ fprintf(stderr,"[qtier] topk>32 unsupported\n"); return 0; }
     memset(&G,0,sizeof G);
     G.nl=nl; G.ne=ne; G.D=D; G.Ih=Ih; G.topk=topk;
+    /* Placement state is re-derived per init: the device fold-in below reads
+     * COLI_PLACE before the automatic placement has decided anything, and a
+     * parse latched from an earlier init (tests start the tier many times)
+     * would otherwise stand in for the current environment. */
+    G_place_done = 0; G_place_n = 0; G_auto_on = 0;
 
     /* devices: COLI_GPUS="0,1" (default: first two visible devices) */
     const char *gl=getenv("COLI_GPUS");
@@ -281,6 +422,60 @@ int qt_init(int nl, int ne, int D, int Ih, int cap, int topk, int expert_gs,
     int have=coli_cuda_device_count();
     if(have<G.ndev){ G.ndev=have; }
     if(G.ndev<1){ fprintf(stderr,"[qtier] no CUDA devices -> CPU path\n"); return 0; }
+
+    /* Weight format and bytes per expert come first now: the automatic
+     * placement below needs them to price the experts a trunk item displaces. */
+    G.wfmt = expert_is_int4 ? 4 : 1;
+    if(G.wfmt==1 && expert_gs>0){
+        fprintf(stderr,"[qtier] int8 experts with grouped scales (gs=%d) cannot be "
+                       "expressed on the GPU (fmt=1 is per-row only) -> CPU path\n", expert_gs);
+        return 0;
+    }
+    G.egs = expert_gs;
+    G.sc_gu = expert_gs ? (size_t)Ih * ((D + expert_gs - 1)/expert_gs) : (size_t)Ih;
+    G.sc_d  = expert_gs ? (size_t)D  * ((Ih + expert_gs - 1)/expert_gs) : (size_t)D;
+    G.exp_bytes = (G.wfmt==1 ? 3ull*D*Ih : 3ull*D*Ih/2)
+                + (2*G.sc_gu+G.sc_d)*sizeof(float) + 4096; /* + allocation slack */
+
+    /* Per-device allowance for tier + trunk: CUDA_EXPERT_GB when numeric,
+     * else free minus 1 GB headroom. The heat table is loaded here too (it
+     * used to be loaded after the budgets) because the placer prices
+     * experts by heat. */
+    size_t capacity[QT_MAX_DEV]; int capdev[QT_MAX_DEV]; int ncap = G.ndev;
+    const char *bg=getenv("CUDA_EXPERT_GB");
+    for(int i=0;i<G.ndev;i++){
+        size_t freeb=0,totb=0; coli_cuda_mem_info(G.dev[i],&freeb,&totb);
+        capdev[i] = G.dev[i];
+        capacity[i] = (bg && strcmp(bg,"auto") && atof(bg)>0)
+                   ? (size_t)(atof(bg)*1024.0*1024.0*1024.0)
+                   : (freeb>(1ull<<30) ? freeb-(1ull<<30) : 0);
+        fprintf(stderr,"[qtier] dev %d: %.1f GB free, allowance %.1f GB\n",
+                G.dev[i], freeb/1073741824.0, capacity[i]/1073741824.0);
+    }
+    G.slot=calloc((size_t)nl*ne,sizeof(QSlot));
+    if(!G.slot) return 0;
+    const char *hf=getenv("HEAT_FILE");
+    if(hf){
+        FILE *f=fopen(hf,"rb");
+        if(f){
+            uint32_t hdr[3]={0,0,0};
+            if(fread(hdr,4,3,f)==3 && hdr[0]==0x51544831u && hdr[1]==(uint32_t)nl && hdr[2]==(uint32_t)ne){
+                G.heat0=malloc((size_t)nl*ne*4);
+                if(G.heat0 && fread(G.heat0,4,(size_t)nl*ne,f)==(size_t)nl*ne){
+                    for(size_t i=0;i<(size_t)nl*ne;i++) G.slot[i].heat=G.heat0[i]>>1; /* decay */
+                    fprintf(stderr,"[qtier] HEAT_FILE loaded: %s\n",hf);
+                } else { free(G.heat0); G.heat0=NULL; }
+            }
+            fclose(f);
+        }
+    }
+    if(auto_mode()){
+        if(G_offer_n) auto_place(nl, ne, topk, capacity, G.heat0);
+        else { G_auto_on = 1; G_auto_lmh = QT_PLACE_CPU; for(int l=0;l<QT_DN_MAX_LAYERS;l++) G_auto_dnp[l]=QT_PLACE_CPU; }
+    } else {
+        const char *e = getenv("COLI_PLACE");
+        if(e && !strcmp(e, "off")){ G_auto_on = 1; G_auto_lmh = QT_PLACE_CPU; for(int l=0;l<QT_DN_MAX_LAYERS;l++) G_auto_dnp[l]=QT_PLACE_CPU; }
+    }
 
     /* R4 role split: the lm_head device (COLI_LMHEAD_GPU) is initialized above
      * but removed from the expert PLACEMENT list. Zeroing its budget instead
@@ -323,10 +518,10 @@ int qt_init(int nl, int ne, int D, int Ih, int cap, int topk, int expert_gs,
                 G.dev[0]=ed; G.ndev=1;
                 fprintf(stderr,"[place] Experten auf Device %d festgelegt\n",ed);
             } else fprintf(stderr,"[place] experts=%d nicht verfuegbar -> COLI_GPUS bleibt\n",ed);
-        } else if(G_place_n && qt_place_named("experts")){
+        } else if(!G_auto_on && G_place_n && qt_place_named("experts")){
             fprintf(stderr,"[place] experts=cpu -> VRAM-Tier aus\n");
             return 0;
-        } else if(nres){
+        } else if(nres && !G_auto_on){
             int w=0;
             for(int i=0;i<G.ndev;i++){
                 int res=0; for(int r=0;r<nres;r++) if(G.dev[i]==reserved[r]) res=1;
@@ -341,61 +536,25 @@ int qt_init(int nl, int ne, int D, int Ih, int cap, int topk, int expert_gs,
         }
     }
 
-    /* per-device budget: CUDA_EXPERT_GB, or auto = free minus 1 GB headroom.
-     * Scale counts follow the container: per-row (expert_gs=0) or grouped
-     * (gs64: [O, ceil(I/gs)] per projection). */
-    G.wfmt = expert_is_int4 ? 4 : 1;
-    /* fmt=1 non ha scale raggruppate: backend_cuda le onora solo per fmt=4
-     * (want_gs = (fmt==4 && ...)). Un container int8 con scale a gruppi non e'
-     * esprimibile sulla GPU, e promuoverlo lo stesso darebbe numeri sbagliati:
-     * meglio restare su CPU dicendolo. Rifiutare qui, PRIMA di riservare
-     * qualunque budget, e' il punto giusto -- il difetto di #1331 era proprio
-     * riservare per poi non promuovere.  */
-    if(G.wfmt==1 && expert_gs>0){
-        fprintf(stderr,"[qtier] int8 experts with grouped scales (gs=%d) cannot be "
-                       "expressed on the GPU (fmt=1 is per-row only) -> CPU path\n", expert_gs);
-        return 0;
-    }
-    G.egs = expert_gs;
-    G.sc_gu = expert_gs ? (size_t)Ih * ((D + expert_gs - 1)/expert_gs) : (size_t)Ih;
-    G.sc_d  = expert_gs ? (size_t)D  * ((Ih + expert_gs - 1)/expert_gs) : (size_t)D;
-    /* int8 occupa il doppio dell'int4 impacchettato: il budget deve saperlo,
-     * se no si promettono il doppio degli esperti che ci stanno. */
-    G.exp_bytes = (G.wfmt==1 ? 3ull*D*Ih : 3ull*D*Ih/2)
-                + (2*G.sc_gu+G.sc_d)*sizeof(float) + 4096; /* + allocation slack */
-    const char *bg=getenv("CUDA_EXPERT_GB");
+    /* Expert budget per device: the allowance minus the trunk that landed
+     * there. The hand-written list gets the same subtraction now: with
+     * COLI_PLACE="dnproj=0" the 0.7 GB of projections used to come out of the
+     * expert cache unannounced (the R4 measurement). Devices may have been
+     * dropped from the expert list by the role split above; match by ordinal. */
     for(int i=0;i<G.ndev;i++){
-        size_t freeb=0,totb=0; coli_cuda_mem_info(G.dev[i],&freeb,&totb);
-        size_t b = (bg && strcmp(bg,"auto") && atof(bg)>0)
-                   ? (size_t)(atof(bg)*1024.0*1024.0*1024.0)
-                   : (freeb>(1ull<<30) ? freeb-(1ull<<30) : 0);
-        G.budget[i]=b;
-        fprintf(stderr,"[qtier] dev %d: %.1f GB free, budget %.1f GB (~%zu experts)\n",
-                G.dev[i], freeb/1073741824.0, b/1073741824.0, b/G.exp_bytes);
+        size_t trunk = 0;
+        for(int o=0;o<G_offer_n;o++)
+            if(qt_place_of(G_offer[o].name, G_offer[o].layer)==G.dev[i]) trunk += G_offer[o].bytes;
+        size_t cap_i = 0;
+        for(int j=0;j<ncap;j++) if(capdev[j]==G.dev[i]) cap_i = capacity[j];
+        G.budget[i] = cap_i > trunk ? cap_i - trunk : 0;
+        fprintf(stderr,"[qtier] dev %d: budget %.2f GB for experts (~%zu experts)%s\n",
+                G.dev[i], G.budget[i]/1073741824.0, G.budget[i]/G.exp_bytes,
+                trunk ? " after trunk" : "");
     }
-    G.slot=calloc((size_t)nl*ne,sizeof(QSlot));
-    /* qt_issue strides each device's block by 32*D floats (its max row
-     * count), not 8*D: a device other than 0 with a full 32-row issue used
-     * to run past its own slice and off the end of this allocation (#1339). */
     G.is_x_floats=(size_t)G.ndev*32*D;
     G.is_x=malloc(G.is_x_floats*sizeof(float));
-    if(!G.slot||!G.is_x) return 0;
-    /* load learned heat (HEAT_FILE): warmstart order + initial values */
-    const char *hf=getenv("HEAT_FILE");
-    if(hf){
-        FILE *f=fopen(hf,"rb");
-        if(f){
-            uint32_t hdr[3]={0,0,0};
-            if(fread(hdr,4,3,f)==3 && hdr[0]==0x51544831u && hdr[1]==(uint32_t)nl && hdr[2]==(uint32_t)ne){
-                G.heat0=malloc((size_t)nl*ne*4);
-                if(G.heat0 && fread(G.heat0,4,(size_t)nl*ne,f)==(size_t)nl*ne){
-                    for(size_t i=0;i<(size_t)nl*ne;i++) G.slot[i].heat=G.heat0[i]>>1; /* decay */
-                    fprintf(stderr,"[qtier] HEAT_FILE loaded: %s\n",hf);
-                } else { free(G.heat0); G.heat0=NULL; }
-            }
-            fclose(f);
-        }
-    }
+    if(!G.is_x) return 0;
     pthread_mutex_init(&G.mx,NULL); pthread_cond_init(&G.cv,NULL); pthread_cond_init(&G.cv_take,NULL);
     if(pthread_create(&G.th,NULL,uploader,NULL)!=0) return 0;
     G.on=1;

--- a/c/qwen36_tier.h
+++ b/c/qwen36_tier.h
@@ -36,6 +36,35 @@
 int  qt_lmhead_init(const int8_t *q, const float *sc, int I, int O);
 int  qt_lmhead_matmul(float *y, const float *x, int I, int O);
 
+/* ---- placement table (R4) ------------------------------------------------
+ * Every movable piece of the forward pass can be pinned to the CPU or to a
+ * specific CUDA device, so configurations can be A/B'd instead of argued
+ * about. One variable, not one per component:
+ *
+ *   COLI_PLACE="experts=0,lmhead=0,dnproj=1,dnout=1,attnproj=cpu"
+ *
+ * Target is `cpu` or a CUDA ordinal. A component may also be split across
+ * cards by layer count, joined with '+' so it cannot be confused with the
+ * component separator:
+ *
+ *   COLI_PLACE="dnproj=0:15+1:15"   first 15 DeltaNet layers on dev 0, rest on 1
+ *
+ * Unnamed components keep their default (CPU; experts keep following
+ * COLI_GPUS). Splitting matters because the DeltaNet projections hang
+ * serially in the layer chain anyway -- a slower card delays only its own
+ * layers, never the whole stream, which is what sank asymmetric EXPERT
+ * placement. `layer` is the model layer index; pass 0 for whole-model
+ * components like lmhead. */
+#define QT_PLACE_CPU (-1)
+int  qt_place_of(const char *component, int layer);
+
+/* DeltaNet input projections, qkv ++ z fused into one resident tensor per
+ * layer: one GEMV instead of two, and the engine's qkv/z buffers are laid out
+ * contiguously so the result needs no split copy. */
+int  qt_dnproj_init(int layer, const int8_t *q, const float *sc,
+                    int I, int O, int device);
+int  qt_dnproj_matmul(int layer, float *y, const float *x, int I, int O);
+
 int  qt_init(int n_layers, int n_experts, int hidden, int inter,
              int cap_experts_per_layer, int topk, int expert_gs,
              int expert_is_int4);
@@ -77,6 +106,10 @@ void qt_stats(void);
 static inline int  qt_init(int a,int b,int c,int d,int e,int f,int g,int h){(void)h;(void)a;(void)b;(void)c;(void)d;(void)e;(void)f;(void)g;return 0;}
 static inline int  qt_lmhead_init(const int8_t*a,const float*b,int c,int d){(void)a;(void)b;(void)c;(void)d;return 0;}
 static inline int  qt_lmhead_matmul(float*a,const float*b,int c,int d){(void)a;(void)b;(void)c;(void)d;return 0;}
+#define QT_PLACE_CPU (-1)
+static inline int  qt_place_of(const char*a,int b){(void)a;(void)b;return QT_PLACE_CPU;}
+static inline int  qt_dnproj_init(int a,const int8_t*b,const float*c,int d,int e,int f){(void)a;(void)b;(void)c;(void)d;(void)e;(void)f;return 0;}
+static inline int  qt_dnproj_matmul(int a,float*b,const float*c,int d,int e){(void)a;(void)b;(void)c;(void)d;(void)e;return 0;}
 static inline int  qt_ready(void){return 0;}
 static inline int  qt_is_resident(int a,int b){(void)a;(void)b;return 0;}
 static inline void qt_shutdown(void){}

--- a/c/qwen36_tier.h
+++ b/c/qwen36_tier.h
@@ -57,6 +57,14 @@ int  qt_lmhead_matmul(float *y, const float *x, int I, int O);
  * components like lmhead. */
 #define QT_PLACE_CPU (-1)
 int  qt_place_of(const char *component, int layer);
+/* Automatic placement (COLI_PLACE unset or "auto"; "off" disables). The
+ * engine offers each trunk component with its byte size BEFORE qt_init --
+ * "lmhead" once (layer 0), "dnproj" per DeltaNet layer -- and qt_init decides
+ * by bytes saved per token per byte of VRAM, pricing displaced experts by
+ * heat. The decision is what qt_place_of() then returns, and the placed
+ * bytes come out of that device's expert budget. Sizes only; the tensors
+ * follow through qt_lmhead_init / qt_dnproj_init as before. */
+void qt_trunk_offer(const char *component, int layer, size_t bytes);
 
 /* DeltaNet input projections, qkv ++ z fused into one resident tensor per
  * layer: one GEMV instead of two, and the engine's qkv/z buffers are laid out
@@ -108,6 +116,7 @@ static inline int  qt_lmhead_init(const int8_t*a,const float*b,int c,int d){(voi
 static inline int  qt_lmhead_matmul(float*a,const float*b,int c,int d){(void)a;(void)b;(void)c;(void)d;return 0;}
 #define QT_PLACE_CPU (-1)
 static inline int  qt_place_of(const char*a,int b){(void)a;(void)b;return QT_PLACE_CPU;}
+static inline void qt_trunk_offer(const char*a,int b,size_t c){(void)a;(void)b;(void)c;}
 static inline int  qt_dnproj_init(int a,const int8_t*b,const float*c,int d,int e,int f){(void)a;(void)b;(void)c;(void)d;(void)e;(void)f;return 0;}
 static inline int  qt_dnproj_matmul(int a,float*b,const float*c,int d,int e){(void)a;(void)b;(void)c;(void)d;(void)e;return 0;}
 static inline int  qt_ready(void){return 0;}

--- a/c/qwen36_tier.h
+++ b/c/qwen36_tier.h
@@ -29,6 +29,13 @@
 /* expert_is_int4: 1 = pesi int4 impacchettati (fmt=4), 0 = int8 (fmt=1). Il
  * chiamante lo determina dalla TAGLIA SU DISCO, non da meta.ebits, che su
  * qualche container mente (cfr. il rilevamento in qwen36.c). */
+/* R4 role split: park the dense-i8 lm_head on its own CUDA device
+ * (COLI_LMHEAD_GPU=<dev>). One GEMV per token, at token end — outside the
+ * per-layer latency chain — so a slower second card can host it without
+ * pacing the expert stream. qt_init places no experts on that device. */
+int  qt_lmhead_init(const int8_t *q, const float *sc, int I, int O);
+int  qt_lmhead_matmul(float *y, const float *x, int I, int O);
+
 int  qt_init(int n_layers, int n_experts, int hidden, int inter,
              int cap_experts_per_layer, int topk, int expert_gs,
              int expert_is_int4);
@@ -68,6 +75,8 @@ void qt_stats(void);
 #else /* !COLI_CUDA: inline stubs, engine stays CPU-only */
 
 static inline int  qt_init(int a,int b,int c,int d,int e,int f,int g,int h){(void)h;(void)a;(void)b;(void)c;(void)d;(void)e;(void)f;(void)g;return 0;}
+static inline int  qt_lmhead_init(const int8_t*a,const float*b,int c,int d){(void)a;(void)b;(void)c;(void)d;return 0;}
+static inline int  qt_lmhead_matmul(float*a,const float*b,int c,int d){(void)a;(void)b;(void)c;(void)d;return 0;}
 static inline int  qt_ready(void){return 0;}
 static inline int  qt_is_resident(int a,int b){(void)a;(void)b;return 0;}
 static inline void qt_shutdown(void){}

--- a/c/tests/qwen36_fake_cuda.h
+++ b/c/tests/qwen36_fake_cuda.h
@@ -93,4 +93,13 @@ void coli_cuda_stats(int device, size_t *count, size_t *bytes) {
     (void)device; if (count) *count = 0; if (bytes) *bytes = 0;
 }
 
+/* dense GEMV on a resident tensor (lm_head / DeltaNet projections placed on a
+ * device). Counted, never computed: the placement tests check WHERE work
+ * went; the arithmetic has its own oracle in the CUDA build. Parameters are
+ * unused on purpose (CFLAGS carry -Wno-unused-parameter). */
+static int fake_matmuls;
+int coli_cuda_matmul(ColiCudaTensor **tensor, float *y, const float *x, const void *weights, const float *scales, int fmt, int S, int I, int O, int device, int gs) {
+    fake_matmuls++; return 1;
+}
+
 #endif /* QWEN36_FAKE_CUDA_H */

--- a/c/tests/qwen36_fake_cuda.h
+++ b/c/tests/qwen36_fake_cuda.h
@@ -42,6 +42,7 @@ static unsigned char captured[4096];
 static size_t captured_len;
 
 static int fake_ndev = 1;
+static size_t fake_free_bytes = 2ull << 30;    /* what coli_cuda_mem_info reports as free */
 static int (*fake_issue_hook)(int device, int count, const float *x) = NULL;
 
 static int upload_common(ColiCudaTensor **t, const void *w, int fmt,
@@ -73,7 +74,7 @@ int coli_cuda_init(const int *d, int n) { (void)d; (void)n; return 1; }
 void coli_cuda_shutdown(void) {}
 int coli_cuda_mem_info(int device, size_t *freeb, size_t *total) {
     (void)device;
-    *freeb = 2ull << 30; *total = 4ull << 30;      /* 2 GiB liberi */
+    *freeb = fake_free_bytes; *total = 4ull << 30;   /* 2 GiB liberi by default */
     return 1;
 }
 int coli_cuda_expert_group_issue(ColiCudaTensor *const *g, ColiCudaTensor *const *u,

--- a/c/tests/test_qwen36_tier_autoplace.c
+++ b/c/tests/test_qwen36_tier_autoplace.c
@@ -1,0 +1,186 @@
+/* Automatic placement of the dense trunk (COLI_PLACE unset or "auto").
+ *
+ * The rule under test, stated once: a trunk component goes into VRAM when the
+ * bytes it saves on the memory bus per token beat the bytes the experts it
+ * displaces would have saved -- dense weights are read every token, an expert
+ * with the probability a token routes to it, and the CPU reads an int4 expert
+ * as an int8 slot (twice the VRAM bytes). Everything else here is that rule
+ * applied: no heat means the trunk wins, hot marginal experts mean it loses,
+ * an explicit list is obeyed, "off" places nothing, and whatever lands in
+ * VRAM comes out of that device's expert budget, on one card and on two.
+ *
+ * Fake backend, no GPU: free VRAM is whatever the test says it is. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "qwen36_fake_cuda.h"
+
+#include "../qwen36_tier.c"
+
+static int fails;
+static void check(int ok, const char *what) {
+    if (!ok) { printf("  FAIL: %s\n", what); fails++; }
+}
+
+enum { D = 64, IH = 32 };
+#define MiB (1024ull * 1024ull)
+
+/* every case starts from a clean tier: no offers, no auto decision, env set */
+static void fresh(const char *place, const char *gpus, int ndev, const char *budget_gb) {
+    G_offer_n = 0; G_auto_on = 0;
+    setenv("COLI_CUDA", "1", 1);
+    setenv("COLI_GPUS", gpus, 1);
+    setenv("QT_NO_WARMSTART", "1", 1);
+    setenv("COLI_PLACE", place, 1);                 /* "" == unset == auto */
+    setenv("CUDA_EXPERT_GB", budget_gb, 1);        /* the per-device allowance */
+    setenv("HEAT_FILE", "", 1);
+    fake_ndev = ndev;
+}
+
+static int start(int nl, int ne, int topk) {
+    return qt_init(nl, ne, D, IH, ne, topk, 0 /* per-row */, 1 /* int4 */);
+}
+
+/* HEAT_FILE with every expert at the same heat: p_e = topk / n_experts */
+static const char *write_uniform_heat(int nl, int ne) {
+    static char path[256];
+    snprintf(path, sizeof path, "qwen36_autoplace_heat_%d_%d.bin", nl, ne);
+    FILE *f = fopen(path, "wb");
+    uint32_t hdr[3] = { 0x51544831u, (uint32_t)nl, (uint32_t)ne };
+    fwrite(hdr, 4, 3, f);
+    for (int i = 0; i < nl * ne; i++) { uint32_t h = 1000; fwrite(&h, 4, 1, f); }
+    fclose(f);
+    return path;
+}
+
+int main(void) {
+    printf("qwen36 tier automatic placement\n");
+
+    /* ---- 1. auto, one device: everything offered fits, budget shrinks by it ---- */
+    printf(" 1. auto, one device, trunk fits\n");
+    fresh("", "0", 1, "0.0625");                          /* 64 MiB allowance */
+    qt_trunk_offer("lmhead", 0, 10 * MiB);
+    for (int l = 0; l < 8; l++) if (l % 4 != 3) qt_trunk_offer("dnproj", l, 2 * MiB);
+    check(start(8, 16, 4), "tier starts in auto mode");
+    check(qt_place_of("lmhead", 0) == 0, "lmhead lands on device 0");
+    check(qt_place_of("dnproj", 0) == 0 && qt_place_of("dnproj", 6) == 0, "offered dnproj layers land on device 0");
+    check(qt_place_of("dnproj", 3) == QT_PLACE_CPU, "an attention layer (never offered) stays on the CPU");
+    check(qt_place_of("attnproj", 0) == QT_PLACE_CPU, "components not yet placed by auto stay on the CPU");
+    check(G.ndev == 1 && G.on, "one card keeps experts and trunk together (no role-split reservation in auto)");
+    check(G.budget[0] == 64 * MiB - 22 * MiB, "expert budget = allowance minus the 22 MiB of trunk placed");
+    check(G_lmh.dev_ok && G_lmh.dev == 0, "lm_head device is armed for qt_lmhead_init");
+    qt_shutdown();
+
+    /* ---- 2. auto: a trunk item larger than the allowance stays on the CPU ---- */
+    printf(" 2. auto, trunk does not fit\n");
+    fresh("", "0", 1, "0.0625");
+    qt_trunk_offer("lmhead", 0, 100 * MiB);
+    qt_trunk_offer("dnproj", 0, 2 * MiB);
+    check(start(8, 16, 4), "tier starts");
+    check(qt_place_of("lmhead", 0) == QT_PLACE_CPU, "100 MiB lmhead cannot fit 64 MiB: CPU");
+    check(qt_place_of("dnproj", 0) == 0, "the 2 MiB projection still fits and is placed");
+    check(G.budget[0] == 64 * MiB - 2 * MiB, "budget shrinks only by what was placed");
+    qt_shutdown();
+
+    /* ---- 3. heat decides: hot marginal experts keep their VRAM ---- */
+    printf(" 3. heat: hot marginal experts beat the trunk, cold ones do not\n");
+    {
+        /* nl=1, ne=48. Allowance for exactly 16 experts, so 32 of 48 do not fit
+         * and the trunk would displace real residents. Offer one expert-sized
+         * projection (k=1). Uniform heat -> p_e = topk/48. */
+        enum { NL = 1, NE = 48 };
+        const char *heat = write_uniform_heat(NL, NE);
+        char gb[64];
+        /* exp_bytes for D=64, IH=32, per-row int4: 3072 + 512 + 4096 = 7680 */
+        size_t exp_bytes = 3ull * D * IH / 2 + (2 * IH + D) * sizeof(float) + 4096;
+        snprintf(gb, sizeof gb, "%.15f", (double)(16 * exp_bytes + exp_bytes / 2) / 1073741824.0);
+        /* the allowance as the tier will parse it back from the string */
+        size_t allowance = (size_t)(atof(gb) * 1024.0 * 1024.0 * 1024.0);
+
+        /* topk 32: p = 0.667, CPU factor 2 -> 1.33 bytes/token per VRAM byte > 1.0: trunk loses */
+        fresh("", "0", 1, gb); setenv("HEAT_FILE", heat, 1);
+        qt_trunk_offer("dnproj", 0, exp_bytes);
+        check(start(NL, NE, 32), "tier starts with a heat file");
+        check(G.heat0 != NULL, "heat table loaded");
+        check(qt_place_of("dnproj", 0) == QT_PLACE_CPU,
+              "with p_marginal 0.67 the displaced expert is worth 1.33 bytes/token per byte: trunk stays on CPU");
+        check(G.budget[0] == allowance, "nothing placed, budget untouched");
+        qt_shutdown();
+
+        /* topk 8: p = 0.167 -> 0.33 < 1.0: trunk wins */
+        fresh("", "0", 1, gb); setenv("HEAT_FILE", heat, 1);
+        qt_trunk_offer("dnproj", 0, exp_bytes);
+        check(start(NL, NE, 8), "tier starts");
+        check(qt_place_of("dnproj", 0) == 0, "with p_marginal 0.17 the trunk item is worth more: placed");
+        check(G.budget[0] == allowance - exp_bytes, "budget shrinks by the placed item");
+        qt_shutdown();
+
+        /* no heat, topk 32: uniform assumption p = 32/48 as well -- same answer as with the file */
+        fresh("", "0", 1, gb);
+        qt_trunk_offer("dnproj", 0, exp_bytes);
+        check(start(NL, NE, 32), "tier starts without heat");
+        check(qt_place_of("dnproj", 0) == QT_PLACE_CPU, "without a heat file the uniform estimate gives the same verdict");
+        qt_shutdown();
+
+        /* room to spare: allowance for 100 experts, only 48 exist -> displaces nothing, always placed */
+        snprintf(gb, sizeof gb, "%.15f", (double)(100 * exp_bytes) / 1073741824.0);
+        fresh("", "0", 1, gb); setenv("HEAT_FILE", heat, 1);
+        qt_trunk_offer("dnproj", 0, exp_bytes);
+        check(start(NL, NE, 32), "tier starts");
+        check(qt_place_of("dnproj", 0) == 0, "VRAM nobody would use goes to the trunk regardless of heat");
+        qt_shutdown();
+        remove(heat);
+    }
+
+    /* ---- 4. an explicit list wins over auto, and still pays for its trunk ---- */
+    printf(" 4. explicit COLI_PLACE\n");
+    fresh("lmhead=cpu,dnproj=0", "0", 1, "0.0625");
+    qt_trunk_offer("lmhead", 0, 10 * MiB);
+    for (int l = 0; l < 8; l++) if (l % 4 != 3) qt_trunk_offer("dnproj", l, 2 * MiB);
+    check(start(8, 16, 4), "tier starts with an explicit list");
+    check(!G_auto_on, "auto is off when a list is given");
+    check(qt_place_of("lmhead", 0) == QT_PLACE_CPU, "lmhead=cpu is obeyed even though it would fit");
+    check(qt_place_of("dnproj", 2) == 0, "dnproj=0 is obeyed");
+    check(G.budget[0] == 64 * MiB - 12 * MiB, "the explicit list's 12 MiB of projections come out of the expert budget too");
+    qt_shutdown();
+
+    /* ---- 5. off: nothing placed, full budget ---- */
+    printf(" 5. COLI_PLACE=off\n");
+    fresh("off", "0", 1, "0.0625");
+    qt_trunk_offer("lmhead", 0, 10 * MiB);
+    qt_trunk_offer("dnproj", 0, 2 * MiB);
+    check(start(8, 16, 4), "tier starts with placement off");
+    check(qt_place_of("lmhead", 0) == QT_PLACE_CPU && qt_place_of("dnproj", 0) == QT_PLACE_CPU, "off places nothing");
+    check(G.budget[0] == 64 * MiB, "off leaves the whole allowance to the experts");
+    qt_shutdown();
+
+    /* ---- 6. auto, two devices: greedy by room, both keep experts ---- */
+    printf(" 6. auto, two devices\n");
+    fresh("", "0,1", 2, "0.0625");
+    qt_trunk_offer("lmhead", 0, 10 * MiB);
+    for (int l = 0; l < 8; l++) if (l % 4 != 3) qt_trunk_offer("dnproj", l, 9 * MiB);
+    check(start(8, 16, 4), "tier starts on two fake devices");
+    check(G.ndev == 2, "auto keeps experts on both devices");
+    check(qt_place_of("lmhead", 0) == 0, "lmhead goes to the first device (both equal, first wins)");
+    /* greedy by most room, 9 MiB each, after lmhead dev0=54 dev1=64:
+       l0 -> dev1 (55), l1 -> dev1 (46), l2 -> dev0 (45), l4 -> dev1 (37),
+       l5 -> dev0 (36), l6 -> dev1 (27): dev0 holds lmhead+2 = 28 MiB, dev1 4 = 36 MiB */
+    check(qt_place_of("dnproj", 0) == 1 && qt_place_of("dnproj", 1) == 1 && qt_place_of("dnproj", 2) == 0 &&
+          qt_place_of("dnproj", 4) == 1 && qt_place_of("dnproj", 5) == 0 && qt_place_of("dnproj", 6) == 1,
+          "projections go to whichever device has the most room left");
+    check(G.budget[0] == 64 * MiB - 28 * MiB && G.budget[1] == 64 * MiB - 36 * MiB,
+          "each device's expert budget is its allowance minus its own trunk");
+    qt_shutdown();
+
+    /* ---- 7. nothing offered: auto is a no-op, budgets are the allowance ---- */
+    printf(" 7. auto with nothing offered\n");
+    fresh("", "0", 1, "0.0625");
+    check(start(8, 16, 4), "tier starts");
+    check(qt_place_of("lmhead", 0) == QT_PLACE_CPU && G.budget[0] == 64 * MiB, "no offers: nothing placed, full budget");
+    qt_shutdown();
+
+    if (fails) { printf("test_qwen36_tier_autoplace: %d failure(s)\n", fails); return 1; }
+    printf("test_qwen36_tier_autoplace: ok\n");
+    return 0;
+}

--- a/c/tests/test_qwen36_tier_invariants.c
+++ b/c/tests/test_qwen36_tier_invariants.c
@@ -1,0 +1,440 @@
+/* Invariants of the qwen36 VRAM expert tier, checked rather than assumed.
+ *
+ * #1339, #1340 and #1341 were each found by reading, and each had a
+ * one-scenario regression test written after the fact. This file states the
+ * rules those scenarios are instances of, and checks the rules directly on
+ * the fake CUDA backend (tests/qwen36_fake_cuda.h), so the next drift fails
+ * here before anyone reads the code again:
+ *
+ *   1. Budget accounting balances. On every device, bytes in use never exceed
+ *      the budget, and once the queue is drained, bytes in use equal exactly
+ *      resident experts times bytes per expert: every reservation was either
+ *      consumed by an upload or handed back. Checked on one and on two
+ *      devices, and across the path where a planned expert is never handed
+ *      over -- the reservation must not leak with it.
+ *
+ *   2. Shutdown returns from every wait state at once. Four places sleep on
+ *      cv_take (the uploader's victim wait, qt_note_block, qt_note_planned,
+ *      qt_fill_wait); #1340 was shutdown waking none of them. Here all four
+ *      are parked at the same time, under a portable watchdog, and shutdown
+ *      has to bring every one of them home.
+ *
+ *   3. Issue geometry holds under random routing. Random resident sets,
+ *      random K up to the row limit, one to three devices, many seeds: every
+ *      device block lies inside the replica buffer, blocks of different
+ *      devices never overlap, mask bits name exactly the routed experts that
+ *      were resident on a device whose issue succeeded, and hits plus misses
+ *      add up to everything routed. Under ASan (make test-asan) this doubles
+ *      as a fuzz for the class of #1339. The row limit is read from the array
+ *      the rows index, so the stride cannot drift from it again.
+ *
+ * Everything runs in the plain CPU build; no GPU, no toolkit. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#if defined(_WIN32)
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+#include "qwen36_fake_cuda.h"
+
+#include "../qwen36_tier.c"
+
+static int fails;
+static void check(int ok, const char *what) {
+    if (!ok) { printf("  FAIL: %s\n", what); fails++; }
+}
+
+/* ---- portable watchdog: a hang is a failure, not a stuck CI job ----------
+ * Static state on purpose: the thread outlives the function that armed it,
+ * and a pointer into that function's frame is a stack-use-after-return the
+ * moment it returns -- the same lifetime mistake as #1277, caught here by
+ * ASan on the first draft of this very test. Disarmed after a successful
+ * shutdown so a late wake-up cannot fail a run that already passed. */
+static volatile int watchdog_armed;
+static int watchdog_seconds;
+static void *watchdog(void *arg) {
+    (void)arg;
+    struct timespec limit = { watchdog_seconds, 0 };
+    nanosleep(&limit, NULL);
+    if (!watchdog_armed) return NULL;
+    fprintf(stderr, "FAIL: tier did not come home within %d s (hang, see #1340)\n", watchdog_seconds);
+    _exit(1);
+}
+static void arm_watchdog(int seconds) {
+    pthread_t t;
+    watchdog_seconds = seconds; watchdog_armed = 1;
+    pthread_create(&t, NULL, watchdog, NULL);
+    pthread_detach(t);
+}
+static void disarm_watchdog(void) { watchdog_armed = 0; }
+
+/* wait (2 ms polls) until a G.mx-guarded condition holds, or give up */
+#define WAIT_UNTIL(cond, max_polls)                                    \
+    do {                                                               \
+        for (int wu_i = 0; wu_i < (max_polls); wu_i++) {               \
+            pthread_mutex_lock(&G.mx); int wu_ok = (cond);             \
+            pthread_mutex_unlock(&G.mx);                               \
+            if (wu_ok) break;                                          \
+            struct timespec wu_ts = {0, 2000000}; nanosleep(&wu_ts, NULL); \
+        }                                                              \
+    } while (0)
+
+/* the queue being empty is not the same as the uploader being done: the last
+ * dequeued expert is still queued=1 until its upload returns */
+static int all_settled(void) {
+    if (G.qn != 0) return 0;
+    for (int l = 0; l < G.nl; l++) for (int e = 0; e < G.ne; e++) if (qs(l, e)->queued) return 0;
+    return 1;
+}
+#define WAIT_IDLE() WAIT_UNTIL(all_settled(), 1000)
+
+/* ---- fake weights: one set per expert, recognisable bytes ---------------- */
+enum { D = 64, IH = 32 };
+#define MB4 (D * IH / 2)
+#define NSC (2 * IH + D)             /* per-row scales: gs=0 -> sc_gu = IH, sc_d = D */
+
+static unsigned char g4s[64][MB4], u4s[64][MB4], d4s[64][MB4];
+static float scs[64][NSC];
+static void make_weights(int ne) {
+    for (int e = 0; e < ne; e++) {
+        memset(g4s[e], (unsigned char)(e + 1), MB4);
+        memset(u4s[e], (unsigned char)(e + 2), MB4);
+        memset(d4s[e], (unsigned char)(e + 3), MB4);
+        for (int i = 0; i < NSC; i++) scs[e][i] = 1.0f;
+    }
+}
+#define NOTE(fn, l, e) fn((l), (e), g4s[e], u4s[e], d4s[e], scs[e], scs[e] + IH, scs[e] + 2 * IH)
+
+static int start_tier(int ndev, int nl, int ne, int topk, const char *budget_gb) {
+    setenv("COLI_CUDA", "1", 1);
+    setenv("COLI_GPUS", ndev == 1 ? "0" : ndev == 2 ? "0,1" : "0,1,2", 1);
+    setenv("QT_NO_WARMSTART", "1", 1);
+    /* "auto" is the tier's own spelling of "no explicit budget" (free minus
+     * 1 GiB); unsetenv would be POSIX-only and MinGW has no equivalent */
+    setenv("CUDA_EXPERT_GB", budget_gb ? budget_gb : "auto", 1);
+    fake_ndev = ndev;
+    fake_uploads = 0;
+    fake_issue_hook = NULL;
+    return qt_init(nl, ne, D, IH, ne, topk, 0 /* per-row */, 1 /* int4 */);
+}
+
+static size_t resident_on(int dev) {
+    size_t n = 0;
+    for (int l = 0; l < G.nl; l++)
+        for (int e = 0; e < G.ne; e++)
+            if (home(e) == dev && qs(l, e)->resident) n++;
+    return n;
+}
+
+/* Bytes per expert as the tier computed it, plus the budget that holds
+ * exactly `n` of them and not n+1 (so the fill stops on budget, not on the
+ * end of the list). Written as GiB text because that is the knob. */
+static void budget_for(int n, char *out, size_t len) {
+    double gib = ((double)G.exp_bytes * n + G.exp_bytes / 2) / 1073741824.0;
+    snprintf(out, len, "%.12f", gib);
+}
+
+/* ======================================================================== */
+/* 1. budget accounting                                                     */
+/* ======================================================================== */
+static void check_balance(const char *ctx) {
+    char msg[160];
+    pthread_mutex_lock(&G.mx);
+    for (int di = 0; di < G.ndev; di++) {
+        size_t res = resident_on(di);
+        snprintf(msg, sizeof msg, "%s: dev %d used %zu > budget %zu", ctx, di, G.used[di], G.budget[di]);
+        check(G.used[di] <= G.budget[di], msg);
+        snprintf(msg, sizeof msg, "%s: dev %d used %zu != %zu resident x %zu B (a reservation leaked or was double-returned)",
+                 ctx, di, G.used[di], res, G.exp_bytes);
+        check(G.used[di] == res * G.exp_bytes, msg);
+    }
+    pthread_mutex_unlock(&G.mx);
+}
+
+static void test_budget_accounting(int ndev) {
+    enum { NL = 2, NE = 16 };
+    make_weights(NE);
+    /* first start only to learn exp_bytes, then restart with a budget that
+     * holds 5 experts per device: 10 of 32 fit, the rest must stay CPU */
+    if (!start_tier(ndev, NL, NE, 4, NULL)) { check(0, "tier did not start"); return; }
+    char b[64]; budget_for(5, b, sizeof b);
+    qt_shutdown();
+    if (!start_tier(ndev, NL, NE, 4, b)) { check(0, "tier did not start with a small budget"); return; }
+
+    int layers[NL * NE], eids[NL * NE];
+    int planned = qt_plan_fill(layers, eids, NL * NE);
+    check(planned == 5 * ndev, "plan_fill should reserve exactly the budget: 5 experts per device");
+    pthread_mutex_lock(&G.mx);
+    for (int di = 0; di < G.ndev; di++)
+        check(G.used[di] == 5 * G.exp_bytes, "plan_fill reservations must equal 5 x exp_bytes per device");
+    pthread_mutex_unlock(&G.mx);
+
+    /* hand over all but the last planned expert normally; the last one is
+     * reported the way the warmstart reports an expert whose loader came back
+     * empty -- with NULL weights */
+    for (int i = 0; i < planned - 1; i++) NOTE(qt_note_planned, layers[i], eids[i]);
+    qt_note_planned(layers[planned - 1], eids[planned - 1], NULL, NULL, NULL, NULL, NULL, NULL);
+    qt_fill_wait();
+    WAIT_IDLE();
+
+    /* a second hand-over of an already-resident expert must not return a
+     * reservation it does not hold (double return would drive used below
+     * what is resident) */
+    NOTE(qt_note_planned, layers[0], eids[0]);
+    /* the free-running path (decode-time note) on a non-planned expert on a
+     * full device must be refused without touching the books */
+    int extra_l = NL - 1, extra_e = NE - 1;
+    while (qs(extra_l, extra_e)->planned || qs(extra_l, extra_e)->resident) extra_e--;
+    NOTE(qt_note, extra_l, extra_e);
+    /* and make every remaining expert known to the tier (g4 set, upload
+     * refused by the full budget) so an LFRU swap has candidates on each
+     * device -- exactly the population decode-time qt_note builds up */
+    for (int l = 0; l < NL; l++) for (int e = 0; e < NE; e++) NOTE(qt_note, l, e);
+    WAIT_IDLE();
+
+    pthread_mutex_lock(&G.mx);
+    QSlot *orphan = qs(layers[planned - 1], eids[planned - 1]);
+    int orphan_dev = home(eids[planned - 1]);
+    size_t used_orphan_dev = G.used[orphan_dev], res_orphan_dev = resident_on(orphan_dev);
+    pthread_mutex_unlock(&G.mx);
+    /* The rule under test: a reservation is consumed or returned. The
+     * planned-but-never-delivered expert holds neither a tensor nor a right
+     * to the budget; if its bytes are still counted, the device is smaller
+     * than the tier believes for the life of the process, and
+     * "if(resident||queued||planned) continue" never reconsiders it. */
+    check(!orphan->resident && !orphan->queued && !orphan->planned,
+          "an expert reported with no weights must end up neither resident, queued nor planned");
+    check(used_orphan_dev == res_orphan_dev * G.exp_bytes,
+          "undelivered planned expert: its reservation is still counted (leak: planned=1 keeps it and the "
+          "budget never gets those bytes back)");
+    check_balance(ndev == 1 ? "1 device, after warmstart" : "2 devices, after warmstart");
+
+    /* budget is per device: a device must not overflow because another has room */
+    for (int di = 0; di < G.ndev; di++)
+        check(resident_on(di) <= 5, "no device may hold more than its own budget allows");
+
+    /* exercise one LFRU swap end to end and re-check the books: a swap is
+     * budget-neutral by construction, so used must not move */
+    pthread_mutex_lock(&G.mx);
+    size_t used_before[QT_MAX_DEV]; memcpy(used_before, G.used, sizeof used_before);
+    int vict_l = -1, vict_e = -1, hot_l = -1, hot_e = -1;
+    for (int l = 0; l < NL && vict_l < 0; l++)
+        for (int e = 0; e < NE; e++)
+            if (qs(l, e)->resident) { vict_l = l; vict_e = e; break; }
+    for (int l = 0; l < NL && hot_l < 0; l++)
+        for (int e = 0; e < NE; e++)
+            if (!qs(l, e)->resident && !qs(l, e)->queued && qs(l, e)->g4 && home(e) == home(vict_e)) {
+                hot_l = l; hot_e = e; break; }
+    int swapped = 0;
+    if (vict_l >= 0 && hot_l >= 0) {
+        qs(vict_l, vict_e)->resident = 0;
+        swapped = enqueue_locked(hot_l, hot_e, vict_l, vict_e, 0);
+        if (!swapped) qs(vict_l, vict_e)->resident = 1;
+    }
+    pthread_mutex_unlock(&G.mx);
+    check(swapped, "an LFRU swap between a resident and a hot non-resident on the same device must enqueue");
+    WAIT_IDLE();
+    pthread_mutex_lock(&G.mx);
+    for (int di = 0; di < G.ndev; di++)
+        check(G.used[di] == used_before[di], "an LFRU swap is budget-neutral: used must not move");
+    pthread_mutex_unlock(&G.mx);
+    check(qt_is_resident(hot_l, hot_e) && !qt_is_resident(vict_l, vict_e), "after the swap the hot expert is resident and the victim is not");
+    check_balance("after one LFRU swap");
+
+    qt_shutdown();
+    check(!G.on, "shutdown must switch the tier off");
+}
+
+/* ======================================================================== */
+/* 2. shutdown wakes every waiter                                            */
+/* ======================================================================== */
+static int t_note_block_done, t_note_planned_done, t_fill_wait_done;
+static void *th_note_block(void *a)   { (void)a; NOTE(qt_note_block, 1, 31);   t_note_block_done = 1;   return NULL; }
+static void *th_note_planned(void *a) { (void)a; NOTE(qt_note_planned, 1, 30); t_note_planned_done = 1; return NULL; }
+static void *th_fill_wait(void *a)    { (void)a; qt_fill_wait();               t_fill_wait_done = 1;    return NULL; }
+
+static void test_shutdown_wakes_everyone(void) {
+    enum { NL = 2, NE = 32 };            /* 64 experts: more swap candidates than the queue holds */
+    make_weights(NE);
+    if (!start_tier(1, NL, NE, 1, NULL)) { check(0, "tier did not start"); return; }
+    char b[64]; budget_for(1, b, sizeof b);
+    qt_shutdown();
+    if (!start_tier(1, NL, NE, 1, b)) { check(0, "tier did not start with a one-expert budget"); return; }
+
+    /* one resident expert, everything else known to the tier but refused by
+     * the budget -- exactly the population an LFRU swap needs */
+    for (int l = 0; l < NL; l++) for (int e = 0; e < NE; e++) if (l || e != 30) if (l != 1 || (e != 30 && e != 31)) NOTE(qt_note, l, e);
+    WAIT_IDLE();
+    check(qt_is_resident(0, 0), "expert (0,0) should have taken the one-expert budget");
+
+    /* open a group and never take it: issue_open stays set, which is the
+     * state the uploader's victim wait keys on */
+    fake_issue_hook = NULL;                 /* issue fails -> mask 0, but issue_open is set regardless */
+    float x[D]; for (int i = 0; i < D; i++) x[i] = (float)i;
+    int e0 = 0; (void)qt_issue(0, &e0, 1, x);
+    pthread_mutex_lock(&G.mx);
+    check(G.issue_open == 1, "a group must be open after qt_issue");
+    /* fill the queue to capacity with swaps against the one victim, so that
+     * the uploader parks on the victim wait AND the queue reads full */
+    qs(0, 0)->resident = 0;
+    int queued = 0;
+    for (int e = 1; e < NE && queued < QT_QCAP; e++)
+        if (enqueue_locked(0, e, 0, 0, 0)) queued++;
+    for (int e = 0; e < NE - 2 && queued < QT_QCAP; e++)      /* (1,30) and (1,31) stay for the waiter threads */
+        if (enqueue_locked(1, e, 0, 0, 0)) queued++;
+    int qn_now = G.qn;
+    pthread_mutex_unlock(&G.mx);
+    check(queued >= 1, "at least one swap must be enqueued to park the uploader");
+    /* the uploader dequeues exactly one and parks; the rest stay queued */
+    WAIT_UNTIL(G.qn == qn_now - 1, 500);
+    pthread_mutex_lock(&G.mx);
+    int parked_qn = G.qn;
+    /* top the queue back up to full so qt_note_block / qt_note_planned have to wait */
+    for (int l = 0; l < NL && G.qn < QT_QCAP; l++)
+        for (int e = 0; e < NE && G.qn < QT_QCAP; e++)
+            if (!(l == 1 && e >= 30) && !qs(l, e)->resident && !qs(l, e)->queued && qs(l, e)->g4)
+                enqueue_locked(l, e, 0, 0, 0);
+    int full = (G.qn == QT_QCAP);
+    pthread_mutex_unlock(&G.mx);
+    (void)parked_qn;
+    check(full, "the upload queue must be full for the blocking note paths to park");
+
+    /* three more waiters, each on cv_take through a different entry point */
+    pthread_t a, bth, c;
+    t_note_block_done = t_note_planned_done = t_fill_wait_done = 0;
+    pthread_create(&a, NULL, th_note_block, NULL);
+    pthread_create(&bth, NULL, th_note_planned, NULL);
+    pthread_create(&c, NULL, th_fill_wait, NULL);
+    struct timespec settle = {0, 50000000}; nanosleep(&settle, NULL);   /* 50 ms: let them park */
+    check(!t_note_block_done && !t_note_planned_done && !t_fill_wait_done,
+          "with a full queue and an open group all three callers must be parked before shutdown");
+
+    arm_watchdog(10);
+    qt_shutdown();
+    pthread_join(a, NULL); pthread_join(bth, NULL); pthread_join(c, NULL);
+    disarm_watchdog();
+    check(!G.on, "shutdown_returns_with_four_waiters_parked");
+    check(t_note_block_done && t_note_planned_done && t_fill_wait_done,
+          "every cv_take waiter must return once shutdown has been requested");
+    /* the abandoned swaps left the books consistent: the victim still holds
+     * its tensor and says so, no queued flag survives */
+    pthread_mutex_lock(&G.mx);
+    int stale_queued = 0;
+    for (int l = 0; l < NL; l++) for (int e = 0; e < NE; e++) stale_queued += qs(l, e)->queued;
+    pthread_mutex_unlock(&G.mx);
+    check(qs(0, 0)->resident == 1 && qs(0, 0)->tg != NULL, "the victim of an abandoned swap keeps its tensor and its resident flag");
+    check(stale_queued == 0, "no expert may still read as queued after shutdown drained or abandoned the queue");
+}
+
+/* ======================================================================== */
+/* 3. issue geometry under random routing                                    */
+/* ======================================================================== */
+enum { MAX_REC = 8 };
+static struct { int device, count; const float *x; } rec[MAX_REC];
+static int nrec;
+static int fail_device = -1;
+static int record_issue(int device, int count, const float *x) {
+    if (nrec < MAX_REC) { rec[nrec].device = device; rec[nrec].count = count; rec[nrec].x = x; nrec++; }
+    return device != fail_device;
+}
+
+static uint32_t rng_state;
+static uint32_t rng(void) { rng_state ^= rng_state << 13; rng_state ^= rng_state >> 17; rng_state ^= rng_state << 5; return rng_state; }
+
+static void test_issue_geometry(int ndev, int seeds) {
+    enum { NL = 1, NE = 64 };
+    const int ROWS = (int)(sizeof G.is_k[0] / sizeof G.is_k[0][0]);   /* the array the rows index */
+    make_weights(NE);
+    if (!start_tier(ndev, NL, NE, ROWS, NULL)) { check(0, "tier did not start"); return; }
+    check(G.is_x_floats == (size_t)G.ndev * ROWS * G.D,
+          "replica buffer must hold ROWS rows per device, ROWS read from is_k, not a second literal");
+    /* everything resident: 2 GiB fake budget per device holds all 64 */
+    for (int e = 0; e < NE; e++) NOTE(qt_note_block, 0, e);
+    qt_fill_wait();
+    WAIT_IDLE();
+    for (int e = 0; e < NE; e++) if (!qt_is_resident(0, e)) { check(0, "warmstart left an expert non-resident"); break; }
+
+    fake_issue_hook = record_issue;
+    float x[D]; for (int i = 0; i < D; i++) x[i] = (float)i;
+    float val[32]; for (int k = 0; k < 32; k++) val[k] = 1.0f;
+    float out[D];
+    uint64_t hits0 = 0, miss0 = 0;
+
+    for (int s = 1; s <= seeds; s++) {
+        rng_state = 0x9E3779B9u * (uint32_t)s + 1u;
+        /* random resident set: knock out a random subset for this round */
+        int knocked[NE]; memset(knocked, 0, sizeof knocked);
+        pthread_mutex_lock(&G.mx);
+        for (int e = 0; e < NE; e++) if ((rng() & 3) == 0) { knocked[e] = 1; qs(0, e)->resident = 0; }
+        pthread_mutex_unlock(&G.mx);
+        /* random K distinct experts, random failing device on some rounds */
+        int K = 1 + (int)(rng() % (uint32_t)ROWS);
+        int eids[32]; int used[NE]; memset(used, 0, sizeof used);
+        for (int k = 0; k < K; k++) { int e; do e = (int)(rng() % NE); while (used[e]); used[e] = 1; eids[k] = e; }
+        fail_device = (rng() % 4 == 0) ? (int)(rng() % (uint32_t)ndev) : -1;
+
+        pthread_mutex_lock(&G.mx);
+        for (int di = 0; di < G.ndev; di++) hits0 += G.hits[di];
+        miss0 = G.miss; uint64_t hits_before = hits0, miss_before = miss0; hits0 = 0;
+        pthread_mutex_unlock(&G.mx);
+
+        nrec = 0;
+        uint32_t mask = qt_issue(0, eids, K, x);
+
+        /* (a) every block inside the buffer, (b) blocks pairwise disjoint,
+           (c) each block at its device's slot: base + device_index * ROWS * D */
+        for (int i = 0; i < nrec; i++) {
+            const float *lo = G.is_x, *hi = G.is_x + G.is_x_floats;
+            check(rec[i].x >= lo && rec[i].x + (size_t)rec[i].count * G.D <= hi, "issue block outside the replica buffer");
+            int di = -1; for (int d = 0; d < G.ndev; d++) if (G.dev[d] == rec[i].device) di = d;
+            check(di >= 0 && rec[i].x == G.is_x + (size_t)di * ROWS * G.D, "issue block not at its device's slot");
+            for (int j = 0; j < i; j++) {
+                int disjoint = (rec[i].x + (size_t)rec[i].count * G.D <= rec[j].x) ||
+                               (rec[j].x + (size_t)rec[j].count * G.D <= rec[i].x);
+                check(disjoint, "issue blocks of two devices overlap");
+            }
+        }
+        /* (d) the mask names exactly: routed, resident, on a device whose issue succeeded */
+        uint32_t expect = 0; int expect_hits = 0, expect_miss = 0;
+        for (int k = 0; k < K; k++) {
+            int e = eids[k];
+            if (knocked[e]) { expect_miss++; continue; }
+            expect_hits++;
+            if (home(e) != fail_device) expect |= 1u << k;
+        }
+        check(mask == expect, "mask bits must be exactly the resident experts on devices whose issue succeeded");
+        /* (e) hits + misses account for every routed expert */
+        pthread_mutex_lock(&G.mx);
+        uint64_t hits_after = 0; for (int di = 0; di < G.ndev; di++) hits_after += G.hits[di];
+        check(hits_after - hits_before == (uint64_t)expect_hits && G.miss - miss_before == (uint64_t)expect_miss,
+              "hits + misses must add up to the routed experts");
+        pthread_mutex_unlock(&G.mx);
+        /* (f) take closes the group whatever the fake returned (is_cnt is
+           re-initialised by the next qt_issue, so it is not a contract here) */
+        memset(out, 0, sizeof out);
+        qt_take(mask, val, K, out);
+        pthread_mutex_lock(&G.mx);
+        check(G.issue_open == 0, "qt_take must close the group");
+        for (int e = 0; e < NE; e++) if (knocked[e]) qs(0, e)->resident = 1;   /* restore for the next round */
+        pthread_mutex_unlock(&G.mx);
+        if (fails) { printf("  (stopping the geometry sweep at seed %d, ndev %d, K %d)\n", s, ndev, K); break; }
+    }
+    fake_issue_hook = NULL;
+    qt_shutdown();
+}
+
+int main(void) {
+    printf("qwen36 tier invariants\n");
+    printf(" 1. budget accounting, 1 device\n");  test_budget_accounting(1);
+    printf(" 1. budget accounting, 2 devices\n"); test_budget_accounting(2);
+    printf(" 2. shutdown wakes every waiter\n");  test_shutdown_wakes_everyone();
+    printf(" 3. issue geometry, random routing, 1/2/3 devices x 200 seeds\n");
+    test_issue_geometry(1, 200); test_issue_geometry(2, 200); test_issue_geometry(3, 200);
+    if (fails) { printf("test_qwen36_tier_invariants: %d failure(s)\n", fails); return 1; }
+    printf("test_qwen36_tier_invariants: ok\n");
+    return 0;
+}

--- a/c/tests/test_qwen36_tier_multidev.c
+++ b/c/tests/test_qwen36_tier_multidev.c
@@ -62,6 +62,19 @@ int main(void) {
         qt_note_block(0, eid, g4[eid], u4[eid], d4[eid], sc[eid], sc[eid] + IH, sc[eid] + 2 * IH);
     }
     qt_fill_wait();
+    /* qt_fill_wait returns when the QUEUE is empty; the expert the uploader
+     * dequeued last is still queued=1 (not yet resident) until its upload
+     * returns. Checking residency right here raced that upload and failed
+     * about one run in fifteen. Wait for the uploader to settle. */
+    for (int i = 0; i < 1000; i++) {
+        int pending = 0;
+        pthread_mutex_lock(&G.mx);
+        for (int eid = 0; eid < NE; eid++) pending += qs(0, eid)->queued;
+        pthread_mutex_unlock(&G.mx);
+        if (!pending) break;
+        struct timespec ts = {0, 2000000};
+        nanosleep(&ts, NULL);
+    }
     for (int eid = 0; eid < NE; eid++)
         check(qt_is_resident(0, eid), "expert did not become resident during warmstart");
 

--- a/docs/qwen36-cuda-tier.md
+++ b/docs/qwen36-cuda-tier.md
@@ -37,6 +37,59 @@ SNAP=<container> N_NEW=200 ./c/qwen36 256 4 prompt.txt
 only (the int8 container keeps the CPU path). `COLI_TIMERS=1` prints
 per-phase timings and tier telemetry.
 
+## Placement: where the dense trunk goes (`COLI_PLACE`)
+
+The tier moves the routed experts. On this hybrid model that is the *small*
+part of a token: 40 layers × top-8 experts, ~190 MB of int8 per token at an
+81 % hit rate, against a dense trunk -- attention, DeltaNet projections,
+shared expert, lm_head -- of **1.8 GB of int8 read on every token**. Leaving
+the trunk on the CPU is why a 6 GB card sees the hit rate stop mattering
+(#1040): the GPU is doing the cheap job.
+
+By default the engine now places the trunk itself. Before the tier decides its
+budget, the engine offers each trunk component with its size (lm_head once, the
+fused DeltaNet projection of every DeltaNet layer), and the tier prices them
+against the experts they would displace, in **bytes saved on the memory bus per
+token, per byte of VRAM**:
+
+- a dense component is read every token: 1.0 per byte;
+- a routed expert is read with the probability a token routes to it -- its heat
+  share when `HEAT_FILE` exists, `topk / n_experts` otherwise -- and the CPU
+  fallback reads the int8 slot, twice the VRAM bytes of an int4 expert: 2·p per
+  byte.
+
+A component goes to the device with the most room if its value beats that of
+the coldest experts it pushes out. Without heat that tail is worth 0.06 per byte
+on the 35B and the trunk always wins; with heat, a card whose marginal expert is
+routed on more than every second token keeps its experts. Placed bytes come out
+of that device's expert budget, and each decision prints as a `[place]` line.
+
+| `COLI_PLACE` | behaviour |
+|---|---|
+| unset or `auto` | automatic, as above |
+| `off` | nothing placed: experts only (the behaviour before this) |
+| `lmhead=0,dnproj=0:20+1:20,experts=0` | hand-written list (the measurement tool); obeyed as written, trunk bytes still charged to the budget |
+
+First calibration, one RTX 3070 (8 GB), per-row int4 container, 200-token
+decode, same prompt, output bit-identical in all four runs:
+
+| | `off` | `auto` |
+|---|---|---|
+| trunk in VRAM | -- | lm_head 0.47 GB + 30 dnproj 0.70 GB |
+| experts resident | 4,391 | 3,595 |
+| cold: hit rate / tok/s | 44 % / 8.64 | 36 % / **9.62** |
+| warm: hit rate / tok/s | 95 % / 9.63 | 90.6 % / **12.92** |
+
+The warm row is the one that matters: at a 95 % hit rate the marginal expert
+is as valuable as it gets on this card, and the trunk still wins by a third.
+The hit rate drops only 4.4 points for 796 fewer residents because the
+displaced experts are the coldest of the heat order -- exactly the ones the
+placer priced as cheap. More points (a budget capped at 5 GB to stand in for
+a 6 GB card, the Quadro, two cards) follow as they are measured.
+
+Peak RSS is ~2 GB higher under `auto`: the host-side int8 copies stay as the
+CPU fallback. Known, not yet addressed.
+
 ## Measured (Threadripper 3945WX 12C, RTX 3070 8 GB + Quadro RTX 4000 8 GB, Qwen3.6-35B-A3B int4, 200-token decode)
 
 | | 1 GPU (8 GB) | 2 GPUs (16 GB) |

--- a/docs/qwen36-cuda-tier.md
+++ b/docs/qwen36-cuda-tier.md
@@ -82,6 +82,7 @@ decode, same prompt, output bit-identical in all four runs:
 | same card, budget capped at 5 GB (a 6 GB card's share), warm | 88.9 % / 9.50 | 81.2 % / **13.15** |
 | Quadro RTX 4000 (8 GB) alone, warm | 93.6 % / 11.09 | 88.4 % / **16.55** |
 | both cards, experts on both, warm | 100 % / 10.79 | 100 % / **14.80** |
+| reference: Ollama 0.32.5, same model Q4_K_M, same prompt, both cards (57 % CPU / 43 % GPU, 11.8 GB VRAM) | 20.3 warm (21.3 cold) | |
 
 The warm row is the one that matters: at a 95 % hit rate the marginal expert
 is as valuable as it gets on this card, and the trunk still wins by a third.
@@ -89,7 +90,11 @@ The hit rate drops only 4.4 points for 796 fewer residents because the
 displaced experts are the coldest of the heat order -- exactly the ones the
 placer priced as cheap. The smaller or slower the card, the larger the
 relative win: +34 % on the 3070, +38 % at a 5 GB budget, +49 % on the Quadro.
-All sixteen runs of this calibration produced bit-identical text.
+All sixteen runs of this calibration produced bit-identical text. Against
+Ollama on the same box the gap closes from 1.5× (14.97 vs 22.4 in August, two
+cards, hand-placed) to **1.23× on a single 8 GB card** (16.55 vs 20.3) --
+with Ollama holding its dense weights at ~0.56 bytes per weight (Q4_K_M)
+against this engine's 1.0 (int8), and using both cards.
 
 **Two cards are the open case.** With experts on both cards the second card
 paces every layer (the slower `take()` gates the chain), so `off` on two cards

--- a/docs/qwen36-cuda-tier.md
+++ b/docs/qwen36-cuda-tier.md
@@ -80,14 +80,26 @@ decode, same prompt, output bit-identical in all four runs:
 | cold: hit rate / tok/s | 44 % / 8.64 | 36 % / **9.62** |
 | warm: hit rate / tok/s | 95 % / 9.63 | 90.6 % / **12.92** |
 | same card, budget capped at 5 GB (a 6 GB card's share), warm | 88.9 % / 9.50 | 81.2 % / **13.15** |
+| Quadro RTX 4000 (8 GB) alone, warm | 93.6 % / 11.09 | 88.4 % / **16.55** |
+| both cards, experts on both, warm | 100 % / 10.79 | 100 % / **14.80** |
 
 The warm row is the one that matters: at a 95 % hit rate the marginal expert
 is as valuable as it gets on this card, and the trunk still wins by a third.
 The hit rate drops only 4.4 points for 796 fewer residents because the
 displaced experts are the coldest of the heat order -- exactly the ones the
-placer priced as cheap. The smaller the card, the larger the relative win:
-+34 % at 8 GB, +38 % at a 5 GB budget. The Quadro and the two-card case
-follow as they are measured.
+placer priced as cheap. The smaller or slower the card, the larger the
+relative win: +34 % on the 3070, +38 % at a 5 GB budget, +49 % on the Quadro.
+All sixteen runs of this calibration produced bit-identical text.
+
+**Two cards are the open case.** With experts on both cards the second card
+paces every layer (the slower `take()` gates the chain), so `off` on two cards
+is barely ahead of the Quadro alone (10.79 vs 11.09), and `auto` -- which in
+this version spreads the trunk by free room and leaves the experts on both --
+reaches 14.80 where the hand-written R4 split (`experts=0,lmhead=0,
+dnproj=0:20+1:20`: experts on ONE card, trunk across both) reaches 17.11. On
+two unequal cards the list still wins; the next version of the placer has to
+learn that lesson (experts on one card, the trunk on the other) rather than
+have it written for it.
 
 Peak RSS is ~2 GB higher under `auto`: the host-side int8 copies stay as the
 CPU fallback. Known, not yet addressed.

--- a/docs/qwen36-cuda-tier.md
+++ b/docs/qwen36-cuda-tier.md
@@ -70,7 +70,7 @@ of that device's expert budget, and each decision prints as a `[place]` line.
 | `off` | nothing placed: experts only (the behaviour before this) |
 | `lmhead=0,dnproj=0:20+1:20,experts=0` | hand-written list (the measurement tool); obeyed as written, trunk bytes still charged to the budget |
 
-First calibration, one RTX 3070 (8 GB), per-row int4 container, 200-token
+First calibration, one Quadro RTX 4000 (8 GB), per-row int4 container, 200-token
 decode, same prompt, output bit-identical in all four runs:
 
 | | `off` | `auto` |
@@ -80,7 +80,7 @@ decode, same prompt, output bit-identical in all four runs:
 | cold: hit rate / tok/s | 44 % / 8.64 | 36 % / **9.62** |
 | warm: hit rate / tok/s | 95 % / 9.63 | 90.6 % / **12.92** |
 | same card, budget capped at 5 GB (a 6 GB card's share), warm | 88.9 % / 9.50 | 81.2 % / **13.15** |
-| Quadro RTX 4000 (8 GB) alone, warm | 93.6 % / 11.09 | 88.4 % / **16.55** |
+| RTX 3070 (8 GB) alone, warm | 93.6 % / 11.09 | 88.4 % / **16.55** |
 | both cards, experts on both, warm | 100 % / 10.79 | 100 % / **14.80** |
 | reference: Ollama 0.32.5, same model Q4_K_M, same prompt, both cards (57 % CPU / 43 % GPU, 11.8 GB VRAM) | 20.3 warm (21.3 cold) | |
 
@@ -88,8 +88,10 @@ The warm row is the one that matters: at a 95 % hit rate the marginal expert
 is as valuable as it gets on this card, and the trunk still wins by a third.
 The hit rate drops only 4.4 points for 796 fewer residents because the
 displaced experts are the coldest of the heat order -- exactly the ones the
-placer priced as cheap. The smaller or slower the card, the larger the
-relative win: +34 % on the 3070, +38 % at a 5 GB budget, +49 % on the Quadro.
+placer priced as cheap. The relative win grows with the trunk's share of the
+token: +34 % on the Quadro, +38 % at a 5 GB budget, +49 % on the 3070. (An
+earlier version of this table had the two card names swapped: CUDA orders
+devices fastest-first, `nvidia-smi` by bus, and I had read the wrong one.)
 All sixteen runs of this calibration produced bit-identical text. Against
 Ollama on the same box the gap closes from 1.5× (14.97 vs 22.4 in August, two
 cards, hand-placed) to **1.23× on a single 8 GB card** (16.55 vs 20.3) --
@@ -98,7 +100,7 @@ against this engine's 1.0 (int8), and using both cards.
 
 **Two cards are the open case.** With experts on both cards the second card
 paces every layer (the slower `take()` gates the chain), so `off` on two cards
-is barely ahead of the Quadro alone (10.79 vs 11.09), and `auto` -- which in
+is barely ahead of the 3070 alone (10.79 vs 11.09), and `auto` -- which in
 this version spreads the trunk by free room and leaves the experts on both --
 reaches 14.80 where the hand-written R4 split (`experts=0,lmhead=0,
 dnproj=0:20+1:20`: experts on ONE card, trunk across both) reaches 17.11. On

--- a/docs/qwen36-cuda-tier.md
+++ b/docs/qwen36-cuda-tier.md
@@ -79,13 +79,15 @@ decode, same prompt, output bit-identical in all four runs:
 | experts resident | 4,391 | 3,595 |
 | cold: hit rate / tok/s | 44 % / 8.64 | 36 % / **9.62** |
 | warm: hit rate / tok/s | 95 % / 9.63 | 90.6 % / **12.92** |
+| same card, budget capped at 5 GB (a 6 GB card's share), warm | 88.9 % / 9.50 | 81.2 % / **13.15** |
 
 The warm row is the one that matters: at a 95 % hit rate the marginal expert
 is as valuable as it gets on this card, and the trunk still wins by a third.
 The hit rate drops only 4.4 points for 796 fewer residents because the
 displaced experts are the coldest of the heat order -- exactly the ones the
-placer priced as cheap. More points (a budget capped at 5 GB to stand in for
-a 6 GB card, the Quadro, two cards) follow as they are measured.
+placer priced as cheap. The smaller the card, the larger the relative win:
++34 % at 8 GB, +38 % at a 5 GB budget. The Quadro and the two-card case
+follow as they are measured.
 
 Peak RSS is ~2 GB higher under `auto`: the host-side int8 copies stay as the
 CPU fallback. Known, not yet addressed.


### PR DESCRIPTION
**Stacked on #1360** (which is stacked on #1344). Until those land, their four commits show in this diff; this PR's own commits are the seven from `9d7c00b` to `bd6c4c7`. I will rebase as each lands.

## Why

sehHeiden's measurement series in #1040 (GTX 1660 Ti, 6 GB): the CUDA expert tier reaches 6.6 tok/s warm and the hit rate stops mattering (33 → 95 % hit buys +13 %), while llama.cpp `--cpu-moe -ngl 99` does 19.9 on the same box. The mechanism is placement, not the tier: the tier moves the routed experts, which on this hybrid model are the *small* part of a token (~190 MB of int8 at 81 % hit), and leaves the dense trunk -- attention, DeltaNet projections, shared expert, lm_head, **1.8 GB of int8 read on every token** -- on the CPU. llama.cpp places the mirror image.

The hand-written `COLI_PLACE` list from my fork proved the point (13.84 → 17.11 tok/s on two cards) but nobody running a 6 GB card should have to work out that 1.2 GB of trunk is worth more than 800 experts. The engine knows every size involved, so now it decides.

## What this adds

**1. `COLI_PLACE` and two resident trunk components** (the two R4 commits, adapted to #1344): lm_head and the fused per-layer DeltaNet projection (qkv ++ z, one GEMV instead of two) as resident int8 tensors on a CUDA device, and a placement table `qt_place_of(component, layer)` every movable piece consults. Bit-identical to the CPU path.

**2. Automatic placement** (`feat(qwen36): automatic placement of the dense trunk`). Before the tier decides its budget, the engine offers each trunk component with its size (`qt_trunk_offer`: lm_head once, dnproj per DeltaNet layer, sizes from the same dense-i8 entries the uploads use). `qt_init` prices them against the experts they would displace, in **bytes saved on the memory bus per token, per byte of VRAM**:

- a dense component is read every token: value 1.0 per byte;
- a routed expert is read with the probability p_e a token routes to it -- its heat share when `HEAT_FILE` exists, `topk / n_experts` otherwise -- and the CPU fallback reads the int8 slot, twice the VRAM bytes of an int4 expert: value 2·p_e per byte (1·p_e on an int8 container).

A component goes to the device with the most room if its value beats that of the coldest experts it would push out (the tail of the heat order that still fits). Without heat the tail is worth 2·topk/n_experts per byte (0.06 on the 35B) and the trunk always wins; with heat, a card whose marginal expert is routed on more than every second token keeps its experts -- the R4 case where moving all projections onto one near-full card cost 0.7 GB of hot experts and the 13 ms it had saved.

| `COLI_PLACE` | behaviour |
|---|---|
| unset or `auto` | automatic |
| `off` | nothing placed: experts only, the behaviour before this PR |
| a list, e.g. `lmhead=0,dnproj=0:20+1:20,experts=0` | obeyed as written; the trunk's bytes are now charged to that device's expert budget, which the list never did (the 0.7 GB above was the discovery) |

Every decision prints a `[place]` line with the numbers that made it; `qt_stats` names the trunk share of VRAM so "used > budget" does not read as an overrun.

**3. Tests on the fake backend** (`tests/test_qwen36_tier_autoplace.c`, seven cases, free VRAM is whatever the test says): fits → placed and the budget shrinks by exactly the trunk; too big → CPU; heat verdicts both ways (p_marginal 0.67 keeps the experts, 0.17 places the trunk, with and without a heat file, and room nobody would use always goes to the trunk); an explicit list obeyed and charged; `off`; two devices greedy by room with per-device budgets; nothing offered → no-op. `qwen36_fake_cuda.h` gains a counting `coli_cuda_matmul` stub and a settable free-VRAM figure.

## Calibration (Qwen3.6-35B-A3B per-row int4, 200-token decode, same prompt throughout; Threadripper 3945WX, 12 threads)

| | `off` | `auto` | |
|---|---|---|---|
| RTX 3070 (8 GB), cold | 44 % hit / 8.64 tok/s | 36 % / 9.62 | +11 % |
| RTX 3070, warm | 95.0 % / 9.63 | 90.6 % / **12.92** | **+34 %** |
| RTX 3070, budget capped at 5 GB (a 6 GB card's share), warm | 88.9 % / 9.50 | 81.2 % / **13.15** | **+38 %** |
| Quadro RTX 4000 (8 GB), warm | 93.6 % / 11.09 | 88.4 % / **16.55** | **+49 %** |
| both cards, experts on both, warm | 100 % / 10.79 | 100 % / 14.80 | +37 % |
| reference: Ollama 0.32.5, same model Q4_K_M, same prompt, both cards, 57 % CPU / 43 % GPU | 20.3 warm (21.3 cold) | | |

**All sixteen runs produced bit-identical text** (`cmp`, full output), across cards, budgets, cold and warm, off and auto. The warm rows are the ones that matter: at 95 % hit rate the marginal expert is as valuable as it gets on an 8 GB card, and the trunk still wins by a third; the hit rate drops only 4.4 points for 796 fewer residents because the displaced experts are the coldest of the heat order -- exactly the ones the placer priced as cheap. The smaller or slower the card, the larger the relative win, which is the shape of sehHeiden's problem.

Against Ollama on the same box the gap closes from 1.5× (August, two cards, hand-placed) to **1.23× on a single 8 GB card**, with Ollama holding its dense weights at ~0.56 bytes/weight (Q4_K_M) against this engine's 1.0 (int8) and using both cards.

## What this does not settle: two cards

With experts on both cards the second card paces every layer (the slower `take()` gates the chain), so `off` on two cards is barely ahead of the Quadro alone (10.79 vs 11.09) despite 100 % hit rate. This version's placer spreads the trunk by free room and leaves the experts on both, reaching 14.80, where the hand-written split -- experts on **one** card, trunk across both -- reaches 17.11. On two unequal cards the list still wins; the placer's next version has to learn that (experts on one card, trunk on the other, the expert card chosen by a short probe rather than guessed). Said in the docs rather than hidden.

Also known: peak RSS is ~2 GB higher under `auto` because the host int8 copies stay as the CPU fallback; `dnout` and `attnproj` are in the table but not yet offered.

## Verified

- six tier tests green (`test_qwen36_tier_{int8,multidev,shutdown,invariants,autoplace,int8_engine}`), the invariants and autoplace tests clean under ASan+UBSan
- CPU build and `CUDA=1` build; the calibration above is the CUDA build on the real container
- the R4 commits arrive without the binaries the fork commit accidentally carried, and with `qt_init`'s device selection resolved against #1344 (COLI_PLACE devices are folded in after the COLI_GPUS/auto selection)

Thanks to Claude Code. 
