### PR TITLE
fix(qwen36 tier): qt_fill_wait returns only when the last upload is resident

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1683,6 +1683,13 @@ tests/test_qwen36_tier_shutdown$(EXE): tests/test_qwen36_tier_shutdown.c tests/q
 tests/test_qwen36_tier_invariants$(EXE): tests/test_qwen36_tier_invariants.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h
 	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
 
+# Same fake backend, with uploads that take time: qt_fill_wait must not return
+# until the last enqueued expert is RESIDENT, not merely dequeued -- the engine
+# frees the RAM int8 copies right after it (#1360 saw the gap one run in
+# fifteen; here the slow upload hook makes it every run without the fix).
+tests/test_qwen36_tier_fill_wait$(EXE): tests/test_qwen36_tier_fill_wait.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h
+	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
+
 # Same fake backend: the automatic placement (COLI_PLACE unset/"auto") puts
 # the offered dense trunk into VRAM by bytes-saved-per-byte, prices displaced
 # experts by heat, keeps the trunk on the CPU when the marginal experts are

--- a/c/qwen36_tier.c
+++ b/c/qwen36_tier.c
@@ -44,6 +44,10 @@ static struct {
     /* upload ring with staging copies */
     struct { int layer, eid; uint8_t *w; float *s; int v_layer, v_eid; } q[QT_QCAP];
     int qh, qt_, qn;
+    int inflight;   /* enqueued and not yet resident. qn frees the ring slot at
+                     * dequeue, BEFORE the backend copies anything, so "queue
+                     * empty" says nothing about the last expert; qt_fill_wait
+                     * needs this separate completion count (#1360). */
     pthread_cond_t cv;
     /* statistics */
     uint64_t hits[QT_MAX_DEV], miss, uploads, q_full_skips;
@@ -157,7 +161,8 @@ static void *uploader(void *arg){
                  * cleared the victim's resident flag before enqueueing, so
                  * restore it to keep the flag consistent with the tensor it
                  * still holds. */
-                v->resident=1; qs(layer,eid)->queued=0;
+                v->resident=1; qs(layer,eid)->queued=0; G.inflight--;
+                pthread_cond_broadcast(&G.cv_take);
                 pthread_mutex_unlock(&G.mx); free(w); free(sc); continue;
             }
             ColiCudaTensor *a=v->tg,*b=v->tu,*ct=v->td;
@@ -201,6 +206,8 @@ static void *uploader(void *arg){
         else  { int hd=home(eid); G.used[hd]-=G.exp_bytes;
                 G.budget[hd]=G.used[hd];   /* device genuinely full: stop trying */ }
         s->queued=0;
+        G.inflight--;
+        pthread_cond_broadcast(&G.cv_take);          /* this upload is complete */
         pthread_mutex_unlock(&G.mx);
     }
 }
@@ -774,7 +781,7 @@ static int enqueue_locked(int layer,int eid,int v_layer,int v_eid,int reserved){
     stage(w,sc,s->g4,s->u4,s->d4,s->gs,s->us,s->ds);
     G.q[G.qt_].layer=layer; G.q[G.qt_].eid=eid; G.q[G.qt_].w=w; G.q[G.qt_].s=sc;
     G.q[G.qt_].v_layer=v_layer; G.q[G.qt_].v_eid=v_eid;
-    G.qt_=(G.qt_+1)%QT_QCAP; G.qn++;
+    G.qt_=(G.qt_+1)%QT_QCAP; G.qn++; G.inflight++;
     pthread_cond_signal(&G.cv);
     return 1;
 }
@@ -941,11 +948,16 @@ void qt_note_planned(int layer,int eid,
     pthread_mutex_unlock(&G.mx);
 }
 
-/* waits until the upload queue is drained (end of warmstart). */
+/* Blocks until every enqueued upload has COMPLETED (end of warmstart): the
+ * engine frees the RAM int8 copies of the planned experts right after this
+ * returns, so "dequeued" is not enough -- the uploader drops qn before it
+ * calls the backend, and the last expert would still be queued=1 (#1360).
+ * Must not be called with an expert group open: an LFRU swap parks the
+ * uploader on issue_open until qt_take() clears it. */
 void qt_fill_wait(void){
     if(!G.on) return;
     pthread_mutex_lock(&G.mx);
-    while(G.qn>0 && !G.th_stop) pthread_cond_wait(&G.cv_take,&G.mx);
+    while(G.inflight>0 && !G.th_stop) pthread_cond_wait(&G.cv_take,&G.mx);
     pthread_mutex_unlock(&G.mx);
 }
 

--- a/c/qwen36_tier.h
+++ b/c/qwen36_tier.h
@@ -111,7 +111,7 @@ int  qt_fill_next(int *layer, int *eid);
 void qt_note_block(int layer, int eid,
              const uint8_t *g4, const uint8_t *u4, const uint8_t *d4,
              const float *gs, const float *us, const float *ds);
