### PR TITLE
fix(glm53): correct RAM sizing and Apple unified-memory planning

### DIFF
--- a/c/resource_plan.py
+++ b/c/resource_plan.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import platform
 import re
 import shutil
 import statistics
@@ -328,6 +329,17 @@ def memory_available():
         except (OSError, subprocess.SubprocessError, ValueError):
             pass
     return 0
+
+
+def _host_unified_memory():
+    """Whether the host itself exposes one CPU/GPU physical memory pool.
+
+    This is intentionally separate from accelerator placement.  A CPU-only
+    engine such as glm53 still runs on unified-memory Apple Silicon, but that
+    fact must not fabricate a VRAM tier or make an unrelated GPU steer cache
+    placement.
+    """
+    return sys.platform == "darwin" and platform.machine().lower() in ("arm64", "aarch64")
 
 
 # Strict .coli_ssd grammar -- the byte-for-byte mirror of colibri.c's
@@ -795,11 +807,18 @@ def cpu_socket_count():
     return 1
 
 
-def _auto_tune(bottleneck_class, projected_hit, gpus, cpu_sockets, plan_has_metal):
+def _auto_tune(bottleneck_class, projected_hit, gpus, cpu_sockets, plan_has_metal,
+               engine_group=None):
     """Derive tuning knobs from the bottleneck classification."""
     tune = {}
     has_gpu = bool(gpus)
     n_gpu = len(gpus)
+
+    # glm53 has its own loader/cache controls and does not consume the generic
+    # DRAFT/PIPE/PIN/NUMA knobs below. Recommending them is worse than leaving
+    # them unset because `coli tune` then reports changes the engine ignores.
+    if engine_group == "glm53":
+        return tune
 
     # MTP: costs more than it saves when compute-bound (#389 measured 42% loss)
     # or streaming-bound (#467 measured 32% loss under CUDA at 85% hit).
@@ -950,7 +969,9 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
     # plans_placement().
     planning_gpus = [gpu for gpu in gpus if plans_placement(gpu)]
 
-    unified = any(gpu.get("unified_memory", False) for gpu in planning_gpus)
+    placement_unified = any(gpu.get("unified_memory", False)
+                            for gpu in planning_gpus)
+    unified = placement_unified or _host_unified_memory()
     typical = info["typical_expert_bytes"]
     max_expert = info["max_expert_bytes"] or typical
     kv_bytes = (geometry.context_state_bytes + geometry.fixed_state_bytes) * kv_slots
@@ -974,17 +995,17 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
     requested_vram = int(vram_gb * GB) if vram_gb > 0 else safe_vram
     requested_vram_before_clamp = requested_vram
     unified_pool = max(0, available_memory - info["dense_bytes"] - runtime_bytes)
-    if unified:
+    if placement_unified:
         # Unified devices expose one physical pool to CUDA and the host. Do not
         # let an expert tier consume pages that the RAM tier also believes are
         # available. Dense/runtime reservations are shared exactly once below.
         requested_vram = min(requested_vram, unified_pool)
