### PR TITLE
feat(web): reasoning depth selector for GLM (off/low/medium/high/max)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -46,6 +46,24 @@ const message = (role: ChatMessage["role"], content: string): ChatMessage => {
   return { id, role, content }
 }
 
+/* Reasoning depth for GLM. The engine renders enable_thinking + reasoning_effort;
+   these levels map onto the words GLM understands (Low/Medium/High/Max), and "off"
+   turns thinking off entirely. GLM 5.3 cannot disable reasoning, so "off" is dropped
+   for it -- the model's own constraint, mirrored in the control rather than sent and
+   silently ignored. */
+type ReasoningLevel = "off" | "low" | "medium" | "high" | "max"
+
+const REASONING_EFFORT: Record<Exclude<ReasoningLevel, "off">, string> = {
+  low: "low", medium: "medium", high: "high", max: "xhigh",
+}
+
+const modelForcesReasoning = (model: string) => /5\.3/.test(model)
+
+const reasoningLevelsFor = (model: string): ReasoningLevel[] =>
+  modelForcesReasoning(model)
+    ? ["low", "medium", "high", "max"]
+    : ["off", "low", "medium", "high", "max"]
+
 export default function App() {
   const { t, locale, setLocale, locales } = useLocale()
 
@@ -61,7 +79,7 @@ export default function App() {
   const [model, setModel] = useState(() => stored(localStorage, "colibri.model", "glm-5.2-colibri"))
   const [temperature, setTemperature] = useState(0.7)
   const [maxTokens, setMaxTokens] = useState(4096)
-  const [thinking, setThinking] = useState(false)
+  const [reasoning, setReasoning] = useState<ReasoningLevel>("off")
   const [cacheSlot, setCacheSlot] = useState(0)
   const [conversations, setConversations] = useState<Record<number, ChatMessage[]>>({ 0: [] })
   const [health, setHealth] = useState<HealthResponse | null>(null)
@@ -160,6 +178,13 @@ export default function App() {
   // EFFECT #6
   useEffect(() => { setLastRun(null) }, [cacheSlot])
 
+  /* GLM 5.3 cannot turn reasoning off. If the user switches to such a model
+     while "off" is selected, lift it to a sane on-state instead of sending a
+     level the model will ignore. */
+  useEffect(() => {
+    if (modelForcesReasoning(model)) setReasoning((level) => level === "off" ? "high" : level)
+  }, [model])
+
   // EFFECT #7
   useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: "smooth" }) }, [messages])
 
