### PR TITLE
kimi_k3, qwen38: EMAP and HITS (Brain tab)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -822,7 +822,7 @@ jobs:
       # rieseguiva un binario non strumentato. Uno di quei test era rosso da
       # settimane senza che nessuno potesse vederlo.
       - name: Build the engines those tests exercise
-        run: make -C c kimi_k3 inkling colibri
+        run: make -C c kimi_k3 inkling colibri olmoe
       - name: Python test suite
         run: cd c && python3 -m unittest discover -s tests -p 'test_*.py'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,7 +522,7 @@ jobs:
             exit 1
           fi
           grep -qE "elements, expected|gated residual dimensions" qwen38-bad.log
-      - name: Brain tab: EMAP after READY and STAT, HITS after every turn
+      - name: "Brain tab: EMAP after READY and STAT, HITS after every turn"
         run: |
           cd c
           # the oracle fixture has no tokenizer; serve mode needs one

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,6 +522,13 @@ jobs:
             exit 1
           fi
           grep -qE "elements, expected|gated residual dimensions" qwen38-bad.log
+      - name: Brain tab: EMAP after READY and STAT, HITS after every turn
+        run: |
+          cd c
+          # the oracle fixture has no tokenizer; serve mode needs one
+          python3 tools/make_edge_tiny_tokenizer.py --vocab-size "$(python3 -c 'import json;print(json.load(open("qwen38_tiny/config.json"))["vocab_size"])')" qwen38_tiny
+          make qwen38 >/dev/null
+          QWEN38_TINY=qwen38_tiny python3 -m unittest -v tests.test_qwen38_dashboard
 
   inkling-oracle:
     name: Inkling oracle (token-exact vs transformers)
@@ -822,7 +829,7 @@ jobs:
       # rieseguiva un binario non strumentato. Uno di quei test era rosso da
       # settimane senza che nessuno potesse vederlo.
       - name: Build the engines those tests exercise
-        run: make -C c kimi_k3 inkling colibri olmoe
+        run: make -C c kimi_k3 inkling colibri olmoe qwen38
       - name: Python test suite
         run: cd c && python3 -m unittest discover -s tests -p 'test_*.py'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,39 @@ jobs:
             echo "FAIL: refused, but not for the reason under test"; cat bad.log; exit 1; }
           echo "refused as expected:"; grep '^\[cfg\]' bad.log
 
+  olmoe-tiny-check:
+    name: OLMoE tiny oracle (token-exact + dashboard HITS)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: c/tools/oracle-requirements.txt
+      - name: Install torch (CPU) + transformers
+        run: pip install -r c/tools/oracle-requirements.txt
+      - name: Tiny OLMoE checkpoint, converted
+        run: |
+          cd c
+          # 4 layers x 8 experts at toy dimensions, greedy reference from the
+          # HF model in ref_olmoe.json. The converter is the real one.
+          python3 tools/make_olmoe_tiny.py --output olmoe_tiny
+          python3 tools/convert_olmoe_merged.py --model olmoe_tiny --out olmoe_tiny_c
+          # weights only: serve mode needs a tokenizer to encode the prompt
+          python3 tools/make_edge_tiny_tokenizer.py --vocab-size 128 olmoe_tiny_c
+      - name: Token-exact against the reference
+        run: |
+          cd c
+          make olmoe
+          SNAP=olmoe_tiny_c ./olmoe 8 8 olmoe_tiny/ref_olmoe.json | tee oracle.log
+          # the engine prints the score and exits 0 either way: the gate is here
+          grep -qE 'Matching tokens: ([0-9]+)/\1$' oracle.log
+      - name: Brain tab: HITS after every turn, on the grid EMAP declared
+        run: |
+          cd c
+          OLMOE_TINY=olmoe_tiny_c python3 -m unittest -v tests.test_olmoe_dashboard_hits
+
   qwen38-tiny-check:
     name: Qwen3.8 tiny oracle (GDN + QSA + PLE + MoE)
     runs-on: ubuntu-latest
@@ -527,6 +560,10 @@ jobs:
           # the only gate that would catch it. Needs the fixture above, which is
           # why it runs here and not in `make check`.
           INKLING_TINY=tiny_inkling python3 -m unittest -v tests.test_inkling_prefix_serve
+      - name: Brain tab: HITS after every turn, on the grid EMAP declared
+        run: |
+          cd c
+          INKLING_TINY=tiny_inkling python3 -m unittest -v tests.test_inkling_dashboard_hits
 
   # The efficiency suite against the tiny GLM oracle. These 8 tests existed but
   # had never run anywhere: they looked for c/glm.exe, a name that stopped

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,7 +474,7 @@ jobs:
           SNAP=olmoe_tiny_c ./olmoe 8 8 olmoe_tiny/ref_olmoe.json | tee oracle.log
           # the engine prints the score and exits 0 either way: the gate is here
           grep -qE 'Matching tokens: ([0-9]+)/\1$' oracle.log
-      - name: Brain tab: HITS after every turn, on the grid EMAP declared
+      - name: "Brain tab: HITS after every turn, on the grid EMAP declared"
         run: |
           cd c
           OLMOE_TINY=olmoe_tiny_c python3 -m unittest -v tests.test_olmoe_dashboard_hits
@@ -560,7 +560,7 @@ jobs:
           # the only gate that would catch it. Needs the fixture above, which is
           # why it runs here and not in `make check`.
           INKLING_TINY=tiny_inkling python3 -m unittest -v tests.test_inkling_prefix_serve
-      - name: Brain tab: HITS after every turn, on the grid EMAP declared
+      - name: "Brain tab: HITS after every turn, on the grid EMAP declared"
         run: |
           cd c
           INKLING_TINY=tiny_inkling python3 -m unittest -v tests.test_inkling_dashboard_hits

--- a/c/Makefile
+++ b/c/Makefile
@@ -647,6 +647,9 @@ kimi-k3-tiny-check: kimi-k3-tiny-generate kimi_k3$(EXE)
 	$(PYTHON) tests/test_kimi_k3_ckpt.py \
 		--binary ./kimi_k3$(EXE) \
 		--fixture ./kimi_k3_tiny
+	$(PYTHON) tests/test_kimi_k3_dashboard.py \
+		--binary ./kimi_k3$(EXE) \
+		--fixture ./kimi_k3_tiny
 
 .PHONY: deepseek-v4 deepseek-v4-oracle deepseek-v4-tiny-generate \
 	deepseek-v4-tiny-check deepseek-v4-clean