-    vram_limit = unified_pool if unified else safe_vram
+    vram_limit = unified_pool if placement_unified else safe_vram
     vram_budget = min(requested_vram, vram_limit, info["expert_bytes"])
     vram_experts = int(vram_budget // typical) if typical else 0
     hot_bytes = min(info["expert_bytes"], vram_experts * typical)
     warnings = []
-    if unified:
+    if placement_unified:
         requested_ram = int(ram_gb * GB) if ram_gb > 0 else int(available_memory * 0.88)
         requested_ram_experts = max(0, requested_ram - info["dense_bytes"] - runtime_bytes)
         ram_expert_bytes = min(requested_ram_experts,
@@ -997,7 +1018,7 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
     else:
         ram_budget = int(ram_gb * GB) if ram_gb > 0 else int(available_memory * 0.88)
     if ram_budget < 4 * GB:
-        ram_budget = 8 * GB if not unified else max(0, ram_budget)
+        ram_budget = 8 * GB if not placement_unified else max(0, ram_budget)
     cache_bytes = max(0, ram_budget - info["dense_bytes"] - runtime_bytes)
     cap = int(cache_bytes // per_cap) if per_cap else 0
     if configured_experts:
@@ -1017,7 +1038,7 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
                 f"GPU {gpu['index']} ({gpu['name']}) was detected but its free memory is "
                 "not qualified as a placement budget on this platform; it is reported "
                 "only and drives no automatic tier")
-    if unified:
+    if placement_unified:
         warnings.append(
             "GPU and RAM share one physical memory pool; budgets were jointly constrained")
     # The plan sizes the hot tier from *free* VRAM, so running it while an engine
@@ -1058,7 +1079,8 @@ def build_plan(model, ram_gb=0, context=4096, gpu_indices=None, vram_gb=0,
         bottleneck_class = "memory"
 
     tune = _auto_tune(bottleneck_class, projected_hit, planning_gpus, cpu_sockets,
-                      plan_has_metal=False)
+                      plan_has_metal=False,
+                      engine_group=resolved.descriptor.engine_group)
     probe_state, probe_gbs = ssd_probe_state(info["path"])
     actions = _next_actions(bottleneck_class, projected_hit, probe_state,
                             probe_gbs, planning_gpus)

--- a/c/tests/test_resource_plan.py
+++ b/c/tests/test_resource_plan.py
@@ -97,6 +97,32 @@ class ResourcePlanTest(unittest.TestCase):
         # 0 slots/layer. The value must be a sane positive number of bytes.
         self.assertGreater(memory_available(), 0)
 
+    def test_apple_silicon_reports_unified_host_memory_without_fake_vram(self):
+        # Host memory topology is a hardware fact, independent of whether the
+        # selected engine can place anything on the GPU.  In particular glm53
+        # is CPU-only today, but an M-series Mac must not be reported as
+        # memory.unified=false merely because planning_gpus is empty.
+        with mock.patch.object(sys, "platform", "darwin"), \
+             mock.patch("resource_plan.platform.machine", return_value="arm64"):
+            plan = build_plan(self.model, ram_gb=16, available_memory=32 * GB,
+                              available_disk=1, gpus=[], physical_cpus=8,
+                              cpu_sockets=1)
+        self.assertTrue(plan["memory"]["unified"])
+        self.assertEqual(plan["tiers"]["vram"]["budget_bytes"], 0)
+        self.assertFalse(any("jointly constrained" in warning
+                             for warning in plan["warnings"]))
+
+    def test_glm53_auto_tune_does_not_emit_generic_inert_knobs(self):
+        from resource_plan import _auto_tune
+
+        generic = _auto_tune("disk", 0.50, [], 1, False)
+        self.assertIn("DRAFT", generic)
+        self.assertIn("PIPE", generic)
+
+        glm53 = _auto_tune("disk", 0.50, [], 1, False,
+                           engine_group="glm53")
+        self.assertEqual(glm53, {})
+
     def test_cpu_socket_count_is_positive(self):
         self.assertGreaterEqual(cpu_socket_count(), 1)
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -323,7 +323,7 @@ See `docs/glm53-flash.md`.
 | Variable | Default | Effect |
 |---|---|---|
 | `GLM53_BITS` | `4` | Precision of the resident dense weights: 4, 8 or 32. Routed experts are not affected — they arrive already quantized in the container and are never requantized. |
-| `GLM53_EXPERT_GB` | measured | RAM budget (GB) for the expert LRU cache; per-layer slots are derived from it. Unset, it is taken from `MemAvailable` after the weights are loaded, minus a 3 GB margin. A fixed number is wrong in both directions: too small on a large machine leaves memory idle while the disk does all the work. |
+| `GLM53_EXPERT_GB` | measured | RAM budget (GB) for the expert LRU cache; per-layer slots are derived from it. Unset, it is taken from reclaimable physical memory after the weights are loaded (Linux `MemAvailable`, Windows available physical memory, macOS free+inactive+purgeable pages), minus a 3 GB margin. A fixed number is wrong in both directions: too small on a large machine leaves memory idle while the disk does all the work. |
 | `GLM53_MAXT` | `8192` | KV state capacity in tokens, and the session size in serve mode. |
 | `GLM53_PREFILL_CHUNK` | `128` | Prefill chunk size in tokens. Smaller keeps the workspace smaller; too small re-reads experts once per chunk per layer instead of amortizing them. |
 | `GLM53_MAX_IMAGE_TOKENS` | checkpoint's (8000) | Ceiling on tokens per image. Each covers 28×28 pixels, so 256 keeps ordinary text legible and 64 keeps shapes and colours. The image is shrunk, not cropped. Lower it: 8000 is 2691 tokens for a 1080p photo, i.e. a prefill nobody will sit through. |


### PR DESCRIPTION
# PR B — GLM-5.3-Flash resource planning on Apple Silicon

## Proposed title

`fix(glm53): correct RAM sizing and Apple unified-memory planning`

## Summary

This change fixes three related resource-planning problems for the `glm53` engine:

1. `glm53` auto expert-cache sizing used Linux `/proc/meminfo` unconditionally. On macOS this returned `0`, causing the fallback expert budget to collapse to `1.0 GB`.
2. The generic resource planner reported `memory.unified=false` for Apple Silicon when the selected engine did not expose a placement-capable GPU. This mixed up physical host memory topology with accelerator placement support.
3. Generic auto-tuning suggested knobs such as `DRAFT`, `PIPE`, `PIN_GB`, and `COLI_NUMA` for `glm53`, even though the engine does not consume those controls.

The patch keeps `glm53` CPU-only placement semantics intact: Apple Silicon is reported as unified-memory hardware, but no artificial VRAM tier or GPU placement budget is created.

## Files changed

- `c/glm53.c`
- `c/resource_plan.py`
- `c/tests/test_resource_plan.py`
- `docs/ENVIRONMENT.md`

Final diff before commit:

- 4 modified files
- 83 insertions
- 9 deletions
- `git diff --check`: clean

## Problem 1 — `glm53` auto expert cache collapsed to 1 GB on macOS

### Reproduction before the fix

On an Apple Silicon Mac with 128 GB unified memory, starting GLM-5.3-Flash without an explicit `GLM53_EXPERT_GB` produced:

```text
budget esperti: 1.0 GB
```

The relevant implementation was:

```c
static double memory_available_gb(void) {
    FILE *f = fopen("/proc/meminfo", "r");
    if (!f) return 0.0;
    ...
}
```

and the expert cache then used:

```c
budget = free_now - 3.0;
if (budget < 1.0) budget = 1.0;
```

Since macOS has no `/proc/meminfo`, `memory_available_gb()` returned `0.0`, and the budget was always forced to the 1 GB floor.

### Fix

`memory_available_gb()` is now platform-aware:

- Windows: existing `compat_meminfo()`
- macOS: Mach VM statistics using `free + inactive + purgeable` pages
- Linux/other existing path: `/proc/meminfo` / `MemAvailable`

The macOS implementation follows the same reclaimable-memory definition already used by other Colibri code paths rather than using total physical RAM, which would overestimate what can safely be allocated under memory pressure.

### Real-machine validation after the fix

Test system:

- Apple Silicon Mac Studio
- M4 Max
- 128 GB unified memory
- GLM-5.3-Flash Colibri model

Command was run with `GLM53_EXPERT_GB` unset and `GLM53_VERBOSE=1`.

Observed startup:

```text
budget esperti: 102.4 GB (105.4 disponibili, 3 di margine)
esperti: slot da 14.2 MB, 172 per layer su 42 layer sparsi (102.3 GB residenti)
```

The inference completed successfully.

Observed generation rate during this validation run:

```text
0.562 tok/s
```

This run validates sizing and runtime stability only. It is not used as a controlled performance comparison.

## Problem 2 — Apple Silicon was reported as non-unified for CPU-only `glm53`

### Root cause

The planner derived `memory.unified` only from placement-capable GPUs:

```python
planning_gpus = [gpu for gpu in gpus if plans_placement(gpu)]
unified = any(gpu.get("unified_memory", False) for gpu in planning_gpus)
```

For `glm53`, the planner intentionally has no accelerator placement tier, so `planning_gpus` is empty. As a result, an Apple Silicon host could incorrectly be described as:

```text
memory.unified = false
```

even though the machine physically uses one unified CPU/GPU memory pool.

### Fix

The patch separates two different concepts:

- physical host unified-memory topology
- unified accelerator placement

A new `_host_unified_memory()` helper identifies native Apple Silicon hosts.

The output-level `memory.unified` flag becomes true if either the host is Apple Silicon or a placement-capable accelerator uses unified memory.

All VRAM/shared-budget calculations continue to use `placement_unified`, not the host-topology flag. Therefore a CPU-only `glm53` plan does not fabricate VRAM capacity.

### Real planner validation

Machine-readable plan after the fix:

```text
memory.unified: true
available_bytes: 120253218816

vram.devices: []
vram.budget_bytes: 0

tune: {}
```

This is the intended result:

- host topology is correctly reported as unified
- `glm53` remains CPU-only
- no fake GPU/VRAM tier is introduced
- RAM and VRAM budgets are not double-counted

A normal `coli plan --ram 96 --ctx 8192` run also retained the expected CPU-only placement while planning approximately:

```text
RAM budget:            96 GB
warm expert cache:     ~85.4 GB
slots/layer:           140
cold expert bytes:     ~89.9 GB
VRAM:                  no supported GPU detected / CPU path
```

## Problem 3 — Generic tuning knobs were suggested for `glm53`

### Root cause

`_auto_tune()` was family-agnostic and could emit generic recommendations for disk-bound workloads, including:

```text
DRAFT
PIPE
PIN_GB
COLI_NUMA
```

The `glm53` engine does not consume these generic controls, so presenting them in `coli tune` was misleading.

### Fix

`_auto_tune()` now accepts the resolved engine group. For:

```text
engine_group == "glm53"
```

it returns no generic tune knobs.

The planner passes:

```python
resolved.descriptor.engine_group
```

to `_auto_tune()`.

This is intentionally narrow and preserves the previous tuning behavior for other engines.

### Real tune validation

After the patch, `coli tune` for GLM-5.3-Flash did not emit:

```text
DRAFT
PIPE
PIN_GB
COLI_NUMA
```

The machine-readable plan reported:

```text
tune: {}
```

The normal tune run evaluated the relevant baseline/OMP candidates and kept the baseline. No inert `glm53` recommendations were generated.

## Tests

### Targeted resource-plan tests

```text
Ran 64 tests in 2.699s
OK
```

Two regression tests were added:

1. Apple Silicon host memory is reported as unified without creating a fake VRAM budget.
2. `glm53` auto-tune does not emit generic inert knobs, while generic-family behavior remains unchanged.

### `glm53` build

The `glm53` target compiled successfully.

The build emitted three existing `missing field 'vk' initializer` warnings around `Mat`. These warnings predate this change and are unrelated to PR B.

### Real GLM-5.3-Flash runtime test

With `GLM53_EXPERT_GB` unset:

Before:

```text
budget esperti: 1.0 GB
```

After:

```text
budget esperti: 102.4 GB (105.4 disponibili, 3 di margine)
esperti: slot da 14.2 MB, 172 per layer su 42 layer sparsi (102.3 GB residenti)
```

Inference completed successfully.

### Full regression suite

```text
Ran 724 tests in 54.967s
OK (skipped=35)
```

No failures and no errors.

### Diff validation

```text
git diff --check
```

completed with no output.

## Documentation

`docs/ENVIRONMENT.md` now documents the platform-specific source used when `GLM53_EXPERT_GB` is unset:

- Linux: `MemAvailable`
- Windows: available physical memory
- macOS: free + inactive + purgeable pages

The existing 3 GB safety margin remains unchanged.

## Compatibility and scope

The Linux `MemAvailable` behavior is unchanged.

The Windows path now uses Colibri's existing `compat_meminfo()` helper.

On macOS, the new implementation uses Mach VM statistics and does not rely on Linux `/proc`.

The planner change deliberately does not add Apple GPU discovery or GPU placement support to `glm53`. It only corrects the reported physical memory topology.

The generic auto-tuner remains unchanged for non-`glm53` engine groups.

## Limitations / notes

- This PR does not attempt to improve GLM-5.3-Flash token-generation speed.
- The observed `0.562 tok/s` runtime is recorded only as evidence that the corrected auto-sized cache runs successfully; it is not a controlled before/after benchmark.
- The Apple host-topology helper currently identifies native `arm64`/`aarch64` macOS. Rosetta-translated execution was not tested.
- No GPU/Metal execution path is added to `glm53`.
- No storage-probe changes are included in this PR.
- Mirror I/O is outside this PR and is handled separately.

## Validation commands

Targeted tests and build:

```zsh
cd /Users/sascha/Developer/colibri/c
python3 -m unittest tests.test_resource_plan
make glm53
```

Real automatic RAM-sizing test:

```zsh
cd /Users/sascha/Developer/colibri/c
unset GLM53_EXPERT_GB
GLM53_VERBOSE=1 GLM53_MAXT=8192 COLI_MODEL="/Users/sascha/lllm-colibri/Justvugg/GLM-5.3-Flash-colibri-int4-g64" ./coli run "Reply with exactly: OK" --ngen 4
```

Planner/tuner validation:

```zsh
cd /Users/sascha/Developer/colibri/c
MODEL="/Users/sascha/lllm-colibri/Justvugg/GLM-5.3-Flash-colibri-int4-g64"
./coli plan --model "$MODEL" --ram 96 --ctx 8192
./coli tune --model "$MODEL" --ram 96 --ctx 8192
./coli plan --model "$MODEL" --ram 96 --ctx 8192 --json
```

Full regression suite:

```zsh
cd /Users/sascha/Developer/colibri/c
python3 -m unittest discover -s tests
```

Final diff checks:

```zsh
cd /Users/sascha/Developer/colibri
git diff --check
git --no-pager diff --stat
git --no-pager diff -- c/glm53.c c/resource_plan.py c/tests/test_resource_plan.py docs/ENVIRONMENT.md
```

