### PR TITLE
feat(glm53): add routing usage telemetry and .coli_usage support

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1124,7 +1124,7 @@ NOCUDA_LDFLAGS = $(filter-out -lcudart -lstdc++ -lcuda -L$(CUDA_HOME)/lib64 \
 
 # GLM-5.3-Flash: routed experts stream from the int4-gs64 container.
 # METAL=1 accelerates resident matrices and routed MoE; CPU remains fallback.
-glm53$(EXE): glm53.c cli_args.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h serve_poll.h quant.h hyper_connections.h delta_attention.h sparse_index.h vision_tower.h backend_metal.h backend_vulkan.h edge_adapter_internal.h edge_adapters.h edge_runtime.h segment_adapter_internal.h segment_adapters.h segment_runtime.h $(METAL_OBJ) $(VK_OBJ) $(VK_SPV)
+glm53$(EXE): glm53.c cli_args.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h serve_poll.h route_trace.h quant.h hyper_connections.h delta_attention.h sparse_index.h vision_tower.h backend_metal.h backend_vulkan.h edge_adapter_internal.h edge_adapters.h edge_runtime.h segment_adapter_internal.h segment_adapters.h segment_runtime.h $(METAL_OBJ) $(VK_OBJ) $(VK_SPV)
 	$(CC) $(CFLAGS) glm53.c $(METAL_OBJ) $(VK_OBJ) -o glm53$(EXE) $(LDFLAGS)
 
 kimi_k3$(EXE): kimi_k3.c cli_args.h st.h json.h tok.h tok_unicode.h tok_unicode_o200k.h compat.h quant.h omp_tune.h route_trace.h kv_prefix.h serve_codec.h backend_cuda.h backend_metal.h backend_vulkan.h edge_adapters.h edge_runtime.h edge_tok_internal.h hybrid_split.h segment_adapter_internal.h segment_adapters.h segment_runtime.h $(CUDA_OBJ) $(VK_OBJ) $(VK_SPV) $(METAL_OBJ)

--- a/c/glm53.c
+++ b/c/glm53.c
@@ -88,6 +88,7 @@ static int g_vk_ready = 0;
 #endif
 #include "compat.h"
 #include "serve_poll.h"          /* CANCEL a meta' turno (#1332) */
+#include "route_trace.h"
 #include <time.h>
 #ifndef _WIN32
 #include <sys/resource.h>
@@ -122,6 +123,30 @@ typedef struct {
     int image_token, image_start_token, image_end_token;
     int video_token, video_start_token, video_end_token;
 } Cfg;
+
+static char g_glm53_usage[2100];
+
+/* Routing telemetry belongs to the standalone/serve lifecycle. Segment may
+ * host multiple engines in one process, while route_trace.h owns one process-
+ * global stream/counter set, so range-native Segment loads stay detached. */
+static void glm53_telemetry_init(const char *snap, const Cfg *c) {
+    rt_init("glm53", c->n_layers, c->n_experts);
+    for (int i = 0; i < c->first_dense; i++) rt_drop_row(i);
+    rt_drop_row(c->n_layers);                    /* inclusive extra row; no routed MTP here */
+
+    const char *up = getenv("COLI_USAGE");
+    if (up && *up) snprintf(g_glm53_usage, sizeof g_glm53_usage, "%s", up);
+    else snprintf(g_glm53_usage, sizeof g_glm53_usage, "%s/.coli_usage", snap);
+
+    int64_t history = rt_load(g_glm53_usage);
+    if (history > 0)
+        fprintf(stderr, "[USAGE] expert history: %lld selections (%s)\n",
+                (long long)history, g_glm53_usage);
+}
+
+static void glm53_telemetry_save(void) {
+    if (g_glm53_usage[0]) rt_save(g_glm53_usage, 0);
+}
 
 static double req_num(jval *object, const char *key) {
     jval *value = json_get(object, key);
@@ -1477,7 +1502,12 @@ static void ffn_layer(GModel *m, const GLayer *l, int index, const float *x,
         }
         for (int k = 0; k < topk; k++)
             mine_w[k] = mine_w[k] / (total + 1e-20f) * c->routed_scale;
+
+        /* Record the exact experts and post-normalisation gates applied by
+         * this layer. The shared helper also bumps .coli_usage counters. */
+        rt_route(index, t, mine, mine_w, topk);
     }
+    rt_trace_end();
     free(score);
 
     /* --- secondo e terzo tempo, a blocchi che stanno in cache ---
@@ -2987,6 +3017,7 @@ int main(int argc, char **argv) {
         GModel served;
         memset(&served, 0, sizeof(served));
         model_load(&served, snap);
+        glm53_telemetry_init(snap, &served.c);
         Tok serve_tok;
         char tokenizer_path[1024];
         snprintf(tokenizer_path, sizeof(tokenizer_path), "%s/tokenizer.json", snap);
@@ -2994,6 +3025,8 @@ int main(int argc, char **argv) {
         const char *batch = getenv("SERVE_BATCH");
         arm_stops(snap, &serve_tok, batch && atoi(batch));
         serve_loop(&served, &serve_tok);
+        glm53_telemetry_save();
+        rt_destroy();
         tok_free(&serve_tok);
         return 0;
     }
@@ -3041,6 +3074,7 @@ int main(int argc, char **argv) {
     memset(&model, 0, sizeof(model));     /* contatori e puntatori opzionali */
     const double load_start = now_s();
     model_load(&model, dir);
+    glm53_telemetry_init(dir, &model.c);
     const double load_seconds = now_s() - load_start;
     if (getenv("GLM53_VERBOSE")) cfg_report(&model.c);
 
@@ -3146,6 +3180,8 @@ int main(int argc, char **argv) {
 #endif
     free(logits);
     session_close(&model, session);
+    glm53_telemetry_save();
+    rt_destroy();
     free(vision);
     free(tokens);
     return 0;

--- a/c/route_trace.h
+++ b/c/route_trace.h
@@ -60,7 +60,7 @@
 #define RT_IKU1_MAGIC 0x31554B49u      /* "IKU1" — inkling.c's usage_save/pins_load */
 
 /* engines that write this format; the table exists so a mismatch names both sides */
-static const char *rt_engine_names[] = { "glm_moe_dsa", "inkling", "olmoe", "kimi_k3", "deepseek_v4", "qwen38", NULL };
+static const char *rt_engine_names[] = { "glm_moe_dsa", "inkling", "olmoe", "kimi_k3", "deepseek_v4", "qwen38", "glm53", NULL };
 
 static uint32_t rt_hash(const char *s){        /* FNV-1a 32, stable across builds */
     uint32_t h = 2166136261u;

--- a/c/tests/test_glm53_telemetry.py
+++ b/c/tests/test_glm53_telemetry.py
@@ -1,0 +1,35 @@
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+GLM = (ROOT / "glm53.c").read_text()
+TRACE = (ROOT / "route_trace.h").read_text()
+
+
+class Glm53RoutingTelemetryTest(unittest.TestCase):
+    def test_shared_route_trace_wiring(self):
+        self.assertIn('#include "route_trace.h"', GLM)
+        self.assertIn('rt_init("glm53", c->n_layers, c->n_experts);', GLM)
+        self.assertIn('rt_route(index, t, mine, mine_w, topk);', GLM)
+        self.assertIn('rt_trace_end();', GLM)
+
+    def test_rows_and_usage_lifecycle(self):
+        self.assertIn('for (int i = 0; i < c->first_dense; i++) rt_drop_row(i);', GLM)
+        self.assertIn('rt_drop_row(c->n_layers);', GLM)
+        self.assertIn('getenv("COLI_USAGE")', GLM)
+        self.assertIn('rt_load(g_glm53_usage)', GLM)
+        self.assertIn('rt_save(g_glm53_usage, 0)', GLM)
+
+    def test_engine_identity_registered(self):
+        self.assertIn('"glm53"', TRACE)
+
+    def test_segment_open_does_not_attach_global_telemetry(self):
+        start = GLM.index('static int glm53_segment_engine_open(')
+        end = GLM.index('static void glm53_segment_engine_destroy(', start)
+        segment_open = GLM[start:end]
+        self.assertNotIn('glm53_telemetry_init', segment_open)
+        self.assertNotIn('rt_init(', segment_open)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/docs/routing-telemetry.md
+++ b/docs/routing-telemetry.md
@@ -6,9 +6,9 @@ the header both are implemented in. Background and design discussion in
 
 ## Why one header
 
-Six of colibrì's seven engines use this header: `colibri.c` (GLM-5.2),
-`kimi_k3.c`, `inkling.c`, `olmoe.c`, `deepseek_v4.c`, and `qwen38.c`.
-Qwen3.6 is the one existing exception. The learning cache described in
+Seven of colibrì's eight engines use this header: `colibri.c` (GLM-5.2),
+`kimi_k3.c`, `inkling.c`, `olmoe.c`, `deepseek_v4.c`, `qwen38.c`, and
+`glm53.c`. Qwen3.6 is the one existing exception. The learning cache described in
 [tuning.md](tuning.md) is only as good as the history it reads. Before
 `route_trace.h`, that history was per-engine: `colibri.c` wrote sparse text,
 `inkling.c` wrote a dense binary block with an `IKU1` magic, and the other


### PR DESCRIPTION
# PR C — GLM-5.3-Flash routing telemetry and `.coli_usage`

## Pull request

**Upstream PR:** JustVugg/colibri #1457  
**Title:** `feat(glm53): add routing usage telemetry and .coli_usage support`  
**Branch:** `feat/glm53-routing-telemetry`  
**Commit:** `2fff4deba2574335e9e617942ea0497c0f99249d`

## Summary

GLM-5.3-Flash did not participate in Colibri's shared `route_trace.h` routing telemetry. Consequently, inference through the `glm53` engine did not generate or update `.coli_usage`, leaving usage-driven expert placement and partial-mirror planning without GLM-5.3 routing history.

PR C integrates `glm53` into the existing shared telemetry implementation.

## Implementation

The change:

- registers `glm53` as a routing-telemetry engine;
- initializes telemetry for standalone and serve execution;
- records the exact top-k experts and post-normalization gates selected by each routed MoE layer;
- loads existing `.coli_usage` history before inference;
- saves accumulated history after inference;
- honors `COLI_USAGE`;
- inherits `USAGE_SAVE=0` read-only semantics from `route_trace.h`;
- supports `ROUTE_TRACE`;
- excludes the initial dense layers and the unused extra/MTP row;
- keeps Segment range-native loads detached from process-global telemetry state;
- adds `route_trace.h` to the `glm53` Makefile dependencies;
- updates routing-telemetry documentation.

Files changed:

- `c/Makefile`
- `c/glm53.c`
- `c/route_trace.h`
- `c/tests/test_glm53_telemetry.py`
- `docs/routing-telemetry.md`

Final diff: **76 additions, 5 deletions**.

## Regression tests

`c/tests/test_glm53_telemetry.py` adds four source/logic regression tests covering:

1. shared `route_trace.h` wiring;
2. usage lifecycle and dropped rows;
3. `glm53` engine identity registration;
4. Segment loads remaining detached from global telemetry.

An initial full-suite run exposed a Makefile dependency failure because `glm53.c` newly included `route_trace.h` without listing it as a `glm53` target prerequisite. The Makefile was corrected and the complete suite was rerun successfully.

## Real GLM-5.3-Flash validation

Model:

`Justvugg/GLM-5.3-Flash-colibri-int4-g64`

Platform: Apple Silicon, native `glm53` engine.

An isolated inference produced both `.coli_usage` and `ROUTE_TRACE`.

First run:

- 3,024 expert selections;
- 1,640 distinct `(layer, expert)` entries;
- 1,642 usage-file lines including headers;
- routing records begin at layer 3, correctly excluding the first three dense layers;
- route trace contains top-8 expert IDs and gates.

## History accumulation

A subsequent inference loaded the existing **3,024** selections and accumulated the history to **5,376** selections.

The line count need not increase because `.coli_usage` stores sparse `(layer, expert)` counters and existing records are incremented.

## `USAGE_SAVE=0`

Read-only behavior was verified using SHA-256.

Before the read-only run:

`8e6c89e2a7de9b0bba584c17ecf5de15ba031585d47d9b93942a99d95e5cc527`

After inference with `USAGE_SAVE=0`:

`8e6c89e2a7de9b0bba584c17ecf5de15ba031585d47d9b93942a99d95e5cc527`

The file remained byte-identical while existing history was loaded.

After a subsequent normal accumulation run:

`5eb0862d722078d1a468422f9151db761af2803164d4ae38cfc18e05b0e7e189`

This confirms that normal operation writes updated counters while `USAGE_SAVE=0` remains read-only.

## Build and full-suite validation

`glm53` builds successfully. Existing `missing field 'vk' initializer` warnings remain unrelated to this change.

Final complete test run:

```text
Ran 726 tests in 53.974s

OK (skipped=39)
```

`git diff --check` completed cleanly.

## Compatibility and scope

The default CPU build remains dependency-free. No model files, generated binaries, benchmark artifacts, CUDA/Metal/Vulkan execution changes, model-format changes, or routing-policy changes are included.

Segment adapters deliberately do not attach to the process-global routing telemetry state.

This PR makes **no performance claim**. Runtime inference was used only to validate telemetry semantics.

## Git state

Signed commit:

`2fff4deba2574335e9e617942ea0497c0f99249d`

GitHub displays the commit as **Verified**.

Remote branch:

`trigger2k20/colibri:feat/glm53-routing-telemetry`

Upstream pull request:

`JustVugg/colibri #1457`
