### PR TITLE
cuda tier: size the VRAM prefix from the VRAM budget on a single GPU, dense trunk on a card that holds it (#1409)

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -826,6 +826,20 @@ def env_for(a):
                                         kv_slots=requested_kv_slots(a,e))
                         e.update(environment_for_plan(plan,e,cuda_enabled=True))
                         vt=plan["tiers"]["vram"]
+                        # #1409: the dense trunk is read on every token; leaving
+                        # it on the CPU next to a 30 GB expert tier is the
+                        # slowest possible placement of a card that could hold
+                        # it. Put it on the GPU when the plan says it fits with
+                        # room for experts, and take its bytes out of the expert
+                        # budget: dense uploads are lazy, and a tier that already
+                        # filled the card makes them fail (#687). Explicit
+                        # CUDA_DENSE / CUDA_EXPERT_GB from the user always win.
+                        dense=int(plan["tiers"].get("ram",{}).get("dense_bytes",0) or 0)
+                        room=int(vt.get("budget_bytes",0) or 0)-dense
+                        if dense>0 and room>=4*(1024**3) and "CUDA_DENSE" not in e:
+                            e["CUDA_DENSE"]="1"
+                            if "CUDA_EXPERT_GB" in e:
+                                e["CUDA_EXPERT_GB"]=f"{room/(1024**3):.3f}"
                         names=",".join(g["name"].strip() for g in gpus)
                         print(f"  {C.dim}[GPU] auto-enabled CUDA · {names} · "
                               f"{format_bytes(vt['budget_bytes'])} expert tier{C.r}", file=sys.stderr)

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -11020,18 +11020,19 @@ int main(int argc, char **argv){
     if(getenv("CUDA_RELEASE_HOST")) g_cuda_release_host=atoi(getenv("CUDA_RELEASE_HOST"));
     else if(g_cuda_ndev>1)          g_cuda_release_host=1;          /* unchanged */
     else if(g_cuda_enabled && (g_cuda_expert_gb>0||g_cuda_expert_auto)){
-        const char *pg=getenv("PIN_GB");
-        /* "large PIN_GB" = all, or >= the VRAM tier itself. Under CUDA_EXPERT_GB=auto
-         * the tier is sized to the whole card, so any explicit PIN_GB qualifies. */
-        if(pg&&*pg){
-            if(!strcmp(pg,"all")) g_cuda_release_host=1;
-            else { double p=atof(pg);
-                   if(p>0 && (g_cuda_expert_auto || p>=g_cuda_expert_gb)) g_cuda_release_host=1; }
-        }
-        if(g_cuda_release_host)
-            fprintf(stderr,"[CUDA] single-GPU with a large PIN_GB: releasing host copies of the "
-                           "VRAM tier so the RAM tier can use that memory (#686; "
-                           "CUDA_RELEASE_HOST=0 keeps them)\n");
+        /* #1409: not only under a large PIN_GB. Without the release the VRAM
+         * prefix is bounded by the RAM pin (gpu_prefix <= npin), and the RAM
+         * pin is whatever the autopin planner left after its LRU reserve: on a
+         * 5090 + 128 GB host that was 1.1 GB, so the card got 53 experts of a
+         * 30.7 GB budget and the user saw an idle GPU (#1405). With the release
+         * the prefix is priced against the VRAM budget itself (pin_load), and
+         * the host copies were provably redundant already (#686: a CUDA
+         * failure reloads from disk). An explicit CUDA_RELEASE_HOST=0 keeps
+         * the old behaviour. */
+        g_cuda_release_host=1;
+        fprintf(stderr,"[CUDA] single GPU with an expert tier: releasing host copies of the "
+                       "VRAM tier so the RAM tier can use that memory and the tier is sized "
+                       "from the VRAM budget (#686, #1409; CUDA_RELEASE_HOST=0 keeps them)\n");
     }
     if((getenv("COLI_GPU")||getenv("COLI_GPUS"))&&!g_cuda_enabled){ fprintf(stderr,"COLI_GPU(S) requires COLI_CUDA=1\n"); return 2; }
     if(g_cuda_dense&&!g_cuda_enabled){ fprintf(stderr,"CUDA_DENSE requires COLI_CUDA=1\n"); return 2; }
@@ -11326,7 +11327,15 @@ int main(int argc, char **argv){
               (expert_available-lru_reserve)/1e9, pin_bytes/1e9,
               pin_bytes+1.0<planned_pin ? "  [CAPPED by the LRU reserve]" : "");
           double pin_gb=pin_bytes/1e9;
+          /* #1409: the VRAM prefix is loaded by the same pin_load, priced against
+           * the VRAM budget (CUDA_RELEASE_HOST). A RAM pin under the 0.5 GB floor
+           * used to skip the call, and with it the whole VRAM tier. */
+          int vram_tier=0;
+#ifdef COLI_CUDA
+          vram_tier=g_cuda_enabled&&g_cuda_release_host&&(g_cuda_expert_gb>0||g_cuda_expert_auto);
+#endif
           if(pin_gb>=0.5) pin_load(&m, g_usage_path, pin_gb, 0);   /* auto-discovered: not trusted */
+          else if(vram_tier) pin_load(&m, g_usage_path, 0.0, 0);   /* VRAM prefix only, no RAM pin */
       }
       /* SEMPRE: senza clamp la LRU cresce fino a cap*76 layer = decine di GB -> OOM-kill.
        * RAM_GB assente o <=0 = budget automatico da MemAvailable. */

