### PR TITLE
test(v4): make the ExpertStore knobs reach getenv() on Windows

### DIFF
--- a/c/tests/test_deepseek_v4.c
+++ b/c/tests/test_deepseek_v4.c
@@ -5,6 +5,7 @@
 #include "../native_quant_fp4_rows16.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <math.h>
@@ -14,6 +15,36 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+
+/* compat.h maps setenv() onto SetEnvironmentVariableA, which updates the Win32
+ * environment block -- but getenv() reads the CRT's own copy of it and never
+ * sees the value.  The three ExpertStore tests below set knobs that the engine
+ * reads with getenv(), so on Windows the setenv() spelling was a no-op and they
+ * ran with the very defaults they meant to override.  The same trap is spelled
+ * out in test_qwen36_ctx.c and test_inkling_shared_batch.c; _putenv_s updates
+ * the copy getenv() reads. */
+static void env_set(const char *name, const char *value) {
+#ifdef _WIN32
+    _putenv_s(name, value);
+#else
+    setenv(name, value, 1);
+#endif
+}
+
+/* mkdtemp() hands out a scratch directory, the engine appends <snap>/.coli_usage
+ * to it whenever it saves its expert history, and rmdir() then fails on a
+ * directory that is no longer empty.  Nothing was listening to that failure, so
+ * a knob that did not arrive left the directory behind and the test still said
+ * ok.  Removing the fixture and checking the rmdir turns that back into a
+ * failure. */
+static int scratch_remove(const char *directory, const char *fixture) {
+    unlink(fixture);
+    if (rmdir(directory) == 0) return 0;
+    fprintf(stderr, "scratch directory %s survived its test (errno=%d): the "
+                    "engine wrote into it, so the knobs this test sets did not "
+                    "reach getenv()\n", directory, errno);
+    return 1;
+}
 
 /* ==== begin test_deepseek_v4_attention_cache.c ==== */
 /* umbrella headers */
@@ -611,9 +642,9 @@ static int test_expert_store(void) {
     /* Native MinGW binaries do not resolve the MSYS /tmp mount. */
     char directory[] = "colibri-v4-store-XXXXXX";
     char path[256], error[256];
-    setenv("COLI_V4_AUTOPIN", "0", 1);
-    setenv("COLI_V4_SAVE_USAGE", "0", 1);
-    setenv("COLI_V4_ROWS16", "0", 1);
+    env_set("COLI_V4_AUTOPIN", "0");
+    env_set("COLI_V4_SAVE_USAGE", "0");
+    env_set("COLI_V4_ROWS16", "0");
     if (!mkdtemp(directory)) { perror("mkdtemp"); return 1; }
     snprintf(path, sizeof(path), "%s/model.safetensors", directory);
     if (write_fixture(path) != 0) { perror("write_fixture"); return 1; }
@@ -780,8 +811,7 @@ static int test_expert_store(void) {
         return 1;
     }
     store->ops->destroy(store);
-    unlink(path);
-    rmdir(directory);
+    if (scratch_remove(directory, path)) return 1;
     puts("DeepSeek-V4 ExpertStore tests: ok");
     return 0;
 }
