### PR TITLE
test(fp8): mirror the Windows CFLAGS in the e2e harness build

### DIFF
--- a/c/tests/test_fp8_e2e_repack_load.py
+++ b/c/tests/test_fp8_e2e_repack_load.py
@@ -69,8 +69,18 @@ def _cc_flags():
         # becomes a -Wunknown-pragmas warning (-Wall enables it), and the assertion
         # below requires an empty stderr -- so on Linux this test failed for a
         # reason that had nothing to do with what it is testing. macOS gets the
-        # libomp probe just below; Windows/MinGW is left alone.
+        # libomp probe just below.
         cflags += ["-fopenmp"]
+        ldflags += ["-fopenmp"]
+    if sys.platform == "win32":
+        # MinGW mirrors CFLAGS too, rather than being left alone. compat.h
+        # refuses to compile a Windows off_t that is not 64-bit, and the
+        # Makefile passes -D_FILE_OFFSET_BITS=64 (and -fopenmp) on Windows as
+        # well. Without the define the harness died on the #error, so this test
+        # could only ever run where torch is absent -- i.e. it skipped on CI's
+        # Windows job and failed on any Windows box that had torch installed,
+        # for a reason that had nothing to do with what it is testing.
+        cflags += ["-D_FILE_OFFSET_BITS=64", "-fopenmp"]
         ldflags += ["-fopenmp"]
     if sys.platform == "darwin":
         try:


### PR DESCRIPTION
## Summary

`test_fp8_e2e_repack_load` could not run on Windows. Its `_cc_flags()` builds a harness out of `colibri.c` with a hand-written flag list meant to mirror the Makefile, and on `win32` it mirrored neither of the two flags `c/Makefile:106` passes there:

- Without `-D_FILE_OFFSET_BITS=64`, `c/compat.h:89` hard-errors:
  `#error "_FILE_OFFSET_BITS=64 required on Windows (add -D_FILE_OFFSET_BITS=64 to CFLAGS)"`. That guard is deliberate — a 32-bit `off_t` would silently wrap offsets past 4 GB — so the harness cannot be built on Windows without the define.
- `_cc_flags()` also skips `-fopenmp` on `win32` on purpose ("Windows/MinGW is left alone"). That is a second failure hiding behind the first: with only the define added, every `#pragma omp` in `colibri.c` becomes `-Wunknown-pragmas` and `test_harness_builds_without_warnings` fails its `assertEqual(build.stderr.strip(), "")`.

The project's own Windows build does use `-fopenmp`; the MSYS2/UCRT64 CI log shows `gcc -D_FILE_OFFSET_BITS=64 -O3 -march=x86-64-v3 -fopenmp … colibri.c -o colibri.exe`. So the comment's premise no longer holds.

The change adds a `win32` branch to `_cc_flags()` that mirrors CFLAGS, next to the existing macOS branch. The `not in ("darwin", "win32")` branch and the macOS `libomp` probe are untouched, so Linux and macOS behaviour is bit-for-bit what it was.

**Why this never showed up:** the module raises `unittest.SkipTest` at import when `torch` is missing, and CI's Windows job installs only `make`, `mingw-w64-ucrt-x86_64-gcc` and `mingw-w64-ucrt-x86_64-python`. So the module runs on Linux/macOS CI and skips on Windows CI — it is reachable on Windows only by someone who installed `torch`, which is what `docs/glm53-flash.md` §Tests and `pyproject.toml`'s `oracle` extra tell you to do for fixture work. On such a machine `make check` fails for a reason unrelated to whatever the contributor was changing.

Fixes #1413.

## Validation

- [x] `make -C c check`
- [ ] CUDA changes were tested with `make -C c cuda-test` (if applicable)
- [ ] Performance claims include hardware, commands, and repeatable measurements
- [ ] Performance claims include a validated experiment manifest with raw evidence

Not a CUDA change; no performance claim.

**Directly, on Windows** (MinGW-w64 UCRT, WinLibs GCC 16.2.0, Python 3.13.13 with torch):

before —
```
ERROR: setUpClass (test_fp8_e2e_repack_load.Fp8RepackLoadE2ETest)
AssertionError: e2e harness build failed:
c/compat.h:89:2: error: #error "_FILE_OFFSET_BITS=64 required on Windows …"
Ran 4 tests in 14.6s
FAILED (errors=1)
```

after —
```
test_collision_shape_resident_loads_fmt8_and_the_stamp_is_what_does_it ... ok
test_container_declaration_stays_inert_even_when_malformed ... ok
test_harness_builds_without_warnings ... ok
test_real_repack_output_loads_through_real_c_loader ... ok

Ran 4 tests in 13.556s
OK
```

`test_harness_builds_without_warnings` is the one that matters most here: it is the gate that would have caught a `-fopenmp`-shaped mistake, and it now passes on Windows instead of never running.

**`make -C c check`** — one caveat worth stating plainly. The sandbox that produced this patch ships GNU make as `mingw32-make.exe` and has no binary named `make`, which makes six `test_cuda_test_makefile` tests error on `FileNotFoundError: [WinError 2]` before anything else is reached. With a GNU make available under the name `make`:

| tree | result |
|---|---|
| pristine `dev` @ `173c757` | 1 error — this one |
| this branch | 0 errors |

So the only failure this change removes is the one it is about, and it removes it completely. The pristine figure was taken from a separate git worktree at `173c757`, not by reverting.

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included

Test-only change; no engine, build, CI, dependency or API surface is touched. Linux and macOS take a code path that is unchanged, since `sys.platform == "win32"` is false there.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
