### PR TITLE
docs(windows): CUDA DLL builds from a git clone in c/, not from the release zip (#1405)

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -31,7 +31,7 @@ Windows 11 pro english.\
 **Software installs:**\
 `- nvidia drivers` from https://www.nvidia.com/en-us/drivers/\
 `- nvidia cuda toolkit` from https://developer.nvidia.com/cuda-downloads?target_os=Windows&target_arch=x86_64&target_version=11&target_type=exe_local\
-`- msys2` from https://github.com/msys2/msys2-installer/releases/download/2026-06-11/msys2-x86_64-20260611.exe\
+`- msys2` from <https://github.com/msys2/msys2-installer/releases/download/2026-06-11/msys2-x86_64-20260611.exe> (the angle brackets keep the trailing line-break marker out of the link; the old form 404ed, #1405)\
 `- Microsoft Visual Studio 2022 built tools` installer from https://aka.ms/vs/17/release/vs_buildtools.exe then install Desktop Development with C++\
 `- winget install git.git python.python.3.14`\
 \
@@ -49,6 +49,8 @@ To see which code optimizations are active in gcc compiler with the native flag 
 For guidance about gcc optimizations, a good source cab be: `https://wiki.gentoo.org/wiki/GCC_optimization`\
 \
 **colibri.exe and coli_cuda.*** build from MS Visual Studio and Nvidia CUDA Toolkit:\
+\
+> **Build from a git clone, inside `c/`.** The release zip ships the engines and the Python only, no `Makefile` and no `backend_cuda.cu`: `make cuda-dll` in the unzipped release folder answers `No rule to make target 'cuda-dll'` (#1405). `git clone https://github.com/JustVugg/colibri`, then every `make` below runs in `colibri\c`.\
 Microsoft Visual Studio tools includes a `vcvars64.bat` batch file that appropriately sets all the paths. \
 It is in `"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"`\
 \
@@ -59,7 +61,7 @@ Open a command prompt shell (`cmd`, not powershell), cd to subfolder `c\` of the
 `%comspec% /k "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"`
 `set PATH=%PATH%;C:\msys64\usr\bin`\
 `cd C:\Users\YOUR_USER\COLIBRI_REPO_FOLDER\c`\
-`make cuda-dll CUDA-ARCH=sm_89`\
+`make cuda-dll CUDA_ARCH=sm_89`\
 `make colibri.exe CUDA_DLL=1 ARCH=native`\
 `make iobench.exe`\
 \


### PR DESCRIPTION
Three fixes to docs/windows.md from #1405: the msys2 installer link had the markdown line-break backslash glued to the URL (404); CUDA-ARCH is CUDA_ARCH; and a note at the top of the build steps that the release zip has no Makefile or sources, so the DLL is built from a git clone inside c/. Docs only.