### PR TITLE
docs: replace the expired Discord invite (all 4 READMEs + site)

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://discord.gg/MAaKtQRc"><b>Discord</b></a> ·
+  <a href="https://discord.gg/FkyrEeJR"><b>Discord</b></a> ·
   <a href="README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.zh-TW.md">繁體中文</a> · Italiano
 </p>
 
@@ -352,7 +352,7 @@ Se ti è utile:
 - ⭐ metti una stella al repository e condividilo;
 - 🐛 apri issue con i numeri di benchmark del tuo hardware — i datapoint
   fanno avanzare questo progetto più di qualsiasi altra cosa;
-- 💬 entra nella [comunità Discord](https://discord.gg/MAaKtQRc) per discutere
+- 💬 entra nella [comunità Discord](https://discord.gg/FkyrEeJR) per discutere
   esperimenti, risultati hardware e direzioni di ricerca;
 - 💬 contattaci via GitHub issues per sponsorizzare lo sviluppo o donare hardware.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <p align="center">
   <a href="https://justvugg.github.io/colibri"><b>Website</b></a> ·
-  <a href="https://discord.gg/MAaKtQRc"><b>Discord</b></a> ·
+  <a href="https://discord.gg/FkyrEeJR"><b>Discord</b></a> ·
   English · <a href="README.zh-CN.md">简体中文</a> · <a href="README.zh-TW.md">繁體中文</a> · <a href="README.it.md">Italiano</a>
 </p>
 
@@ -597,7 +597,7 @@ today its numbers come from a community of real machines. If it's useful to you:
 - ⭐ star the repo and share it;
 - 🐛 open issues with benchmark numbers from your hardware — datapoints move
   this project more than anything else;
-- 💬 join the [Discord community](https://discord.gg/MAaKtQRc) to discuss
+- 💬 join the [Discord community](https://discord.gg/FkyrEeJR) to discuss
   experiments, hardware results, and research directions;
 - 💬 reach out via GitHub issues to sponsor development or donate hardware.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://discord.gg/MAaKtQRc"><b>Discord</b></a> ·
+  <a href="https://discord.gg/FkyrEeJR"><b>Discord</b></a> ·
   <a href="README.md">English</a> · 简体中文 · <a href="README.zh-TW.md">繁體中文</a> · <a href="README.it.md">Italiano</a>
 </p>
 
@@ -322,7 +322,7 @@ colibrì 最初由一人使用 12 核心、25 GB RAM 的笔记本开发；
 
 - ⭐ 为仓库加星并分享；
 - 🐛 以 issue 提交你的硬件 benchmark 数据——实测数据比任何其他事都更能推动项目；
-- 💬 加入 [Discord 社区](https://discord.gg/MAaKtQRc)，讨论实验、硬件数据与研究方向；
+- 💬 加入 [Discord 社区](https://discord.gg/FkyrEeJR)，讨论实验、硬件数据与研究方向；
 - 💬 若想赞助开发或捐赠硬件，请通过 GitHub issues 联系。
 
 ## 仓库结构

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://discord.gg/MAaKtQRc"><b>Discord</b></a> ·
+  <a href="https://discord.gg/FkyrEeJR"><b>Discord</b></a> ·
   <a href="README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · 繁體中文 · <a href="README.it.md">Italiano</a>
 </p>
 
@@ -302,7 +302,7 @@ colibrì 最初是由一人使用 12 核心、25 GB RAM 的筆電開發；
 
 - ⭐ 為儲存庫加星並分享；
 - 🐛 以 issue 提交你的硬體 benchmark 數據——實測資料比任何其他事都更能推動專案；
-- 💬 加入 [Discord 社群](https://discord.gg/MAaKtQRc)，討論實驗、硬體數據與研究方向；
+- 💬 加入 [Discord 社群](https://discord.gg/FkyrEeJR)，討論實驗、硬體數據與研究方向；
 - 💬 若想贊助開發或捐贈硬體，請透過 GitHub issues 聯絡。
 
 ## 儲存庫結構

--- a/site/index.html
+++ b/site/index.html
@@ -199,7 +199,7 @@ footer li a:hover{color:var(--on-dark)}
       <a href="#models">Models</a>
       <a href="#hardware">Hardware</a>
       <a href="https://github.com/JustVugg/colibri/blob/main/docs/benchmarks.md">Benchmarks</a>
-      <a href="https://discord.gg/MAaKtQRc">Discord</a>
+      <a href="https://discord.gg/FkyrEeJR">Discord</a>
       <a class="btn" href="https://github.com/JustVugg/colibri">Star on GitHub</a>
     </div>
   </div>
@@ -371,7 +371,7 @@ footer li a:hover{color:var(--on-dark)}
       </ul></div>
       <div><h4>Project</h4><ul>
         <li><a href="https://github.com/JustVugg/colibri/issues">Issues</a></li>
-        <li><a href="https://discord.gg/MAaKtQRc">Discord</a></li>
+        <li><a href="https://discord.gg/FkyrEeJR">Discord</a></li>
         <li><a href="https://github.com/JustVugg/colibri/blob/main/docs/benchmarks.md">Community results</a></li>
         <li><a href="https://github.com/JustVugg/colibri">Apache 2.0 license</a></li>
       </ul></div>


### PR DESCRIPTION
The Discord invite we publish is dead. The Discord API on the current code:

```
GET /api/v10/invites/MAaKtQRc  ->  {"message": "Invite is expired.", "code": 50270}
```

It appears in 10 places — the header badge and the community line of all four READMEs, and twice in `site/index.html`. Anyone clicking Discord from the repo or the site today lands on an error page.

Replaced with the new invite, verified live before opening this:

```
GET /api/v10/invites/FkyrEeJR  ->  guild "Colibri - inference AI", 102 members
```

Docs and site only, no code touched.

**One caveat worth acting on separately:** the new invite carries `expires_at: 2026-09-12`, so this exact problem returns in six days. A link published in a README wants an invite set to never expire with no max-uses cap; happy to swap the code again once one exists.
