### PR TITLE
ci: add Alpine/musl build leg + comment on malloc_trim guard

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -128,6 +128,18 @@ jobs:
           python c/tools/make_edge_tiny_tokenizer.py --vocab-size 281 /tmp/glm53_stream-i4
           cd c && COLI_GLM53_FIXTURE=/tmp/glm53_stream-i4 python -m unittest -v tests.test_glm53_dashboard
 
+  linux-musl:
+    name: Linux (Alpine/musl)
+    runs-on: ubuntu-latest
+    container: alpine:3.20
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build deps
+        run: apk add build-base python3
+      - name: make check
+        run: make -C c check
+
   macos:
     # clang; libomp for the threaded path (Makefile falls back to
     # single-threaded automatically if it's ever missing).

--- a/c/colibri.c
+++ b/c/colibri.c
@@ -8455,6 +8455,7 @@ static void rss_guard(Model *m){
     if(dropped)
         fprintf(stderr,"[RAM-GUARD] RSS %.1f GB over the %.1f GB budget (#403): "
                        "dropped %d cached experts, cap -> %d\n", rss, lim, dropped, m->ecap);
+/* musl lacks malloc_trim, but free() returns large slabs to the OS directly */
 #ifdef __GLIBC__
     malloc_trim(1024);
 #endif


### PR DESCRIPTION
Adds an Alpine (musl libc) CI job to catch build regressions like #1430 early.

Also adds the one-line comment requested in #1435 review explaining why the `malloc_trim` guard is safe on musl.