### PR TITLE
fix(compat): setenv must be visible to getenv in the same process (Windows)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,14 @@ jobs:
             echo "::endgroup::"
           done
           exit $rc
+      - name: "Environment shims: setenv is visible to getenv in-process"
+        run: |
+          cd c
+          # This is the one gate that has to run OFF Linux. compat.h's setenv
+          # used to write only the Win32 block, which getenv never reads, so
+          # the C suite on the Linux job could not see the defect at all.
+          make tests/test_compat_env
+          ./tests/test_compat_env
       - if: matrix.os == 'macos-latest'
         name: Build every Metal-capable engine with METAL=1
         # `make <engine>` above builds the CPU path only: everything behind

--- a/c/Makefile
+++ b/c/Makefile
@@ -1808,6 +1808,9 @@ tests/test_moe_gs_guard$(EXE): tests/test_moe_gs_guard.c colibri.c st.h uring.h 
 tests/test_omp_tune$(EXE): tests/test_omp_tune.c omp_tune.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
+tests/test_compat_env$(EXE): tests/test_compat_env.c compat.h
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+
 tests/test_kvb_notice$(EXE): tests/test_kvb_notice.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 

--- a/c/compat.h
+++ b/c/compat.h
@@ -15,6 +15,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdlib.h>   /* getenv / _putenv_s, used by the Windows env shims */
 #ifndef _WIN32
 #include <sys/mman.h>
 #include <unistd.h>
@@ -322,16 +323,39 @@ static inline off_t compat_fsize(int fd){
     return (off_t)li.QuadPart;
 }
 
-/* --- setenv -> SetEnvironmentVariableA (POSIX setenv assente su Windows) --- */
+/* --- setenv / unsetenv (assenti su Windows) ---
+ *
+ * A Windows process carries TWO views of its environment and they are not the
+ * same object: the Win32 environment block, which child processes inherit, and
+ * the CRT's own copy, which getenv() reads and which is populated once at
+ * startup. SetEnvironmentVariableA writes the first and leaves the second
+ * alone, so a setenv() followed by getenv() in the same process used to return
+ * the stale value -- silently, which is the worst way to not support
+ * something. Six test files had grown a private _putenv_s helper around it
+ * (#1416, #1417, #1420).
+ *
+ * _putenv_s writes the CRT copy AND keeps the Win32 block in sync, so both
+ * views agree. SetEnvironmentVariableA is kept alongside it so that a CRT that
+ * ever stopped syncing could not quietly break the inheritance the engine
+ * relies on (omp_tune.h's re-exec, inkling's OMP variables): the two calls
+ * write the same value to the two views, which is the invariant that matters.
+ *
+ * One difference from POSIX remains, and cannot be removed: the Windows CRT
+ * has no representation for a variable whose value is the empty string, so
+ * setenv(name, "", 1) REMOVES the variable instead of defining it empty. Code
+ * that distinguishes "" from unset must not rely on it. */
 static inline int compat_setenv(const char *name, const char *value, int overwrite){
     if(!overwrite && getenv(name)) return 0;
-    return SetEnvironmentVariableA(name, value) ? 0 : -1;
+    int rc = _putenv_s(name, value ? value : "");
+    SetEnvironmentVariableA(name, (value && *value) ? value : NULL);
+    return rc == 0 ? 0 : -1;
 }
 #define setenv(name,value,overwrite) compat_setenv(name,value,overwrite)
 
-/* --- unsetenv -> SetEnvironmentVariableA(NULL) --- */
 static inline int compat_unsetenv(const char *name){
-    return SetEnvironmentVariableA(name, NULL) ? 0 : -1;
+    int rc = _putenv_s(name, "");          /* empty value == remove, on Windows */
+    SetEnvironmentVariableA(name, NULL);
+    return rc == 0 ? 0 : -1;
 }
 #define unsetenv(name) compat_unsetenv(name)
 

