### PR TITLE
cuda tier: price the VRAM prefix per row, not at the container's widest (#1351)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -9651,6 +9651,25 @@ static int pin_count_for_budget(Model *m, const PinRec *r, int from, int n,
     }
     return count;
 }
+/* #1351: how many ranked experts a VRAM budget holds, priced at each row's
+ * real width. Dividing the budget by expert_bytes_probe() priced every routed
+ * int4 expert at the int8 MTP width, and the single-GPU auto tier stopped at
+ * 56% of the card (3,604 experts in 136 GB, exact to the expert). The probe's
+ * width is right for slots shared ACROSS rows (ws[], staging); the VRAM prefix
+ * is one upload per expert at that expert's own width.
+ *
+ * raw_n >= 0 is the COLI_ANS split: the first raw_n ranked experts go up raw,
+ * the rest entropy-coded at ~0.80 of their width (same factor as before).
+ * Returns the count only; the caller adds its per-device slack. */
+static int pin_prefix_for_budget(Model *m, const PinRec *r, int n, double budget_b, int raw_n){
+    if(budget_b<=0.0 || n<=0) return 0;
+    if(raw_n<0) return pin_count_for_budget(m,r,0,n,budget_b);
+    if(raw_n>n) raw_n=n;
+    int got=pin_count_for_budget(m,r,0,raw_n,budget_b);
+    if(got<raw_n) return got;                    /* the budget ends inside the raw prefix */
+    double left=budget_b-pin_range_bytes(m,r,0,got);
+    return got+pin_count_for_budget(m,r,got,n,left/0.80);
+}
 
 #ifdef __linux__
 /* #419: bind the pinned hot-store as ONE arena per layer instead of one mbind
@@ -9786,14 +9805,17 @@ static void pin_load(Model *m, const char *statspath, double gb, int trusted){
      * tier under CUDA_DENSE=1 regardless of the configured budget (#491). */
     if(g_cuda_expert_auto) budget=safe_total;
     if(g_cuda_enabled&&g_cuda_release_host&&budget>0){
-        prefix_est=(int)(budget/eb)+g_cuda_ndev;
+        /* Per row, not budget/eb: eb is the container's WIDEST expert (the int8
+         * MTP row on shipped GLM-5.2), the right price for a slot shared across
+         * rows and the wrong one for a VRAM upload, which costs the expert's own
+         * width. With the widest as divisor the single-GPU auto tier placed 56%
+         * of its budget and stopped (#1351). The staging cap below keeps eb on
+         * purpose: it bounds a HOST peak of slabs that are reused across rows. */
+        int raw_n=-1;
 #ifdef COLI_ANS
-        if(g_cuda_raw_experts>=0){
-            int raw=g_cuda_raw_experts;
-            if((double)raw*eb>budget) raw=(int)(budget/eb);
-            prefix_est=raw+(int)((budget-(double)raw*eb)/(0.80*eb))+g_cuda_ndev;
-        }
+        raw_n=g_cuda_raw_experts;
 #endif
+        prefix_est=pin_prefix_for_budget(m,r,n,budget,raw_n)+g_cuda_ndev;
         if(prefix_est>n) prefix_est=n;
         cpu_from=prefix_est;                    /* prefix RAM is returned after upload */
     }

--- a/c/tests/test_cap_mixed_width.c
+++ b/c/tests/test_cap_mixed_width.c
@@ -223,6 +223,39 @@ int main(void){
         CHECK(pin_count_for_budget(&m,mixed,1,3,(double)wide+(double)narrow)==2);
         CHECK(pin_count_for_budget(&m,mixed,3,3,1e9)==0);
     }
