### PR TITLE
cuda tier: size the VRAM prefix against the measured headroom, not the requested budget (#1405)

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -9815,7 +9815,16 @@ static void pin_load(Model *m, const char *statspath, double gb, int trusted){
 #ifdef COLI_ANS
         raw_n=g_cuda_raw_experts;
 #endif
-        prefix_est=pin_prefix_for_budget(m,r,n,budget,raw_n)+g_cuda_ndev;
+        /* Size the prefix against what the card can actually take, not the
+         * number on the command line. An explicit CUDA_EXPERT_GB above the
+         * measured headroom is honoured by the upload loop (#491: it degrades
+         * per expert), but a prefix estimated from it lands its excess in the
+         * RAM pin: 5090 + CUDA_DENSE=1 + CUDA_EXPERT_GB=28, headroom ~18 GB,
+         * 864 uploaded and the other ~450 of a 1,314 prefix pinned in RAM on
+         * top of PIN_GB, 9.7 GB the user never asked for (#1405). */
+        double prefix_budget=budget;
+        if(safe_total>0 && safe_total<prefix_budget) prefix_budget=safe_total;
+        prefix_est=pin_prefix_for_budget(m,r,n,prefix_budget,raw_n)+g_cuda_ndev;
         if(prefix_est>n) prefix_est=n;
         cpu_from=prefix_est;                    /* prefix RAM is returned after upload */
     }


### PR DESCRIPTION
From the third banner in #1405: `CUDA_DENSE=1 CUDA_EXPERT_GB=28` on a 5090 leaves ~18 GB of headroom for experts once the dense trunk is on the card. The upload loop honours the explicit 28 GB and degrades per expert (#491), which is fine, but `prefix_est` was computed from the same 28 GB: 1,314 experts, 864 uploaded, and the other ~450 stayed in the RAM pin on top of `PIN_GB=95`, 9.7 GB the user never asked for; the memory guard then refused the run for 4 GB.

The prefix is now sized against `min(budget, safe_total)` (the measured headroom the same block already computes); the upload loop is unchanged. One statement, comment says why. `colibri` builds, `-DCOLI_CUDA` syntax clean; needs a card to observe, the reporter has one and the workaround (`CUDA_EXPERT_GB=18`) to compare against.