### PR TITLE
gateway: GLM-5.3 replies always start inside the think block (#1278)

### DIFF
--- a/c/openai_server.py
+++ b/c/openai_server.py
@@ -1950,8 +1950,14 @@ def starts_in_reasoning(enable_thinking):
     dice il suo interruttore: acceso apre il blocco e il modello lo chiude da
     solo, spento lo chiude gia' il prompt e quello che torna e' risposta pura.
     Se le due cose non concordano il ragionamento finisce incollato davanti
-    alla risposta, che e' il difetto che questa funzione esiste per non avere."""
-    return enable_thinking
+    alla risposta, che e' il difetto che questa funzione esiste per non avere.
+
+    GLM-5.3 e' l'eccezione che rende la regola esplicita: il suo template non
+    ha un interruttore, render_chat_glm53 apre <think> SEMPRE, e "thinking
+    spento" vuol dire solo effort Low. L'uscita comincia dentro al blocco in
+    ogni caso; partire in modalita' testo perche' il client ha detto False e'
+    esattamente il ragionamento incollato davanti alla risposta di #1278."""
+    return enable_thinking or ARCH == "glm53"
 
 
 class ThinkingStreamSplit:

--- a/c/tests/test_openai_server.py
+++ b/c/tests/test_openai_server.py
@@ -2024,6 +2024,21 @@ class ThinkingSplitUnitTest(unittest.TestCase):
         self.assertEqual(split_thinking_reply("plain answer", enable_thinking=False),
                          ("", "plain answer"))
 
+    def test_glm53_starts_in_reasoning_even_with_thinking_off(self):
+        """#1278: render_chat_glm53 opens <think> unconditionally (the template
+        has no switch; "off" only lowers the effort), so the reply always starts
+        inside the block. With the splitter started in text mode the reasoning
+        streamed as `content`, glued in front of the answer. The family, not the
+        client flag, decides where the output starts."""
+        import openai_server as srv
+        with patch("openai_server.ARCH", "glm53"):
+            self.assertTrue(srv.starts_in_reasoning(False))
+            self.assertEqual(split_thinking_reply("why</think>answer", enable_thinking=False),
+                             ("why", "answer"))
+        with patch("openai_server.ARCH", "glm"):
+            self.assertFalse(srv.starts_in_reasoning(False),
+                             "GLM-5.2 closes the block in the prompt when thinking is off")
+
     def test_missing_close_tag_surfaces_reasoning(self):
         self.assertEqual(split_thinking_reply("thought with no end"),
                          ("thought with no end", ""))


### PR DESCRIPTION
Fixes the remaining half of #1278: reasoning glued to the answer in `coli chat` on GLM-5.3-Flash.

## Cause

`render_chat_glm53` opens `<think>` unconditionally (the template has no switch; "thinking off" only lowers the effort to Low), but `starts_in_reasoning()` returned the client's `enable_thinking` flag. With thinking off the splitter started in text mode, so the reasoning streamed as `content`, and the TUI printed it as part of the answer with no boundary. The comment at the Anthropic call site already described this exact case; the function it relied on never implemented it.

## Fix

`starts_in_reasoning()` decides from the family: glm53 always starts inside the block, the others keep following the flag (GLM-5.2 closes the block in the prompt when thinking is off, and a pure answer must not be filed as reasoning). All three splitter call sites (streaming, tool-call path, Anthropic path) go through it.

With thinking off the reasoning now arrives as `reasoning_content` (the TUI renders it in the dim box, `COLI_SHOW_THINK=0` hides it) and `content` is the pure answer.

## Checks

- New test pins both families; it fails on dev without the fix (checked).
- `tests.test_openai_server`: 169 tests OK.