### PR TITLE
release: 1.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,59 @@
 All notable changes to colibrì are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [1.10.2] — 2026-09-06
+
+Patch release. Three of these fixes answer reports made against 1.10.1 in the
+days after it shipped.
+
+### Fixed
+
+- `coli convert` picks the converter from the checkpoint's `config.json`. It ran
+  GLM-5.2's converter on everything; on GLM-5.3-Flash that quantized the nested
+  embedding and the engine refused the result hours later inside `coli web`.
+  An option the target converter does not take is refused, not dropped (#1368,
+  #1369). The converter also refuses a checkpoint it cannot serve, with a
+  per-family pointer (#1305).
+- `coli doctor` no longer reports two missing core tensors on a healthy
+  GLM-5.3-Flash: it matches roles, prefix-agnostically, instead of GLM-5.2's
+  literal names (#1365, #1366).
+- The release archive ships every file `coli` reaches: `iq3_pack.py`, its grid
+  data file, and `tools/convert_glm53.py`, which had never been packaged
+  (#1359, #1364).
+- The RSS guard counts anonymous memory, not reclaimable page cache, so a mapped
+  container no longer evicts experts to free memory it was not using (#1350).
+- `serve` honors CANCEL while a turn is still running (#1336), and the
+  disconnect scenario is built rather than hoped for (#1329).
+- Metal: bit-exact fp8-e4m3 decode (#1346). Qwen3.6: tokenizer merges in both
+  spellings (#1319). macOS: Homebrew prefixes found when `brew` is off the PATH
+  (#1320). DeepSeek V4 on macOS: real CPU and memory in HWINFO (#1308).
+- `coli doctor` omits the GPU plan for a CPU-only engine (#1322); a missing core
+  tensor explains itself on every fatal path (#1318); GLM-5.3-Flash `--no-think`
+  is the template's lowest effort level, not a shape of ours (#1327).
+
+### Changed
+
+- The GLM family is named `GLM-5.2/5.3`: the two checkpoints share the base
+  model and cannot be told apart from their configuration (#1367).
+- DeepSeek V4 Flash REAP-150B (85 GB, 132 of 256 experts) loads with the same
+  engine (#1310), is documented, and is announced by its measured geometry
+  rather than the official checkpoint's 284B.
+- The qwen36 VRAM tier promotes int8 experts instead of reserving for nothing
+  (#1334); Kimi K3 stops paying for a DSA indexer nothing reads (#1335).
+- Opt-in: `COLI_MAP_EXPERTS=1` serves experts through a per-shard file mapping
+  (#1325). Off by default; output is byte-identical either way.
+
+### Build and CI
+
+- Makefile lists the headers each engine includes as prerequisites (#1284,
+  #1349). Site and READMEs carry the eight families with real RAM figures under
+  a contract test (#1302).
+
+## [1.10.1] — 2026-08-31
+
+Packaging repair for the prebuilt archives; no engine changes.
+
+## [1.10.0] — 2026-08-31
 
 ### A seventh engine: Qwen3.8-Flash-Next
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,17 @@ days after it shipped.
   engine (#1310), is documented, and is announced by its measured geometry
   rather than the official checkpoint's 284B.
 - The qwen36 VRAM tier promotes int8 experts instead of reserving for nothing
-  (#1334); Kimi K3 stops paying for a DSA indexer nothing reads (#1335).
+  (#1334), and the three tier bugs that surfaced with it are fixed: an `is_x`
+  overrun with two or more GPUs, a shutdown that could hang, and a
+  use-after-free on int8 containers (#1339, #1340, #1341, #1344). Kimi K3
+  stops paying for a DSA indexer nothing reads (#1335).
 - Opt-in: `COLI_MAP_EXPERTS=1` serves experts through a per-shard file mapping
   (#1325). Off by default; output is byte-identical either way.
+
+### Docs
+
+- Windows DeepSeek V4 users are led to the release launcher (`coli.cmd`)
+  instead of a source build (#1291).
 
 ### Build and CI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ days after it shipped.
 - `coli doctor` omits the GPU plan for a CPU-only engine (#1322); a missing core
   tensor explains itself on every fatal path (#1318); GLM-5.3-Flash `--no-think`
   is the template's lowest effort level, not a shape of ours (#1327).
+- GLM-5.3-Flash `serve` can use the 16 KV slots the engine has; the registry
+  declared 1 (#1283).
+- `image_url` local reads: `..` is refused, and with `COLI_IMAGE_ROOT` set a
+  path must resolve inside it, so an authenticated client of a non-loopback
+  server cannot read arbitrary files through the image API. Error messages no
+  longer confirm a path or its permissions (#1354).
 
 ### Changed
 
@@ -55,6 +61,8 @@ days after it shipped.
 
 ### Build and CI
 
+- CI workflows run with `contents: read`, and third-party actions are pinned
+  by commit SHA (#1354).
 - Makefile lists the headers each engine includes as prerequisites (#1284,
   #1349). Site and READMEs carry the eight families with real RAM figures under
   a contract test (#1302).

--- a/README.it.md
+++ b/README.it.md
@@ -34,7 +34,7 @@ ma non ridefinire il modello di nascosto.
 
 ```
 $ ./coli chat
-  🐦 colibri v1.10.1 — GLM-5.2 · 744B MoE · int4 · streaming CPU
+  🐦 colibri v1.10.2 — GLM-5.2 · 744B MoE · int4 · streaming CPU
   ✓ ready in 32s · resident 9.9 GB
   › ciao!
   ◆ Ciao! 😊 Come posso aiutarti oggi?

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ may reduce speed; it must not quietly redefine the model.
 
 ```
 $ ./coli chat
-  🐦 colibri v1.10.1 — GLM-5.2 · 744B MoE · int4 · streaming CPU
+  🐦 colibri v1.10.2 — GLM-5.2 · 744B MoE · int4 · streaming CPU
   ✓ ready in 32s · resident 9.9 GB
   › ciao!
   ◆ Ciao! 😊 Come posso aiutarti oggi?

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,7 +25,7 @@ Colibrì 刻意用于验证激进的系统思路——因此**对速度不作 SL
 
 ```
 $ ./coli chat
-  🐦 colibri v1.10.1 — GLM-5.2 · 744B MoE · int4 · streaming CPU
+  🐦 colibri v1.10.2 — GLM-5.2 · 744B MoE · int4 · streaming CPU
   ✓ ready in 32s · resident 9.9 GB
   › ciao!
   ◆ Ciao! 😊 Come posso aiutarti oggi?

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -25,7 +25,7 @@ Colibrì 刻意用於驗證激進的系統構想——因此**對速度不作 SL
 
 ```
 $ ./coli chat
-  🐦 colibri v1.10.1 — GLM-5.2 · 744B MoE · int4 · streaming CPU
+  🐦 colibri v1.10.2 — GLM-5.2 · 744B MoE · int4 · streaming CPU
   ✓ ready in 32s · resident 9.9 GB
   › ciao!
   ◆ Ciao! 😊 Come posso aiutarti oggi?

--- a/c/version.py
+++ b/c/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for the colibri version number."""
 
-__version__ = "1.10.1"
+__version__ = "1.10.2"

--- a/site/index.html
+++ b/site/index.html
@@ -229,7 +229,7 @@ footer li a:hover{color:var(--on-dark)}
     <div><div class="n">510</div><div class="l">pull requests merged</div></div>
     <div><div class="n">6</div><div class="l">families · 4 backends · 3 platforms</div></div>
     <div class="since">All of it in <b data-gh-age>six weeks</b>, in the open: issues filed from strangers' machines,
-      reproduced and fixed the same day. Currently shipping <b>v1.10.1</b>.</div>
+      reproduced and fixed the same day. Currently shipping <b>v1.10.2</b>.</div>
   </div>
 </section>
 


### PR DESCRIPTION
Version bump to 1.10.2 and the changelog for it. Everything else is already on `dev`.

- `1.10.1` → `1.10.2` in the six places the version lives: `c/version.py`, the four README badges, the site's "Currently shipping" line. The `1.10.1` in `desktop/src-tauri/Cargo.lock` is `httparse`/`hyper`, not ours.
- `CHANGELOG.md` had stopped at 1.7.0. The `[Unreleased]` block was Qwen3.8, which shipped as 1.10.0 on 2026-08-31 per that release's notes, so it is labelled as such; 1.10.1 is recorded as the packaging repair it was; 1.10.2 lists what `dev` accumulated since, grouped by what a user would look for.

The GitHub release text is in the PR's first comment, ready to paste when tagging.

Contract tests (version ↔ site ↔ READMEs) green. The dev→main merge and the tag stay with the maintainer.