@@ -808,9 +838,9 @@ static int test_expert_store_prefill_pool(void) {
     enum { LAYERS = 2, EXPERTS = 8, SLOTS_PER_LAYER = 6 };
     char directory[] = "colibri-v4-pool-XXXXXX";
     char path[256], error[256];
-    setenv("COLI_V4_AUTOPIN", "0", 1);
-    setenv("COLI_V4_SAVE_USAGE", "0", 1);
-    setenv("COLI_V4_ROWS16", "0", 1);
+    env_set("COLI_V4_AUTOPIN", "0");
+    env_set("COLI_V4_SAVE_USAGE", "0");
+    env_set("COLI_V4_ROWS16", "0");
     if (!mkdtemp(directory)) { perror("mkdtemp pool"); return 1; }
     snprintf(path, sizeof(path), "%s/model.safetensors", directory);
     if (write_fixture_layers(path, LAYERS, EXPERTS)) {
@@ -956,8 +986,7 @@ static int test_expert_store_prefill_pool(void) {
         failed = 1;
     }
     store->ops->destroy(store);
-    unlink(path);
-    rmdir(directory);
+    failed |= scratch_remove(directory, path);
     if (failed) return 1;
     puts("DeepSeek-V4 ExpertStore prefill pool: ok "
          "(A/B bytes 816->408, second sweep=0 reads, warm entries + decode reserve retained)");
@@ -1030,9 +1059,9 @@ static int run_expert_miss_scaling_case(const char *directory, int experts,
 static int test_expert_store_miss_scaling(void) {
     char directory[] = "colibri-v4-scaling-XXXXXX";
     char path[256];
-    setenv("COLI_V4_AUTOPIN", "0", 1);
-    setenv("COLI_V4_SAVE_USAGE", "0", 1);
-    setenv("COLI_V4_ROWS16", "0", 1);
+    env_set("COLI_V4_AUTOPIN", "0");
+    env_set("COLI_V4_SAVE_USAGE", "0");
+    env_set("COLI_V4_ROWS16", "0");
     if (!mkdtemp(directory)) { perror("mkdtemp scaling"); return 1; }
     snprintf(path, sizeof(path), "%s/model.safetensors", directory);
     if (write_fixture_experts(path, 256)) {
@@ -1043,8 +1072,7 @@ static int test_expert_store_miss_scaling(void) {
     int result = run_expert_miss_scaling_case(directory, 256, 44) ||
                  run_expert_miss_scaling_case(directory, 256, 104) ||
                  run_expert_miss_scaling_case(directory, 256, 208);
-    unlink(path);
-    rmdir(directory);
+    result |= scratch_remove(directory, path);
     if (result) return 1;
     puts("DeepSeek-V4 ExpertStore miss scaling: ok "
          "(44/104/208 slots=1 probe each)");


### PR DESCRIPTION
## Summary

Fixes #1416.

On Windows, `make check` leaves three scratch directories behind in `c/`, every run — `colibri-v4-store-<pid>/`, `colibri-v4-pool-<pid>/`, `colibri-v4-scaling-<pid>/`, each holding a `.coli_usage` the test never asked for. Four runs on this machine left twelve of them. The suite reports `ok` throughout.

The three ExpertStore tests set the knobs they need like this:

```c
setenv("COLI_V4_AUTOPIN", "0", 1);
setenv("COLI_V4_SAVE_USAGE", "0", 1);
setenv("COLI_V4_ROWS16", "0", 1);
```

`compat.h:330` maps `setenv()` onto `SetEnvironmentVariableA`, which updates the **Win32** environment block. `getenv()` reads the **CRT's** copy of it, which was populated at startup and is never updated by that call. So on Windows all three knobs are no-ops for the code under test: `hot_usage_save()` (`c/deepseek_v4.c:8096`) does `getenv("COLI_V4_SAVE_USAGE")`, gets `NULL`, and writes `<scratch>/.coli_usage`. The cleanup then loses the evidence, because `rmdir()` on a directory that is no longer empty returns `ENOTEMPTY` and nothing was reading the result.

This trap is already written down twice in this repo, with the fix:

- `c/tests/test_qwen36_ctx.c:27-33`
- `c/tests/test_inkling_shared_batch.c:16-19`

Both define an `env_set()` helper that uses `_putenv_s` on Windows. `test_deepseek_v4.c` was left on the bare `setenv()` spelling.

### The change

Two helpers at the top of `c/tests/test_deepseek_v4.c`, then nine call sites and three cleanups:

1. **`env_set()`** — `_putenv_s` on Windows, `setenv` elsewhere, the same shape as the two files above. All nine `setenv("COLI_V4_*")` calls now go through it, so the three tests run, on Windows, the configuration they already run on Linux CI.
2. **`scratch_remove()`** — unlinks the fixture and **checks the `rmdir`**, failing the test with the errno if the directory survived. This is what makes the next regression of this kind loud instead of silent: a directory that outlives its own test now means a knob did not arrive.

Both are worth having together. `env_set()` alone fixes today's symptom; without the checked `rmdir`, the symptom can only ever be noticed by someone reading `git status`.

The four **error-path** `rmdir(directory)` calls in the same file (lines 818, 833, 862, 1040 on this base) have the same shape but run only after the test has already failed; they are left alone to keep this change to the path that leaks on every run.

## Validation

- [ ] `make -C c check`
- [ ] CUDA changes were tested with `make -C c cuda-test` (if applicable)
- [ ] Performance claims include hardware, commands, and repeatable measurements
- [ ] Performance claims include a validated experiment manifest with raw evidence

Not a CUDA change; no performance claim. The first box is left unticked, for the same reason as my other two PRs on this repository: this machine has no binary named `make` (GNU make ships as `mingw32-make.exe`) and does have `torch` installed, so the suite's number here is not the number CI would print. With a GNU `make` on `PATH`:

| | result |
|---|---|
| pristine `dev` @ `173c757` | `Ran 928 tests … FAILED (errors=1, skipped=68)` |
| this branch | `Ran 928 tests in 203.312s … FAILED (errors=1, skipped=68)` |

The single error is identical on both, and is not this PR's: `ERROR: setUpClass (test_fp8_e2e_repack_load.Fp8RepackLoadE2ETest)` — the Windows CFLAGS bug in that harness, filed as #1413 with its own PR. On CI it does not fire, because the Windows job installs no `torch` and the module skips at import. So the gate differs by zero tests, and I would rather show the number than tick a box it does not support.

### The test itself

Native MinGW build (WinLibs GCC 16.2.0, UCRT64), run in an empty directory with no env vars preset:

**pristine `dev` @ `173c757`** — exit 0, three directories left behind:

```
$ ls
colibri-v4-pool-<pid>  colibri-v4-scaling-<pid>  colibri-v4-store-<pid>
$ ls -la colibri-v4-store-<pid>
-rw-r--r-- ... 74  .coli_usage
```

**this branch** — exit 0, nothing left behind:

```
$ ls
out.txt
```

And end to end, after a full `make check` in each of the four worktrees that were built here:

| worktree | `c/colibri-v4-*` directories left behind |
|---|---|
| pristine `173c757`, two gate runs | 6 |
| `fix/fp8-e2e-windows-cflags`, four gate runs | 12 |
| `fix/glm53-serve-cancel`, one gate run | 3 |
| **this branch, one gate run** | **0** |

Twenty-one directories across the three unpatched trees, none in the patched one — and all three ExpertStore tests still report `ok` inside the gate.

**Negative control**, this branch with `env_set()`'s Windows branch put back to the pre-fix spelling — exit 1:

```
scratch directory colibri-v4-store-<pid> survived its test (errno=41): the engine
wrote into it, so the knobs this test sets did not reach getenv()

FAIL: test_expert_store
```

`errno=41` is `ENOTEMPTY`. The control fails for the right reason and names it.

### Why the two settings are the same test

Setting the variable in the **environment** (before the process starts, so the CRT copy has it) prevents the leftovers on the unpatched binary too:

| on pristine `173c757` | leftovers |
|---|---|
| nothing set | 3 directories |
| `COLI_V4_SAVE_USAGE=0` | none |
| `USAGE_SAVE=0` | none (`route_trace.h:340`, the second gate) |

That is what isolates the cause to the `setenv` spelling rather than to the engine saving history it should not save — and it is why the fix is in the test and not in `hot_usage_save`.

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included

Test-only change; no production code is touched. `_putenv_s` is the CRT function the two sibling tests already use on Windows, and the non-Windows branch is the same `setenv()` the file used before.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