--- a/c/tests/test_env_defaults.py
+++ b/c/tests/test_env_defaults.py
@@ -203,8 +203,33 @@ class CudaAutoEnableTest(unittest.TestCase):
         # so it must be present and positive — never a guess or zero.
         self.assertIn("CUDA_EXPERT_GB", e)
         self.assertGreater(float(e["CUDA_EXPERT_GB"]), 0.0)
-        # Dense offload is an explicit opt-in (matches --auto-tier): not set here.
+        # No dense size in this plan: dense placement is not decided here.
         self.assertNotIn("CUDA_DENSE", e)
+
+    def test_win32_puts_the_dense_trunk_on_a_card_that_holds_it(self):
+        """#1409: a 5090 (30.7 GB tier) with a 12.5 GB dense trunk ran the trunk
+        on the CPU because the auto path never set CUDA_DENSE. When the plan says
+        the trunk fits with room for experts, it goes on the card and its bytes
+        leave the expert budget, or the lazy dense uploads fail against a full
+        tier (#687)."""
+        GPB = 1024 ** 3
+        gpus = [self._fake_gpu(name="NVIDIA GeForce RTX 5090", total_mib=34000, free_mib=33000)]
+        plan = {"tiers": {"ram": {"budget_bytes": 120 * GPB, "cache_slots_per_layer": 62,
+                                  "dense_bytes": int(12.5 * GPB)},
+                          "vram": {"budget_bytes": int(30.7 * GPB), "devices": gpus}}}
+        e = self._env_for("win32", cuda=True, gpus=gpus, plan=plan)
+        self.assertEqual(e["CUDA_DENSE"], "1")
+        self.assertAlmostEqual(float(e["CUDA_EXPERT_GB"]), 30.7 - 12.5, places=2)
+
+    def test_win32_keeps_the_dense_trunk_on_cpu_when_the_card_is_too_small(self):
+        GPB = 1024 ** 3
+        gpus = [self._fake_gpu(total_mib=16384, free_mib=15000)]
+        plan = {"tiers": {"ram": {"budget_bytes": 64 * GPB, "cache_slots_per_layer": 8,
+                                  "dense_bytes": int(12.5 * GPB)},
+                          "vram": {"budget_bytes": int(13.0 * GPB), "devices": gpus}}}
+        e = self._env_for("win32", cuda=True, gpus=gpus, plan=plan)
+        self.assertNotIn("CUDA_DENSE", e)          # 0.5 GB left for experts: not worth it
+        self.assertAlmostEqual(float(e["CUDA_EXPERT_GB"]), 13.0, places=2)
 
     def test_win32_falls_back_to_cpu_when_nvidia_smi_missing(self):
         # coli_cuda.dll present (cuda=True) but nvidia-smi absent (no GPUs found)


### PR DESCRIPTION
Fixes #1409, found through #1405: a 5090 with a 30.7 GB expert budget held 53 experts and the dense trunk stayed on the CPU, so decode streamed everything from disk at 5 s per token on a 128 GB host.

## Changes

1. **`CUDA_RELEASE_HOST` defaults on for any single GPU with an expert tier** (was: only under a large `PIN_GB`, #686). Without it `gpu_prefix <= npin`, and the autopin planner had capped the RAM pin at 1.1 GB behind its 101 GB LRU reserve, so the card got 1.1 GB too. With it the prefix is priced against the VRAM budget in `pin_load` (per row since #1394). Host copies were redundant already; `CUDA_RELEASE_HOST=0` keeps the old behaviour. The autopin block also calls `pin_load` when its RAM pin is under the 0.5 GB floor, because that call is what loads the VRAM tier.
2. **`coli` auto-enabled CUDA sets `CUDA_DENSE=1` when the plan says the trunk fits with at least 4 GB left for experts**, and subtracts the dense bytes from `CUDA_EXPERT_GB` so the lazy dense uploads do not fail against a full tier (#687). Explicit user settings win. Two tests in `test_env_defaults.py` pin both directions; the existing "no dense size in the plan" case is unchanged.

## Verification

- `tests.test_env_defaults`: OK. `colibri` builds; `-DCOLI_CUDA` syntax check clean; the Windows DLL job builds the loader host.
- Not run on a card here. The reporter of #1405 has the 5090 and the manual recipe (`PIN_GB=all CUDA_DENSE=1 CUDA_EXPERT_GB=28`) to compare against: the expected `[CUDA] hot expert tier` line is on the order of 1,300 experts instead of 53, with `mode` no longer `resident dense on CPU`.