### PR TITLE
feat(glm53): Brain and Profile tabs for GLM-5.3-Flash

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -114,6 +114,19 @@ jobs:
         run: |
           python c/tools/make_glm53_tiny.py --output /tmp/glm53_tiny
           python c/tools/check_glm53_checkpoint.py --model /tmp/glm53_tiny
+      # The dashboard's Brain and Profile tabs read EMAP/HITS/PROF from the
+      # engine's stdout. GLM-5.3-Flash emitted none of them and both tabs were
+      # blank (Discord, 2026-09-06). This drives the built engine through
+      # `coli serve` and the /experts and /profile endpoints on a streaming
+      # fixture, the same path the dashboard takes, so a family that stops
+      # emitting a line fails here and not on a user's screen.
+      - name: Build glm53 and check the dashboard contract
+        run: |
+          make -C c glm53
+          python c/tools/make_glm53_multimodal_tiny.py --output /tmp/glm53_mm
+          python c/tools/make_glm53_streaming_pair.py --fixture /tmp/glm53_mm --output /tmp/glm53_stream
+          python c/tools/make_edge_tiny_tokenizer.py --vocab-size 281 /tmp/glm53_stream-i4
+          cd c && COLI_GLM53_FIXTURE=/tmp/glm53_stream-i4 python -m unittest -v tests.test_glm53_dashboard
 
   macos:
     # clang; libomp for the threaded path (Makefile falls back to

