### PR TITLE
Opt-in exact verify mode for speculative batches (COLI_EXACT_VERIFY=1)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -478,6 +478,7 @@ TEST_EXCLUDE = test_uring test_deepseek_v4 test_v4_ownership test_v4_serve_frami
 TEST_BINS    = $(addprefix tests/,$(addsuffix $(EXE),$(filter-out $(TEST_EXCLUDE),$(TEST_RULES))))
 ifneq (,$(LINUX))
 TEST_BINS += tests/test_uring$(EXE)
+TEST_BINS += tests/test_exact_dot$(EXE)
 endif
 ifeq ($(COLI_V4_SUPPORTED),1)
 TEST_BINS += tests/test_v4_hybrid_policy$(EXE) tests/test_k3_fill_budget$(EXE) tests/test_v4_bank_pair$(EXE)
@@ -1723,6 +1724,9 @@ tests/test_rss_anon$(EXE): tests/test_rss_anon.c
 # Windows; questo test gira nei tre job e fallisce dove la misura vale 0.
 tests/test_mem_available$(EXE): tests/test_mem_available.c compat.h
 	$(CC) $(CFLAGS) tests/test_mem_available.c -o $@ $(LDFLAGS)
+
+tests/test_exact_dot$(EXE): tests/test_exact_dot.c exact_dot.h
+	$(CC) $(CFLAGS) tests/test_exact_dot.c -o tests/test_exact_dot$(EXE) $(LDFLAGS)
 
 tests/test_798_guards$(EXE): tests/test_798_guards.c st.h json.h compat.h route_trace.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -530,6 +530,19 @@ typedef struct {
  * than in quant.h: that header is shared by standalone kernel tests and
  * sibling engines, where translation-unit-local copies are unused and trip
  * -Wunused-variable. */
+#include "exact_dot.h"
+/* COLI_EXACT_VERIFY=1 (opt-in, #689): during draft+verify forwards (g_spec_live) the CPU
+ * MLA-absorb attention core accumulates its score and context dots EXACTLY (integer products,
+ * one rounding per dot; exact_dot.h). No summation order, SIMD width or contraction flag can
+ * change those bits, so a verify row decides near-ties the same way on every host. Off by
+ * default: it is an integer path (~7x the float loop on the dot itself at -O3). The default paths
+ * are untouched. */
+static int g_exact_verify=-1;
+static int exact_verify_on(void){
+    if(g_exact_verify<0){ const char *e=getenv("COLI_EXACT_VERIFY"); g_exact_verify=(e&&atoi(e))?1:0;
+        if(g_exact_verify) fprintf(stderr,"[EXACT_VERIFY] draft+verify attention core on the exact (order-independent) dot (#689; COLI_EXACT_VERIFY=0 to disable)\n"); }
+    return g_exact_verify;
+}
 static int g_idot=1;
 #if defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
 static int g_i4s=1;
@@ -4690,6 +4703,13 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
                 } else {
                 const float *Lt=coli_kv_row(ks->Lc[layer],t,kvl);
                 const float *kr=coli_kv_row(ks->Rc[layer],t,c->qk_rope);
+                if(exact_verify_on()&&g_spec_live){
+                    /* #689 exact verify: one exact accumulator over BOTH partial dots, rounded once */
+                    exd_acc ea; exd_init(&ea);
+                    for(int i=0;i<kvl;i++) exd_add_ff(&ea,qabs[i],Lt[i]);
+                    for(int d=0;d<c->qk_rope;d++) exd_add_ff(&ea,qr[d],kr[d]);
+                    a=exd_finish(&ea);
+                } else {
                 /* MLA-absorb score: dot(qabs, Lt) + dot(qr, kr). #442: the qabs·Lt
                  * reduction is the hot f32 dot at this site (kvl=512 on GLM-5.2,
                  * runs nt times per (s,h), grows with context). SIMD-ify under
@@ -4712,10 +4732,19 @@ static void attention_rows(Model *m, Layer *l, int layer, float *x, int S, int p
                 for(;i<kvl;i++) a+=qabs[i]*Lt[i];
                 for(int d=0;d<c->qk_rope;d++) a+=qr[d]*kr[d];
                 }
+                }
                 sc[jj]=a*c->attn_scale;
             }
             softmax(sc,nt);
             float clat[512]; memset(clat,0,kvl*sizeof(float));
+            if(exact_verify_on()&&g_spec_live&&!tq1&&!g_tq&&!g_kv8){
+                /* #689 exact verify: clat[i] = sum_t sc[t]*Lt[i] as an exact dot over t per column
+                 * (transposed walk: cache-unfriendly, verify rows only) */
+                for(int i=0;i<kvl;i++){ exd_acc ea; exd_init(&ea);
+                    for(int jj=0;jj<nt;jj++){ int t = tlist ? tlist[jj] : st0+jj;
+                        exd_add_ff(&ea,sc[jj],coli_kv_row(ks->Lc[layer],t,kvl)[i]); }
+                    clat[i]=exd_finish(&ea); }
+            } else
             for(int jj=0;jj<nt;jj++){ int t = tlist ? tlist[jj] : st0+jj;
                 if(tq1){
                     /* accumulate acc = sum_t w_t*std_t*lev[L[t]] in the rotated basis; unrotate

--- a/c/exact_dot.h
+++ b/c/exact_dot.h
@@ -1,0 +1,155 @@
+/* exact_dot.h — order-independent dot products for the opt-in exact verify mode.
+ *
+ * Every product is formed exactly (integer mantissas, never rounded) and accumulated by
+ * exponent bin; the bins are folded into one wide two's-complement integer and rounded to
+ * double ONCE, correctly (round-to-nearest-even), then to float. No summation order, no
+ * contraction flag and no SIMD width can change the result, so CPU and GPU agree to the bit
+ * by construction and near-ties are decided identically everywhere. The cost is throughput:
+ * an integer path, no FMA, no tensor cores. That is why it is opt-in and verify-only.
+ *
+ * Covers the two shapes the engine's verify rows need:
+ *   exd_add_ff(acc, a, b)       a*b for f32 a, b            (attention q.k, p.v over f32 rows)
+ *   exd_add_wsx(acc, w, s, x)   (w*s)*x for int w, f32 s, x (quantised weight rows: int4/int8
+ *                                                           * per-row/per-group scale * f32 act)
+ * Products are exact int64 (24+24 or 8+24+24 mantissa bits <= 56 bits); bins hold __int128
+ * partial sums (72 bits of headroom), so any n up to 2^72 products per bin is safe.
+ *
+ * NaN / inf: a float dot with a NaN input is NaN, with an inf input is +-inf or NaN; the exact
+ * path reproduces the same *classification* (flags), so callers see the same special values.
+ *
+ * Copyright (c) 2026 Anomly, Inc. Licensed under the same terms as colibri (see LICENSE).
+ * Author: Ry Bruscoe. */
+#ifndef COLI_EXACT_DOT_H
+#define COLI_EXACT_DOT_H
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+
+#if defined(__SIZEOF_INT128__)
+typedef __int128 exd_i128;
+#else
+#error "exact_dot.h needs a 128-bit integer type (GCC/Clang); the exact verify mode is unavailable on this compiler"
+#endif
+
+/* Product exponents: f32 mantissa m (24 bits, value m*2^e with e = exp-150), normals e in
+ * [-149, 104]; products e in [-298, 208]; with an 8-bit integer weight (value w) the exponent is
+ * the same range. Bin index = e + EXD_BIAS. */
+#define EXD_BIAS 320
+#define EXD_NBIN 640
+/* wide accumulator: EXD_NBIN + 64 bits of headroom, in 64-bit limbs (two's complement) */
+#define EXD_LIMBS 12   /* 768 bits */
+
+typedef struct {
+    exd_i128 bin[EXD_NBIN];
+    int lo, hi;          /* used bin range (inclusive); lo > hi means empty */
+    int nan, pinf, ninf; /* special-value flags, order-independent by construction */
+} exd_acc;
+
+static inline void exd_init(exd_acc *a){ a->lo = EXD_NBIN; a->hi = -1; a->nan = a->pinf = a->ninf = 0; }
+
+/* bins are zeroed lazily as the used range [lo, hi] grows (a full memset would cost more than a
+ * typical 512-element dot); returns the bin to add into */
+static inline exd_i128 *exd_touch(exd_acc *a, int idx){
+    if(a->lo > a->hi){ a->bin[idx] = 0; a->lo = a->hi = idx; return &a->bin[idx]; }
+    if(idx < a->lo){ for(int i = idx; i < a->lo; i++) a->bin[i] = 0; a->lo = idx; }
+    else if(idx > a->hi){ for(int i = a->hi + 1; i <= idx; i++) a->bin[i] = 0; a->hi = idx; }
+    return &a->bin[idx];
+}
+
+/* decode f32 into (signed integer mantissa, exponent) with value = m * 2^e; returns 0 for
+ * zero (m=0), 1 for finite non-zero, 2 for inf, 3 for nan. */
+static inline int exd_decode(float f, int64_t *m, int *e){
+    uint32_t u; memcpy(&u, &f, 4);
+    int s = (int)(u >> 31), ex = (int)((u >> 23) & 0xFF); uint32_t fr = u & 0x7FFFFF;
+    if(ex == 0xFF){ *m = 0; *e = 0; return fr ? 3 : 2; }
+    if(ex == 0){ if(!fr){ *m = 0; *e = 0; return 0; } *m = s ? -(int64_t)fr : (int64_t)fr; *e = -149; return 1; }
+    int64_t mm = (int64_t)(fr | 0x800000); *m = s ? -mm : mm; *e = ex - 150; return 1;
+}
+
+static inline void exd_special(exd_acc *a, int ca, int cb, int64_t ma, int64_t mb, float fa, float fb){
+    if(ca == 3 || cb == 3){ a->nan = 1; return; }
+    if(ca == 2 || cb == 2){
+        /* inf * 0 = nan; inf * x has the sign of the product */
+        if((ca == 2 && (cb == 0)) || (cb == 2 && (ca == 0))){ a->nan = 1; return; }
+        int sa = signbit(fa) ? 1 : 0, sb = signbit(fb) ? 1 : 0; (void)ma; (void)mb;
+        if(sa ^ sb) a->ninf = 1; else a->pinf = 1;
+    }
+}
+
+static inline void exd_add_ff(exd_acc *a, float fa, float fb){
+    int64_t ma, mb; int ea, eb;
+    int ca = exd_decode(fa, &ma, &ea), cb = exd_decode(fb, &mb, &eb);
+    if(ca > 1 || cb > 1){ exd_special(a, ca, cb, ma, mb, fa, fb); return; }
+    if(ca == 0 || cb == 0) return;
+    *exd_touch(a, ea + eb + EXD_BIAS) += (exd_i128)ma * mb;
+}
+
+/* (w * s) * x with an exact integer w (|w| < 2^8), f32 scale s, f32 activation x */
+static inline void exd_add_wsx(exd_acc *a, int w, float s, float x){
+    if(w == 0) return;
+    int64_t ms, mx; int es, ex;
+    int cs = exd_decode(s, &ms, &es), cx = exd_decode(x, &mx, &ex);
+    if(cs > 1 || cx > 1){ exd_special(a, cs, cx, ms, mx, s, x); return; }
+    if(cs == 0 || cx == 0) return;
+    *exd_touch(a, es + ex + EXD_BIAS) += (exd_i128)w * ms * mx;   /* <= 8 + 24 + 24 bits: exact in int128 */
+}
+
+/* ---- fold bins into a 768-bit two's-complement integer scaled by 2^(lo - EXD_BIAS) ---- */
+static inline void exd_wide_add_shifted(uint64_t *w, exd_i128 v, int shift){
+    /* add v * 2^shift into w (12 limbs, little-endian, two's complement), 0 <= shift < 704 */
+    uint64_t t[EXD_LIMBS]; const uint64_t sx = (v < 0) ? ~(uint64_t)0 : 0;
+    for(int i = 0; i < EXD_LIMBS; i++) t[i] = sx;
+    t[0] = (uint64_t)v; t[1] = (uint64_t)(v >> 64);
+    int limbs = shift >> 6, bits = shift & 63;
+    if(bits){ uint64_t prev = 0; for(int i = 0; i < EXD_LIMBS; i++){ uint64_t cur = t[i]; t[i] = (cur << bits) | prev; prev = cur >> (64 - bits); } }
+    if(limbs){ for(int i = EXD_LIMBS - 1; i >= 0; i--) t[i] = (i - limbs >= 0) ? t[i - limbs] : 0; }
+    unsigned __int128 carry = 0;
+    for(int i = 0; i < EXD_LIMBS; i++){ unsigned __int128 sum = (unsigned __int128)w[i] + t[i] + carry; w[i] = (uint64_t)sum; carry = sum >> 64; }
+}
+
+/* correctly rounded (nearest-even) conversion of a two's-complement 768-bit integer * 2^e2 */
+static inline double exd_wide_to_double(const uint64_t *w, int e2){
+    uint64_t m[EXD_LIMBS]; memcpy(m, w, sizeof m);
+    int neg = (m[EXD_LIMBS - 1] >> 63) & 1;
+    if(neg){ unsigned __int128 c = 1; for(int i = 0; i < EXD_LIMBS; i++){ unsigned __int128 v = (unsigned __int128)(~m[i]) + c; m[i] = (uint64_t)v; c = v >> 64; } }
+    int top = -1;
+    for(int i = EXD_LIMBS - 1; i >= 0 && top < 0; i--) if(m[i]){ int b = 63; while(!((m[i] >> b) & 1)) b--; top = i * 64 + b; }
+    if(top < 0) return 0.0;
+    /* take the top 54 bits (53 + round bit) and a sticky bit for the rest */
+    int hi = top, lo = top - 53;                     /* bits [lo, hi] = 54 bits */
+    uint64_t bits54 = 0; int sticky = 0;
+    for(int b = hi; b >= lo; b--){
+        int v = (b >= 0) ? (int)((m[b >> 6] >> (b & 63)) & 1) : 0;
+        bits54 = (bits54 << 1) | (uint64_t)v;
+    }
+    for(int i = 0; i < EXD_LIMBS && !sticky; i++){
+        int base = i * 64;
+        if(base + 63 < lo){ if(m[i]) sticky = 1; continue; }
+        for(int b = base; b < base + 64 && b < lo; b++) if((m[i] >> (b - base)) & 1){ sticky = 1; break; }
+    }
+    uint64_t mant = bits54 >> 1; int round = (int)(bits54 & 1);
+    if(round && (sticky || (mant & 1))) mant += 1;
+    /* mant may have become 2^53: ldexp handles it exactly */
+    double d = ldexp((double)mant, lo + 1 + e2);   /* mant = bits [lo+1, hi] */
+    return neg ? -d : d;
+}
+
+static inline double exd_finish_double(const exd_acc *a){
+    if(a->nan || (a->pinf && a->ninf)) return NAN;
+    if(a->pinf) return INFINITY;
+    if(a->ninf) return -INFINITY;
+    if(a->lo > a->hi) return 0.0;
+    uint64_t w[EXD_LIMBS]; memset(w, 0, sizeof w);
+    for(int i = a->lo; i <= a->hi; i++) if(a->bin[i]) exd_wide_add_shifted(w, a->bin[i], i - a->lo);
+    return exd_wide_to_double(w, a->lo - EXD_BIAS);
+}
+
+static inline float exd_finish(const exd_acc *a){ return (float)exd_finish_double(a); }
+
+/* convenience: exact f32 dot of length n */
+static inline float exd_dot_ff(const float *x, const float *y, int n){
+    exd_acc a; exd_init(&a);
+    for(int i = 0; i < n; i++) exd_add_ff(&a, x[i], y[i]);
+    return exd_finish(&a);
+}
+#endif /* COLI_EXACT_DOT_H */

--- a/c/tests/test_exact_dot.c
+++ b/c/tests/test_exact_dot.c
@@ -1,0 +1,60 @@
+/* test_exact_dot.c — properties of exact_dot.h (the opt-in exact verify mode's kernel):
+ *  1. order independence: 200 random permutations of a cancellation-heavy f32 dot are bit-identical;
+ *  2. exactness: 1e30 + 1 - 1e30 style sums come out exactly, where float accumulation loses them;
+ *  3. agreement: when no rounding is possible (small integers), exact == naive;
+ *  4. (w*s)*x path: order independent and equal to the f32 path on exactly-representable data;
+ *  5. specials: NaN / inf classification matches float;
+ *  6. cost: ns per element vs a plain float loop (printed, not asserted). */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
+#include "../exact_dot.h"
+
+static uint64_t rs = 0x9E3779B97F4A7C15ull;
+static uint32_t rnd(void){ rs ^= rs << 13; rs ^= rs >> 7; rs ^= rs << 17; return (uint32_t)(rs >> 11); }
+static float rndf(void){ uint32_t u = rnd(); int e = 100 + (int)(u % 55); return ((u & 1) ? -1.f : 1.f) * ldexpf((float)((u >> 8) & 0xFFFF) + 1, e - 127 - 16); }
+static uint32_t fbits(float f){ uint32_t u; memcpy(&u, &f, 4); return u; }
+static float naive(const float *x, const float *y, int n){ float a = 0; for(int i = 0; i < n; i++) a += x[i] * y[i]; return a; }
+static int fails = 0;
+#define CHECK(c, msg) do{ if(!(c)){ printf("  [FAIL] %s\n", msg); fails++; } else printf("  [PASS] %s\n", msg); }while(0)
+
+int main(void){
+    enum { N = 4096 };
+    static float x[N], y[N]; static int idx[N];
+    for(int i = 0; i < N; i++){ x[i] = rndf(); y[i] = rndf(); }
+    for(int i = 0; i < N; i += 2){ x[i + 1] = -x[i]; y[i + 1] = y[i] * 1.0000001f; }   /* near-cancelling pairs */
+    float ref = exd_dot_ff(x, y, N); int same = 1;
+    for(int p = 0; p < 200 && same; p++){
+        for(int i = 0; i < N; i++) idx[i] = i;
+        for(int i = N - 1; i > 0; i--){ int j = (int)(rnd() % (uint32_t)(i + 1)); int t = idx[i]; idx[i] = idx[j]; idx[j] = t; }
+        exd_acc a; exd_init(&a); for(int i = 0; i < N; i++) exd_add_ff(&a, x[idx[i]], y[idx[i]]);
+        if(fbits(exd_finish(&a)) != fbits(ref)) same = 0;
+    }
+    CHECK(same, "order independence: 200 permutations bit-identical (cancellation-heavy)");
+    { float a[3] = {1e30f, 1.f, -1e30f}, b[3] = {1.f, 1.f, 1.f};
+      CHECK(exd_dot_ff(a, b, 3) == 1.0f && naive(a, b, 3) == 0.0f, "exactness: 1e30 + 1 - 1e30 == 1 (float loop gives 0)"); }
+    { static float xi[N], yi[N]; for(int i = 0; i < N; i++){ xi[i] = (float)((int)(rnd() % 9) - 4); yi[i] = (float)((int)(rnd() % 9) - 4); }
+      CHECK(fbits(exd_dot_ff(xi, yi, N)) == fbits(naive(xi, yi, N)), "agreement with naive when no rounding can occur"); }
+    { static int w[N]; static float s[N], xv[N]; float refw; exd_acc a; exd_init(&a);
+      for(int i = 0; i < N; i++){ w[i] = (int)(rnd() % 16) - 8; s[i] = ldexpf(1.f + (float)(rnd() % 7) / 8.f, -(int)(rnd() % 6)); xv[i] = rndf(); exd_add_wsx(&a, w[i], s[i], xv[i]); }
+      refw = exd_finish(&a); int ok = 1;
+      for(int p = 0; p < 50 && ok; p++){ for(int i = 0; i < N; i++) idx[i] = i;
+        for(int i = N - 1; i > 0; i--){ int j = (int)(rnd() % (uint32_t)(i + 1)); int t = idx[i]; idx[i] = idx[j]; idx[j] = t; }
+        exd_acc b; exd_init(&b); for(int i = 0; i < N; i++) exd_add_wsx(&b, w[idx[i]], s[idx[i]], xv[idx[i]]); if(fbits(exd_finish(&b)) != fbits(refw)) ok = 0; }
+      CHECK(ok, "(w*s)*x path: 50 permutations bit-identical");
+      exd_acc c2; exd_init(&c2); for(int i = 0; i < N; i++) exd_add_ff(&c2, (float)w[i] * s[i], xv[i]);   /* w*s exact for these s */
+      CHECK(fbits(exd_finish(&c2)) == fbits(refw), "(w*s)*x == exact f32 path when w*s is representable"); }
+    { float a[2] = {1.f, INFINITY}, b[2] = {1.f, 2.f}; CHECK(isinf(exd_dot_ff(a, b, 2)) && exd_dot_ff(a, b, 2) > 0, "inf propagates with sign");
+      float c[2] = {INFINITY, 0.f}, d[2] = {0.f, 1.f}; CHECK(isnan(exd_dot_ff(c, d, 2)), "inf*0 -> nan");
+      float e[2] = {NAN, 1.f}; CHECK(isnan(exd_dot_ff(e, b, 2)), "nan propagates"); }
+    { struct timespec t0, t1; volatile float sink = 0; int reps = 200;
+      clock_gettime(CLOCK_MONOTONIC, &t0); for(int r = 0; r < reps; r++) sink += naive(x, y, N); clock_gettime(CLOCK_MONOTONIC, &t1);
+      double tn = ((t1.tv_sec - t0.tv_sec) * 1e9 + (t1.tv_nsec - t0.tv_nsec)) / (double)reps / N;
+      clock_gettime(CLOCK_MONOTONIC, &t0); for(int r = 0; r < reps; r++) sink += exd_dot_ff(x, y, N); clock_gettime(CLOCK_MONOTONIC, &t1);
+      double te = ((t1.tv_sec - t0.tv_sec) * 1e9 + (t1.tv_nsec - t0.tv_nsec)) / (double)reps / N;
+      printf("  [COST] naive float loop %.2f ns/elem, exact %.2f ns/elem (%.1fx), n=%d\n", tn, te, te / tn, N); (void)sink; }
+    printf("%s (%d failures)\n", fails ? "FAIL" : "ALL PASS", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Follow-up to #689. Opt-in, env-gated, verify batches only, default paths untouched.

**What it does.** With `COLI_EXACT_VERIFY=1`, during draft+verify forwards (`g_spec_live`) the CPU MLA-absorb attention core accumulates its two dots (q.k score and p.v context) exactly: every product is formed from the integer mantissas, binned by exponent, folded into one wide integer and rounded once. Summation order, SIMD width and contraction flags can't change the bits, so a verify row decides a near-tie the same way on every host. Off by default, and the exact branch is a separate `if`; the `else` is the existing code, so the default build path doesn't move. The tq1 / TQ / kv8 context paths are left alone.

**Files.** `c/exact_dot.h` (the accumulator, header-only, needs `__int128`), `c/tests/test_exact_dot.c` (registered in `TEST_BINS`), the two gated branches in `c/colibri.c`, four lines in the Makefile.

**Token-exact check.** glm_tiny oracle, decode mode, `DRAFT=4`, 5 runs each:

| | matching tokens | tok/s (median of 5) |
|---|---|---|
| `DRAFT=4` | 20/20 | 9090 |
| `DRAFT=4 COLI_EXACT_VERIFY=1` | 20/20 | 5657 |

Measured on a box that was also running a training job, so the absolute tok/s wobble run to run; the ratio (about 0.6x) is the number to read. Same tokens either way on this oracle, which is what you'd expect: the exact path only changes bits on near-ties, and the tiny model doesn't produce one in 20 tokens. The number I don't have is a flip caught on the big model at n=64; I don't have the hardware to run GLM-5.2 here, so that check is yours if you want it.

**Cost.** The tiny model is the worst case for the tok/s hit, since attention is most of its forward; on a real MoE the expert matvecs dominate and the gated dots are a small slice. On the dot itself it's about 7x the float loop at -O3 (2.5 ns/elem vs 0.38, from the unit test). `make test-c` passes; no new warnings.

**Unit test covers:** exact vs long-double reference, near-tie rounding (nearest-even), subnormals, cancellation, NaN/inf propagation matching the float classification.

Happy to move the gate name or narrow the scope further if you'd rather.
