### PR TITLE
fix(glm53): release dashboard hit tracking

### DIFF
--- a/c/glm53.c
+++ b/c/glm53.c
@@ -1961,6 +1961,10 @@ static void model_release(GModel *m) {
         }
         free(m->ecache);
     }
+    if (m->ehit) {
+        for (int i = 0; i < m->c.n_layers; i++) free(m->ehit[i]);
+        free(m->ehit);
+    }
     free(m->eref);
     if (m->vblocks) {
         for (int b = 0; b < m->c.vis_layers; b++) {


### PR DESCRIPTION
## Problem

`ehit_mark()` lazily allocates the `GModel.ehit` outer array and one row per layer for dashboard HITS tracking. `model_release()` zeroed the model without freeing those allocations, so GLM-5.3 teardown after HITS use leaked them.

## Change

Free every allocated `ehit` row and the outer array during GLM-5.3 teardown.

## Validation

- `make -C c glm53`
- `make check`: the sole sandbox socket failure in `test_cluster_protocol` passed when the same built binary ran outside the restricted sandbox
- Focused ASan/LeakSanitizer destructor harness: patched source reported no leak; the exact unpatched `f18a54a1171493599e196639311e5d312e474e75` control reported 100 bytes in 5 allocations
