### PR TITLE
fix(glm53): initialise the two Mat fields #1462 added, so #1458's cleanup holds

### DIFF
--- a/c/glm53.c
+++ b/c/glm53.c
@@ -1408,11 +1408,11 @@ static void expert_mats(const GModel *m, const Slot *slot, Mat *gate, Mat *up, M
     const int hidden = m->c.hidden, inter = m->c.moe_inter;
     const Mat shape[3] = {
         { 4, NULL, NULL, slot->piece[0], (const float *)slot->piece[1],
-          inter, hidden, 64, NULL },
+          inter, hidden, 64, NULL, 0, NULL },
         { 4, NULL, NULL, slot->piece[2], (const float *)slot->piece[3],
-          inter, hidden, 64, NULL },
+          inter, hidden, 64, NULL, 0, NULL },
         { 4, NULL, NULL, slot->piece[4], (const float *)slot->piece[5],
-          hidden, inter, 64, NULL },
+          hidden, inter, 64, NULL, 0, NULL },
     };
     *gate = shape[0]; *up = shape[1]; *down = shape[2];
 }


### PR DESCRIPTION
#1458 silenced `-Wmissing-field-initializers` on the three `expert_mats` initialisers by naming the `vk` field. #1462 landed alongside it and gave `Mat` two more trailing fields, `resident` and `metal`, so the warning did not go away, it moved to `resident`.

The zero the compiler was already supplying is the right value: a streamed expert slot is not resident and has no Metal tensor. This only says so explicitly. glm53 builds clean under `-Wextra` again; verified locally.