### PR TITLE
fix(ctx): announce the context ceiling, refuse what cannot be honored, report the right number (#1376)

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -492,7 +492,14 @@ def env_for_engine(a, arch, plan=None):
             except (TypeError, ValueError):
                 pass
     if a.ctx:
-        env[family_by_id(arch).limits.context_env] = str(a.ctx)
+        limits = family_by_id(arch).limits
+        # #1376: the engine clamps silently to its hard ceiling. A flag that is
+        # accepted and then ignored is worse than one refused with the number.
+        if limits.max_context and a.ctx > limits.max_context:
+            sys.exit(f"{C.yel}--ctx {a.ctx} exceeds what {family_by_id(arch).display_name} "
+                     f"supports ({limits.max_context} tokens).{C.r}\n"
+                     f"  Pass --ctx {limits.max_context} or less.")
+        env[limits.context_env] = str(a.ctx)
     if arch == "deepseek_v4":
         # Speculation stays opt-in. Real multi-turn chat measured only 1/15
         # accepted prompt-lookup candidates; recurrent-state replay dominated

--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -84,8 +84,20 @@ def _engine_error(fields, message):
     know how to compact a conversation actually get the chance to (previously the engine
     silently truncated the prompt instead, which is #401)."""
     if fields and fields[0] == "CONTEXT_EXCEEDED":
-        limit = fields[2] if len(fields) > 2 else "the context"
-        used = fields[1] if len(fields) > 1 else "?"
+        # Two spellings of the same frame. colibri and deepseek_v4 write the
+        # original `CONTEXT_EXCEEDED <used> <limit>`; qwen36 and qwen38 write
+        # `prompt_tokens=N requested=M capacity=C`. Reading the second by
+        # position took "requested=M" (the completion budget) as the limit and
+        # printed it raw: "maximum context length is requested=4 tokens", with
+        # the real ceiling nowhere (#1376). Unifying the engines' spelling is
+        # a separate change; the server must read both meanwhile.
+        kv = dict(f.split("=", 1) for f in fields[1:] if "=" in f)
+        if kv:
+            limit = kv.get("capacity") or "the context"
+            used = kv.get("prompt_tokens") or "?"
+        else:
+            limit = fields[2] if len(fields) > 2 else "the context"
+            used = fields[1] if len(fields) > 1 else "?"
         return APIError(400,
                         f"This model's maximum context length is {limit} tokens, however your "
                         f"messages resulted in at least {used} tokens. Please shorten the "

--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -2751,8 +2751,11 @@ int main(int argc, char **argv) {
     float smooth = getenv("SMOOTH") ? (float)atof(getenv("SMOOTH")) : 0.3f;
     float conf   = getenv("CONF_LIMIT") ? (float)atof(getenv("CONF_LIMIT")) : 0.92f;
 
-    fprintf(stderr, "== qwen36 Phase-2 engine | cache=%d/layer bits=%d pilot=%d wide=%d hot=%d smooth=%.2f conf=%.2f ==\n",
-           cap, bits, g_pilot, g_wide, hot_n, smooth, conf);
+    /* #1376: every capacity knob announced itself here except the one that
+     * refuses requests. The context ceiling surfaced only in the
+     * CONTEXT_EXCEEDED line, i.e. after a request had already failed. */
+    fprintf(stderr, "== qwen36 Phase-2 engine | cache=%d/layer bits=%d ctx=%d pilot=%d wide=%d hot=%d smooth=%.2f conf=%.2f ==\n",
+           cap, bits, qwen36_max_ctx(), g_pilot, g_wide, hot_n, smooth, conf);
 
 
     int is_ref = 0;

--- a/c/tests/test_cli_output.py
+++ b/c/tests/test_cli_output.py
@@ -377,5 +377,39 @@ class OmpThreadsForEveryEngineTest(unittest.TestCase):
             self.coli.env_for_engine(vram_args, "qwen38")
 
 
+class ContextFlagHonestyTest(unittest.TestCase):
+    """#1376: `--ctx` above what a family supports was accepted, then clamped
+    by the engine in silence. A flag that appears to work and does not is
+    worse than one refused with the number."""
+
+    @classmethod
+    def setUpClass(cls):
+        loader = SourceFileLoader("coli_ctx_under_test", str(CLI))
+        spec = importlib.util.spec_from_loader(loader.name, loader)
+        cls.coli = importlib.util.module_from_spec(spec)
+        loader.exec_module(cls.coli)
+
+    class Args(types.SimpleNamespace):
+        """env_for_engine reads whatever flags the family cares about; every
+        one not set here reads as "not given", which is what argparse yields."""
+        def __getattr__(self, name):
+            return None
+
+    def args(self, ctx):
+        return self.Args(ctx=ctx, ram=0)
+
+    def test_ctx_above_the_family_maximum_is_refused_with_the_number(self):
+        family = self.coli.family_by_id("qwen36")
+        too_big = family.limits.max_context + 1
+        with self.assertRaises(SystemExit) as stop:
+            self.coli.env_for_engine(self.args(too_big), "qwen36")
+        self.assertIn(str(family.limits.max_context), str(stop.exception))
+
+    def test_ctx_within_the_maximum_reaches_the_engine_variable(self):
+        family = self.coli.family_by_id("qwen36")
+        env = self.coli.env_for_engine(self.args(65536), "qwen36")
+        self.assertEqual(env.get(family.limits.context_env), "65536")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -2611,5 +2611,35 @@ class ImageUrlPathGuard(unittest.TestCase):
         self.assertNotIn("secret-name", str(caught.exception))
 
 
+class ContextExceededMessageTest(unittest.TestCase):
+    """#1376: the engine writes `CONTEXT_EXCEEDED prompt_tokens=N requested=M
+    capacity=C`. The message took fields[2] ("requested=M", the completion
+    budget) as the limit and printed the raw key=value token, so a user with a
+    9000-token prompt on an 8192 ceiling read "maximum context length is
+    requested=4 tokens". The number that mattered, capacity, appeared nowhere."""
+
+    def test_limit_is_capacity_and_used_is_prompt_tokens(self):
+        from openai_server import _engine_error
+        err = _engine_error(["CONTEXT_EXCEEDED", "prompt_tokens=9000", "requested=4",
+                             "capacity=8192"], "ignored")
+        text = str(err)
+        self.assertIn("8192", text)
+        self.assertIn("9000", text)
+        self.assertNotIn("requested=", text)
+        self.assertNotIn("prompt_tokens=", text)
+        self.assertNotIn("capacity=", text)
+
+    def test_the_positional_spelling_of_colibri_and_deepseek_still_reads(self):
+        from openai_server import _engine_error
+        text = str(_engine_error(["CONTEXT_EXCEEDED", "8321", "4094"], "ignored"))
+        self.assertIn("4094", text)
+        self.assertIn("8321", text)
+
+    def test_missing_fields_do_not_crash_the_message(self):
+        from openai_server import _engine_error
+        text = str(_engine_error(["CONTEXT_EXCEEDED"], "ignored"))
+        self.assertIn("the context", text)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
For #1376. Three things were reported; two are defects on `dev` and are fixed here, the third does not reproduce and the fix makes it self-diagnosing.

## What reproduces, and what does not

On the qwen36 tiny fixture through `coli serve`:

| run | 30-token prompt |
|---|---|
| `--ctx 20` | **400**, context exceeded |
| no `--ctx` | **200** |

So `--ctx` reaches the qwen36 engine through the launcher on `dev` (`env_for_engine` maps it to `Q36_MAXT`, which `qwen36.c` reads). The mapping has been there since the family registry landed on 2026-08-16; a build from before that would show exactly the reported symptom. I cannot tell from the report which build produced `capacity=8192` after `--ctx 65536`, and after this PR nobody will have to guess, because of the first fix.

## Fixed

**1. The banner says the ceiling.** Every capacity knob announced itself at startup except the one that refuses requests. Now:

```
== qwen36 Phase-2 engine | cache=4/layer bits=8 ctx=8192 pilot=0 ... ==
```

Verified on the fixture: default `ctx=8192`, `Q36_MAXT=20` gives `ctx=20`, an absurd value gives `ctx=262144`, which is the hard clamp made visible at start instead of at the first failed request.

**2. The server's message had the wrong number in it.** Two engines write `CONTEXT_EXCEEDED <used> <limit>` (colibri, deepseek_v4) and two write `prompt_tokens=N requested=M capacity=C` (qwen36, qwen38). The server read both by position, so for the second spelling it took `requested=M`, the completion budget, as the limit and printed it raw. A user with a 9000-token prompt on an 8192 ceiling read:

> This model's maximum context length is requested=4 tokens

The real ceiling appeared nowhere. The server now reads both spellings and reports capacity as the limit and prompt tokens as the usage. Unifying the engines' spelling is a separate change; the existing positional test still passes.

**3. `--ctx` above the family's maximum is refused, with the number.** The engine clamps silently to its hard limit; the launcher knows `max_context` and now says no instead of passing on a value it knows will not be honored. Same policy `docs/qwen36.md` already states for `--ram`.

## Tests

Parser: both spellings, plus the degenerate frame. Launcher: refusal above `max_context` with the number in the message, pass-through below it. Reverting each fix fails its test. `test_openai_server` 168 and `test_cli_output` 31 green.
