### PR TITLE
tests: drop the per-test _putenv_s helpers now that compat.h's setenv works

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1350,7 +1350,7 @@ tests/test_kv_disk$(EXE): tests/test_kv_disk.c colibri.c st.h json.h tok.h tok_u
 tests/test_e8_kernel$(EXE): tests/test_e8_kernel.c quant.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
-tests/test_rans$(EXE): tests/test_rans.c rans.h
+tests/test_rans$(EXE): tests/test_rans.c rans.h compat.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 # Structured-mutation fuzz for the rans record parser/decoder under
@@ -1604,7 +1604,7 @@ V4_TEST_LINK_OBJS += COLI_V4_UNIT_GPU.o backend_loader_dsv4.o
 V4_TEST_EXTRA_TARGETS = COLI_V4_UNIT_GPU.o backend_loader_dsv4.o
 endif
 
-tests/test_deepseek_v4$(EXE): tests/test_deepseek_v4.c deepseek_v4.c deepseek_v4.h \
+tests/test_deepseek_v4$(EXE): tests/test_deepseek_v4.c deepseek_v4.c deepseek_v4.h compat.h \
 		Makefile.deepseek-v4.units Makefile.deepseek-v4
 	$(MAKE) -f Makefile.deepseek-v4 ARCH=$(ARCH) deepseek-v4-test-objs \
 		COLI_V4_UNIT_ST.o COLI_V4_UNIT_CONFIG.o COLI_V4_UNIT_MATH.o COLI_V4_UNIT_SPARSE_ATTENTION.o \
@@ -1656,7 +1656,7 @@ tests/test_v4_serve_framing$(EXE): tests/test_v4_serve_framing.c deepseek_v4.c \
 
 endif
 
-tests/test_route_trace$(EXE): tests/test_route_trace.c route_trace.h
+tests/test_route_trace$(EXE): tests/test_route_trace.c route_trace.h compat.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_cli_args$(EXE): tests/test_cli_args.c cli_args.h
@@ -1666,19 +1666,19 @@ tests/test_cli_args$(EXE): tests/test_cli_args.c cli_args.h
 # coli_cuda_* e registra cosa riceve. E' il solo modo di provare in CI che un
 # esperto arriva davvero in VRAM e nel formato giusto (#1331) -- un test che si
 # fermasse a "qt_init ritorna 1" sarebbe passato anche col difetto.
-tests/test_qwen36_tier_int8$(EXE): tests/test_qwen36_tier_int8.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h
+tests/test_qwen36_tier_int8$(EXE): tests/test_qwen36_tier_int8.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h compat.h
 	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
 
 # Same fake backend (tests/qwen36_fake_cuda.h), two devices: proves the tier's
 # per-device input-replica block (G.is_x) is sized and strided so device 1's
 # block cannot run past the end of the buffer or into device 0's (#1339).
-tests/test_qwen36_tier_multidev$(EXE): tests/test_qwen36_tier_multidev.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h
+tests/test_qwen36_tier_multidev$(EXE): tests/test_qwen36_tier_multidev.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h compat.h
 	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
 
 # Same fake backend, single device: proves qt_shutdown returns (under an
 # alarm(10) watchdog) instead of hanging forever when a group is still open
 # and an LFRU swap is parked waiting for cv_take (#1340).
-tests/test_qwen36_tier_shutdown$(EXE): tests/test_qwen36_tier_shutdown.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h
+tests/test_qwen36_tier_shutdown$(EXE): tests/test_qwen36_tier_shutdown.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h compat.h
 	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
 
 # Same fake backend, but driving the ENGINE: the warmstart in qwen36.c hands the
@@ -1693,7 +1693,7 @@ tests/test_qwen36_tier_shutdown$(EXE): tests/test_qwen36_tier_shutdown.c tests/q
 # issue blocks stay inside, disjoint and at their device's slot under random
 # routing on 1-3 devices. Under test-asan the third doubles as a fuzz for the
 # #1339 class.
-tests/test_qwen36_tier_invariants$(EXE): tests/test_qwen36_tier_invariants.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h
+tests/test_qwen36_tier_invariants$(EXE): tests/test_qwen36_tier_invariants.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h compat.h
 	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
 
 # Same fake backend: the automatic placement (COLI_PLACE unset/"auto") puts
@@ -1701,14 +1701,14 @@ tests/test_qwen36_tier_invariants$(EXE): tests/test_qwen36_tier_invariants.c tes
 # experts by heat, keeps the trunk on the CPU when the marginal experts are
 # hotter, honours an explicit list and "off", and takes placed bytes out of
 # the expert budget -- on one and on two devices.
-tests/test_qwen36_tier_autoplace$(EXE): tests/test_qwen36_tier_autoplace.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h
+tests/test_qwen36_tier_autoplace$(EXE): tests/test_qwen36_tier_autoplace.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h compat.h
 	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
 
 # Same fake backend: the fp8 streaming mode a model whose experts do not fit
 # in RAM needs (Qwen3.8) -- cap < n_experts accepted, fmt=8 uploads with
 # 128x128 block scales, bytes staged unchanged, no pointer kept into the
 # engine's recycled slot, promotion decided when the bytes pass by.
-tests/test_qwen36_tier_fp8$(EXE): tests/test_qwen36_tier_fp8.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h
+tests/test_qwen36_tier_fp8$(EXE): tests/test_qwen36_tier_fp8.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h compat.h
 	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
 
 tests/test_qwen36_tier_int8_engine$(EXE): tests/test_qwen36_tier_int8_engine.c tests/qwen36_fake_cuda.h qwen36.c qwen36_tier.c qwen36_tier.h backend_cuda.h cli_args.h st.h json.h compat.h
