### PR TITLE
fix(build): clean up Clang compiler warnings

### DIFF
--- a/c/deepseek_v4.c
+++ b/c/deepseek_v4.c
@@ -2726,8 +2726,6 @@ int coli_v4_attention_window_batch_ref(
 
 #ifdef COLI_V4_GPU_TIER
     int gpu_batch = coli_v4_gpu_attn_batch_wanted() && batch > 1;
-#else
-    int gpu_batch = 0;
 #endif
     /* Whole-chunk GPU projections for the compressor and the indexer's
      * compressor; the per-token state advance stays on the CPU. NULL means
@@ -3759,7 +3757,9 @@ int coli_v4_indexer_select_batch(ColiDeepSeekV4Indexer *state, int *indices,
     const uint16_t *raw_weights = value(
         state->weights, "attn.indexer.weights_proj.weight", NULL);
     size_t qn = (size_t)heads * dimension;
+#ifdef COLI_V4_GPU_TIER
     size_t cols = (size_t)wq.columns;
+#endif
 
 #define ALIGN32(n) (((size_t)(n) + 31) & ~(size_t)31)
     size_t sz_queries = ALIGN32((size_t)batch * qn * sizeof(float));
@@ -3769,8 +3769,6 @@ int coli_v4_indexer_select_batch(ColiDeepSeekV4Indexer *state, int *indices,
     size_t sz_stoken = ALIGN32((size_t)need * sizeof(int));
     size_t sz_scores = ALIGN32((size_t)need * max_count * sizeof(float));
     size_t sz_ranked = ALIGN32((size_t)max_count * sizeof(IndexScore));
-    size_t sz_scales = ALIGN32((size_t)dimension / 32);
-    size_t sz_qdq = ALIGN32((size_t)dimension * sizeof(float));
 #ifdef COLI_V4_GPU_TIER
     size_t sz_xq = (need <= 1024) ? ALIGN32((size_t)need * cols * sizeof(float)) : 0;
     size_t sz_yq = (need <= 1024) ? ALIGN32((size_t)need * qn * sizeof(float)) : 0;
@@ -3780,7 +3778,7 @@ int coli_v4_indexer_select_batch(ColiDeepSeekV4Indexer *state, int *indices,
 #endif
 
     size_t total_scratch = sz_queries + sz_sq + sz_head_weights + sz_scounts + sz_stoken +
-                           sz_scores + sz_ranked + sz_scales + sz_qdq + sz_xq + sz_yq + sz_xs + 256;
+                           sz_scores + sz_ranked + sz_xq + sz_yq + sz_xs + 256;
 
     char *scratch_ptr = (char *)indexer_scratch_alloc(state, total_scratch);
     if (!scratch_ptr || !raw_weights) {
@@ -3797,8 +3795,6 @@ int coli_v4_indexer_select_batch(ColiDeepSeekV4Indexer *state, int *indices,
     int *stoken = (int *)scratch_ptr; scratch_ptr += sz_stoken;
     float *scores = (float *)scratch_ptr; scratch_ptr += sz_scores;
     IndexScore *ranked = (IndexScore *)scratch_ptr; scratch_ptr += sz_ranked;
-    uint8_t *scales = (uint8_t *)scratch_ptr; scratch_ptr += sz_scales;
-    float *qdq = (float *)scratch_ptr; scratch_ptr += sz_qdq;
     int result = 0;
 
     /* Query projection. Preferred: host fp8 activation quantization (the
@@ -4977,11 +4973,15 @@ static int moe_token_pipeline(float *output,
 
 #ifdef COLI_V4_EXPERIMENTAL_DUAL_EXPERT_LOADER
     ColiExpertView *views = malloc((size_t)selected * sizeof(*views));
+#ifdef COLI_V4_GPU_TIER
     int gpu_compute = 0;
+#endif
     if (!views) result = -1;
     if (!result) {
         memset(views, 0, (size_t)selected * sizeof(*views));
+#ifdef COLI_V4_GPU_TIER
         gpu_compute = 1;
+#endif
         for (int current = 0; !result && current < selected; current++) {
             int slot = current % dual_loader_lanes();
             if (!loader_active[slot] ||
@@ -5001,9 +5001,11 @@ static int moe_token_pipeline(float *output,
                     coli_v4_gpu_expert_attach(store, &views[current]);
             }
 #endif
+#ifdef COLI_V4_GPU_TIER
             if (!views[current].gate.gpu || !views[current].up.gpu ||
                 !views[current].down.gpu)
                 gpu_compute = 0;
+#endif
 
             int next = current + dual_loader_lanes();
             if (next < selected) {

--- a/c/expert_store_registry.c
+++ b/c/expert_store_registry.c
@@ -17,10 +17,22 @@
  * and call register() from their own constructors, so these symbols must
  * survive LTO inlining. Without this, gcc drops them when the only caller in
  * the current link is inside the same LTO set. */
-#if defined(__GNUC__)
-#define COLI_ESR_EXPORT __attribute__((externally_visible, used))
+#if defined(__has_attribute)
+#  if __has_attribute(externally_visible)
+#    define COLI_ESR_EXTERNALLY_VISIBLE __attribute__((externally_visible))
+#  else
+#    define COLI_ESR_EXTERNALLY_VISIBLE
+#  endif
+#elif defined(__GNUC__)
+#  define COLI_ESR_EXTERNALLY_VISIBLE __attribute__((externally_visible))
 #else
-#define COLI_ESR_EXPORT
+#  define COLI_ESR_EXTERNALLY_VISIBLE
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#  define COLI_ESR_EXPORT COLI_ESR_EXTERNALLY_VISIBLE __attribute__((used))
+#else
+#  define COLI_ESR_EXPORT
 #endif
 
 /* The built-in on-disk/mmap backend, defined in the COLI_V4_UNIT_EXPERT_STORE_AUTO

--- a/c/glm53.c
+++ b/c/glm53.c
@@ -1340,11 +1340,11 @@ static void expert_mats(const GModel *m, const Slot *slot, Mat *gate, Mat *up, M
     const int hidden = m->c.hidden, inter = m->c.moe_inter;
     const Mat shape[3] = {
         { 4, NULL, NULL, slot->piece[0], (const float *)slot->piece[1],
-          inter, hidden, 64 },
+          inter, hidden, 64, NULL },
         { 4, NULL, NULL, slot->piece[2], (const float *)slot->piece[3],
-          inter, hidden, 64 },
+          inter, hidden, 64, NULL },
         { 4, NULL, NULL, slot->piece[4], (const float *)slot->piece[5],
-          hidden, inter, 64 },
+          hidden, inter, 64, NULL },
     };
     *gate = shape[0]; *up = shape[1]; *down = shape[2];
 }
@@ -1987,12 +1987,13 @@ static void model_load(GModel *m, const char *dir) {
 static float *forward_span(GModel *m, GSession *s, const int *tokens, int n,
                            const float *vision, int n_vision) {
     const Cfg *c = &m->c;
+    const int H = c->hc_mult;
     const int start = s->filled;   /* NON 'base': nel ciclo dei layer e' gia' preso */
     if (start + n > s->cap) {
         fprintf(stderr, "contesto esaurito: %d posizioni su %d\n", start + n, s->cap);
         exit(1);
     }
-    const int H = c->hc_mult, D = c->hidden;
+    const int D = c->hidden;
     float *streams = malloc((size_t)n * H * D * sizeof(float));
     float *next = malloc((size_t)n * H * D * sizeof(float));
     /* l'embedding entra replicato in ognuno degli H flussi residui; sui token
@@ -3229,7 +3230,8 @@ static int glm53_edge_embed(void *engine_impl, const ColiEdgeEmbedRequest *reque
 static int glm53_edge_final(const Glm53EdgeEngine *engine, const float *streams,
                             float *logits, float *collapsed, float *normed) {
     const Cfg *c = &engine->model.c;
-    const int H = c->hc_mult, D = c->hidden;
+    const int H = c->hc_mult;
+    const int D = c->hidden;
     for (int d = 0; d < D; d++) {
         float sum = 0.0f;
         for (int h = 0; h < H; h++) sum += streams[(size_t)h * D + d];
@@ -3284,7 +3286,7 @@ static int glm53_edge_select(void *engine_impl, const ColiEdgeSelectRequest *req
         return coli_edge_adapter_error(error, error_size,
                                        "GLM-5.3 Edge select got bad arguments");
     const Cfg *c = &engine->model.c;
-    const int H = c->hc_mult, D = c->hidden;
+    const int D = c->hidden;
     const size_t width = engine->state_width;
     if (request->input_bytes < (size_t)request->rows * width * sizeof(float) ||
         request->token_capacity < request->rows)

--- a/c/qwen38.c
+++ b/c/qwen38.c
@@ -2606,10 +2606,16 @@ static int qwen38_edge_select(void *engine_impl,
 }
 
 static const ColiEdgeAdapter qwen38_edge_adapter={
-    sizeof(ColiEdgeAdapter),COLI_EDGE_ABI_VERSION,"qwen38",
-    qwen38_edge_engine_open,qwen38_edge_engine_destroy,
-    qwen38_edge_tokenize,qwen38_edge_detokenize,
-    qwen38_edge_embed,qwen38_edge_select,{0}
+    .struct_size = sizeof(ColiEdgeAdapter),
+    .abi_version = COLI_EDGE_ABI_VERSION,
+    .engine_id = "qwen38",
+    .engine_open = qwen38_edge_engine_open,
+    .engine_destroy = qwen38_edge_engine_destroy,
+    .tokenize = qwen38_edge_tokenize,
+    .detokenize = qwen38_edge_detokenize,
+    .embed = qwen38_edge_embed,
+    .select = qwen38_edge_select,
+    .reserved_fn = {0}
 };
 
 int coli_qwen38_edge_adapter_register(void) {

--- a/c/tests/test_expert_store_ops.c
+++ b/c/tests/test_expert_store_ops.c
@@ -67,7 +67,7 @@ int main(void) {
         mock_lookup, mock_release, mock_prefetch, mock_stats, mock_destroy
     };
     MockState state = {0};
-    ColiExpertStore store = {&ops, &state};
+    ColiExpertStore store = {&ops, &state, NULL};
     ColiExpertView view;
     ColiExpertView other;
     ColiExpertKey key = {7, 19};


### PR DESCRIPTION
Clean up Clang compiler warnings

## Branch and commit

- Branch: `fix/clang-compiler-warnings`
- Commit: `e79aee8`
- Commit message: `fix(build): clean up Clang compiler warnings`
- Base used for development: `fd93c41aa6ae2c7d1cc1a1e2d6b79dbe6d341708` (`v1.10.2`)

## Summary

This change removes Apple Clang compiler warnings from the portable CPU/test build without globally suppressing warning classes.

The cleanup covers GLM-5.3, Qwen3.8 Edge adapter initialization, the expert-store registry/test initialization, and DeepSeek V4 CPU/GPU conditional compilation. The changes are intended to be warning cleanup only; no performance claim is made.

## Changes

### GLM-5.3

- Explicitly initializes the `Mat.vk` field to `NULL` in the three affected matrix initializers.
- Keeps `hc_mult` declarations only in code paths where the value is actually used, avoiding unused-variable diagnostics in alternate/Segment builds.

### Qwen3.8

- Converts the `ColiEdgeAdapter` initializer to designated initialization.
- Initializes the `reserved_fn` array explicitly.
- Removes the scalar-brace/missing-field diagnostics and makes the adapter initializer less dependent on struct field order.

### Expert store

- Explicitly initializes the additional `ColiExpertStore` field in `test_expert_store_ops.c`.
- Makes `COLI_ESR_EXPORT` feature-detect `externally_visible` instead of unconditionally applying an attribute unsupported by Apple Clang.
- Retains the `used` attribute on GCC/Clang builds.

### DeepSeek V4

- Restricts `gpu_batch`, `cols`, and `gpu_compute` state to GPU-tier compilation where those values are consumed.
- Removes unused `scales`/`qdq` scratch allocations and their size accounting.
- Keeps the CPU-only path free of GPU-only unused-variable diagnostics.

## Compiler diagnostics addressed

The original Apple Clang build/test output contained warnings in these groups:

1. Three `glm53.c` `missing field 'vk' initializer` diagnostics.
2. One GLM-5.3 Segment-build `unused variable 'H'` diagnostic.
3. Qwen3.8 Edge adapter `braces around scalar initializer`.
4. Qwen3.8 Edge adapter `missing field 'reserved_fn' initializer`.
5. Expert-store test `missing field 'gpu' initializer`.
6. Four `expert_store_registry.c` `unknown attribute 'externally_visible' ignored` diagnostics.
7. DeepSeek V4 `unused variable 'gpu_batch'`.
8. DeepSeek V4 `unused variable 'cols'`.
9. DeepSeek V4 `unused variable 'scales'`.
10. DeepSeek V4 `unused variable 'qdq'`.
11. DeepSeek V4 `variable 'gpu_compute' set but not used`.

Expected runtime/test diagnostics containing the word `warning` were not treated as compiler warnings.

## Validation

Final validation on macOS/Apple Clang:

```text
Ran 722 tests in 54.468s

OK (skipped=39)

=== COMPILER WARNINGS ===
ZERO COMPILER WARNINGS
```

The compiler-warning check matched source-location compiler diagnostics separately from expected runtime/test messages.

`git diff --check` also passed.

## Scope

Files changed:

- `c/deepseek_v4.c`
- `c/expert_store_registry.c`
- `c/glm53.c`
- `c/qwen38.c`
- `c/tests/test_expert_store_ops.c`

Final commit diff:

```text
5 files changed, 43 insertions(+), 21 deletions(-)
```

## Notes

- No warning class is disabled globally.
- No throughput/performance improvement is claimed.
- GPU-only DeepSeek variables remain available in GPU-tier builds; the cleanup avoids defining them in CPU-only builds where they are not consumed.
- The registry attribute handling uses feature detection so Apple Clang can omit `externally_visible` while compilers supporting it retain the attribute.
