### PR TITLE
fix(build): guard malloc_trim to glibc for musl libc compatibility

### DIFF
--- a/c/colibri.c
+++ b/c/colibri.c
@@ -40,6 +40,8 @@
 #include <sys/mman.h>                             /* mlock: inchioda le pagine in RAM / wire pages into RAM */
 #ifdef __linux__
 #include <sys/syscall.h>                          /* COLI_NUMA: mbind degli slab expert / expert-slab interleave */
+#endif
+#ifdef __GLIBC__
 #include <malloc.h>                               /* Needed to actually free memory if we go over our RAM budget */
 #endif
 #include <sys/stat.h>                             /* fstat per mmap degli shard (COLI_MMAP) */
@@ -8453,7 +8455,7 @@ static void rss_guard(Model *m){
     if(dropped)
         fprintf(stderr,"[RAM-GUARD] RSS %.1f GB over the %.1f GB budget (#403): "
                        "dropped %d cached experts, cap -> %d\n", rss, lim, dropped, m->ecap);
-#ifdef __linux__
+#ifdef __GLIBC__
     malloc_trim(1024);
 #endif
 }


### PR DESCRIPTION
Fixes #1430.

musl libc defines \_\_linux\_\_ without declaring malloc_trim, which is a GNU extension. Guard the call and its include with \_\_GLIBC\_\_ so builds on Alpine Linux (musl) succeed.

---

This is a re-submission of #1431 (closed because the source branch was forked from main, causing extra unrelated commits to appear in the diff).