### PR TITLE
fix(coli): preserve explicit Windows expert budgets

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -836,7 +836,10 @@ def env_for(a):
                         # CUDA_DENSE / CUDA_EXPERT_GB from the user always win.
                         dense=int(plan["tiers"].get("ram",{}).get("dense_bytes",0) or 0)
                         room=int(vt.get("budget_bytes",0) or 0)-dense
-                        if dense>0 and room>=4*(1024**3) and "CUDA_DENSE" not in e:
+                        # An explicit expert budget owns the placement decision:
+                        # do not shrink it or add a trunk outside that budget.
+                        if (dense>0 and room>=4*(1024**3) and "CUDA_DENSE" not in e
+                                and "CUDA_EXPERT_GB" not in explicit_env):
                             e["CUDA_DENSE"]="1"
                             if "CUDA_EXPERT_GB" in e:
                                 e["CUDA_EXPERT_GB"]=f"{room/(1024**3):.3f}"

--- a/c/tests/test_env_defaults.py
+++ b/c/tests/test_env_defaults.py
@@ -231,6 +231,36 @@ class CudaAutoEnableTest(unittest.TestCase):
         self.assertNotIn("CUDA_DENSE", e)          # 0.5 GB left for experts: not worth it
         self.assertAlmostEqual(float(e["CUDA_EXPERT_GB"]), 13.0, places=2)
 
+    def test_win32_preserves_explicit_expert_budget_before_dense_placement(self):
+        """Automatic dense placement must not resize an explicit expert tier.
+
+        Exercise the real environment_for_plan: it preserves the user's value,
+        so env_for must not overwrite it afterwards or add an unbudgeted trunk.
+        Device discovery and the size plan are synthetic; no GPU is required.
+        """
+        import resource_plan
+        GPB = 1024 ** 3
+        gpus = [self._fake_gpu(total_mib=34000, free_mib=33000)]
+        for requested in ("20.000", "auto", "0"):
+            with self.subTest(CUDA_EXPERT_GB=requested):
+                budget = 20.0 if requested == "20.000" else 30.7
+                plan = {"policy": {"name": "quality"},
+                        "cpu": {"physical_cores": 8},
+                        "tiers": {"ram": {"budget_bytes": 120 * GPB,
+                                          "cache_slots_per_layer": 62,
+                                          "dense_bytes": int(12.5 * GPB)},
+                                  "vram": {"budget_bytes": int(budget * GPB),
+                                           "devices": gpus}}}
+                with mock.patch.dict(os.environ, {"CUDA_EXPERT_GB": requested}, clear=True), \
+                     mock.patch.object(sys, "platform", "win32"), \
+                     mock.patch.object(coli, "cuda_binary", return_value=True), \
+                     mock.patch.object(resource_plan, "discover_gpus", return_value=gpus), \
+                     mock.patch.object(resource_plan, "physical_cpu_count", return_value=8), \
+                     mock.patch.object(resource_plan, "build_plan", return_value=plan):
+                    e = coli.env_for(args())
+                self.assertEqual(e["CUDA_EXPERT_GB"], requested)
+                self.assertNotIn("CUDA_DENSE", e)
+
     def test_win32_falls_back_to_cpu_when_nvidia_smi_missing(self):
         # coli_cuda.dll present (cuda=True) but nvidia-smi absent (no GPUs found)
         # -> warn + CPU-only, never crash, never set COLI_CUDA.


### PR DESCRIPTION
On Windows, bare `coli chat` can overwrite an explicit `CUDA_EXPERT_GB` after `environment_for_plan()` has preserved it. When the automatic dense-placement condition is met, a numeric budget is reduced, `auto` becomes a fixed number, and `0` can become a positive expert tier.

Skip automatic dense placement when the user supplied the expert budget. Preserve that value and the existing explicit `CUDA_DENSE` behavior; automatic placement with neither setting supplied continues to work.

The regression exercises `env_for()` with the real `environment_for_plan()` and synthetic discovery/plan inputs. On the parent, the three cases return `7.500` instead of `20.000`, and `18.200` instead of either `auto` or `0`. All three pass with this guard.

Validation: 25 launcher tests pass; 111 additional related Python tests and two C checks pass. The loopback-only test passed outside the restricted sandbox. Linux CPU builds of colibri and glm53 complete; unchanged glm53 code emits three missing-field-initializer warnings. The 12-GiB planner fixture was excluded for disk capacity, and two trunk token-equivalence tests skip because the generated fixture is absent. No native Windows/GPU validation or model inference is claimed.