-void qt_fill_wait(void);   /* blocks until the upload queue is drained */
+void qt_fill_wait(void);   /* blocks until every enqueued upload is resident (not merely dequeued) */
 
 /* One telemetry block on stderr: residency, hits/misses, uploads per device. */
 void qt_stats(void);

--- a/c/tests/qwen36_fake_cuda.h
+++ b/c/tests/qwen36_fake_cuda.h
@@ -6,13 +6,17 @@
  * traffic without a GPU or the CUDA toolkit. A test that only checked
  * "qt_init returns 1" would pass even with the tier fully broken.
  *
- * Two settable hooks beyond plain recording:
+ * Three settable hooks beyond plain recording:
  *   fake_ndev        - device count returned by coli_cuda_available_device_count
  *                       and coli_cuda_device_count (default 1).
  *   fake_issue_hook   - called by coli_cuda_expert_group_issue with the issuing
  *                       device (taken from g[0]->device), the row count and the
  *                       input pointer; its return value is what issue returns.
- *                       NULL (the default) reproduces the old always-0 stub. */
+ *                       NULL (the default) reproduces the old always-0 stub.
+ *   fake_upload_hook  - called at the start of every tensor upload, on the
+ *                       uploader thread, with the tensor's fmt. A test that
+ *                       needs an upload to take TIME (a real cudaMemcpy does)
+ *                       sleeps here; NULL (the default) uploads instantly. */
 #ifndef QWEN36_FAKE_CUDA_H
 #define QWEN36_FAKE_CUDA_H
 
@@ -44,9 +48,11 @@ static size_t captured_len;
 static int fake_ndev = 1;
 static size_t fake_free_bytes = 2ull << 30;    /* what coli_cuda_mem_info reports as free */
 static int (*fake_issue_hook)(int device, int count, const float *x) = NULL;
