### PR TITLE
build: restore the missing recipe for bench_inkling_shared_batch

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1279,6 +1279,7 @@ tests/test_inkling_shared_batch$(EXE): tests/test_inkling_shared_batch.c inkling
 # Reproducible local A/B for the shared-expert prefill path.  This is timing
 # evidence, not a CI gate: build and run it explicitly on the target CPU.
 tests/bench_inkling_shared_batch$(EXE): tests/bench_inkling_shared_batch.c inkling.c st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h omp_tune.h route_trace.h kv_prefix.h serve_codec.h $(INK_CUDA_OBJ) $(METAL_OBJ)
+	$(CC) $(CFLAGS) $< $(INK_CUDA_OBJ) $(METAL_OBJ) -o $@ $(LDFLAGS)
 
 tests/test_inkling_cache_index$(EXE): tests/test_inkling_cache_index.c inkling.c st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h omp_tune.h route_trace.h kv_prefix.h serve_codec.h $(INK_CUDA_OBJ) $(METAL_OBJ)
 	$(CC) $(CFLAGS) $< $(INK_CUDA_OBJ) $(METAL_OBJ) -o $@ $(LDFLAGS)


### PR DESCRIPTION
## Summary

`tests/bench_inkling_shared_batch` has had its prerequisites line in `c/Makefile` but no recipe since a774efd, so GNU make fell back to its implicit rule with none of the repository flags (no `-fopenmp`, no include paths), and the target could not build the way its siblings do. It is only reachable explicitly (`make tests/bench_inkling_shared_batch`), which is why the break went unnoticed: nothing in CI builds it.

Restore the recipe the sibling `tests/test_inkling_shared_batch` target already carries; prerequisites unchanged. The added line is the same single compile command as its sibling, so nothing else is touched.

## Validation

- [x] `make -C c check` (see notes)
- [ ] CUDA changes were tested with `make -C c cuda-test` (not applicable, no CUDA changes)
- [ ] Performance claims include hardware, commands, and repeatable measurements (not applicable; this only fixes the bench's build, it reports no measurement)

Notes (isolated Linux sandbox, GCC 15.3.0):

- `make tests/bench_inkling_shared_batch` builds clean (0 warnings) with the recipe restored, matching the flags every sibling test uses; without it, the same command never builds (the builtin rule emits implicit-declaration errors). The bench output itself is unchanged; this restores the build only.
- `make -C c check` exhibits the same sandbox-environment failures with or without this change (the bench is not part of the check target).

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included