--- a/c/glm53.c
+++ b/c/glm53.c
@@ -1887,21 +1887,21 @@ static float *run_layers(GModel *m, GSession *s, float *streams, float *next,
             for (int t = 0; t < n; t++)
                 rms(normed + (size_t)t * D, collapsed + (size_t)t * D,
                     site ? l->post_ln : l->in_ln, D, c->eps);
+            const double t_phase = now_s();
             if (!site) {
                 GLayerState *st = &s->layer[i];
                 /* Lo stato non si azzera a ogni chiamata: e' della
                  * conversazione, e azzerarlo qui vorrebbe dire ricominciare
                  * la ricorrenza a ogni token generato. */
-                double t_phase = now_s();
                 if (c->is_full[i]) mla_layer(c, l, normed, n, branch, st, start);
                 else kda_layer(c, l, normed, n, branch, st->kda_state, st->kda_window,
                                s->kda_scratch);
-                m->t_attn += now_s() - t_phase;
             } else {
-                double t_phase = now_s();
                 ffn_layer(m, l, i, normed, n, branch);
-                m->t_ffn += now_s() - t_phase;
             }
+            /* Un solo paio di letture del clock per sito, il ramo dice a chi
+             * va il tempo. */
+            *(site ? &m->t_ffn : &m->t_attn) += now_s() - t_phase;
             for (int t = 0; t < n; t++)
                 coli_hc_post(next + (size_t)t * H * D, branch + (size_t)t * D,
                              streams + (size_t)t * H * D, post + (size_t)t * H,
@@ -2208,7 +2208,11 @@ static int load_stops(const char *dir, int *out, int max) {
  * questo motore riprefilla ogni volta invece di riprendere la conversazione da
  * dove era. E' piu' lento e non e' sbagliato, e il giorno che ci sara' una
  * cache il protocollo non cambia. */
-static double now_s(void) {
+/* noinline: GCC 16.1 (MSYS2 UCRT64) crashes in its IPA inliner when this
+ * clock is inlined into run_layers/forward_span at every phase timer; the
+ * bisect on the CI runner points at the inlining, not the timers, and a call
+ * per phase costs nothing next to a layer. */
+__attribute__((noinline)) static double now_s(void) {
     struct timespec t; clock_gettime(CLOCK_MONOTONIC, &t);
     return t.tv_sec + t.tv_nsec * 1e-9;
 }
@@ -2604,7 +2608,6 @@ static void serve_one(GModel *m, Tok *tokenizer, ServeReq *q) {
  * matmul esperti (ffn_layer meno il disco), attention (mla/kda), testa
  * (mv su lm_head). L'attesa asincrona non esiste qui: glm53 legge in modo
  * sincrono, quindi expert_wait_s e' 0 per costruzione, non per omissione. */
-__attribute__((noinline, optimize("no-tree-vectorize")))
 static void ehit_mark(GModel *m, int layer, int eid) {
     const Cfg *c = &m->c;
     if (!m->ehit) {
@@ -2613,13 +2616,11 @@ static void ehit_mark(GModel *m, int layer, int eid) {
     }
     if (layer >= 0 && layer < c->n_layers && eid >= 0 && eid < c->n_experts) m->ehit[layer][eid] = 1;
 }
-__attribute__((noinline, optimize("no-tree-vectorize")))
 static int dash_rows(const GModel *m) {
     int rows = 0;
     for (int i = m->c.first_dense; i < m->c.n_layers; i++) if (i >= m->layer_begin && i < m->layer_end) rows++;
     return rows;
 }
-__attribute__((noinline, optimize("no-tree-vectorize")))
 static void emap_emit(GModel *m) {
     const Cfg *c = &m->c;
     const int rows = dash_rows(m), cols = c->n_experts;
@@ -2637,7 +2638,6 @@ static void emap_emit(GModel *m) {
     hex[w] = 0;
     serve_line("EMAP %d %d %s\n", rows, cols, hex); free(hex);
 }
-__attribute__((noinline, optimize("no-tree-vectorize")))
 static void hits_emit(GModel *m) {
     const Cfg *c = &m->c;
     /* Un turno che non ha toccato esperti (tutto denso, o tutto riuso) emette

--- a/c/glm53.c
+++ b/c/glm53.c
@@ -2604,6 +2604,7 @@ static void serve_one(GModel *m, Tok *tokenizer, ServeReq *q) {
  * matmul esperti (ffn_layer meno il disco), attention (mla/kda), testa
  * (mv su lm_head). L'attesa asincrona non esiste qui: glm53 legge in modo
  * sincrono, quindi expert_wait_s e' 0 per costruzione, non per omissione. */
+__attribute__((noinline, optimize("no-tree-vectorize")))
 static void ehit_mark(GModel *m, int layer, int eid) {
     const Cfg *c = &m->c;
     if (!m->ehit) {
@@ -2612,11 +2613,13 @@ static void ehit_mark(GModel *m, int layer, int eid) {
     }
     if (layer >= 0 && layer < c->n_layers && eid >= 0 && eid < c->n_experts) m->ehit[layer][eid] = 1;
 }
+__attribute__((noinline, optimize("no-tree-vectorize")))
 static int dash_rows(const GModel *m) {
     int rows = 0;
     for (int i = m->c.first_dense; i < m->c.n_layers; i++) if (i >= m->layer_begin && i < m->layer_end) rows++;
     return rows;
 }
+__attribute__((noinline, optimize("no-tree-vectorize")))
 static void emap_emit(GModel *m) {
     const Cfg *c = &m->c;
     const int rows = dash_rows(m), cols = c->n_experts;
@@ -2634,6 +2637,7 @@ static void emap_emit(GModel *m) {
     hex[w] = 0;
     serve_line("EMAP %d %d %s\n", rows, cols, hex); free(hex);
 }
+__attribute__((noinline, optimize("no-tree-vectorize")))
 static void hits_emit(GModel *m) {
     const Cfg *c = &m->c;
     /* Un turno che non ha toccato esperti (tutto denso, o tutto riuso) emette

--- a/c/glm53.c
+++ b/c/glm53.c
@@ -1339,9 +1339,9 @@ static Slot *expert_slot(GModel *m, int layer, int eid) {
             if (cache->s[j].used < cache->s[lru].used) lru = j;
         slot = &cache->s[lru];
     }
-    const double t0 = now_s();
+    double t_read0 = now_s();
     expert_read(m, layer, eid, slot);
-    m->t_disk += now_s() - t0;
+    m->t_disk += now_s() - t_read0;
     slot->used = ++m->clock;
     return slot;
 }
@@ -1494,7 +1494,8 @@ static void ffn_layer(GModel *m, const GLayer *l, int index, const float *x,
             slot_of[i] = (int)(victim - cache->s);
             to_read[reads++] = i;
         }
-        const double t_batch = now_s();
+        double t_batch0;
+        t_batch0 = now_s();
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic, 1)
 #endif
@@ -1502,7 +1503,7 @@ static void ffn_layer(GModel *m, const GLayer *l, int index, const float *x,
             const int i = to_read[r];
             expert_read(m, index, union_ids[base + i], &cache->s[slot_of[i]]);
         }
-        m->t_disk += now_s() - t_batch;   /* fuori dalla regione omp: e' il muro del batch */
+        m->t_disk += now_s() - t_batch0;  /* fuori dalla regione omp: e' il muro del batch */
 
         /* Un esperto per volta, e per ognuno tutti i token che lo hanno
          * scelto. Nell'ordine opposto i suoi 12,6 MB di pesi verrebbero
@@ -1891,15 +1892,15 @@ static float *run_layers(GModel *m, GSession *s, float *streams, float *next,
                 /* Lo stato non si azzera a ogni chiamata: e' della
                  * conversazione, e azzerarlo qui vorrebbe dire ricominciare
                  * la ricorrenza a ogni token generato. */
-                const double t0 = now_s();
+                double t_phase = now_s();
                 if (c->is_full[i]) mla_layer(c, l, normed, n, branch, st, start);
                 else kda_layer(c, l, normed, n, branch, st->kda_state, st->kda_window,
                                s->kda_scratch);
-                m->t_attn += now_s() - t0;
+                m->t_attn += now_s() - t_phase;
             } else {
-                const double t0 = now_s();
+                double t_phase = now_s();
                 ffn_layer(m, l, i, normed, n, branch);
-                m->t_ffn += now_s() - t0;
+                m->t_ffn += now_s() - t_phase;
             }
             for (int t = 0; t < n; t++)
                 coli_hc_post(next + (size_t)t * H * D, branch + (size_t)t * D,
@@ -2065,10 +2066,10 @@ static float *forward_span(GModel *m, GSession *s, const int *tokens, int n,
         rms(normed + (size_t)t * D, collapsed + (size_t)t * D, m->final_norm, D, c->eps);
 
     float *logits = malloc((size_t)n * c->vocab * sizeof(float));
-    const double th = now_s();
+    double t_head0 = now_s();
     for (int t = 0; t < n; t++)
         mv(logits + (size_t)t * c->vocab, &m->head, normed + (size_t)t * D);
-    m->t_head += now_s() - th;
+    m->t_head += now_s() - t_head0;
     m->forwards++;
 
     free(normed); free(collapsed);

--- a/c/glm53.c
+++ b/c/glm53.c
@@ -668,6 +668,12 @@ typedef struct {
     int64_t e_len[6], e_at[6], e_slot;
     uint64_t clock, ebytes;
     long hits, miss;
+    /* Telemetria per la dashboard (#1376 follow-up: Brain e Profile erano
+     * vuoti su Flash perche' il motore non emetteva nulla). Tempi di fase
+     * cumulativi dall'avvio; il turno ne prende la differenza. */
+    double t_attn, t_ffn, t_disk, t_head;
+    uint64_t forwards;
+    uint8_t **ehit;                       /* [layer][expert] toccato in questo turno */
     /* torre vision: presente solo se il checkpoint la porta */
     int has_vision;
     ColiVisionTower vision;
@@ -1317,7 +1323,12 @@ static void expert_read(GModel *m, int layer, int eid, Slot *slot) {
 
 /* Lo slot dell'esperto chiesto, letto se non c'e'. La vittima e' quella usata
  * meno di recente. */
+static double now_s(void);
+static void ehit_mark(GModel *m, int layer, int eid);
+static void hits_emit(GModel *m);
+static void emap_emit(GModel *m);
 static Slot *expert_slot(GModel *m, int layer, int eid) {
+    ehit_mark(m, layer, eid);
     Slot *slot = slot_find(m, layer, eid);
     if (slot) return slot;
     LCache *cache = &m->ecache[layer];
@@ -1328,7 +1339,9 @@ static Slot *expert_slot(GModel *m, int layer, int eid) {
             if (cache->s[j].used < cache->s[lru].used) lru = j;
         slot = &cache->s[lru];
     }
+    const double t0 = now_s();
     expert_read(m, layer, eid, slot);
+    m->t_disk += now_s() - t0;
     slot->used = ++m->clock;
     return slot;
 }
@@ -1464,6 +1477,7 @@ static void ffn_layer(GModel *m, const GLayer *l, int index, const float *x,
         int reads = 0;
         for (int i = 0; i < here; i++) {
             const int eid = union_ids[base + i];
+            ehit_mark(m, index, eid);
             Slot *hit = slot_find(m, index, eid);
             if (hit) { slot_of[i] = (int)(hit - cache->s); continue; }
             Slot *victim;
@@ -1480,6 +1494,7 @@ static void ffn_layer(GModel *m, const GLayer *l, int index, const float *x,
             slot_of[i] = (int)(victim - cache->s);
             to_read[reads++] = i;
         }
+        const double t_batch = now_s();
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic, 1)
 #endif
@@ -1487,6 +1502,7 @@ static void ffn_layer(GModel *m, const GLayer *l, int index, const float *x,
             const int i = to_read[r];
             expert_read(m, index, union_ids[base + i], &cache->s[slot_of[i]]);
         }
+        m->t_disk += now_s() - t_batch;   /* fuori dalla regione omp: e' il muro del batch */
 
         /* Un esperto per volta, e per ognuno tutti i token che lo hanno
          * scelto. Nell'ordine opposto i suoi 12,6 MB di pesi verrebbero
@@ -1875,11 +1891,15 @@ static float *run_layers(GModel *m, GSession *s, float *streams, float *next,
                 /* Lo stato non si azzera a ogni chiamata: e' della
                  * conversazione, e azzerarlo qui vorrebbe dire ricominciare
                  * la ricorrenza a ogni token generato. */
+                const double t0 = now_s();
                 if (c->is_full[i]) mla_layer(c, l, normed, n, branch, st, start);
                 else kda_layer(c, l, normed, n, branch, st->kda_state, st->kda_window,
                                s->kda_scratch);
+                m->t_attn += now_s() - t0;
             } else {
+                const double t0 = now_s();
                 ffn_layer(m, l, i, normed, n, branch);
+                m->t_ffn += now_s() - t0;
             }
             for (int t = 0; t < n; t++)
                 coli_hc_post(next + (size_t)t * H * D, branch + (size_t)t * D,
@@ -2045,8 +2065,11 @@ static float *forward_span(GModel *m, GSession *s, const int *tokens, int n,
         rms(normed + (size_t)t * D, collapsed + (size_t)t * D, m->final_norm, D, c->eps);
 
     float *logits = malloc((size_t)n * c->vocab * sizeof(float));
+    const double th = now_s();
     for (int t = 0; t < n; t++)
         mv(logits + (size_t)t * c->vocab, &m->head, normed + (size_t)t * D);
+    m->t_head += now_s() - th;
+    m->forwards++;
 
     free(normed); free(collapsed);
     free(next); free(streams);
@@ -2461,6 +2484,8 @@ static void serve_one(GModel *m, Tok *tokenizer, ServeReq *q) {
     }
 
     const double started = now_s();
+    const double s_attn = m->t_attn, s_ffn = m->t_ffn, s_disk = m->t_disk, s_head = m->t_head;
+    const uint64_t s_fw = m->forwards;
     int emitted = 0, limited = 0;
     const int budget = q->max_tokens > 0 ? q->max_tokens : 256;
 
@@ -2549,11 +2574,82 @@ static void serve_one(GModel *m, Tok *tokenizer, ServeReq *q) {
      * occhi di chi voleva solo la risposta. */
     if (getenv("GLM53_VERBOSE"))
         fprintf(stderr, "REUSE %llu %d %d\n", q->id, reused, prompt_tokens);
+    hits_emit(m);
+    {
+        const double disk = m->t_disk - s_disk, ffn = m->t_ffn - s_ffn;
+        serve_line("PROF %.3f %d %d %.3f %.3f %.3f %.3f %.3f %llu\n", elapsed,
+                   prompt_tokens, emitted, disk, 0.0, ffn > disk ? ffn - disk : 0.0,
+                   m->t_attn - s_attn, m->t_head - s_head,
+                   (unsigned long long)(m->forwards - s_fw));
+    }
     serve_line("DONE %llu STAT %d %.2f %.1f %.1f %d %d\n", q->id, emitted,
                elapsed > 0 ? emitted / elapsed : 0.0,
                m->miss + m->hits ? 100.0 * m->hits / (double)(m->hits + m->miss) : 0.0,
                rss_gb(), prompt_tokens, limited);
     free(sequence);
+}
+
+/* --- Dashboard: Brain e Profile ------------------------------------------
+ * Il server legge quattro righe dallo stdout del motore e nient'altro:
+ *   EMAP rows cols hex   griglia (layer sparsi x esperti), una volta all'avvio
+ *   HITS rows cols hex   bitmap degli esperti toccati nel turno, a fine turno
+ *   PROF + 9 numeri      tempi per fase del turno
+ * colibri.c le emette da mesi (telemetry.h); deepseek_v4.c anche. Qui non
+ * c'erano, e le due schede su GLM-5.3-Flash restavano vuote: non c'era
+ * niente da attivare, mancava l'emissione. Stesso formato byte per byte,
+ * cosi' la dashboard non distingue i motori.
+ *
+ * Fasi che questo motore misura: disco (expert_read, muro del batch),
+ * matmul esperti (ffn_layer meno il disco), attention (mla/kda), testa
+ * (mv su lm_head). L'attesa asincrona non esiste qui: glm53 legge in modo
+ * sincrono, quindi expert_wait_s e' 0 per costruzione, non per omissione. */
+static void ehit_mark(GModel *m, int layer, int eid) {
+    const Cfg *c = &m->c;
+    if (!m->ehit) {
+        m->ehit = calloc((size_t)c->n_layers, sizeof(uint8_t *));
+        for (int i = 0; i < c->n_layers; i++) m->ehit[i] = calloc((size_t)c->n_experts, 1);
+    }
+    if (layer >= 0 && layer < c->n_layers && eid >= 0 && eid < c->n_experts) m->ehit[layer][eid] = 1;
+}
+static int dash_rows(const GModel *m) {
+    int rows = 0;
+    for (int i = m->c.first_dense; i < m->c.n_layers; i++) if (i >= m->layer_begin && i < m->layer_end) rows++;
+    return rows;
+}
+static void emap_emit(GModel *m) {
+    const Cfg *c = &m->c;
+    const int rows = dash_rows(m), cols = c->n_experts;
+    char *hex = malloc((size_t)rows * cols * 2 + 1); int w = 0;
+    for (int i = c->first_dense; i < c->n_layers; i++) {
+        if (i < m->layer_begin || i >= m->layer_end) continue;
+        for (int e = 0; e < cols; e++) {
+            int tier = 0;                       /* 0 = su disco, 1 = in RAM (cache) */
+            if (m->ecache) { const LCache *cache = &m->ecache[i];
+                for (int j = 0; j < cache->n; j++) if (cache->s[j].eid == e) { tier = 1; break; } }
+            const int b = tier << 6;            /* nessun contatore di calore qui: heat = 0 */
+            hex[w++] = "0123456789abcdef"[b >> 4]; hex[w++] = "0123456789abcdef"[b & 15];
+        }
+    }
+    hex[w] = 0;
+    serve_line("EMAP %d %d %s\n", rows, cols, hex); free(hex);
+}
+static void hits_emit(GModel *m) {
+    const Cfg *c = &m->c;
+    /* Un turno che non ha toccato esperti (tutto denso, o tutto riuso) emette
+     * una bitmap a zero: la dashboard deve vedere QUESTO turno, non l'ultimo
+     * che ha avuto hit. */
+    if (!m->ehit) ehit_mark(m, -1, -1);
+    const int rows = dash_rows(m), cols = c->n_experts, nb = (rows * cols + 7) / 8;
+    uint8_t *bm = calloc((size_t)nb, 1); int bit = 0;
+    for (int i = c->first_dense; i < c->n_layers; i++) {
+        if (i < m->layer_begin || i >= m->layer_end) continue;
+        for (int e = 0; e < cols; e++, bit++)
+            if (m->ehit[i][e]) { bm[bit >> 3] |= (uint8_t)(1 << (bit & 7)); m->ehit[i][e] = 0; }
+    }
+    char *hex = malloc((size_t)nb * 2 + 1); int w = 0;
+    for (int b = 0; b < nb; b++) { hex[w++] = "0123456789abcdef"[bm[b] >> 4]; hex[w++] = "0123456789abcdef"[bm[b] & 15]; }
+    hex[w] = 0;
+    serve_line("HITS %d %d %s\n", rows, cols, hex); free(hex); free(bm);
 }
 
 static void serve_loop(GModel *m, Tok *tokenizer) {
@@ -2562,6 +2658,9 @@ static void serve_loop(GModel *m, Tok *tokenizer) {
     slots_init(m);
     serve_line("\x01\x01READY\x01\x01\n");
     serve_line("STAT 0 0.00 0.0 %.1f\n", rss_gb());
+    /* La griglia va DOPO READY: il lettore di boot del server scarta tutto
+     * fino al sentinel, e colibri.c fa lo stesso (READY, STAT, poi EMAP). */
+    emap_emit(m);
     for (;;) {
         ServeReq q; char verb[16];
         if (!serve_read_req(&q, verb, sizeof(verb))) break;   /* EOF: si esce */

--- a/c/tests/test_glm53_dashboard.py
+++ b/c/tests/test_glm53_dashboard.py
@@ -1,0 +1,118 @@
+"""The dashboard's Brain and Profile tabs read four lines from the engine's
+stdout: EMAP, HITS, PROF, TIERS. On GLM-5.3-Flash they were empty, not because
+anything needed activating but because glm53.c emitted none of them. This
+test drives the engine the way the dashboard does -- through `coli serve`
+and the /experts and /profile endpoints -- and asserts the data arrives in
+the shape the server parses, so a family that stops emitting a line fails
+here rather than as a blank tab on a user's screen.
+
+It needs a GLM-5.3-Flash container and a built `glm53`. Set
+COLI_GLM53_FIXTURE to the container directory; without it the test is
+skipped, with the reason on the record.
+"""
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import unittest
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent.parent
+FIXTURE = os.environ.get("COLI_GLM53_FIXTURE")
+
+
+def free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def get_json(url, timeout=10):
+    with urllib.request.urlopen(url, timeout=timeout) as r:
+        return json.load(r)
+
+
+@unittest.skipUnless(FIXTURE and Path(FIXTURE, "config.json").is_file(),
+                     "COLI_GLM53_FIXTURE not set to a GLM-5.3-Flash container")
+@unittest.skipUnless((HERE / "glm53").exists() or (HERE / "glm53.exe").exists(),
+                     "glm53 engine is not built")
+class Glm53DashboardTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.port = free_port()
+        cls.proc = subprocess.Popen(
+            [sys.executable, str(HERE / "coli"), "serve", "--model", FIXTURE,
+             "--port", str(cls.port), "--cap", "2"],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        deadline = time.time() + 180
+        while time.time() < deadline:
+            try:
+                get_json(f"http://127.0.0.1:{cls.port}/health", timeout=2)
+                break
+            except Exception:
+                if cls.proc.poll() is not None:
+                    raise RuntimeError("coli serve exited: " + cls.proc.stdout.read()[-2000:])
+                time.sleep(1)
+        else:
+            raise RuntimeError("coli serve did not come up in 180 s")
+        model = get_json(f"http://127.0.0.1:{cls.port}/v1/models")["data"][0]["id"]
+        body = json.dumps({"model": model, "prompt": "abcabcabc", "max_tokens": 3}).encode()
+        req = urllib.request.Request(f"http://127.0.0.1:{cls.port}/v1/completions", data=body,
+                                     headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=300) as r:
+            cls.completion = json.load(r)
+        cls.experts = get_json(f"http://127.0.0.1:{cls.port}/experts")
+        cls.profile = get_json(f"http://127.0.0.1:{cls.port}/profile")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        try:
+            cls.proc.wait(10)
+        except subprocess.TimeoutExpired:
+            cls.proc.kill()
+
+    def test_brain_has_a_grid(self):
+        """EMAP: one row per sparse layer served, one column per expert, two
+        hex digits per cell. Emitted after READY: the boot reader discards
+        everything before the sentinel, which is exactly the mistake the first
+        draft of this feature made."""
+        e = self.experts
+        self.assertGreater(e.get("rows", 0), 0, "no EMAP reached the server")
+        self.assertGreater(e.get("cols", 0), 0)
+        self.assertEqual(len(e["map"]), e["rows"] * e["cols"] * 2)
+
+    def test_brain_lights_up_after_a_turn(self):
+        """HITS: a bitmap of the experts this turn touched, packed 8 per hex
+        pair, refreshed every turn even when nothing was touched."""
+        e = self.experts
+        self.assertGreaterEqual(e.get("seq", 0), 1, "no HITS reached the server")
+        bits = e["rows"] * e["cols"]
+        self.assertEqual(len(e["hits"]), ((bits + 7) // 8) * 2)
+        self.assertNotEqual(int(e["hits"], 16), 0,
+                            "a 9-token prompt through a sparse layer touched no expert")
+
+    def test_profile_records_the_turn_with_its_phases(self):
+        """PROF: wall, prompt/completion tokens, five phase timings, forwards.
+        expert_wait_s is 0 by construction (glm53 reads synchronously), the
+        others must add up to something real."""
+        turns = self.profile.get("turns", [])
+        self.assertEqual(len(turns), 1, "exactly one turn was made")
+        t = turns[0]
+        for key in ("wall_s", "prompt_tokens", "completion_tokens", "expert_disk_s",
+                    "expert_wait_s", "expert_matmul_s", "attention_s", "lm_head_s", "forwards"):
+            self.assertIn(key, t)
+        self.assertEqual(t["completion_tokens"], 3)
+        self.assertEqual(t["forwards"], 3, "one forward per generated token")
+        self.assertEqual(t["expert_wait_s"], 0.0)
+        phases = t["expert_disk_s"] + t["expert_matmul_s"] + t["attention_s"] + t["lm_head_s"]
+        self.assertGreater(phases, 0.0)
+        self.assertLessEqual(phases, t["wall_s"] * 1.05 + 0.01,
+                             "phase timings exceed the wall clock: a timer is double-counting")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Brain and Profile tabs for GLM-5.3-Flash. Asked on Discord: "How do I activate the Brain and Profile tabs? They load, but they aren't processing anything when I chat." Nothing needed activating. The engine emitted none of the lines the tabs read.

## What the tabs read

Four lines on the engine's stdout, parsed by `openai_server.py`, nothing else:

| line | tab | when |
|---|---|---|
| `EMAP rows cols hex` | Brain grid | once, **after** READY |
| `HITS rows cols hex` | Brain lights | end of every turn |
| `PROF` + 9 numbers | Profile | end of every turn |
| `TIERS ...` | tiers widget | |

`colibri.c` has emitted them for months (`telemetry.h`); `deepseek_v4.c` too. `glm53.c`: none. Hence blank tabs on Flash.

## What this adds, and the two things it got wrong on the way

`glm53.c` now emits EMAP, HITS and PROF in the same bytes as colibri, so the server cannot tell the engines apart.

- **EMAP after READY.** The first draft emitted it before the sentinel; the boot reader discards everything until READY, and `/experts` stayed empty. colibri does READY, STAT, then EMAP. Now so does glm53.
- **HITS every turn, all-zero included.** The first draft returned early when no expert had been marked, which would have left the tab showing the previous turn's hits. Marks are taken on both expert paths, the single-slot lookup and the batched union read.
- **Profile phases are measured, not padded.** Disk is the wall of `expert_read` (on the union path, the batch's wall taken outside the `omp` region); expert matmul is `ffn_layer` minus disk; attention wraps `mla_layer`/`kda_layer`; the head wraps `mv`. `expert_wait_s` is 0 by construction: glm53 reads synchronously, and the comment says so rather than inventing a number.

## Verified

- `coli serve` on the streaming fixture, one completion, then the endpoints: `/experts` rows 1, cols 4, map `00000000`, hits `0b` (experts 0, 1, 3 touched); `/profile` one turn with `wall_s 8.4, prompt 9, completion 3, disk 0.015, matmul 1.51, attention 6.73, head 0.16, forwards 3`.
- **Token-identical** to `dev` on the fixture (`--ids 1,2,3 --greedy 8`): full stdout equal except the timing line.
- `tests/test_glm53_dashboard.py` takes the dashboard's own path (`coli serve` + HTTP) and asserts grid shape, a non-zero bitmap after a 9-token prompt, and a turn whose phase sum does not exceed the wall clock. Skipped without `COLI_GLM53_FIXTURE`, with the reason on record.
- Wired into the `Linux (generated GLM-5.3 oracle contract)` job, which already installs the pinned generators; the whole chain (multimodal tiny, streaming pair, tokenizer, build, test) was run from scratch here with the same pinned `transformers 5.16.1`: 3 tests, green.
- Negative controls: without the marks, `test_brain_lights_up_after_a_turn` fails; with EMAP before READY, `test_brain_has_a_grid` fails.

## Still blank elsewhere

After this: Brain full on GLM-5.2/5.3, DeepSeek V4 Flash, **GLM-5.3-Flash**; grid without lights on Inkling and OLMoE (they emit EMAP, not HITS); none on Qwen3.6, Kimi K3, Qwen3.8. Profile everywhere except Qwen3.6. Same recipe applies; qwen36 is the next one worth doing.