@@ -1805,7 +1805,7 @@ tests/test_pilot_ring$(EXE): tests/test_pilot_ring.c colibri.c st.h uring.h json
 tests/test_moe_gs_guard$(EXE): tests/test_moe_gs_guard.c colibri.c st.h uring.h json.h tok.h tok_unicode.h compat.h grammar.h tier.h quant.h sample.h kv_persist.h telemetry.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
-tests/test_omp_tune$(EXE): tests/test_omp_tune.c omp_tune.h
+tests/test_omp_tune$(EXE): tests/test_omp_tune.c omp_tune.h compat.h
 	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 tests/test_compat_env$(EXE): tests/test_compat_env.c compat.h

--- a/c/Makefile.deepseek-v4
+++ b/c/Makefile.deepseek-v4
@@ -269,11 +269,12 @@ endif
 deepseek-v4-test-objs: $(TEST_UNIT_OBJS)
 
 # Registry unit test (no engine link — stubs the auto open fn).
+# -D_FILE_OFFSET_BITS=64: compat.h (setenv/unsetenv shims) requires it on Windows.
 deepseek-v4-test-registry: test_expert_store_registry
 	./test_expert_store_registry
 test_expert_store_registry: test_expert_store_registry.c expert_store_registry.c \
-	expert_store_registry.h expert_store.h
-	$(CC) -O2 -Wall -Wextra test_expert_store_registry.c expert_store_registry.c -o $@
+	expert_store_registry.h expert_store.h compat.h
+	$(CC) -O2 -Wall -Wextra -D_FILE_OFFSET_BITS=64 test_expert_store_registry.c expert_store_registry.c -o $@
 
 deepseek-v4-clean:
 	rm -f $(V4_BINARY) $(V4_OBJS) $(TEST_UNIT_OBJS) $(V4_HOT_TEST_OBJ) \

--- a/c/test_expert_store_registry.c
+++ b/c/test_expert_store_registry.c
@@ -11,7 +11,7 @@
  * we stub it here so this test links without the engine. The stub records that
  * it was called and returns a sentinel so we can observe dispatch.
  *
- *   gcc -O2 test_expert_store_registry.c expert_store_registry.c -o test_expert_store_registry
+ *   gcc -O2 -D_FILE_OFFSET_BITS=64 test_expert_store_registry.c expert_store_registry.c -o test_expert_store_registry
  *   ./test_expert_store_registry
  */
 #include "expert_store_registry.h"
@@ -19,20 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* Windows has no setenv/unsetenv at all -- MinGW fails this file at link time
- * with "undefined reference to `setenv'".  compat.h's SetEnvironmentVariableA
- * shim fixes the link but not the test: coli_expert_store_backend_open_selected
- * reads COLI_EXPERT_STORE with getenv(), and getenv() reads the CRT's own copy
- * of the environment, which that shim does not update -- the same trap
- * test_qwen36_ctx.c and test_inkling_shared_batch.c document. _putenv_s is the
- * one that updates the copy getenv() reads. */
-#ifdef _WIN32
-static void env_set(const char *name, const char *value) { _putenv_s(name, value); }
-static void env_unset(const char *name) { _putenv_s(name, ""); }
-#else
-static void env_set(const char *name, const char *value) { setenv(name, value, 1); }
-static void env_unset(const char *name) { unsetenv(name); }
-#endif
+#include "compat.h"    /* setenv/unsetenv: MinGW has neither */
 
 static int g_auto_called = 0;
 
