### PR TITLE
ci: build the portable Windows CUDA DLL and publish it as an artifact (#1405)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -752,13 +752,15 @@ jobs:
       - name: MSVC environment (puts cl.exe on PATH for nvcc -ccbin)
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
       - name: Install CUDA toolkit (compiler only)
-        uses: Jimver/cuda-toolkit@4bd727d5619dc6fa323b1e76c3aa5dca94f5ec6d # v0.2.19
+        uses: Jimver/cuda-toolkit@b8bf9c6c28f8a92fbb04dcfcaee872e60c57462d # v0.2.36
         with:
-          # Same pin as engine-cuda-syntax: v0.2.19's version table stops at
-          # 12.6.2. This installs to the default "C:\Program Files\NVIDIA GPU
-          # Computing Toolkit\..." path, so CUDA_HOME is space-bearing here —
-          # which is exactly the #314 regression this job would have caught.
-          cuda: '12.6.2'
+          # 12.8 is the floor for sm_120 (RTX 50-series), which the portable
+          # DLL below carries; the 12.x runtime keeps the driver floor where
+          # users already are (#1405). v0.2.19 stopped at 12.6.2, hence the
+          # action bump. This installs to the default "C:\Program Files\NVIDIA
+          # GPU Computing Toolkit\..." path, so CUDA_HOME is space-bearing here
+          # -- which is exactly the #314 regression this job would have caught.
+          cuda: '12.8.1'
           method: network
           # cudart as well as nvcc: unlike the Linux job (which only needs to
           # *compile* backend_cuda.cu), cuda-dll links it, and on Windows the
@@ -803,12 +805,16 @@ jobs:
         shell: msys2 {0}
         run: |
           cd c
-          # CUDA_ARCH is pinned: the default is `native`, which asks the driver
-          # what card is present — there is none here, so it must be explicit.
-          # sm_80 matches engine-cuda-syntax and is supported by the 12.6 pin.
-          make cuda-dll CUDA_ARCH=sm_80
+          # CUDA_ARCH is explicit: the default is `native`, which asks the driver
+          # what card is present, and there is none here. `portable` is the DLL
+          # a Windows user can download and run: SASS for sm_80/86/89/90/120
+          # plus PTX, one file for the 30xx, 40xx and 50xx cards (#1405). The
+          # runner cannot execute it; the artifact below is for the people who
+          # can, until the release ships it.
+          make cuda-dll CUDA_ARCH=portable
           test -f coli_cuda.dll || { echo "cuda-dll reported success but produced no DLL" >&2; exit 1; }
-          echo "coli_cuda.dll built (MSVC host)"
+          ls -l coli_cuda.dll
+          echo "coli_cuda.dll built (MSVC host, portable gencode)"
       - name: make colibri CUDA_DLL=1 (host links backend_loader, not cudart)
         shell: msys2 {0}
         run: |
@@ -816,6 +822,28 @@ jobs:
           make colibri CUDA_DLL=1
           test -f colibri.exe || { echo "colibri CUDA_DLL=1 reported success but produced no exe" >&2; exit 1; }
           echo "colibri.exe built against the DLL loader"
+          make qwen36 CUDA_DLL=1
+          test -f qwen36.exe || { echo "qwen36 CUDA_DLL=1 reported success but produced no exe" >&2; exit 1; }
+          echo "qwen36.exe built against the DLL loader"
+      - name: Collect the runtime the DLL links (cudart64_12.dll)
+        shell: bash
+        run: |
+          # coli_cuda.dll links cudart dynamically; without the toolkit on the
+          # user's machine the loader reports "module or one of its dependencies
+          # was not found". Ship the runtime next to it, from this same toolkit.
+          ls "$CUDA_PATH/bin"/cudart64_*.dll
+          cp "$CUDA_PATH/bin"/cudart64_*.dll c/
+      - name: Publish the portable DLL for people with a card (#1405)
+        uses: actions/upload-artifact@v4
+        with:
+          name: coli_cuda-windows-portable
+          if-no-files-found: error
+          retention-days: 30
+          path: |
+            c/coli_cuda.dll
+            c/cudart64_*.dll
+            c/colibri.exe
+            c/qwen36.exe
 
   web:
     name: Web UI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -827,6 +827,12 @@ jobs:
           make qwen36.exe CUDA_DLL=1
           test -f qwen36.exe || { echo "qwen36 CUDA_DLL=1 reported success but produced no exe" >&2; exit 1; }
           echo "qwen36.exe built against the DLL loader"
+          # kimi_k3 links the same loader: three engines share coli_cuda.dll.
+          # deepseek_v4 has its own DLL (coli_cuda_dsv4.dll, Makefile.deepseek-v4)
+          # and joins in a later step; inkling's CUDA object has no Windows loader.
+          make kimi_k3.exe CUDA_DLL=1
+          test -f kimi_k3.exe || { echo "kimi_k3 CUDA_DLL=1 reported success but produced no exe" >&2; exit 1; }
+          echo "kimi_k3.exe built against the DLL loader"
       - name: Collect the runtime the DLL links (cudart64_12.dll)
         shell: bash
         run: |
@@ -846,6 +852,7 @@ jobs:
             c/cudart64_*.dll
             c/colibri.exe
             c/qwen36.exe
+            c/kimi_k3.exe
 
   web:
     name: Web UI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -822,7 +822,9 @@ jobs:
           make colibri CUDA_DLL=1
           test -f colibri.exe || { echo "colibri CUDA_DLL=1 reported success but produced no exe" >&2; exit 1; }
           echo "colibri.exe built against the DLL loader"
-          make qwen36 CUDA_DLL=1
+          # qwen36.exe, not qwen36: only colibri has a phony alias; the bare
+          # name falls into make's builtin rule and links qwen36.c alone.
+          make qwen36.exe CUDA_DLL=1
           test -f qwen36.exe || { echo "qwen36 CUDA_DLL=1 reported success but produced no exe" >&2; exit 1; }
           echo "qwen36.exe built against the DLL loader"
       - name: Collect the runtime the DLL links (cudart64_12.dll)

--- a/c/backend_loader.c
+++ b/c/backend_loader.c
@@ -99,6 +99,8 @@ typedef int            (*fn_fp8_set_lut)(const float *lut);
 typedef int            (*fn_matmul)(ColiCudaTensor **tensor, float *y, const float *x,
                                     const void *weights, const float *scales,
                                     int fmt, int S, int I, int O, int device, int gs);
+typedef int            (*fn_matmul_mxfp4)(float *y, const float *x, const unsigned char *q4,
+                                          const unsigned char *e8s, int S, int I, int O);
 typedef void           (*fn_tensor_free)(ColiCudaTensor *tensor);
 typedef size_t         (*fn_tensor_bytes)(const ColiCudaTensor *tensor);
 typedef size_t         (*fn_tensor_vram)(const ColiCudaTensor *tensor);
@@ -174,6 +176,7 @@ static struct {
     fn_e8_set_grid     e8_set_grid;
     fn_fp8_set_lut     fp8_set_lut;
     fn_matmul          matmul;
+    fn_matmul_mxfp4    matmul_mxfp4;
     fn_tensor_free     tensor_free;
     fn_tensor_bytes    tensor_bytes;
     fn_tensor_vram     tensor_vram;
@@ -1420,6 +1423,10 @@ static int coli_cuda_load(void){
     RESOLVE_OPT(e8_set_grid, fn_e8_set_grid)
     RESOLVE_OPT(fp8_set_lut, fn_fp8_set_lut)
     RESOLVE(matmul,         fn_matmul)
+    /* Kimi K3's MXFP4 expert matmul. Optional: a DLL built before it exports
+     * nothing by this name, and the wrapper's 0 is the engine's own "fall back
+     * to CPU" result, so an older DLL still serves GLM and Qwen3.6 (#1405). */
+    RESOLVE_OPT(matmul_mxfp4,   fn_matmul_mxfp4)
     RESOLVE(tensor_free,    fn_tensor_free)
     RESOLVE(tensor_bytes,   fn_tensor_bytes)
     /* Optional, same reasoning as e8_set_grid above: a DLL predating #687
@@ -1619,6 +1626,12 @@ int coli_cuda_matmul(ColiCudaTensor **tensor, float *y, const float *x,
                      int fmt, int S, int I, int O, int device, int gs){
     if(!g_cuda.available) return 0;
     return g_cuda.matmul(tensor, y, x, weights, scales, fmt, S, I, O, device, gs);
+}
+
+int coli_cuda_matmul_mxfp4(float *y, const float *x, const unsigned char *q4,
+                           const unsigned char *e8s, int S, int I, int O){
+    if(!g_cuda.available || !g_cuda.matmul_mxfp4) return 0;   /* 0 = CPU path */
+    return g_cuda.matmul_mxfp4(y, x, q4, e8s, S, I, O);
 }
 
 void coli_cuda_tensor_free(ColiCudaTensor *tensor){

--- a/c/tests/test_backend_loader.py
+++ b/c/tests/test_backend_loader.py
@@ -874,7 +874,7 @@ class LoaderStubFixtureTest(unittest.TestCase):
             cls.fixture = None
 
     def test_abi_is_derived_from_the_loader_source(self):
-        """47 mandatory + 6 optional, parsed from backend_loader.c.
+        """47 mandatory + 7 optional, parsed from backend_loader.c.
 
         The counts are a deliberate tripwire: adding a RESOLVE to the loader
         widens the ABI every Windows DLL must satisfy, and that should be a
@@ -885,7 +885,7 @@ class LoaderStubFixtureTest(unittest.TestCase):
         """
         f = self.fixture
         self.assertEqual(len(f.mandatory), 47)
-        self.assertEqual(len(f.optional), 6)
+        self.assertEqual(len(f.optional), 7)   # +matmul_mxfp4 (kimi_k3 via the DLL, #1405)
         self.assertEqual(len(f.exports), 53)
         self.assertEqual(len(f.exports), len(f.mandatory) + len(f.optional))
         self.assertIn("coli_cuda_init", f.mandatory)

--- a/c/tests/test_backend_loader.py
+++ b/c/tests/test_backend_loader.py
@@ -886,7 +886,7 @@ class LoaderStubFixtureTest(unittest.TestCase):
         f = self.fixture
         self.assertEqual(len(f.mandatory), 47)
         self.assertEqual(len(f.optional), 7)   # +matmul_mxfp4 (kimi_k3 via the DLL, #1405)
-        self.assertEqual(len(f.exports), 53)
+        self.assertEqual(len(f.exports), 54)
         self.assertEqual(len(f.exports), len(f.mandatory) + len(f.optional))
         self.assertIn("coli_cuda_init", f.mandatory)
         self.assertIn("coli_cuda_e8_set_grid", f.optional)

--- a/c/tests/test_glm53_dashboard.py
+++ b/c/tests/test_glm53_dashboard.py
@@ -109,7 +109,12 @@ class Glm53DashboardTest(unittest.TestCase):
         self.assertEqual(t["forwards"], 3, "one forward per generated token")
         self.assertEqual(t["expert_wait_s"], 0.0)
         phases = t["expert_disk_s"] + t["expert_matmul_s"] + t["attention_s"] + t["lm_head_s"]
-        self.assertGreater(phases, 0.0)
+        # Not > 0: PROF prints milliseconds and a 3-token turn on a tiny model
+        # finishes under a millisecond on a fast runner, so every phase rounds
+        # to 0.000 and the sum is legitimately zero (CI, 2026-09-10). What the
+        # contract holds is that phases never exceed the wall.
+        self.assertGreaterEqual(phases, 0.0)
+        self.assertGreater(t["wall_s"], 0.0)
         self.assertLessEqual(phases, t["wall_s"] * 1.05 + 0.01,
                              "phase timings exceed the wall clock: a timer is double-counting")
 

--- a/c/tests/test_qwen36_dashboard.py
+++ b/c/tests/test_qwen36_dashboard.py
@@ -114,7 +114,12 @@ class Qwen36DashboardTest(unittest.TestCase):
         self.assertEqual(t["completion_tokens"], 3)
         self.assertEqual(t["forwards"], 3, "prefill plus one forward per token after the first")
         phases = t["expert_disk_s"] + t["expert_matmul_s"] + t["attention_s"] + t["lm_head_s"]
-        self.assertGreater(phases, 0.0)
+        # Not > 0: PROF prints milliseconds and a 3-token turn on a tiny model
+        # finishes under a millisecond on a fast runner, so every phase rounds
+        # to 0.000 and the sum is legitimately zero (CI, 2026-09-10). What the
+        # contract holds is that phases never exceed the wall.
+        self.assertGreaterEqual(phases, 0.0)
+        self.assertGreater(t["wall_s"], 0.0)
         self.assertLessEqual(phases, t["wall_s"] * 1.05 + 0.01,
                              "phase timings exceed the wall clock: a timer is double-counting")
 


### PR DESCRIPTION
Step 1 of #1405. The Windows CUDA job built the DLL for sm_80 on CUDA 12.6.2 and discarded it. Now:

- Jimver/cuda-toolkit bumped to v0.2.36 (pinned by SHA), CUDA 12.8.1: the floor for sm_120 (RTX 50-series) while staying on the 12.x runtime.
- `make cuda-dll CUDA_ARCH=portable`: SASS for sm_80/86/89/90/120 plus a compute_120 PTX fallback, from the existing Makefile block.
- `colibri.exe` and `qwen36.exe` built with `CUDA_DLL=1` (runtime loader; CPU-only when the DLL is absent).
- `cudart64_12.dll` copied from the same toolkit, since the DLL links it dynamically.
- All four published as the `coli_cuda-windows-portable` artifact (30 days).

The runner has no GPU: this proves the build, not the run. The reporter has 30xx/40xx/50xx cards and offered to test the artifact; step 2 (shipping the same files in `release.yml`) waits for that.

Risk: the DeepGEMM fp8 kernels now compile for five architectures instead of one, so the job takes longer; if it exceeds the runner budget the fix is to split the gencode list, not to drop archs.