--- a/c/tests/test_compat_env.c
+++ b/c/tests/test_compat_env.c
@@ -1,0 +1,78 @@
+/* setenv() must be visible to getenv() in the same process.
+ *
+ * On Windows the two are different objects: SetEnvironmentVariableA writes the
+ * Win32 environment block that children inherit, getenv() reads the CRT's own
+ * copy, and the shim used to write only the first. A value set by the engine
+ * and read back by the engine was therefore the OLD value, with no error
+ * anywhere -- the failure mode that made six test files grow their own
+ * _putenv_s helper (#1416, #1417, #1420).
+ *
+ * The assertions below are the POSIX contract, so they hold on every platform
+ * and the Windows shim is held to the same one. The empty-value case is the
+ * single place the platforms genuinely differ, and it is asserted as what it
+ * is rather than papered over.
+ */
+/* stdio before compat.h: the header uses FILE and stderr without including
+ * them, as every engine that pulls it in already has. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../compat.h"
+
+static int fails = 0;
+
+static void ck(int cond, const char *what) {
+    if (cond) { printf("  ok   %s\n", what); return; }
+    printf("  FAIL %s\n", what);
+    fails++;
+}
+
+static const char *NAME = "COLI_COMPAT_ENV_PROBE";
+
+int main(void) {
+    printf("compat env shims\n");
+    unsetenv(NAME);
+    ck(getenv(NAME) == NULL, "unset to start with");
+
+    ck(setenv(NAME, "first", 1) == 0, "setenv reports success");
+    const char *seen = getenv(NAME);
+    ck(seen != NULL && !strcmp(seen, "first"),
+       "getenv sees what setenv just wrote, in this process");
+
+    ck(setenv(NAME, "second", 0) == 0, "setenv without overwrite reports success");
+    seen = getenv(NAME);
+    ck(seen != NULL && !strcmp(seen, "first"),
+       "overwrite 0 leaves the existing value alone");
+
+    ck(setenv(NAME, "second", 1) == 0, "setenv with overwrite reports success");
+    seen = getenv(NAME);
+    ck(seen != NULL && !strcmp(seen, "second"), "overwrite 1 replaces it");
+
+#ifdef _WIN32
+    /* The other view: what a child process would inherit. Both have to carry
+     * the value, or the engine's re-exec (omp_tune.h) loses its settings. */
+    char block[64];
+    DWORD got = GetEnvironmentVariableA(NAME, block, (DWORD)sizeof(block));
+    ck(got > 0 && got < sizeof(block) && !strcmp(block, "second"),
+       "the Win32 block a child inherits carries it too");
+#endif
+
+    ck(unsetenv(NAME) == 0, "unsetenv reports success");
+    ck(getenv(NAME) == NULL, "getenv no longer sees it");
+
+    /* Windows has no representation for an empty value: setenv(name, "", 1)
+     * removes the variable there. Assert each platform's real behaviour so the
+     * difference is documented by a test rather than discovered by a user. */
+    setenv(NAME, "", 1);
+    seen = getenv(NAME);
+#ifdef _WIN32
+    ck(seen == NULL, "empty value removes the variable (Windows CRT limitation)");
+#else
+    ck(seen != NULL && *seen == '\0', "empty value is an empty value");
+#endif
+    unsetenv(NAME);
+
+    printf("%s\n", fails ? "FAILED" : "PASS");
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #1420.

## The defect

A Windows process carries two views of its environment and they are not the same
object. The Win32 environment block is what child processes inherit; the CRT
keeps its own copy, populated once at startup, and that is the one `getenv`
reads. `compat.h` wrote only the first, so `setenv` followed by `getenv` in the
same process returned the stale value, with no error anywhere.

Nothing in the engine reads back what it sets today, which is the only reason
this has not reached a user: the `setenv` calls that exist are for children
(`omp_tune.h`'s re-exec, inkling's OMP variables) or for Metal. Tests did hit
it, and rather than fixing the shim they grew private `_putenv_s` helpers around
it (#1416, #1417).

## The fix

`_putenv_s` writes the CRT copy and keeps the Win32 block in sync.
`SetEnvironmentVariableA` stays alongside it, so that a CRT that ever stopped
syncing could not quietly break the inheritance the re-exec depends on: the two
calls write the same value to the two views, which is the invariant that
matters. `overwrite` semantics are unchanged.

One difference from POSIX cannot be removed and is now documented by a test
rather than by a comment alone: the Windows CRT has no representation for a
variable whose value is the empty string, so `setenv(name, "", 1)` removes the
variable there instead of defining it empty.

## The test

`tests/test_compat_env.c` asserts the POSIX contract, so it holds on every
platform and the Windows shim is held to the same one: set then read back,
`overwrite 0` leaves an existing value alone, `overwrite 1` replaces it, unset
makes it disappear. On Windows it additionally checks that the block a child
would inherit carries the value too, which is the half the old shim got right
and this must not lose.

It has to run off Linux to mean anything, since `make test-c` runs on the Linux
job where the shim is not even compiled. It is therefore both a gate in
`test-c` (it has a Makefile rule, so `TEST_RULES` picks it up) and a step in the
every-platform engine job, which is the one that builds under msys2.

## Deliberately not here

Deleting the per-test `_putenv_s` helpers. There are fourteen of them rather
than the six the issue counted, they are correct as they stand, and several live
in files that open pull requests are already editing. They become dead weight
once this lands and can go in a quiet pass afterwards, when they will not
conflict with anyone.

## Verified

- `make -C c test-c`: ALL PASS, 0 failures, including the new gate.
- `./tests/test_compat_env` on Linux: 10 assertions, PASS.
- `make colibri qwen36 glm53`: build, no new warnings.
- The Windows and macOS legs of the engine job run the new step; that is what I
  am watching on this PR, since the defect only exists there.
