### PR TITLE
test(v4): make the expert-store registry test build on Windows

### DIFF
--- a/c/test_expert_store_registry.c
+++ b/c/test_expert_store_registry.c
@@ -19,6 +19,21 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Windows has no setenv/unsetenv at all -- MinGW fails this file at link time
+ * with "undefined reference to `setenv'".  compat.h's SetEnvironmentVariableA
+ * shim fixes the link but not the test: coli_expert_store_backend_open_selected
+ * reads COLI_EXPERT_STORE with getenv(), and getenv() reads the CRT's own copy
+ * of the environment, which that shim does not update -- the same trap
+ * test_qwen36_ctx.c and test_inkling_shared_batch.c document. _putenv_s is the
+ * one that updates the copy getenv() reads. */
+#ifdef _WIN32
+static void env_set(const char *name, const char *value) { _putenv_s(name, value); }
+static void env_unset(const char *name) { _putenv_s(name, ""); }
+#else
+static void env_set(const char *name, const char *value) { setenv(name, value, 1); }
+static void env_unset(const char *name) { unsetenv(name); }
+#endif
+
 static int g_auto_called = 0;
 
 /* Stub for the built-in backend's open fn. */
@@ -51,7 +66,7 @@ int main(void) {
     ColiExpertStore *out = NULL;
 
     /* Unregistered backend selected by env -> clean error, no dispatch. */
-    setenv("COLI_EXPERT_STORE", "example-not-linked", 1);
+    env_set("COLI_EXPERT_STORE", "example-not-linked");
     g_auto_called = 0;
     int rc = coli_expert_store_backend_open_selected(NULL, NULL, NULL, &out, err, sizeof(err));
     if (rc == 0 || g_auto_called) {
@@ -66,7 +81,7 @@ int main(void) {
     printf("unregistered backend -> clean error: %s\n", err);
 
     /* Env unset -> default 'auto' -> dispatch to the stub. */
-    unsetenv("COLI_EXPERT_STORE");
+    env_unset("COLI_EXPERT_STORE");
     g_auto_called = 0;
     err[0] = 0;
     rc = coli_expert_store_backend_open_selected(NULL, NULL, NULL, &out, err, sizeof(err));
@@ -79,14 +94,14 @@ int main(void) {
     printf("default (COLI_EXPERT_STORE unset) -> dispatched to 'auto'\n");
 
     /* Explicit 'auto' also dispatches. */
-    setenv("COLI_EXPERT_STORE", "auto", 1);
+    env_set("COLI_EXPERT_STORE", "auto");
     g_auto_called = 0;
     coli_expert_store_backend_open_selected(NULL, NULL, NULL, &out, err, sizeof(err));
     if (!g_auto_called) {
         printf("FAIL: explicit 'auto' did not dispatch\n");
         return 1;
     }
-    unsetenv("COLI_EXPERT_STORE");
+    env_unset("COLI_EXPERT_STORE");
     printf("explicit 'auto' -> dispatched to 'auto'\n");
 
     printf("ALL OK\n");


### PR DESCRIPTION
## Summary

Fixes #1417.

`c/test_expert_store_registry.c` does not build on Windows, so the `deepseek-v4-test-registry` target is unreachable there:

```
$ cd c && make -f Makefile.deepseek-v4 deepseek-v4-test-registry
test_expert_store_registry.c:54:5: error: implicit declaration of function 'setenv'; did you mean 'getenv'? [-Wimplicit-function-declaration]
test_expert_store_registry.c:69:5: error: implicit declaration of function 'unsetenv' [-Wimplicit-function-declaration]
make: *** [Makefile.deepseek-v4:276: test_expert_store_registry] Error 1
```

The file is the only one under `c/` that calls `setenv`/`unsetenv` without `compat.h`, which is where every other platform in this tree gets them from; MinGW has neither symbol, so forcing the implicit declaration through just moves the failure to the link (`undefined reference to 'setenv'`).

### Why `compat.h` is the wrong include here

Adding it links, and then the test fails — which is the more interesting half of this:

```
FAIL: unregistered backend should error without dispatch (rc=-1, auto_called=1)
```

`compat.h:330` maps `setenv` onto `SetEnvironmentVariableA`, which updates the Win32 environment block; `getenv()` reads the CRT's own copy of it and never sees the change. `coli_expert_store_backend_open_selected()` reads `COLI_EXPERT_STORE` with `getenv()` (`c/expert_store_registry.c:83`), so it never saw `example-not-linked` and fell through to the default `auto` — the assertion this test exists for (an unregistered name errors cleanly, *without dispatch*) would have been silently skipped. A green-looking test that proves nothing is worse than the build error.

### The change

`env_set()` / `env_unset()` at the top of the file: `_putenv_s` on Windows, `setenv`/`unsetenv` elsewhere. That is the helper six other test files in this tree already carry for exactly this reason — `test_qwen36_ctx.c:27-33`, `test_inkling_shared_batch.c:16-19`, `test_omp_tune.c`, `test_qwen36_dense_batch.c` and the two benches — and `_putenv_s` is the one that updates the copy `getenv()` reads. Four call sites change; nothing else does.

## Validation

- [ ] `make -C c check`
- [ ] CUDA changes were tested with `make -C c cuda-test` (if applicable)
- [ ] Performance claims include hardware, commands, and repeatable measurements
- [ ] Performance claims include a validated experiment manifest with raw evidence

Not a CUDA change; no performance claim. The first box is left unticked because it cannot say anything about this PR either way: the file is **not part of `make check`**. `deepseek-v4-test-registry` is a `.PHONY` target in `Makefile.deepseek-v4` that belongs to no aggregate, and `c/Makefile` never calls it — which is also why the Windows break went unnoticed. Ticking a box for a gate that does not build the file would be worse than leaving it. **The target demonstrated below is the validation.**

For completeness, `make -C c check` on this branch is unchanged from pristine `dev` at `173c757` (`Ran 928 tests … FAILED (errors=1, skipped=68)`, the one error being the unrelated `test_fp8_e2e_repack_load` Windows CFLAGS bug filed as #1413) — but that is the same number with or without this change, so it is not evidence for it.

### The target this fixes

**pristine `dev` @ `173c757`** (WinLibs GCC 16.2.0, UCRT64) — exit 2:

```
$ cd c && make -f Makefile.deepseek-v4 deepseek-v4-test-registry
test_expert_store_registry.c:54:5: error: implicit declaration of function 'setenv'; ...
make: *** [Makefile.deepseek-v4:276: test_expert_store_registry] Error 1
```

**this branch** — exit 0:

```
$ cd c && make -f Makefile.deepseek-v4 deepseek-v4-test-registry
gcc -O2 -Wall -Wextra test_expert_store_registry.c expert_store_registry.c -o test_expert_store_registry
./test_expert_store_registry
unregistered backend -> clean error: expert store backend 'example-not-linked' is not registered (set COLI_EXPERT_STORE to a linked backend; default is 'auto')
default (COLI_EXPERT_STORE unset) -> dispatched to 'auto'
explicit 'auto' -> dispatched to 'auto'
ALL OK
```

Both `-Wall -Wextra` warnings the target asks for are clean. `test_expert_store_registry(.exe)` is already in `c/.gitignore:11`.

The documented one-liner in the file's own header (`c/test_expert_store_registry.c:14`) builds and runs the same way, so the instructions in the file are true again on Windows.

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included

Test-only change; no production code is touched. `_putenv_s` is a CRT function, already used by six test files in this tree; the non-Windows branch is the same `setenv`/`unsetenv` the file called before.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