+static void (*fake_upload_hook)(int fmt) = NULL;
 
 static int upload_common(ColiCudaTensor **t, const void *w, int fmt,
                          int I, int O, int device, int gs) {
+    if (fake_upload_hook) fake_upload_hook(fmt);
     ColiCudaTensor *n = (ColiCudaTensor *)calloc(1, sizeof *n);
     n->fmt = fmt; n->I = I; n->O = O; n->device = device; n->gs = gs; n->w = w;
     *t = n;

--- a/c/tests/test_qwen36_tier_fill_wait.c
+++ b/c/tests/test_qwen36_tier_fill_wait.c
@@ -1,0 +1,80 @@
+/* qt_fill_wait() returns before the last upload has landed.
+ *
+ * The defect: qt_fill_wait waited for the upload QUEUE to drain (G.qn == 0).
+ * The uploader frees the ring slot when it DEQUEUES an entry, before it calls
+ * the backend, so the queue is empty while the last expert is still being
+ * copied to the device. Whoever called qt_fill_wait then sees that expert as
+ * queued=1, resident=0 -- and the engine's warmstart frees the RAM int8 copy
+ * of every planned expert right after qt_fill_wait returns, trusting that
+ * they are all in VRAM. #1360 met this as a one-in-fifteen failure of
+ * test_qwen36_tier_multidev and papered over it in the test with a poll.
+ *
+ * This test makes the race deterministic instead of probabilistic: the fake
+ * backend's upload hook sleeps a few milliseconds per tensor, so the uploader
+ * is always mid-copy when the queue empties. With the old wait the last
+ * expert is caught queued=1 every run; with the fix (an in-flight count that
+ * the uploader decrements only after the slot is resident) qt_fill_wait
+ * blocks until every enqueued expert has actually landed. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "qwen36_fake_cuda.h"
+
+#include "../qwen36_tier.c"
+
+static int fails;
+static void check(int ok, const char *what) {
+    if (!ok) { printf("  FAIL: %s\n", what); fails++; }
+}
+
+/* 3 ms per tensor, 9 ms per expert: long against the microseconds the
+ * dequeue-to-upload gap takes, short against the test budget. */
+static void slow_upload(int fmt) {
+    (void)fmt;
+    struct timespec ts = {0, 3000000};
+    nanosleep(&ts, NULL);
+}
+
+int main(void) {
+    enum { NL = 1, NE = 8, D = 64, IH = 32, TOPK = 2 };
+    setenv("COLI_CUDA", "1", 1);
+    setenv("COLI_GPUS", "0", 1);
+    setenv("QT_NO_WARMSTART", "1", 1);
+    fake_upload_hook = slow_upload;
+
+    if (!qt_init(NL, NE, D, IH, NE, TOPK, 0 /* per-row */, 1 /* int4 */)) {
+        printf("  FAIL: the tier should start on the fake backend\n");
+        return 1;
+    }
+
+    static unsigned char g4[NE][D * IH / 2], u4[NE][D * IH / 2], d4[NE][D * IH / 2];
+    static float sc[NE][2 * IH + D];   /* gs=0 -> sc_gu=IH, sc_d=D */
+    for (int eid = 0; eid < NE; eid++) {
+        memset(g4[eid], (unsigned char)(eid + 1), sizeof g4[eid]);
+        memset(u4[eid], (unsigned char)(eid + 2), sizeof u4[eid]);
+        memset(d4[eid], (unsigned char)(eid + 3), sizeof d4[eid]);
+        for (int i = 0; i < 2 * IH + D; i++) sc[eid][i] = 1.0f;
+        qt_note_block(0, eid, g4[eid], u4[eid], d4[eid], sc[eid], sc[eid] + IH, sc[eid] + 2 * IH);
+    }
+
+    qt_fill_wait();
+
+    /* The property, read under the tier's own lock the instant the wait
+     * returns: nothing is still queued, and everything we enqueued is
+     * resident. No polling, no sleeping -- the wait IS the guarantee. */
+    int queued = 0, resident = 0;
+    pthread_mutex_lock(&G.mx);
+    for (int eid = 0; eid < NE; eid++) { queued += qs(0, eid)->queued; resident += qs(0, eid)->resident; }
+    pthread_mutex_unlock(&G.mx);
+    check(queued == 0, "an expert is still queued when qt_fill_wait returns");
+    check(resident == NE, "not every enqueued expert is resident when qt_fill_wait returns");
+    check(fake_uploads == 3 * NE, "each expert should have uploaded exactly three tensors by the time the wait returns");
+
+    qt_shutdown();
+
+    if (fails) { printf("test_qwen36_tier_fill_wait: %d failures\n", fails); return 1; }
+    printf("test_qwen36_tier_fill_wait: ok\n");
+    return 0;
+}

--- a/c/tests/test_qwen36_tier_multidev.c
+++ b/c/tests/test_qwen36_tier_multidev.c
@@ -62,19 +62,9 @@ int main(void) {
         qt_note_block(0, eid, g4[eid], u4[eid], d4[eid], sc[eid], sc[eid] + IH, sc[eid] + 2 * IH);
     }
     qt_fill_wait();
-    /* qt_fill_wait returns when the QUEUE is empty; the expert the uploader
-     * dequeued last is still queued=1 (not yet resident) until its upload
-     * returns. Checking residency right here raced that upload and failed
-     * about one run in fifteen. Wait for the uploader to settle. */
-    for (int i = 0; i < 1000; i++) {
-        int pending = 0;
-        pthread_mutex_lock(&G.mx);
-        for (int eid = 0; eid < NE; eid++) pending += qs(0, eid)->queued;
-        pthread_mutex_unlock(&G.mx);
-        if (!pending) break;
-        struct timespec ts = {0, 2000000};
-        nanosleep(&ts, NULL);
-    }
+    /* qt_fill_wait now returns only once every enqueued expert is resident
+     * (test_qwen36_tier_fill_wait pins that), so residency can be read right
+     * here; the poll this used to need is gone with the race it papered over. */
     for (int eid = 0; eid < NE; eid++)
         check(qt_is_resident(0, eid), "expert did not become resident during warmstart");
 


### PR DESCRIPTION
Root-cause fix for the race @kreuzzelg found in #1360 ("queue empty is not uploader done") and covered there on the test side.

## The defect

`qt_fill_wait` waited for the upload queue to drain (`qn == 0`). The uploader frees the ring slot when it *dequeues* an entry, before it calls the backend, so the queue is empty while the last expert is still being copied to the device: the caller sees it `queued=1, resident=0`. The engine's warmstart frees the RAM int8 copy of every planned expert right after `qt_fill_wait`, trusting that they are all in VRAM.

## The fix

Count what is in flight, not what is queued. `enqueue_locked` increments `G.inflight`; the uploader decrements it only once the slot is resident (or the upload failed, or the entry was abandoned at shutdown) and broadcasts `cv_take`; `qt_fill_wait` blocks on `inflight`. Same lock, same condition variable, one extra broadcast per completed upload, nothing new on the decode path.

## The test, in the shape #1344 set

One commit, one test that fails before the fix. `tests/test_qwen36_tier_fill_wait.c` makes the race deterministic instead of one-in-fifteen: the fake backend gains a third hook, `fake_upload_hook`, the test sleeps 3 ms per tensor in it, and reads `queued`/`resident` under `G.mx` the instant the wait returns.

| | before | after |
|---|---|---|
| `test_qwen36_tier_fill_wait` | fails 5/5 (all three assertions) | passes 10/10 |
| `test_qwen36_tier_multidev`, poll removed | — | passes 20/20 |
| fill_wait, multidev, shutdown under ASan+UBSan | — | clean |

The poll bdeb338 added to the multidev test is removed: the wait is now the guarantee. The other tier tests and `make qwen36` are unchanged and green.

## Relation to the other open PRs

- Merges cleanly with #1388.
- #1338 carries the same `inflight` counter as part of its Vulkan work (the Vulkan backend has no completion signal of its own, so it needed one). Once this lands I will rebase #1338 onto it and drop its copy, which shrinks that PR.

Verified on macOS 13 x86_64 (2017 iMac), Apple clang, fake CUDA backend.