--- a/c/inkling.c
+++ b/c/inkling.c
@@ -158,6 +158,7 @@ typedef struct {
     LCache *cache;
     int64_t rb13, rb2;                    /* container row-bytes (0 = not container) */
     uint32_t **eusage;                    /* per-layer expert selection counts */
+    uint8_t **ehit;                       /* experts routed this turn, for HITS (dashboard Brain) */
     int npin;                             /* pinned experts per sparse layer */
     uint64_t clock, hits, miss;
     uint64_t ereq, euse;                  /* routed richiesti (topk) vs usati dopo TOPP */
@@ -1158,6 +1159,19 @@ static Slot *slot_indexed(Model *m, int layer, int eid) {
     if (i < 0 || i >= lc->n || lc->slots[i].eid != eid) return NULL;
     return &lc->slots[i];
 }
+/* One byte per expert: routed in this turn or not. The dashboard's Brain tab
+ * reads it as the HITS bitmap after every turn (serve_hits), and it is cleared
+ * there. Lives outside INKLING_NO_MAIN because the routing site that marks it
+ * is compiled into the segment adapter object too. */
+static void ehit_mark(Model *m, int layer, int eid) {
+    Cfg *c = &m->c;
+    if (!m->ehit) {
+        m->ehit = calloc((size_t)c->n_layers, sizeof(uint8_t *));
+        for (int i = 0; i < c->n_layers; i++) m->ehit[i] = calloc((size_t)c->n_experts, 1);
+    }
+    if (layer >= 0 && layer < c->n_layers && eid >= 0 && eid < c->n_experts) m->ehit[layer][eid] = 1;
+}
+
 static Slot *slot_find(Model *m, int layer, int eid) {
     Slot *s = slot_indexed(m, layer, eid);
     if (s) s->used = ++m->clock;
@@ -1628,6 +1642,7 @@ static void moe(Model *m, Layer *l, int layer, float *x, int S, float *out) {
             if (kk >= keff[s]) { use[t - base] = NULL; continue; }   /* scartato da TOPP */
             int eid = idx[(int64_t)s*K + kk];
             if (m->eusage && m->eusage[layer]) m->eusage[layer][eid]++;
+            ehit_mark(m, layer, eid);
             Slot *e = slot_find(m, layer, eid);
             if (e) m->hits++;
             else {
@@ -2174,6 +2189,29 @@ static int serve_read_cmd(FILE *input, FILE *output, const char *cur_id) {
     return 0;
 }
 
+/* HITS rows cols hex: which experts this turn routed, one bit each over the
+ * sparse layers (same rows and columns as EMAP), packed 8 per hex pair. Same
+ * line colibri.c emits; the Brain tab lights up from it. A turn that routed
+ * nothing still reports a bitmap, all zero, so the tab shows THIS turn. */
+static void serve_hits(Model *m) {
+    Cfg *c = &m->c; int E = c->n_experts;
+    if (!m->ehit) ehit_mark(m, -1, -1);
+    int nsp = 0;
+    for (int i = 0; i < c->n_layers; i++) if (c->sparse[i]) nsp++;
+    int nb = (nsp * E + 7) / 8;
+    uint8_t *bm = calloc((size_t)nb, 1); int bit = 0;
+    for (int i = 0; i < c->n_layers; i++) {
+        if (!c->sparse[i]) continue;
+        for (int e = 0; e < E; e++, bit++)
+            if (m->ehit[i][e]) { bm[bit >> 3] |= (uint8_t)(1 << (bit & 7)); m->ehit[i][e] = 0; }
+    }
+    char *hex = malloc((size_t)nb * 2 + 1); int w = 0;
+    for (int b = 0; b < nb; b++) { hex[w++] = "0123456789abcdef"[bm[b] >> 4]; hex[w++] = "0123456789abcdef"[bm[b] & 15]; }
+    hex[w] = 0;
+    printf("HITS %d %d %s\n", nsp, E, hex);
+    fflush(stdout); free(hex); free(bm);
+}
+
 static int serve_one(Model *m, Tok *T, SReq *q) {
     Cfg *c = &m->c;
     int cap = q->plen + 16;
@@ -2235,6 +2273,7 @@ static int serve_one(Model *m, Tok *T, SReq *q) {
     /* `reuse` is the ABSOLUTE position of the first fresh token: attention and
      * the KV slots are position-indexed, so this has to be the real offset. */
     float *logit = step_mm(m, ids + reuse, np - reuse, reuse, NULL, q->audio, naud);
+    int forwards = 1;                      /* il prefill e' il primo forward */
     int len = np, gen = 0, limited = 1, cancelled = 0;
     char buf[512];
     /* repetition-penalty history: prompt tail + emitted tokens, ring of 128 */
@@ -2257,7 +2296,7 @@ static int serve_one(Model *m, Tok *T, SReq *q) {
             if (r > 0) { cancelled = 1; limited = 0; }
         }
         if (cancelled || s == q->max_tok - 1) break;
-        logit = step(m, &tk, 1, len - 1, NULL);
+        logit = step(m, &tk, 1, len - 1, NULL); forwards++;
     }
     free(logit);
     double dt = now_s() - t0;
@@ -2270,8 +2309,9 @@ static int serve_one(Model *m, Tok *T, SReq *q) {
     /* PROF: per-turn phase timings for the dashboard (gateway schema — we map
      * expert_wait -> shared-expert compute, lm_head folded into 0). */
     printf("PROF %.3f %d %d %.3f %.3f %.3f %.3f %.3f %d\n", dt, np, gen,
-           m->t_fill - f0, m->t_shared - s0, m->t_expert - e0, m->t_attn - a0, 0.0, gen + 1);
+           m->t_fill - f0, m->t_shared - s0, m->t_expert - e0, m->t_attn - a0, 0.0, forwards);
     fflush(stdout);
+    serve_hits(m);
     free(ids);
     return 0;
 }

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -228,6 +228,7 @@ typedef struct {
     /* experts */
     ERef *eref;                           /* [n_layers][n_experts] (dense rows zeroed) */
     LCache *ecache;
+    uint8_t **ehit;                       /* experts routed this turn, for HITS (dashboard Brain) */
     int64_t e_w1p, e_w1s, e_w2p, e_w2s, e_slot;
     uint64_t clock, hits, miss, ebytes;
     double t_attn, t_moe, t_eload, t_head;
@@ -1508,6 +1509,16 @@ static uint64_t g_slot_index_probes;
 #else
 #define SLOT_INDEX_PROBE() ((void)0)
 #endif
+/* One byte per expert: routed in this turn or not. The dashboard's Brain tab
+ * reads it as the HITS bitmap after every turn (serve_hits), cleared there. */
+static void ehit_mark(Model *m, int li, int eid){
+    Cfg *c=&m->c;
+    if(!m->ehit){
+        m->ehit=calloc((size_t)c->n_layers,sizeof(uint8_t*));
+        for(int i=0;i<c->n_layers;i++) m->ehit[i]=calloc((size_t)c->n_experts,1);
+    }
+    if(li>=0&&li<c->n_layers&&eid>=0&&eid<c->n_experts) m->ehit[li][eid]=1;
+}
 static Slot *slot_indexed(Model *m, int li, int eid){
     LCache *lc=&m->ecache[li];
     if(eid<0||eid>=m->c.n_experts||!lc->slot_by_expert) return NULL;
@@ -1786,6 +1797,7 @@ static void experts_apply_union(Model *m, int li, int nu, const int *uids,
         int nb=nu-base<LP_MAX?nu-base:LP_MAX;
         Slot *use[LP_MAX]; int missk[LP_MAX]; int qof[LP_MAX]; int nmiss=0;
         for(int j=0;j<nb;j++){
+            ehit_mark(m,li,uids[base+j]);
             use[j]=slot_find(m,li,uids[base+j]); qof[j]=-1;
             if(!use[j]){ m->miss++; use[j]=&m->ws[nmiss]; qof[j]=nmiss; missk[nmiss++]=j; }
         }
@@ -2868,6 +2880,44 @@ static void serve_tool(const char *id, const char *p, int n){
     coli_serve_write_tool(stdout,id,p,(size_t)n);
 }
 
+/* ---------- dashboard protocol: EMAP / HITS ----------
+ * Same stdout lines colibri.c emits for the web dashboard's Brain tab; the
+ * gateway parses them, nothing else does. Rows are the sparse layers, columns
+ * the experts. EMAP: one byte per expert as two hex digits, tier<<6 | heat
+ * (tier 1 = resident in the layer cache, heat 0: this engine keeps no usage
+ * counter). Printed once after READY and again after every turn, because
+ * the cache fills as the turn runs. HITS: one bit per expert routed in the
+ * turn, packed 8 per hex pair, printed after DONE next to PROF. */
+static void serve_emap(Model *m){
+    Cfg *c=&m->c; int E=c->n_experts, rows=0;
+    for(int i=0;i<c->n_layers;i++) if(m->L[i].sparse) rows++;
+    char *hex=malloc((size_t)rows*E*2+1); int w=0;
+    for(int i=0;i<c->n_layers;i++){
+        if(!m->L[i].sparse) continue;
+        for(int e=0;e<E;e++){
+            int b=(slot_indexed(m,i,e)?1:0)<<6;
+            hex[w++]="0123456789abcdef"[b>>4]; hex[w++]="0123456789abcdef"[b&15];
+        }
+    }
+    hex[w]=0;
+    printf("EMAP %d %d %s\n",rows,E,hex); fflush(stdout); free(hex);
+}
+static void serve_hits(Model *m){
+    Cfg *c=&m->c; int E=c->n_experts, rows=0;
+    if(!m->ehit) ehit_mark(m,-1,-1);   /* a turn that routed nothing still reports a bitmap: all zero */
+    for(int i=0;i<c->n_layers;i++) if(m->L[i].sparse) rows++;
+    int nb=(rows*E+7)/8; uint8_t *bm=calloc((size_t)nb,1); int bit=0;
+    for(int i=0;i<c->n_layers;i++){
+        if(!m->L[i].sparse) continue;
+        for(int e=0;e<E;e++,bit++)
+            if(m->ehit[i][e]){ bm[bit>>3]|=(uint8_t)(1<<(bit&7)); m->ehit[i][e]=0; }
+    }
+    char *hex=malloc((size_t)nb*2+1); int w=0;
+    for(int b=0;b<nb;b++){ hex[w++]="0123456789abcdef"[bm[b]>>4]; hex[w++]="0123456789abcdef"[bm[b]&15]; }
+    hex[w]=0;
+    printf("HITS %d %d %s\n",rows,E,hex); fflush(stdout); free(hex); free(bm);
+}
+
 static int serve_one(Model *m, Tok *T, ServeReq *q){
     int cap=65536, *ids=malloc((size_t)cap*sizeof(int)), np=0;
     if(!ids){ coli_serve_write_error(stdout,q->id,"out of memory"); return 0; }
@@ -2955,6 +3005,7 @@ static int serve_one(Model *m, Tok *T, ServeReq *q){
     int gen=0, limited=1, cancelled=0, xsup=0, xopen=0, xtl=0, xtool=0;
     char buf[512], xtag[320];   /* tool-call open tags carry attributes: call tool="..." index="..." (#1143) */
     double tg=now_s();
+    int forwards=1;                       /* the prefill; decode steps are counted where they run */
     for(int s=0;s<q->max_tok&&!cancelled;s++){
         int tk=sample_tok(lo,m->c.vocab,q->temp,q->top_p);
         free(lo); lo=NULL;
@@ -3003,7 +3054,7 @@ static int serve_one(Model *m, Tok *T, ServeReq *q){
         }
         if(cancelled){ limited=0; break; }
         if(eos){ limited=0; break; }
-        if(s+1<q->max_tok) lo=step_chunk(m,&tk,np+s,1);
+        if(s+1<q->max_tok){ lo=step_chunk(m,&tk,np+s,1); forwards++; }
     }
     if(poll.fatal){ free(lo); free(ids); return -1; }
     free(lo); free(ids);
@@ -3019,8 +3070,9 @@ static int serve_one(Model *m, Tok *T, ServeReq *q){
     if(done_bytes>0) fwrite(done_line,1,(size_t)done_bytes,stdout);
     double moe=m->t_moe-e0, disk=m->t_eload-d0;
     printf("PROF %.3f %d %d %.3f %.3f %.3f %.3f %.3f %d\n",
-           dt,np,gen,disk,0.0,moe>disk?moe-disk:moe,m->t_attn-a0,m->t_head-h0,gen+1);
+           dt,np,gen,disk,0.0,moe>disk?moe-disk:moe,m->t_attn-a0,m->t_head-h0,forwards);
     fflush(stdout);
+    serve_hits(m);
 #ifdef COLI_VULKAN
     if(g_k3_vk){
         if(g_vk_up_auto)
@@ -3043,11 +3095,12 @@ static void serve_loop(Model *m, Tok *T){
      * e' nato senza. */
     coli_serve_stdio_init();
     coli_serve_write_ready(stdout,rss_gb());
+    serve_emap(m);                        /* after READY and STAT: the boot reader discards what precedes them */
     for(;;){
         ServeReq q={0}; int r;
         do r=serve_read_req(stdin,stdout,&q,NULL); while(r==0);
         if(r<0) return;
-        if(r==2){ int fatal=serve_one(m,T,&q); free(q.payload); if(fatal<0) return; }
+        if(r==2){ int fatal=serve_one(m,T,&q); free(q.payload); if(fatal<0) return; serve_emap(m); }
     }
 }
 

--- a/c/olmoe.c
+++ b/c/olmoe.c
@@ -101,6 +101,7 @@ typedef struct {
     double dense_load_s;
     /* IMPROVEMENT 2: expert frequency heatmap */
     uint32_t **freq;                   /* per-layer expert counts, owned by route_trace.h */
+    uint8_t **ehit;                    /* experts routed this turn, for HITS (dashboard Brain) */
     int freq_token_count, hot_pinned, hot_n, warmup_tokens;
     int token_count;
     /* PREDICTION IMPROVEMENT A: per-layer EMA of gate logits across tokens.
@@ -568,9 +569,22 @@ static void load_expert_merged(Model *m, int layer, int eid, Slot *s) {
 }
 
 /* ---------- cache expert: ritorna i pesi quantizzati (q+scale) da cache o disco ---------- */
+/* One byte per expert: routed in this turn or not. The dashboard's Brain tab
+ * reads it as the HITS bitmap after every turn (serve_hits), and it is cleared
+ * there. Outside OLMOE_NO_MAIN: expert_get is in the segment adapter object. */
+static void ehit_mark(Model *m, int layer, int eid) {
+    Cfg *c = &m->c;
+    if (!m->ehit) {
+        m->ehit = calloc((size_t)c->n_layers, sizeof(uint8_t *));
+        for (int i = 0; i < c->n_layers; i++) m->ehit[i] = calloc((size_t)c->n_experts, 1);
+    }
+    if (layer >= 0 && layer < c->n_layers && eid >= 0 && eid < c->n_experts) m->ehit[layer][eid] = 1;
+}
+
 static void expert_get(Model *m, int layer, int eid, Slot **out) {
     LCache *lc = &m->cache[layer];
     pthread_mutex_lock(&g_pilot_mx);
+    ehit_mark(m, layer, eid);          /* under the lock: the routing loop is parallel */
     Slot *hit = slot_indexed(m, layer, eid);
     if (hit) {
         m->hits++; hit->used = ++m->clock; *out = hit;
@@ -1326,6 +1340,24 @@ static int serve_read_cmd(FILE *in, FILE *out, const char *cur_id) {
     return 0;
 }
 
+/* HITS rows cols hex: which experts this turn routed, one bit each, every
+ * layer (all are MoE here, same rows and columns as EMAP), packed 8 per hex
+ * pair. Same line colibri.c emits; the Brain tab lights up from it. */
+static void serve_hits(Model *m) {
+    Cfg *c = &m->c; int E = c->n_experts, rows = c->n_layers;
+    if (!m->ehit) ehit_mark(m, -1, -1);
+    int nb = (rows * E + 7) / 8;
+    uint8_t *bm = calloc((size_t)nb, 1); int bit = 0;
+    for (int i = 0; i < rows; i++)
+        for (int e = 0; e < E; e++, bit++)
+            if (m->ehit[i][e]) { bm[bit >> 3] |= (uint8_t)(1 << (bit & 7)); m->ehit[i][e] = 0; }
+    char *hex = malloc((size_t)nb * 2 + 1); int w = 0;
+    for (int b = 0; b < nb; b++) { hex[w++] = "0123456789abcdef"[bm[b] >> 4]; hex[w++] = "0123456789abcdef"[bm[b] & 15]; }
+    hex[w] = 0;
+    printf("HITS %d %d %s\n", rows, E, hex);
+    fflush(stdout); free(hex); free(bm);
+}
+
 static int serve_one(Model *m, Tok *T, SReq *q, int ctx_cap) {
     Cfg *c = &m->c;
     int cap = q->plen + 16;
@@ -1380,6 +1412,7 @@ static int serve_one(Model *m, Tok *T, SReq *q, int ctx_cap) {
      * is future work, not a protocol requirement. */
     printf("PROF %.3f %d %d 0.0 0.0 0.0 0.0 0.0 %d\n", dt, np, gen, gen + 1);
     fflush(stdout);
+    serve_hits(m);
     free(ids);
     return 0;
 }

--- a/c/qwen38.c
+++ b/c/qwen38.c
@@ -1465,6 +1465,40 @@ static int q38_format_prof(char *out,size_t capacity,double wall_s,int prompt_to
     return count>=0&&(size_t)count<capacity?count:-1;
 }
 
+/* ---------- dashboard protocol: EMAP / HITS ----------
+ * Same stdout lines colibri.c emits for the web dashboard's Brain tab. Every
+ * layer here is a MoE layer, so rows are all layers, columns the experts.
+ * EMAP: one byte per expert as two hex digits, tier<<6 | heat (tier 1 =
+ * resident in the layer cache; heat 0, no usage counter here). Printed after
+ * READY and STAT, and again after every turn. HITS: one bit per expert routed
+ * in the turn, packed 8 per hex pair, printed after DONE next to PROF. */
+static void serve_emap(Model *m){
+    const Cfg *c=&m->c; int E=c->experts, rows=c->layers;
+    char *hex=(char*)malloc((size_t)rows*E*2+1); int w=0;
+    for(int i=0;i<rows;i++){
+        LCache *lc=&m->cache[i];
+        for(int e=0;e<E;e++){
+            int si=lc->by_expert?lc->by_expert[e]:-1;
+            int b=(si>=0&&si<lc->n&&lc->slots[si].eid==e?1:0)<<6;
+            hex[w++]="0123456789abcdef"[b>>4]; hex[w++]="0123456789abcdef"[b&15];
+        }
+    }
+    hex[w]=0;
+    printf("EMAP %d %d %s\n",rows,E,hex); fflush(stdout); free(hex);
+}
+static void serve_hits(Model *m){
+    const Cfg *c=&m->c; int E=c->experts, rows=c->layers;
+    if(!m->ehit)q38_ehit_mark(m,-1,-1);   /* a turn that routed nothing still reports a bitmap: all zero */
+    int nb=(rows*E+7)/8; uint8_t *bm=(uint8_t*)calloc((size_t)nb,1); int bit=0;
+    for(int i=0;i<rows;i++)
+        for(int e=0;e<E;e++,bit++)
+            if(m->ehit[i][e]){ bm[bit>>3]|=(uint8_t)(1<<(bit&7)); m->ehit[i][e]=0; }
+    char *hex=(char*)malloc((size_t)nb*2+1); int w=0;
+    for(int b=0;b<nb;b++){ hex[w++]="0123456789abcdef"[bm[b]>>4]; hex[w++]="0123456789abcdef"[bm[b]&15]; }
+    hex[w]=0;
+    printf("HITS %d %d %s\n",rows,E,hex); fflush(stdout); free(hex); free(bm);
+}
+
 static int serve_one(Model *m, ServeReq *q){
     int *ids=NULL, np=0;
     encode_text_n(q->payload,(size_t)q->plen,&ids,&np); /* byte-counted prompt; qwen38 adds no BOS */
@@ -1590,6 +1624,7 @@ static int serve_one(Model *m, ServeReq *q){
     if(profile_bytes>0)fwrite(profile,1,(size_t)profile_bytes,stdout);
     else fprintf(stderr,"[qwen38] internal error: PROF frame overflow\n");
     fflush(stdout);
+    serve_hits(m);
     q38_tm_report_bank(&timers,"request");
     return input_eof?-1:0;
 }
@@ -1606,6 +1641,7 @@ static void serve_loop(Model *m){
     fputs("\x01\x01READY\x01\x01\n",stdout);
     printf("STAT 0 0.00 0.0 %.2f\n",rss_gb());
     fflush(stdout);
+    serve_emap(m);                       /* after READY and STAT: the boot reader discards what precedes them */
     for(;;){
         ServeReq q={0}; int r;
         do r=serve_read_req(stdin,stdout,&q,NULL); while(r!=2&&r>=0);
@@ -1613,6 +1649,7 @@ static void serve_loop(Model *m){
         if(r==2){
             int status=serve_one(m,&q);free(q.payload);
             if(status<0){q38_prefix_cache_release(m);return;}
+            serve_emap(m);
         }
     }
 }

--- a/c/qwen38_core.h
+++ b/c/qwen38_core.h
@@ -114,6 +114,7 @@ typedef struct {
     GatedResidual final_gr;
     Layer *L;
     LCache *cache;
+    uint8_t **ehit;                    /* experts routed this turn, for HITS (dashboard Brain) */
     Q38ExpertScaleCache *expert_scales;
     uint64_t clock, hits, miss;
     uint64_t expert_weight_reads, expert_scale_reads, expert_pair_reads;
@@ -1238,7 +1239,19 @@ static void q38_load_expert(Model *m,int layer,int eid,Slot *s) {
     }
 }
 
+/* One byte per expert: routed in this turn or not. The dashboard's Brain tab
+ * reads it as the HITS bitmap after every turn (serve_hits in qwen38.c),
+ * cleared there. Marked on both lookup paths, single and batched. */
+static void q38_ehit_mark(Model *m,int layer,int eid) {
+    const Cfg *c=&m->c;
+    if(!m->ehit){
+        m->ehit=(uint8_t**)calloc((size_t)c->layers,sizeof(uint8_t*));
+        for(int i=0;i<c->layers;i++)m->ehit[i]=(uint8_t*)calloc((size_t)c->experts,1);
+    }
+    if(layer>=0&&layer<c->layers&&eid>=0&&eid<c->experts)m->ehit[layer][eid]=1;
+}
 static Slot *q38_expert_get(Model *m,int layer,int eid) {
+    q38_ehit_mark(m,layer,eid);
     LCache *lc=&m->cache[layer]; int si=lc->by_expert[eid];
     if(si>=0){m->hits++;lc->slots[si].used=++m->clock;return &lc->slots[si];}
     m->miss++; Slot *s;
@@ -1271,6 +1284,7 @@ static int q38_expert_get_batch(Model *m,int layer,const int *experts,int count,
     for(int index=0;index<count;index++){
         int expert=experts[index];
         if(expert<0||expert>=m->c.experts)return 0;
+        q38_ehit_mark(m,layer,expert);
         for(int previous=0;previous<index;previous++)
             if(experts[previous]==expert)return 0;
         int slot_index=cache->by_expert[expert];

--- a/c/tests/test_inkling_dashboard_hits.py
+++ b/c/tests/test_inkling_dashboard_hits.py
@@ -1,0 +1,72 @@
+"""The dashboard's Brain tab lights up from a HITS line the engine prints
+after every turn: which experts the turn routed, one bit each, packed 8 per
+hex pair, over the same rows and columns as EMAP. inkling.c printed EMAP
+(the grid, refreshed every turn) but never HITS, so on Inkling the grid
+stayed dark. Same harness as the prefix-reuse test, one turn, read to the
+last line of the turn.
+"""
+import unittest
+
+from tests.test_inkling_prefix_serve import ENGINE, FIXTURE, MAXTOK, Engine, ensure_tokenizer
+
+
+def read_until(engine, kind, limit=200):
+    """Lines after the previous read, up to and including the first `kind`."""
+    lines = []
+    for _ in range(limit):
+        line = engine.p.stdout.readline()
+        if not line:
+            raise RuntimeError("engine closed: " + "".join(engine._err)[-2000:])
+        text = line.decode("latin-1").rstrip("\n")
+        if text.split(" ", 1)[0] == "DATA":
+            engine.p.stdout.read(int(text.split()[2]))
+            engine.p.stdout.readline()
+            continue
+        lines.append(text)
+        if text.startswith(kind + " "):
+            return lines
+    raise RuntimeError(f"no {kind} within {limit} lines:\n" + "\n".join(lines[-10:]))
+
+
+@unittest.skipUnless(ENGINE.exists(), "inkling is not built")
+@unittest.skipUnless((FIXTURE / "config.json").exists(),
+                     "tiny inkling fixture is absent (tools/make_tiny_inkling.py)")
+class InklingDashboardHitsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        ensure_tokenizer(FIXTURE)
+        engine = Engine(log_prefix=False)
+        try:
+            cls.boot = read_until(engine, "EMAP")        # the grid, printed once after READY
+            engine.ask(1, b"abcabcabc")                  # returns at DONE
+            cls.turn = read_until(engine, "HITS")        # PROF, then HITS, then the refreshed grid
+        finally:
+            engine.close()
+
+    @staticmethod
+    def only(lines, kind):
+        found = [l.split() for l in lines if l.startswith(kind + " ")]
+        assert len(found) == 1, f"expected exactly one {kind}: {found}"
+        return found[0]
+
+    def test_hits_matches_the_grid(self):
+        """Rows and columns are EMAP's (the sparse layers), or the Brain tab
+        paints the bits on the wrong cells."""
+        _, rows, cols, hexs = self.only(self.turn, "HITS")
+        _, erows, ecols, emap = self.only(self.boot, "EMAP")
+        self.assertEqual((rows, cols), (erows, ecols))
+        self.assertEqual(len(hexs), ((int(rows) * int(cols) + 7) // 8) * 2)
+        self.assertNotEqual(int(hexs, 16), 0,
+                            "a 9-token prompt through the sparse layers routed no expert at all")
+
+    def test_prof_counts_forwards_not_tokens(self):
+        """A turn stopped by max_tokens does not run a forward for the token it
+        never samples: prefill plus one per token after the first."""
+        prof = self.only(self.turn, "PROF")
+        self.assertEqual(len(prof), 10)
+        self.assertEqual(int(prof[3]), MAXTOK, "completion tokens")
+        self.assertEqual(int(prof[9]), MAXTOK)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tests/test_kimi_k3_dashboard.py
+++ b/c/tests/test_kimi_k3_dashboard.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Brain tab on Kimi K3: EMAP after READY and STAT, HITS after every turn.
+
+The dashboard reads two lines from the engine's stdout for its Brain tab:
+EMAP (the grid: one row per sparse layer, one column per expert, two hex
+digits per cell) and HITS (which experts the turn routed, one bit each,
+packed 8 per hex pair, after DONE next to PROF). kimi_k3.c emitted neither,
+so on Kimi K3 the tab was empty. Same harness as test_kimi_k3_ckpt.py: the
+tiny fixture plus tests/tok_kimi_tiny.json as tokenizer.
+
+Exit 0 when the lines arrive in the shape the gateway parses, 1 otherwise.
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+PROMPT = b"abcabcabc"
+MAX_NEW = 3
+
+
+def read_until(process, kind, limit=400):
+    lines = []
+    for _ in range(limit):
+        line = process.stdout.readline()
+        if not line:
+            raise RuntimeError("engine closed before " + kind)
+        text = line.decode("latin-1").rstrip("\n")
+        if text.split(" ", 1)[0] == "DATA":
+            process.stdout.read(int(text.split()[2]))
+            process.stdout.readline()
+            continue
+        lines.append(text)
+        if text.startswith(kind):
+            return lines
+    raise RuntimeError(f"no {kind} within {limit} lines:\n" + "\n".join(lines[-10:]))
+
+
+def only(lines, kind):
+    found = [l.split() for l in lines if l.startswith(kind + " ")]
+    if len(found) != 1:
+        raise AssertionError(f"expected exactly one {kind}, got {found}")
+    return found[0]
+
+
+def check(binary, model, stderr_path):
+    env = dict(os.environ, SERVE="1", SNAP=str(model))
+    with open(stderr_path, "wb") as stderr_file:
+        process = subprocess.Popen([str(binary)], stdin=subprocess.PIPE,
+                                   stdout=subprocess.PIPE, stderr=stderr_file, env=env)
+        try:
+            read_until(process, "\x01\x01READY")
+            boot = read_until(process, "EMAP")
+            header = f"SUBMIT r1 0 {len(PROMPT)} {MAX_NEW} 0.0 1.0\n".encode()
+            process.stdin.write(header + PROMPT + b"\n")
+            process.stdin.flush()
+            turn = read_until(process, "HITS")
+            after = read_until(process, "EMAP")
+        finally:
+            process.stdin.close()
+            process.wait(timeout=60)
+    config = json.loads((model / "config.json").read_text())
+    text_config = config.get("text_config", config)
+    sparse = text_config["num_hidden_layers"] - text_config.get("first_k_dense_replace", 0)
+    experts = text_config["num_experts"] if "num_experts" in text_config else text_config["n_routed_experts"]
+
+    kinds = [l.split(" ", 1)[0] for l in boot]
+    assert kinds.index("STAT") < kinds.index("EMAP"), "EMAP must follow READY and STAT"
+    _, rows, cols, grid = only(boot, "EMAP")
+    assert (int(rows), int(cols)) == (sparse, experts), f"EMAP {rows}x{cols}, config says {sparse}x{experts}"
+    assert len(grid) == int(rows) * int(cols) * 2, "EMAP: two hex digits per cell"
+
+    kinds = [l.split(" ", 1)[0] for l in turn]
+    assert kinds.index("DONE") < kinds.index("HITS"), "HITS belongs after DONE, with PROF"
+    _, hrows, hcols, hits = only(turn, "HITS")
+    assert (hrows, hcols) == (rows, cols), "HITS must use EMAP's rows and columns"
+    assert len(hits) == ((int(rows) * int(cols) + 7) // 8) * 2, "HITS: 8 experts per hex pair"
+    assert int(hits, 16) != 0, "a 9-token prompt through the sparse layers routed no expert"
+
+    prof = only(turn, "PROF")
+    assert len(prof) == 10, "PROF keeps its ten fields"
+    assert int(prof[3]) == MAX_NEW, "completion tokens"
+    assert int(prof[9]) == MAX_NEW, "forwards: prefill plus one per token after the first"
+
+    _, _, _, refreshed = only(after, "EMAP")
+    assert int(refreshed, 16) != 0, "after a turn the cache holds experts: the refreshed grid shows them"
+    return rows, cols, hits
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--binary", required=True)
+    parser.add_argument("--fixture", required=True)
+    parser.add_argument("--tokenizer",
+                        default=str(Path(__file__).parent / "tok_kimi_tiny.json"))
+    args = parser.parse_args()
+    base = Path(args.fixture)
+    work = Path(tempfile.mkdtemp(prefix="kimi-k3-dash-"))
+    try:
+        model = work / "fixture"
+        model.mkdir()
+        shutil.copy(base / "config.json", model / "config.json")
+        shutil.copy(base / "model.safetensors", model / "model.safetensors")
+        shutil.copy(args.tokenizer, model / "tokenizer.json")
+        try:
+            rows, cols, hits = check(args.binary, model, work / "engine.stderr")
+        except (AssertionError, RuntimeError) as failure:
+            print(f"FAIL: {failure}")
+            err = (work / "engine.stderr").read_text(errors="replace")
+            if err:
+                print(err[-2000:])
+            return 1
+        print(f"kimi_k3 dashboard: EMAP {rows}x{cols}, HITS {hits}")
+        return 0
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/c/tests/test_olmoe_dashboard_hits.py
+++ b/c/tests/test_olmoe_dashboard_hits.py
@@ -1,0 +1,107 @@
+"""The dashboard's Brain tab lights up from a HITS line the engine prints
+after every turn: which experts the turn routed, one bit each, packed 8 per
+hex pair, over the same rows and columns as EMAP. olmoe.c printed EMAP (the
+grid) but never HITS, so on OLMoE the grid stayed dark. This test drives the
+engine over stdio the way the gateway does and reads the turn to its last
+line.
+
+It needs a converted OLMoE container with a tokenizer.json and a built
+`olmoe`. Set OLMOE_TINY to the container; without it the test is skipped
+with the reason on the record. CI builds the tiny checkpoint from
+tools/make_olmoe_tiny.py, converts it, and adds the byte tokenizer.
+"""
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent.parent
+ENGINE = HERE / ("olmoe.exe" if sys.platform == "win32" else "olmoe")
+FIXTURE = Path(os.environ.get("OLMOE_TINY", ""))
+MAXTOK = 3
+
+
+def one_turn(prompt=b"abcabcabc"):
+    """Run the engine in serve mode, submit one prompt, return the protocol
+    lines of the turn (DATA payloads consumed) up to and including HITS.
+    stdin stays open for the whole turn: the engine polls it per token and an
+    EOF there is a cancel, which is what a `printf | ./olmoe` pipe gets."""
+    env = dict(os.environ, SNAP=str(FIXTURE), SERVE="1")
+    p = subprocess.Popen([str(ENGINE), "4", "8"], env=env, stdin=subprocess.PIPE,
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=0)
+    try:
+        while True:
+            line = p.stdout.readline()
+            if not line:
+                raise RuntimeError("engine exited before READY: "
+                                   + p.stderr.read().decode(errors="replace")[-2000:])
+            if b"READY" in line:
+                break
+        p.stdin.write(f"SUBMIT 7 0 {len(prompt)} {MAXTOK} 0 1\n".encode() + prompt + b"\n")
+        p.stdin.flush()
+        lines = []
+        for _ in range(200):
+            line = p.stdout.readline()
+            if not line:
+                raise RuntimeError("engine closed mid-turn: "
+                                   + p.stderr.read().decode(errors="replace")[-2000:])
+            text = line.decode("latin-1").rstrip("\n")
+            kind = text.split(" ", 1)[0]
+            if kind == "DATA":
+                p.stdout.read(int(text.split()[2]))
+                p.stdout.readline()
+                continue
+            lines.append(text)
+            if kind == "HITS":
+                return lines
+        raise RuntimeError("no HITS within 200 lines after SUBMIT:\n" + "\n".join(lines[-10:]))
+    finally:
+        p.stdin.close()
+        try:
+            p.wait(30)
+        except subprocess.TimeoutExpired:
+            p.kill()
+
+
+@unittest.skipUnless(ENGINE.exists(), "olmoe is not built")
+@unittest.skipUnless((FIXTURE / "config.json").is_file() and (FIXTURE / "tokenizer.json").is_file(),
+                     "OLMOE_TINY not set to a converted OLMoE container with a tokenizer")
+class OlmoeDashboardHitsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.lines = one_turn()
+        cls.config = json.loads((FIXTURE / "config.json").read_text())
+
+    def line(self, kind):
+        found = [l for l in self.lines if l.startswith(kind + " ")]
+        self.assertEqual(len(found), 1, f"expected exactly one {kind} line, got {found}")
+        return found[0].split()
+
+    def test_hits_closes_the_turn_after_done(self):
+        kinds = [l.split(" ", 1)[0] for l in self.lines]
+        self.assertIn("DONE", kinds)
+        self.assertLess(kinds.index("DONE"), kinds.index("HITS"),
+                        "HITS belongs to the turn it describes: after DONE, with PROF")
+
+    def test_hits_has_the_grid_shape(self):
+        """Rows and columns must be EMAP's, or the Brain tab paints the bits on
+        the wrong cells: every layer here is a MoE layer."""
+        _, rows, cols, hexs = self.line("HITS")
+        self.assertEqual(int(rows), self.config["num_hidden_layers"])
+        self.assertEqual(int(cols), self.config["num_experts"])
+        self.assertEqual(len(hexs), ((int(rows) * int(cols) + 7) // 8) * 2)
+        self.assertNotEqual(int(hexs, 16), 0,
+                            "a 9-token prompt through MoE layers routed no expert at all")
+
+    def test_prof_still_has_its_ten_fields(self):
+        prof = self.line("PROF")
+        self.assertEqual(len(prof), 10)
+        self.assertEqual(int(prof[3]), MAXTOK, "completion tokens")
+        self.assertEqual(int(prof[9]), MAXTOK + 1,
+                         "prefill plus one forward per token: this engine steps the last one too")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/c/tests/test_qwen38_dashboard.py
+++ b/c/tests/test_qwen38_dashboard.py
@@ -1,0 +1,111 @@
+"""The dashboard's Brain tab reads two lines from the engine's stdout: EMAP
+(the grid, after READY and STAT and again after every turn) and HITS (which
+experts the turn routed, after DONE next to PROF). qwen38.c emitted neither,
+so on Qwen3.8 the tab was empty. This test drives the engine over stdio the
+way the gateway does and reads the turn to its last line.
+
+It needs a Qwen3.8 tiny fixture with a tokenizer.json and a built `qwen38`.
+Set QWEN38_TINY to the fixture; without it the test is skipped with the
+reason on the record. CI uses the oracle fixture and adds the byte tokenizer.
+"""
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent.parent
+ENGINE = HERE / ("qwen38.exe" if sys.platform == "win32" else "qwen38")
+FIXTURE = Path(os.environ.get("QWEN38_TINY", ""))
+MAXTOK = 3
+
+
+def read_until(p, kind, limit=400):
+    """Lines up to and including the first `kind`; DATA payloads consumed."""
+    lines = []
+    for _ in range(limit):
+        line = p.stdout.readline()
+        if not line:
+            raise RuntimeError("engine closed: " + p.stderr.read().decode(errors="replace")[-2000:])
+        text = line.decode("latin-1").rstrip("\n")
+        if text.split(" ", 1)[0] == "DATA":
+            p.stdout.read(int(text.split()[2]))
+            p.stdout.readline()
+            continue
+        lines.append(text)
+        if text.startswith(kind + " ") or text.startswith(kind):
+            return lines
+    raise RuntimeError(f"no {kind} within {limit} lines:\n" + "\n".join(lines[-10:]))
+
+
+def one_turn(prompt=b"abcabcabc"):
+    """stdin stays open for the whole turn: the engine polls it per token and
+    an EOF there is a cancel, which is what a `printf | ./qwen38` pipe gets."""
+    env = dict(os.environ, SNAP=str(FIXTURE), SERVE="1")
+    p = subprocess.Popen([str(ENGINE), "1", "8"], env=env, stdin=subprocess.PIPE,
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=0)
+    try:
+        read_until(p, "\x01\x01READY")
+        boot = read_until(p, "EMAP")
+        p.stdin.write(f"SUBMIT 7 0 {len(prompt)} {MAXTOK} 0 1\n".encode() + prompt + b"\n")
+        p.stdin.flush()
+        turn = read_until(p, "HITS")
+        after = read_until(p, "EMAP")
+        return boot, turn, after
+    finally:
+        p.stdin.close()
+        try:
+            p.wait(30)
+        except subprocess.TimeoutExpired:
+            p.kill()
+
+
+@unittest.skipUnless(ENGINE.exists(), "qwen38 is not built")
+@unittest.skipUnless((FIXTURE / "config.json").is_file() and (FIXTURE / "tokenizer.json").is_file(),
+                     "QWEN38_TINY not set to a Qwen3.8 fixture with a tokenizer")
+class Qwen38DashboardTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.boot, cls.turn, cls.after = one_turn()
+        cls.config = json.loads((FIXTURE / "config.json").read_text())
+
+    @staticmethod
+    def only(lines, kind):
+        found = [l.split() for l in lines if l.startswith(kind + " ")]
+        assert len(found) == 1, f"expected exactly one {kind}: {found}"
+        return found[0]
+
+    def test_grid_after_ready_and_stat(self):
+        """The boot reader consumes READY then STAT; EMAP must come after
+        both, and is one row per layer (every layer is MoE here)."""
+        kinds = [l.split(" ", 1)[0] for l in self.boot]
+        self.assertLess(kinds.index("STAT"), kinds.index("EMAP"))
+        _, rows, cols, hexs = self.only(self.boot, "EMAP")
+        self.assertEqual(int(rows), self.config["num_hidden_layers"])
+        self.assertEqual(int(cols), self.config["num_experts"])
+        self.assertEqual(len(hexs), int(rows) * int(cols) * 2)
+
+    def test_grid_refreshed_after_the_turn_shows_residents(self):
+        """Tier bit 6: after a turn the cache holds experts, so the grid is no
+        longer all zero (cap 1 keeps one per layer)."""
+        _, _, _, hexs = self.only(self.after, "EMAP")
+        self.assertNotEqual(int(hexs, 16), 0, "no expert resident after a turn")
+
+    def test_hits_matches_the_grid(self):
+        kinds = [l.split(" ", 1)[0] for l in self.turn]
+        self.assertLess(kinds.index("DONE"), kinds.index("HITS"))
+        _, rows, cols, hexs = self.only(self.turn, "HITS")
+        _, erows, ecols, _ = self.only(self.boot, "EMAP")
+        self.assertEqual((rows, cols), (erows, ecols))
+        self.assertEqual(len(hexs), ((int(rows) * int(cols) + 7) // 8) * 2)
+        self.assertNotEqual(int(hexs, 16), 0, "a 9-token prompt routed no expert at all")
+
+    def test_prof_is_still_there(self):
+        prof = self.only(self.turn, "PROF")
+        self.assertEqual(len(prof), 10)
+        self.assertEqual(int(prof[3]), MAXTOK)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on #1386 (its two commits are included; merge that one first, then this shows only the Kimi/Qwen3.8 delta).

## What

Kimi K3 and Qwen3.8 emitted nothing for the dashboard's Brain tab. Both now print `EMAP` (grid, after READY and STAT and after every turn) and `HITS` (experts routed by the turn, after DONE next to PROF), same bytes as colibri.c. With #1383, #1385 and #1386 merged, every family has Brain and Profile data.

## How

- Kimi: rows are the sparse layers (`L[i].sparse`), tier from `slot_indexed`; marks in the expert acquisition loop. PROF forwards counted where `step_chunk` runs (gen+1 was one too many when `max_tokens` stops the turn).
- Qwen3.8: rows are all layers, tier from `by_expert`; marks in `q38_expert_get` and in the batched lookup used by the parallel-read mode. Forwards were already counted.
- No heat counter in either engine: heat is 0, the tier bit carries the grid.

## Checks

- Kimi: `make kimi-k3-tiny-check` (vendor oracle, checkpoint test, and the new dashboard test) passes on the patched engine.
- Qwen3.8: tiny oracle 8/8, numeric gate PASS; `tests/test_qwen38_dashboard.py` drives a turn over stdio and checks EMAP after STAT, HITS after DONE on EMAP's shape and non-zero, the refreshed grid showing residents, PROF intact.
- CI: dashboard test added to the `kimi-k3-tiny-check` target (check.yml runs it) and a step in the Qwen3.8 tiny job (byte tokenizer for the oracle fixture); the Python job builds `qwen38` so the registry guard is satisfied.