### PR TITLE
engines: publish the lazy HITS table under a lock (the parallel warmstart segfaulted on first touch)

### DIFF
--- a/c/glm53.c
+++ b/c/glm53.c
@@ -59,6 +59,7 @@
  */
 #define _GNU_SOURCE
 #include <stdio.h>
+#include <pthread.h>   /* ehit_mark publishes the lazy HITS table under a lock */
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
@@ -2720,13 +2721,27 @@ static int serve_one(GModel *m, Tok *tokenizer, ServeReq *q) {
  * matmul esperti (ffn_layer meno il disco), attention (mla/kda), testa
  * (mv su lm_head). L'attesa asincrona non esiste qui: glm53 legge in modo
  * sincrono, quindi expert_wait_s e' 0 per costruzione, non per omissione. */
+static pthread_mutex_t g_ehit_mx = PTHREAD_MUTEX_INITIALIZER;
 static void ehit_mark(GModel *m, int layer, int eid) {
     const Cfg *c = &m->c;
-    if (!m->ehit) {
-        m->ehit = calloc((size_t)c->n_layers, sizeof(uint8_t *));
-        for (int i = 0; i < c->n_layers; i++) m->ehit[i] = calloc((size_t)c->n_experts, 1);
+    /* The first touch can come from a parallel region (qwen36: the tier
+     * warmstart's omp loop calls expert_get from twelve threads at once):
+     * one thread published m->ehit while it was still filling the rows and
+     * a sibling dereferenced m->ehit[layer] == NULL -- SIGSEGV in about one
+     * run in twelve on a CUDA warmstart. Build the table privately, publish
+     * it once under a lock (double-checked), and read it with acquire order. */
+    uint8_t **ehit = __atomic_load_n(&m->ehit, __ATOMIC_ACQUIRE);
+    if (!ehit) {
+        pthread_mutex_lock(&g_ehit_mx);
+        ehit = m->ehit;
+        if (!ehit) {
+            ehit = calloc((size_t)c->n_layers, sizeof(uint8_t *));
+            for (int i = 0; i < c->n_layers; i++) ehit[i] = calloc((size_t)c->n_experts, 1);
+            __atomic_store_n(&m->ehit, ehit, __ATOMIC_RELEASE);
+        }
+        pthread_mutex_unlock(&g_ehit_mx);
     }
-    if (layer >= 0 && layer < c->n_layers && eid >= 0 && eid < c->n_experts) m->ehit[layer][eid] = 1;
+    if (layer >= 0 && layer < c->n_layers && eid >= 0 && eid < c->n_experts) ehit[layer][eid] = 1;
 }
 static int dash_rows(const GModel *m) {
     int rows = 0;

--- a/c/kimi_k3.c
+++ b/c/kimi_k3.c
@@ -1511,13 +1511,27 @@ static uint64_t g_slot_index_probes;
 #endif
 /* One byte per expert: routed in this turn or not. The dashboard's Brain tab
  * reads it as the HITS bitmap after every turn (serve_hits), cleared there. */
+static pthread_mutex_t g_ehit_mx = PTHREAD_MUTEX_INITIALIZER;
 static void ehit_mark(Model *m, int li, int eid){
     Cfg *c=&m->c;
-    if(!m->ehit){
-        m->ehit=calloc((size_t)c->n_layers,sizeof(uint8_t*));
-        for(int i=0;i<c->n_layers;i++) m->ehit[i]=calloc((size_t)c->n_experts,1);
+    /* The first touch can come from a parallel region (qwen36: the tier
+     * warmstart's omp loop calls expert_get from twelve threads at once):
+     * one thread published m->ehit while it was still filling the rows and
+     * a sibling dereferenced m->ehit[layer] == NULL -- SIGSEGV in about one
+     * run in twelve on a CUDA warmstart. Build the table privately, publish
+     * it once under a lock (double-checked), and read it with acquire order. */
+    uint8_t **ehit=__atomic_load_n(&m->ehit,__ATOMIC_ACQUIRE);
+    if(!ehit){
+        pthread_mutex_lock(&g_ehit_mx);
+        ehit=m->ehit;
+        if(!ehit){
+            ehit=calloc((size_t)c->n_layers,sizeof(uint8_t*));
+            for(int i=0;i<c->n_layers;i++) ehit[i]=calloc((size_t)c->n_experts,1);
+            __atomic_store_n(&m->ehit,ehit,__ATOMIC_RELEASE);
+        }
+        pthread_mutex_unlock(&g_ehit_mx);
     }
-    if(li>=0&&li<c->n_layers&&eid>=0&&eid<c->n_experts) m->ehit[li][eid]=1;
+    if(li>=0&&li<c->n_layers&&eid>=0&&eid<c->n_experts) ehit[li][eid]=1;
 }
 static Slot *slot_indexed(Model *m, int li, int eid){
     LCache *lc=&m->ecache[li];

--- a/c/qwen36.c
+++ b/c/qwen36.c
@@ -1595,13 +1595,27 @@ static void slot_ensure_int8(Model *m, Slot *s) {
 /* Segna l'esperto instradato per la bitmap HITS della dashboard. Vive qui,
  * fuori dalla regione QWEN36_NO_MAIN: expert_get la chiama anche nel build
  * del segment adapter, dove il resto della telemetria serve non esiste. */
+static pthread_mutex_t g_ehit_mx = PTHREAD_MUTEX_INITIALIZER;
 static void ehit_mark(Model *m, int layer, int eid){
     const Cfg *c=&m->c;
-    if(!m->ehit){
-        m->ehit=calloc((size_t)c->n_layers,sizeof(uint8_t*));
-        for(int i=0;i<c->n_layers;i++) m->ehit[i]=calloc((size_t)c->n_experts,1);
+    /* The first touch can come from a parallel region (qwen36: the tier
+     * warmstart's omp loop calls expert_get from twelve threads at once):
+     * one thread published m->ehit while it was still filling the rows and
+     * a sibling dereferenced m->ehit[layer] == NULL -- SIGSEGV in about one
+     * run in twelve on a CUDA warmstart. Build the table privately, publish
+     * it once under a lock (double-checked), and read it with acquire order. */
+    uint8_t **ehit=__atomic_load_n(&m->ehit,__ATOMIC_ACQUIRE);
+    if(!ehit){
+        pthread_mutex_lock(&g_ehit_mx);
+        ehit=m->ehit;
+        if(!ehit){
+            ehit=calloc((size_t)c->n_layers,sizeof(uint8_t*));
+            for(int i=0;i<c->n_layers;i++) ehit[i]=calloc((size_t)c->n_experts,1);
+            __atomic_store_n(&m->ehit,ehit,__ATOMIC_RELEASE);
+        }
+        pthread_mutex_unlock(&g_ehit_mx);
     }
-    if(layer>=0&&layer<c->n_layers&&eid>=0&&eid<c->n_experts) m->ehit[layer][eid]=1;
+    if(layer>=0&&layer<c->n_layers&&eid>=0&&eid<c->n_experts) ehit[layer][eid]=1;
 }
 static void expert_get(Model *m, int layer, int eid, Slot **out) {
     ehit_mark(m, layer, eid);   /* tocca solo m->ehit[layer][eid] */

--- a/c/qwen38_core.h
+++ b/c/qwen38_core.h
@@ -8,6 +8,7 @@
  */
 #ifndef COLI_QWEN38_CORE_H
 #define COLI_QWEN38_CORE_H
+#include <pthread.h>   /* q38_ehit_mark publishes the lazy HITS table under a lock */
 
 #define Q38_MAX_LAYERS 512
 #define Q38_MAX_EXPERTS 1024
@@ -1242,13 +1243,27 @@ static void q38_load_expert(Model *m,int layer,int eid,Slot *s) {
 /* One byte per expert: routed in this turn or not. The dashboard's Brain tab
  * reads it as the HITS bitmap after every turn (serve_hits in qwen38.c),
  * cleared there. Marked on both lookup paths, single and batched. */
+static pthread_mutex_t g_q38_ehit_mx=PTHREAD_MUTEX_INITIALIZER;
 static void q38_ehit_mark(Model *m,int layer,int eid) {
     const Cfg *c=&m->c;
-    if(!m->ehit){
-        m->ehit=(uint8_t**)calloc((size_t)c->layers,sizeof(uint8_t*));
-        for(int i=0;i<c->layers;i++)m->ehit[i]=(uint8_t*)calloc((size_t)c->experts,1);
+    /* The first touch can come from a parallel region (qwen36: the tier
+     * warmstart's omp loop calls expert_get from twelve threads at once):
+     * one thread published m->ehit while it was still filling the rows and
+     * a sibling dereferenced m->ehit[layer] == NULL -- SIGSEGV in about one
+     * run in twelve on a CUDA warmstart. Build the table privately, publish
+     * it once under a lock (double-checked), and read it with acquire order. */
+    uint8_t **ehit=__atomic_load_n(&m->ehit,__ATOMIC_ACQUIRE);
+    if(!ehit){
+        pthread_mutex_lock(&g_q38_ehit_mx);
+        ehit=m->ehit;
+        if(!ehit){
+            ehit=(uint8_t**)calloc((size_t)c->layers,sizeof(uint8_t*));
+            for(int i=0;i<c->layers;i++)ehit[i]=(uint8_t*)calloc((size_t)c->experts,1);
+            __atomic_store_n(&m->ehit,ehit,__ATOMIC_RELEASE);
+        }
+        pthread_mutex_unlock(&g_q38_ehit_mx);
     }
-    if(layer>=0&&layer<c->layers&&eid>=0&&eid<c->experts)m->ehit[layer][eid]=1;
+    if(layer>=0&&layer<c->layers&&eid>=0&&eid<c->experts)ehit[layer][eid]=1;
 }
 static Slot *q38_expert_get(Model *m,int layer,int eid) {
     q38_ehit_mark(m,layer,eid);


### PR DESCRIPTION
Fixes #1422.

## The defect

`ehit_mark` (3365fbb) allocates `m->ehit` on first touch with no synchronisation, and `expert_get` calls it before it takes `g_pilot_mx`. On a CUDA run the first touch is `tier_warmstart`'s `omp parallel for`: one thread publishes the outer array while it is still filling the rows, a sibling sees non-NULL and dereferences `m->ehit[layer] == NULL`. Measured on `dev` `6f9117f` with CI's `qwen36_tiny` as an int8 container, two cards: 6 segfaults in 64 default-warmstart runs, backtrace in the issue. Never on the CPU-only path (single-threaded first touch), never with `QT_NO_WARMSTART=1`.

## The fix

One shape in all four places that carry the code (`qwen36.c`, `kimi_k3.c`, `glm53.c`, `qwen38_core.h`): build the table in a local, publish it once under a static mutex (double-checked), read it with an acquire load, mark through the local. Nothing changes for the single-threaded first touch, `hits_emit`'s `ehit_mark(m,-1,-1)` still creates the all-zero bitmap, and the fast path stays one atomic load. `glm53.c` and `qwen38_core.h` gain a `<pthread.h>` include; both engines already link pthread.

Whether kimi_k3, glm53 and qwen38 can reach their first touch from a parallel region today I did not verify; the code is identical and the lock is cheap, so they get it too rather than waiting for their own crash.

## Verified

RTX 3070 + Quadro RTX 4000, driver 580.173, CUDA 12.0, `make qwen36 CUDA=1`:

| | before | after |
|---|---|---|
| int8 container, default warmstart, `./qwen36 8 8 ref_full.json` | 6 crashes / 64 runs | 0 / 80, 16/16 tokens |
| int4 container, `./qwen36 8 4` | crashes at the same rate | 0 / 20, 16/16 tokens |
| `tests/test_qwen36_tier_*` (nine) | -- | all pass |
| `make qwen38-tiny-check` | -- | 8/8 tokens, cosine 0.99998958 PASS |
| `make qwen36 qwen38 kimi_k3 glm53` | -- | build, no new warnings (glm53's three `Mat.vk` initializer warnings are on `dev` already) |

No test is added: the race needs real thread timing and does not reproduce on the fake backend; the 80-run loop above is the regression check, and it is in the issue for anyone with a card.

Thanks on Claude Code

