### PR TITLE
qwen36 tier: QT_MAX_ROWS, placement pin, ownership-based int8 free (follow-up to #1344)

### DIFF
--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -2787,8 +2787,13 @@ static void tier_warmstart(Model *m, int expert_is_int4) {
              * slot_ensure_int8() unable to bring the expert back: it returns
              * early without g4, and the CPU fallback in the decode loop then
              * dereferences NULL. Keep it (#1341). COLI_KEEP_INT8 keeps its
-             * meaning for int4. */
-            if (!keep8 && expert_is_int4 && e->g) { free(e->g); e->g = e->u = e->d = NULL; }
+             * meaning for int4.
+             * The condition is ownership, not format: do not free what was
+             * just handed over. int4 handed g4 (wg != e->g), so the int8
+             * copy is spare; int8 handed e->g itself, so it stays. A future
+             * format that also aliases e->g is then correct without anyone
+             * remembering to extend a format check here. */
+            if (!keep8 && e->g && wg != (const uint8_t *)e->g) { free(e->g); e->g = e->u = e->d = NULL; }
         }
     }
     qt_fill_wait();

--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -2793,8 +2793,17 @@ static void tier_warmstart(Model *m, int expert_is_int4) {
     }
     qt_fill_wait();
     free(wpl); free(wpe); free(planned);
-    fprintf(stderr, "[qtier] warmstart (parallel): all %d experts in RAM (int8 only for non-residents), %d in VRAM -- %.1f s\n",
-            cap_total, wn, now_s()-t0);
+    /* The parenthesis used to read "int8 only for non-residents", which was
+     * true only while the int8 copy of every resident was freed. Since #1341
+     * that free is int4-only: on an int8 container every resident keeps its
+     * weights, so the RSS saving the old line implied does not exist there.
+     * Say which container this is instead of promising a saving the reader
+     * will not see. */
+    fprintf(stderr, "[qtier] warmstart (parallel): all %d experts in RAM (%s), %d in VRAM -- %.1f s\n",
+            cap_total,
+            expert_is_int4 ? "int8 copy dropped for residents, kept for non-residents"
+                           : "int8 container: all experts keep their weights in RAM",
+            wn, now_s()-t0);
 }
 
 int main(int argc, char **argv) {

--- a/c/qwen36_tier.c
+++ b/c/qwen36_tier.c
@@ -13,6 +13,11 @@
 #include "tier.h"
 
 #define QT_MAX_DEV 8
+/* Max rows in one issued group = max topk. The stride of a device's input
+ * replica block, the width of every per-device row array and the topk clamp
+ * must all agree: #1339 was three of these disagreeing, each spelling the
+ * same literal 32 separately. Name it once. */
+#define QT_MAX_ROWS 32
 #define QT_QCAP 48            /* upload queue depth (staging ~1.6 MB/entry) */
 
 typedef struct {
@@ -49,8 +54,8 @@ static struct {
     uint64_t hits[QT_MAX_DEV], miss, uploads, q_full_skips;
     /* issue state of the (single) decode thread */
     int is_cnt[QT_MAX_DEV];
-    int is_k[QT_MAX_DEV][32];
-    float *is_x; size_t is_x_floats;      /* 32*D input replicas per device */
+    int is_k[QT_MAX_DEV][QT_MAX_ROWS];
+    float *is_x; size_t is_x_floats;      /* QT_MAX_ROWS*D input replicas per device */
     /* M3 */
     int *fill_order; int fill_cur;        /* warmstart order (heat desc) */
     int issue_open;                       /* guard: no tensor_free while a group is in flight */
@@ -479,7 +484,7 @@ int qt_init(int nl, int ne, int D, int Ih, int cap, int topk, int expert_gs,
         fprintf(stderr,"[qtier] cap=%d != n_experts=%d -> tier disabled (needs full RAM residency)\n",cap,ne);
         return 0;
     }
-    if(topk>32){ fprintf(stderr,"[qtier] topk>32 unsupported\n"); return 0; }
+    if(topk>QT_MAX_ROWS){ fprintf(stderr,"[qtier] topk>%d unsupported\n",QT_MAX_ROWS); return 0; }
     memset(&G,0,sizeof G);
     G.nl=nl; G.ne=ne; G.D=D; G.Ih=Ih; G.topk=topk;
     /* Placement state is re-derived per init: the device fold-in below reads
@@ -683,7 +688,11 @@ int qt_init(int nl, int ne, int D, int Ih, int cap, int topk, int expert_gs,
                 G.dev[i], G.budget[i]/1073741824.0, G.budget[i]/G.exp_bytes,
                 trunk ? " after trunk" : "");
     }
-    G.is_x_floats=(size_t)G.ndev*32*D;
+    /* qt_issue strides each device's block by QT_MAX_ROWS*D floats (its max
+     * row count), not 8*D: a device other than 0 with a full 32-row issue
+     * used to run past its own slice and off the end of this allocation
+     * (#1339). The stride and G.is_k's row capacity are the same constant. */
+    G.is_x_floats=(size_t)G.ndev*QT_MAX_ROWS*D;
     G.is_x=malloc(G.is_x_floats*sizeof(float));
     if(!G.is_x) return 0;
     pthread_mutex_init(&G.mx,NULL); pthread_cond_init(&G.cv,NULL); pthread_cond_init(&G.cv_take,NULL);
@@ -977,11 +986,11 @@ static void qt_lfru_tick_locked(void){
 }
 
 uint32_t qt_issue(int layer,const int *eids,int K,const float *x){
-    if(!G.on||K>32) return 0;
+    if(!G.on||K>QT_MAX_ROWS) return 0;
     uint32_t mask=0;
-    ColiCudaTensor *tg[QT_MAX_DEV][32],*tu[QT_MAX_DEV][32],*td[QT_MAX_DEV][32];
-    static int rows[32]={0};
-    if(!rows[0]) for(int i=0;i<32;i++) rows[i]=1;
+    ColiCudaTensor *tg[QT_MAX_DEV][QT_MAX_ROWS],*tu[QT_MAX_DEV][QT_MAX_ROWS],*td[QT_MAX_DEV][QT_MAX_ROWS];
+    static int rows[QT_MAX_ROWS]={0};
+    if(!rows[0]) for(int i=0;i<QT_MAX_ROWS;i++) rows[i]=1;
     for(int i=0;i<G.ndev;i++) G.is_cnt[i]=0;
 
     pthread_mutex_lock(&G.mx);
@@ -1001,7 +1010,7 @@ uint32_t qt_issue(int layer,const int *eids,int K,const float *x){
     for(int di=0;di<G.ndev;di++){
         int c=G.is_cnt[di];
         if(!c) continue;
-        float *xr=G.is_x + (size_t)di*32*G.D;              /* per-device input block */
+        float *xr=G.is_x + (size_t)di*QT_MAX_ROWS*G.D;     /* per-device input block */
         for(int j=0;j<c;j++) memcpy(xr+(size_t)j*G.D, x, (size_t)G.D*sizeof(float));
         if(!coli_cuda_expert_group_issue(tg[di],tu[di],td[di],rows,c,xr)){
             /* issue failed -> hand these k back to the CPU */

--- a/c/qwen36_tier.c
+++ b/c/qwen36_tier.c
@@ -392,8 +392,8 @@ static double auto_displaced_value(int di, size_t room, int k, size_t exp_bytes,
         }
     }
     qsort(p, m, sizeof *p, cmp_double_desc);
-    double value = 0, pm = 0; int cnt = 0;
-    for(size_t r = (fit > (size_t)k ? fit - k : 0); r < fit && r < m; r++){ value += cpu_factor * p[r] * (double)exp_bytes; pm = p[r]; cnt++; }
+    double value = 0, pm = 0;
+    for(size_t r = (fit > (size_t)k ? fit - k : 0); r < fit && r < m; r++){ value += cpu_factor * p[r] * (double)exp_bytes; pm = p[r]; }
     free(p);
     *p_marginal_out = pm;
     return value;

--- a/c/tests/test_qwen36_tier_multidev.c
+++ b/c/tests/test_qwen36_tier_multidev.c
@@ -105,12 +105,32 @@ int main(void) {
     }
     check(inside, "blocks_stay_inside_the_replica_buffer");
 
+    /* In-bounds and disjoint are both necessary and both insufficient: a
+     * stride SMALLER than the row capacity keeps every block inside the
+     * allocation while sliding device 1's window down onto device 0's, and a
+     * single-row issue on device 1 is disjoint from device 0's under any
+     * stride at all. The two checks below pin the stride itself. */
+    check(sizeof G.is_k[0] / sizeof G.is_k[0][0] == QT_MAX_ROWS &&
+          G.is_x_floats == (size_t)G.ndev * (sizeof G.is_k[0] / sizeof G.is_k[0][0]) * (size_t)G.D,
+          "replica_block_stride_equals_the_per_device_row_capacity");
+
     check(nrec == base2 + 2, "the mixed batch should issue once per device (two calls)");
     if (nrec == base2 + 2) {
         const float *a0 = records[base2].x, *a1 = records[base2 + 1].x;
         size_t c0 = (size_t)records[base2].count, c1 = (size_t)records[base2 + 1].count;
         int disjoint = (a0 + c0 * G.D <= a1) || (a1 + c1 * G.D <= a0);
         check(disjoint, "device_blocks_do_not_overlap");
+        /* Where, not just whether: device di's block starts at
+         * G.is_x + di*QT_MAX_ROWS*D. This is the one assertion that fails on
+         * the old 8*D stride even when device 1 carries a single row. */
+        int dev0 = records[base2].device == 0 ? base2 : base2 + 1;
+        int dev1 = dev0 == base2 ? base2 + 1 : base2;
+        check(records[dev0].device == 0 && records[dev1].device == 1,
+              "the mixed batch should issue once on device 0 and once on device 1");
+        check(records[dev0].x == G.is_x,
+              "device_0_block_starts_at_the_buffer_base");
+        check(records[dev1].x == G.is_x + (size_t)QT_MAX_ROWS * (size_t)G.D,
+              "device_1_block_starts_one_full_row_capacity_in");
     }
 
     float val[32]; for (int k = 0; k < 32; k++) val[k] = 1.0f;

--- a/docs/qwen36-cuda-tier.md
+++ b/docs/qwen36-cuda-tier.md
@@ -28,10 +28,14 @@ more GPUs and computed there through the existing shared CUDA backend
   groups on all devices (`coli_cuda_expert_group_issue/take`); VRAM misses
   fall back to the CPU int8 path and overlap with the in-flight groups, as
   does the shared expert. Placement never changes routing or precision.
-- **Memory:** the warmstart frees the RAM int8 copies of VRAM-resident
-  experts (rematerialized from the packed int4 copy on LFRU eviction; no
-  container access). Peak RSS for the 35B int4 container: ~29 GB with two
-  8 GB GPUs.
+- **Memory:** on an **int4 container** the warmstart frees the RAM int8 copies
+  of VRAM-resident experts (rematerialized from the packed int4 copy on LFRU
+  eviction; no container access). Peak RSS for the 35B int4 container: ~29 GB
+  with two 8 GB GPUs. The RSS saving is a property of packed containers only:
+  on an **int8 container** there is no second copy to rematerialize from, so
+  since #1341 nothing is freed and every resident keeps its full RAM weights —
+  such a run gets the tier's VRAM speed at full residency cost, and the 29 GB
+  figure below does not apply to it.
 
 ## Usage
 
@@ -129,6 +133,9 @@ CPU fallback. Known, not yet addressed.
 | VRAM hit rate (cold / warm) | 44 % / 95 % | 85 % / 100 % |
 | peak RSS | 40 GB | **29 GB** |
 | reference: Ollama q4_K_M, same box | 7.5 | 10.5 |
+
+All figures above are int4-container measurements; the peak-RSS row in
+particular has no int8 analogue (see **Memory**).
 
 CPU-only baseline of this engine before the tier: 0.35 tok/s.
 Numerics: logits cosine vs the f32 CPU reference 0.9992 (dense int8 on),


### PR DESCRIPTION
Follow-up to #1344, addressing the review there from @kreuzzelg and @JustVugg. Three commits on current `dev`.

## 1. Review response (original implementation by @mfethe1, crichalchemist/colibri#1)

- **`QT_MAX_ROWS`** replaces the seven literal `32`s in `qwen36_tier.c` that had to agree (`is_k`, the `K>` clamp, `tg/tu/td`, `rows[]`, the topk clamp message, `is_x_floats`, the `qt_issue` stride). #1339 was three of them disagreeing. Since #1344 the `is_x` allocation moved below the auto-placer; the constant follows it there.
- **Placement pin** in `test_qwen36_tier_multidev`: asserts device 0's block starts at `G.is_x` and device 1's at `G.is_x + QT_MAX_ROWS*D`, plus the `sizeof`-based stride check. They detect different drifts: a stride reverted to `8*D` trips the pin (in-bounds and disjointness both still pass on a single-row issue), while widening `is_k` without touching the stride trips only the `sizeof` check. Both kept.
- **Warmstart log line and `docs/qwen36-cuda-tier.md`** say which container they describe: on an int8 container nothing is freed since #1341, and the 40 → 29 GB RSS row is an int4 measurement with no int8 analogue.

The shutdown-test watchdog from the original follow-up is already on `dev` via fa8142d, so this PR does not touch `test_qwen36_tier_shutdown.c`.

## 2. The #1341 free keys on ownership, not on format

@JustVugg's suggestion from the review. `if (!keep8 && expert_is_int4 && e->g)` encoded today's correspondence between weight format and memory ownership; a third format that also aliases `e->g` would reintroduce the use-after-free without anyone reading a format flag as an ownership statement. Now:

```c
if (!keep8 && e->g && wg != (const uint8_t *)e->g) { free(e->g); ... }
```

Do not free what was just handed over. Same behaviour on both current containers (`test_qwen36_tier_int8_engine` covers both), correct by construction for the next one.

## 3. One warning

`cnt` in the placement pricing loop (ff13134) was set and never read; `-Wunused-but-set-variable` flagged it in every test build that includes `qwen36_tier.c`. Removed.

## Verified

macOS 13 x86_64 (2017 iMac, i7-7700K), Apple clang, fake CUDA backend: `make qwen36` and all seven `tests/test_qwen36_tier_*` binaries with 0 warnings, all passing (autoplace, fp8, int8, int8_engine, invariants, multidev, shutdown). Not built on MinGW/UCRT64 locally; the Windows job here is the proof for that.
