### PR TITLE
feat(web): drop redundant Medium from GLM 5.3 reasoning selector

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -39,30 +39,13 @@ import { persistPublicSettings, stored } from "@/lib/storage"
 import { Markdown } from "@/components/Markdown"
 import { cn } from "@/lib/utils"
 import { useLocale } from "./i18n"
+import { REASONING_EFFORT, modelForcesReasoning, reasoningLevelsFor, type ReasoningLevel } from "@/lib/reasoning"
 
 const message = (role: ChatMessage["role"], content: string): ChatMessage => {
   let id: string
   try { id = crypto.randomUUID() } catch { id = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => { const r = Math.random() * 16 | 0; return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16) }) }
   return { id, role, content }
 }
-
-/* Reasoning depth for GLM. The engine renders enable_thinking + reasoning_effort;
-   these levels map onto the words GLM understands (Low/Medium/High/Max), and "off"
-   turns thinking off entirely. GLM 5.3 cannot disable reasoning, so "off" is dropped
-   for it -- the model's own constraint, mirrored in the control rather than sent and
-   silently ignored. */
-type ReasoningLevel = "off" | "low" | "medium" | "high" | "max"
-
-const REASONING_EFFORT: Record<Exclude<ReasoningLevel, "off">, string> = {
-  low: "low", medium: "medium", high: "high", max: "xhigh",
-}
-
-const modelForcesReasoning = (model: string) => /5\.3/.test(model)
-
-const reasoningLevelsFor = (model: string): ReasoningLevel[] =>
-  modelForcesReasoning(model)
-    ? ["low", "medium", "high", "max"]
-    : ["off", "low", "medium", "high", "max"]
 
 export default function App() {
   const { t, locale, setLocale, locales } = useLocale()
@@ -178,11 +161,13 @@ export default function App() {
   // EFFECT #6
   useEffect(() => { setLastRun(null) }, [cacheSlot])
 
-  /* GLM 5.3 cannot turn reasoning off. If the user switches to such a model
-     while "off" is selected, lift it to a sane on-state instead of sending a
-     level the model will ignore. */
+  /* GLM 5.3 cannot turn reasoning off and has no distinct "medium" (it collapses
+     onto High). If the user switches to such a model while "off" or "medium" is
+     selected, lift it to a level the model actually honors instead of leaving the
+     control on a value it no longer offers. */
   useEffect(() => {
-    if (modelForcesReasoning(model)) setReasoning((level) => level === "off" ? "high" : level)
+    if (modelForcesReasoning(model))
+      setReasoning((level) => (level === "off" || level === "medium" ? "high" : level))
   }, [model])
 
   // EFFECT #7

--- a/web/src/lib/reasoning.test.ts
+++ b/web/src/lib/reasoning.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import { REASONING_EFFORT, modelForcesReasoning, reasoningLevelsFor } from "./reasoning"
+
+describe("modelForcesReasoning", () => {
+  it("is true for GLM 5.3 ids and false otherwise", () => {
+    expect(modelForcesReasoning("glm-5.3-flash-colibri")).toBe(true)
+    expect(modelForcesReasoning("glm-5.2-colibri")).toBe(false)
+    expect(modelForcesReasoning("qwen3.8-colibri")).toBe(false)
+  })
+})
+
+describe("reasoningLevelsFor", () => {
+  it("offers the full ladder (incl. off and medium) for non-forced models", () => {
+    expect(reasoningLevelsFor("glm-5.2-colibri")).toEqual([
+      "off",
+      "low",
+      "medium",
+      "high",
+      "max",
+    ])
+  })
+
+  it("drops off and the redundant medium for GLM 5.3 (template is Low/High/Max)", () => {
+    const levels = reasoningLevelsFor("glm-5.3-flash-colibri")
+    expect(levels).toEqual(["low", "high", "max"])
+    expect(levels).not.toContain("off")
+    expect(levels).not.toContain("medium")
+  })
+})
+
+describe("REASONING_EFFORT", () => {
+  it("maps max onto the engine's xhigh effort", () => {
+    expect(REASONING_EFFORT.max).toBe("xhigh")
+    expect(REASONING_EFFORT.low).toBe("low")
+  })
+})

--- a/web/src/lib/reasoning.ts
+++ b/web/src/lib/reasoning.ts
@@ -1,0 +1,18 @@
+/* Reasoning depth for GLM. The engine renders enable_thinking + reasoning_effort;
+   these levels map onto the words GLM understands (Low/Medium/High/Max), and "off"
+   turns thinking off entirely. GLM 5.3 cannot disable reasoning, and its template
+   exposes only Low/High/Max (it renders "medium" as High). So for 5.3 both "off" and
+   the now-redundant "medium" are dropped -- mirroring the model's own constraint in
+   the control instead of offering a level it silently collapses onto High. */
+export type ReasoningLevel = "off" | "low" | "medium" | "high" | "max"
+
+export const REASONING_EFFORT: Record<Exclude<ReasoningLevel, "off">, string> = {
+  low: "low", medium: "medium", high: "high", max: "xhigh",
+}
+
+export const modelForcesReasoning = (model: string) => /5\.3/.test(model)
+
+export const reasoningLevelsFor = (model: string): ReasoningLevel[] =>
+  modelForcesReasoning(model)
+    ? ["low", "high", "max"]
+    : ["off", "low", "medium", "high", "max"]


### PR DESCRIPTION
Follow-up to #1382, closing the nit raised in review.

On GLM 5.3 the chat template exposes only Low/High/Max and renders `medium` as High, so the Medium entry duplicated High for reasoning-forced models. `reasoningLevelsFor` now drops it (returns `[low, high, max]`; `off` was already dropped), and the model-switch effect lifts a selected `off`/`medium` to `high` so the selector never sits on a value the model no longer offers.

## What changed
- `reasoningLevelsFor` returns `[low, high, max]` for models that force reasoning (`/5.3/`); the full `[off, low, medium, high, max]` ladder is unchanged for every other model.
- Switching to a reasoning-forced model now lifts `off` **or** `medium` to `high` (previously only `off`).
- Extracted the reasoning helpers (`ReasoningLevel`, `REASONING_EFFORT`, `modelForcesReasoning`, `reasoningLevelsFor`) into `src/lib/reasoning.ts` so they are unit-testable in isolation, mirroring `lib/api.ts`.

## Validation
- `npm run build` (tsc -b + vite): clean, 0 type errors
- `npm test` (vitest): 37 passed, including the new `lib/reasoning.test.ts` (full ladder on 5.2, `[low, high, max]` on 5.3, `max -> xhigh` mapping)

Thanks a lot for the thorough review on #1382 (checking each pinned SHA and testing the path cases against the gateway on dev, plus the note on the 5.3 template). Really appreciate it, and I intend to keep contributing to the project.
