### PR TITLE
fix(coli): the cluster worker handed the engine the string "None" as its cap

### DIFF
--- a/c/coli
+++ b/c/coli
@@ -1852,7 +1852,14 @@ def cmd_cluster_worker(a):
               "COLI_MMAP":os.environ.get("COLI_MMAP", "1")})
     print(f"  {C.dim}[CLUSTER] expert worker · {host}:{a.port} · layers {a.layers}{C.r}")
     try:
-        return subprocess.call([engine,str(a.cap),str(a.ebits),str(a.dbits)],env=e)
+        # cap_for_launch, not a.cap: --cap defaults to None and str(None) is the
+        # literal "None", which the engine's argument parser refuses with
+        # `cache/layer: expected a whole number, got "None"` -- so the worker
+        # could only ever start with an explicit --cap (#1452). Fallback 0 is
+        # what the other GLM launch sites pass: the engine resolves its own cap
+        # when the argument is zero.
+        return subprocess.call([engine,str(cap_for_launch(a.cap,e,0)),
+                                str(a.ebits),str(a.dbits)],env=e)
     finally:
         stop_heartbeat.set()
 

--- a/c/tests/test_env_defaults.py
+++ b/c/tests/test_env_defaults.py
@@ -369,3 +369,37 @@ class Dsv4CudaDetectTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ClusterWorkerCapTest(unittest.TestCase):
+    """`coli cluster worker` must hand the engine a number, never "None".
+
+    --cap comes from the shared parser and defaults to None, meaning "auto".
+    The worker used to stringify it straight into argv, so a launch without an
+    explicit --cap died on the engine's own argument check with
+    `cache/layer: expected a whole number, got "None"` (#1452). Every other
+    direct-engine launcher resolves it through cap_for_launch; this one now
+    does too.
+    """
+
+    def _worker_argv(self, cap):
+        captured = {}
+
+        def fake_call(cmd, env=None, **kwargs):
+            captured["cmd"] = cmd
+            return 0
+
+        a = args(cap=cap, ebits=8, dbits=8, port=9100, layers="0-1",
+                 coordinator=None, advertise_host=None, node_id=None)
+        with mock.patch.object(coli, "need_worker_model", return_value="/tmp/engine"), \
+             mock.patch.object(coli.subprocess, "call", fake_call):
+            coli.cmd_cluster_worker(a)
+        return captured["cmd"]
+
+    def test_auto_cap_becomes_a_number(self):
+        argv = self._worker_argv(None)
+        self.assertNotIn("None", argv)
+        int(argv[1])                       # raises if it is not a whole number
+
+    def test_explicit_cap_is_passed_through(self):
+        self.assertEqual(self._worker_argv(24)[1], "24")


### PR DESCRIPTION
Fixes #1452.

`coli cluster worker` without an explicit `--cap` could never start:

```
cache/layer: expected a whole number, got "None"
```

`--cap` comes from the shared parser and defaults to `None`, meaning auto. Every other direct-engine launcher resolves that through `cap_for_launch`; this one stringified it into argv, and `str(None)` is the literal `"None"`, which the engine's own argument check refuses before anything else runs. So the documented default was the one value that could not work, on Linux and Windows alike, which is what the reporter saw on both of their machines.

Fallback 0 matches the other GLM launch sites: `colibri.c` treats a zero cap as "not given" and resolves its own, after the Metal and SSD probes the platform default depends on.

`tests/test_env_defaults.py` gains the regression: the worker's argv must parse as an integer, and an explicit `--cap` must still pass through. I checked the test fails with the old line restored, rather than trusting that it would.

Full python suite green.