### PR TITLE
fix(registry): the GLM family names both models it loads (GLM-5.2/5.3)

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -12,7 +12,7 @@ miliardi a 2,8 mila miliardi di parametri** — su hardware consumer ed eterogen
 in C puro e senza dipendenze del motore, trattando storage, RAM e VRAM come
 un'unica gerarchia di inferenza.
 
-Oggi girano otto famiglie: **GLM-5.2** (744B), **GLM-5.3-Flash** (321B, con
+Oggi girano otto famiglie: **GLM-5.2/5.3** (744B), **GLM-5.3-Flash** (321B, con
 vision), **Inkling** (975B), **Kimi K3** (2,8T), **DeepSeek V4 Flash** (284B),
 **Qwen3.8-Flash-Next** (125B + 51B n-gram), **Qwen3.6** (35B-A3B) e
 **OLMoE** (7B) — un

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ parameters** — on consumer and heterogeneous hardware, in pure C with zero
 engine dependencies, by treating storage, RAM, and VRAM as a single inference
 hierarchy (AI memory multitiering).
 
-Eight families run today: **GLM-5.2** (744B), **GLM-5.3-Flash** (321B, with
+Eight families run today: **GLM-5.2/5.3** (744B), **GLM-5.3-Flash** (321B, with
 vision), **Inkling** (975B), **Kimi K3** (2.8T), **DeepSeek V4 Flash** (284B),
 **Qwen3.8-Flash-Next** (125B + 51B n-gram), **Qwen3.6** (35B-A3B) and
 **OLMoE** (7B) —
@@ -405,7 +405,7 @@ the model's `config.json`):
 > | Model | Disk for the weights | RAM | GPU |
 > |---|---|---|---|
 > | **OLMoE** | ~7 GB (int8 container) | 8 GB | not needed |
-> | **GLM-5.2** | ~372 GB | 16 GB min, 24 GB comfortable | not needed |
+> | **GLM-5.2/5.3** | ~372 GB | 16 GB min, 24 GB comfortable | not needed |
 > | **GLM-5.3-Flash** | ~195 GB converted | 25 GB (12 GB weights at int4 + expert cache) | not needed |
 > | **Inkling** | ~469 GB | 25 GB with the int4 dense container, ~120 GB without | not needed |
 > | **Kimi K3** | ~1.6 TB | 32 GB+ | not needed |
@@ -419,7 +419,7 @@ the model's `config.json`):
 
 | Family | Total / active | Weights | Build | Docs |
 |---|---|---|---|---|
-| **GLM-5.2** | 744B / 40B | [`mastouri/…-int4-g64-with-int8-mtp`](https://huggingface.co/mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp) (372 GB) | `make -C c glm` | this page |
+| **GLM-5.2/5.3** | 744B / 40B | [`mastouri/…-int4-g64-with-int8-mtp`](https://huggingface.co/mastouri/GLM-5.2-colibri-int4-g64-with-int8-mtp) (372 GB) | `make -C c glm` | this page |
 | **Inkling** (Thinking Machines) | 975B / 41B | [`nbeerbower/Inkling-colibri-int4`](https://huggingface.co/nbeerbower/Inkling-colibri-int4) (469 GB) | `make -C c inkling` | [inkling.md](docs/inkling.md) |
 | **GLM-5.3-Flash** (Z.ai) | 321B / 40B | [`zai-org/GLM-5.3-Flash`](https://huggingface.co/zai-org/GLM-5.3-Flash) — converted to **int4-gs64** routed experts, dense stays BF16 and the precision is a load-time choice; vision included | `make -C c glm53` | [glm53-flash.md](docs/glm53-flash.md) |
 | **Kimi K3** (Moonshot) | 2.8T / 104B | [`moonshotai/Kimi-K3`](https://huggingface.co/moonshotai/Kimi-K3) — original checkpoint, routed experts stay **native MXFP4** | `make -C c kimi_k3` | [kimi_k3.md](docs/kimi_k3.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
 **小巧引擎，庞大模型。**在消费级与异构硬件上运行**前沿 MoE 模型——从 744B 到
 2.8T 参数**——以引擎零依赖的纯 C 实现，将存储、RAM 与 VRAM 视为统一的推理层级。
 
-目前可运行八个模型家族：**GLM-5.2**（744B）、**GLM-5.3-Flash**（321B，含视觉）、
+目前可运行八个模型家族：**GLM-5.2/5.3**（744B）、**GLM-5.3-Flash**（321B，含视觉）、
 **Inkling**（975B）、**Kimi K3**（2.8T）、**DeepSeek V4 Flash**（284B）、
 **Qwen3.8-Flash-Next**（125B + 51B n-gram）、**Qwen3.6**（35B-A3B）与 **OLMoE**（7B）
 ——各自一个 C 文件，共用同一套 `coli chat` / `coli serve` / `coli web` 前端。[完整列表](README.md#other-supported-models)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -10,7 +10,7 @@
 **小巧引擎，龐大模型。**在消費級與異質硬體上執行**前沿 MoE 模型——從 744B 到
 2.8T 參數**——以引擎零相依套件的純 C 實作，將儲存、RAM 與 VRAM 視為統一的推論階層。
 
-目前可執行八個模型家族：**GLM-5.2**（744B）、**GLM-5.3-Flash**（321B，含視覺）、
+目前可執行八個模型家族：**GLM-5.2/5.3**（744B）、**GLM-5.3-Flash**（321B，含視覺）、
 **Inkling**（975B）、**Kimi K3**（2.8T）、**DeepSeek V4 Flash**（284B）、
 **Qwen3.8-Flash-Next**（125B + 51B n-gram）、**Qwen3.6**（35B-A3B）與 **OLMoE**（7B）
 ——各自一個 C 檔案，共用同一套 `coli chat` / `coli serve` / `coli web` 前端。[完整清單](README.md#other-supported-models)

--- a/c/family_registry.py
+++ b/c/family_registry.py
@@ -928,7 +928,23 @@ FAMILIES = (
     FamilyDescriptor(
         id="glm",
         model_types=("glm_moe_dsa", "glm5_moe", "glm"),
-        display_name="GLM-5.2",
+        # Two model names, one family, and that is not a shortcut. Z.ai state
+        # it on GLM-5.3's own card: "GLM-5.3 uses the same base model as
+        # GLM-5.2 -- every gain comes from post-training." The checkpoints
+        # agree. Diffing the two config.json leaves exactly one extra key
+        # (moe_router_dtype) and the transformers_version that wrote the file:
+        # same 78 layers, 256 experts, hidden 6144, moe_intermediate 2048, same
+        # parameter count. There is nothing architectural to tell them apart,
+        # so no rule over the configuration can name one and not the other, now
+        # or later. #1326's approach for Qwen -- name a checkpoint by its
+        # geometry -- cannot apply here, because the geometry is identical.
+        #
+        # Announcing a GLM-5.3 container as "GLM-5.2" was wrong in the one way
+        # that matters: the engine ran the right weights and the banner named a
+        # different model. Naming both is the honest statement of what this
+        # family loads. If a future release ever adds a real discriminator,
+        # split this then, on evidence.
+        display_name="GLM-5.2/5.3",
         display_scale="744B",
         engine_artifact="colibri",
         engine_aliases=("glm",),

--- a/c/tests/test_family_registry.py
+++ b/c/tests/test_family_registry.py
@@ -1412,5 +1412,59 @@ class FamilyRegistryTest(unittest.TestCase):
                       "l'archivio non spedirebbe family_registry.py")
 
 
+class GlmFamilyNamesBothModelsTest(unittest.TestCase):
+    """#1365 follow-up: a GLM-5.3 container was announced as "GLM-5.2 744B".
+
+    The engine loaded the right weights; only the banner named a different
+    model. The fix is the name, and the reason the name covers two models
+    rather than choosing between them is worth pinning here, because the
+    obvious "improvement" later is to add detection.
+
+    There is nothing to detect. Z.ai say so on GLM-5.3's own card -- "GLM-5.3
+    uses the same base model as GLM-5.2; every gain comes from post-training"
+    -- and the checkpoints agree: diffing the two real config.json leaves one
+    extra key and the transformers_version that wrote the file. If a release
+    ever ships a genuine discriminator, split the family then, on evidence,
+    and this test is where to record it.
+    """
+
+    #: The two configs, reduced to what the registry reads plus the only two
+    #: keys that actually differ between the real files.
+    BASE = {
+        "model_type": "glm_moe_dsa",
+        "num_hidden_layers": 78,
+        "n_routed_experts": 256,
+        "hidden_size": 6144,
+        "moe_intermediate_size": 2048,
+    }
+
+    def test_both_checkpoints_resolve_to_the_same_family(self):
+        v52 = dict(self.BASE, transformers_version="5.12.0")
+        v53 = dict(self.BASE, transformers_version="5.15.0",
+                   moe_router_dtype="float32")
+        self.assertEqual(family_for_config(v52).id, family_for_config(v53).id)
+        self.assertEqual(family_for_config(v53).engine_artifact, "colibri")
+
+    def test_the_only_differences_are_not_discriminators(self):
+        """Neither key can carry the decision, so neither may be read as if it
+        could. `transformers_version` records the library that wrote the file
+        and changes when anyone re-exports; `moe_router_dtype` is a precision
+        hint that a re-export of GLM-5.2 could equally carry."""
+        source = Path(__file__).resolve().parents[1] / "family_registry.py"
+        text = source.read_text(encoding="utf-8")
+        for key in ("transformers_version", "moe_router_dtype"):
+            self.assertNotIn(f'"{key}"', text,
+                             f"{key} is not a version discriminator; naming a "
+                             f"checkpoint from it would be a guess wearing a "
+                             f"rule's clothes")
+
+    def test_the_name_states_both_models(self):
+        family = family_for_config(dict(self.BASE))
+        for model in ("5.2", "5.3"):
+            self.assertIn(model, family.display_name,
+                          "a user running one of the two must not read the "
+                          "name of the other")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/site/index.html
+++ b/site/index.html
@@ -263,7 +263,7 @@ footer li a:hover{color:var(--on-dark)}
     <div class="overline">The models</div>
     <h2 class="sec-h">Eight families run today, one engine each.</h2>
     <div class="cards">
-      <div class="card"><h3>GLM-5.2</h3><p class="desc">The flagship target: an int4 container, token-exact versus reference, with the full expert atlas published.</p>
+      <div class="card"><h3>GLM-5.2/5.3</h3><p class="desc">The flagship target: an int4 container, token-exact versus reference, with the full expert atlas published.</p>
         <div class="tags"><span class="tag">reasoning</span><span class="tag">tools</span></div>
         <div class="meta"><div class="row"><span class="k">Maker</span><span class="v">Z.ai</span></div><div class="row"><span class="k">Size &middot; RAM</span><span class="v">744B MoE &middot; from 16 GB</span></div></div>
         <a class="btn ghost" href="https://github.com/JustVugg/colibri#quick-start">Run it &rarr;</a></div>
@@ -364,7 +364,7 @@ footer li a:hover{color:var(--on-dark)}
         <li><a href="https://github.com/JustVugg/colibri/blob/main/docs/benchmarks.md">Benchmarks</a></li>
       </ul></div>
       <div><h4>Models</h4><ul>
-        <li><a href="#models">GLM-5.2</a></li><li><a href="#models">GLM-5.3-Flash</a></li>
+        <li><a href="#models">GLM-5.2/5.3</a></li><li><a href="#models">GLM-5.3-Flash</a></li>
         <li><a href="#models">Qwen3.8-Flash-Next</a></li><li><a href="#models">Kimi K3</a></li>
         <li><a href="#models">Inkling</a></li><li><a href="#models">DeepSeek V4 Flash</a></li>
         <li><a href="#models">Qwen3.6</a></li><li><a href="#models">OLMoE</a></li>


### PR DESCRIPTION
A GLM-5.3 container is announced as **"GLM-5.2 744B"**. The engine loads the right weights and runs them correctly; only the banner names a different model.

```
before:  GLM-5.3 checkpoint  ->  GLM-5.2 744B
after:   GLM-5.3 checkpoint  ->  GLM-5.2/5.3 744B
         GLM-5.2 checkpoint  ->  GLM-5.2/5.3 744B
```

Both verified by resolving the two real `config.json` through the registry.

## Why the name covers both instead of choosing

This is the substance of the change, not an excuse for a weak fix: **there is nothing to detect.** Z.ai say it on GLM-5.3's own model card:

> GLM-5.3 uses the same base model as GLM-5.2. Every gain comes from post-training.

The files agree. Diffing the two real configs leaves exactly this:

```
only in 5.3     : moe_router_dtype
different value : transformers_version   5.2="5.12.0"  |  5.3="5.15.0"
```

Same 78 layers, 256 experts, hidden 6144, moe_intermediate 2048, same parameter count, same container shape (mastouri's GLM-5.2 repo is 149 files / 429 GB; the GLM-5.3 conversion is 148 / 419).

Neither difference is a discriminator. `transformers_version` records which library wrote the file and changes when anyone re-exports. `moe_router_dtype` is a precision hint a re-export of GLM-5.2 could equally carry. Naming a checkpoint from either would be a guess wearing a rule's clothes, and it would be wrong silently.

**#1326's approach for Qwen -- name a checkpoint by its geometry -- cannot apply here, because the geometry is identical.** That is the whole difficulty, and it is why the honest statement is what the family loads rather than which of the two it guessed.

## What moved, and what deliberately did not

The name changes wherever the family is **enumerated**: the "families run today" line in all four READMEs, the model table and the RAM table in `README.md`, the model card and the nav entry in `site/index.html`. Each replacement was asserted to match exactly once before being applied.

Mentions of GLM-5.2 **as a fact** are left alone, because they are still true: DSA came from its lightning indexer, the MTP head is its, the multi-SSD and cold-cache numbers were measured on it, and the pre-converted container on Hugging Face is a 5.2 container. Rewriting those would trade a wrong label for a wrong history.

Untouched on purpose: `default_model_id="glm-5.2-colibri"`. It is an API identifier that users already have in their requests, and this PR is about what people read, not what they type.

## Tests

Three new cases in `test_family_registry.py`, because the obvious later "improvement" is to add detection and that must fail loudly:

- both configs, differing only by the two keys above, resolve to one family
- neither key appears in `family_registry.py` at all, so neither can quietly become a discriminator
- the display name states both models

Reverting the name fails the third and nothing else, which is the correct blast radius.

The existing contract tests already required every family's display name to appear in all four READMEs and the site, so those were the mechanism that made the docs update mandatory rather than optional. They pass.

**751 Python tests green locally.**

If a future release ever ships a real discriminator, split the family then, on evidence. The test file is where that decision is recorded.