@@ -66,7 +53,7 @@ int main(void) {
     ColiExpertStore *out = NULL;
 
     /* Unregistered backend selected by env -> clean error, no dispatch. */
-    env_set("COLI_EXPERT_STORE", "example-not-linked");
+    setenv("COLI_EXPERT_STORE", "example-not-linked", 1);
     g_auto_called = 0;
     int rc = coli_expert_store_backend_open_selected(NULL, NULL, NULL, &out, err, sizeof(err));
     if (rc == 0 || g_auto_called) {
@@ -81,7 +68,7 @@ int main(void) {
     printf("unregistered backend -> clean error: %s\n", err);
 
     /* Env unset -> default 'auto' -> dispatch to the stub. */
-    env_unset("COLI_EXPERT_STORE");
+    unsetenv("COLI_EXPERT_STORE");
     g_auto_called = 0;
     err[0] = 0;
     rc = coli_expert_store_backend_open_selected(NULL, NULL, NULL, &out, err, sizeof(err));
@@ -94,14 +81,14 @@ int main(void) {
     printf("default (COLI_EXPERT_STORE unset) -> dispatched to 'auto'\n");
 
     /* Explicit 'auto' also dispatches. */
-    env_set("COLI_EXPERT_STORE", "auto");
+    setenv("COLI_EXPERT_STORE", "auto", 1);
     g_auto_called = 0;
     coli_expert_store_backend_open_selected(NULL, NULL, NULL, &out, err, sizeof(err));
     if (!g_auto_called) {
         printf("FAIL: explicit 'auto' did not dispatch\n");
         return 1;
     }
-    env_unset("COLI_EXPERT_STORE");
+    unsetenv("COLI_EXPERT_STORE");
     printf("explicit 'auto' -> dispatched to 'auto'\n");
 
     printf("ALL OK\n");

--- a/c/tests/bench_inkling_shared_batch.c
+++ b/c/tests/bench_inkling_shared_batch.c
@@ -13,21 +13,6 @@
 
 enum { S = 16, D = 2048, I = 1024, K = 2, NS = 2, REPS = 3 };
 
-static void env_set(const char *name,const char *value) {
-#ifdef _WIN32
-    _putenv_s(name,value);
-#else
-    setenv(name,value,1);
-#endif
-}
-static void env_unset(const char *name) {
-#ifdef _WIN32
-    _putenv_s(name,"");
-#else
-    unsetenv(name);
-#endif
-}
-
 static uint16_t to_bf16(float x) {
     union { float f; uint32_t u; } v = { x };
     return (uint16_t)(v.u >> 16);
@@ -61,8 +46,8 @@ static void init_q4(Wt *w, int rows, int cols, int salt) {
 static double one(Model *m, Layer *l, const float *x, const float *wgt,
                   const float *seed, float *out, const char *mode) {
     float *g = falloc(2 * I), *u = g + I, *hh = falloc(D);
-    if (mode) env_set("INK_SHARED_BATCH", mode);
-    else env_unset("INK_SHARED_BATCH");
+    if (mode) setenv("INK_SHARED_BATCH", mode, 1);
+    else unsetenv("INK_SHARED_BATCH");
     memcpy(out, seed, (size_t)S * D * sizeof(float));
     double t0 = now_s();
     shared_experts_cpu(m, l, x, S, out, wgt, g, u, hh);
@@ -125,7 +110,7 @@ int main(void) {
     qbytes+=(double)(NS*I*((D+63)/64)*2+NS*D*((I+63)/64))*sizeof(float);
     failed|=measure("int4-g64",qbytes/1048576.0,&m,&l,x,wgt,seed,scalar,batch);
 
-    env_unset("INK_SHARED_BATCH");
+    unsetenv("INK_SHARED_BATCH");
     free(l.sh_g.q4);free(l.sh_g.qs);free(l.sh_u.q4);free(l.sh_u.qs);
     free(l.sh_d.q4);free(l.sh_d.qs);
     free(x); free(wgt); free(seed); free(scalar); free(batch);

--- a/c/tests/bench_qwen36_dense_batch.c
+++ b/c/tests/bench_qwen36_dense_batch.c
@@ -24,26 +24,11 @@ static double batch(float *y,const float *x,const int8_t *q,const float *sc) {
     double t0=now_s();matmul_q_batch(y,x,q,sc,S,I,O);return now_s()-t0;
 }
 
-static void env_set(const char *name,const char *value) {
-#ifdef _WIN32
-    _putenv_s(name,value);
-#else
-    setenv(name,value,1);
-#endif
-}
-static void env_unset(const char *name) {
-#ifdef _WIN32
-    _putenv_s(name,"");
-#else
-    unsetenv(name);
-#endif
-}
-
 static double shared_run(Model *m,Layer *l,const float *x,const float *seed,
                          float *out,const char *mode) {
     float *g=falloc(O),*u=falloc(O),*hh=falloc(I);
-    if(mode){env_set("QWEN_SHARED_BATCH",mode);env_set("QWEN_DENSE_BATCH",mode);}
-    else{env_unset("QWEN_SHARED_BATCH");env_unset("QWEN_DENSE_BATCH");}
+    if(mode){setenv("QWEN_SHARED_BATCH",mode,1);setenv("QWEN_DENSE_BATCH",mode,1);}
+    else{unsetenv("QWEN_SHARED_BATCH");unsetenv("QWEN_DENSE_BATCH");}
     memcpy(out,seed,(size_t)S*I*sizeof(float));double t0=now_s();
     qwen_shared_experts_cpu(m,l,x,S,out,g,u,hh);double dt=now_s()-t0;
     free(g);free(u);free(hh);return dt;
@@ -75,12 +60,12 @@ static int shared_benchmark(void) {
     printf("scalar %.6f s  batch %.6f s  speedup %.2fx  calls %d -> 3\n",ts,tb,ts/tb,S*3);
     for(int i=0;i<g_qdw_n;i++){free(g_qdw[i].q);free(g_qdw[i].sc);}g_qdw_n=0;
     free(l.sh_g);free(l.sh_u);free(l.sh_d);free(l.sh_gate);
-    free(x);free(seed);free(a);free(b);env_unset("QWEN_SHARED_BATCH");env_unset("QWEN_DENSE_BATCH");
+    free(x);free(seed);free(a);free(b);unsetenv("QWEN_SHARED_BATCH");unsetenv("QWEN_DENSE_BATCH");
     return 0;
 }
 
 int main(void) {
-    env_unset("COLI_DENSE_I8");
+    unsetenv("COLI_DENSE_I8");
     float *x=falloc((int64_t)S*I),*a=falloc((int64_t)S*O),*b=falloc((int64_t)S*O);
     int8_t *q=malloc((size_t)O*I);float *sc=falloc(O);
     if(!q){fputs("OOM qwen dense benchmark\n",stderr);return 2;}

--- a/c/tests/qwen36_fake_cuda.h
+++ b/c/tests/qwen36_fake_cuda.h
@@ -22,15 +22,6 @@
 #include <stdint.h>
 #include <time.h>
 
-/* MinGW non ha setenv: il tier legge la sua configurazione dall'ambiente, e il
- * test deve poterla impostare anche su Windows. */
-#if defined(_WIN32)
-#include <stdlib.h>
-static int test_setenv(const char *name, const char *value, int overwrite) {
-    (void)overwrite; return _putenv_s(name, value);
-}
-#define setenv test_setenv
-#endif
 #include "../backend_cuda.h"
 
 struct ColiCudaTensor { int fmt, I, O, device, gs; const void *w; };

--- a/c/tests/test_deepseek_v4.c
+++ b/c/tests/test_deepseek_v4.c
@@ -16,21 +16,6 @@
 #include <string.h>
 #include <unistd.h>
 
-/* compat.h maps setenv() onto SetEnvironmentVariableA, which updates the Win32
- * environment block -- but getenv() reads the CRT's own copy of it and never
- * sees the value.  The three ExpertStore tests below set knobs that the engine
- * reads with getenv(), so on Windows the setenv() spelling was a no-op and they
- * ran with the very defaults they meant to override.  The same trap is spelled
- * out in test_qwen36_ctx.c and test_inkling_shared_batch.c; _putenv_s updates
- * the copy getenv() reads. */
-static void env_set(const char *name, const char *value) {
-#ifdef _WIN32
-    _putenv_s(name, value);
-#else
-    setenv(name, value, 1);
-#endif
-}
-
 /* mkdtemp() hands out a scratch directory, the engine appends <snap>/.coli_usage
  * to it whenever it saves its expert history, and rmdir() then fails on a
  * directory that is no longer empty.  Nothing was listening to that failure, so
@@ -642,9 +627,9 @@ static int test_expert_store(void) {
     /* Native MinGW binaries do not resolve the MSYS /tmp mount. */
     char directory[] = "colibri-v4-store-XXXXXX";
     char path[256], error[256];
-    env_set("COLI_V4_AUTOPIN", "0");
-    env_set("COLI_V4_SAVE_USAGE", "0");
-    env_set("COLI_V4_ROWS16", "0");
+    setenv("COLI_V4_AUTOPIN", "0", 1);
+    setenv("COLI_V4_SAVE_USAGE", "0", 1);
+    setenv("COLI_V4_ROWS16", "0", 1);
     if (!mkdtemp(directory)) { perror("mkdtemp"); return 1; }
     snprintf(path, sizeof(path), "%s/model.safetensors", directory);
     if (write_fixture(path) != 0) { perror("write_fixture"); return 1; }
@@ -838,9 +823,9 @@ static int test_expert_store_prefill_pool(void) {
     enum { LAYERS = 2, EXPERTS = 8, SLOTS_PER_LAYER = 6 };
     char directory[] = "colibri-v4-pool-XXXXXX";
     char path[256], error[256];
-    env_set("COLI_V4_AUTOPIN", "0");
-    env_set("COLI_V4_SAVE_USAGE", "0");
-    env_set("COLI_V4_ROWS16", "0");
+    setenv("COLI_V4_AUTOPIN", "0", 1);
+    setenv("COLI_V4_SAVE_USAGE", "0", 1);
+    setenv("COLI_V4_ROWS16", "0", 1);
     if (!mkdtemp(directory)) { perror("mkdtemp pool"); return 1; }
     snprintf(path, sizeof(path), "%s/model.safetensors", directory);
     if (write_fixture_layers(path, LAYERS, EXPERTS)) {
@@ -1059,9 +1044,9 @@ static int run_expert_miss_scaling_case(const char *directory, int experts,
 static int test_expert_store_miss_scaling(void) {
     char directory[] = "colibri-v4-scaling-XXXXXX";
     char path[256];
-    env_set("COLI_V4_AUTOPIN", "0");
-    env_set("COLI_V4_SAVE_USAGE", "0");
-    env_set("COLI_V4_ROWS16", "0");
+    setenv("COLI_V4_AUTOPIN", "0", 1);
+    setenv("COLI_V4_SAVE_USAGE", "0", 1);
+    setenv("COLI_V4_ROWS16", "0", 1);
     if (!mkdtemp(directory)) { perror("mkdtemp scaling"); return 1; }
     snprintf(path, sizeof(path), "%s/model.safetensors", directory);
     if (write_fixture_experts(path, 256)) {

--- a/c/tests/test_inkling_shared_batch.c
+++ b/c/tests/test_inkling_shared_batch.c
@@ -13,24 +13,6 @@ static int failures;
     fprintf(stderr,"FAIL %s:%d: ",__FILE__,__LINE__); \
     fprintf(stderr,__VA_ARGS__); fputc('\n',stderr); failures++; } } while (0)
 
-/* compat.h maps setenv() to SetEnvironmentVariableA on Windows, but getenv()
- * reads the CRT environment copy.  Use _putenv_s there so the production
- * getenv("INK_SHARED_BATCH") sees the mode under test. */
-static void env_set(const char *name,const char *value) {
-#ifdef _WIN32
-    _putenv_s(name,value);
-#else
-    setenv(name,value,1);
-#endif
-}
-static void env_unset(const char *name) {
-#ifdef _WIN32
-    _putenv_s(name,"");
-#else
-    unsetenv(name);
-#endif
-}
-
 static float value(int64_t i, int salt) {
     int v = (int)((i * 37 + salt * 17) % 101);
     return (float)(v - 50) / (float)(71 + salt);
@@ -63,7 +45,7 @@ static void compare_paths(const char *format,Model *m,Layer *l,int S,
     size_t out_bytes=(size_t)S*D*sizeof(float);
     float *scalar=falloc((int64_t)S*D),*out=falloc((int64_t)S*D);
     float *g=falloc((int64_t)2*I),*u=g+I,*hh=falloc(D);
-    memcpy(scalar,seed,out_bytes);env_set("INK_SHARED_BATCH","0");
+    memcpy(scalar,seed,out_bytes);setenv("INK_SHARED_BATCH","0",1);
     g_matmul_w_calls=0;shared_experts_cpu(m,l,x,S,scalar,wgt,g,u,hh);
     CHECK(g_matmul_w_calls==(uint64_t)S*ns*3,
           "%s scalar calls=%llu expected=%d",format,
@@ -72,7 +54,7 @@ static void compare_paths(const char *format,Model *m,Layer *l,int S,
     const char *modes[]={NULL,"3"};
     for(int z=0;z<2;z++){
         memcpy(out,seed,out_bytes);
-        if(modes[z])env_set("INK_SHARED_BATCH",modes[z]);else env_unset("INK_SHARED_BATCH");
+        if(modes[z])setenv("INK_SHARED_BATCH",modes[z],1);else unsetenv("INK_SHARED_BATCH");
         g_matmul_w_calls=0;shared_experts_cpu(m,l,x,S,out,wgt,g,u,hh);
         int chunks=modes[z]?(S+2)/3:1,expected=chunks*ns*3;
         CHECK(!memcmp(out,scalar,out_bytes),"%s mode=%s is not scalar bit-exact",
@@ -86,7 +68,7 @@ static void compare_paths(const char *format,Model *m,Layer *l,int S,
     }
 
     /* Decode must remain the original one-row GEMV path. */
-    memcpy(out,seed,(size_t)D*sizeof(float));env_unset("INK_SHARED_BATCH");
+    memcpy(out,seed,(size_t)D*sizeof(float));unsetenv("INK_SHARED_BATCH");
     g_matmul_w_calls=0;shared_experts_cpu(m,l,x,1,out,wgt,g,u,hh);
     CHECK(!memcmp(out,scalar,(size_t)D*sizeof(float)),"%s decode row changed",format);
     CHECK(g_matmul_w_calls==(uint64_t)ns*3,"%s decode used batch shape",format);
@@ -118,7 +100,7 @@ int main(void){
     run_format("f32",0,12,17,13);
     run_format("bf16",1,12,32,16);
     run_format("int4-g64",2,12,64,64);
-    env_unset("INK_SHARED_BATCH");
+    unsetenv("INK_SHARED_BATCH");
     if(failures){fprintf(stderr,"inkling shared batch: %d failure(s)\n",failures);return 1;}
     puts("inkling shared batch: ok");return 0;
 }

--- a/c/tests/test_omp_tune.c
+++ b/c/tests/test_omp_tune.c
@@ -11,6 +11,7 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
+#include "../compat.h"       /* setenv/unsetenv: MinGW has neither */
 #include "../omp_tune.h"
 
 #ifdef _WIN32
@@ -39,24 +40,6 @@ static int test_windows_variable_records(void)
 }
 #endif
 
-static void env_set(const char *name, const char *value)
-{
-#ifdef _WIN32
-    _putenv_s(name, value);
-#else
-    setenv(name, value, 1);
-#endif
-}
-
-static void env_unset(const char *name)
-{
-#ifdef _WIN32
-    _putenv_s(name, "");
-#else
-    unsetenv(name);
-#endif
-}
-
 int main(void)
 {
 #ifndef _OPENMP
@@ -71,8 +54,8 @@ int main(void)
     fail |= test_windows_variable_records();
 #endif
 
-    env_unset("OMP_NUM_THREADS");
-    env_unset("COLI_NO_OMP_TUNE");
+    unsetenv("OMP_NUM_THREADS");
+    unsetenv("COLI_NO_OMP_TUNE");
     omp_set_num_threads(logical);
     coli_omp_tune_threads("test");
     int got = omp_get_max_threads();
@@ -85,22 +68,22 @@ int main(void)
 
     int sentinel = logical > 1 ? logical - 1 : 1;
     omp_set_num_threads(sentinel);
-    env_set("OMP_NUM_THREADS", "7");
+    setenv("OMP_NUM_THREADS", "7", 1);
     coli_omp_tune_threads("test");
     if (omp_get_max_threads() != sentinel) {
         fprintf(stderr, "explicit OMP_NUM_THREADS override was not preserved\n");
         fail = 1;
     }
-    env_unset("OMP_NUM_THREADS");
+    unsetenv("OMP_NUM_THREADS");
 
     omp_set_num_threads(sentinel);
-    env_set("COLI_NO_OMP_TUNE", "1");
+    setenv("COLI_NO_OMP_TUNE", "1", 1);
     coli_omp_tune_threads("test");
     if (omp_get_max_threads() != sentinel) {
         fprintf(stderr, "COLI_NO_OMP_TUNE kill switch was not preserved\n");
         fail = 1;
     }
-    env_unset("COLI_NO_OMP_TUNE");
+    unsetenv("COLI_NO_OMP_TUNE");
 
     if (fail) {
         puts("test_omp_tune: FAIL");

--- a/c/tests/test_qwen36_ctx.c
+++ b/c/tests/test_qwen36_ctx.c
@@ -23,27 +23,6 @@
 
 static int fails = 0;
 
-/* Same pattern as test_omp_tune.c / test_stops.c, and for the same reason:
- * compat.h maps setenv() to SetEnvironmentVariableA, which updates the Win32
- * environment block -- but getenv() reads the CRT's own copy and never sees
- * it, so the value under test would silently not arrive. _putenv_s updates
- * the copy getenv() reads. */
-static void env_set(const char *name, const char *value) {
-#ifdef _WIN32
-    _putenv_s(name, value);
-#else
-    setenv(name, value, 1);
-#endif
-}
-
-static void env_unset(const char *name) {
-#ifdef _WIN32
-    _putenv_s(name, "");
-#else
-    unsetenv(name);
-#endif
-}
-
 static void ck(int cond, const char *what) {
     if (cond) { printf("  ok   %s\n", what); return; }
     printf("  FAIL %s\n", what);
@@ -134,12 +113,12 @@ static void case_ceiling(void) {
     ck(1, "every thread's score row holds max_t entries");
 
     /* Q36_MAXT may lower the ceiling but never raise it past the capacity. */
-    env_set("Q36_MAXT", "999999999");
+    setenv("Q36_MAXT", "999999999", 1);
     ck(qwen36_max_ctx() == QWEN36_ATTN_MAX_CTX,
        "Q36_MAXT cannot be raised past the capacity");
-    env_set("Q36_MAXT", "4096");
+    setenv("Q36_MAXT", "4096", 1);
     ck(qwen36_max_ctx() == 4096, "Q36_MAXT can lower the ceiling");
-    env_unset("Q36_MAXT");
+    unsetenv("Q36_MAXT");
     ck(qwen36_max_ctx() == QWEN36_DEFAULT_MAX_CTX,
        "unset Q36_MAXT falls back to the conservative default");
 }

--- a/c/tests/test_qwen36_dense_batch.c
+++ b/c/tests/test_qwen36_dense_batch.c
@@ -46,21 +46,6 @@ static void one_shape(int S, int I, int O) {
     free(x);free(q);free(sc);free(ref);free(got);
 }
 
-static void env_set(const char *name,const char *value) {
-#ifdef _WIN32
-    _putenv_s(name,value);
-#else
-    setenv(name,value,1);
-#endif
-}
-static void env_unset(const char *name) {
-#ifdef _WIN32
-    _putenv_s(name,"");
-#else
-    unsetenv(name);
-#endif
-}
-
 static void clear_qdw(void) {
     for(int i=0;i<g_qdw_n;i++){free(g_qdw[i].q);free(g_qdw[i].sc);}
     g_qdw_n=0;
@@ -81,14 +66,14 @@ static void shared_case(const char *format,int quantized) {
     float *g=falloc(I),*u=falloc(I),*hh=falloc(D);
     for(int64_t i=0;i<(int64_t)S*D;i++){x[i]=input_value(i,6);seed[i]=input_value(i,7);}
 
-    memcpy(ref,seed,(size_t)S*D*sizeof(float));env_set("QWEN_SHARED_BATCH","0");
-    env_set("QWEN_DENSE_BATCH","0");g_qwen_matmul_d_calls=0;
+    memcpy(ref,seed,(size_t)S*D*sizeof(float));setenv("QWEN_SHARED_BATCH","0",1);
+    setenv("QWEN_DENSE_BATCH","0",1);g_qwen_matmul_d_calls=0;
     qwen_shared_experts_cpu(&m,&l,x,S,ref,g,u,hh);
     CHECK(g_qwen_matmul_d_calls==(uint64_t)S*3,"%s scalar calls=%llu expected=%d",format,
           (unsigned long long)g_qwen_matmul_d_calls,S*3);
 
-    memcpy(got,seed,(size_t)S*D*sizeof(float));env_unset("QWEN_SHARED_BATCH");
-    env_unset("QWEN_DENSE_BATCH");g_qwen_matmul_d_calls=0;
+    memcpy(got,seed,(size_t)S*D*sizeof(float));unsetenv("QWEN_SHARED_BATCH");
+    unsetenv("QWEN_DENSE_BATCH");g_qwen_matmul_d_calls=0;
     qwen_shared_experts_cpu(&m,&l,x,S,got,g,u,hh);
     CHECK(!memcmp(ref,got,(size_t)S*D*sizeof(float)),"%s shared batch is not scalar bit-exact",format);
     CHECK(g_qwen_matmul_d_calls==3,"%s batch calls=%llu expected=3",format,
@@ -107,14 +92,14 @@ static void shared_case(const char *format,int quantized) {
 
 int main(void) {
     /* This gate owns the dense-int8 mode regardless of the caller's shell. */
-    env_unset("COLI_DENSE_I8");
+    unsetenv("COLI_DENSE_I8");
     one_shape(1, 17, 13);       /* decode-shaped fallback */
     one_shape(2, 32, 31);       /* one vector block, one row pair */
     one_shape(4, 64, 73);       /* even prompt, serial OpenMP clause */
     one_shape(5, 67, 259);      /* odd prompt + scalar tail + parallel clause */
     shared_case("f32",0);
     shared_case("int8",1);
-    env_unset("QWEN_SHARED_BATCH");env_unset("QWEN_DENSE_BATCH");
+    unsetenv("QWEN_SHARED_BATCH");unsetenv("QWEN_DENSE_BATCH");
     if(failures){fprintf(stderr,"qwen dense batch: %d failure(s)\n",failures);return 1;}
     puts("qwen dense batch: ok");return 0;
 }

--- a/c/tests/test_qwen36_tier_autoplace.c
+++ b/c/tests/test_qwen36_tier_autoplace.c
@@ -14,6 +14,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../compat.h"   /* setenv/unsetenv: MinGW has neither */
+
 #include "qwen36_fake_cuda.h"
 
 #include "../qwen36_tier.c"

--- a/c/tests/test_qwen36_tier_fp8.c
+++ b/c/tests/test_qwen36_tier_fp8.c
@@ -18,6 +18,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../compat.h"   /* setenv/unsetenv: MinGW has neither */
+
 #include "qwen36_fake_cuda.h"
 
 #include "../qwen36_tier.c"

--- a/c/tests/test_qwen36_tier_int8.c
+++ b/c/tests/test_qwen36_tier_int8.c
@@ -16,6 +16,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../compat.h"   /* setenv/unsetenv: MinGW has neither */
+
 /* ---- backend CUDA finto: le firme vengono da backend_cuda.h, che il tier
    include per conto suo; il corpo (condiviso con gli altri test del tier) e'
    in qwen36_fake_cuda.h. ---- */

--- a/c/tests/test_qwen36_tier_int8_decode.c
+++ b/c/tests/test_qwen36_tier_int8_decode.c
@@ -33,12 +33,6 @@
 #include "../qwen36.c"
 #undef main
 
-#ifdef _WIN32
-#undef setenv
-#undef unsetenv
-#define unsetenv(name) _putenv_s(name, "")
-#endif
-
 #include "qwen36_fake_cuda.h"
 
 #include "../qwen36_tier.c"

--- a/c/tests/test_qwen36_tier_int8_engine.c
+++ b/c/tests/test_qwen36_tier_int8_engine.c
@@ -31,18 +31,6 @@
 #include "../qwen36.c"
 #undef main
 
-/* compat.h (pulled in by qwen36.c) maps setenv/unsetenv to
- * SetEnvironmentVariableA, which updates the Win32 environment block -- but
- * getenv() reads the CRT's own copy and never sees it, so the tier would
- * silently not get COLI_CUDA here. Drop that mapping before the fake backend
- * installs its _putenv_s version, and unset the same way. Same reasoning as
- * tests/test_qwen36_ctx.c. */
-#ifdef _WIN32
-#undef setenv
-#undef unsetenv
-#define unsetenv(name) _putenv_s(name, "")
-#endif
-
 #include "qwen36_fake_cuda.h"
 
 #include "../qwen36_tier.c"

--- a/c/tests/test_qwen36_tier_invariants.c
+++ b/c/tests/test_qwen36_tier_invariants.c
@@ -39,6 +39,8 @@
 #include <unistd.h>
 #endif
 
+#include "../compat.h"   /* setenv/unsetenv: MinGW has neither */
+
 #include "qwen36_fake_cuda.h"
 
 #include "../qwen36_tier.c"

--- a/c/tests/test_qwen36_tier_multidev.c
+++ b/c/tests/test_qwen36_tier_multidev.c
@@ -18,6 +18,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "../compat.h"   /* setenv/unsetenv: MinGW has neither */
+
 #include "qwen36_fake_cuda.h"
 
 #include "../qwen36_tier.c"

--- a/c/tests/test_qwen36_tier_shutdown.c
+++ b/c/tests/test_qwen36_tier_shutdown.c
@@ -21,6 +21,8 @@
 #include <unistd.h>
 #include <time.h>
 
+#include "../compat.h"   /* setenv/unsetenv: MinGW has neither */
+
 #include "qwen36_fake_cuda.h"
 
 #include "../qwen36_tier.c"

--- a/c/tests/test_rans.c
+++ b/c/tests/test_rans.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "../compat.h"   /* setenv/unsetenv: MinGW has neither */
 #include "../rans.h"
 
 static int failures = 0;
@@ -558,51 +559,40 @@ static void test_arm_identity_suite(void) {
 }
 
 static void test_path_envelope(void) {
-#ifdef _WIN32
-    _putenv_s("RANS_PATH", ""); _putenv_s("RANS_NEON", ""); _putenv_s("RANS_AVX512", "");
-#else
     unsetenv("RANS_PATH"); unsetenv("RANS_NEON"); unsetenv("RANS_AVX512");
-#endif
     /* default selection is never invalid, and its name is real */
     rans_path best = rans_path_select();
     CHECK(best != RANS_PATH_INVALID, "default path select");
     CHECK(strcmp(rans_path_name(best), "invalid") != 0, "best path name");
 
     /* kill-switches force the vector arms out of best-path selection */
-#ifdef _WIN32
-#define SET_ENV(k, v) _putenv_s(k, v)
-#define UNSET_ENV(k) _putenv_s(k, "")
-#else
-#define SET_ENV(k, v) setenv(k, v, 1)
-#define UNSET_ENV(k) unsetenv(k)
-#endif
-    SET_ENV("RANS_NEON", "0");
-    SET_ENV("RANS_AVX512", "0");
+    setenv("RANS_NEON", "0", 1);
+    setenv("RANS_AVX512", "0", 1);
     rans_path p = rans_path_select();
     CHECK(p == RANS_PATH_SCALAR_BF, "kill-switches leave scalar_bf, got %s",
           rans_path_name(p));
 
     /* forcing a killed arm must refuse, not downgrade */
-    SET_ENV("RANS_PATH", "neon");
+    setenv("RANS_PATH", "neon", 1);
     p = rans_path_select();
     CHECK(p == RANS_PATH_INVALID, "forced killed neon: got %s", rans_path_name(p));
-    SET_ENV("RANS_PATH", "avx512");
+    setenv("RANS_PATH", "avx512", 1);
     p = rans_path_select();
     CHECK(p == RANS_PATH_INVALID, "forced killed avx512: got %s", rans_path_name(p));
 
     /* unknown forced name refuses */
-    SET_ENV("RANS_PATH", "warp-drive");
+    setenv("RANS_PATH", "warp-drive", 1);
     p = rans_path_select();
     CHECK(p == RANS_PATH_INVALID, "unknown forced path");
 
     /* forcing scalar always works */
-    SET_ENV("RANS_PATH", "scalar");
+    setenv("RANS_PATH", "scalar", 1);
     p = rans_path_select();
     CHECK(p == RANS_PATH_SCALAR, "forced scalar");
 
-    UNSET_ENV("RANS_PATH");
-    UNSET_ENV("RANS_NEON");
-    UNSET_ENV("RANS_AVX512");
+    unsetenv("RANS_PATH");
+    unsetenv("RANS_NEON");
+    unsetenv("RANS_AVX512");
 
     /* with the switches cleared, any compiled+selftested vector arm is
      * preferred over the scalar twins */
@@ -611,8 +601,6 @@ static void test_path_envelope(void) {
     CHECK(p == RANS_PATH_NEON || p == RANS_PATH_AVX512,
           "vector arm preferred on this build, got %s", rans_path_name(p));
 #endif
-#undef SET_ENV
-#undef UNSET_ENV
 }
 
 /* ---- 5. fix-round hardening regressions ---------------------------------- */

--- a/c/tests/test_route_trace.c
+++ b/c/tests/test_route_trace.c
@@ -308,26 +308,14 @@ int main(void){
      * staying frozen. Enforced in rt_save itself so every engine gets it. */
     {
         rt_counts(3)[4] = 99;
-#ifdef _WIN32
-        _putenv_s("USAGE_SAVE", "0");
-#else
         setenv("USAGE_SAVE", "0", 1);
-#endif
         long before = fsize(TMP);
         check(rt_save(TMP, 1) == 1, "USAGE_SAVE=0: a requested skip is not a failure");
         check(fsize(TMP) == before, "USAGE_SAVE=0: the history file is not rewritten");
-#ifdef _WIN32
-        _putenv_s("USAGE_SAVE", "1");
-#else
         setenv("USAGE_SAVE", "1", 1);
-#endif
         check(rt_save(TMP, 1) == 1, "USAGE_SAVE=1: saving works again");
         check(fsize(TMP) != before, "USAGE_SAVE=1: the new counter reaches the file");
-#ifdef _WIN32
-        _putenv_s("USAGE_SAVE", "");
-#else
         unsetenv("USAGE_SAVE");
-#endif
     }
 
     remove(TMP);

--- a/c/tests/test_stops.c
+++ b/c/tests/test_stops.c
@@ -63,22 +63,6 @@ static int expect(const char *what, int id, int want){
     return 0;
 }
 
-static void test_set_env(const char *name, const char *value){
-#ifdef _WIN32
-    _putenv_s(name,value);
-#else
-    setenv(name,value,1);
-#endif
-}
-
-static void clear_env(const char *name){
-#ifdef _WIN32
-    _putenv_s(name,"");
-#else
-    unsetenv(name);
-#endif
-}
-
 int main(void){
     int fail=0;
     /* Relative to the CWD, like test_compat_direct's TMPF — NOT "/tmp/...".
@@ -147,23 +131,23 @@ int main(void){
     /* 6. Private chat uses SERVE=1 for the byte protocol but has no Python
      *    StopFilter. Only the batched gateway may reduce the engine stop set. */
     { Cfg c; memset(&c,0,sizeof c); c.stop_ids[0]=100; c.n_stop=1;
-      test_set_env("SERVE","1"); clear_env("SERVE_BATCH"); clear_env("COLI_SERVE_ALL_STOPS");
+      setenv("SERVE","1",1); unsetenv("SERVE_BATCH"); unsetenv("COLI_SERVE_ALL_STOPS");
       stops_arm_tok(&c,100,&T);
       fail|=expect("private chat keeps <|user|>",101,1);
       fail|=expect("private chat keeps <|observation|>",102,1);
       if(g_nstop!=5){ fprintf(stderr,"  FAIL private chat: expected 5 stops, got %d\n",g_nstop); fail=1; }
 
-      test_set_env("SERVE_BATCH","1");
+      setenv("SERVE_BATCH","1",1);
       stops_arm_tok(&c,100,&T);
       fail|=expect("batched gateway keeps EOS",100,1);
       fail|=expect("batched gateway filters <|user|>",101,0);
       if(g_nstop!=1){ fprintf(stderr,"  FAIL batched gateway: expected 1 stop, got %d\n",g_nstop); fail=1; }
 
-      test_set_env("COLI_SERVE_ALL_STOPS","1");
+      setenv("COLI_SERVE_ALL_STOPS","1",1);
       stops_arm_tok(&c,100,&T);
       fail|=expect("gateway override restores <|user|>",101,1);
       if(g_nstop!=5){ fprintf(stderr,"  FAIL gateway override: expected 5 stops, got %d\n",g_nstop); fail=1; }
-      clear_env("COLI_SERVE_ALL_STOPS"); clear_env("SERVE_BATCH"); clear_env("SERVE");
+      unsetenv("COLI_SERVE_ALL_STOPS"); unsetenv("SERVE_BATCH"); unsetenv("SERVE");
       if(!fail) printf("  private chat keeps 5 stops; batched gateway filters to EOS   ok\n"); }
 
     rm_file(dir,"config.json"); rm_file(dir,"generation_config.json"); rm_file(dir,"tokenizer.json");


### PR DESCRIPTION
## Summary

`compat.h`'s `setenv` now writes through `_putenv_s` (and keeps the Win32 block in sync), so `setenv()` followed by `getenv()` in the same process works on Windows. The duplicated environment helpers and Windows overrides the tests carried because of the old shim are redundant: replace them with direct `setenv()`/`unsetenv()` calls and `compat.h` includes.

The fourteen files listed in #1429, plus the six qwen36 tier tests: they set their environment through `setenv()` and inherited the Windows half from `qwen36_fake_cuda.h`, so with the header's shim gone they include `compat.h` directly. Rules whose sources newly include `compat.h` list it as a prerequisite, and the registry test builds with `-D_FILE_OFFSET_BITS=64` (`compat.h` requires it on Windows).

No intended change to these tests' environment-setting behavior: every converted call passes `overwrite=1` and discards the return value.

Fixes #1429.

## Validation

- [x] `make -C c check` (see notes)
- [ ] CUDA changes were tested with `make -C c cuda-test` (not applicable, no CUDA changes)
- [ ] Performance claims include hardware, commands, and repeatable measurements (not applicable, no performance claims)

Notes (isolated Linux sandbox, GCC 15.3.0, 2 vCPU):

- All C tests pass except sandbox-environment failures that also reproduce on pristine `dev` with the same command: `test_inkling_shared_batch` (bf16 batch-vs-scalar bit-exactness) and `test_rss_anon` (/proc RSS accounting) fail consistently, and `test_uring` / `test_v4_serve_framing` fail intermittently (io_uring and socket fixtures under this sandbox). No failure is unique to this branch.
- The Python suite additionally hits environment failures here (a cluster of errors plus the runner being resource-killed mid-run). The Makefile- and compat-sensitive Python tests (`test_makefile_deps`, `test_makefile_platform`, `test_cuda_test_makefile`, `test_env_defaults`) all pass standalone.
- Aside from the environment-class failures above, every converted test passes in the sandbox (`test_rans`, `test_route_trace`, `test_stops`, `test_omp_tune`, the qwen36 tier family, `test_compat_env`). Windows behaviour is exercised by the UCRT64 CI job, the authoritative run for the affected paths.

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included