+    /* ---- C. the VRAM prefix is priced per row too (#1351) ------------------ */
+    /* pin_load bounded the CUDA prefix by budget/expert_bytes_probe(): on the
+     * shipped GLM-5.2 that is the int8 MTP width for every int4 routed expert,
+     * and the single-GPU auto tier placed 3,604 experts in a 136 GB budget and
+     * stopped at 56%. Same ranked list as B: four routed experts' worth of VRAM
+     * must admit four routed experts, not two. */
+    {
+        PinRec ranked[5]={
+            {FIRST_DENSE,0,500}, {FIRST_DENSE+1,0,400},
+            {FIRST_DENSE+2,0,300}, {FIRST_DENSE+3,0,200},
+            {N_LAYERS,0,100}
+        };
+        double four_narrow=4.0*(double)narrow;
+        int per_row=pin_prefix_for_budget(&m,ranked,5,four_narrow,-1);
+        int widest =(int)(four_narrow/(double)probe);
+        printf("C. VRAM budget %.0f B: per-row prefix %d experts, widest-divisor %d\n",
+            four_narrow,per_row,widest);
+        CHECK(per_row==4);
+        CHECK(widest<per_row);                 /* the 56% stop, at this fixture's scale */
+        CHECK(pin_range_bytes(&m,ranked,0,per_row)<=four_narrow);
+        /* The MTP expert at rank 5 costs its own (wide) width: one more wide
+         * expert's worth of budget admits it, one byte less does not. */
+        CHECK(pin_prefix_for_budget(&m,ranked,5,four_narrow+(double)wide-1.0,-1)==4);
+        CHECK(pin_prefix_for_budget(&m,ranked,5,four_narrow+(double)wide,-1)==5);
+        /* COLI_ANS split: the first raw_n go up raw, the rest at 0.80 of their
+         * width. Two raw experts plus 0.80 of two more is 3.6 narrow; 3.7 keeps
+         * the check off the rounding edge. Without the split, 3.7 holds three. */
+        CHECK(pin_prefix_for_budget(&m,ranked,5,3.7*(double)narrow,2)==4);
+        CHECK(pin_prefix_for_budget(&m,ranked,5,3.7*(double)narrow,-1)==3);
+        /* budget that ends inside the raw prefix: no entropy-coded tail is added */
+        CHECK(pin_prefix_for_budget(&m,ranked,5,1.5*(double)narrow,4)==1);
+        CHECK(pin_prefix_for_budget(&m,ranked,5,0.0,-1)==0);
+    }
 
     /* ---- (1) the divisor is the sum of the REAL widths --------------------- */
     int nsp=0; for(int i=0;i<c->n_layers;i++) if(m.L[i].sparse) nsp++;


### PR DESCRIPTION
Fixes #1351 (single-GPU auto tier stops at ~56% of budget on mixed-width containers).

## Cause

`prefix_est = budget / expert_bytes_probe()`. Since #766 the probe returns the container's widest expert (the int8 MTP row, 37.8 MB, on shipped GLM-5.2); routed experts upload at 21.2 MB. `136.2e9 / 37789696 + 1 = 3605`, placed 3604: the reporter's number, exact to the expert.

## Fix

`pin_prefix_for_budget()` walks the ranked list and charges each expert its own row width via `expert_bytes_row` (#856), keeping the `COLI_ANS` split (first `g_cuda_raw_experts` raw, the rest at 0.80). The staging cap keeps the widest width on purpose: it bounds a host peak of slabs reused across rows, which is the case the probe was written for. A comment at each site says why the two divisors differ.

## Test

Section C in `tests/test_cap_mixed_width.c` (real container on disk, no GPU): four routed experts' worth of VRAM admits four, the widest divisor gives two; a wide expert at rank 5 costs its own width to the byte; the ANS split and the in-prefix cutoff are pinned. `colibri` builds; the test passes.

## Sequencing

As agreed in the issue, this should land together with or after #1244: with the prefix no longer under-estimated, the tier fills to its budget, and without #1244 `remaining[]` still charges logical bytes rather than VRAM, which is #687. Not merging this one first. @terrizoaguimor, the re-run of the #687 sweep on the merged tree is welcome once both are in.