### PR TITLE
fix(tests): the qwen36 fill-wait test needs compat.h to build on Windows

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1714,7 +1714,7 @@ tests/test_qwen36_tier_invariants$(EXE): tests/test_qwen36_tier_invariants.c tes
 # until the last enqueued expert is RESIDENT, not merely dequeued -- the engine
 # frees the RAM int8 copies right after it (#1360 saw the gap one run in
 # fifteen; here the slow upload hook makes it every run without the fix).
-tests/test_qwen36_tier_fill_wait$(EXE): tests/test_qwen36_tier_fill_wait.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h
+tests/test_qwen36_tier_fill_wait$(EXE): tests/test_qwen36_tier_fill_wait.c tests/qwen36_fake_cuda.h qwen36_tier.c qwen36_tier.h backend_cuda.h compat.h
 	$(CC) $(CFLAGS) -DCOLI_CUDA $< -o $@ $(LDFLAGS)
 
 # Same fake backend: the automatic placement (COLI_PLACE unset/"auto") puts

--- a/c/tests/test_qwen36_tier_fill_wait.c
+++ b/c/tests/test_qwen36_tier_fill_wait.c
@@ -24,6 +24,9 @@
 
 #include "../qwen36_tier.c"
 
+#include "../compat.h"   /* setenv: MinGW has none, and qwen36_tier.c does not
+                          * pull it in the way an engine .c does */
+
 static int fails;
 static void check(int ok, const char *what) {
     if (!ok) { printf("  FAIL: %s\n", what); fails++; }


### PR DESCRIPTION
`dev` is red on `Windows UCRT64` / `make check` since #1390 landed:

```
tests/test_qwen36_tier_fill_wait.c:42:5: error: implicit declaration of function 'setenv'; did you mean 'getenv'?
```

MinGW has no `setenv`. Tests that include an engine `.c` inherit `compat.h` through it; this one includes `qwen36_tier.c`, which does not. Linux never noticed because glibc has `setenv`, and modern GCC makes an implicit declaration an error rather than a warning, so the Windows leg is where it surfaced. Same shape as #1440.

Reproduced locally against mingw-w64 with the Makefile's own Windows flags plus `-Werror=implicit-function-declaration`, fixed, then **every gated test was cross-compiled the same way**: this file is the only one affected. The three that still fail that sweep (`test_uring`, `test_deepseek_v4`, `test_v4_ownership`) are in `TEST_EXCLUDE` and are not built on the Windows leg.

`compat.h` also joins the rule's prerequisites, so editing the shim relinks the test.