### PR TITLE
tests: include compat.h directly in the converted tests

### DIFF
--- a/c/tests/bench_inkling_shared_batch.c
+++ b/c/tests/bench_inkling_shared_batch.c
@@ -11,6 +11,8 @@
 #include "../inkling.c"
 #undef main
 
+#include "../compat.h"   /* setenv/unsetenv: MinGW has neither */
+
 enum { S = 16, D = 2048, I = 1024, K = 2, NS = 2, REPS = 3 };
 
 static uint16_t to_bf16(float x) {

--- a/c/tests/bench_qwen36_dense_batch.c
+++ b/c/tests/bench_qwen36_dense_batch.c
@@ -9,6 +9,8 @@
 #include "../qwen36.c"
 #undef main
 
+#include "../compat.h"   /* setenv/unsetenv: MinGW has neither */
+
 enum { S=16, I=2048, O=512, REPS=7 };
 
 static float value(int64_t i, int salt) {

--- a/c/tests/test_inkling_shared_batch.c
+++ b/c/tests/test_inkling_shared_batch.c
@@ -8,6 +8,8 @@
 #include "../inkling.c"
 #undef main
 
+#include "../compat.h"   /* setenv/unsetenv: MinGW has neither */
+
 static int failures;
 #define CHECK(cond, ...) do { if (!(cond)) { \
     fprintf(stderr,"FAIL %s:%d: ",__FILE__,__LINE__); \

--- a/c/tests/test_qwen36_ctx.c
+++ b/c/tests/test_qwen36_ctx.c
@@ -21,6 +21,8 @@
 #include "../qwen36.c"
 #undef main
 
+#include "../compat.h"   /* setenv/unsetenv: MinGW has neither */
+
 static int fails = 0;
 
 static void ck(int cond, const char *what) {

--- a/c/tests/test_qwen36_dense_batch.c
+++ b/c/tests/test_qwen36_dense_batch.c
@@ -7,6 +7,8 @@
 #include "../qwen36.c"
 #undef main
 
+#include "../compat.h"   /* setenv/unsetenv: MinGW has neither */
+
 static int failures;
 #define CHECK(cond, ...) do { if (!(cond)) { \
     fprintf(stderr,"FAIL %s:%d: ",__FILE__,__LINE__); \

--- a/c/tests/test_qwen36_tier_int8_decode.c
+++ b/c/tests/test_qwen36_tier_int8_decode.c
@@ -33,6 +33,8 @@
 #include "../qwen36.c"
 #undef main
 
+#include "../compat.h"   /* setenv/unsetenv: MinGW has neither */
+
 #include "qwen36_fake_cuda.h"
 
 #include "../qwen36_tier.c"

--- a/c/tests/test_qwen36_tier_int8_engine.c
+++ b/c/tests/test_qwen36_tier_int8_engine.c
@@ -31,6 +31,8 @@
 #include "../qwen36.c"
 #undef main
 
+#include "../compat.h"   /* setenv/unsetenv: MinGW has neither */
+
 #include "qwen36_fake_cuda.h"
 
 #include "../qwen36_tier.c"

--- a/c/tests/test_route_trace.c
+++ b/c/tests/test_route_trace.c
@@ -9,9 +9,11 @@
  * easy to break by "tidying" the header into a comment line or moving the engine hash
  * into the second field, so it is asserted here against a literal copy of that loop.
  *
- * This test includes route_trace.h and nothing else: no Model, no Cfg, no st.h. That is
- * the point of the header — any engine can use it — and compiling this file proves it. */
+ * This test includes route_trace.h (plus compat.h) and nothing else: no Model, no Cfg, no st.h.
+ * That is the point of the header — any engine can use it — and compiling this file proves it. */
 #include "../route_trace.h"
+
+#include "../compat.h"   /* setenv/unsetenv: MinGW has neither */
 
 static int g_nfails = 0;
 static void check(int cond, const char *what){

--- a/c/tests/test_stops.c
+++ b/c/tests/test_stops.c
@@ -23,6 +23,8 @@
 #include "../colibri.c"
 #undef main
 
+#include "../compat.h"   /* setenv/unsetenv: MinGW has neither */
+
 static const char *TOKJSON =
 "{\"model\":{\"vocab\":{\"a\":0,\"b\":1,\"c\":2},\"merges\":[[\"a\",\"b\"]]},"
 " \"added_tokens\":["


### PR DESCRIPTION
## Summary

Direct follow-up to #1432, as raised in review: the nine converted test sources call `setenv()`/`unsetenv()` but relied on `compat.h` arriving transitively (through `st.h` for the engine tests, through `route_trace.h` for `test_route_trace`). They now include `../compat.h` directly, so a future reorder of the engine headers cannot silently drop the shims from these Windows C tests.

No functional change: each direct include sits after the file's primary include, and the `COMPAT_H` guard is already set by then, so preprocessing is unchanged apart from shifted diagnostic line numbers. One adjacent comment in `test_route_trace.c` is updated to match ("...and compat.h..."), and the two tier tests place the include where their sibling `test_qwen36_tier_int8.c` already does.

## Validation

- [x] `make -C c check` (see notes)
- [ ] CUDA changes were tested with `make -C c cuda-test` (not applicable, no CUDA changes)
- [ ] Performance claims include hardware, commands, and repeatable measurements (not applicable, no performance claims)

Notes (isolated Linux sandbox, GCC 15.3.0):
- All nine targets build with zero warnings, and the runnable suites pass: `test_qwen36_ctx`, `test_qwen36_dense_batch`, `test_qwen36_tier_int8_decode`, `test_qwen36_tier_int8_engine`, `test_route_trace`, `test_stops`, `bench_qwen36_dense_batch`.
- `test_inkling_shared_batch` and `bench_inkling_shared_batch` keep their pre-existing results, identical to unmodified `dev` in this sandbox (bf16 scalar-vs-batch bit-exactness; `int4-g64: 24077 values differ, worst=4.76837e-07`).
- `c/tests/test_makefile_deps.py` passes (2 tests).
- Windows behavior is exercised by the UCRT64 CI job, the authoritative run for these paths.

## Compatibility

- [x] The default CPU build remains dependency-free
- [x] No model files, generated binaries, or benchmark artifacts are included