@@ -236,7 +261,8 @@ export default function App() {
         messages: history,
         temperature,
         maxTokens,
-        enableThinking: thinking,
+        enableThinking: reasoning !== "off",
+        reasoningEffort: reasoning === "off" ? undefined : REASONING_EFFORT[reasoning],
         cacheSlot: supportsCacheSlots(health) ? cacheSlot : undefined,
         signal: controller.signal,
         /* Reasoning tokens are tokens: they count toward the rate, and the
@@ -349,9 +375,11 @@ export default function App() {
           </select><span className="field-help">{t("sidebar.kvSessionHelp")}</span></label> : null}
           <label><span className="label-line"><span>{t("sidebar.temperature")}</span><code>{temperature.toFixed(1)}</code></span><input className="range" type="range" min="0" max="2" step="0.1" value={temperature} onChange={(event) => setTemperature(Number(event.target.value))} /></label>
           <label>{t("sidebar.maxTokens")}<Input type="number" min={1} max={32768} value={maxTokens} onChange={(event) => { const value = Number(event.target.value); if (Number.isFinite(value)) setMaxTokens(Math.min(32768, Math.max(1, Math.round(value)))) }} /></label>
-          <button type="button" className={cn("toggle-row", thinking && "active")} aria-pressed={thinking} onClick={() => setThinking((value) => !value)}>
-            <span><BrainCircuit className="size-4" /> {t("sidebar.reasoning")}</span><i><b /></i>
-          </button>
+          <label><span className="label-line"><span><BrainCircuit className="size-4" /> {t("sidebar.reasoning")}</span></span>
+            <select value={reasoning} onChange={(event) => setReasoning(event.target.value as ReasoningLevel)} disabled={loading}>
+              {reasoningLevelsFor(model).map((level) => <option key={level} value={level}>{t(`sidebar.reasoning.${level}`)}</option>)}
+            </select>
+          </label>
         </section>
 
         <div className="sidebar-foot">

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -47,6 +47,11 @@ const de: Record<string, string> = {
   "sidebar.temperature": "Temperatur",
   "sidebar.maxTokens": "Maximale Ausgabetokens",
   "sidebar.reasoning": "Reasoning",
+  "sidebar.reasoning.off": "Aus",
+  "sidebar.reasoning.low": "Niedrig",
+  "sidebar.reasoning.medium": "Mittel",
+  "sidebar.reasoning.high": "Hoch",
+  "sidebar.reasoning.max": "Max",
   "sidebar.transport": "OpenAI-kompatibler Transport",
 
   // Kopfzeile

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -47,6 +47,11 @@ const en: Record<string, string> = {
   "sidebar.temperature": "Temperature",
   "sidebar.maxTokens": "Max output tokens",
   "sidebar.reasoning": "Reasoning",
+  "sidebar.reasoning.off": "Off",
+  "sidebar.reasoning.low": "Low",
+  "sidebar.reasoning.medium": "Medium",
+  "sidebar.reasoning.high": "High",
+  "sidebar.reasoning.max": "Max",
   "sidebar.transport": "OpenAI-compatible transport",
 
   // top bar

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -41,6 +41,11 @@ const it: Record<string, string> = {
   "sidebar.temperature": "Temperatura",
   "sidebar.maxTokens": "Token di output massimi",
   "sidebar.reasoning": "Ragionamento",
+  "sidebar.reasoning.off": "Off",
+  "sidebar.reasoning.low": "Basso",
+  "sidebar.reasoning.medium": "Medio",
+  "sidebar.reasoning.high": "Alto",
+  "sidebar.reasoning.max": "Max",
   "sidebar.transport": "Trasporto compatibile OpenAI",
 
   "topbar.activeModel": "MODELLO ATTIVO",

--- a/web/src/i18n/zh-CN.ts
+++ b/web/src/i18n/zh-CN.ts
@@ -41,6 +41,11 @@ const zhCN: Record<string, string> = {
   "sidebar.temperature": "温度",
   "sidebar.maxTokens": "最大输出 token 数",
   "sidebar.reasoning": "推理模式",
+  "sidebar.reasoning.off": "关闭",
+  "sidebar.reasoning.low": "低",
+  "sidebar.reasoning.medium": "中",
+  "sidebar.reasoning.high": "高",
+  "sidebar.reasoning.max": "最高",
   "sidebar.transport": "OpenAI 兼容协议",
 
   "topbar.activeModel": "当前模型",

--- a/web/src/i18n/zh-TW.ts
+++ b/web/src/i18n/zh-TW.ts
@@ -41,6 +41,11 @@ const zhTW: Record<string, string> = {
   "sidebar.temperature": "溫度",
   "sidebar.maxTokens": "最大輸出 token 數",
   "sidebar.reasoning": "推理模式",
+  "sidebar.reasoning.off": "關閉",
+  "sidebar.reasoning.low": "低",
+  "sidebar.reasoning.medium": "中",
+  "sidebar.reasoning.high": "高",
+  "sidebar.reasoning.max": "最高",
   "sidebar.transport": "OpenAI 相容協定",
 
   "topbar.activeModel": "目前模型",

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -56,7 +56,9 @@ describe("chat request extensions", () => {
     headers: { "content-type": "text/event-stream" },
   })
 
-  async function requestBody(cacheSlot?: number) {
+  async function requestBody(
+    extra: { cacheSlot?: number; enableThinking?: boolean; reasoningEffort?: string } = {},
+  ) {
     const fetchMock = vi.fn().mockResolvedValue(completedStream())
     vi.stubGlobal("fetch", fetchMock)
     await streamChat({
@@ -66,8 +68,9 @@ describe("chat request extensions", () => {
       messages: [],
       temperature: 0,
       maxTokens: 8,
-      enableThinking: false,
-      cacheSlot,
+      enableThinking: extra.enableThinking ?? false,
+      reasoningEffort: extra.reasoningEffort,
+      cacheSlot: extra.cacheSlot,
       signal: new AbortController().signal,
       onDelta: () => undefined,
     })
@@ -79,6 +82,17 @@ describe("chat request extensions", () => {
   })
 
   it("sends cache_slot zero when colibrì advertises KV slots", async () => {
-    expect(await requestBody(0)).toMatchObject({ cache_slot: 0 })
+    expect(await requestBody({ cacheSlot: 0 })).toMatchObject({ cache_slot: 0 })
+  })
+
+  it("sends reasoning_effort when reasoning is on", async () => {
+    expect(await requestBody({ enableThinking: true, reasoningEffort: "high" }))
+      .toMatchObject({ enable_thinking: true, reasoning_effort: "high" })
+  })
+
+  it("omits reasoning_effort when reasoning is off, even if a level is passed", async () => {
+    const body = await requestBody({ enableThinking: false, reasoningEffort: "high" })
+    expect(body).toMatchObject({ enable_thinking: false })
+    expect(body).not.toHaveProperty("reasoning_effort")
   })
 })

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -152,6 +152,10 @@ export interface StreamChatOptions {
   temperature: number
   maxTokens: number
   enableThinking: boolean
+  /* GLM reasoning depth when enableThinking is on: low | medium | high | xhigh.
+     The server maps it onto the model's own words (Low/Medium/High/Max); when
+     absent it keeps the server default, so a plain on/off client still works. */
+  reasoningEffort?: string
   cacheSlot?: number
   signal: AbortSignal
   onDelta: (text: string) => void
@@ -181,6 +185,8 @@ export async function streamChat(options: StreamChatOptions): Promise<StreamChat
       temperature: options.temperature,
       max_completion_tokens: options.maxTokens,
       enable_thinking: options.enableThinking,
+      ...(options.enableThinking && options.reasoningEffort
+        ? { reasoning_effort: options.reasoningEffort } : {}),
       ...(options.cacheSlot === undefined ? {} : { cache_slot: options.cacheSlot }),
       stream: true,
       stream_options: { include_usage: true },


### PR DESCRIPTION
Closes #1311.

The web UI only had a boolean reasoning toggle, but the GLM chat template already accepts a level: `render_chat` maps `reasoning_effort` (low/medium/high/xhigh) onto the words the model understands (Low/Medium/High/Max) when `enable_thinking` is on. So the web client could ask for "some reasoning", never how much.

## What changed

- **Level selector instead of on/off.** The sidebar toggle becomes a selector with `Off / Low / Medium / High / Max`. Each maps onto what the engine renders (`enable_thinking` + `reasoning_effort`).
- **Backward compatible.** `reasoning_effort` is sent only when reasoning is on, so a plain on/off client (and any non-GLM backend) behaves exactly as before.
- **GLM 5.3 constraint honored.** GLM 5.3 cannot disable reasoning, so `Off` is dropped from the choices for those models, and switching to one while `Off` is selected lifts the level to `High` — mirroring the model's own rule instead of sending a level it will ignore. Detection is by model id (`/5\.3/`).
- **i18n.** Level strings added for all five locales (en, de, it, zh-CN, zh-TW).

## Mapping (UI level -> request)

| UI | enable_thinking | reasoning_effort | GLM renders |
|----|-----------------|------------------|-------------|
| Off | false | (omitted) | Non-thinking |
| Low | true | low | Low |
| Medium | true | medium | Medium |
| High | true | high | High |
| Max | true | xhigh | Max |

## Validation
- `npm run build` (tsc -b + vite build) — clean, 0 type errors
- `npm test` (vitest) — 33 passed, including two new cases in `api.test.ts` (reasoning_effort sent when on / omitted when off)

## Notes / open questions for the maintainer
- 5.2-vs-5.3 detection is by model-id substring, the only version signal the web client has today. If the server exposed the family on `/v1/models`, the check could key off that instead — happy to follow that up if preferred.
- The alternative in the issue (drop the toggle entirely on 5.3) is a subset of this: here 5.3 keeps the Low/High/Max choices and only loses `Off`.