### PR TITLE
qwen36: Brain and Profile tabs (EMAP, HITS, PROF)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,6 +445,15 @@ jobs:
           grep -q "config.json says 4 layers" bad.log || {
             echo "FAIL: refused, but not for the reason under test"; cat bad.log; exit 1; }
           echo "refused as expected:"; grep '^\[cfg\]' bad.log
+      - name: Brain and Profile reach the dashboard
+        run: |
+          cd c
+          # The oracle fixture has no tokenizer (weights only); `coli serve`
+          # needs one to encode the prompt. The byte tokenizer is test data
+          # sized to the fixture's vocab, the same as the GLM-5.3 gate uses.
+          python3 tools/make_edge_tiny_tokenizer.py --vocab-size 320 qwen36_tiny_c
+          make qwen36 >/dev/null
+          COLI_QWEN36_FIXTURE=qwen36_tiny_c python3 -m unittest -v tests.test_qwen36_dashboard
 
   qwen38-tiny-check:
     name: Qwen3.8 tiny oracle (GDN + QSA + PLE + MoE)

--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -633,6 +633,10 @@ typedef struct {
     float **DN_rec;         /* [n_layers] recurrent state S[h]=[kdim,vdim] for DeltaNet layers (NULL for attn) */
     float **DN_conv;        /* [n_layers] conv ring [conv_dim, convk-1] for DeltaNet layers (NULL for attn) */
     uint64_t clock, hits, miss;
+    /* Telemetria per la dashboard (Brain/Profile): tempo di lettura esperti
+     * accumulato dall'avvio, e bitmap degli esperti toccati nel turno. */
+    double t_disk;
+    uint8_t **ehit;
     float **K, **V; int kv_len, max_t, kv_cap;
     float *attn_sc;            /* [attn_sc_thr * kv_cap] score rows, one per thread */
     int attn_sc_thr;
@@ -736,7 +740,7 @@ static void tm_add(int S, int idx, double ms){
         g_tm_dec[idx]+=ms;
         if(idx==2) g_tm_win_moe+=ms;
         if(idx==5 && ++g_tm_win_n==32){
-            fprintf(stderr,"[timers] window: moe %.0f ms/token (last 32)\n", g_tm_win_moe/32.0);
+            if(tm_on()) fprintf(stderr,"[timers] window: moe %.0f ms/token (last 32)\n", g_tm_win_moe/32.0);
             g_tm_win_moe=0; g_tm_win_n=0;
         }
     } else g_tm_pre[idx]+=ms;
@@ -1569,7 +1573,9 @@ static void slot_ensure_int8(Model *m, Slot *s) {
     s->g = w; s->u = w + ng; s->d = w + ng + ng;
 }
 
+static void ehit_mark(Model *m, int layer, int eid);
 static void expert_get(Model *m, int layer, int eid, Slot **out) {
+    ehit_mark(m, layer, eid);   /* tocca solo m->ehit[layer][eid] */
     LCache *lc = &m->cache[layer];
     pthread_mutex_lock(&g_pilot_mx);
     Slot *hit = slot_indexed(m, layer, eid);
@@ -1618,8 +1624,11 @@ static void expert_get(Model *m, int layer, int eid, Slot **out) {
     }
     cache_hide(m, layer, s); s->used = ++m->clock;
     pthread_mutex_unlock(&g_pilot_mx);
+    double t_read0 = now_s();
     load_expert_merged(m, layer, eid, s);
+    double t_read = now_s() - t_read0;
     pthread_mutex_lock(&g_pilot_mx);
+    m->t_disk += t_read;        /* sotto lock: qui arrivano anche i thread del PILOT */
     cache_publish(m, layer, s, eid); s->pinned = m->is_pinned[layer * c->n_experts + eid]; s->used = ++m->clock;
     *out = s; pthread_mutex_unlock(&g_pilot_mx);
 }
@@ -1840,7 +1849,7 @@ static void qwen_shared_experts_cpu(Model *m, Layer *l, const float *x, int S,
                                     float *out, float *g, float *u, float *hh) {
     Cfg *c=&m->c; int D=c->hidden, I=c->shared_inter;
     int B=qwen_shared_batch_rows(S,D,I);
-    double _ts=tm_on()?tm_now():0.0;
+    double _ts=tm_now();
     if (B == 1) {
         for (int s=0;s<S;s++) {
             const float *xs=x+(int64_t)s*D;
@@ -1872,7 +1881,7 @@ static void qwen_shared_experts_cpu(Model *m, Layer *l, const float *x, int S,
         }
         free(bg);free(bh);
     }
-    if(tm_on())tm_add(S,3,tm_now()-_ts);
+    tm_add(S,3,tm_now()-_ts);
 }
 
 /* MoE: grouped top-k routing (+ optional router bias) + shared expert.
@@ -1881,9 +1890,9 @@ static void qwen_shared_experts_cpu(Model *m, Layer *l, const float *x, int S,
 static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
     Cfg *c = &m->c; int D = c->hidden, E = c->n_experts, K = c->topk, I = c->inter;
     float *logits = falloc((int64_t)S*E);
-    double _tr = tm_on() ? tm_now() : 0.0;
+    double _tr = tm_now();
     matmul_d(logits, x, l->gate, S, D, E);
-    if (tm_on()) tm_add(S, 4, tm_now()-_tr);
+    tm_add(S, 4, tm_now()-_tr);
     if (c->has_bias && l->gate_bias) {
         for (int s = 0; s < S; s++) { float *pr = logits + (int64_t)s*E; for (int e = 0; e < E; e++) pr[e] += l->gate_bias[e]; }
     }
@@ -1949,9 +1958,9 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
                 Slot *e; expert_get(m, layer, idx[kk], &e);
                 if (e->g4) qt_note(layer, idx[kk], e->g4, e->u4, e->d4, e->gs, e->us, e->ds);
             }
-            double _q0 = tm_on()? tm_now():0;
+            double _q0 = tm_now();
             uint32_t qmask = qt_issue(layer, idx, K, xs);
-            double _q1 = tm_on()? tm_now():0;
+            double _q1 = tm_now();
             for (int kk = 0; kk < K; kk++) {
                 if (qmask & (1u<<kk)) continue;
                 Slot *e; expert_get(m, layer, idx[kk], &e);
@@ -1966,7 +1975,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
             /* Compute the shared expert NOW so it overlaps with the GPU
              * groups; the common block below is skipped. */
             {
-                double _ts2 = tm_on() ? tm_now() : 0.0;
+                double _ts2 = tm_now();
                 int Ish = c->shared_inter;
                 matmul_d(sh, xs, l->sh_g, 1, D, Ish);
                 matmul_d(shu, xs, l->sh_u, 1, D, Ish);
@@ -1980,9 +1989,9 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
                 }
                 float *os = out + (int64_t)s*D;
                 for (int d = 0; d < D; d++) os[d] += sgate * shd[d];
-                if (tm_on()) tm_add(S, 3, tm_now()-_ts2);
+                tm_add(S, 3, tm_now()-_ts2);
             }
-            double _q2 = tm_on()? tm_now():0;
+            double _q2 = tm_now();
             qt_take(qmask, val, K, out + (int64_t)s*D);
             if (tm_on() && S==1) {
                 extern double g_qt_iss, g_qt_cpu, g_qt_tak;
@@ -2056,7 +2065,7 @@ static void deltanet(Model *m, Layer *l, int layer, float *x, int S, int pos_bas
     for (int s = 0; s < S; s++) {
         const float *xs = x + (int64_t)s * H;
         extern double g_dn_sub[4];
-        double _d0 = tm_on()? tm_now():0;
+        double _d0 = tm_now();
         /* projections (single-token matmuls). One fused GEMV when this layer's
          * dnproj is placed on a GPU, the two CPU matmuls otherwise. */
         if (!qt_dnproj_matmul(layer, qkvz, xs, H, conv_dim + value_dim)) {
@@ -2192,13 +2201,13 @@ static void layers_forward_range(Model *m, float *x, int S, int pos_base,
     for (int i = layer_begin; i < layer_end; i++) {
         Layer *l = &m->L[i];
         for (int s = 0; s < S; s++) rmsnorm_row(nrm + (int64_t)s*D, x + (int64_t)s*D, l->in_ln, D, c->eps);
-        double _t0 = tm_on() ? tm_now() : 0.0;
+        double _t0 = tm_now();
         if (c->is_attn[i]) {
             attention(m, l, i, nrm, S, pos_base, tmp);
-            if (tm_on()) tm_add(S, 1, tm_now()-_t0);
+            tm_add(S, 1, tm_now()-_t0);
         } else {
             deltanet(m, l, i, nrm, S, pos_base, tmp);
-            if (tm_on()) tm_add(S, 0, tm_now()-_t0);
+            tm_add(S, 0, tm_now()-_t0);
         }
         if (lf) fwrite(tmp + (int64_t)(S-1)*D, sizeof(float), D, lf);   /* sublayer output */
         for (int64_t j = 0; j < (int64_t)S*D; j++) x[j] += tmp[j];
@@ -2206,9 +2215,9 @@ static void layers_forward_range(Model *m, float *x, int S, int pos_base,
         if (allow_prefetch && g_pilot >= 1 && S <= 8 && i + 1 < c->n_layers)
             pilot_prefetch(m, i + 1, x, S);
         for (int s = 0; s < S; s++) rmsnorm_row(nrm + (int64_t)s*D, x + (int64_t)s*D, l->post_ln, D, c->eps);
-        _t0 = tm_on() ? tm_now() : 0.0;
+        _t0 = tm_now();
         moe(m, l, i, nrm, S, tmp);
-        if (tm_on()) tm_add(S, 2, tm_now()-_t0);
+        tm_add(S, 2, tm_now()-_t0);
         for (int64_t j = 0; j < (int64_t)S*D; j++) x[j] += tmp[j];
         if (lf) fwrite(x + (int64_t)(S-1)*D, sizeof(float), D, lf);
         if (allow_prefetch && g_pilot >= 2 && S <= 8 && i + 2 < c->n_layers)
@@ -2251,7 +2260,7 @@ static float *step(Model *m, const int *ids, int S, int pos_base) {
     float *last = falloc(D);
     rmsnorm_row(last, x + (int64_t)(S-1)*D, m->final_norm, D, c->eps);
     float *logit = falloc(c->vocab);
-    double _th = tm_on() ? tm_now() : 0.0;
+    double _th = tm_now();
     if (!qt_lmhead_matmul(logit, last, D, c->vocab))
         matmul_d(logit, last, m->lm_head, 1, D, c->vocab);
     if (tm_on()) { tm_add(S, 5, tm_now()-_th); if (S==1) g_tm_dec_tokens++; else g_tm_pre_tokens += S; }
@@ -2284,8 +2293,11 @@ static void pilot_realload(Model *m, int layer, int eid) {
     }
     cache_hide(m, layer, s); s->used = ++m->clock;
     pthread_mutex_unlock(&g_pilot_mx);
+    double t_read0 = now_s();
     load_expert_merged(m, layer, eid, s);
+    double t_read = now_s() - t_read0;
     pthread_mutex_lock(&g_pilot_mx);
+    m->t_disk += t_read;        /* sotto lock: qui arrivano anche i thread del PILOT */
     cache_publish(m, layer, s, eid); s->pinned = m->is_pinned[layer*c->n_experts+eid]; s->used = ++m->clock;
     m->is_queued[layer*c->n_experts+eid] = 0; pthread_mutex_unlock(&g_pilot_mx);
 }
@@ -2447,7 +2459,7 @@ static void generate(Model *m, const int *prompt, int np, int n_new, int *out) {
         }
         free(logit); out[len++] = best;
         int one = best;
-        { extern double g_tm_step; double _s0 = tm_on()? tm_now():0;
+        { extern double g_tm_step; double _s0 = tm_now();
           logit = step(m, &one, 1, len - 1);
           if (tm_on()) g_tm_step += tm_now()-_s0; }
     }
@@ -2600,6 +2612,48 @@ static int serve_cancel_pending(const char *id){
     return cancelled;
 }
 
+/* --- Dashboard: Brain e Profile ------------------------------------------
+ * Stesse quattro righe di colibri.c/glm53.c, stessi byte: EMAP dopo READY,
+ * HITS e PROF prima di DONE. Qui ogni layer e' MoE, quindi la griglia e'
+ * n_layers x n_experts. Il tier VRAM non espone una query di residenza:
+ * la griglia distingue solo disco (0) e cache RAM (1). Le fasi del Profile
+ * vengono dai timer che il motore ha gia' (deltanet, attention, moe, head),
+ * ora accumulati sempre e riportati a schermo solo con COLI_TIMERS=1; il
+ * disco e' misurato attorno a load_expert_merged su entrambi i percorsi.
+ * L'attesa asincrona resta 0 per costruzione. */
+static void ehit_mark(Model *m, int layer, int eid){
+    const Cfg *c=&m->c;
+    if(!m->ehit){
+        m->ehit=calloc((size_t)c->n_layers,sizeof(uint8_t*));
+        for(int i=0;i<c->n_layers;i++) m->ehit[i]=calloc((size_t)c->n_experts,1);
+    }
+    if(layer>=0&&layer<c->n_layers&&eid>=0&&eid<c->n_experts) m->ehit[layer][eid]=1;
+}
+static void dash_hex(const uint8_t *bytes,int n,char *hex){
+    for(int b=0;b<n;b++){ hex[2*b]="0123456789abcdef"[bytes[b]>>4]; hex[2*b+1]="0123456789abcdef"[bytes[b]&15]; }
+    hex[2*n]=0;
+}
+static void emap_emit(Model *m){
+    const Cfg *c=&m->c; const int rows=c->n_layers, cols=c->n_experts;
+    uint8_t *cells=calloc((size_t)rows*cols,1);
+    pthread_mutex_lock(&g_pilot_mx);
+    for(int i=0;i<rows;i++) for(int e=0;e<cols;e++)
+        cells[(size_t)i*cols+e]=(uint8_t)((slot_indexed(m,i,e)?1:0)<<6);
+    pthread_mutex_unlock(&g_pilot_mx);
+    char *hex=malloc((size_t)rows*cols*2+1); dash_hex(cells,rows*cols,hex);
+    printf("EMAP %d %d %s\n",rows,cols,hex); fflush(stdout); free(hex); free(cells);
+}
+static void hits_emit(Model *m){
+    const Cfg *c=&m->c; const int rows=c->n_layers, cols=c->n_experts, nb=(rows*cols+7)/8;
+    if(!m->ehit) ehit_mark(m,-1,-1);
+    uint8_t *bm=calloc((size_t)nb,1); int bit=0;
+    for(int i=0;i<rows;i++) for(int e=0;e<cols;e++,bit++)
+        if(m->ehit[i][e]){ bm[bit>>3]|=(uint8_t)(1<<(bit&7)); m->ehit[i][e]=0; }
+    char *hex=malloc((size_t)nb*2+1); dash_hex(bm,nb,hex);
+    printf("HITS %d %d %s\n",rows,cols,hex); fflush(stdout); free(hex); free(bm);
+}
+static double tm_sum(int idx){ return (g_tm_dec[idx]+g_tm_pre[idx])/1e3; }   /* ms -> s */
+
 static void serve_one(Model *m, ServeReq *q){
     int *ids=NULL, np=0;
     encode_text(q->payload, &ids, &np);          /* payload is raw prompt text; qwen36 adds no BOS */
@@ -2621,7 +2675,8 @@ static void serve_one(Model *m, ServeReq *q){
         memset(m->momentum_logits, 0,
                (size_t)m->c.n_layers * m->c.n_experts * sizeof(float));
     float *lo = step(m, ids, np, 0);
-    int gen=0, limited=1;
+    int gen=0, limited=1, forwards=1;   /* il prefill e' il primo forward */
+    const double s_disk=m->t_disk, s_attn=tm_sum(0)+tm_sum(1), s_moe=tm_sum(2), s_head=tm_sum(5);
     int eos_ids[4]; int n_eos=serve_eos_ids(eos_ids,4);
     double t0=now_s();
     unsigned char sbuf[16]; int sbn=0;
@@ -2648,11 +2703,19 @@ static void serve_one(Model *m, ServeReq *q){
          * serve_one() resets the recurrent/KV state for every request, so
          * stepping here would only run a full discarded decode pass. */
         if(s == q->max_tok - 1) break;
-        lo = step(m, &tk, 1, np+s);
+        lo = step(m, &tk, 1, np+s); forwards++;
     }
     if(sbn>0) serve_data(q->id,(char*)sbuf,sbn);   /* flush trailing partial UTF-8 */
     free(lo); free(ids);
     double dt=now_s()-t0;
+    hits_emit(m);
+    {
+        double disk=m->t_disk-s_disk, moe=tm_sum(2)-s_moe;
+        printf("PROF %.3f %d %d %.3f %.3f %.3f %.3f %.3f %llu\n", dt, np, gen,
+               disk, 0.0, moe>disk?moe-disk:0.0, tm_sum(0)+tm_sum(1)-s_attn, tm_sum(5)-s_head,
+               (unsigned long long)forwards);   /* contati, non dedotti: l'ultimo token non ne fa uno */
+        fflush(stdout);
+    }
     printf("DONE %s STAT %d %.3f %.1f %.2f %d %d\n",q->id,gen,
            dt>0?gen/dt:0.0,0.0,rss_gb(),np,limited);
     fflush(stdout);
@@ -2663,6 +2726,8 @@ static void serve_loop(Model *m){
     setvbuf(stdin,NULL,_IONBF,0);
     fputs("\x01\x01READY\x01\x01\n",stdout);
     printf("STAT 0 0.00 0.0 %.2f\n",rss_gb());
+    fflush(stdout);
+    emap_emit(m);          /* dopo READY e STAT: il boot reader legge STAT dopo il sentinel */
     fflush(stdout);
     for(;;){
         ServeReq q={0}; int r;

--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -1573,7 +1573,17 @@ static void slot_ensure_int8(Model *m, Slot *s) {
     s->g = w; s->u = w + ng; s->d = w + ng + ng;
 }
 
-static void ehit_mark(Model *m, int layer, int eid);
+/* Segna l'esperto instradato per la bitmap HITS della dashboard. Vive qui,
+ * fuori dalla regione QWEN36_NO_MAIN: expert_get la chiama anche nel build
+ * del segment adapter, dove il resto della telemetria serve non esiste. */
+static void ehit_mark(Model *m, int layer, int eid){
+    const Cfg *c=&m->c;
+    if(!m->ehit){
+        m->ehit=calloc((size_t)c->n_layers,sizeof(uint8_t*));
+        for(int i=0;i<c->n_layers;i++) m->ehit[i]=calloc((size_t)c->n_experts,1);
+    }
+    if(layer>=0&&layer<c->n_layers&&eid>=0&&eid<c->n_experts) m->ehit[layer][eid]=1;
+}
 static void expert_get(Model *m, int layer, int eid, Slot **out) {
     ehit_mark(m, layer, eid);   /* tocca solo m->ehit[layer][eid] */
     LCache *lc = &m->cache[layer];
@@ -2621,14 +2631,6 @@ static int serve_cancel_pending(const char *id){
  * ora accumulati sempre e riportati a schermo solo con COLI_TIMERS=1; il
  * disco e' misurato attorno a load_expert_merged su entrambi i percorsi.
  * L'attesa asincrona resta 0 per costruzione. */
-static void ehit_mark(Model *m, int layer, int eid){
-    const Cfg *c=&m->c;
-    if(!m->ehit){
-        m->ehit=calloc((size_t)c->n_layers,sizeof(uint8_t*));
-        for(int i=0;i<c->n_layers;i++) m->ehit[i]=calloc((size_t)c->n_experts,1);
-    }
-    if(layer>=0&&layer<c->n_layers&&eid>=0&&eid<c->n_experts) m->ehit[layer][eid]=1;
-}
 static void dash_hex(const uint8_t *bytes,int n,char *hex){
     for(int b=0;b<n;b++){ hex[2*b]="0123456789abcdef"[bytes[b]>>4]; hex[2*b+1]="0123456789abcdef"[bytes[b]&15]; }
     hex[2*n]=0;

--- a/c/tests/test_qwen36_dashboard.py
+++ b/c/tests/test_qwen36_dashboard.py
@@ -1,0 +1,123 @@
+"""The dashboard's Brain and Profile tabs read four lines from the engine's
+stdout: EMAP, HITS, PROF, TIERS. On Qwen3.6 they were empty, not because
+anything needed activating but because qwen36.c emitted none of them. This
+test drives the engine the way the dashboard does -- through `coli serve`
+and the /experts and /profile endpoints -- and asserts the data arrives in
+the shape the server parses, so a family that stops emitting a line fails
+here rather than as a blank tab on a user's screen.
+
+It needs a Qwen3.6 container with a tokenizer.json and a built `qwen36`.
+Set COLI_QWEN36_FIXTURE to the container directory; without it the test is
+skipped, with the reason on the record. The CI job builds the tiny fixture it
+already uses for the token-exact oracle and adds the byte tokenizer from
+tools/make_edge_tiny_tokenizer.py, which is all `coli serve` needs.
+"""
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import unittest
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent.parent
+FIXTURE = os.environ.get("COLI_QWEN36_FIXTURE")
+
+
+def free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def get_json(url, timeout=10):
+    with urllib.request.urlopen(url, timeout=timeout) as r:
+        return json.load(r)
+
+
+@unittest.skipUnless(FIXTURE and Path(FIXTURE, "config.json").is_file()
+                     and Path(FIXTURE, "tokenizer.json").is_file(),
+                     "COLI_QWEN36_FIXTURE not set to a Qwen3.6 container with a tokenizer")
+@unittest.skipUnless((HERE / "qwen36").exists() or (HERE / "qwen36.exe").exists(),
+                     "qwen36 engine is not built")
+class Qwen36DashboardTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.port = free_port()
+        cls.proc = subprocess.Popen(
+            [sys.executable, str(HERE / "coli"), "serve", "--model", FIXTURE,
+             "--port", str(cls.port), "--cap", "4"],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        deadline = time.time() + 180
+        while time.time() < deadline:
+            try:
+                get_json(f"http://127.0.0.1:{cls.port}/health", timeout=2)
+                break
+            except Exception:
+                if cls.proc.poll() is not None:
+                    raise RuntimeError("coli serve exited: " + cls.proc.stdout.read()[-2000:])
+                time.sleep(1)
+        else:
+            raise RuntimeError("coli serve did not come up in 180 s")
+        model = get_json(f"http://127.0.0.1:{cls.port}/v1/models")["data"][0]["id"]
+        body = json.dumps({"model": model, "prompt": "abcabcabc", "max_tokens": 3}).encode()
+        req = urllib.request.Request(f"http://127.0.0.1:{cls.port}/v1/completions", data=body,
+                                     headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=300) as r:
+            cls.completion = json.load(r)
+        cls.experts = get_json(f"http://127.0.0.1:{cls.port}/experts")
+        cls.profile = get_json(f"http://127.0.0.1:{cls.port}/profile")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        try:
+            cls.proc.wait(10)
+        except subprocess.TimeoutExpired:
+            cls.proc.kill()
+
+    def test_brain_has_a_grid(self):
+        """EMAP: one row per layer, one column per expert, two hex digits per
+        cell. This engine's boot reader expects READY then STAT, so the grid
+        goes after both: emitted between them it is an invalid engine status,
+        emitted before READY it is discarded. Both mistakes end here as an
+        empty grid."""
+        e = self.experts
+        self.assertGreater(e.get("rows", 0), 0, "no EMAP reached the server")
+        self.assertGreater(e.get("cols", 0), 0)
+        self.assertEqual(len(e["map"]), e["rows"] * e["cols"] * 2)
+
+    def test_brain_lights_up_after_a_turn(self):
+        """HITS: a bitmap of the experts this turn touched, packed 8 per hex
+        pair, refreshed every turn. Every layer of this model is a MoE layer,
+        so a prompt through it must touch experts somewhere."""
+        e = self.experts
+        self.assertGreaterEqual(e.get("seq", 0), 1, "no HITS reached the server")
+        bits = e["rows"] * e["cols"]
+        self.assertEqual(len(e["hits"]), ((bits + 7) // 8) * 2)
+        self.assertNotEqual(int(e["hits"], 16), 0,
+                            "a 9-token prompt through MoE layers touched no expert")
+
+    def test_profile_records_the_turn_with_its_phases(self):
+        """PROF: wall, prompt/completion tokens, five phase timings, forwards.
+        The forwards are COUNTED where step() is called, not derived from the
+        token count: a turn that stops at max_tokens does not run a forward
+        for the token it will never sample."""
+        turns = self.profile.get("turns", [])
+        self.assertEqual(len(turns), 1, "exactly one turn was made")
+        t = turns[0]
+        for key in ("wall_s", "prompt_tokens", "completion_tokens", "expert_disk_s",
+                    "expert_wait_s", "expert_matmul_s", "attention_s", "lm_head_s", "forwards"):
+            self.assertIn(key, t)
+        self.assertEqual(t["completion_tokens"], 3)
+        self.assertEqual(t["forwards"], 3, "prefill plus one forward per token after the first")
+        phases = t["expert_disk_s"] + t["expert_matmul_s"] + t["attention_s"] + t["lm_head_s"]
+        self.assertGreater(phases, 0.0)
+        self.assertLessEqual(phases, t["wall_s"] * 1.05 + 0.01,
+                             "phase timings exceed the wall clock: a timer is double-counting")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Qwen3.6 now emits the four telemetry lines the dashboard reads (`EMAP`, `HITS`, `PROF`, wait is 0 by construction), so the Brain and Profile tabs work on this family too. Same format as colibri.c and deepseek_v4.c, byte for byte. Companion of #1383 (GLM-5.3-Flash); after both, only Inkling/OLMoE (grid but no HITS) and Kimi K3/Qwen3.8 (nothing) remain.

## How

- `EMAP` after `READY` and the `STAT 0 ...` line: this engine's boot reader in `openai_server.py` expects STAT right after READY. Between them the grid is an "invalid engine status", before READY it is discarded. Both were tried and both give an empty tab.
- `HITS` from marks set in `expert_get` (every routed expert, hit or miss), cleared at emission.
- `PROF` from the existing per-phase timers, now always on (two `clock_gettime` per site; the `[timers]` report stays behind `TIMERS=1`). Expert disk time measured around `load_expert_merged` on both load sites (`expert_get` and the pilot reload), accumulated under `g_pilot_mx`.
- Forwards counted where `step()` is called. A turn stopped by `max_tokens` does not run a forward for the token it never samples, so `gen+1` was one too many in the common case.

## Checks

- Token-exact vs the tiny full-hybrid oracle at cap 1 and 8: 16/16, identical to dev.
- Negative control: with the `ehit_mark` call removed, `/experts` returns an all-zero `hits` (the test would fail).
- `tests/test_qwen36_dashboard.py`: `coli serve` end to end, `/experts` and `/profile`, gated on `COLI_QWEN36_FIXTURE`; skipped (not failed) without it. The Qwen3.6 CI job builds the byte tokenizer for its oracle fixture and runs it.
- `[timers]` lines on stderr with the default environment: 0.