### PR TITLE
fix(glm53 serve): honor CANCEL while the turn is still running (#1332)

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1114,7 +1114,7 @@ NOCUDA_LDFLAGS = $(filter-out -lcudart -lstdc++ -lcuda -L$(CUDA_HOME)/lib64 \
 # GLM-5.3-Flash: CPU puro, esperti in streaming dal contenitore int4 gs64.
 # Nessun oggetto CUDA/Vulkan/Metal fra le dipendenze perche' il motore non ne
 # ha ancora: quando li avra', questa riga somigliera' a quella di kimi_k3.
-glm53$(EXE): glm53.c cli_args.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h hyper_connections.h delta_attention.h sparse_index.h vision_tower.h backend_vulkan.h edge_adapter_internal.h edge_adapters.h edge_runtime.h segment_adapter_internal.h segment_adapters.h segment_runtime.h $(VK_OBJ) $(VK_SPV)
+glm53$(EXE): glm53.c cli_args.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h serve_poll.h quant.h hyper_connections.h delta_attention.h sparse_index.h vision_tower.h backend_vulkan.h edge_adapter_internal.h edge_adapters.h edge_runtime.h segment_adapter_internal.h segment_adapters.h segment_runtime.h $(VK_OBJ) $(VK_SPV)
 	$(CC) $(CFLAGS) glm53.c $(VK_OBJ) -o glm53$(EXE) $(LDFLAGS)
 
 kimi_k3$(EXE): kimi_k3.c cli_args.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h omp_tune.h route_trace.h kv_prefix.h serve_codec.h backend_cuda.h backend_metal.h backend_vulkan.h edge_adapters.h edge_runtime.h edge_tok_internal.h hybrid_split.h segment_adapter_internal.h segment_adapters.h segment_runtime.h $(CUDA_OBJ) $(VK_OBJ) $(VK_SPV) $(METAL_OBJ)

--- a/c/glm53.c
+++ b/c/glm53.c
@@ -75,6 +75,7 @@
 static int g_vk_ready = 0;
 #endif
 #include "compat.h"
+#include "serve_poll.h"          /* CANCEL a meta' turno (#1332) */
 #include <time.h>
 #ifndef _WIN32
 #include <sys/resource.h>
@@ -2462,30 +2463,105 @@ static int serve_read_req(ServeReq *q, char *verb, size_t verb_size) {
     return 1;
 }
 
-/* Genera per una richiesta e chiude col suo DONE. */
-static void serve_one(GModel *m, Tok *tokenizer, ServeReq *q) {
-    if (!q->plen) { serve_line("ERROR %llu EMPTY_PROMPT\n", q->id); return; }
+/* Cosa ha chiesto il gateway mentre il turno girava: niente, un abort del
+ * client, o uno stop del template. Vedi serve_cancel_pending per il perche'
+ * CANCEL e STOP non possono condividere un esito. */
+enum { SERVE_CTL_NONE = 0, SERVE_CTL_CANCEL = 1, SERVE_CTL_STOP = 2 };
+
+/* Un CANCEL per la richiesta in corso, visto SENZA bloccarsi (#1332).
+ *
+ * Prima serve_read_req era l'unico posto che leggeva un CANCEL, e serve_loop
+ * la chiama solo fra una richiesta e l'altra: quando il comando arrivava, il
+ * turno che doveva fermare era gia' finito, e la riga qui sotto lo diceva pure
+ * ("un CANCEL arriva sempre per una che non e' piu' in volo"). Il gateway
+ * intanto manda CANCEL e aspetta l'ack tenendo l'ammissione dello scheduler,
+ * quindi un client che si disconnette non libera niente: si aspetta comunque la
+ * fine del turno, e le richieste successive restano in coda dietro a una
+ * generazione che nessuno vuole piu'. Su un n_new lungo o su un modello che
+ * entra in loop di ripetizione non restava che uccidere il processo.
+ *
+ * Ritorna cosa ha chiesto il gateway: SERVE_CTL_NONE, SERVE_CTL_CANCEL, o
+ * SERVE_CTL_STOP. Si legge il frame intero con serve_read_req, non una riga: il
+ * SUBMIT porta il payload a byte contati, e consumarne solo l'header
+ * lascerebbe i byte del prompt nello stream, disallineando tutto quello che
+ * segue.
+ *
+ * CANCEL e STOP NON sono la stessa cosa e non possono finire nello stesso
+ * posto. CANCEL e' un client che se n'e' andato: si aborta e si risponde
+ * ERROR <id> CANCELLED. STOP e' un template di stop che ha combaciato -- la
+ * risposta e' completa e va consegnata -- e il protocollo dice testualmente
+ * "STOP ends generation through the normal successful DONE path. Statistics,
+ * usage history, and KV state are persisted". Il gateway la aspetta: dopo aver
+ * mandato STOP consuma i frame fino al DONE e lo tratta come riuscito
+ * (openai_server.py alza ClientCancelled solo se aveva mandato CANCEL). Se
+ * arrivano tutti e due nello stesso giro vince il CANCEL: il client non c'e'
+ * piu' e il DONE non lo consegnerebbe a nessuno.
+ *
+ * Un SUBMIT non puo' legalmente arrivare mentre lo slot e' occupato -- il
+ * gateway serve una richiesta per volta e aspetta il DONE -- ma se arriva non
+ * lo si tiene in coda: si risponde SLOT_BUSY, il codice che il protocollo
+ * documenta e che colibri.c usa sul suo mux, cosi' il thread del gateway
+ * fallisce subito invece di aspettare una pipa che nessuno legge. IMAGE resta
+ * in g_pending per il SUBMIT che lo nomina.
+ *
+ * Un CANCEL per un id che non conosciamo risponde NOT_FOUND, che e' il codice
+ * che il protocollo gli da'. Uno STOP per un id che non conosciamo si ignora,
+ * come fa gia' serve_loop: li' non c'e' niente da consegnare e nessuno che
+ * aspetti.
+ *
+ * Non legge MAI se stdin non e' pronto: una fgets bloccante qui fermerebbe la
+ * generazione in attesa di un comando che potrebbe non arrivare mai -- un
+ * guasto peggiore di quello che questa funzione cura. */
+static int serve_cancel_pending(unsigned long long id, int *input_eof) {
+    int cancelled = 0, stopped = 0;
+    while (coli_serve_stdin_ready()) {
+        ServeReq n; char verb[16];
+        if (!serve_read_req(&n, verb, sizeof(verb))) { *input_eof = 1; break; }
+        if (!strcmp(verb, "CANCEL")) {
+            if (n.id == id) cancelled = 1;
+            else serve_line("ERROR %llu NOT_FOUND\n", n.id);
+        } else if (!strcmp(verb, "STOP")) {
+            if (n.id == id) stopped = 1;
+        } else if (!strcmp(verb, "SUBMIT")) {
+            serve_line("ERROR %llu SLOT_BUSY\n", n.id);
+            free(n.payload);
+        } else if (!strcmp(verb, "BAD_FRAME")) {
+            serve_line("ERROR %llu BAD_FRAME\n", n.id);
+        }
+        /* IMAGE non risponde niente, come nel ciclo principale. */
+    }
+    if (cancelled) return SERVE_CTL_CANCEL;
+    return stopped ? SERVE_CTL_STOP : SERVE_CTL_NONE;
+}
+
+/* Genera per una richiesta e chiude col suo DONE.
+ *
+ * Ritorna -1 se stdin ha raggiunto EOF durante il turno, 0 altrimenti: il turno
+ * e' comunque finito e il suo DONE e' gia' partito, ma serve_loop deve sapere
+ * che dopo non c'e' piu' un gateway a cui rispondere e puo' uscire. */
+static int serve_one(GModel *m, Tok *tokenizer, ServeReq *q) {
+    if (!q->plen) { serve_line("ERROR %llu EMPTY_PROMPT\n", q->id); return 0; }
     g_temp = q->temp; g_topp = q->top_p > 0.0f ? q->top_p : 1.0f;
 
     if (q->slot < 0 || q->slot >= g_n_slots) {
         serve_line("ERROR %llu BAD_REQUEST\n", q->id);
-        return;
+        return 0;
     }
     KVSlot *slot = &g_slots[q->slot];
     const int room = g_slot_context;
     int *sequence = malloc((size_t)room * sizeof(int));
-    if (!sequence) { serve_line("ERROR %llu BAD_REQUEST\n", q->id); return; }
+    if (!sequence) { serve_line("ERROR %llu BAD_REQUEST\n", q->id); return 0; }
     int total = tok_encode(tokenizer, q->payload, q->plen, sequence, room);
     const int prompt_tokens = total;
     if (!total) {
         free(sequence);
         serve_line("ERROR %llu EMPTY_PROMPT\n", q->id);
-        return;
+        return 0;
     }
     if (total >= room) {
         free(sequence);
         serve_line("ERROR %llu BAD_REQUEST\n", q->id);
-        return;
+        return 0;
     }
 
     const double started = now_s();
@@ -2528,7 +2604,7 @@ static void serve_one(GModel *m, Tok *tokenizer, ServeReq *q) {
             pending_clear();
             free(sequence);
             serve_line("ERROR %llu BAD_REQUEST\n", q->id);
-            return;
+            return 0;
         }
         if (shared) {                             /* niente riuso con un'immagine */
             slot_reset(m, slot);
@@ -2544,8 +2620,23 @@ static void serve_one(GModel *m, Tok *tokenizer, ServeReq *q) {
     float *logits = forward_prefill(m, slot->session, sequence + shared,
                                     total - shared, vision, n_vision, 0);
     GSession *session = slot->session;
-    int rows = 1;
+    int rows = 1, ctl = SERVE_CTL_NONE, input_eof = 0;
     for (int step = 0; step < budget; step++) {
+        /* #1332: una guardata a stdin per token. Il costo e' una select con
+         * timeout zero; il guadagno e' che il gateway smette di aspettare un
+         * turno che nessuno vuole piu'. In cima al ciclo, non in fondo: qui la
+         * sessione ha macinato esattamente `total` token, quindi la storia che
+         * slot_remember scrive sotto combacia con quello che la cache contiene
+         * davvero (`filled`). */
+        /* EOF NON chiude il turno: "EOF on stdin = graceful shutdown: in-flight
+         * requests finish first". Serviva solo a smettere di leggere, quindi da
+         * li' in poi non si legge piu': con la pipa chiusa
+         * coli_serve_stdin_ready resterebbe pronto per sempre, e ogni token
+         * pagherebbe una select e una fgets a vuoto. Il turno finisce qui sotto
+         * e il DONE parte lo stesso; e' serve_one a dire a serve_loop, col
+         * valore di ritorno, che dopo non c'e' piu' nessuno. */
+        if (!input_eof) ctl = serve_cancel_pending(q->id, &input_eof);
+        if (ctl != SERVE_CTL_NONE) break;
         if (total >= room) { limited = 1; break; }
         int next = sample_token(logits + (size_t)(rows - 1) * m->c.vocab, m->c.vocab);
         free(logits);
@@ -2565,6 +2656,26 @@ static void serve_one(GModel *m, Tok *tokenizer, ServeReq *q) {
     /* La sessione resta allo slot per il turno dopo, con la sequenza che ha
      * davvero macinato: prompt piu' quello che ha generato. */
     slot_remember(slot, sequence, total);
+    /* Il turno e' stato interrotto: si risponde col frame che il gateway
+     * aspetta per rilasciare l'ammissione dello scheduler (openai_server.py
+     * accetta ERROR <id> CANCELLED oppure un DONE, ma il DONE direbbe al
+     * client che la risposta e' completa, che e' falso). Niente PROF ne'
+     * HITS: sono il ritratto di un turno che non e' finito.
+     *
+     * Lo slot resta com'e': la sessione ha macinato `total` token e la storia
+     * scritta sopra e' esattamente quella, quindi il turno dopo puo' ancora
+     * riusare il prefisso. Buttarlo costerebbe un prefill intero per punire
+     * un client che ha cambiato idea. */
+    if (ctl == SERVE_CTL_CANCEL) {
+        serve_line("ERROR %llu CANCELLED\n", q->id);
+        free(sequence);
+        return input_eof ? -1 : 0;
+    }
+    /* ctl == SERVE_CTL_STOP non esce qui: cade nel DONE qui sotto, che e' il
+     * "normal successful DONE path" del protocollo, con STAT, PROF e HITS di un
+     * turno che il client ha ricevuto per intero. `limited` resta 0 -- non e'
+     * stato il limite di token a fermarlo -- e la storia e' gia' stata scritta
+     * sopra, quindi lo slot resta quello che e'. */
     const double elapsed = now_s() - started;
     /* Quanto prefisso lo slot ha risparmiato.
      *
@@ -2592,6 +2703,7 @@ static void serve_one(GModel *m, Tok *tokenizer, ServeReq *q) {
                m->miss + m->hits ? 100.0 * m->hits / (double)(m->hits + m->miss) : 0.0,
                rss_gb(), prompt_tokens, limited);
     free(sequence);
+    return input_eof ? -1 : 0;
 }
 
 /* --- Dashboard: Brain e Profile ------------------------------------------
@@ -2670,19 +2782,32 @@ static void serve_loop(GModel *m, Tok *tokenizer) {
         ServeReq q; char verb[16];
         if (!serve_read_req(&q, verb, sizeof(verb))) break;   /* EOF: si esce */
         if (!strcmp(verb, "SUBMIT")) {
-            serve_one(m, tokenizer, &q);
+            /* < 0: stdin e' finito mentre il turno girava. Il turno e' stato
+             * servito per intero (e' la regola: "in-flight requests finish
+             * first"), ma ora non c'e' piu' nessuno dall'altra parte, quindi si
+             * esce senza riprovare a leggere. */
+            int gateway_gone = serve_one(m, tokenizer, &q) < 0;
             free(q.payload);
+            if (gateway_gone) break;
         } else if (!strcmp(verb, "IMAGE")) {
             /* annunciata: nessuna risposta, la si usa al SUBMIT che segue */
         } else if (!strcmp(verb, "BAD_FRAME")) {
             serve_line("ERROR %llu BAD_FRAME\n", q.id);
         } else if (!strcmp(verb, "CANCEL")) {
-            /* Le richieste qui si servono una per volta e a fine giro, quindi
-             * un CANCEL arriva sempre per una che non e' piu' in volo. */
+            /* Un CANCEL per una richiesta in volo non arriva piu' qui: il ciclo
+             * di decode lo vede da solo, una volta per token
+             * (serve_cancel_pending, #1332). Questo ramo resta per l'id che non
+             * conosciamo -- una richiesta gia' chiusa, o mai vista -- ed e' il
+             * NOT_FOUND che il protocollo documenta. */
             serve_line("ERROR %llu NOT_FOUND\n", q.id);
         }
         /* STOP e le righe che non riconosciamo si ignorano: la regola di
-         * compatibilita' del protocollo vale in tutte e due le direzioni. */
+         * compatibilita' del protocollo vale in tutte e due le direzioni. Uno
+         * STOP per la richiesta in volo non passa di qui -- lo raccoglie il
+         * ciclo di decode, che chiude il turno col DONE normale -- e uno STOP
+         * per un id gia' chiuso non ha niente da fermare ne' nessuno che
+         * aspetti una risposta: il gateway manda STOP e poi continua a leggere
+         * fino al DONE, non si mette in attesa di un ack. */
     }
 }
 

--- a/c/tests/test_glm53_serve.py
+++ b/c/tests/test_glm53_serve.py
@@ -175,11 +175,190 @@ def main() -> int:
                   "quello di prima")
             return 1
 
+        # --- CANCEL a meta' turno (#1332) ---
+        #
+        # Un CANCEL che arriva mentre il turno gira deve fermarlo. Prima
+        # serve_read_req era l'unico posto che leggeva il comando, e serve_loop
+        # la chiama solo fra una richiesta e l'altra: il CANCEL restava nella
+        # pipa fino alla fine dei token chiesti, e il gateway -- che manda
+        # CANCEL e poi aspetta l'ack tenendo l'ammissione dello scheduler --
+        # non liberava niente, quindi un client che si disconnetteva lasciava
+        # le richieste successive in coda dietro una generazione che nessuno
+        # voleva piu'.
+        #
+        # La prova che il turno e' stato interrotto davvero e' il numero di
+        # DATA arrivati: molti meno dei max_tokens chiesti. Un motore che
+        # leggesse il CANCEL solo a fine turno ne emetterebbe `budget`.
+        budget = 512
+        submit(process, 12, prompt, max_tokens=budget)
+        emitted_before = 0
+        while True:
+            line = read_line(process.stdout)
+            if not line.startswith("DATA "):
+                break
+            _, got_id, count = line.split()
+            if int(got_id) != 12:
+                raise AssertionError(f"DATA per {got_id}, atteso 12")
+            process.stdout.read(int(count) + 1)
+            emitted_before += 1
+            if emitted_before == 1:
+                process.stdin.write(b"CANCEL 12\n")
+                process.stdin.flush()
+        if line != "ERROR 12 CANCELLED":
+            print(f"FAIL: CANCEL a meta' turno -> {line!r}, atteso "
+                  f"ERROR 12 CANCELLED (il turno ha emesso {emitted_before} token)")
+            return 1
+        if emitted_before >= budget:
+            print(f"FAIL: il turno ha emesso tutti i {budget} token chiesti prima "
+                  f"di rispondere al CANCEL: non e' stato onorato a meta' turno")
+            return 1
+
+        # Dopo un CANCEL lo stream deve restare allineato come dopo un errore:
+        # il gateway riusa la stessa pipa per la richiesta successiva.
+        submit(process, 13, prompt, max_tokens=1)
+        _, done13, _ = collect(process, 13)
+        if not done13.startswith("DONE 13 "):
+            print(f"FAIL: dopo un CANCEL lo stream si e' disallineato: {done13!r}")
+            return 1
+
+        # --- STOP a meta' turno ---
+        #
+        # STOP non e' CANCEL, e i due non possono finire nello stesso posto. Il
+        # protocollo: "STOP ends generation through the normal successful DONE
+        # path. Statistics, usage history, and KV state are persisted". Il
+        # gateway lo manda quando un template di stop combacia -- cioe' quando
+        # la risposta e' completa e va consegnata -- e dopo averlo mandato
+        # continua a leggere fino al DONE trattandolo come riuscito (alza
+        # ClientCancelled solo se aveva mandato CANCEL). Rispondere
+        # ERROR <id> CANCELLED butterebbe via una risposta che il client ha gia'
+        # ricevuto per intero.
+        stop_budget = 512
+        submit(process, 14, prompt, max_tokens=stop_budget)
+        emitted_stop = 0
+        done14 = None
+        while True:
+            line = read_line(process.stdout)
+            if line.startswith("DATA "):
+                _, got_id, count = line.split()
+                if int(got_id) != 14:
+                    raise AssertionError(f"DATA per {got_id}, atteso 14")
+                process.stdout.read(int(count) + 1)
+                emitted_stop += 1
+                if emitted_stop == 1:
+                    process.stdin.write(b"STOP 14\n")
+                    process.stdin.flush()
+            elif line.startswith("DONE ") or line.startswith("ERROR "):
+                done14 = line
+                break
+            # HITS, PROF e compagnia: si ignorano, come fa il gateway.
+        if not done14.startswith("DONE 14 "):
+            print(f"FAIL: STOP a meta' turno -> {done14!r}, atteso un DONE "
+                  f"(il protocollo vuole il percorso riuscito, non CANCELLED)")
+            return 1
+        if emitted_stop >= stop_budget:
+            print(f"FAIL: il turno ha emesso tutti i {stop_budget} token chiesti "
+                  f"prima di rispondere allo STOP: non e' stato onorato a meta' "
+                  f"turno")
+            return 1
+
+        # --- SUBMIT mentre lo slot e' occupato ---
+        #
+        # Non puo' legalmente arrivare -- il gateway serve una richiesta per
+        # volta e aspetta il DONE -- ma se arriva non lo si tiene in coda: si
+        # risponde SLOT_BUSY, che e' il codice che il protocollo documenta.
+        # `BUSY` non esiste: un gateway che lo ricevesse non saprebbe che farsene
+        # e il suo thread resterebbe appeso su una pipa che nessuno legge.
+        #
+        # La seconda meta' del controllo e' che il payload del SUBMIT rifiutato
+        # venga comunque consumato: e' a byte contati, e lasciarlo nello stream
+        # disallineerebbe tutto quello che segue.
+        busy_budget = 8
+        submit(process, 15, prompt, max_tokens=busy_budget)
+        sent_intruder = False
+        busy = None
+        done15 = None
+        while True:
+            line = read_line(process.stdout)
+            if line.startswith("DATA "):
+                _, got_id, count = line.split()
+                if int(got_id) != 15:
+                    raise AssertionError(f"DATA per {got_id}, atteso 15")
+                process.stdout.read(int(count) + 1)
+                if not sent_intruder:
+                    sent_intruder = True
+                    submit(process, 16, prompt, max_tokens=1)
+            elif line.startswith("ERROR "):
+                busy = line
+            elif line.startswith("DONE "):
+                done15 = line
+                break
+        if busy != "ERROR 16 SLOT_BUSY":
+            print(f"FAIL: SUBMIT a slot occupato -> {busy!r}, atteso "
+                  f"ERROR 16 SLOT_BUSY")
+            return 1
+        if not done15.startswith("DONE 15 "):
+            print(f"FAIL: il turno in volo e' finito con {done15!r}, atteso DONE 15")
+            return 1
+
+        # Il SUBMIT rifiutato non deve aver lasciato il suo payload nella pipa:
+        # se ci fosse ancora, la richiesta dopo leggerebbe i suoi byte come
+        # header e lo stream sarebbe perso.
+        submit(process, 17, prompt, max_tokens=1)
+        _, done17, _ = collect(process, 17)
+        if not done17.startswith("DONE 17 "):
+            print(f"FAIL: dopo un SUBMIT rifiutato lo stream si e' disallineato: "
+                  f"{done17!r}")
+            return 1
+
         process.stdin.close()
         process.wait(timeout=60)
     finally:
         if process.poll() is None:
             process.kill()
+
+    # --- EOF su stdin a meta' turno ---
+    #
+    # "EOF on stdin = graceful shutdown: in-flight requests finish first." La
+    # pipa che si chiude sotto un turno in volo non e' un motivo per troncare la
+    # risposta: il turno finisce, il DONE parte, e solo dopo il motore esce.
+    #
+    # La prova non e' che il DONE arrivi -- arriverebbe anche troncando, perche'
+    # il ciclo esce e il DONE e' la riga dopo -- ma che i token siano gli
+    # STESSI di un turno con la pipa aperta. Greedy e a temperatura zero, quindi
+    # lo stesso prompt deve dare la stessa sequenza: se il turno si fermasse al
+    # primo token, qui si vedrebbe.
+    def turn_with_eof(close_stdin):
+        eof_process = engine(binary, arguments.fixture)
+        try:
+            handshake(eof_process)
+            submit(eof_process, 19, prompt, max_tokens=8)
+            if close_stdin:
+                eof_process.stdin.close()
+            pieces, done, _ = collect(eof_process, 19)
+            if not done.startswith("DONE 19 "):
+                return None, done
+            if close_stdin:
+                eof_process.wait(timeout=60)
+            else:
+                eof_process.stdin.close()
+                eof_process.wait(timeout=60)
+            return pieces, done
+        finally:
+            if eof_process.poll() is None:
+                eof_process.kill()
+
+    control, done_control = turn_with_eof(False)
+    interrupted, done_interrupted = turn_with_eof(True)
+    if control is None or interrupted is None:
+        print(f"FAIL: EOF a meta' turno -> controllo {done_control!r}, "
+              f"con la pipa chiusa {done_interrupted!r}, attesi due DONE")
+        return 1
+    if interrupted != control:
+        print(f"FAIL: la pipa chiusa a meta' turno ha troncato la risposta\n"
+              f"  pipa aperta: {control!r} ({len(control)} byte)\n"
+              f"  pipa chiusa: {interrupted!r} ({len(interrupted)} byte)")
+        return 1
+    emitted_eof = len(control)
 
     # Lo stesso prompt su una sessione pulita: il riuso deve essere esatto, non
     # solo veloce. Se qui la risposta cambia, la cache tenuta fra i turni sta
@@ -218,7 +397,11 @@ def main() -> int:
     print(f"PASS GLM-5.3 serve: handshake, frame a byte contati, {emitted} token "
           f"decodificati identici alla CLI, prompt vuoto rifiutato, stream "
           f"ancora allineato dopo l'errore, {reused} token di prefisso riusati "
-          f"al secondo turno con la stessa risposta di una sessione pulita")
+          f"al secondo turno con la stessa risposta di una sessione pulita, "
+          f"CANCEL onorato a meta' turno dopo {emitted_before} token su {budget}, "
+          f"STOP chiuso col DONE dopo {emitted_stop} token su {stop_budget}, "
+          f"SUBMIT a slot occupato rifiutato con SLOT_BUSY, "
+          f"{emitted_eof} token portati a termine con la pipa gia' chiusa")
     return 0
 
 


### PR DESCRIPTION
## Summary

`glm53` was the last engine that could not be interrupted mid-turn. `serve_read_req()` was the only place that read a command from stdin, and `serve_loop()` calls it only *between* requests — never while a turn is decoding. A `CANCEL` that arrived during a turn therefore sat in the pipe until all `max_tokens` had been generated and flushed.

`docs/serve_protocol.md` requires the opposite:

> A `CANCEL` is acknowledged by `ERROR <id> CANCELLED` after the slot's KV is persisted.

The gateway depends on that ack: `openai_server.py` sends `CANCEL` and then **holds the scheduler's admission** until the engine answers with `ERROR <id> CANCELLED` or `DONE`. So a client that disconnected left every later request queued behind a generation nobody wanted any more.

Seven of the eight engines already poll stdin while a turn is running: `colibri` through its own `mux_ctl_poll` (#678), `qwen36` through `serve_poll.h`, and `qwen38`, `olmoe`, `inkling`, `deepseek_v4`, `kimi_k3` through `coli_stdin_readable()` in `compat.h`. `glm53` was the one left out (#1332).

### The change

`serve_cancel_pending()`, called once per token at the **top** of the decode loop in `serve_one`:

- **At the top, not the bottom.** When the poll runs, the session has ground exactly `total` tokens, so the history `slot_remember()` writes underneath matches what the KV cache actually holds (`session->filled`). Polling after the step would acknowledge a `CANCEL` against a sequence one token longer than the cache.
- **A whole frame, not a line scan.** Unlike `qwen36`, glm53's `SUBMIT` carries a byte-counted payload, so the probe consumes complete frames through `serve_read_req()` — a raw line scan would read the payload as commands and desynchronise the stream.
- **Never blocks.** The loop is gated on `coli_serve_stdin_ready()` (from `serve_poll.h`, #1336), so the decode path does not gain a blocking read.
- On a match, `serve_one` emits `ERROR <id> CANCELLED` after persisting the slot, exactly as the protocol documents, and frees `sequence` on the way out.

### What the first version of this patch got wrong

The change was pushed, re-read against the protocol, and three things were wrong. They are listed here rather than quietly amended away, because two of them are the kind of mistake this PR exists to fix:

| | was | now | why |
|---|---|---|---|
| mid-turn `STOP` | `ERROR <id> CANCELLED` | normal `DONE` path | the protocol says "`STOP` ends generation through the normal successful `DONE` path. Statistics, usage history, and KV state are persisted". The gateway sends `STOP` when a client stop sequence matches — the answer is *complete* — then reads on to the `DONE` and treats it as successful. Cancelling it threw away a response the client had already received in full. |
| mid-turn `SUBMIT` | `ERROR <id> BUSY` | `ERROR <id> SLOT_BUSY` | `BUSY` is not a protocol code. The documented set is `BAD_FRAME`, `BAD_REQUEST`, `SLOT_BUSY`, `DUPLICATE_ID`, `EMPTY_PROMPT`, `NOT_FOUND`, `CANCELLED`, and `SLOT_BUSY` is what `colibri.c`'s mux already emits for the same condition. |
| stdin EOF | `break` — turn truncated | turn finishes, then the loop exits | "EOF on stdin = graceful shutdown: in-flight requests finish first". Closing the pipe truncated the response to zero tokens. |

`CANCEL` and `STOP` now return distinct outcomes and only `CANCEL` takes the abort path; if both arrive in the same drain, `CANCEL` wins, since the client is gone and a `DONE` would be delivered to nobody. EOF no longer ends the turn — it only stops the polling (with the pipe closed, `coli_serve_stdin_ready()` stays ready forever, so every remaining token would pay for a `select` and an empty `fgets`) — and `serve_one` returns `-1` so `serve_loop` knows to exit after the turn is framed. A `STOP`/`CANCEL` for an *unknown* id is unchanged: `NOT_FOUND` for `CANCEL`, ignored for `STOP`, matching what `serve_loop` already does.

`c/Makefile` gains `serve_poll.h` in glm53's prerequisite list, matching the rule `qwen36` already has — without it an edit to the header would not rebuild `glm53`.

## Validation

- [ ] `make -C c check`
- [ ] CUDA changes were tested with `make -C c cuda-test` (if applicable)
- [ ] Performance claims include hardware, commands, and repeatable measurements
- [ ] Performance claims include a validated experiment manifest with raw evidence

Not a CUDA change; no performance claim.

**The first box is deliberately left unticked — please read why**, because "unticked" here does not mean "red because of this PR":

My machine ships GNU make as `mingw32-make.exe` and has no binary named `make`, and it has `torch` installed. Both facts bend the suite, so the number depends on the tree:

| | pristine `dev` @ `173c757` | this branch |
|---|---|---|
| without a `make` binary | 7 errors | 7 errors |
| with a `make` binary | 1 error | 1 error |

The 7 are `test_cuda_test_makefile` (6 — it shells out to `["make", ...]`) and `test_fp8_e2e_repack_load` (1). With a GNU make present under the name `make`, the 6 clear and **one** remains, identically on pristine `dev` and on this branch:

```
ERROR: setUpClass (test_fp8_e2e_repack_load.Fp8RepackLoadE2ETest)
AssertionError: e2e harness build failed:
c/compat.h:89:2: error: #error "_FILE_OFFSET_BITS=64 required on Windows (add -D_FILE_OFFSET_BITS=64 to CFLAGS)"
```

That is pre-existing and unrelated — `_cc_flags()` in that test omits the define `c/Makefile:106` passes, a Windows-only harness-build failure reported separately as #1413 with its own PR rather than smuggled in here. On CI it does not fire, because the Windows job installs no `torch` and the module skips at import.

So `make check` on this branch and on pristine `dev` differ by **zero** tests — but it is not green here, and I am not going to tick a box that isn't. What the suite also cannot show is the fix itself: `test_glm53_serve.py` skips without a generated fixture, and `make check` never builds `glm53` at all (only `colibri`). That is what the targeted run below is for. (Concretely: pristine `Ran 928 tests … FAILED (errors=1, skipped=68)`, this branch the same 1 error attributed to `test_fp8_e2e_repack_load`.)

### Targeted validation of the fix

Fixture: `python3 c/tools/make_glm53_multimodal_tiny.py --output ~/glm53_mm` (transformers 5.16.1), engine built with WinLibs GCC 16.2.0 (UCRT64, `-D_FILE_OFFSET_BITS=64`, `-fopenmp`).

`c/tests/test_glm53_serve.py` gains four mid-turn cases:

1. **CANCEL** — `max_tokens=512`, `CANCEL 12` sent after the *first* `DATA`; the turn must stop early and answer `ERROR 12 CANCELLED`, and the stream must still be aligned for the next request.
2. **STOP** — same shape; the turn must close with a `DONE`, not `CANCELLED`.
3. **Intruding SUBMIT** — `SUBMIT 16` sent mid-turn must be refused with `ERROR 16 SLOT_BUSY`, and a following request must still get its `DONE` — which is what proves the refused frame's *counted payload* was consumed rather than left in the pipe.
4. **EOF** — the same request with the pipe closed right after the `SUBMIT` must produce byte-identical output to one run with the pipe open.

**With the fix** — exit 0:

```
PASS GLM-5.3 serve: handshake, frame a byte contati, 4 token decodificati identici
alla CLI, prompt vuoto rifiutato, stream ancora allineato dopo l'errore, 2 token di
prefisso riusati al secondo turno con la stessa risposta di una sessione pulita,
CANCEL onorato a meta' turno dopo 1 token su 512, STOP chiuso col DONE dopo 1 token
su 512, SUBMIT a slot occupato rifiutato con SLOT_BUSY, 8 token portati a termine con
la pipa gia' chiusa
```

**Negative control, pristine `173c757`** (`glm53-base.exe`; its `glm53.c` is byte-identical to `dev`'s modulo CRLF) — exit 1:

```
FAIL: CANCEL a meta' turno -> 'HITS 1 4 00', atteso ERROR 12 CANCELLED
      (il turno ha emesso 512 token)
```

512 tokens emitted against 1: the turn now stops where it is told to.

**Negative control, the first version of this patch** — with the STOP assertion made non-fatal so the later cases are reached, all three of the fixed defects are caught:

```
FAIL: STOP a meta' turno -> 'ERROR 14 CANCELLED', atteso un DONE
      (il protocollo vuole il percorso riuscito, non CANCELLED)
FAIL: SUBMIT a slot occupato -> 'ERROR 16 BUSY', atteso ERROR 16 SLOT_BUSY
FAIL: la pipa chiusa a meta' turno ha troncato la risposta
  pipa aperta: b'?e\xce\x8d{\xa1\x16\x9c' (8 byte)
  pipa chiusa: b'' (0 byte)
```

The other five assertions (handshake, byte-counted frames, CLI-identical decode, empty-prompt refusal, KV prefix reuse) pass on all three engines, and a diff of the compiler output against the base build shows **no new warnings** — the same three pre-existing `-Wmissing-field-initializers` in `expert_mats`, nothing else.

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included

No new dependency: `serve_poll.h` is already in the tree (#1336) and is included today by exactly one engine, `c/qwen36.c`; this PR adds glm53 as its second user. The other five engines that poll mid-turn do it through the older `coli_stdin_readable()` in `compat.h` — either primitive would work here, and `serve_poll.h` is the one whose Windows path treats a broken pipe as readable rather than silently reporting "nothing to read", which is the behaviour this fix wants when the gateway dies.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
